### PR TITLE
Fix table layout to properly handle visibility:collapse on columns

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7883,8 +7883,6 @@ http/tests/iframe-memory-monitor/video-iframe.html [ Skip ]
 # css/CSS2/tables failures
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/border-collapse-006.html [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/border-collapse-dynamic-column-002.xht [ ImageOnlyFailure ]
-webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/border-collapse-visibility-collapse-001.tentative.html [ ImageOnlyFailure ]
-webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/border-collapse-visibility-collapse-002.tentative.html [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/border-conflict-element-001d.xht [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/border-conflict-element-001e.xht [ ImageOnlyFailure ]
 webkit.org/b/288957 imported/w3c/web-platform-tests/css/CSS2/tables/caption-position-001.xht [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-001-expected.txt
@@ -12,5 +12,5 @@ row 2
 row 3	
 
 PASS col visibility:collapse doesn't change table height
-FAIL col visibility:collapse changes table width assert_equals: expected 116 but got 222
+PASS col visibility:collapse changes table width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-002-expected.txt
@@ -12,5 +12,5 @@ row 2
 row 3	
 
 PASS col visibility:collapse doesn't change table height
-FAIL col visibility:collapse changes table width assert_equals: col visibility:collapse changes table width expected 10 but got 222
+PASS col visibility:collapse changes table width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-003-expected.txt
@@ -12,5 +12,5 @@ row 2
 row 3	
 
 PASS col visibility:collapse doesn't change table height
-FAIL col visibility:collapse changes table width assert_equals: col visibility:collapse changes table width expected 116 but got 222
+PASS col visibility:collapse changes table width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-004-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-004-dynamic-expected.txt
@@ -8,5 +8,5 @@ row 2
 row 3	
 
 PASS col visibility:collapse doesn't change table height
-FAIL col visibility:collapse changes table width assert_equals: col visibility:collapse changes table width expected 122 but got 232
+FAIL col visibility:collapse changes table width assert_equals: col visibility:collapse changes table width expected 122 but got 124
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-005-expected.txt
@@ -5,5 +5,5 @@ Setting a spanning column to visibility:collapse changes table width but not hei
 
 
 PASS col visibility:collapse doesn't change table height
-FAIL col visibility:collapse changes table width assert_equals: col visibility:collapse changes table width expected 100 but got 111
+PASS col visibility:collapse changes table width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-colspan-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-colspan-002-expected.txt
@@ -5,5 +5,5 @@ Setting a spanning column to visibility:collapse changes table width but not hei
 
 
 PASS col visibility:collapse doesn't change table height
-FAIL col visibility:collapse changes table width assert_equals: col visibility:collapse changes table width expected 50 but got 60
+PASS col visibility:collapse changes table width
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt
@@ -4,6 +4,6 @@ Spec
 Setting row and column to visibility:collapse changes both height and width. The collapsed result should have whitespace in the bottom right corner.
 
 
-FAIL spanning col visibility:collapse changes table width assert_equals: spanning col visibility:collapse changes table width expected 112 but got 148
+FAIL spanning col visibility:collapse changes table width assert_equals: spanning col visibility:collapse changes table width expected 112 but got 114
 PASS spanning row visibility:collapse changes height
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-002-expected.txt
@@ -4,6 +4,6 @@ Spec
 Setting row and spanning column to visibility:collapse changes height and width.
 
 
-FAIL spanning row visibility:collapse doesn't change table width assert_equals: spanning row visibility:collapse doesn't change table width expected 45 but got 130
+PASS spanning row visibility:collapse doesn't change table width
 PASS spanning row visibility:collapse doesn't change height in this case
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2352
+layer at (0,0) size 785x2416
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2352
-  RenderBlock {HTML} at (0,0) size 785x2353
-    RenderBody {BODY} at (8,8) size 769x2329
+layer at (0,0) size 785x2416
+  RenderBlock {HTML} at (0,0) size 785x2417
+    RenderBody {BODY} at (8,8) size 769x2393
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 432x36
           text run at (0,0) width 432: "Example 4: Some simple tables."
@@ -542,47 +542,47 @@ layer at (0,0) size 785x2352
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,112) size 769x18
           RenderBR {BR} at (0,0) size 0x17
-        RenderTable {TABLE} at (0,130) size 138x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 138x18
-            RenderInline {B} at (52,0) size 33x17
-              RenderText {#text} at (52,0) size 33x17
-                text run at (52,0) width 33: "after"
+        RenderTable {TABLE} at (0,130) size 107x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 107x18
+            RenderInline {B} at (37,0) size 33x17
+              RenderText {#text} at (37,0) size 33x17
+                text run at (37,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 136x50
-            RenderTableRow {TR} at (0,2) size 136x22
+          RenderTableSection {TBODY} at (1,19) size 105x50
+            RenderTableRow {TR} at (0,2) size 105x22
               RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (35,2) size 31x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (35,2) size -2x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (68,2) size 66x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (35,2) size 66x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 62x17
                   text run at (2,2) width 62: "C13 large"
-            RenderTableRow {TR} at (0,26) size 136x0
+            RenderTableRow {TR} at (0,26) size 105x0
               RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x17
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (35,14) size 31x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (35,14) size -2x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x17
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (68,14) size 66x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (35,14) size 66x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x17
                   text run at (2,2) width 27: "C23"
-            RenderTableRow {TR} at (0,26) size 136x22
+            RenderTableRow {TR} at (0,26) size 105x22
               RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (35,26) size 31x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (35,26) size -2x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C32"
-              RenderTableCell {TD} at (68,26) size 66x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (35,26) size 66x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1628) size 769x213
+      RenderBlock {P} at (0,1628) size 769x245
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 745x17
             text run at (0,0) width 745: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -641,61 +641,64 @@ layer at (0,0) size 785x2352
               RenderTableCell {TD} at (155,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,126) size 188x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 188x18
-            RenderInline {B} at (78,0) size 32x17
-              RenderText {#text} at (78,0) size 32x17
-                text run at (78,0) width 32: "after"
+        RenderTable {TABLE} at (0,126) size 95x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 95x18
+            RenderInline {B} at (31,0) size 33x17
+              RenderText {#text} at (31,0) size 33x17
+                text run at (31,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 186x66
-            RenderTableRow {TR} at (0,0) size 186x22
+          RenderTableSection {TBODY} at (1,19) size 93x98
+            RenderTableRow {TR} at (0,0) size 93x22
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (31,0) size 62x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (31,0) size 0x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (93,0) size 62x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (31,0) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C13"
-              RenderTableCell {TD} at (155,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (62,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 186x0
+            RenderTableRow {TR} at (0,22) size 93x0
               RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (31,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,2) size 120x17
-                  text run at (2,2) width 120: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (155,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (31,11) size 31x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-9) size 27x71
+                  text run at (2,2) width 27: "C12"
+                  text run at (2,20) width 27: "C13"
+                  text run at (2,38) width 27: "C22"
+                  text run at (2,56) width 27: "C23"
+              RenderTableCell {TD} at (62,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 186x22
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+            RenderTableRow {TR} at (0,22) size 93x54
+              RenderTableCell {TD} at (0,38) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x17
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (155,22) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (62,38) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x17
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,44) size 186x22
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,76) size 93x22
+              RenderTableCell {TD} at (0,76) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (31,44) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (31,76) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C42"
-              RenderTableCell {TD} at (93,44) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (31,76) size 31x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (155,44) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (62,76) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,1856) size 769x227
+      RenderBlock {P} at (0,1888) size 769x227
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 455x17
             text run at (0,0) width 455: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -822,7 +825,7 @@ layer at (0,0) size 785x2352
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,208) size 769x18
           RenderBR {BR} at (0,0) size 0x17
-      RenderBlock {P} at (0,2098) size 769x231
+      RenderBlock {P} at (0,2130) size 769x263
         RenderBlock (anonymous) at (0,0) size 769x36
           RenderText {#text} at (0,0) size 755x35
             text run at (0,0) width 554: "The following table is similar to a previous table except that the direction is right-to-left. "
@@ -883,57 +886,60 @@ layer at (0,0) size 785x2352
               RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,144) size 188x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 188x18
-            RenderInline {B} at (78,0) size 32x17
-              RenderText {#text} at (78,0) size 32x17
-                text run at (78,0) width 32: "after"
+        RenderTable {TABLE} at (0,144) size 95x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 95x18
+            RenderInline {B} at (31,0) size 33x17
+              RenderText {#text} at (31,0) size 33x17
+                text run at (31,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 186x66
-            RenderTableRow {TR} at (0,0) size 186x22
-              RenderTableCell {TD} at (155,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableSection {TBODY} at (1,19) size 93x98
+            RenderTableRow {TR} at (0,0) size 93x22
+              RenderTableCell {TD} at (62,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (93,0) size 62x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-                RenderText {#text} at (33,2) size 27x17
-                  text run at (33,2) width 27: "C12"
-              RenderTableCell {TD} at (31,0) size 62x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-                RenderText {#text} at (33,2) size 27x17
-                  text run at (33,2) width 27: "C13"
+              RenderTableCell {TD} at (62,0) size 0x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+                RenderText {#text} at (-25,2) size 27x17
+                  text run at (-25,2) width 27: "C12"
+              RenderTableCell {TD} at (31,0) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,2) size 27x17
+                  text run at (2,2) width 27: "C13"
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 186x0
-              RenderTableCell {TD} at (155,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,22) size 93x0
+              RenderTableCell {TD} at (62,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (31,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,2) size 120x17
-                  text run at (2,2) width 120: "C12 C13 C22 C23"
+              RenderTableCell {TD} at (31,11) size 31x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-9) size 27x71
+                  text run at (2,2) width 27: "C12"
+                  text run at (2,20) width 27: "C13"
+                  text run at (2,38) width 27: "C22"
+                  text run at (2,56) width 27: "C23"
               RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x17
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 186x22
-              RenderTableCell {TD} at (155,22) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+            RenderTableRow {TR} at (0,22) size 93x54
+              RenderTableCell {TD} at (62,38) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x17
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x17
+              RenderTableCell {TD} at (0,38) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x17
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,44) size 186x22
-              RenderTableCell {TD} at (155,44) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,76) size 93x22
+              RenderTableCell {TD} at (62,76) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (93,44) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
-                RenderText {#text} at (33,2) size 27x17
-                  text run at (33,2) width 27: "C42"
-              RenderTableCell {TD} at (31,44) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
-                RenderText {#text} at (33,2) size 27x17
-                  text run at (33,2) width 27: "C43"
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (62,76) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+                RenderText {#text} at (-25,2) size 27x17
+                  text run at (-25,2) width 27: "C42"
+              RenderTableCell {TD} at (31,76) size 31x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,2) size 27x17
+                  text run at (2,2) width 27: "C43"
+              RenderTableCell {TD} at (0,76) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x17
                   text run at (2,2) width 27: "C44"

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x2563
+layer at (0,0) size 800x2635
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x2563
-  RenderBlock {HTML} at (0,0) size 800x2564
-    RenderBody {BODY} at (8,8) size 784x2540
+layer at (0,0) size 800x2635
+  RenderBlock {HTML} at (0,0) size 800x2636
+    RenderBody {BODY} at (8,8) size 784x2612
       RenderBlock {H1} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 432x36
           text run at (0,1) width 432: "Example 4: Some simple tables."
@@ -542,47 +542,47 @@ layer at (0,0) size 800x2563
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,122) size 784x20
           RenderBR {BR} at (0,0) size 0x19
-        RenderTable {TABLE} at (0,142) size 138x76 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 138x20
-            RenderInline {B} at (52,0) size 34x19
-              RenderText {#text} at (52,0) size 34x19
-                text run at (52,0) width 34: "after"
+        RenderTable {TABLE} at (0,142) size 108x76 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 108x20
+            RenderInline {B} at (37,0) size 33x19
+              RenderText {#text} at (37,0) size 33x19
+                text run at (37,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,21) size 136x54
-            RenderTableRow {TR} at (0,2) size 136x24
+          RenderTableSection {TBODY} at (1,21) size 106x54
+            RenderTableRow {TR} at (0,2) size 106x24
               RenderTableCell {TD} at (2,2) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (34,2) size 32x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,2) size -1x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (67,2) size 67x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (34,2) size 68x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x19
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,28) size 136x0
+            RenderTableRow {TR} at (0,28) size 106x0
               RenderTableCell {TD} at (2,15) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-11) size 27x19
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (34,15) size 32x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,15) size -1x24 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,-11) size 27x19
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (67,15) size 67x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (34,15) size 68x24 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,-11) size 27x19
                   text run at (2,2) width 27: "C23"
-            RenderTableRow {TR} at (0,28) size 136x24
+            RenderTableRow {TR} at (0,28) size 106x24
               RenderTableCell {TD} at (2,28) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (34,28) size 32x24 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,28) size -1x24 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C32"
-              RenderTableCell {TD} at (67,28) size 67x24 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (34,28) size 68x24 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1775) size 784x233
+      RenderBlock {P} at (0,1775) size 784x269
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 756x19
             text run at (0,0) width 756: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -641,61 +641,64 @@ layer at (0,0) size 800x2563
               RenderTableCell {TD} at (153,72) size 32x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,138) size 187x94 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 187x20
-            RenderInline {B} at (76,0) size 34x19
-              RenderText {#text} at (76,0) size 34x19
-                text run at (76,0) width 34: "after"
+        RenderTable {TABLE} at (0,138) size 95x130 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 95x20
+            RenderInline {B} at (30,0) size 34x19
+              RenderText {#text} at (30,0) size 34x19
+                text run at (30,0) width 34: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,21) size 185x72
-            RenderTableRow {TR} at (0,0) size 185x24
+          RenderTableSection {TBODY} at (1,21) size 93x108
+            RenderTableRow {TR} at (0,0) size 93x24
               RenderTableCell {TD} at (0,0) size 31x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (30,0) size 63x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (30,0) size 0x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (92,0) size 62x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,0) size 32x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C13"
-              RenderTableCell {TD} at (153,0) size 32x24 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (61,0) size 32x24 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,24) size 185x0
+            RenderTableRow {TR} at (0,24) size 93x0
               RenderTableCell {TD} at (0,12) size 31x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,24) size 124x24 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,2) size 119x19
-                  text run at (2,2) width 119: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (153,12) size 32x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (30,12) size 32x84 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-10) size 27x79
+                  text run at (2,2) width 27: "C12"
+                  text run at (2,22) width 27: "C13"
+                  text run at (2,42) width 27: "C22"
+                  text run at (2,62) width 27: "C23"
+              RenderTableCell {TD} at (61,12) size 32x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,24) size 185x24
-              RenderTableCell {TD} at (0,24) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+            RenderTableRow {TR} at (0,24) size 93x60
+              RenderTableCell {TD} at (0,42) size 31x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,20) size 27x19
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (153,24) size 32x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (61,42) size 32x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,20) size 27x19
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,48) size 185x24
-              RenderTableCell {TD} at (0,48) size 31x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,84) size 93x24
+              RenderTableCell {TD} at (0,84) size 31x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (30,48) size 63x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (30,84) size 0x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C42"
-              RenderTableCell {TD} at (92,48) size 62x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,84) size 32x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (153,48) size 32x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (61,84) size 32x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,2023) size 784x249
+      RenderBlock {P} at (0,2059) size 784x249
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 463x19
             text run at (0,0) width 463: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -822,7 +825,7 @@ layer at (0,0) size 800x2563
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,228) size 784x20
           RenderBR {BR} at (0,0) size 0x19
-      RenderBlock {P} at (0,2287) size 784x253
+      RenderBlock {P} at (0,2323) size 784x289
         RenderBlock (anonymous) at (0,0) size 784x40
           RenderText {#text} at (0,0) size 775x39
             text run at (0,0) width 571: "The following table is similar to a previous table except that the direction is right-to-left. "
@@ -883,57 +886,60 @@ layer at (0,0) size 800x2563
               RenderTableCell {TD} at (0,72) size 31x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,158) size 187x94 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 187x20
-            RenderInline {B} at (76,0) size 34x19
-              RenderText {#text} at (76,0) size 34x19
-                text run at (76,0) width 34: "after"
+        RenderTable {TABLE} at (0,158) size 95x130 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 95x20
+            RenderInline {B} at (30,0) size 34x19
+              RenderText {#text} at (30,0) size 34x19
+                text run at (30,0) width 34: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,21) size 185x72
-            RenderTableRow {TR} at (0,0) size 185x24
-              RenderTableCell {TD} at (153,0) size 32x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableSection {TBODY} at (1,21) size 93x108
+            RenderTableRow {TR} at (0,0) size 93x24
+              RenderTableCell {TD} at (61,0) size 32x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (92,0) size 62x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x19
-                  text run at (32,2) width 28: "C12"
-              RenderTableCell {TD} at (30,0) size 63x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x19
-                  text run at (32,2) width 28: "C13"
+              RenderTableCell {TD} at (61,0) size 0x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+                RenderText {#text} at (-25,2) size 27x19
+                  text run at (-24,2) width 26: "C12"
+              RenderTableCell {TD} at (30,0) size 32x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,2) size 27x19
+                  text run at (2,2) width 27: "C13"
               RenderTableCell {TD} at (0,0) size 31x24 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,24) size 185x0
-              RenderTableCell {TD} at (153,12) size 32x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,24) size 93x0
+              RenderTableCell {TD} at (61,12) size 32x24 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,24) size 124x24 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,2) size 119x19
-                  text run at (2,2) width 119: "C12 C13 C22 C23"
+              RenderTableCell {TD} at (30,12) size 32x84 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-10) size 27x79
+                  text run at (2,2) width 27: "C12"
+                  text run at (2,22) width 27: "C13"
+                  text run at (2,42) width 27: "C22"
+                  text run at (2,62) width 27: "C23"
               RenderTableCell {TD} at (0,12) size 31x24 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x19
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,24) size 185x24
-              RenderTableCell {TD} at (153,24) size 32x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+            RenderTableRow {TR} at (0,24) size 93x60
+              RenderTableCell {TD} at (61,42) size 32x24 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,20) size 27x19
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (0,24) size 31x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x19
+              RenderTableCell {TD} at (0,42) size 31x24 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,20) size 27x19
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,48) size 185x24
-              RenderTableCell {TD} at (153,48) size 32x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,84) size 93x24
+              RenderTableCell {TD} at (61,84) size 32x24 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (92,48) size 62x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x19
-                  text run at (32,2) width 28: "C42"
-              RenderTableCell {TD} at (30,48) size 63x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x19
-                  text run at (32,2) width 28: "C43"
-              RenderTableCell {TD} at (0,48) size 31x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (61,84) size 0x24 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+                RenderText {#text} at (-25,2) size 27x19
+                  text run at (-24,2) width 26: "C42"
+              RenderTableCell {TD} at (30,84) size 32x24 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,2) size 27x19
+                  text run at (2,2) width 27: "C43"
+              RenderTableCell {TD} at (0,84) size 31x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x19
                   text run at (2,2) width 27: "C44"

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2354
+layer at (0,0) size 785x2418
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2354
-  RenderBlock {HTML} at (0,0) size 785x2355
-    RenderBody {BODY} at (8,8) size 769x2331
+layer at (0,0) size 785x2418
+  RenderBlock {HTML} at (0,0) size 785x2419
+    RenderBody {BODY} at (8,8) size 769x2395
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 432x37
           text run at (0,0) width 432: "Example 4: Some simple tables."
@@ -542,47 +542,47 @@ layer at (0,0) size 785x2354
                   text run at (2,2) width 27: "C33"
         RenderBlock (anonymous) at (0,112) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-        RenderTable {TABLE} at (0,130) size 138x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 138x18
-            RenderInline {B} at (52,0) size 34x18
-              RenderText {#text} at (52,0) size 34x18
-                text run at (52,0) width 34: "after"
+        RenderTable {TABLE} at (0,130) size 108x70 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 108x18
+            RenderInline {B} at (37,0) size 33x18
+              RenderText {#text} at (37,0) size 33x18
+                text run at (37,0) width 33: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 136x50
-            RenderTableRow {TR} at (0,2) size 136x22
+          RenderTableSection {TBODY} at (1,19) size 106x50
+            RenderTableRow {TR} at (0,2) size 106x22
               RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (34,2) size 32x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,2) size -1x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (67,2) size 67x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (34,2) size 68x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 63x18
                   text run at (2,2) width 63: "C13 large"
-            RenderTableRow {TR} at (0,26) size 136x0
+            RenderTableRow {TR} at (0,26) size 106x0
               RenderTableCell {TD} at (2,14) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (34,14) size 32x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,14) size -1x22 [border: (1px inset #000000)] [r=1 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C22"
-              RenderTableCell {TD} at (67,14) size 67x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (34,14) size 68x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,-10) size 27x18
                   text run at (2,2) width 27: "C23"
-            RenderTableRow {TR} at (0,26) size 136x22
+            RenderTableRow {TR} at (0,26) size 106x22
               RenderTableCell {TD} at (2,26) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (34,26) size 32x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (34,26) size -1x22 [border: (1px inset #000000)] [r=2 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C32"
-              RenderTableCell {TD} at (67,26) size 67x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (34,26) size 68x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1630) size 769x213
+      RenderBlock {P} at (0,1630) size 769x245
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 756x18
             text run at (0,0) width 756: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -641,61 +641,64 @@ layer at (0,0) size 785x2354
               RenderTableCell {TD} at (153,66) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,126) size 187x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 187x18
-            RenderInline {B} at (76,0) size 34x18
-              RenderText {#text} at (76,0) size 34x18
-                text run at (76,0) width 34: "after"
+        RenderTable {TABLE} at (0,126) size 95x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 95x18
+            RenderInline {B} at (30,0) size 34x18
+              RenderText {#text} at (30,0) size 34x18
+                text run at (30,0) width 34: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 185x66
-            RenderTableRow {TR} at (0,0) size 185x22
+          RenderTableSection {TBODY} at (1,19) size 93x98
+            RenderTableRow {TR} at (0,0) size 93x22
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (30,0) size 63x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (30,0) size 0x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C12"
-              RenderTableCell {TD} at (92,0) size 62x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,0) size 32x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C13"
-              RenderTableCell {TD} at (153,0) size 32x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (61,0) size 32x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 185x0
+            RenderTableRow {TR} at (0,22) size 93x0
               RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,2) size 119x18
-                  text run at (2,2) width 119: "C12 C13 C22 C23"
-              RenderTableCell {TD} at (153,11) size 32x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (30,11) size 32x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-9) size 27x72
+                  text run at (2,2) width 27: "C12"
+                  text run at (2,20) width 27: "C13"
+                  text run at (2,38) width 27: "C22"
+                  text run at (2,56) width 27: "C23"
+              RenderTableCell {TD} at (61,11) size 32x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 185x22
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+            RenderTableRow {TR} at (0,22) size 93x54
+              RenderTableCell {TD} at (0,38) size 31x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (153,22) size 32x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (61,38) size 32x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x18
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,44) size 185x22
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,76) size 93x22
+              RenderTableCell {TD} at (0,76) size 31x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (30,44) size 63x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (30,76) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C42"
-              RenderTableCell {TD} at (92,44) size 62x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (30,76) size 32x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C43"
-              RenderTableCell {TD} at (153,44) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (61,76) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,1858) size 769x227
+      RenderBlock {P} at (0,1890) size 769x227
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 463x18
             text run at (0,0) width 463: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -822,7 +825,7 @@ layer at (0,0) size 785x2354
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,208) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,2100) size 769x231
+      RenderBlock {P} at (0,2132) size 769x263
         RenderBlock (anonymous) at (0,0) size 769x36
           RenderText {#text} at (0,0) size 747x36
             text run at (0,0) width 571: "The following table is similar to a previous table except that the direction is right-to-left. "
@@ -883,57 +886,60 @@ layer at (0,0) size 785x2354
               RenderTableCell {TD} at (0,66) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-        RenderTable {TABLE} at (0,144) size 187x86 [bgcolor=#FFA500] [border: (1px outset #000000)]
-          RenderBlock {CAPTION} at (0,0) size 187x18
-            RenderInline {B} at (76,0) size 34x18
-              RenderText {#text} at (76,0) size 34x18
-                text run at (76,0) width 34: "after"
+        RenderTable {TABLE} at (0,144) size 95x118 [bgcolor=#FFA500] [border: (1px outset #000000)]
+          RenderBlock {CAPTION} at (0,0) size 95x18
+            RenderInline {B} at (30,0) size 34x18
+              RenderText {#text} at (30,0) size 34x18
+                text run at (30,0) width 34: "after"
           RenderTableCol {COLGROUP} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
             RenderTableCol {COL} at (0,0) size 0x0
-          RenderTableSection {TBODY} at (1,19) size 185x66
-            RenderTableRow {TR} at (0,0) size 185x22
-              RenderTableCell {TD} at (153,0) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
+          RenderTableSection {TBODY} at (1,19) size 93x98
+            RenderTableRow {TR} at (0,0) size 93x22
+              RenderTableCell {TD} at (61,0) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C11"
-              RenderTableCell {TD} at (92,0) size 62x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x18
-                  text run at (32,2) width 28: "C12"
-              RenderTableCell {TD} at (30,0) size 63x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x18
-                  text run at (32,2) width 28: "C13"
+              RenderTableCell {TD} at (61,0) size 0x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
+                RenderText {#text} at (-25,2) size 27x18
+                  text run at (-24,2) width 26: "C12"
+              RenderTableCell {TD} at (30,0) size 32x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,2) size 27x18
+                  text run at (2,2) width 27: "C13"
               RenderTableCell {TD} at (0,0) size 31x22 [border: (1px inset #000000)] [r=0 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 185x0
-              RenderTableCell {TD} at (153,11) size 32x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,22) size 93x0
+              RenderTableCell {TD} at (61,11) size 32x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C21"
-              RenderTableCell {TD} at (30,22) size 124x22 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
-                RenderText {#text} at (2,2) size 119x18
-                  text run at (2,2) width 119: "C12 C13 C22 C23"
+              RenderTableCell {TD} at (30,11) size 32x76 [border: (1px inset #000000)] [r=1 c=1 rs=2 cs=2]
+                RenderText {#text} at (2,-9) size 27x72
+                  text run at (2,2) width 27: "C12"
+                  text run at (2,20) width 27: "C13"
+                  text run at (2,38) width 27: "C22"
+                  text run at (2,56) width 27: "C23"
               RenderTableCell {TD} at (0,11) size 31x22 [border: (1px inset #000000)] [r=1 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,-9) size 27x18
                   text run at (2,2) width 27: "C14"
-            RenderTableRow {TR} at (0,22) size 185x22
-              RenderTableCell {TD} at (153,22) size 32x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+            RenderTableRow {TR} at (0,22) size 93x54
+              RenderTableCell {TD} at (61,38) size 32x22 [border: (1px inset #000000)] [r=2 c=0 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x18
                   text run at (2,2) width 27: "C31"
-              RenderTableCell {TD} at (0,22) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
-                RenderText {#text} at (2,2) size 27x18
+              RenderTableCell {TD} at (0,38) size 31x22 [border: (1px inset #000000)] [r=2 c=3 rs=1 cs=1]
+                RenderText {#text} at (2,18) size 27x18
                   text run at (2,2) width 27: "C34"
-            RenderTableRow {TR} at (0,44) size 185x22
-              RenderTableCell {TD} at (153,44) size 32x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,76) size 93x22
+              RenderTableCell {TD} at (61,76) size 32x22 [border: (1px inset #000000)] [r=3 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C41"
-              RenderTableCell {TD} at (92,44) size 62x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x18
-                  text run at (32,2) width 28: "C42"
-              RenderTableCell {TD} at (30,44) size 63x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
-                RenderText {#text} at (32,2) size 28x18
-                  text run at (32,2) width 28: "C43"
-              RenderTableCell {TD} at (0,44) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (61,76) size 0x22 [border: (1px inset #000000)] [r=3 c=1 rs=1 cs=1]
+                RenderText {#text} at (-25,2) size 27x18
+                  text run at (-24,2) width 26: "C42"
+              RenderTableCell {TD} at (30,76) size 32x22 [border: (1px inset #000000)] [r=3 c=2 rs=1 cs=1]
+                RenderText {#text} at (2,2) size 27x18
+                  text run at (2,2) width 27: "C43"
+              RenderTableCell {TD} at (0,76) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"


### PR DESCRIPTION
#### 3ea149a5173afeffcbc8a96e7f28b977fe6868a5
<pre>
Fix table layout to properly handle visibility:collapse on columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=305905">https://bugs.webkit.org/show_bug.cgi?id=305905</a>
<a href="https://rdar.apple.com/168556786">rdar://168556786</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Columns with visibility:collapse should not contribute to table width
calculations. This patch modifies AutoTableLayout to:

1. Skip collapsed columns in recalcColumn() by setting their min/max
   widths to 0 early.

2. Skip collapsed columns throughout layout() when distributing
   available width to columns.

3. Skip adding border-spacing after collapsed columns when calculating
   column positions.

Previously, collapsed columns were treated as normal columns and
received width allocation, causing tables to be wider than expected.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-004-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-col-005-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-colspan-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-rowcol-002-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt:
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::recalcColumn):
(WebCore::AutoTableLayout::layout):

Canonical link: <a href="https://commits.webkit.org/305997@main">https://commits.webkit.org/305997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f46301207ba798c316b49db5238ea62f8dc86f0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148208 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b7e4b47-d4a1-4553-83b1-92fde3481b8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12595 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69ada1e7-f37e-4a06-9fe0-004dc991a001) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10111 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88112 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a988ee17-64c9-41a2-9ab6-a75db31696e5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7292 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8494 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150996 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12141 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10779 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12171 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/11958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->