### PR TITLE
REGRESSION(304651@main): wpt /webauthn/createcredential-passing.https.html, /webauthn/getcredential-passing.https.html

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt
@@ -1,6 +1,7 @@
 
 PASS PublicKeyCredential's [[get]] calling toJSON on the result.
 PASS PublicKeyCredential's [[get]] with minimum options in a mock hid authenticator.
+PASS PublicKeyCredential's [[get]] with invalid userVerification value in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with matched allow credentials in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with userVerification { preferred } in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with userVerification { discouraged } in a mock hid authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html
@@ -52,6 +52,20 @@
         const options = {
             publicKey: {
                 challenge: Base64URL.parse("MTIzNDU2"),
+                userVerification: "baloney",
+                timeout: 100
+            }
+        };
+
+        return navigator.credentials.get(options).then(credential => {
+            return checkCtapGetAssertionResult(credential);
+        });
+    }, "PublicKeyCredential's [[get]] with invalid userVerification value in a mock hid authenticator.");
+
+    promise_test(t => {
+        const options = {
+            publicKey: {
+                challenge: Base64URL.parse("MTIzNDU2"),
                 allowCredentials: [
                     { type: "public-key", id: Base64URL.parse(testHidCredentialIdBase64), transports: ["usb"] }
                 ],

--- a/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.idl
@@ -32,5 +32,5 @@
     [PermissiveInvalidValue] AuthenticatorAttachment authenticatorAttachment;
     [PermissiveInvalidValue] ResidentKeyRequirement  residentKey;
     boolean                                          requireResidentKey = false;
-    UserVerificationRequirement                      userVerification = "preferred";
+    [PermissiveInvalidValue] UserVerificationRequirement                      userVerification = "preferred";
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
@@ -38,7 +38,7 @@
     unsigned long timeout;
     sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
     AuthenticatorSelectionCriteria authenticatorSelection;
-    AttestationConveyancePreference attestation = "none";
+    [PermissiveInvalidValue] AttestationConveyancePreference attestation = "none";
     AuthenticationExtensionsClientInputs extensions;
 };
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
@@ -33,6 +33,6 @@
     unsigned long timeout;
     DOMString rpId;
     sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-    UserVerificationRequirement userVerification = "preferred";
+    [PermissiveInvalidValue] UserVerificationRequirement userVerification = "preferred";
     AuthenticationExtensionsClientInputs extensions;
 };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "JSDOMConvertDictionary.h"
+#include "JSDOMConvertEnumeration.h"
 #include "TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.h"
 
 namespace WebCore {
@@ -28,5 +29,12 @@ namespace WebCore {
 template<> ConversionResult<IDLDictionary<TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability>> convertDictionary<TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability>(JSC::JSGlobalObject&, JSC::JSValue);
 
 JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject&, JSDOMGlobalObject&, const TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability&);
+
+String convertEnumerationToString(TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum);
+template<> JSC::JSString* convertEnumerationToJS(JSC::VM&, TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum);
+
+template<> std::optional<TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum> parseEnumerationFromString<TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum>(const String&);
+template<> std::optional<TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum> parseEnumeration<TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> ASCIILiteral expectedEnumerationValues<TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum>();
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.idl
+++ b/Source/WebCore/bindings/scripts/test/TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.idl
@@ -22,6 +22,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+enum TestLegacyEnum { "value1", "value2" };
+
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
@@ -29,4 +31,6 @@
 ] dictionary TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability {
     required Node requiredInterfaceMember;
     Node optionalInterfaceMember;
+    [PermissiveInvalidValue] TestLegacyEnum permissiveEnumMember;
+    [PermissiveInvalidValue] TestLegacyEnum permissiveEnumMemberWithDefault = "value1";
 };

--- a/Source/WebCore/bindings/scripts/test/TestStandaloneDictionary.idl
+++ b/Source/WebCore/bindings/scripts/test/TestStandaloneDictionary.idl
@@ -39,6 +39,7 @@ enum TestEnumInStandaloneDictionaryFile { "enumValue1", "enumValue2" };
     DOMString stringMember;
     TestEnumInStandaloneDictionaryFile enumMember;
     [PermissiveInvalidValue] TestEnumInStandaloneDictionaryFile permissiveEnumMember;
+    [PermissiveInvalidValue] TestEnumInStandaloneDictionaryFile permissiveEnumMemberWithDefault = "enumValue1";
     VoidCallback callbackMember;
     (TestEnumInStandaloneDictionaryFile or double) unionMemberWithDefaultValue = "enumValue1";
     (DOMString or boolean)? nullableUnionWithNullDefaultValue = null;


### PR DESCRIPTION
#### 31f32eac0f4dcc2f277f6b24b3dd089b993e5665
<pre>
REGRESSION(304651@main): wpt /webauthn/createcredential-passing.https.html, /webauthn/getcredential-passing.https.html
<a href="https://rdar.apple.com/168533890">rdar://168533890</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305872">https://bugs.webkit.org/show_bug.cgi?id=305872</a>

Reviewed by Chris Dumez.

These tests regressed because [PermissiveInvalidValue] was not fully implemented
for enum dictionary members with default values. The attribute worked correctly
for enums without defaults, but enums with defaults (like userVerification = &quot;preferred&quot;
and attestation = &quot;none&quot;) still used the throwing conversion path.

This change:
- Adds GetPermissiveEnumDefault helper to centralize enum class name and default value extraction
- Implements PermissiveInvalidValue handling in GenerateDictionaryImplementationMemberConversion
  (aggregate initialization path) for enums with defaults
- Implements PermissiveInvalidValue handling in GenerateConvertDictionaryForLegacyNativeDictionaryRequiredInterfaceNullability
  (in-place assignment path) for enums with defaults - this was the missing case affecting WebAuthn

For invalid enum values, the generated code now uses parseEnumeration&lt;&gt;() which returns
std::optional, then falls back to the default via value_or() instead of throwing TypeError.

* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-hid.https.html:
* Source/WebCore/Modules/webauthn/AuthenticatorSelectionCriteria.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GetPermissiveEnumDefault):
(GenerateDictionaryImplementationMemberConversion):
(GenerateConvertDictionaryForLegacyNativeDictionaryRequiredInterfaceNullability):
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.cpp:
(WebCore::convertDictionary&lt;TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability&gt;):
(WebCore::convertDictionaryToJS):
(WebCore::convertEnumerationToString):
(WebCore::convertEnumerationToJS):
(WebCore::parseEnumerationFromString&lt;TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum&gt;):
(WebCore::parseEnumeration&lt;TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum&gt;):
(WebCore::expectedEnumerationValues&lt;TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability::LegacyEnum&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
(WebCore::convertDictionary&lt;DictionaryImplName&gt;):
(WebCore::convertDictionaryToJS):
* Source/WebCore/bindings/scripts/test/TestDictionaryLegacyNativeDictionaryRequiredInterfaceNullability.idl:
* Source/WebCore/bindings/scripts/test/TestStandaloneDictionary.idl:

Canonical link: <a href="https://commits.webkit.org/306287@main">https://commits.webkit.org/306287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2cbf443a07fa178c205d24d48f14f1f2ee72dcb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149339 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14006 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13448 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108125 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143863 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89026 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7990 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9346 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151875 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12997 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/116696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29673 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/12765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13025 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12764 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76726 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/12808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->