### PR TITLE
[JSC][WASM][Debugger] Use RunLoop dispatch to handle Stop-The-World for idle VMs

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2293,6 +2293,7 @@
 		FFD49E722E276CA10083E383 /* WasmExecutionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5C2E276CA10083E383 /* WasmExecutionHandler.h */; };
 		FFD49E732E276CA10083E383 /* WasmDebugServerUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E642E276CA10083E383 /* WasmDebugServerUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFD49E742E276CA10083E383 /* WasmMemoryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5E2E276CA10083E383 /* WasmMemoryHandler.h */; };
+		FFE0C0472F24802E00198308 /* ExecutionHandlerIdleStopTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFE0C0462F24802E00198308 /* ExecutionHandlerIdleStopTest.cpp */; };
 		FFE21FE52CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */; };
 		FFE31BDB2E6212CD006FE0B7 /* WasmVirtualAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = FFE31BDA2E6212CD006FE0B7 /* WasmVirtualAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */; };
@@ -6379,6 +6380,8 @@
 		FFD49E612E276CA10083E383 /* WasmQueryHandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmQueryHandler.cpp; sourceTree = "<group>"; };
 		FFD49E642E276CA10083E383 /* WasmDebugServerUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmDebugServerUtilities.h; sourceTree = "<group>"; };
 		FFD49E652E276CA10083E383 /* WasmDebugServerUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmDebugServerUtilities.cpp; sourceTree = "<group>"; };
+		FFE0C0452F24802E00198308 /* ExecutionHandlerIdleStopTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerIdleStopTest.h; sourceTree = "<group>"; };
+		FFE0C0462F24802E00198308 /* ExecutionHandlerIdleStopTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionHandlerIdleStopTest.cpp; sourceTree = "<group>"; };
 		FFE21FE32CC1BE1800DEC268 /* DFGLoopUnrollingPhase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGLoopUnrollingPhase.h; path = dfg/DFGLoopUnrollingPhase.h; sourceTree = "<group>"; };
 		FFE21FE42CC1BE1800DEC268 /* DFGLoopUnrollingPhase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGLoopUnrollingPhase.cpp; path = dfg/DFGLoopUnrollingPhase.cpp; sourceTree = "<group>"; };
 		FFE31BDA2E6212CD006FE0B7 /* WasmVirtualAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmVirtualAddress.h; sourceTree = "<group>"; };
@@ -10597,6 +10600,8 @@
 			children = (
 				FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */,
 				FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */,
+				FFE0C0462F24802E00198308 /* ExecutionHandlerIdleStopTest.cpp */,
+				FFE0C0452F24802E00198308 /* ExecutionHandlerIdleStopTest.h */,
 				FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */,
 				FFE88B9C2EC96CA700C9F5E2 /* ExecutionHandlerTest.h */,
 				FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */,
@@ -13868,6 +13873,7 @@
 			files = (
 				FFA2E02D2EA16F37006661A3 /* BinaryTests.cpp in Sources */,
 				FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */,
+				FFE0C0472F24802E00198308 /* ExecutionHandlerIdleStopTest.cpp in Sources */,
 				FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */,
 				FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */,
 				FF1344662EB3F2A600940C00 /* ExtGCTests.cpp in Sources */,

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -322,6 +322,9 @@ private:
     void incrementActiveVMs(VM&) WTF_REQUIRES_LOCK(m_worldLock);
     void decrementActiveVMs(VM&) WTF_REQUIRES_LOCK(m_worldLock);
 
+    void dispatchStopHandler(VM&);
+    void handleStopViaDispatch(VM&);
+
     JS_EXPORT_PRIVATE static bool isValidVMSlow(VM*);
     JS_EXPORT_PRIVATE VM* findMatchingVMImpl(const ScopedLambda<TestCallback>&);
     JS_EXPORT_PRIVATE void forEachVMImpl(const ScopedLambda<IteratorCallback>&);

--- a/Source/JavaScriptCore/shell/CMakeLists.txt
+++ b/Source/JavaScriptCore/shell/CMakeLists.txt
@@ -86,6 +86,7 @@ if (DEVELOPER_MODE)
 
         ../wasm/debugger/tests/BinaryTests.cpp
         ../wasm/debugger/tests/ControlFlowTests.cpp
+        ../wasm/debugger/tests/ExecutionHandlerIdleStopTest.cpp
         ../wasm/debugger/tests/ExecutionHandlerTest.cpp
         ../wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
         ../wasm/debugger/tests/ExtGCTests.cpp

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerIdleStopTest.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerIdleStopTest.cpp
@@ -1,0 +1,456 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ExecutionHandlerIdleStopTest.h"
+
+#include <wtf/DataLog.h>
+
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
+
+#include "Completion.h"
+#include "ExecutionHandlerTestSupport.h"
+#include "JSCJSValue.h"
+#include "JSCJSValueInlines.h"
+#include "JSGlobalObject.h"
+#include "JSLock.h"
+#include "Protect.h"
+#include "SourceCode.h"
+#include "SourceOrigin.h"
+#include "Structure.h"
+#include "StructureInlines.h"
+#include "VM.h"
+#include "VMManager.h"
+#include "WasmDebugServer.h"
+#include "WasmExecutionHandler.h"
+#include <wtf/Condition.h>
+#include <wtf/Lock.h>
+#include <wtf/Threading.h>
+#include <wtf/URL.h>
+#include <wtf/Vector.h>
+
+namespace ExecutionHandlerIdleStopTest {
+
+using ExecutionHandlerTestSupport::setupTestEnvironment;
+using JSC::VM;
+using JSC::VMManager;
+using JSC::Wasm::DebugServer;
+using JSC::Wasm::ExecutionHandler;
+
+// ========== Test Configuration ==========
+
+static constexpr bool verboseLogging = false;
+static constexpr unsigned STRESS_TEST_ITERATIONS = 10000;
+static constexpr ASCIILiteral WORKER_THREAD_NAME = "RunLoopDispatchTestVM"_s;
+
+// ========== Test Runtime State ==========
+
+static int failuresFound = 0;
+static DebugServer* debugServer = nullptr;
+static ExecutionHandler* executionHandler = nullptr;
+static std::atomic<bool> doneTesting = false;
+
+#define TEST_LOG(...) dataLogLn(__VA_ARGS__)
+#define VLOG(...) dataLogLnIf(verboseLogging, __VA_ARGS__)
+
+#define CHECK(condition, ...)                                   \
+    do {                                                        \
+        if (!(condition)) {                                     \
+            dataLogLn("FAIL: ", #condition, ": ", __VA_ARGS__); \
+            dataLogLn("    @ " __FILE__, ":", __LINE__);        \
+            failuresFound++;                                    \
+            return;                                             \
+        }                                                       \
+    } while (false)
+
+// ========== SIMPLE VM TASK ==========
+
+// Control when VM starts executing (becomes active)
+static std::atomic<bool> runVM = false;
+
+// Signaling for VM construction completion
+static Lock vmReadyLock;
+static Condition vmReadyCondition;
+static bool vmReady = false;
+
+static void simpleVMTask()
+{
+    VLOG("[VMThread] Starting VM construction");
+    // Create VM once - RunLoop dispatch will handle both active and idle states
+    VM& vm = VM::create(JSC::HeapType::Large).leakRef();
+    JSC::JSGlobalObject* globalObject = nullptr;
+
+    {
+        JSC::JSLockHolder locker(vm);
+        globalObject = JSC::JSGlobalObject::create(vm, JSC::JSGlobalObject::createStructure(vm, JSC::jsNull()));
+        gcProtect(globalObject);
+
+        // Signal that VM is fully constructed and ready
+        {
+            Locker locker { vmReadyLock };
+            vmReady = true;
+            vmReadyCondition.notifyOne();
+        }
+        VLOG("[VMThread] VM constructed and ready");
+    } // Release API lock - VM is now truly idle without lock
+
+    // Keep VM alive and execute script when signaled
+    while (!doneTesting.load()) {
+        VLOG("[VMThread] Top of loop, runVM=", runVM.load(), ", doneTesting=", doneTesting.load());
+
+        // Wait for signal to execute (exchange atomically reads and resets flag)
+        // Process RunLoop events while idle to handle dispatch callbacks
+        // IMPORTANT: API lock is NOT held here - VM is truly idle
+        while (!runVM.exchange(false) && !doneTesting.load())
+            WTF::RunLoop::cycle(DefaultRunLoopMode);
+
+        VLOG("[VMThread] After wait loop, doneTesting=", doneTesting.load());
+        if (doneTesting.load()) {
+            VLOG("[VMThread] doneTesting detected, breaking loop");
+            break;
+        }
+
+        VLOG("[VMThread] About to execute script");
+        // Execute simple script - VM becomes active (calls notifyVMActivation)
+        {
+            JSC::JSLockHolder locker(vm);
+            JSC::SourceOrigin origin(URL({ }, "test"_s));
+            JSC::SourceCode sourceCode = JSC::makeSource("1 + 1"_s, origin, JSC::SourceTaintedOrigin::Untainted);
+
+            NakedPtr<JSC::Exception> exception;
+            JSC::evaluate(globalObject, sourceCode, JSC::JSValue(), exception);
+            VLOG("[VMThread] Script execution completed");
+        } // Release API lock - VM becomes idle again
+
+        // Script finished - VM becomes idle again
+    }
+
+    // Manually release the VM reference to trigger destructor
+    {
+        JSC::JSLockHolder locker(vm);
+        gcUnprotect(globalObject);
+        vm.derefSuppressingSaferCPPChecking();
+    }
+
+    VLOG("[VMThread] Exiting simpleVMTask");
+}
+
+// ========== HELPER FUNCTIONS ==========
+
+static void waitForVMConstruction()
+{
+    Locker locker { vmReadyLock };
+    while (!vmReady)
+        vmReadyCondition.wait(vmReadyLock);
+}
+
+static void waitForVMCleanup()
+{
+    VLOG("Waiting for VM from previous test to be destroyed...");
+    bool cleanedUp = ExecutionHandlerTestSupport::waitForCondition([]() {
+        return !VMManager::info().numberOfVMs;
+    });
+
+    if (!cleanedUp)
+        TEST_LOG("WARNING: VM not cleaned up within timeout (count: ", VMManager::info().numberOfVMs, ")");
+    else
+        VLOG("VM cleaned up successfully");
+}
+
+static bool isRunning()
+{
+    auto info = VMManager::info();
+    return info.worldMode == VMManager::Mode::RunAll;
+}
+
+static bool isStopped()
+{
+    auto info = VMManager::info();
+    return info.worldMode == VMManager::Mode::Stopped;
+}
+
+// ========== ORDERING 1: VM Enter → Interrupt → Continue ==========
+// VM becomes active, then gets interrupted
+
+static void testOrderingVMEnterInterruptContinue()
+{
+    TEST_LOG("\n=== Ordering: VM Enter → Interrupt → Continue ===");
+    TEST_LOG("VM signaled to run, then interrupted");
+
+    // Create ONE VM thread that will be reused for all iterations
+    runVM = false;
+    vmReady = false;
+    RefPtr<Thread> vmThread = Thread::create(WORKER_THREAD_NAME, simpleVMTask);
+
+    // Wait for VM to be fully constructed and idle
+    waitForVMConstruction();
+
+    unsigned successCount = 0;
+
+    for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
+        VLOG("[Test1][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+
+        // Signal VM to execute (becomes active)
+        runVM = true;
+
+        // Interrupt - may catch VM while active or before it starts
+        executionHandler->interrupt();
+
+        // Verify we got a stop (either trap or RunLoop dispatch callback)
+        CHECK(isStopped(), "Should be stopped after interrupt");
+        auto info = VMManager::info();
+        VLOG("[Test1][Iter ", i, "] After interrupt: worldMode=", (int)info.worldMode, ", numberOfVMs=", info.numberOfVMs, ", numberOfActiveVMs=", info.numberOfActiveVMs);
+
+        // Continue
+        executionHandler->resume();
+
+        // Verify world is running
+        CHECK(isRunning(), "Should be running after resume");
+
+        successCount++;
+        VLOG("[Test1][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+    }
+
+    TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
+
+    // Cleanup
+    doneTesting = true;
+    runVM = true;
+    vmThread->waitForCompletion();
+    waitForVMCleanup();
+    executionHandler->reset();
+    doneTesting = false;
+}
+
+// ========== ORDERING 2: Interrupt → VM Enter → Continue ==========
+// Interrupt while idle, VM becomes active during stop
+
+static void testOrderingInterruptVMEnterContinue()
+{
+    TEST_LOG("\n=== Ordering: Interrupt → VM Enter → Continue ===");
+    TEST_LOG("VM enters at various points during interrupt");
+
+    // Create ONE VM thread that will be reused for all iterations
+    runVM = false;
+    vmReady = false;
+    RefPtr<Thread> vmThread = Thread::create(WORKER_THREAD_NAME, simpleVMTask);
+
+    // Wait for VM to be fully constructed and idle
+    waitForVMConstruction();
+
+    unsigned successCount = 0;
+
+    for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
+        VLOG("[Test2][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+
+        // Interrupt FIRST (VM idle, not executing)
+        // RunLoop dispatch will handle callback delivery
+        executionHandler->interrupt();
+
+        // Verify we got a stop (via RunLoop dispatch since VM was idle)
+        CHECK(isStopped(), "Should be stopped after interrupt");
+        auto info = VMManager::info();
+        VLOG("[Test2][Iter ", i, "] After interrupt: worldMode=", (int)info.worldMode);
+
+        // Signal VM to start executing (natural timing creates races)
+        runVM = true;
+        VLOG("[Test2][Iter ", i, "] Signaled VM to run");
+
+        // Continue (VM may become active before, during, or after this call)
+        executionHandler->resume();
+        VLOG("[Test2][Iter ", i, "] After resume");
+
+        // Verify resume completed correctly
+        CHECK(isRunning(), "Should be running after resume");
+
+        successCount++;
+        VLOG("[Test2][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+    }
+
+    TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
+
+    // Cleanup
+    doneTesting = true;
+    runVM = true;
+    vmThread->waitForCompletion();
+    waitForVMCleanup();
+    executionHandler->reset();
+    doneTesting = false;
+}
+
+// ========== ORDERING 3: Interrupt → Continue → VM Enter ==========
+// VM enters after resume completes
+
+static void testOrderingInterruptContinueVMEnter()
+{
+    TEST_LOG("\n=== Ordering: Interrupt → Continue → VM Enter ===");
+    TEST_LOG("VM enters after resume completes");
+
+    // Create ONE VM thread that will be reused for all iterations
+    runVM = false;
+    vmReady = false;
+    RefPtr<Thread> vmThread = Thread::create(WORKER_THREAD_NAME, simpleVMTask);
+
+    // Wait for VM to be fully constructed and idle
+    waitForVMConstruction();
+
+    unsigned successCount = 0;
+
+    for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
+        VLOG("[Test3][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+
+        // Interrupt FIRST (VM should be idle)
+        executionHandler->interrupt();
+
+        // Verify we got a stop
+        CHECK(isStopped(), "Should be stopped after interrupt");
+        auto info = VMManager::info();
+        VLOG("[Test3][Iter ", i, "] After interrupt: worldMode=", (int)info.worldMode);
+
+        // Continue BEFORE VM starts executing
+        executionHandler->resume();
+        VLOG("[Test3][Iter ", i, "] After resume");
+
+        // Verify world is running
+        CHECK(isRunning(), "Should be running after resume");
+
+        // Signal VM to start executing AFTER resume
+        runVM = true;
+        VLOG("[Test3][Iter ", i, "] Signaled VM to run");
+
+        // VM should be running normally (not stopped)
+        info = VMManager::info();
+        CHECK(info.worldMode == VMManager::Mode::RunAll, "World should remain running");
+        CHECK(info.numberOfVMs >= 1, "VM should be running");
+
+        successCount++;
+        VLOG("[Test3][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+    }
+
+    TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
+
+    // Cleanup
+    doneTesting = true;
+    runVM = true;
+    vmThread->waitForCompletion();
+    waitForVMCleanup();
+    executionHandler->reset();
+    doneTesting = false;
+}
+
+// ========== ORDERING 4: Idle VM Interrupt/Resume Loops ==========
+// VM stays idle throughout - pure RunLoop dispatch testing
+
+static void testIdleVMInterruptResumeLoops()
+{
+    TEST_LOG("\n=== Idle VM Interrupt/Resume Loops ===");
+    TEST_LOG("VM remains idle, interrupt/resume via RunLoop dispatch only");
+
+    // Create ONE VM thread that will remain idle the entire test
+    runVM = false;
+    vmReady = false;
+    RefPtr<Thread> vmThread = Thread::create(WORKER_THREAD_NAME, simpleVMTask);
+
+    // Wait for VM to be fully constructed and idle
+    waitForVMConstruction();
+
+    unsigned successCount = 0;
+
+    for (unsigned i = 0; i < STRESS_TEST_ITERATIONS; ++i) {
+        VLOG("[Test4][Iter ", i, "] start >>>>>>>>>>>>>>>>>>>>>>> ");
+
+        // Interrupt while VM is idle - ONLY RunLoop dispatch can handle this
+        executionHandler->interrupt();
+
+        // Verify we got a stop (via RunLoop dispatch callback)
+        CHECK(isStopped(), "Should be stopped after interrupt");
+        auto info = VMManager::info();
+        VLOG("[Test4][Iter ", i, "] After interrupt: worldMode=", (int)info.worldMode, ", numberOfVMs=", info.numberOfVMs, ", numberOfActiveVMs=", info.numberOfActiveVMs);
+
+        // Resume
+        executionHandler->resume();
+
+        // Verify world is running
+        CHECK(isRunning(), "Should be running after resume");
+
+        // VM stays idle - never signal runVM = true
+        // This ensures we're testing pure RunLoop dispatch without any trap checking
+
+        successCount++;
+        VLOG("[Test4][Iter ", i, "] end <<<<<<<<<<<<<<<<<<<<<<<<< ");
+    }
+
+    TEST_LOG("PASS: ", successCount, "/", STRESS_TEST_ITERATIONS, " iterations succeeded");
+
+    // Cleanup
+    doneTesting = true;
+    runVM = true; // Allow thread to exit
+    vmThread->waitForCompletion();
+    waitForVMCleanup();
+    executionHandler->reset();
+    doneTesting = false;
+}
+
+// ========== MAIN TEST RUNNER ==========
+
+UNUSED_FUNCTION static int runIdleVMStopStressTests()
+{
+    TEST_LOG("========================================");
+    TEST_LOG("Idle VM Stress Tests");
+    TEST_LOG("Testing Interrupt/Resume Race Scenarios");
+    TEST_LOG("========================================");
+
+    setupTestEnvironment(debugServer, executionHandler);
+
+    // Run the 4 core orderings - all should work uniformly with RunLoop dispatch
+    testOrderingVMEnterInterruptContinue(); // VM active when interrupted
+    testOrderingInterruptVMEnterContinue(); // VM enters during interrupt
+    testOrderingInterruptContinueVMEnter(); // VM enters after resume
+    testIdleVMInterruptResumeLoops(); // VM stays idle throughout
+
+    TEST_LOG("\n========================================");
+    TEST_LOG(failuresFound ? "FAIL" : "PASS", " - Idle VM Stress Tests");
+    TEST_LOG("Total Failures: ", failuresFound);
+    TEST_LOG("========================================");
+
+    return failuresFound;
+}
+
+#undef TEST_LOG
+#undef CHECK
+
+} // namespace ExecutionHandlerIdleStopTest
+
+#endif // ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR)
+
+int testExecutionHandlerIdleStop()
+{
+#if ENABLE(WEBASSEMBLY) && ENABLE(REMOTE_INSPECTOR) && CPU(ARM64)
+    return ExecutionHandlerIdleStopTest::runIdleVMStopStressTests();
+#else
+    dataLogLn("Idle VM Stress Tests SKIPPED (only supported on ARM64)");
+    return 0;
+#endif
+}

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerIdleStopTest.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerIdleStopTest.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+int testExecutionHandlerIdleStop();

--- a/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
@@ -31,6 +31,7 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
+#include "ExecutionHandlerIdleStopTest.h"
 #include "ExecutionHandlerTest.h"
 #include "GDBPacketParserTest.h"
 #include "InitializeThreading.h"
@@ -310,14 +311,18 @@ static int runAllTests()
     dataLogLn("\n--- WASM Debugger Execution Handler Tests ---");
     int executionHandlerTestsFailed = testExecutionHandler();
 
+    dataLogLn("\n--- WASM Debugger Idle VM Stress Tests ---");
+    int idleStopTestsFailed = testExecutionHandlerIdleStop();
+
     dataLogLn("===============================================");
     dataLogLn("Combined Test Results:");
     dataLogLn("  VirtualAddress Tests - PASSED (assertion-based)");
     dataLogLn("  WASM Debug Info Tests - See detailed results above");
     dataLogLn("  WASM Debugger Stress Tests - See detailed results above");
-    dataLogLn("  Total Failures: ", testsFailed, " (VirtualAddress) + ", debugInfoTestsFailed, " (Debug Info) + ", executionHandlerTestsFailed, " (Stress) = ", testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed);
+    dataLogLn("  WASM Debugger Idle VM Tests - See detailed results above");
+    dataLogLn("  Total Failures: ", testsFailed, " (VirtualAddress) + ", debugInfoTestsFailed, " (Debug Info) + ", executionHandlerTestsFailed, " (Stress) + ", idleStopTestsFailed, " (Idle VM) = ", testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed + idleStopTestsFailed);
 
-    int totalFailures = testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed;
+    int totalFailures = testsFailed + debugInfoTestsFailed + executionHandlerTestsFailed + idleStopTestsFailed;
     if (!totalFailures) {
         dataLogLn("All tests PASSED!");
         dataLogLn("WASM debugger infrastructure is working correctly");


### PR DESCRIPTION
#### b5980d315589223566316cb2953766abbf40497d
<pre>
[JSC][WASM][Debugger] Use RunLoop dispatch to handle Stop-The-World for idle VMs
<a href="https://rdar.apple.com/168561224">rdar://168561224</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305908">https://bugs.webkit.org/show_bug.cgi?id=305908</a>

Reviewed by Keith Miller.

Enable LLDB to interrupt and stop idle websites where WASM/JavaScript code
hasn&apos;t executed yet, improving the debugging experience for event-driven
web applications.

The Problem:
When LLDB sends an interrupt request, VMManager sets trap bits and expects
VMs to check their traps and call notifyVMStop(). However, idle VMs (not
executing code) never check traps - they&apos;re just processing RunLoop events.
Previously, the debugger would wait indefinitely for idle VMs to stop,
eventually timing out.

The Solution:
When requesting Stop-The-World, dispatch a callback to each VM&apos;s RunLoop.
This ensures that both active and idle VMs can be stopped:
- Active VMs: Check traps during execution and call notifyVMStop()
- Idle VMs: RunLoop processes the dispatched callback and calls notifyVMStop()
This ensures exactly one notifyVMStop() call per VM regardless of timing.

Test Coverage:
Added ExecutionHandlerIdleStopTest with test scenarios including pure
idle VM interrupt/resume loops to stress-test the RunLoop dispatch mechanism.

Canonical link: <a href="https://commits.webkit.org/306284@main">https://commits.webkit.org/306284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef9310d0bb9af079b7e445dffe2300e0bda46dc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140824 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93912 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108037 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78387 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88939 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10354 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7923 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9258 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132802 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151787 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1623 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12894 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2257 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116294 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116632 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12640 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122704 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68034 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21742 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12937 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172116 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12676 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76637 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44649 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12875 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->