### PR TITLE
[Win] Fix JSCOnly build on Windows

### DIFF
--- a/Source/JavaScriptCore/PlatformJSCOnly.cmake
+++ b/Source/JavaScriptCore/PlatformJSCOnly.cmake
@@ -37,3 +37,10 @@ if (USE_LIBBACKTRACE)
         LIBBACKTRACE::LIBBACKTRACE
     )
 endif ()
+
+if (WIN32)
+    # WasmDebugServer uses winsock functions
+    list(APPEND JavaScriptCore_LIBRARIES
+        ws2_32
+    )
+endif ()

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -19,12 +19,16 @@ if (WIN32)
         win/PathWalker.cpp
         win/SignalsWin.cpp
         win/ThreadingWin.cpp
+        win/WTFCRTDebug.cpp
         win/Win32Handle.cpp
     )
     list(APPEND WTF_LIBRARIES
         DbgHelp
         shlwapi
         winmm
+    )
+    list(APPEND WTF_PUBLIC_HEADERS
+        win/WTFCRTDebug.h
     )
 else ()
     list(APPEND WTF_SOURCES

--- a/Source/cmake/OptionsJSCOnly.cmake
+++ b/Source/cmake/OptionsJSCOnly.cmake
@@ -73,6 +73,10 @@ if (WIN32)
     # FIXME: warning STL4042: std::float_denorm_style, std::numeric_limits::has_denorm, and std::numeric_limits::has_denorm_loss are deprecated in C++23.
     add_definitions(-D_SILENCE_CXX23_DENORM_DEPRECATION_WARNING)
 
+    # If <winsock2.h> is not included before <windows.h> redefinition errors occur
+    # unless _WINSOCKAPI_ is defined before <windows.h> is included
+    add_definitions(-D_WINSOCKAPI_=)
+
     if (DEFINED ENV{WEBKIT_IGNORE_PATH})
         set(CMAKE_IGNORE_PATH $ENV{WEBKIT_IGNORE_PATH})
     endif ()
@@ -84,7 +88,6 @@ if (WIN32)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
-    set(CMAKE_DISABLE_PRECOMPILE_HEADERS OFF)
 endif ()
 
 if (ENABLE_JSC_GLIB_API)


### PR DESCRIPTION
#### 2d96c99b553946b611978b26dd1f83a8b68be10a
<pre>
[Win] Fix JSCOnly build on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=305906">https://bugs.webkit.org/show_bug.cgi?id=305906</a>

Reviewed by Yusuke Suzuki.

This patch changes for following changes:

- Add _WINSOCKAPI_ to prevent winsock2.h/windows.h redefinition errors
- Add WTFCRTDebug.cpp/h for WTF Windows support
- Link ws2_32 for WasmDebugServer socket functions
- Remove CMAKE_DISABLE_PRECOMPILE_HEADERS OFF to avoid Ninja+clang-cl PCH race

* Source/JavaScriptCore/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/cmake/OptionsJSCOnly.cmake:

Canonical link: <a href="https://commits.webkit.org/305923@main">https://commits.webkit.org/305923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03b4ad22b0b9c4bbed06d8ad719692a4e80f5696

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/147968 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107069 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87942 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9602 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7107 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8258 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150752 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/622 "Found 1 new JSC stress test failure: stress/re-enter-resolve-rope-string.js.no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11892 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115482 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29418 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10572 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121703 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1182 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171098 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75621 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->