### PR TITLE
[JSC] Introduce B3 WasmRefCast / WasmRefTest values

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2118,6 +2118,7 @@
 		E3C295DD1ED2CBDA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C295DC1ED2CBAA00D3016F /* ObjectPropertyChangeAdaptiveWatchpoint.h */; };
 		E3C4131D289E08EA001150F8 /* SyntheticModuleRecord.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C4131C289E08E5001150F8 /* SyntheticModuleRecord.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C694B323026877006FBE42 /* WasmOSREntryData.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C694B123026873006FBE42 /* WasmOSREntryData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E3C6BB872F20C4CB002E8D84 /* B3WasmRefTypeCheckValue.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C6BB842F20C4CB002E8D84 /* B3WasmRefTypeCheckValue.h */; };
 		E3C73A9125BFA73B00EFE303 /* WasmStreamingPlan.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C73A9025BFA73400EFE303 /* WasmStreamingPlan.h */; };
 		E3C79CAB1DB9A4DC00D1ECA4 /* DOMJITEffect.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C79CAA1DB9A4D600D1ECA4 /* DOMJITEffect.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C8ED4323A1DBCB00131958 /* IsoInlinedHeapCellType.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C8ED4223A1DBC500131958 /* IsoInlinedHeapCellType.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -6015,6 +6016,8 @@
 		E3C4630626DB5DE900896336 /* TemporalCalendarPrototype.lut.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalCalendarPrototype.lut.h; sourceTree = "<group>"; };
 		E3C694B123026873006FBE42 /* WasmOSREntryData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmOSREntryData.h; sourceTree = "<group>"; };
 		E3C694B223026874006FBE42 /* WasmTierUpCount.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmTierUpCount.cpp; sourceTree = "<group>"; };
+		E3C6BB842F20C4CB002E8D84 /* B3WasmRefTypeCheckValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = B3WasmRefTypeCheckValue.h; path = b3/B3WasmRefTypeCheckValue.h; sourceTree = "<group>"; };
+		E3C6BB852F20C4CB002E8D84 /* B3WasmRefTypeCheckValue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = B3WasmRefTypeCheckValue.cpp; path = b3/B3WasmRefTypeCheckValue.cpp; sourceTree = "<group>"; };
 		E3C73A8F25BFA73400EFE303 /* WasmStreamingPlan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmStreamingPlan.cpp; sourceTree = "<group>"; };
 		E3C73A9025BFA73400EFE303 /* WasmStreamingPlan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmStreamingPlan.h; sourceTree = "<group>"; };
 		E3C79CAA1DB9A4D600D1ECA4 /* DOMJITEffect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DOMJITEffect.h; sourceTree = "<group>"; };
@@ -6928,6 +6931,8 @@
 				53D444DB1DAF08AB00B92784 /* B3WasmAddressValue.h */,
 				5341FC6F1DAC33E500E7E4D7 /* B3WasmBoundsCheckValue.cpp */,
 				5341FC711DAC343C00E7E4D7 /* B3WasmBoundsCheckValue.h */,
+				E3C6BB852F20C4CB002E8D84 /* B3WasmRefTypeCheckValue.cpp */,
+				E3C6BB842F20C4CB002E8D84 /* B3WasmRefTypeCheckValue.h */,
 				E3952C112F1DDF5700F5BEE8 /* B3WasmStructFieldValue.cpp */,
 				E3952C102F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h */,
 				E3952C132F1DDF5700F5BEE8 /* B3WasmStructGetValue.cpp */,
@@ -10904,6 +10909,7 @@
 				0F2BBD9A1C5FF3F50023EF23 /* B3VariableValue.h in Headers */,
 				53D444DC1DAF08AB00B92784 /* B3WasmAddressValue.h in Headers */,
 				5341FC721DAC343C00E7E4D7 /* B3WasmBoundsCheckValue.h in Headers */,
+				E3C6BB872F20C4CB002E8D84 /* B3WasmRefTypeCheckValue.h in Headers */,
 				E3952C1A2F1DDF5700F5BEE8 /* B3WasmStructFieldValue.h in Headers */,
 				E3952C182F1DDF5700F5BEE8 /* B3WasmStructGetValue.h in Headers */,
 				E3952C192F1DDF5700F5BEE8 /* B3WasmStructNewValue.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -198,6 +198,7 @@ b3/B3WasmStructFieldValue.cpp
 b3/B3WasmStructGetValue.cpp
 b3/B3WasmStructNewValue.cpp
 b3/B3WasmStructSetValue.cpp
+b3/B3WasmRefTypeCheckValue.cpp
 b3/B3Width.cpp
 
 builtins/BuiltinExecutables.cpp

--- a/Source/JavaScriptCore/b3/B3Kind.h
+++ b/Source/JavaScriptCore/b3/B3Kind.h
@@ -134,6 +134,7 @@ public:
         case AtomicXchg:
         case WasmStructGet:
         case WasmStructSet:
+        case WasmRefCast:
             return true;
         default:
             return false;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -365,6 +365,8 @@ enum Opcode : uint8_t {
     WasmStructGet,
     WasmStructSet,
     WasmStructNew,
+    WasmRefCast,
+    WasmRefTest,
 
     // SIMD instructions
     VectorExtractLane,

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -843,6 +843,17 @@ public:
                 VALIDATE(value->numChildren() == 2, ("At ", *value));
                 VALIDATE(value->type() == Int64, ("At ", *value)); // returns struct pointer
                 break;
+            case WasmRefCast:
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->child(0)->type() == Int64, ("At ", *value)); // reference input
+                VALIDATE(value->type() == Int64, ("At ", *value)); // returns reference
+                break;
+            case WasmRefTest:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->child(0)->type() == Int64, ("At ", *value)); // reference input
+                VALIDATE(value->type() == Int32, ("At ", *value)); // returns boolean
+                break;
             case Upsilon:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(value->numChildren() == 1, ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -453,6 +453,8 @@ protected:
         case WasmAddress:
         case WasmBoundsCheck:
         case WasmStructGet:
+        case WasmRefCast:
+        case WasmRefTest:
         case VectorExtractLane:
         case VectorSplat:
         case VectorNot:

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -52,6 +52,7 @@
 #include "B3VariableValue.h"
 #include "B3WasmAddressValue.h"
 #include "B3WasmBoundsCheckValue.h"
+#include "B3WasmRefTypeCheckValue.h"
 #include "B3WasmStructGetValue.h"
 #include "B3WasmStructNewValue.h"
 #include "B3WasmStructSetValue.h"
@@ -175,6 +176,9 @@ namespace JSC { namespace B3 {
         return MACRO(WasmStructSetValue); \
     case WasmStructNew: \
         return MACRO(WasmStructNewValue); \
+    case WasmRefCast: \
+    case WasmRefTest: \
+        return MACRO(WasmRefTypeCheckValue); \
     case AtomicXchgAdd: \
     case AtomicXchgAnd: \
     case AtomicXchgOr: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.h
+++ b/Source/JavaScriptCore/b3/B3ValueKey.h
@@ -35,7 +35,13 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
-namespace JSC { namespace B3 {
+namespace JSC {
+
+namespace Wasm {
+class RTT;
+}
+
+namespace B3 {
 
 class Procedure;
 class Value;
@@ -100,6 +106,9 @@ public:
     ValueKey(Kind, Type, SIMDInfo, Value*, Value*, Value*);
     ValueKey(Kind, Type, SIMDInfo, Value*, uint8_t);
     ValueKey(Kind, Type, SIMDInfo, Value*, Value*, uint8_t);
+
+    ValueKey(Kind, Type, Value* child, unsigned packedFlags, const Wasm::RTT*);
+    ValueKey(Kind, Type, Value* child, unsigned packedFlags, int32_t targetHeapType);
 
     static ValueKey intConstant(Type type, int64_t value);
 
@@ -197,7 +206,8 @@ private:
 };
 
 
-} } // namespace JSC::B3
+} // namespace B3
+} // namespace JSC
 
 namespace WTF {
 

--- a/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueKeyInlines.h
@@ -30,6 +30,7 @@
 #include "B3Procedure.h"
 #include "B3Value.h"
 #include "B3ValueKey.h"
+#include "WasmTypeDefinition.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -112,6 +113,29 @@ inline ValueKey::ValueKey(Kind kind, Type type, SIMDInfo simdInfo, Value* a, Val
     u.indices[0] = a ? a->index() : UINT32_MAX;
     u.indices[1] = b ? b->index() : UINT32_MAX;
     u.indices[2] = immediate;
+}
+
+inline ValueKey::ValueKey(Kind kind, Type type, Value* child, unsigned packedFlags, const Wasm::RTT* rtt)
+    : m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = child->index();
+    u.indices[1] = packedFlags;
+    if (rtt) {
+        uint64_t rttPtr = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(rtt));
+        u.indices[2] = static_cast<unsigned>(rttPtr);
+        u.indices[3] = static_cast<unsigned>(rttPtr >> 32);
+    }
+}
+
+inline ValueKey::ValueKey(Kind kind, Type type, Value* child, unsigned packedFlags, int32_t targetHeapType)
+    : m_kind(kind)
+    , m_type(type)
+{
+    u.indices[0] = child->index();
+    u.indices[1] = packedFlags;
+    u.indices[2] = static_cast<unsigned>(targetHeapType);
+    u.indices[3] = 0;
 }
 
 inline Value* ValueKey::child(Procedure& proc, unsigned index) const

--- a/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3WasmRefTypeCheckValue.h"
+
+#if ENABLE(B3_JIT)
+
+namespace JSC::B3 {
+
+WasmRefTypeCheckValue::~WasmRefTypeCheckValue() = default;
+
+} // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+#include "B3Value.h"
+#include "WasmTypeDefinition.h"
+#include <wtf/OptionSet.h>
+#include <wtf/RefCounted.h>
+#include <wtf/StdLibExtras.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC::B3 {
+
+enum class WasmRefTypeCheckFlag : uint8_t {
+    AllowNull = 1 << 0,
+    ShouldNegate = 1 << 1, // WasmRefTest only
+    ReferenceIsNullable = 1 << 2,
+    DefinitelyIsCellOrNull = 1 << 3,
+    DefinitelyIsWasmGCObjectOrNull = 1 << 4,
+    HasRTT = 1 << 5, // Whether m_targetRTT is non-null (vs using targetHeapType)
+};
+
+class WasmRefTypeCheckValue final : public Value {
+public:
+    static bool accepts(Kind kind) { return kind.opcode() == WasmRefCast || kind.opcode() == WasmRefTest; }
+
+    ~WasmRefTypeCheckValue();
+
+    int32_t targetHeapType() const { return m_targetHeapType; }
+    bool allowNull() const { return m_flags.contains(WasmRefTypeCheckFlag::AllowNull); }
+    bool referenceIsNullable() const { return m_flags.contains(WasmRefTypeCheckFlag::ReferenceIsNullable); }
+    bool definitelyIsCellOrNull() const { return m_flags.contains(WasmRefTypeCheckFlag::DefinitelyIsCellOrNull); }
+    bool definitelyIsWasmGCObjectOrNull() const { return m_flags.contains(WasmRefTypeCheckFlag::DefinitelyIsWasmGCObjectOrNull); }
+    bool shouldNegate() const { return m_flags.contains(WasmRefTypeCheckFlag::ShouldNegate); }
+    const Wasm::RTT* targetRTT() const { return m_targetRTT.get(); }
+    OptionSet<WasmRefTypeCheckFlag> flags() const { return m_flags; }
+
+    B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(1)
+    B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
+
+protected:
+    friend class Procedure;
+    friend class Value;
+
+    template<typename... Arguments>
+    WasmRefTypeCheckValue(Kind kind, Type type, Origin origin, int32_t targetHeapType, OptionSet<WasmRefTypeCheckFlag> flags, RefPtr<const Wasm::RTT> targetRTT, Arguments... arguments)
+        : Value(CheckedOpcode, kind, type, One, origin, arguments...)
+        , m_targetHeapType(targetHeapType)
+        , m_flags(flags)
+        , m_targetRTT(WTF::move(targetRTT))
+    {
+    }
+
+    int32_t m_targetHeapType;
+    OptionSet<WasmRefTypeCheckFlag> m_flags;
+    RefPtr<const Wasm::RTT> m_targetRTT;
+};
+
+} // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -842,8 +842,8 @@ public:
     static_assert(sizeof(const RTT*) == sizeof(RefPtr<const RTT>));
     RTT() = delete;
 
-    static RefPtr<RTT> tryCreate(RTTKind, StructFieldCount fieldCount = 0);
-    static RefPtr<RTT> tryCreate(RTTKind, const RTT&, StructFieldCount fieldCount = 0);
+    static RefPtr<RTT> tryCreate(RTTKind, bool isFinalType, StructFieldCount fieldCount);
+    static RefPtr<RTT> tryCreate(RTTKind, const RTT&, bool isFinalType, StructFieldCount fieldCount);
 
     RTTKind kind() const { return m_kind; }
     DisplayCount displaySizeExcludingThis() const { return m_displaySizeExcludingThis; }
@@ -878,18 +878,20 @@ public:
 
     bool isSubRTT(const RTT& other) const;
     bool isStrictSubRTT(const RTT& other) const;
+    bool isFinalType() const { return m_isFinalType; }
 
     static constexpr ptrdiff_t offsetOfKind() { return OBJECT_OFFSETOF(RTT, m_kind); }
     static constexpr ptrdiff_t offsetOfDisplaySizeExcludingThis() { return OBJECT_OFFSETOF(RTT, m_displaySizeExcludingThis); }
     using TrailingArrayType::offsetOfData;
 
 private:
-    explicit RTT(RTTKind kind, StructFieldCount fieldCount);
-    RTT(RTTKind, const RTT& supertype, StructFieldCount fieldCount);
+    explicit RTT(RTTKind kind, bool isFinalType, StructFieldCount fieldCount);
+    RTT(RTTKind, const RTT& supertype, bool isFinalType, StructFieldCount fieldCount);
 
     const RTTKind m_kind;
-    StructFieldCount m_fieldCount { 0 };
-    unsigned m_displaySizeExcludingThis { };
+    const bool m_isFinalType { false };
+    const unsigned m_displaySizeExcludingThis { };
+    const StructFieldCount m_fieldCount { 0 };
 };
 
 inline void Type::dump(PrintStream& out) const


### PR DESCRIPTION
#### ea11204f2caf684840933f964b24f376ba7524db
<pre>
[JSC] Introduce B3 WasmRefCast / WasmRefTest values
<a href="https://bugs.webkit.org/show_bug.cgi?id=305912">https://bugs.webkit.org/show_bug.cgi?id=305912</a>
<a href="https://rdar.apple.com/168566739">rdar://168566739</a>

Reviewed by Keith Miller.

We introduce WasmRefCast and WasmRefTest B3 values. This is another
high-level B3 nodes for WasmGC. This enables data-flow analysis for wasm
GC operations in B3 finally.
The generated code is literally just moved from OMG IR generator to
B3LowerMacros. We introduce ValueKey Value::key CSE support for these
values.

Based on this high-level semantics, we start using it in ReduceStrength.
We make WasmStructGet, WasmStructSet can remove trapping bits based on
input&apos;s WasmRefCast. And WasmRefCast can make convert itself to non-nullable
based on subsequent values in the same basic block.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/B3Kind.h:
(JSC::B3::Kind::hasTraps const):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/B3ValueKey.h:
* Source/JavaScriptCore/b3/B3ValueKeyInlines.h:
(JSC::B3::ValueKey::ValueKey):
* Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.cpp: Added.
* Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h: Added.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
(JSC::Wasm::OMGIRGenerator::emitCheckOrBranchForCast): Deleted.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::RTT::RTT):
(JSC::Wasm::RTT::tryCreate):
(JSC::Wasm::TypeInformation::createCanonicalRTTForType):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:

Canonical link: <a href="https://commits.webkit.org/306061@main">https://commits.webkit.org/306061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77bc15b9e0e2b62a2ca2f57bcd031e7b2bb77f9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1791 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12815 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/148530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8713 "Failed to checkout and rebase branch from PR 56950") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132253 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151224 "Failed to checkout and rebase branch from PR 56950") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/1076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12349 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/151224 "Failed to checkout and rebase branch from PR 56950") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12360 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/151224 "Failed to checkout and rebase branch from PR 56950") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/11195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21644 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/12389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/171553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12131 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/76088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/171553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/12175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->