### PR TITLE
Reduce use of protected functions in Source/WebKit

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -27,6 +27,7 @@
 
 #include <wtf/CheckedRef.h>
 #include <wtf/RawPtrTraits.h>
+#include <wtf/TypeTraits.h>
 
 namespace WTF {
 
@@ -204,6 +205,19 @@ struct IsSmartPtr<CheckedPtr<T, U>> {
     static constexpr bool isNullable = false;
 };
 
+template<typename T, typename PtrTraits = RawPtrTraits<T>>
+    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedPtr<T, PtrTraits> protect(T* ptr)
+{
+    return CheckedPtr<T, PtrTraits>(ptr);
+}
+
+template<typename T, typename PtrTraits>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedPtr<T, PtrTraits> protect(const CheckedPtr<T, PtrTraits>& ptr)
+{
+    return ptr;
+}
+
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
 inline bool is(CheckedPtr<ArgType, ArgPtrTraits>& source)
 {
@@ -242,4 +256,5 @@ template<typename T> using PackedCheckedPtr = CheckedPtr<T, PackedPtrTraits<T>>;
 
 using WTF::CheckedPtr;
 using WTF::PackedCheckedPtr;
+using WTF::protect;
 

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -31,6 +31,7 @@
 #include <wtf/HashTraits.h>
 #include <wtf/RawPtrTraits.h>
 #include <wtf/SingleThreadIntegralWrapper.h>
+#include <wtf/TypeTraits.h>
 
 #if ASSERT_ENABLED
 #include <wtf/Threading.h>
@@ -263,6 +264,19 @@ inline const CheckedPtr<match_constness_t<ArgType, ExpectedType>> dynamicDowncas
     return dynamicDowncast<ExpectedType>(source.get());
 }
 
+template<typename T, typename PtrTraits = RawPtrTraits<T>>
+    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedRef<T, PtrTraits> protect(T& reference)
+{
+    return CheckedRef<T, PtrTraits>(reference);
+}
+
+template<typename T, typename PtrTraits>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedRef<T, PtrTraits> protect(const CheckedRef<T, PtrTraits>& reference)
+{
+    return reference;
+}
+
 template<typename P> struct CheckedRefHashTraits : SimpleClassHashTraits<CheckedRef<P>> {
     static constexpr bool emptyValueIsZero = true;
     static CheckedRef<P> emptyValue() { return HashTableEmptyValue; }
@@ -386,3 +400,4 @@ public:
 using WTF::CanMakeCheckedPtr;
 using WTF::CanMakeThreadSafeCheckedPtr;
 using WTF::CheckedRef;
+using WTF::protect;

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -504,7 +504,7 @@
 #endif
 #define IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_END }
 
-#if COMPILER(APPLE_CLANG) || defined(CLANG_WEBKIT_BRANCH) || !defined __clang_major__ || __clang_major__ >= 19
+#if COMPILER(APPLE_CLANG) || defined(CLANG_WEBKIT_BRANCH) || (defined(__clang__) && (!defined __clang_major__ || __clang_major__ >= 19))
 #define IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE_ON_MEMBER(...) IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE(__VA_ARGS__)
 #define IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE_ON_CLASS(...) IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE(__VA_ARGS__)
 #define IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE_ON_FUNCTION(...) IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE(__VA_ARGS__)
@@ -556,7 +556,7 @@
 #define SUPPRESS_UNCOUNTED_MEMBER \
     IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE_ON_MEMBER("webkit.NoUncountedMemberChecker")
 
-#if COMPILER(APPLE_CLANG) || defined(CLANG_WEBKIT_BRANCH) || !defined __clang_major__ || __clang_major__ >= 19
+#if COMPILER(APPLE_CLANG) || defined(CLANG_WEBKIT_BRANCH) || (defined(__clang__) && (!defined __clang_major__ || __clang_major__ >= 19))
 #define SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE \
     IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE("webkit.UncountedLambdaCapturesChecker")
 #define SUPPRESS_UNRETAINED_LOCAL \
@@ -567,12 +567,14 @@
     IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE("alpha.webkit.NoUnretainedMemberChecker")
 #define SUPPRESS_RETAINPTR_CTOR_ADOPT \
     IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE("alpha.webkit.RetainPtrCtorAdoptChecker")
+#define CLANG_POINTER_CONVERSION [[clang::annotate_type("webkit.pointerconversion")]]
 #else
 #define SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE
 #define SUPPRESS_UNRETAINED_LOCAL
 #define SUPPRESS_UNRETAINED_ARG
 #define SUPPRESS_UNRETAINED_MEMBER
 #define SUPPRESS_RETAINPTR_CTOR_ADOPT
+#define CLANG_POINTER_CONVERSION
 #endif
 
 // To suppress webkit.RefCntblBaseVirtualDtor, use NoVirtualDestructorBase instead.

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -33,6 +33,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/SwiftBridging.h>
 #include <wtf/TypeCasts.h>
+#include <wtf/TypeTraits.h>
 
 #if ASAN_ENABLED
 extern "C" void __asan_poison_memory_region(void const volatile *addr, size_t size);
@@ -345,6 +346,19 @@ inline Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T& reference)
     return Ref<T, _PtrTraits, RefDerefTraits>(reference, Ref<T, _PtrTraits, RefDerefTraits>::Adopt);
 }
 
+template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
+    requires HasRefPtrMemberFunctions<T>::value
+ALWAYS_INLINE CLANG_POINTER_CONVERSION Ref<T, PtrTraits, RefDerefTraits> protect(T& reference)
+{
+    return Ref<T, PtrTraits, RefDerefTraits>(reference);
+}
+
+template<typename T, typename PtrTraits, typename RefDerefTraits>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION Ref<T, PtrTraits, RefDerefTraits> protect(const Ref<T, PtrTraits, RefDerefTraits>& reference)
+{
+    return reference.copyRef();
+}
+
 template<typename ExpectedType, typename ArgType, typename PtrTraits, typename RefDerefTraits>
 inline bool is(const Ref<ArgType, PtrTraits, RefDerefTraits>& source)
 {
@@ -390,5 +404,6 @@ inline bool arePointingToEqualData(const Ref<T, PtrTraits, RefDerefTraits>& a, c
 using WTF::Ref;
 using WTF::adoptRef;
 using WTF::arePointingToEqualData;
+using WTF::protect;
 using WTF::upcast;
 using WTF::unsafeRefDowncast;

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -222,6 +222,19 @@ inline RefPtr<T, U, V> adoptRef(T* p)
     return RefPtr<T, U, V>(p, RefPtr<T, U, V>::Adopt);
 }
 
+template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
+    requires HasRefPtrMemberFunctions<T>::value
+ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, PtrTraits, RefDerefTraits> protect(T* ptr)
+{
+    return RefPtr<T, PtrTraits, RefDerefTraits>(ptr);
+}
+
+template<typename T, typename PtrTraits, typename RefDerefTraits>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, PtrTraits, RefDerefTraits> protect(const RefPtr<T, PtrTraits, RefDerefTraits>& ptr)
+{
+    return ptr.copyRef();
+}
+
 template<typename T, typename U = RawPtrTraits<T>, typename V = DefaultRefDerefTraits<T>, typename X, typename Y, typename Z>
 inline RefPtr<T, U, V> upcast(const RefPtr<X, Y, Z>& p)
 {
@@ -306,6 +319,7 @@ ALWAYS_INLINE void lazyInitialize(const RefPtr<T>& ptr, Ref<U>&& obj)
 
 using WTF::RefPtr;
 using WTF::adoptRef;
+using WTF::protect;
 using WTF::upcast;
 using WTF::unsafeRefPtrDowncast;
 using WTF::lazyInitialize;

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -318,6 +318,21 @@ template<typename T> inline RetainPtr<RetainPtrType<T>> retainPtr(T ptr)
     return ptr;
 }
 
+#ifdef __OBJC__
+template<typename T>
+    requires IsNSType<T>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION RetainPtr<RetainPtrType<T>> protect(T ptr)
+{
+    return ptr;
+}
+#endif
+
+template<typename T>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION RetainPtr<T> protect(const RetainPtr<T>& ptr)
+{
+    return ptr;
+}
+
 template<typename T> struct IsSmartPtr<RetainPtr<T>> {
     static constexpr bool value = true;
     static constexpr bool isNullable = true;
@@ -379,6 +394,7 @@ ALWAYS_INLINE void lazyInitialize(const RetainPtr<T>& ptr, RetainPtr<U>&& obj)
 using WTF::RetainPtr;
 using WTF::adoptCF;
 using WTF::lazyInitialize;
+using WTF::protect;
 using WTF::retainPtr;
 using WTF::safeCFEqual;
 using WTF::safeCFHash;

--- a/Source/WebKit/UIProcess/API/APIDataTask.cpp
+++ b/Source/WebKit/UIProcess/API/APIDataTask.cpp
@@ -64,7 +64,7 @@ DataTask::DataTask(std::optional<WebKit::DataTaskIdentifier> identifier, WeakPtr
     : m_identifier(identifier)
     , m_page(WTF::move(page))
     , m_originalURL(WTF::move(originalURL))
-    , m_networkProcess(m_page ? WeakPtr { protectedPage()->protectedWebsiteDataStore()->networkProcess() } : nullptr)
+    , m_networkProcess(m_page ? WeakPtr { protect(protectedPage()->websiteDataStore())->networkProcess() } : nullptr)
     , m_sessionID(m_page ? std::optional<PAL::SessionID> { protectedPage()->sessionID() } : std::nullopt)
     , m_client(DataTaskClient::create())
 {

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -79,7 +79,7 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, WebCore::ResourceRe
 Navigation::Navigation(WebCore::ProcessIdentifier processID, Ref<WebBackForwardListFrameItem>&& targetFrameItem, RefPtr<WebBackForwardListItem>&& fromItem, FrameLoadType backForwardFrameLoadType)
     : m_navigationID(WebCore::NavigationIdentifier::generate())
     , m_processID(processID)
-    , m_originalRequest(WTF::URL { targetFrameItem->protectedMainFrame()->url() })
+    , m_originalRequest(WTF::URL { protect(targetFrameItem->mainFrame())->url() })
     , m_currentRequest(m_originalRequest)
     , m_targetFrameItem(WTF::move(targetFrameItem))
     , m_fromItem(WTF::move(fromItem))

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -455,12 +455,12 @@ WKStringRef WKPageCopyTitle(WKPageRef pageRef)
 
 WKFrameRef WKPageGetMainFrame(WKPageRef pageRef)
 {
-    return toAPI(toProtectedImpl(pageRef)->protectedMainFrame().get());
+    return toAPI(protect(toProtectedImpl(pageRef)->mainFrame()).get());
 }
 
 WKFrameRef WKPageGetFocusedFrame(WKPageRef pageRef)
 {
-    return toAPI(toProtectedImpl(pageRef)->protectedFocusedFrame().get());
+    return toAPI(protect(toProtectedImpl(pageRef)->focusedFrame()).get());
 }
 
 WKFrameRef WKPageGetFrameSetLargestFrame(WKPageRef pageRef)
@@ -475,12 +475,12 @@ uint64_t WKPageGetRenderTreeSize(WKPageRef page)
 
 WKWebsiteDataStoreRef WKPageGetWebsiteDataStore(WKPageRef page)
 {
-    return toAPI(toProtectedImpl(page)->protectedWebsiteDataStore().ptr());
+    return toAPI(protect(toProtectedImpl(page)->websiteDataStore()).ptr());
 }
 
 WKInspectorRef WKPageGetInspector(WKPageRef pageRef)
 {
-    return toAPI(toProtectedImpl(pageRef)->protectedInspector().get());
+    return toAPI(protect(toProtectedImpl(pageRef)->inspector()).get());
 }
 
 double WKPageGetEstimatedProgress(WKPageRef pageRef)
@@ -1418,7 +1418,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         milestones.add(WebCore::LayoutMilestone::DidFirstVisuallyNonEmptyLayout);
 
     if (milestones)
-        webPageProxy->protectedLegacyMainFrameProcess()->send(Messages::WebPage::ListenForLayoutMilestones(milestones), webPageProxy->webPageIDInMainFrameProcess());
+        protect(webPageProxy->legacyMainFrameProcess())->send(Messages::WebPage::ListenForLayoutMilestones(milestones), webPageProxy->webPageIDInMainFrameProcess());
 
     webPageProxy->setLoaderClient(WTF::move(loaderClient));
 }
@@ -3034,7 +3034,7 @@ WKArrayRef WKPageCopyRelatedPages(WKPageRef pageRef)
 {
     Vector<RefPtr<API::Object>> relatedPages;
 
-    for (Ref page : toProtectedImpl(pageRef)->protectedLegacyMainFrameProcess()->pages()) {
+    for (Ref page : protect(toProtectedImpl(pageRef)->legacyMainFrameProcess())->pages()) {
         if (page.ptr() != toProtectedImpl(pageRef))
             relatedPages.append(WTF::move(page));
     }
@@ -3525,5 +3525,5 @@ void WKPageFindStringForTesting(WKPageRef pageRef, void* context, WKStringRef st
 void WKPageClearBackForwardCache(WKPageRef page)
 {
     RefPtr protectedPage = toProtectedImpl(page);
-    protectedPage->protectedBackForwardCache()->removeEntriesForPage(*protectedPage);
+    protect(protectedPage->backForwardCache())->removeEntriesForPage(*protectedPage);
 }

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -70,7 +70,7 @@ static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
 
 - (void)dealloc
 {
-    Ref { *_observer }->clearObject();
+    protect(*_observer)->clearObject();
 
     ensureOnMainRunLoop([page = WTF::move(_page), observer = std::exchange(_observer, nullptr)] {
         page->protectedPageLoadState()->removeObserver(*observer);
@@ -101,7 +101,7 @@ static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
 
 - (BOOL)_webProcessIsResponsive
 {
-    return protectedPage(self)->protectedLegacyMainFrameProcess()->isResponsive();
+    return protect(protectedPage(self)->legacyMainFrameProcess())->isResponsive();
 }
 
 - (double)estimatedProgress

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -500,7 +500,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPathsSingleton()
 
         contentNavigation = loadWebContent(webView.get());
         if (!finished)
-            attributedStringActivity = [webView _protectedPage]->protectedLegacyMainFrameProcess()->protectedThrottler()->foregroundActivity("NSAttributedString serialization"_s);
+            attributedStringActivity = protect([webView _protectedPage]->legacyMainFrameProcess())->protectedThrottler()->foregroundActivity("NSAttributedString serialization"_s);
 
         ASSERT(contentNavigation);
         ASSERT(webView.get().loading);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -105,7 +105,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKFrameInfo *)sourceFrame
 {
-    return wrapper(Ref { *_navigationAction }->sourceFrame());
+    return wrapper(protect(*_navigationAction)->sourceFrame());
 }
 
 - (WKFrameInfo *)targetFrame
@@ -181,7 +181,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (NSURL *)_originalURL
 {
-    return Ref { *_navigationAction }->originalURL().createNSURL().autorelease();
+    return protect(*_navigationAction)->originalURL().createNSURL().autorelease();
 }
 
 - (BOOL)_isUserInitiated
@@ -254,7 +254,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
     RefPtr page = sourceFrame->page();
     if (!page)
         return;
-    page->protectedWebsiteDataStore()->storePrivateClickMeasurement(*privateClickMeasurement);
+    protect(page->websiteDataStore())->storePrivateClickMeasurement(*privateClickMeasurement);
 }
 
 - (_WKHitTestResult *)_hitTestResult

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -138,7 +138,7 @@
 {
     if (!layerID)
         return nil;
-    RetainPtr layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->protectedDrawingArea())->layerWithIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() });
+    RetainPtr layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(protect(_page->drawingArea()))->layerWithIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() });
     if (!layer)
         return nil;
 
@@ -426,7 +426,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         completionHandler();
         return;
     }
-    _page->protectedLegacyMainFrameProcess()->sendPrepareToSuspend(WebKit::IsSuspensionImminent::No, 0.0, [completionHandler = makeBlockPtr(completionHandler)] {
+    protect(_page->legacyMainFrameProcess())->sendPrepareToSuspend(WebKit::IsSuspensionImminent::No, 0.0, [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -434,13 +434,13 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (void)_processWillSuspendImminentlyForTesting
 {
     if (_page)
-        _page->protectedLegacyMainFrameProcess()->sendPrepareToSuspend(WebKit::IsSuspensionImminent::Yes, 0.0, [] { });
+        protect(_page->legacyMainFrameProcess())->sendPrepareToSuspend(WebKit::IsSuspensionImminent::Yes, 0.0, [] { });
 }
 
 - (void)_processDidResumeForTesting
 {
     if (_page)
-        _page->protectedLegacyMainFrameProcess()->sendProcessDidResume(WebKit::AuxiliaryProcessProxy::ResumeReason::ForegroundActivity);
+        protect(_page->legacyMainFrameProcess())->sendProcessDidResume(WebKit::AuxiliaryProcessProxy::ResumeReason::ForegroundActivity);
 }
 
 - (void)_setThrottleStateForTesting:(int)value
@@ -448,7 +448,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (!_page)
         return;
 
-    _page->protectedLegacyMainFrameProcess()->setThrottleStateForTesting(static_cast<WebKit::ProcessThrottleState>(value));
+    protect(_page->legacyMainFrameProcess())->setThrottleStateForTesting(static_cast<WebKit::ProcessThrottleState>(value));
 }
 
 - (BOOL)_hasServiceWorkerBackgroundActivityForTesting
@@ -983,7 +983,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (void)_getNotifyStateForTesting:(NSString *)notificationName completionHandler:(void(^)(NSNumber *))completionHandler
 {
 #if ENABLE(NOTIFY_BLOCKING)
-    _page->protectedLegacyMainFrameProcess()->getNotifyStateForTesting(notificationName, [completionHandler = WTF::move(completionHandler)](std::optional<uint64_t> result) mutable {
+    protect(_page->legacyMainFrameProcess())->getNotifyStateForTesting(notificationName, [completionHandler = WTF::move(completionHandler)](std::optional<uint64_t> result) mutable {
         if (!result) {
             completionHandler(nil);
             return;
@@ -1013,7 +1013,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 {
     if (!layerID)
         return nil;
-    RetainPtr layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->protectedDrawingArea())->layerWithIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() });
+    RetainPtr layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(protect(_page->drawingArea()))->layerWithIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() });
     if (!layer)
         return nil;
 
@@ -1223,7 +1223,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         if (!layerID)
             return nullptr;
         WebCore::PlatformLayerIdentifier platformLayerID { ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() };
-        if (RefPtr nodeStack = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(_page->protectedDrawingArea())->animationStackForNodeWithIDForTesting(platformLayerID))
+        if (RefPtr nodeStack = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(protect(_page->drawingArea()))->animationStackForNodeWithIDForTesting(platformLayerID))
             return nodeStack;
         if (CheckedPtr scrollingCoordinator = _page->scrollingCoordinatorProxy())
             return scrollingCoordinator->animationStackForNodeWithIDForTesting(platformLayerID);
@@ -1279,22 +1279,22 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)seekSessionToTime:(double)time withCompletion:(void(^)(BOOL))completionHandler
 {
-    Ref { *m_coordinatorClient }->seekSessionToTime(time, makeBlockPtr(completionHandler));
+    protect(*m_coordinatorClient)->seekSessionToTime(time, makeBlockPtr(completionHandler));
 }
 
 - (void)playSessionWithCompletion:(void(^)(BOOL))completionHandler
 {
-    Ref { *m_coordinatorClient }->playSession({ }, std::optional<MonotonicTime>(), makeBlockPtr(completionHandler));
+    protect(*m_coordinatorClient)->playSession({ }, std::optional<MonotonicTime>(), makeBlockPtr(completionHandler));
 }
 
 - (void)pauseSessionWithCompletion:(void(^)(BOOL))completionHandler
 {
-    Ref { *m_coordinatorClient }->pauseSession(makeBlockPtr(completionHandler));
+    protect(*m_coordinatorClient)->pauseSession(makeBlockPtr(completionHandler));
 }
 
 - (void)setSessionTrack:(NSString*)trackIdentifier withCompletion:(void(^)(BOOL))completionHandler
 {
-    Ref { *m_coordinatorClient }->setSessionTrack(trackIdentifier, makeBlockPtr(completionHandler));
+    protect(*m_coordinatorClient)->setSessionTrack(trackIdentifier, makeBlockPtr(completionHandler));
 }
 
 - (void)coordinatorStateChanged:(_WKMediaSessionCoordinatorState)state
@@ -1303,7 +1303,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     static_assert(static_cast<size_t>(WebCore::MediaSessionCoordinatorState::Joined) == static_cast<size_t>(WKMediaSessionCoordinatorStateJoined), "WKMediaSessionCoordinatorStateJoined does not match WebKit value");
     static_assert(static_cast<size_t>(WebCore::MediaSessionCoordinatorState::Closed) == static_cast<size_t>(WKMediaSessionCoordinatorStateClosed), "WKMediaSessionCoordinatorStateClosed does not match WebKit value");
 
-    Ref { *m_coordinatorClient }->coordinatorStateChanged(static_cast<WebCore::MediaSessionCoordinatorState>(state));
+    protect(*m_coordinatorClient)->coordinatorStateChanged(static_cast<WebCore::MediaSessionCoordinatorState>(state));
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -106,7 +106,7 @@ void WebKitProtocolHandler::handleRequest(WebKitURISchemeRequest* request)
     URL requestURL = URL(String::fromLatin1(webkit_uri_scheme_request_get_uri(request)));
     if (requestURL.host() == "gpu"_s) {
         auto& page = webkitURISchemeRequestGetWebPage(request);
-        page.protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::GetRenderProcessInfo(), [this, request = GRefPtr<WebKitURISchemeRequest>(request)](RenderProcessInfo&& info) {
+        protect(page.legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::GetRenderProcessInfo(), [this, request = GRefPtr<WebKitURISchemeRequest>(request)](RenderProcessInfo&& info) {
             handleGPU(request.get(), WTF::move(info));
         }, page.webPageIDInMainFrameProcess());
         return;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -316,7 +316,7 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
 {
     if (!layerID)
         return nil;
-    RetainPtr view = downcast<WebKit::RemoteLayerTreeDrawingAreaProxyIOS>(_page->protectedDrawingArea())->viewWithLayerIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() });
+    RetainPtr view = downcast<WebKit::RemoteLayerTreeDrawingAreaProxyIOS>(protect(_page->drawingArea()))->viewWithLayerIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() });
     if (!view)
         return nil;
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -168,7 +168,7 @@ static WebCore::FloatBoxExtent coreBoxExtentsFromEdgeInsets(NSEdgeInsets insets)
     if (!page)
         return NO;
 
-    if (!page->protectedLegacyMainFrameProcess()->isResponsive())
+    if (!protect(page->legacyMainFrameProcess())->isResponsive())
         return NO;
 
     if (page->isSuspended())

--- a/Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp
@@ -161,7 +161,7 @@ Inspector::Protocol::ErrorStringOr<Ref<API::HTTPCookieStore>> BidiStorageAgent::
         auto page = session->webPageProxyForHandle("default"_s);
         if (!page)
             SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
-        return { page->protectedWebsiteDataStore()->cookieStore() };
+        return { protect(page->websiteDataStore())->cookieStore() };
     }
 
     auto type = partitionDescriptor->getString("type"_s);
@@ -174,7 +174,7 @@ Inspector::Protocol::ErrorStringOr<Ref<API::HTTPCookieStore>> BidiStorageAgent::
         if (!page)
             SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
 
-        return { page->protectedWebsiteDataStore()->cookieStore() };
+        return { protect(page->websiteDataStore())->cookieStore() };
     }
 
     SYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -61,13 +61,13 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
     }
     websiteDataStore.fetchDomainsWithUserInteraction([
         protectedThis = Ref { *this },
-        websiteDataStore = Ref { websiteDataStore },
-        preferences = Ref { preferences },
+        websiteDataStore = protect(websiteDataStore),
+        preferences = protect(preferences),
         site = Site { site },
         mainFrameSite = Site { mainFrameSite },
         lockdownMode,
         enhancedSecurity,
-        pageConfiguration = Ref { pageConfiguration },
+        pageConfiguration = protect(pageConfiguration),
         completionHandler = WTF::move(completionHandler)
     ](const HashSet<WebCore::RegistrableDomain>& domainsWithUserInteraction) mutable {
 
@@ -288,7 +288,7 @@ void BrowsingContextGroup::transitionPageToRemotePage(WebPageProxy& page, const 
         return HashSet<Ref<RemotePageProxy>> { };
     }).iterator->value;
 
-    Ref newRemotePage = RemotePageProxy::create(page, page.protectedLegacyMainFrameProcess(), openerSite, &page.messageReceiverRegistration(), page.webPageIDInMainFrameProcess());
+    Ref newRemotePage = RemotePageProxy::create(page, protect(page.legacyMainFrameProcess()), openerSite, &page.messageReceiverRegistration(), page.webPageIDInMainFrameProcess());
 #if ASSERT_ENABLED
     for (auto& existingPage : set) {
         ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->site() != newRemotePage->site());

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
@@ -135,7 +135,7 @@ static Vector<Ref<AuxiliaryProcessProxy>> auxiliaryProcessesForPage(WebPageProxy
     // We should fix that, perhaps by storing mediaState on a per-frame basis.
     auxiliaryProcesses.append(page.legacyMainFrameProcess());
 
-    page.protectedBrowsingContextGroup()->forEachRemotePage(page, [&](auto& remotePage) {
+    protect(page.browsingContextGroup())->forEachRemotePage(page, [&](auto& remotePage) {
         if (WebCore::MediaProducer::needsMediaCapability(remotePage.mediaState()))
             auxiliaryProcesses.append(remotePage.process());
     });
@@ -231,7 +231,7 @@ void ExtensionCapabilityGranter::revoke(const ExtensionCapability& capability, W
 
     grants.append(page.legacyMainFrameProcess().extensionCapabilityGrants().take(environmentIdentifier));
 
-    page.protectedBrowsingContextGroup()->forEachRemotePage(page, [&](auto& remotePage) {
+    protect(page.browsingContextGroup())->forEachRemotePage(page, [&](auto& remotePage) {
         grants.append(remotePage.process().extensionCapabilityGrants().take(environmentIdentifier));
     });
 

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -66,7 +66,7 @@ namespace WebKit {
 WKModelView * ModelElementController::modelViewForModelIdentifier(ModelIdentifier modelIdentifier)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled())
+    if (!webPageProxy || !protect(webPageProxy->preferences())->modelElementEnabled())
         return nil;
 
     auto* proxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(webPageProxy->drawingArea());
@@ -90,7 +90,7 @@ void ModelElementController::takeModelElementFullscreen(ModelIdentifier modelIde
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    auto *presentingViewController = Ref { *m_webPageProxy }->uiClient().presentingViewController();
+    auto *presentingViewController = protect(*m_webPageProxy)->uiClient().presentingViewController();
     if (!presentingViewController)
         return;
 
@@ -156,7 +156,7 @@ void ModelElementController::setInteractionEnabledForModelElement(ModelIdentifie
 ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdentifier modelIdentifier)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled())
+    if (!webPageProxy || !protect(webPageProxy->preferences())->modelElementEnabled())
         return nullptr;
 
     return m_inlinePreviews.get(modelIdentifier.uuid);
@@ -165,7 +165,7 @@ ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdenti
 void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCore::FloatSize size, CompletionHandler<void(Expected<std::pair<String, uint32_t>, WebCore::ResourceError>)>&& completionHandler)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled()) {
+    if (!webPageProxy || !protect(webPageProxy->preferences())->modelElementEnabled()) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Model element disabled"_s }));
         return;
     }
@@ -214,7 +214,7 @@ void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCor
 void ModelElementController::modelElementLoadRemotePreview(String uuid, URL fileURL, CompletionHandler<void(std::optional<WebCore::ResourceError>&&)>&& completionHandler)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled()) {
+    if (!webPageProxy || !protect(webPageProxy->preferences())->modelElementEnabled()) {
         completionHandler(WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Model element disabled"_s });
         return;
     }

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -567,7 +567,7 @@ PlaybackSessionManagerProxy::PlaybackSessionManagerProxy(WebPageProxy& page)
     ALWAYS_LOG(LOGIDENTIFIER);
 
     RefPtr protectedPage = m_page.get();
-    protectedPage->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), protectedPage->webPageIDInMainFrameProcess(), *this);
+    protect(protectedPage->legacyMainFrameProcess())->addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), protectedPage->webPageIDInMainFrameProcess(), *this);
 }
 
 PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
@@ -582,7 +582,7 @@ void PlaybackSessionManagerProxy::invalidate()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     if (RefPtr page = m_page.get()) {
-        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
         m_page = nullptr;
     }
 
@@ -1153,7 +1153,7 @@ bool PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabled()
 void PlaybackSessionManagerProxy::requestControlledElementID()
 {
     if (RefPtr page = m_page.get(); m_controlsManagerContextId)
-        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::HandleControlledElementIDRequest(m_controlsManagerContextId->object()), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::PlaybackSessionManager::HandleControlledElementIDRequest(m_controlsManagerContextId->object()), page->webPageIDInMainFrameProcess());
 }
 
 PlatformPlaybackSessionInterface* PlaybackSessionManagerProxy::controlsManagerInterface()

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -194,7 +194,7 @@ void PopUpSOAuthorizationSession::initSecretWebView()
     [m_secretWebView setUIDelegate:m_secretDelegate.get()];
     [m_secretWebView setNavigationDelegate:m_secretDelegate.get()];
 
-    RELEASE_ASSERT(!m_secretWebView->_page->protectedPreferences()->isExtensibleSSOEnabled());
+    RELEASE_ASSERT(!protect(m_secretWebView->_page->preferences())->isExtensibleSSOEnabled());
     AUTHORIZATIONSESSION_RELEASE_LOG("SecretWebView is created.");
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -360,10 +360,10 @@ void SOAuthorizationSession::complete(NSHTTPURLResponse *httpResponse, NSData *d
         size_t totalHeaderSize = 0;
         for (const auto& cookie : cookies)
             totalHeaderSize += cookie.name.length() + cookie.value.length() + 1;
-        AUTHORIZATIONSESSION_RELEASE_LOG("complete: Setting %zu cookies with total header size ~%zu bytes in data store %p", cookies.size(), totalHeaderSize, page->protectedWebsiteDataStore().ptr());
+        AUTHORIZATIONSESSION_RELEASE_LOG("complete: Setting %zu cookies with total header size ~%zu bytes in data store %p", cookies.size(), totalHeaderSize, protect(page->websiteDataStore()).ptr());
     }
 
-    page->protectedWebsiteDataStore()->protectedCookieStore()->setCookies(WTF::move(cookies), [weakThis = ThreadSafeWeakPtr { *this }, response = WTF::move(response), data = adoptNS([[NSData alloc] initWithData:data])] () mutable {
+    protect(page->websiteDataStore())->protectedCookieStore()->setCookies(WTF::move(cookies), [weakThis = ThreadSafeWeakPtr { *this }, response = WTF::move(response), data = adoptNS([[NSData alloc] initWithData:data])] () mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -183,7 +183,7 @@ bool SubFrameSOAuthorizationSession::shouldInterruptLoadForXFrameOptions(Vector<
 
 bool SubFrameSOAuthorizationSession::shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions(const WebCore::ResourceResponse& response)
 {
-    if (RefPtr page = this->page(); page && page->protectedPreferences()->ignoreIframeEmbeddingProtectionsEnabled())
+    if (RefPtr page = this->page(); page && protect(page->preferences())->ignoreIframeEmbeddingProtectionsEnabled())
         return false;
 
     Vector<Ref<SecurityOrigin>> frameAncestorOrigins;

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(UIRemoteObjectRegistry);
 RefPtr<ProcessThrottler::BackgroundActivity> UIRemoteObjectRegistry::backgroundActivity(ASCIILiteral name)
 {
     if (RefPtr page = m_page.get())
-        return page->protectedLegacyMainFrameProcess()->protectedThrottler()->backgroundActivity(name);
+        return protect(page->legacyMainFrameProcess())->protectedThrottler()->backgroundActivity(name);
     return nullptr;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
@@ -157,7 +157,7 @@ bool UserMediaPermissionRequestManagerProxy::permittedToCaptureVideo()
 #if ENABLE(MEDIA_STREAM)
 void UserMediaPermissionRequestManagerProxy::requestSystemValidation(const WebPageProxy& page, UserMediaPermissionRequestProxy& request, CompletionHandler<void(bool)>&& callback)
 {
-    if (page.protectedPreferences()->mockCaptureDevicesEnabled()) {
+    if (protect(page.preferences())->mockCaptureDevicesEnabled()) {
         callback(true);
         return;
     }

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -79,7 +79,7 @@ void RemoteWebInspectorUIProxy::setDiagnosticLoggingAvailable(bool available)
 {
 #if ENABLE(INSPECTOR_TELEMETRY)
     if (RefPtr page = m_inspectorPage.get())
-        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::SetDiagnosticLoggingAvailable(available), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::SetDiagnosticLoggingAvailable(available), page->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(available);
 #endif
@@ -93,7 +93,7 @@ void RemoteWebInspectorUIProxy::initialize(Ref<API::DebuggableInfo>&& debuggable
     createFrontendPageAndWindow();
 
     RefPtr inspectorPage = m_inspectorPage.get();
-    inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::Initialize(m_debuggableInfo->debuggableInfoData(), backendCommandsURL), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(inspectorPage->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::Initialize(m_debuggableInfo->debuggableInfoData(), backendCommandsURL), m_inspectorPage->webPageIDInMainFrameProcess());
     inspectorPage->loadRequest(URL { WebInspectorUIProxy::inspectorPageURL() });
 }
 
@@ -116,19 +116,19 @@ void RemoteWebInspectorUIProxy::show()
 void RemoteWebInspectorUIProxy::showConsole()
 {
     if (RefPtr page = m_inspectorPage.get())
-        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::ShowConsole { }, page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::ShowConsole { }, page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::showResources()
 {
     if (RefPtr page = m_inspectorPage.get())
-        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::ShowResources { }, page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::ShowResources { }, page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::sendMessageToFrontend(const String& message)
 {
     if (RefPtr page = m_inspectorPage.get())
-        page->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::SendMessageToFrontend(message), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::SendMessageToFrontend(message), page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::frontendLoaded()
@@ -217,7 +217,7 @@ void RemoteWebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled(bool enab
     if (!inspectorPage)
         return;
 
-    inspectorPage->protectedPreferences()->setDeveloperExtrasEnabled(enabled);
+    protect(inspectorPage->preferences())->setDeveloperExtrasEnabled(enabled);
 }
 
 void RemoteWebInspectorUIProxy::setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFactor)
@@ -245,7 +245,7 @@ void RemoteWebInspectorUIProxy::createFrontendPageAndWindow()
 
     trackInspectorPage(*inspectorPage, nullptr);
 
-    inspectorPage->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess(), *this);
+    protect(inspectorPage->legacyMainFrameProcess())->addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess(), *this);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = WebInspectorUIExtensionControllerProxy::create(*inspectorPage);
@@ -258,7 +258,7 @@ void RemoteWebInspectorUIProxy::closeFrontendPageAndWindow()
     if (!inspectorPage)
         return;
 
-    inspectorPage->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess());
+    protect(inspectorPage->legacyMainFrameProcess())->removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess());
 
     untrackInspectorPage(*inspectorPage);
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebInspectorUIExtensionControllerProxy);
 WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy(WebPageProxy& inspectorPage)
     : m_inspectorPage(inspectorPage)
 {
-    inspectorPage.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess(), *this);
+    protect(inspectorPage.legacyMainFrameProcess())->addMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess(), *this);
 }
 
 WebInspectorUIExtensionControllerProxy::~WebInspectorUIExtensionControllerProxy()
@@ -94,7 +94,7 @@ void WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose()
     if (!m_inspectorPage)
         return;
 
-    protectedInspectorPage()->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectorPage()->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess());
     m_inspectorPage = nullptr;
 
     m_extensionAPIObjectMap.clear();
@@ -110,7 +110,7 @@ void WebInspectorUIExtensionControllerProxy::registerExtension(const Inspector::
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::RegistrationFailed));
                 return;
@@ -137,7 +137,7 @@ void WebInspectorUIExtensionControllerProxy::unregisterExtension(const Inspector
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::InvalidRequest));
                 return;
@@ -163,7 +163,7 @@ void WebInspectorUIExtensionControllerProxy::createTabForExtension(const Inspect
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::CreateTabForExtension { extensionID, tabName, tabIconURL, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::CreateTabForExtension { extensionID, tabName, tabIconURL, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -175,7 +175,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension(const In
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError> error) mutable {
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError> error) mutable {
             if (error)
                 return completionHandler(makeUnexpected(error.value()));
 
@@ -192,7 +192,7 @@ void WebInspectorUIExtensionControllerProxy::reloadForExtension(const Inspector:
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ReloadForExtension { extensionID, ignoreCache, userAgent, injectedScript }, [completionHandler = WTF::move(completionHandler)] (const std::optional<Inspector::ExtensionError> error) mutable {
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ReloadForExtension { extensionID, ignoreCache, userAgent, injectedScript }, [completionHandler = WTF::move(completionHandler)] (const std::optional<Inspector::ExtensionError> error) mutable {
             if (error) {
                 completionHandler(makeUnexpected(error.value()));
                 return;
@@ -211,7 +211,7 @@ void WebInspectorUIExtensionControllerProxy::showExtensionTab(const Inspector::E
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ShowExtensionTab { extensionTabIdentifier }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ShowExtensionTab { extensionTabIdentifier }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -223,7 +223,7 @@ void WebInspectorUIExtensionControllerProxy::navigateTabForExtension(const Inspe
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::NavigateTabForExtension { extensionTabIdentifier, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::NavigateTabForExtension { extensionTabIdentifier, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -237,7 +237,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab(const 
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError>& error) mutable {
+        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError>& error) mutable {
             if (error)
                 return completionHandler(makeUnexpected(error.value()));
             completionHandler(WTF::move(result));

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -81,7 +81,7 @@ WebInspectorUIProxy::WebInspectorUIProxy(WebPageProxy& inspectedPage)
     , m_closeFrontendAfterInactivityTimer(RunLoop::mainSingleton(), "WebInspectorUIProxy::CloseFrontendAfterInactivityTimer"_s, this, &WebInspectorUIProxy::closeFrontendAfterInactivityTimerFired)
 #endif
 {
-    protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), m_backend.get());
+    protect(protectedInspectedPage()->legacyMainFrameProcess())->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), m_backend.get());
 }
 
 WebInspectorUIProxy::~WebInspectorUIProxy()
@@ -128,7 +128,7 @@ void WebInspectorUIProxy::sendMessageToFrontend(const String& message)
     if (!inspectorPage)
         return;
 
-    inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::SendMessageToFrontend(message), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(inspectorPage->legacyMainFrameProcess())->send(Messages::WebInspectorUI::SendMessageToFrontend(message), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 // Public APIs
@@ -146,7 +146,7 @@ void WebInspectorUIProxy::connect()
     if (!inspectedPage)
         return;
 
-    if (!inspectedPage->protectedPreferences()->developerExtrasEnabled())
+    if (!protect(inspectedPage->preferences())->developerExtrasEnabled())
         return;
 
     if (m_showMessageSent)
@@ -199,7 +199,7 @@ void WebInspectorUIProxy::close()
     if (!inspectedPage)
         return;
 
-    inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::Close(), m_inspectedPage->webPageIDInMainFrameProcess());
+    protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::Close(), m_inspectedPage->webPageIDInMainFrameProcess());
 
     closeFrontendPageAndWindow();
 }
@@ -240,7 +240,7 @@ void WebInspectorUIProxy::resetState()
 void WebInspectorUIProxy::reset()
 {
     if (RefPtr inspectedPage = m_inspectedPage.get()) {
-        inspectedPage->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), inspectedPage->webPageIDInMainFrameProcess());
+        protect(inspectedPage->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), inspectedPage->webPageIDInMainFrameProcess());
         m_inspectedPage = nullptr;
     }
 }
@@ -252,10 +252,10 @@ void WebInspectorUIProxy::updateForNewPageProcess(WebPageProxy& inspectedPage)
     m_inspectedPage = inspectedPage;
     m_inspectedPageIdentifier = inspectedPage.identifier();
 
-    protectedInspectedPage()->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), m_backend.get());
+    protect(protectedInspectedPage()->legacyMainFrameProcess())->addMessageReceiver(Messages::WebInspectorBackendProxy::messageReceiverName(), m_inspectedPage->webPageIDInMainFrameProcess(), m_backend.get());
 
     if (RefPtr inspectorPage = m_inspectorPage.get())
-        inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::UpdateConnection(), m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(inspectorPage->legacyMainFrameProcess())->send(Messages::WebInspectorUI::UpdateConnection(), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::setFrontendConnection(IPC::Connection::Handle&& connectionIdentifier)
@@ -264,7 +264,7 @@ void WebInspectorUIProxy::setFrontendConnection(IPC::Connection::Handle&& connec
     if (!m_inspectedPage)
         return;
 
-    inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::SetFrontendConnection(WTF::move(connectionIdentifier)), inspectedPage->webPageIDInMainFrameProcess());
+    protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::SetFrontendConnection(WTF::move(connectionIdentifier)), inspectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::showConsole()
@@ -275,7 +275,7 @@ void WebInspectorUIProxy::showConsole()
 
     show();
 
-    inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::ShowConsole(), inspectedPage->webPageIDInMainFrameProcess());
+    protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::ShowConsole(), inspectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::showResources()
@@ -286,7 +286,7 @@ void WebInspectorUIProxy::showResources()
 
     show();
 
-    inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::ShowResources(), inspectedPage->webPageIDInMainFrameProcess());
+    protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::ShowResources(), inspectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::showMainResourceForFrame(WebCore::FrameIdentifier frameID)
@@ -332,19 +332,19 @@ void WebInspectorUIProxy::attach(AttachmentSide side)
     if (m_isVisible)
         preferences->setInspectorStartsAttached(true);
 
-    protectedInspectedPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::SetAttached(true), m_inspectedPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectedPage()->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::SetAttached(true), m_inspectedPage->webPageIDInMainFrameProcess());
 
     switch (m_attachmentSide) {
     case AttachmentSide::Bottom:
-        protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::AttachedBottom(), m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::AttachedBottom(), m_inspectorPage->webPageIDInMainFrameProcess());
         break;
 
     case AttachmentSide::Right:
-        protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::AttachedRight(), m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::AttachedRight(), m_inspectorPage->webPageIDInMainFrameProcess());
         break;
 
     case AttachmentSide::Left:
-        protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::AttachedLeft(), m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::AttachedLeft(), m_inspectorPage->webPageIDInMainFrameProcess());
         break;
     }
 
@@ -363,8 +363,8 @@ void WebInspectorUIProxy::detach()
     if (m_isVisible)
         protectedInspectorPagePreferences()->setInspectorStartsAttached(false);
 
-    protectedInspectedPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::SetAttached(false), m_inspectedPage->webPageIDInMainFrameProcess());
-    protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::Detached(), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectedPage()->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::SetAttached(false), m_inspectedPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::Detached(), m_inspectorPage->webPageIDInMainFrameProcess());
 
     platformDetach();
 
@@ -410,9 +410,9 @@ void WebInspectorUIProxy::togglePageProfiling()
 
     RefPtr inspectedPage = m_inspectedPage.get();
     if (m_isProfilingPage)
-        inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::StopPageProfiling(), inspectedPage->webPageIDInMainFrameProcess());
+        protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::StopPageProfiling(), inspectedPage->webPageIDInMainFrameProcess());
     else
-        inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::StartPageProfiling(), inspectedPage->webPageIDInMainFrameProcess());
+        protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::StartPageProfiling(), inspectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::toggleElementSelection()
@@ -423,10 +423,10 @@ void WebInspectorUIProxy::toggleElementSelection()
     RefPtr inspectedPage = m_inspectedPage.get();
     if (m_elementSelectionActive) {
         m_ignoreElementSelectionChange = true;
-        inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::StopElementSelection(), inspectedPage->webPageIDInMainFrameProcess());
+        protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::StopElementSelection(), inspectedPage->webPageIDInMainFrameProcess());
     } else {
         connect();
-        inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::StartElementSelection(), inspectedPage->webPageIDInMainFrameProcess());
+        protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::StartElementSelection(), inspectedPage->webPageIDInMainFrameProcess());
     }
 }
 
@@ -462,7 +462,7 @@ void WebInspectorUIProxy::createFrontendPage()
     // Make sure the inspected page has a running WebProcess so we can inspect it.
     protectedInspectedPage()->launchInitialProcessIfNecessary();
 
-    inspectorPage->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPageIdentifier, *this);
+    protect(inspectorPage->legacyMainFrameProcess())->addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPageIdentifier, *this);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = WebInspectorUIExtensionControllerProxy::create(*inspectorPage);
@@ -484,7 +484,7 @@ void WebInspectorUIProxy::openLocalInspectorFrontend()
     if (!inspectedPage)
         return;
 
-    if (!inspectedPage->protectedPreferences()->developerExtrasEnabled())
+    if (!protect(inspectedPage->preferences())->developerExtrasEnabled())
         return;
 
     if (inspectedPage->inspectorController().hasLocalFrontend()) {
@@ -499,7 +499,7 @@ void WebInspectorUIProxy::openLocalInspectorFrontend()
     if (!inspectorPage)
         return;
 
-    inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::EstablishConnection(m_inspectedPageIdentifier, infoForLocalDebuggable(), m_underTest, inspectionLevel()), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(inspectorPage->legacyMainFrameProcess())->send(Messages::WebInspectorUI::EstablishConnection(m_inspectedPageIdentifier, infoForLocalDebuggable(), m_underTest, inspectionLevel()), m_inspectorPage->webPageIDInMainFrameProcess());
 
     ASSERT(!m_isActiveFrontend);
     m_isActiveFrontend = true;
@@ -513,7 +513,7 @@ void WebInspectorUIProxy::openLocalInspectorFrontend()
         m_isAttached = shouldOpenAttached();
         m_attachmentSide = static_cast<AttachmentSide>(protectedInspectorPagePreferences()->inspectorAttachmentSide());
 
-        inspectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorBackend::SetAttached(m_isAttached), inspectedPage->webPageIDInMainFrameProcess());
+        protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::SetAttached(m_isAttached), inspectedPage->webPageIDInMainFrameProcess());
 
         Ref inspectorPageProcess = inspectorPage->legacyMainFrameProcess();
         if (m_isAttached) {
@@ -566,7 +566,7 @@ void WebInspectorUIProxy::open()
     SetForScope isOpening(m_isOpening, true);
 
     m_isVisible = true;
-    protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::SetIsVisible(m_isVisible), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::SetIsVisible(m_isVisible), m_inspectorPage->webPageIDInMainFrameProcess());
 
     if (m_isAttached && platformCanAttach(m_canAttach))
         platformAttach();
@@ -697,7 +697,7 @@ void WebInspectorUIProxy::attachAvailabilityChanged(bool available)
         return;
 
     if (RefPtr inspectorPage = m_inspectorPage.get(); inspectorPage && !m_underTest)
-        inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::SetDockingUnavailable(!m_canAttach), inspectorPage->webPageIDInMainFrameProcess());
+        protect(inspectorPage->legacyMainFrameProcess())->send(Messages::WebInspectorUI::SetDockingUnavailable(!m_canAttach), inspectorPage->webPageIDInMainFrameProcess());
 
     platformAttachAvailabilityChanged(m_canAttach);
 }
@@ -747,7 +747,7 @@ void WebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled(bool enabled)
     if (!inspectorPage)
         return;
 
-    inspectorPage->protectedPreferences()->setDeveloperExtrasEnabled(enabled);
+    protect(inspectorPage->preferences())->setDeveloperExtrasEnabled(enabled);
 }
 
 void WebInspectorUIProxy::setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFactor)
@@ -786,12 +786,12 @@ void WebInspectorUIProxy::setDeveloperPreferenceOverride(WebCore::InspectorBacke
     switch (developerPreference) {
     case InspectorBackendClient::DeveloperPreference::PrivateClickMeasurementDebugModeEnabled:
         if (RefPtr inspectedPage = m_inspectedPage.get())
-            inspectedPage->protectedWebsiteDataStore()->setPrivateClickMeasurementDebugMode(overrideValue && overrideValue.value());
+            protect(inspectedPage->websiteDataStore())->setPrivateClickMeasurementDebugMode(overrideValue && overrideValue.value());
         return;
 
     case InspectorBackendClient::DeveloperPreference::ITPDebugModeEnabled:
         if (RefPtr inspectedPage = m_inspectedPage.get())
-            inspectedPage->protectedWebsiteDataStore()->setResourceLoadStatisticsDebugMode(overrideValue && overrideValue.value());
+            protect(inspectedPage->websiteDataStore())->setResourceLoadStatisticsDebugMode(overrideValue && overrideValue.value());
         return;
 
     case InspectorBackendClient::DeveloperPreference::MockCaptureDevicesEnabled:
@@ -803,7 +803,7 @@ void WebInspectorUIProxy::setDeveloperPreferenceOverride(WebCore::InspectorBacke
 
     case InspectorBackendClient::DeveloperPreference::NeedsSiteSpecificQuirks:
         if (RefPtr inspectedPage = m_inspectedPage.get())
-            inspectedPage->protectedPreferences()->setNeedsSiteSpecificQuirksInspectorOverride(overrideValue);
+            protect(inspectedPage->preferences())->setNeedsSiteSpecificQuirksInspectorOverride(overrideValue);
         return;
     }
 
@@ -823,7 +823,7 @@ void WebInspectorUIProxy::setEmulatedConditions(std::optional<int64_t>&& bytesPe
 void WebInspectorUIProxy::setDiagnosticLoggingAvailable(bool available)
 {
 #if ENABLE(INSPECTOR_TELEMETRY)
-    protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::SetDiagnosticLoggingAvailable(available), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::SetDiagnosticLoggingAvailable(available), m_inspectorPage->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(available);
 #endif
@@ -831,7 +831,7 @@ void WebInspectorUIProxy::setDiagnosticLoggingAvailable(bool available)
 
 void WebInspectorUIProxy::save(Vector<InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
 {
-    if (!protectedInspectedPage()->protectedPreferences()->developerExtrasEnabled())
+    if (!protect(protectedInspectedPage()->preferences())->developerExtrasEnabled())
         return;
 
     ASSERT(!saveDatas.isEmpty());
@@ -847,7 +847,7 @@ void WebInspectorUIProxy::save(Vector<InspectorFrontendClient::SaveData>&& saveD
 
 void WebInspectorUIProxy::load(const String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    if (!protectedInspectedPage()->protectedPreferences()->developerExtrasEnabled())
+    if (!protect(protectedInspectedPage()->preferences())->developerExtrasEnabled())
         return;
 
     ASSERT(!path.isEmpty());
@@ -859,7 +859,7 @@ void WebInspectorUIProxy::load(const String& path, CompletionHandler<void(const 
 
 void WebInspectorUIProxy::pickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color> &)>&& completionHandler)
 {
-    if (!protectedInspectedPage()->protectedPreferences()->developerExtrasEnabled()) {
+    if (!protect(protectedInspectedPage()->preferences())->developerExtrasEnabled()) {
         completionHandler({ });
         return;
     }
@@ -878,7 +878,7 @@ void WebInspectorUIProxy::evaluateInFrontendForTesting(const String& expression)
     if (!inspectorPage)
         return;
 
-    inspectorPage->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::EvaluateInFrontendForTesting(expression), inspectorPage->webPageIDInMainFrameProcess());
+    protect(inspectorPage->legacyMainFrameProcess())->send(Messages::WebInspectorUI::EvaluateInFrontendForTesting(expression), inspectorPage->webPageIDInMainFrameProcess());
 }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.cpp
@@ -74,7 +74,7 @@ void WebPageInspectorTargetProxy::connect(Inspector::FrontendChannel::Connection
 
     Ref page = m_page.get();
     if (page->hasRunningProcess())
-        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::ConnectInspector(connectionType), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::WebPage::ConnectInspector(connectionType), page->webPageIDInMainFrameProcess());
 }
 
 void WebPageInspectorTargetProxy::disconnect()
@@ -89,7 +89,7 @@ void WebPageInspectorTargetProxy::disconnect()
 
     Ref page = m_page.get();
     if (page->hasRunningProcess())
-        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::DisconnectInspector(), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::WebPage::DisconnectInspector(), page->webPageIDInMainFrameProcess());
 }
 
 void WebPageInspectorTargetProxy::sendMessageToTargetBackend(const String& message)
@@ -101,7 +101,7 @@ void WebPageInspectorTargetProxy::sendMessageToTargetBackend(const String& messa
 
     Ref page = m_page.get();
     if (page->hasRunningProcess())
-        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::SendMessageToTargetBackend(message), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::WebPage::SendMessageToTargetBackend(message), page->webPageIDInMainFrameProcess());
 }
 
 void WebPageInspectorTargetProxy::didCommitProvisionalTarget()

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -110,7 +110,7 @@ WKWebView *RemoteWebInspectorUIProxy::webView() const
 
 void RemoteWebInspectorUIProxy::didBecomeActive()
 {
-    protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::RemoteWebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -338,7 +338,7 @@ using namespace WebCore;
 
 void WebInspectorUIProxy::didBecomeActive()
 {
-    protectedInspectorPage()->protectedLegacyMainFrameProcess()->send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::attachmentViewDidChange(NSView *oldView, NSView *newView)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -64,12 +64,12 @@ RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy(WebPagePr
 #endif
 {
     m_privateCoordinator->setClient(*this);
-    webPageProxy.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
+    protect(webPageProxy.legacyMainFrameProcess())->addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
 }
 
 RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy()
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 std::optional<SharedPreferencesForWebProcess> RemoteMediaSessionCoordinatorProxy::sharedPreferencesForWebProcess(IPC::Connection& connection) const
@@ -165,27 +165,27 @@ void RemoteMediaSessionCoordinatorProxy::trackIdentifierChanged(const String& id
 
 void RemoteMediaSessionCoordinatorProxy::seekSessionToTime(double time, CompletionHandler<void(bool)>&& callback)
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::playSession(std::optional<double> atTime, std::optional<MonotonicTime> hostTime, CompletionHandler<void(bool)>&& callback)
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTF::move(atTime), WTF::move(hostTime) }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTF::move(atTime), WTF::move(hostTime) }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::pauseSession(CompletionHandler<void(bool)>&& callback)
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::setSessionTrack(const String& trackId, CompletionHandler<void(bool)>&& callback)
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged(WebCore::MediaSessionCoordinatorState state)
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 Ref<WebPageProxy> RemoteMediaSessionCoordinatorProxy::protectedWebPageProxy()

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -62,7 +62,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaKeySystemPermissionRequestManagerProxy);
 
 const Logger& MediaKeySystemPermissionRequestManagerProxy::logger() const
 {
-    return Ref { m_page.get() }->logger();
+    return protect(m_page.get())->logger();
 }
 #endif
 
@@ -96,7 +96,7 @@ void MediaKeySystemPermissionRequestManagerProxy::denyRequest(MediaKeySystemPerm
     ALWAYS_LOG(LOGIDENTIFIER, request.mediaKeySystemID().toUInt64(), ", reason: ", message);
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::MediaKeySystemWasDenied(request.mediaKeySystemID(), message), page->webPageIDInMainFrameProcess());
+    protect(page->legacyMainFrameProcess())->send(Messages::WebPage::MediaKeySystemWasDenied(request.mediaKeySystemID(), message), page->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(message);
 #endif
@@ -111,7 +111,7 @@ void MediaKeySystemPermissionRequestManagerProxy::grantRequest(MediaKeySystemPer
 #if ENABLE(ENCRYPTED_MEDIA)
     ALWAYS_LOG(LOGIDENTIFIER, request.mediaKeySystemID().toUInt64(), ", keySystem: ", request.keySystem());
 
-    page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::MediaKeySystemWasGranted { request.mediaKeySystemID(), request.mediaKeysHashSalt() }, page->webPageIDInMainFrameProcess());
+    protect(page->legacyMainFrameProcess())->send(Messages::WebPage::MediaKeySystemWasGranted { request.mediaKeySystemID(), request.mediaKeysHashSalt() }, page->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(request);
 #endif
@@ -126,7 +126,7 @@ void MediaKeySystemPermissionRequestManagerProxy::createRequestForFrame(MediaKey
 
     Ref mediaKeyRequestDocumentSecurityOrigin = request->mediaKeyRequestSecurityOrigin();
     Ref topLevelDocumentSecurityOrigin = request->topLevelDocumentSecurityOrigin();
-    page->protectedWebsiteDataStore()->ensureProtectedDeviceIdHashSaltStorage()->deviceIdHashSaltForOrigin(mediaKeyRequestDocumentSecurityOrigin, topLevelDocumentSecurityOrigin, [request = WTF::move(request), completionHandler = WTF::move(completionHandler)] (String&& mediaKeysHashSalt) mutable {
+    protect(page->websiteDataStore())->ensureProtectedDeviceIdHashSaltStorage()->deviceIdHashSaltForOrigin(mediaKeyRequestDocumentSecurityOrigin, topLevelDocumentSecurityOrigin, [request = WTF::move(request), completionHandler = WTF::move(completionHandler)] (String&& mediaKeysHashSalt) mutable {
         request->setMediaKeysHashSalt(WTF::move(mediaKeysHashSalt));
         completionHandler(WTF::move(request));
     });

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -132,7 +132,7 @@ void WebNotificationManagerMessageHandler::getPermissionStateSync(WebCore::Secur
 
 std::optional<SharedPreferencesForWebProcess> WebNotificationManagerMessageHandler::sharedPreferencesForWebProcess(const IPC::Connection&) const
 {
-    return protectedPage()->protectedLegacyMainFrameProcess()->sharedPreferencesForWebProcess();
+    return protect(protectedPage()->legacyMainFrameProcess())->sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -104,10 +104,10 @@ RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy(WebPageProxy& p
     // FIXME: We should do this somewhere else.
     IOSurfacePool::sharedPoolSingleton().setPoolSize(0);
 
-    if (pageProxy.protectedPreferences()->tiledScrollingIndicatorVisible())
+    if (protect(pageProxy.preferences())->tiledScrollingIndicatorVisible())
         initializeDebugIndicator();
 
-    if (pageProxy.protectedPreferences()->slowFrameIndicatorVisible())
+    if (protect(pageProxy.preferences())->slowFrameIndicatorVisible())
         initializeSlowFrameIndicator();
 }
 
@@ -773,7 +773,7 @@ TextStream& operator<<(TextStream& ts, const PendingCommit& pendingCommit)
 bool RemoteLayerTreeDrawingAreaProxy::allowMultipleCommitLayerTreePending()
 {
     if (RefPtr page = this->page())
-        return page->protectedPreferences()->allowMultipleCommitLayerTreePending();
+        return protect(page->preferences())->allowMultipleCommitLayerTreePending();
     return false;
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -97,7 +97,7 @@ bool RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStor
 {
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     RefPtr page = m_drawingArea->page();
-    return page && page->protectedPreferences()->replayCGDisplayListsIntoBackingStore();
+    return page && protect(page->preferences())->replayCGDisplayListsIntoBackingStore();
 #else
     return false;
 #endif
@@ -115,7 +115,7 @@ bool RemoteLayerTreeHost::threadedAnimationsEnabled() const
 bool RemoteLayerTreeHost::cssUnprefixedBackdropFilterEnabled() const
 {
     RefPtr page = protectedDrawingArea()->page();
-    return page && page->protectedPreferences()->cssUnprefixedBackdropFilterEnabled();
+    return page && protect(page->preferences())->cssUnprefixedBackdropFilterEnabled();
 }
 
 #if PLATFORM(MAC)
@@ -208,7 +208,7 @@ bool RemoteLayerTreeHost::updateLayerTree(const IPC::Connection& connection, con
     // FIXME: with site isolation, a single process can send multiple transactions.
     // https://bugs.webkit.org/show_bug.cgi?id=301261
     if (threadedAnimationsEnabled() && !transaction.timelinesUpdate().isEmpty())
-        Ref { *m_drawingArea }->updateTimelinesRegistration(processIdentifier, transaction.timelinesUpdate(), MonotonicTime::now());
+        protect(*m_drawingArea)->updateTimelinesRegistration(processIdentifier, transaction.timelinesUpdate(), MonotonicTime::now());
 #endif
 
     for (auto& changedLayer : transaction.changedLayerProperties()) {
@@ -376,7 +376,7 @@ void RemoteLayerTreeHost::clearLayers()
 {
     for (auto& keyAndNode : m_nodes) {
         m_animationDelegates.remove(keyAndNode.key);
-        Ref { keyAndNode.value }->detachFromParent();
+        protect(keyAndNode.value)->detachFromParent();
     }
 
     m_nodes.clear();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -176,7 +176,7 @@ void RemoteScrollingCoordinatorProxy::applyScrollingTreeLayerPositionsAfterCommi
 
 void RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical)
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate()
@@ -344,7 +344,7 @@ void RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary()
     if (!m_uiState.changes())
         return;
 
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState), m_webPageProxy->webPageIDInMainFrameProcess());
     m_uiState.clearChanges();
 }
 
@@ -372,19 +372,19 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
 
 void RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
-    protectedWebPageProxy()->protectedLegacyMainFrameProcess()->send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason(std::optional<ScrollingNodeID> nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        protectedWebPageProxy()->protectedLegacyMainFrameProcess()->send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
+        protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason(std::optional<ScrollingNodeID> nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        protectedWebPageProxy()->protectedLegacyMainFrameProcess()->send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
+        protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::viewWillStartLiveResize()

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -62,6 +62,7 @@
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 #include "RemotePageVideoPresentationManagerProxy.h"
+#include "VideoPresentationManagerProxy.h"
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
@@ -143,16 +144,16 @@ void RemotePageProxy::injectPageIntoNewProcess()
     Ref drawingArea = *page->drawingArea();
     m_drawingArea = RemotePageDrawingAreaProxy::create(drawingArea.get(), m_process);
 #if ENABLE(FULLSCREEN_API)
-    m_fullscreenManager = RemotePageFullscreenManagerProxy::create(pageID(), page->protectedFullScreenManager().get(), m_process);
+    m_fullscreenManager = RemotePageFullscreenManagerProxy::create(pageID(), protect(page->fullScreenManager()), m_process);
 #endif
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    m_videoPresentationManager = RemotePageVideoPresentationManagerProxy::create(pageID(), m_process, page->protectedVideoPresentationManager().get());
+    m_videoPresentationManager = RemotePageVideoPresentationManagerProxy::create(pageID(), m_process, protect(page->videoPresentationManager()));
 #endif
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
-    m_webDeviceOrientationUpdateProvider = RemotePageWebDeviceOrientationUpdateProviderProxy::create(pageID(), m_process, page->protectedWebDeviceOrientationUpdateProviderProxy().get());
+    m_webDeviceOrientationUpdateProvider = RemotePageWebDeviceOrientationUpdateProviderProxy::create(pageID(), m_process, protect(page->webDeviceOrientationUpdateProviderProxy()));
 #endif
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
-    m_playbackSessionManager = RemotePagePlaybackSessionManagerProxy::create(pageID(), page->protectedPlaybackSessionManager().get(), m_process);
+    m_playbackSessionManager = RemotePagePlaybackSessionManagerProxy::create(pageID(), protect(page->playbackSessionManager()), m_process);
 #endif
 
     if (RefPtr screenOrientationManager = page->screenOrientationManager())
@@ -166,7 +167,7 @@ void RemotePageProxy::injectPageIntoNewProcess()
             m_webPageID,
             page->creationParametersForRemotePage(m_process, drawingArea.get(), RemotePageParameters {
                 URL(page->pageLoadState().url()),
-                page->protectedMainFrame()->frameTreeCreationParameters(),
+                protect(page->mainFrame())->frameTreeCreationParameters(),
                 websitePolicies ? std::make_optional(websitePolicies->dataForProcess(m_process)) : std::nullopt
             })
         ), 0

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
@@ -82,7 +82,7 @@ SpeechRecognitionPermissionManager::SpeechRecognitionPermissionManager(WebPagePr
 SpeechRecognitionPermissionManager::~SpeechRecognitionPermissionManager()
 {
     for (auto& [request, frameInfo] : m_requests)
-        Ref { request }->complete(WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::NotAllowed, "Permission manager has exited"_s });
+        protect(request)->complete(WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::NotAllowed, "Permission manager has exited"_s });
 }
 
 RefPtr<WebPageProxy> SpeechRecognitionPermissionManager::protectedPage() const
@@ -117,7 +117,7 @@ void SpeechRecognitionPermissionManager::startProcessingRequest()
 {
     Ref page = *this->page();
     page->syncIfMockDevicesEnabledChanged();
-    if (page->protectedPreferences()->mockCaptureDevicesEnabled()) {
+    if (protect(page->preferences())->mockCaptureDevicesEnabled()) {
         m_microphoneCheck = CheckResult::Granted;
         m_speechRecognitionServiceCheck = CheckResult::Granted;
     } else {

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -131,7 +131,7 @@ void ViewGestureController::connectToProcess()
 
     m_webPageIDInMainFrameProcess = page->webPageIDInMainFrameProcess();
     m_mainFrameProcess = page->legacyMainFrameProcess();
-    Ref { *m_mainFrameProcess }->addMessageReceiver(Messages::ViewGestureController::messageReceiverName(), *m_webPageIDInMainFrameProcess, *this);
+    protect(*m_mainFrameProcess)->addMessageReceiver(Messages::ViewGestureController::messageReceiverName(), *m_webPageIDInMainFrameProcess, *this);
     m_isConnectedToProcess = true;
 }
 
@@ -675,7 +675,7 @@ void ViewGestureController::willEndSwipeGesture(WebBackForwardListItem& targetIt
     m_didStartProvisionalLoad = false;
     m_pendingNavigation = page->goToBackForwardItem(targetItem);
 
-    RefPtr currentItem = Ref { page->backForwardList() }->currentItem();
+    RefPtr currentItem = protect(page->backForwardList())->currentItem();
     // The main frame will not be navigated so hide the snapshot right away.
     if (currentItem && currentItem->itemIsClone(targetItem)) {
         removeSwipeSnapshot();
@@ -746,7 +746,7 @@ void ViewGestureController::requestRenderTreeSizeNotificationIfNeeded()
     if (page->provisionalPageProxy())
         page->provisionalPageProxy()->send(Messages::ViewGestureGeometryCollector::SetRenderTreeSizeNotificationThreshold(threshold));
     else
-        page->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::SetRenderTreeSizeNotificationThreshold(threshold), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::ViewGestureGeometryCollector::SetRenderTreeSizeNotificationThreshold(threshold), page->webPageIDInMainFrameProcess());
 }
 
 FloatPoint ViewGestureController::scaledMagnificationOrigin(FloatPoint origin, double scale)
@@ -779,7 +779,7 @@ void ViewGestureController::prepareMagnificationGesture(FloatPoint origin)
         return;
 
     m_magnification = page->pageScaleFactor();
-    page->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::CollectGeometryForMagnificationGesture(), page->webPageIDInMainFrameProcess());
+    protect(page->legacyMainFrameProcess())->send(Messages::ViewGestureGeometryCollector::CollectGeometryForMagnificationGesture(), page->webPageIDInMainFrameProcess());
 
     m_initialMagnification = m_magnification;
     m_initialMagnificationOrigin = FloatPoint(origin);

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -585,7 +585,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
 {
 #if HAVE(UNIFIED_ASC_AUTH_UI)
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->protectedPreferences()->webAuthenticationASEnabled()) {
+    if (!webPageProxy || !protect(webPageProxy->preferences())->webAuthenticationASEnabled()) {
         auto context = contextForRequest(WTF::move(requestData));
         if (context.get() == nullptr) {
             handler({ }, (AuthenticatorAttachment)0, ExceptionData { ExceptionCode::NotAllowedError, "The origin of the document is not the same as its ancestors."_s });

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -58,7 +58,7 @@ Ref<WebAuthenticatorCoordinatorProxy> WebAuthenticatorCoordinatorProxy::create(W
 WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {
-    webPageProxy.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), webPageProxy.webPageIDInMainFrameProcess(), *this);
+    protect(webPageProxy.legacyMainFrameProcess())->addMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), webPageProxy.webPageIDInMainFrameProcess(), *this);
 }
 
 WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy()
@@ -67,13 +67,13 @@ WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy()
     cancel([]() { });
 #endif // HAVE(UNIFIED_ASC_AUTH_UI)
     if (RefPtr webPageProxy = m_webPageProxy.get())
-        webPageProxy->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), webPageProxy->webPageIDInMainFrameProcess());
+        protect(webPageProxy->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), webPageProxy->webPageIDInMainFrameProcess());
 }
 
 std::optional<SharedPreferencesForWebProcess> WebAuthenticatorCoordinatorProxy::sharedPreferencesForWebProcess() const
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    return webPageProxy ? webPageProxy->protectedLegacyMainFrameProcess()->sharedPreferencesForWebProcess() : std::nullopt;
+    return webPageProxy ? protect(webPageProxy->legacyMainFrameProcess())->sharedPreferencesForWebProcess() : std::nullopt;
 }
 
 void WebAuthenticatorCoordinatorProxy::makeCredential(FrameIdentifier frameId, FrameInfoData&& frameInfo, PublicKeyCredentialCreationOptions&& options, MediationRequirement mediation, RequestCompletionHandler&& handler)

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -677,7 +677,7 @@ void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, R
         ASSERT(!isRemoteFrameNavigation || webPageProxy->preferences().siteIsolationEnabled());
 
         auto navigatedFrameID = navigatedFrameState->frameID;
-        Ref item = WebBackForwardListItem::create(completeFrameStateForNavigation(WTF::move(navigatedFrameState)), webPageProxy->identifier(), navigatedFrameID, webPageProxy->protectedBrowsingContextGroup().ptr());
+        Ref item = WebBackForwardListItem::create(completeFrameStateForNavigation(WTF::move(navigatedFrameState)), webPageProxy->identifier(), navigatedFrameID, protect(webPageProxy->browsingContextGroup()).ptr());
         item->setResourceDirectoryURL(webPageProxy->currentResourceDirectoryURL());
         item->setIsRemoteFrameNavigation(isRemoteFrameNavigation);
         item->setEnhancedSecurity(process->enhancedSecurity());
@@ -719,9 +719,9 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
         Ref process = *downcast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
         if (!!item->backForwardCacheEntry() != frameState->hasCachedPage) {
             if (frameState->hasCachedPage)
-            webPageProxy->protectedBackForwardCache()->addEntry(*item, process->coreProcessIdentifier());
+            protect(webPageProxy->backForwardCache())->addEntry(*item, process->coreProcessIdentifier());
             else if (!item->suspendedPage())
-            webPageProxy->protectedBackForwardCache()->removeEntry(*item);
+            protect(webPageProxy->backForwardCache())->removeEntry(*item);
         }
 
         frameItem->setFrameState(WTF::move(frameState));
@@ -749,7 +749,7 @@ void WebBackForwardList::backForwardListContainsItem(WebCore::BackForwardItemIde
 void WebBackForwardList::backForwardGoToItemShared(BackForwardItemIdentifier itemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)
 {
     if (RefPtr webPageProxy = m_page.get())
-        MESSAGE_CHECK_COMPLETION(webPageProxy->protectedLegacyMainFrameProcess(), !WebKit::isInspectorPage(*webPageProxy), completionHandler(counts()));
+        MESSAGE_CHECK_COMPLETION(protect(webPageProxy->legacyMainFrameProcess()), !WebKit::isInspectorPage(*webPageProxy), completionHandler(counts()));
 
     RefPtr item = itemForID(itemID);
     if (!item)

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
@@ -69,7 +69,7 @@ void WebContextMenuProxy::show()
     Ref contextMenuListener = WebContextMenuListenerProxy::create(*this);
     m_contextMenuListener = contextMenuListener.copyRef();
     page->contextMenuClient().getContextMenuFromProposedMenu(*page, proposedItems(), contextMenuListener, m_context.webHitTestResultData().value(),
-        page->protectedLegacyMainFrameProcess()->transformHandlesToObjects(m_userData.protectedObject().get()).get());
+        protect(page->legacyMainFrameProcess())->transformHandlesToObjects(m_userData.protectedObject().get()).get());
 }
 
 void WebContextMenuProxy::useContextMenuItems(Vector<Ref<WebContextMenuItem>>&& items)
@@ -81,7 +81,7 @@ void WebContextMenuProxy::useContextMenuItems(Vector<Ref<WebContextMenuItem>>&& 
         return;
 
     // Since showContextMenuWithItems can spin a nested run loop we need to turn off the responsiveness timer.
-    page->protectedLegacyMainFrameProcess()->stopResponsivenessTimer();
+    protect(page->legacyMainFrameProcess())->stopResponsivenessTimer();
 
     // Protect |this| from being deallocated if WebPageProxy code is re-entered from the menu runloop or delegates.
     Ref protectedThis { *this };

--- a/Source/WebKit/UIProcess/WebEditCommandProxy.cpp
+++ b/Source/WebKit/UIProcess/WebEditCommandProxy.cpp
@@ -59,7 +59,7 @@ void WebEditCommandProxy::unapply()
 
     page->addPendingUndoRedo(m_commandID, UndoOrRedo::Undo);
     // FIXME: <rdar://168324268> Fix this for site isolation.
-    page->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::UnapplyEditCommand(page->undoVersion(), m_commandID), [weakPage = WeakPtr { *page }, commandID = m_commandID]() {
+    protect(page->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::UnapplyEditCommand(page->undoVersion(), m_commandID), [weakPage = WeakPtr { *page }, commandID = m_commandID]() {
         if (RefPtr page = weakPage.get())
             page->removePendingUndoRedo(commandID);
     }, page->webPageIDInMainFrameProcess());
@@ -74,7 +74,7 @@ void WebEditCommandProxy::reapply()
 
     page->addPendingUndoRedo(m_commandID, UndoOrRedo::Redo);
     // FIXME: <rdar://168324268> Fix this for site isolation.
-    page->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::ReapplyEditCommand(page->undoVersion(), m_commandID), [weakPage = WeakPtr { *page }, commandID = m_commandID]() {
+    protect(page->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::ReapplyEditCommand(page->undoVersion(), m_commandID), [weakPage = WeakPtr { *page }, commandID = m_commandID]() {
         if (RefPtr page = weakPage.get())
             page->removePendingUndoRedo(commandID);
     }, page->webPageIDInMainFrameProcess());

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -75,13 +75,13 @@ WebFullScreenManagerProxy::WebFullScreenManagerProxy(WebPageProxy& page, WebFull
     , m_logIdentifier(page.logIdentifier())
 #endif
 {
-    page.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
+    protect(page.legacyMainFrameProcess())->addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
 }
 
 WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
 {
     if (RefPtr page = m_page.get())
-        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
     detachFromClient();
     callCloseCompletionHandlers();
 }
@@ -230,7 +230,7 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
         enterFullScreenForOwnerElementsInOtherProcesses(frameID, WTF::move(completionHandler));
     } };
 
-    if (RefPtr page = m_page.get(); page && page->protectedPreferences()->siteIsolationEnabled())
+    if (RefPtr page = m_page.get(); page && protect(page->preferences())->siteIsolationEnabled())
         co_await page->nextPresentationUpdate();
 
     co_return true;

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -129,7 +129,7 @@ void WebGeolocationManagerProxy::startUpdatingWithProxy(WebProcessProxy& proxy, 
     RefPtr page = WebProcessProxy::webPage(pageProxyID);
     MESSAGE_CHECK(proxy.connection(), !!page);
 
-    auto isValidAuthorizationToken = page->protectedGeolocationPermissionRequestManager()->isValidAuthorizationToken(authorizationToken);
+    auto isValidAuthorizationToken = protect(page->geolocationPermissionRequestManager())->isValidAuthorizationToken(authorizationToken);
     MESSAGE_CHECK(proxy.connection(), isValidAuthorizationToken);
 
     auto& perDomainData = *m_perDomainData.ensure(registrableDomain, [] {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -585,7 +585,7 @@ Ref<WebPageProxy> WebPageProxy::create(PageClient& pageClient, WebProcessProxy& 
 void WebPageProxy::takeVisibleActivity()
 {
     m_mainFrameProcessActivityState->takeVisibleActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().takeVisibleActivity();
     });
 }
@@ -593,7 +593,7 @@ void WebPageProxy::takeVisibleActivity()
 void WebPageProxy::takeAudibleActivity()
 {
     m_mainFrameProcessActivityState->takeAudibleActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().takeAudibleActivity();
     });
 }
@@ -601,7 +601,7 @@ void WebPageProxy::takeAudibleActivity()
 void WebPageProxy::takeCapturingActivity()
 {
     m_mainFrameProcessActivityState->takeCapturingActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().takeCapturingActivity();
     });
 }
@@ -609,7 +609,7 @@ void WebPageProxy::takeCapturingActivity()
 void WebPageProxy::takeMutedCaptureAssertion()
 {
     m_mainFrameProcessActivityState->takeMutedCaptureAssertion();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().takeMutedCaptureAssertion();
     });
 }
@@ -617,7 +617,7 @@ void WebPageProxy::takeMutedCaptureAssertion()
 void WebPageProxy::takeNetworkActivity()
 {
     m_mainFrameProcessActivityState->takeNetworkActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().takeNetworkActivity();
     });
 }
@@ -626,7 +626,7 @@ void WebPageProxy::takeNetworkActivity()
 void WebPageProxy::takeAccessibilityActivityWhenInWindow()
 {
     m_mainFrameProcessActivityState->takeAccessibilityActivityWhenInWindow();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().takeAccessibilityActivityWhenInWindow();
     });
 }
@@ -637,7 +637,7 @@ bool WebPageProxy::hasAccessibilityActivityForTesting()
         return false;
 
     bool result = true;
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&result](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&result](auto& remotePageProxy) {
         result = result || remotePageProxy.processActivityState().hasAccessibilityActivityForTesting();
     });
 
@@ -648,7 +648,7 @@ bool WebPageProxy::hasAccessibilityActivityForTesting()
 void WebPageProxy::resetActivityState()
 {
     m_mainFrameProcessActivityState->reset();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().reset();
     });
 }
@@ -656,7 +656,7 @@ void WebPageProxy::resetActivityState()
 void WebPageProxy::dropVisibleActivity()
 {
     m_mainFrameProcessActivityState->dropVisibleActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().dropVisibleActivity();
     });
 }
@@ -664,7 +664,7 @@ void WebPageProxy::dropVisibleActivity()
 void WebPageProxy::dropAudibleActivity()
 {
     m_mainFrameProcessActivityState->dropAudibleActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().dropAudibleActivity();
     });
 }
@@ -672,7 +672,7 @@ void WebPageProxy::dropAudibleActivity()
 void WebPageProxy::dropCapturingActivity()
 {
     m_mainFrameProcessActivityState->dropCapturingActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().dropCapturingActivity();
     });
 }
@@ -680,7 +680,7 @@ void WebPageProxy::dropCapturingActivity()
 void WebPageProxy::dropMutedCaptureAssertion()
 {
     m_mainFrameProcessActivityState->dropMutedCaptureAssertion();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().dropMutedCaptureAssertion();
     });
 }
@@ -688,7 +688,7 @@ void WebPageProxy::dropMutedCaptureAssertion()
 void WebPageProxy::dropNetworkActivity()
 {
     m_mainFrameProcessActivityState->dropNetworkActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().dropNetworkActivity();
     });
 }
@@ -696,7 +696,7 @@ void WebPageProxy::dropNetworkActivity()
 bool WebPageProxy::hasValidVisibleActivity() const
 {
     bool hasValidVisibleActivity = m_mainFrameProcessActivityState->hasValidVisibleActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&](auto& remotePageProxy) {
         hasValidVisibleActivity &= remotePageProxy.processActivityState().hasValidVisibleActivity();
     });
     return hasValidVisibleActivity;
@@ -705,7 +705,7 @@ bool WebPageProxy::hasValidVisibleActivity() const
 bool WebPageProxy::hasValidAudibleActivity() const
 {
     bool hasValidAudibleActivity = m_mainFrameProcessActivityState->hasValidAudibleActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&](auto& remotePageProxy) {
         hasValidAudibleActivity &= remotePageProxy.processActivityState().hasValidAudibleActivity();
     });
     return hasValidAudibleActivity;
@@ -714,7 +714,7 @@ bool WebPageProxy::hasValidAudibleActivity() const
 bool WebPageProxy::hasValidCapturingActivity() const
 {
     bool hasValidCapturingActivity = m_mainFrameProcessActivityState->hasValidCapturingActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&](auto& remotePageProxy) {
         hasValidCapturingActivity &= remotePageProxy.processActivityState().hasValidCapturingActivity();
     });
     return hasValidCapturingActivity;
@@ -723,7 +723,7 @@ bool WebPageProxy::hasValidCapturingActivity() const
 bool WebPageProxy::hasValidMutedCaptureAssertion() const
 {
     bool hasValidMutedCaptureAssertion = m_mainFrameProcessActivityState->hasValidMutedCaptureAssertion();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&](auto& remotePageProxy) {
         hasValidMutedCaptureAssertion &= remotePageProxy.processActivityState().hasValidMutedCaptureAssertion();
     });
     return hasValidMutedCaptureAssertion;
@@ -732,7 +732,7 @@ bool WebPageProxy::hasValidMutedCaptureAssertion() const
 bool WebPageProxy::hasValidNetworkActivity() const
 {
     bool hasValidNetworkActivity = m_mainFrameProcessActivityState->hasValidNetworkActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&](auto& remotePageProxy) {
         hasValidNetworkActivity &= remotePageProxy.processActivityState().hasValidNetworkActivity();
     });
     return hasValidNetworkActivity;
@@ -742,7 +742,7 @@ bool WebPageProxy::hasValidNetworkActivity() const
 void WebPageProxy::takeOpeningAppLinkActivity()
 {
     m_mainFrameProcessActivityState->takeOpeningAppLinkActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().takeOpeningAppLinkActivity();
     });
 }
@@ -750,7 +750,7 @@ void WebPageProxy::takeOpeningAppLinkActivity()
 void WebPageProxy::dropOpeningAppLinkActivity()
 {
     m_mainFrameProcessActivityState->dropOpeningAppLinkActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().dropOpeningAppLinkActivity();
     });
 }
@@ -758,7 +758,7 @@ void WebPageProxy::dropOpeningAppLinkActivity()
 bool WebPageProxy::hasValidOpeningAppLinkActivity() const
 {
     bool hasValidOpeningAppLinkActivity = m_mainFrameProcessActivityState->hasValidOpeningAppLinkActivity();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&](auto& remotePageProxy) {
         hasValidOpeningAppLinkActivity &= remotePageProxy.processActivityState().hasValidOpeningAppLinkActivity();
     });
     return hasValidOpeningAppLinkActivity;
@@ -770,7 +770,7 @@ bool WebPageProxy::hasValidOpeningAppLinkActivity() const
 void WebPageProxy::updateWebProcessSuspensionDelay()
 {
     m_mainFrameProcessActivityState->updateWebProcessSuspensionDelay();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().updateWebProcessSuspensionDelay();
     });
 }
@@ -912,7 +912,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     , m_toolbarsAreVisible(windowFeature([] (auto& features) { return features.toolBarVisible; }, configuration)
         || windowFeature([] (auto& features) { return features.locationBarVisible; }, configuration))
 {
-    WEBPAGEPROXY_RELEASE_LOG(Loading, "constructor, site isolation enabled %d", protectedPreferences()->siteIsolationEnabled());
+    WEBPAGEPROXY_RELEASE_LOG(Loading, "constructor, site isolation enabled %d", protect(preferences())->siteIsolationEnabled());
 
     ASSERT(!webPageProxyMap().contains(m_identifier));
     webPageProxyMap().set(m_identifier, this);
@@ -934,7 +934,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 
     WebProcessPool::statistics().wkPageCount++;
 
-    protectedPreferences()->addPage(*this);
+    protect(preferences())->addPage(*this);
 
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
     if (RefPtr webExtensionController = this->webExtensionController())
@@ -957,7 +957,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 
 #if PLATFORM(COCOA)
     m_activityStateChangeDispatcher = makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::ActivityStateChange, [this] {
-        Ref { *this }->dispatchActivityStateChange();
+        protect(*this)->dispatchActivityStateChange();
     });
 #endif
 
@@ -982,7 +982,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #endif
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR) && HAVE(GROUP_ACTIVITIES)
-    if (protectedPreferences()->mediaSessionCoordinatorEnabled())
+    if (protect(preferences())->mediaSessionCoordinatorEnabled())
         GroupActivitiesSessionNotifier::singleton().addWebPage(*this);
 #endif
 
@@ -994,7 +994,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
             protectedThis->sendCachedLinkDecorationFilteringData();
     });
 
-    if (protectedPreferences()->scriptTrackingPrivacyProtectionsEnabled())
+    if (protect(preferences())->scriptTrackingPrivacyProtectionsEnabled())
         process.protectedProcessPool()->observeScriptTrackingPrivacyUpdatesIfNeeded();
 #endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 
@@ -1002,11 +1002,11 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     if (RefPtr gpuProcess = GPUProcessProxy::singletonIfCreated())
         gpuProcess->setPresentingApplicationAuditToken(process.coreProcessIdentifier(), m_webPageID, m_presentingApplicationAuditToken);
 #endif
-    if (protectedPreferences()->siteIsolationEnabled())
+    if (protect(preferences())->siteIsolationEnabled())
         IPC::Connection::setShouldCrashOnMessageCheckFailure(true);
 
-    if (protectedPreferences()->enhancedSecurityHeuristicsEnabled())
-        internals().enhancedSecurityTracker.initializeWithWebsiteDataStore(protectedWebsiteDataStore());
+    if (protect(preferences())->enhancedSecurityHeuristicsEnabled())
+        internals().enhancedSecurityTracker.initializeWithWebsiteDataStore(protect(websiteDataStore()));
 }
 
 WebPageProxy::~WebPageProxy()
@@ -1077,7 +1077,7 @@ void WebPageProxy::addAllMessageReceivers()
 void WebPageProxy::removeAllMessageReceivers()
 {
     internals().messageReceiverRegistration.stopReceivingMessages();
-    protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::NotificationManagerMessageHandler::messageReceiverName(), m_webPageID);
+    protect(legacyMainFrameProcess())->removeMessageReceiver(Messages::NotificationManagerMessageHandler::messageReceiverName(), m_webPageID);
 }
 
 WebPageProxyMessageReceiverRegistration& WebPageProxy::messageReceiverRegistration()
@@ -1092,12 +1092,12 @@ std::optional<SharedPreferencesForWebProcess> WebPageProxy::sharedPreferencesFor
 
 bool WebPageProxy::attachmentElementEnabled()
 {
-    return protectedPreferences()->attachmentElementEnabled();
+    return protect(preferences())->attachmentElementEnabled();
 }
 
 bool WebPageProxy::modelElementEnabled()
 {
-    return protectedPreferences()->modelElementEnabled();
+    return protect(preferences())->modelElementEnabled();
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
@@ -1115,29 +1115,9 @@ PageClient* WebPageProxy::pageClient() const
     return m_pageClient.get();
 }
 
-RefPtr<PageClient> WebPageProxy::protectedPageClient() const
-{
-    return pageClient();
-}
-
 PAL::SessionID WebPageProxy::sessionID() const
 {
     return m_websiteDataStore->sessionID();
-}
-
-RefPtr<WebFrameProxy> WebPageProxy::protectedMainFrame() const
-{
-    return m_mainFrame;
-}
-
-RefPtr<WebFrameProxy> WebPageProxy::protectedFocusedFrame() const
-{
-    return m_focusedFrame;
-}
-
-RefPtr<DrawingAreaProxy> WebPageProxy::protectedDrawingArea() const
-{
-    return m_drawingArea;
 }
 
 DrawingAreaProxy* WebPageProxy::provisionalDrawingArea() const
@@ -1158,11 +1138,6 @@ ProcessID WebPageProxy::gpuProcessID() const
 #endif
 
     return 0;
-}
-
-Ref<WebProcessProxy> WebPageProxy::protectedLegacyMainFrameProcess() const
-{
-    return m_legacyMainFrameProcess;
 }
 
 ProcessID WebPageProxy::modelProcessID() const
@@ -1205,9 +1180,9 @@ void WebPageProxy::setPreferences(WebPreferences& preferences)
     if (&preferences == m_preferences.ptr())
         return;
 
-    protectedPreferences()->removePage(*this);
+    protect(m_preferences)->removePage(*this);
     m_preferences = preferences;
-    protectedPreferences()->addPage(*this);
+    preferences.addPage(*this);
 
     preferencesDidChange();
 }
@@ -1245,13 +1220,13 @@ void WebPageProxy::setFormClient(std::unique_ptr<API::FormClient>&& formClient)
 template<typename Message>
 void WebPageProxy::send(Message&& message)
 {
-    protectedLegacyMainFrameProcess()->send(WTF::move(message), webPageIDInMainFrameProcess());
+    protect(legacyMainFrameProcess())->send(WTF::move(message), webPageIDInMainFrameProcess());
 }
 
 template<typename Message, typename CH>
 void WebPageProxy::sendWithAsyncReply(Message&& message, CH&& completionHandler)
 {
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(WTF::move(message), WTF::move(completionHandler), webPageIDInMainFrameProcess());
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(WTF::move(message), WTF::move(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::setUIClient(std::unique_ptr<API::UIClient>&& uiClient)
@@ -1375,7 +1350,7 @@ bool WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs(const API::PageConfi
 
 bool WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs(const WebPageProxy& page) const
 {
-    return hasSameGPUAndNetworkProcessPreferencesAs(Ref { page }->configuration());
+    return hasSameGPUAndNetworkProcessPreferencesAs(protect(page)->configuration());
 }
 
 void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
@@ -1386,24 +1361,24 @@ void WebPageProxy::launchProcess(const Site& site, ProcessLaunchReason reason)
     WEBPAGEPROXY_RELEASE_LOG(Loading, "launchProcess:");
 
     // In case we are currently connected to the dummy process, we need to make sure the inspector proxy
-    // disconnects from the dummy process first. Do not call inspector() / protectedInspector() since they return
-    // null after the page has closed.
-    RefPtr { m_inspector }->reset();
+    // disconnects from the dummy process first. Do not call inspector() since it returns null after the
+    // page has closed.
+    protect(m_inspector)->reset();
 
-    protectedLegacyMainFrameProcess()->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);
+    protect(legacyMainFrameProcess())->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);
     removeAllMessageReceivers();
 
     Ref processPool = m_configuration->processPool();
     RefPtr relatedPage = m_configuration->relatedPage();
 
-    if (RefPtr frameProcess = protectedBrowsingContextGroup()->processForSite(site)) {
-        ASSERT(protectedPreferences()->siteIsolationEnabled());
+    if (RefPtr frameProcess = protect(browsingContextGroup())->processForSite(site)) {
+        ASSERT(protect(preferences())->siteIsolationEnabled());
         m_legacyMainFrameProcess = frameProcess->process();
     } else if (relatedPage && !relatedPage->isClosed() && reason == ProcessLaunchReason::InitialProcess && hasSameGPUAndNetworkProcessPreferencesAs(*relatedPage)) {
         m_legacyMainFrameProcess = relatedPage->ensureRunningProcess();
         WEBPAGEPROXY_RELEASE_LOG(Loading, "launchProcess: Using process (process=%p, PID=%i) from related page", m_legacyMainFrameProcess.ptr(), m_legacyMainFrameProcess->processID());
     } else
-        m_legacyMainFrameProcess = processPool->processForSite(protectedWebsiteDataStore(), WebProcessPool::IsSharedProcess::No, site, site, { }, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled, currentEnhancedSecurityState(), m_configuration, WebCore::ProcessSwapDisposition::None);
+        m_legacyMainFrameProcess = processPool->processForSite(protect(websiteDataStore()), WebProcessPool::IsSharedProcess::No, site, site, { }, shouldEnableLockdownMode() ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled, currentEnhancedSecurityState(), m_configuration, WebCore::ProcessSwapDisposition::None);
 
     m_shouldReloadDueToCrashWhenVisible = false;
     m_isLockdownModeExplicitlySet = m_configuration->isLockdownModeExplicitlySet();
@@ -1471,14 +1446,14 @@ bool WebPageProxy::suspendCurrentPageIfPossible(API::Navigation& navigation, Ref
     WEBPAGEPROXY_RELEASE_LOG(ProcessSwapping, "suspendCurrentPageIfPossible: Suspending current page for process pid %i", m_legacyMainFrameProcess->processID());
     mainFrame->frameLoadState().didSuspend();
 
-    Ref suspendedPage = SuspendedPageProxy::create(*this, protectedLegacyMainFrameProcess(), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
+    Ref suspendedPage = SuspendedPageProxy::create(*this, protect(legacyMainFrameProcess()), mainFrame.releaseNonNull(), std::exchange(m_browsingContextGroup, BrowsingContextGroup::create()), shouldDelayClosingUntilFirstLayerFlush);
 
     LOG(ProcessSwapping, "WebPageProxy %" PRIu64 " created suspended page %s for process pid %i, back/forward item %s" PRIu64, identifier().toUInt64(), suspendedPage->loggingString().utf8().data(), m_legacyMainFrameProcess->processID(), fromItem ? fromItem->identifier().toString().utf8().data() : "0"_s);
 
     m_lastSuspendedPage = suspendedPage.get();
 
     if (fromItem && shouldUseBackForwardCache())
-        protectedBackForwardCache()->addEntry(*fromItem, WTF::move(suspendedPage));
+        protect(backForwardCache())->addEntry(*fromItem, WTF::move(suspendedPage));
     else {
         ASSERT(needsSuspendedPageToPreventFlashing);
         m_suspendedPageKeptToPreventFlashing = WTF::move(suspendedPage);
@@ -1511,7 +1486,7 @@ void WebPageProxy::setBrowsingContextGroup(BrowsingContextGroup& browsingContext
     if (protectedBrowsingContextGroup.ptr() == &browsingContextGroup)
         return;
 
-    if (protectedPreferences()->siteIsolationEnabled()) {
+    if (protect(preferences())->siteIsolationEnabled()) {
         protectedBrowsingContextGroup->removePage(*this);
         browsingContextGroup.addPage(*this);
     }
@@ -1578,7 +1553,7 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
     // We do need to clear it at some point for navigations that aren't from back/forward navigations. Probably in the same place as PSON?
     setBrowsingContextGroup(provisionalPage->browsingContextGroup());
 
-    protectedLegacyMainFrameProcess()->addExistingWebPage(*this, WebProcessProxy::BeginsUsingDataStore::No);
+    protect(legacyMainFrameProcess())->addExistingWebPage(*this, WebProcessProxy::BeginsUsingDataStore::No);
     addAllMessageReceivers();
 
     Site unusedSite(aboutBlankURL());
@@ -1641,13 +1616,13 @@ void WebPageProxy::didAttachToRunningProcess()
 
 #if ENABLE(FULLSCREEN_API)
     ASSERT(!m_fullScreenManager);
-    m_fullScreenManager = WebFullScreenManagerProxy::create(*this, protectedPageClient()->checkedFullScreenManagerProxyClient().get());
+    m_fullScreenManager = WebFullScreenManagerProxy::create(*this, protect(pageClient())->checkedFullScreenManagerProxyClient().get());
 #endif
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     ASSERT(!m_playbackSessionManager);
     m_playbackSessionManager = PlaybackSessionManagerProxy::create(*this);
     ASSERT(!m_videoPresentationManager);
-    m_videoPresentationManager = VideoPresentationManagerProxy::create(*this, *protectedPlaybackSessionManager());
+    m_videoPresentationManager = VideoPresentationManagerProxy::create(*this, *protect(playbackSessionManager()));
     if (RefPtr videoPresentationManager = m_videoPresentationManager)
         videoPresentationManager->setMockVideoPresentationModeEnabled(m_mockVideoPresentationModeEnabled);
 #endif
@@ -1663,7 +1638,7 @@ void WebPageProxy::didAttachToRunningProcess()
 #endif
 
 #if ENABLE(ARKIT_INLINE_PREVIEW)
-    if (protectedPreferences()->modelElementEnabled()) {
+    if (protect(preferences())->modelElementEnabled()) {
         ASSERT(!m_modelElementController);
         m_modelElementController = ModelElementController::create(*this);
     }
@@ -1751,7 +1726,7 @@ void WebPageProxy::setDrawingArea(RefPtr<DrawingAreaProxy>&& newDrawingArea)
         drawingArea->stopReceivingMessages(legacyMainFrameProcess);
 
     m_drawingArea = WTF::move(newDrawingArea);
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [drawingArea = m_drawingArea](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [drawingArea = m_drawingArea](auto& remotePageProxy) {
         remotePageProxy.setDrawingArea(drawingArea.get());
     });
     RefPtr drawingArea = m_drawingArea;
@@ -1786,7 +1761,7 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
 
     if (auto& attributedBundleIdentifier = m_configuration->attributedBundleIdentifier(); !!attributedBundleIdentifier) {
         WebPageNetworkParameters parameters { attributedBundleIdentifier };
-        protectedWebsiteDataStore()->protectedNetworkProcess()->send(Messages::NetworkProcess::AddWebPageNetworkParameters(sessionID(), identifier(), WTF::move(parameters)), 0);
+        protect(websiteDataStore())->protectedNetworkProcess()->send(Messages::NetworkProcess::AddWebPageNetworkParameters(sessionID(), identifier(), WTF::move(parameters)), 0);
     }
 
     if (RefPtr networkProcess = websiteDataStore().networkProcessIfExists()) {
@@ -1809,7 +1784,7 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     m_mainFrame = WebFrameProxy::create(*this, browsingContextGroup->ensureProcessForSite(effectiveSite, site, process, preferences), generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, WebFrameProxy::protectedWebFrame(m_openerFrameIdentifier).get(), IsMainFrame::Yes);
     if (preferences->siteIsolationEnabled())
         browsingContextGroup->addPage(*this);
-    process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protectedDrawingArea(), m_mainFrame->frameID(), std::nullopt)), 0);
+    process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protect(drawingArea()), m_mainFrame->frameID(), std::nullopt)), 0);
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
     internals().frameLoadStateObserver = WebPageProxyFrameLoadStateObserver::create();
@@ -1872,9 +1847,8 @@ void WebPageProxy::close()
 
     m_pageForTesting = nullptr;
 
-    // Do not call inspector() / protectedInspector() since they return
-    // null after the page has closed.
-    RefPtr { m_inspector }->invalidate();
+    // Do not call inspector() since it returns null after the page has closed.
+    protect(m_inspector)->invalidate();
 
     m_backForwardList->pageClosed();
     m_inspectorController->pageClosed();
@@ -1926,7 +1900,7 @@ void WebPageProxy::close()
     // Delay sending close message to next runloop cycle to avoid white flash.
     RunLoop::currentSingleton().dispatch([processesToClose = WTF::move(processesToClose)] {
         for (auto [process, pageID, scope] : processesToClose)
-            Ref { process }->send(Messages::WebPage::Close(), pageID);
+            protect(process)->send(Messages::WebPage::Close(), pageID);
     });
 
     process->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);
@@ -1946,8 +1920,8 @@ void WebPageProxy::close()
     m_internals->recentGamepadAccessHysteresis.cancel();
 #endif
 
-    if (protectedPreferences()->siteIsolationEnabled())
-        protectedBrowsingContextGroup()->removePage(*this);
+    if (protect(preferences())->siteIsolationEnabled())
+        protect(browsingContextGroup())->removePage(*this);
 }
 
 bool WebPageProxy::tryClose()
@@ -2008,7 +1982,7 @@ void WebPageProxy::maybeInitializeSandboxExtensionHandle(WebProcessProxy& proces
     }
 #endif
 
-    auto createSandboxExtension = [protectedProcess = Ref { process }] (const String& path) {
+    auto createSandboxExtension = [protectedProcess = protect(process)] (const String& path) {
         if (auto handle = protectedProcess->sandboxExtensionForFile(path))
             return handle;
         std::optional<SandboxExtension::Handle> handle;
@@ -2167,7 +2141,7 @@ RefPtr<API::Navigation> WebPageProxy::loadRequest(WebCore::ResourceRequest&& req
     setLastNavigationWasAppInitiated(request);
 #endif
 
-    loadRequestWithNavigationShared(protectedLegacyMainFrameProcess(), m_webPageID, navigation, WTF::move(request), shouldOpenExternalURLsPolicy, navigationUpgradeToHTTPSBehavior, userData, ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain(), nullptr, std::nullopt);
+    loadRequestWithNavigationShared(protect(legacyMainFrameProcess()), m_webPageID, navigation, WTF::move(request), shouldOpenExternalURLsPolicy, navigationUpgradeToHTTPSBehavior, userData, ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain(), nullptr, std::nullopt);
     return navigation;
 }
 
@@ -2199,7 +2173,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
 #if PLATFORM(COCOA)
     bool urlIsInvalidButNotEmpty = !url.isValid() && !url.isEmpty();
     if (urlIsInvalidButNotEmpty && WTF::linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::ConvertsInvalidURLsToNull)) {
-        RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, request, navigation = Ref { navigation }] mutable {
+        RunLoop::mainSingleton().dispatch([weakThis = WeakPtr { *this }, request, navigation = protect(navigation)] mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
@@ -2234,17 +2208,17 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
     loadParameters.isRequestFromClientOrUserInput = navigation.isRequestFromClientOrUserInput();
     loadParameters.navigationUpgradeToHTTPSBehavior = navigationUpgradeToHTTPSBehavior;
     loadParameters.isHandledByAboutSchemeHandler = m_aboutSchemeHandler->canHandleURL(url);
-    loadParameters.requiredCookiesVersion = protectedWebsiteDataStore()->cookiesVersion();
+    loadParameters.requiredCookiesVersion = protect(websiteDataStore())->cookiesVersion();
     loadParameters.originatingFrame = navigation.lastNavigationAction() ? std::optional(navigation.lastNavigationAction()->originatingFrameInfoData) : std::nullopt;
     if (auto& action = navigation.lastNavigationAction())
         loadParameters.requester = action->requester;
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    if (protectedPreferences()->iFrameResourceMonitoringEnabled())
-        process->requestResourceMonitorRuleLists(protectedPreferences()->iFrameResourceMonitoringTestingSettingsEnabled());
+    if (protect(preferences())->iFrameResourceMonitoringEnabled())
+        process->requestResourceMonitorRuleLists(protect(preferences())->iFrameResourceMonitoringTestingSettingsEnabled());
 #endif
 
-    maybeInitializeSandboxExtensionHandle(process, url, pageLoadState->resourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, loadParameters = WTF::move(loadParameters), url, navigation = Ref { navigation }, webPageID, shouldTreatAsContinuingLoad] (std::optional<SandboxExtension::Handle>&& sandboxExtensionHandle) mutable {
+    maybeInitializeSandboxExtensionHandle(process, url, pageLoadState->resourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, loadParameters = WTF::move(loadParameters), url, navigation = protect(navigation), webPageID, shouldTreatAsContinuingLoad] (std::optional<SandboxExtension::Handle>&& sandboxExtensionHandle) mutable {
         RefPtr protectedProcess = weakProcess.get();
         RefPtr protectedThis = weakThis.get();
         if (!protectedProcess || !protectedThis)
@@ -2371,7 +2345,7 @@ RefPtr<API::Navigation> WebPageProxy::loadData(Ref<WebCore::SharedBuffer>&& data
     if (shouldForceForegroundPriorityForClientNavigation())
         navigation->setClientNavigationActivity(legacyMainFrameProcess().protectedThrottler()->foregroundActivity("Client navigation"_s));
 
-    loadDataWithNavigationShared(protectedLegacyMainFrameProcess(), m_webPageID, navigation, WTF::move(data), type, encoding, baseURL, userData, ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain(), nullptr, shouldOpenExternalURLsPolicy, SubstituteData::SessionHistoryVisibility::Hidden);
+    loadDataWithNavigationShared(protect(legacyMainFrameProcess()), m_webPageID, navigation, WTF::move(data), type, encoding, baseURL, userData, ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain(), nullptr, shouldOpenExternalURLsPolicy, SubstituteData::SessionHistoryVisibility::Hidden);
     return navigation;
 }
 
@@ -2542,7 +2516,7 @@ void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const
         });
     };
 
-    protectedWebsiteDataStore()->protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, RegistrableDomain(baseURL), LoadedWebArchive::No, WTF::move(continueLoad));
+    protect(websiteDataStore())->protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, RegistrableDomain(baseURL), LoadedWebArchive::No, WTF::move(continueLoad));
 }
 
 void WebPageProxy::stopLoading()
@@ -2559,7 +2533,7 @@ void WebPageProxy::stopLoading()
         provisionalPage->cancel();
         m_provisionalPage = nullptr;
     }
-    protectedLegacyMainFrameProcess()->startResponsivenessTimer();
+    protect(legacyMainFrameProcess())->startResponsivenessTimer();
 }
 
 RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> options)
@@ -2568,7 +2542,7 @@ RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> op
 
     // Make sure the Network & GPU processes are still responsive. This is so that reload() gets us out of the bad state if one of these
     // processes is hung.
-    protectedWebsiteDataStore()->protectedNetworkProcess()->checkForResponsiveness();
+    protect(websiteDataStore())->protectedNetworkProcess()->checkForResponsiveness();
 #if ENABLE(GPU_PROCESS)
     if (RefPtr gpuProcess = m_configuration->processPool().gpuProcess())
         gpuProcess->checkForResponsiveness();
@@ -2597,7 +2571,7 @@ RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> op
     process->markProcessAsRecentlyUsed();
     if (!url.isEmpty()) {
         // We may not have an extension yet if back/forward list was reinstated after a WebProcess crash or a browser relaunch
-        maybeInitializeSandboxExtensionHandle(protectedLegacyMainFrameProcess(), URL { url }, currentResourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, process = WTF::move(process), options = WTF::move(options), sandboxExtensionHandle = WTF::move(sandboxExtensionHandle), navigation](std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
+        maybeInitializeSandboxExtensionHandle(protect(legacyMainFrameProcess()), URL { url }, currentResourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, process = WTF::move(process), options = WTF::move(options), sandboxExtensionHandle = WTF::move(sandboxExtensionHandle), navigation](std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
             if (!weakThis)
                 return;
             if (sandboxExtension)
@@ -2701,7 +2675,7 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
     process->markProcessAsRecentlyUsed();
 
     Ref frameState = item->mainFrameState();
-    if (protectedPreferences()->siteIsolationEnabled()) {
+    if (protect(preferences())->siteIsolationEnabled()) {
         if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this) {
             process = frame->process();
             frameState = frameItem.copyFrameStateWithChildren();
@@ -2773,7 +2747,7 @@ bool WebPageProxy::canShowMIMEType(const String& mimeType)
     if (MIMETypeRegistry::canShowMIMEType(mimeType))
         return true;
 
-    if (protectedPreferences()->pdfJSViewerEnabled() && MIMETypeRegistry::isPDFMIMEType(mimeType))
+    if (protect(preferences())->pdfJSViewerEnabled() && MIMETypeRegistry::isPDFMIMEType(mimeType))
         return true;
 
 #if PLATFORM(COCOA)
@@ -2796,7 +2770,7 @@ void WebPageProxy::setControlledByAutomation(bool controlled)
         return;
 
     send(Messages::WebPage::SetControlledByAutomation(controlled));
-    protectedWebsiteDataStore()->protectedNetworkProcess()->send(Messages::NetworkProcess::SetSessionIsControlledByAutomation(m_websiteDataStore->sessionID(), m_controlledByAutomation), 0);
+    protect(websiteDataStore())->protectedNetworkProcess()->send(Messages::NetworkProcess::SetSessionIsControlledByAutomation(m_websiteDataStore->sessionID(), m_controlledByAutomation), 0);
 }
 
 RefPtr<WebAutomationSession> WebPageProxy::activeAutomationSession() const
@@ -2846,7 +2820,7 @@ void WebPageProxy::setInspectable(bool inspectable)
 
     inspectorDebuggable->setInspectable(inspectable);
 
-    protectedWebsiteDataStore()->updateServiceWorkerInspectability();
+    protect(websiteDataStore())->updateServiceWorkerInspectability();
 }
 
 String WebPageProxy::remoteInspectionNameOverride() const
@@ -2895,10 +2869,10 @@ void WebPageProxy::setObscuredContentInsets(const WebCore::FloatBoxExtent& obscu
     if (!hasRunningProcess())
         return;
 
-    protectedDrawingArea()->updateDebugIndicator();
+    protect(drawingArea())->updateDebugIndicator();
 
 #if PLATFORM(COCOA)
-    send(Messages::WebPage::SetObscuredContentInsetsFenced(m_internals->obscuredContentInsets, protectedDrawingArea()->createFence()));
+    send(Messages::WebPage::SetObscuredContentInsetsFenced(m_internals->obscuredContentInsets, protect(drawingArea())->createFence()));
 #else
     send(Messages::WebPage::SetObscuredContentInsets(m_internals->obscuredContentInsets));
 #endif
@@ -3011,7 +2985,7 @@ void WebPageProxy::viewWillStartLiveResize()
 
     closeOverlayedViews();
 
-    protectedDrawingArea()->viewWillStartLiveResize();
+    protect(drawingArea())->viewWillStartLiveResize();
 
     send(Messages::WebPage::ViewWillStartLiveResize());
 }
@@ -3021,7 +2995,7 @@ void WebPageProxy::viewWillEndLiveResize()
     if (!hasRunningProcess())
         return;
 
-    protectedDrawingArea()->viewWillEndLiveResize();
+    protect(drawingArea())->viewWillEndLiveResize();
 
     send(Messages::WebPage::ViewWillEndLiveResize());
 }
@@ -3194,7 +3168,7 @@ void WebPageProxy::viewDidLeaveWindow()
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     m_mainFrameProcessActivityState->viewDidLeaveWindow();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().viewDidLeaveWindow();
     });
 #endif
@@ -3208,7 +3182,7 @@ void WebPageProxy::viewDidEnterWindow()
 
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     m_mainFrameProcessActivityState->viewDidEnterWindow();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePageProxy) {
         remotePageProxy.processActivityState().viewDidEnterWindow();
     });
 #endif
@@ -3262,7 +3236,7 @@ void WebPageProxy::dispatchActivityStateChange()
     bool isNowInWindow = (changed & ActivityState::IsInWindow) && isInWindow();
     // We always want to wait for the Web process to reply if we've been in-window before and are coming back in-window.
     if (m_viewWasEverInWindow && isNowInWindow) {
-        if (protectedDrawingArea()->hasVisibleContent() && m_waitsForPaintAfterViewDidMoveToWindow && !m_shouldSkipWaitingForPaintAfterNextViewDidMoveToWindow)
+        if (protect(drawingArea())->hasVisibleContent() && m_waitsForPaintAfterViewDidMoveToWindow && !m_shouldSkipWaitingForPaintAfterNextViewDidMoveToWindow)
             m_activityStateChangeWantsSynchronousReply = true;
         m_shouldSkipWaitingForPaintAfterNextViewDidMoveToWindow = false;
     }
@@ -3287,21 +3261,21 @@ void WebPageProxy::dispatchActivityStateChange()
     updateThrottleState();
 
 #if ENABLE(POINTER_LOCK)
-    if (((changed & ActivityState::IsVisible) && !isViewVisible()) || ((changed & ActivityState::WindowIsActive) && !protectedPageClient()->isViewWindowActive())
+    if (((changed & ActivityState::IsVisible) && !isViewVisible()) || ((changed & ActivityState::WindowIsActive) && !protect(pageClient())->isViewWindowActive())
         || ((changed & ActivityState::IsFocused) && !isViewFocused()))
         resetPointerLockState();
 #endif
 
     if (changed & ActivityState::IsVisible) {
         if (isViewVisible())
-            internals().visiblePageToken = protectedLegacyMainFrameProcess()->visiblePageToken();
+            internals().visiblePageToken = protect(legacyMainFrameProcess())->visiblePageToken();
         else {
             internals().visiblePageToken = nullptr;
 
             // If we've started the responsiveness timer as part of telling the web process to update the backing store
             // state, it might not send back a reply (since it won't paint anything if the web page is hidden) so we
             // stop the unresponsiveness timer here.
-            protectedLegacyMainFrameProcess()->stopResponsivenessTimer();
+            protect(legacyMainFrameProcess())->stopResponsivenessTimer();
         }
     }
 
@@ -3321,7 +3295,7 @@ void WebPageProxy::dispatchActivityStateChange()
 #endif
 
     if (isNowInWindow)
-        protectedDrawingArea()->hideContentUntilPendingUpdate();
+        protect(drawingArea())->hideContentUntilPendingUpdate();
 
     updateBackingStoreDiscardableState();
 
@@ -3345,7 +3319,7 @@ void WebPageProxy::dispatchActivityStateChange()
 
 void WebPageProxy::updateThrottleState()
 {
-    bool processSuppressionEnabled = protectedPreferences()->pageVisibilityBasedProcessSuppressionEnabled();
+    bool processSuppressionEnabled = protect(preferences())->pageVisibilityBasedProcessSuppressionEnabled();
 
     Ref processPool = m_configuration->processPool();
 
@@ -3422,7 +3396,7 @@ void WebPageProxy::clearAudibleActivity()
 
 void WebPageProxy::updateHiddenPageThrottlingAutoIncreases()
 {
-    if (!protectedPreferences()->hiddenPageDOMTimerThrottlingAutoIncreases())
+    if (!protect(preferences())->hiddenPageDOMTimerThrottlingAutoIncreases())
         internals().hiddenPageDOMTimerThrottlingAutoIncreasesCount = nullptr;
     else if (!internals().hiddenPageDOMTimerThrottlingAutoIncreasesCount)
         internals().hiddenPageDOMTimerThrottlingAutoIncreasesCount = m_configuration->protectedProcessPool()->hiddenPageThrottlingAutoIncreasesCount();
@@ -3451,7 +3425,7 @@ void WebPageProxy::waitForDidUpdateActivityState(ActivityStateChangeID activityS
 
     m_waitingForDidUpdateActivityState = true;
 
-    protectedDrawingArea()->waitForDidUpdateActivityState(activityStateChangeID);
+    protect(drawingArea())->waitForDidUpdateActivityState(activityStateChangeID);
 }
 
 IntSize WebPageProxy::viewSize() const
@@ -3660,7 +3634,7 @@ void WebPageProxy::executeEditCommand(const String& commandName, const String& a
 
     if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName)) {
         if (auto replyID = willPerformPasteCommand(*pasteAccessCategory, WTF::move(completionHandler), frameID))
-            protectedWebsiteDataStore()->protectedNetworkProcess()->protectedConnection()->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
+            protect(websiteDataStore())->protectedNetworkProcess()->protectedConnection()->waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
     } else
         completionHandler();
 }
@@ -3868,7 +3842,7 @@ void WebPageProxy::propagateDragAndDrop(DragEventForwardingData&& forwardingData
 
         protectedThis->sendWithAsyncReplyToProcessContainingFrame(forwardingData.targetFrameID, Messages::WebPage::PerformDragOperation(forwardingData.targetFrameID, WTF::move(dragData), WTF::move(forwardingData.sandboxExtensionHandle), WTF::move(forwardingData.sandboxExtensionsForUpload)), [protectedThis, frameID = forwardingData.targetFrameID, dragDataCopy = WTF::move(dragDataCopy), dragStorageName] (DragOperationResult dragOperationResult) mutable {
             WTF::switchOn(dragOperationResult, [&](bool handled) {
-                protectedThis->protectedPageClient()->didPerformDragOperation(handled);
+                protect(protectedThis->pageClient())->didPerformDragOperation(handled);
             }, [&](DragEventForwardingData& forwardingData) mutable {
                 if (forwardingData.targetFrameID != frameID)
                     protectedThis->propagateDragAndDrop(WTF::move(forwardingData), dragStorageName, WTF::move(dragDataCopy));
@@ -3886,9 +3860,9 @@ void WebPageProxy::performDragOperation(DragData& dragData, const String& dragSt
 #if PLATFORM(GTK)
     URL url { dragData.asURL() };
     if (url.protocolIsFile())
-        protectedLegacyMainFrameProcess()->assumeReadAccessToBaseURL(*this, url.string(), [] { });
+        protect(legacyMainFrameProcess())->assumeReadAccessToBaseURL(*this, url.string(), [] { });
     else if (!dragData.fileNames().isEmpty())
-        protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(siteIsolatedProcess().coreProcessIdentifier(), dragData.fileNames()), [] { });
+        protect(websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(siteIsolatedProcess().coreProcessIdentifier(), dragData.fileNames()), [] { });
 
     performDragControllerAction(DragControllerAction::PerformDragOperation, dragData);
 #elif PLATFORM(COCOA)
@@ -3904,7 +3878,7 @@ void WebPageProxy::performDragOperation(DragData& dragData, const String& dragSt
 
         protectedThis->sendWithAsyncReplyToProcessContainingFrame(protectedThis->m_mainFrame->frameID(), Messages::WebPage::PerformDragOperation(protectedThis->m_mainFrame->frameID(), WTF::move(dragData), WTF::move(sandboxExtensionHandle), WTF::move(sandboxExtensionsForUpload)), [protectedThis, frameID = protectedThis->m_mainFrame->frameID(), dragDataCopy = WTF::move(dragDataCopy), dragStorageName] (DragOperationResult dragOperationResult) mutable {
             WTF::switchOn(dragOperationResult, [&](bool handled) {
-                protectedThis->protectedPageClient()->didPerformDragOperation(handled);
+                protect(protectedThis->pageClient())->didPerformDragOperation(handled);
             }, [&](DragEventForwardingData& forwardingData) {
                 if (forwardingData.targetFrameID != frameID)
                     protectedThis->propagateDragAndDrop(WTF::move(forwardingData), dragStorageName, WTF::move(dragDataCopy));
@@ -3916,7 +3890,7 @@ void WebPageProxy::performDragOperation(DragData& dragData, const String& dragSt
         return;
 
     sendWithAsyncReplyToProcessContainingFrame(m_mainFrame->frameID(), Messages::WebPage::PerformDragOperation(m_mainFrame->frameID(), WTF::move(dragData), WTF::move(sandboxExtensionHandle), WTF::move(sandboxExtensionsForUpload)), [protectedThis = Ref { *this }, frameID = m_mainFrame->frameID()] (DragOperationResult dragOperationResult) mutable {
-        protectedThis->protectedPageClient()->didPerformDragOperation(std::holds_alternative<bool>(dragOperationResult) ? std::get<bool>(dragOperationResult) : false);
+        protect(protectedThis->pageClient())->didPerformDragOperation(std::holds_alternative<bool>(dragOperationResult) ? std::get<bool>(dragOperationResult) : false);
     });
 #endif
 }
@@ -3958,7 +3932,7 @@ void WebPageProxy::performDragControllerAction(DragControllerAction action, Drag
     if (!filenames.size())
         return afterAllowed();
 
-    protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(processID, filenames), WTF::move(afterAllowed));
+    protect(websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(processID, filenames), WTF::move(afterAllowed));
 #endif
 }
 
@@ -4318,7 +4292,7 @@ void WebPageProxy::handleWheelEvent(const WebWheelEvent& wheelEvent)
     if (!hasRunningProcess())
         return;
 
-    if (protectedDrawingArea()->shouldSendWheelEventsToEventDispatcher()) {
+    if (protect(drawingArea())->shouldSendWheelEventsToEventDispatcher()) {
         continueWheelEventHandling(wheelEvent, { WheelEventProcessingSteps::SynchronousScrolling, false }, { });
         return;
     }
@@ -4364,7 +4338,7 @@ void WebPageProxy::sendWheelEvent(WebCore::FrameIdentifier frameID, const WebWhe
 #endif
 
     Ref process = processContainingFrame(frameID);
-    if (protectedDrawingArea()->shouldSendWheelEventsToEventDispatcher()) {
+    if (protect(drawingArea())->shouldSendWheelEventsToEventDispatcher()) {
         sendWheelEventScrollingAccelerationCurveIfNecessary(frameID, event);
         sendToProcessContainingFrame(frameID, Messages::EventDispatcher::WheelEvent(webPageIDInProcess(process), event, rubberBandableEdges));
     } else {
@@ -4448,7 +4422,7 @@ void WebPageProxy::cacheWheelEventScrollingAccelerationCurve(const NativeWebWhee
     if (nativeWheelEvent.momentumPhase() != WebWheelEvent::Phase::Began)
         return;
 
-    if (!protectedPreferences()->momentumScrollingAnimatorEnabled())
+    if (!protect(preferences())->momentumScrollingAnimatorEnabled())
         return;
 
     // FIXME: We should not have to fetch the curve repeatedly, but it can also change occasionally.
@@ -4494,7 +4468,7 @@ void WebPageProxy::updateDisplayLinkFrequency()
 
     bool wantsFullSpeedUpdates = m_hasActiveAnimatedScroll || internals().wheelEventActivityHysteresis.state() == PAL::HysteresisState::Started;
     if (wantsFullSpeedUpdates != m_registeredForFullSpeedUpdates) {
-        protectedLegacyMainFrameProcess()->setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_displayID, wantsFullSpeedUpdates);
+        protect(legacyMainFrameProcess())->setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_displayID, wantsFullSpeedUpdates);
         m_registeredForFullSpeedUpdates = wantsFullSpeedUpdates;
     }
 }
@@ -4694,7 +4668,7 @@ void WebPageProxy::handleGestureEvent(const NativeWebGestureEvent& event)
 #if ENABLE(IOS_TOUCH_EVENTS)
 void WebPageProxy::sendPreventableTouchEvent(WebCore::FrameIdentifier frameID, const WebTouchEvent& event)
 {
-    if (event.type() == WebEventType::TouchEnd && protectedPreferences()->verifyWindowOpenUserGestureFromUIProcess())
+    if (event.type() == WebEventType::TouchEnd && protect(preferences())->verifyWindowOpenUserGestureFromUIProcess())
         processContainingFrame(frameID)->recordUserGestureAuthorizationToken(frameID, webPageIDInMainFrameProcess(), event.authorizationToken());
 
     if (event.isActivationTriggeringEvent())
@@ -4825,7 +4799,7 @@ void WebPageProxy::didBeginTouchPoint(FloatPoint locationInRootView)
 
 void WebPageProxy::sendUnpreventableTouchEvent(WebCore::FrameIdentifier frameID, const WebTouchEvent& event)
 {
-    if (event.type() == WebEventType::TouchEnd && protectedPreferences()->verifyWindowOpenUserGestureFromUIProcess())
+    if (event.type() == WebEventType::TouchEnd && protect(preferences())->verifyWindowOpenUserGestureFromUIProcess())
         processContainingFrame(frameID)->recordUserGestureAuthorizationToken(frameID, webPageIDInMainFrameProcess(), event.authorizationToken());
 
     if (event.isActivationTriggeringEvent())
@@ -4892,7 +4866,7 @@ void WebPageProxy::handleTouchEvent(IPC::Connection* connection, const NativeWeb
     // we do not send any of the events to the page even if is has listeners.
     if (!m_areActiveDOMObjectsAndAnimationsSuspended) {
         internals().touchEventQueue.append(event);
-        protectedLegacyMainFrameProcess()->startResponsivenessTimer();
+        protect(legacyMainFrameProcess())->startResponsivenessTimer();
         sendWithAsyncReply(Messages::WebPage::TouchEvent(event), [this, protectedThis = Ref { *this }] (IPC::Connection* connection, std::optional<WebEventType> eventType, bool handled) {
             if (!m_pageClient)
                 return;
@@ -5009,7 +4983,7 @@ void WebPageProxy::isForcedIntoAppBoundModeTesting(CompletionHandler<void(bool)>
 void WebPageProxy::disableServiceWorkerEntitlementInNetworkProcess()
 {
 #if ENABLE(APP_BOUND_DOMAINS) && !PLATFORM(MACCATALYST)
-    protectedWebsiteDataStore()->protectedNetworkProcess()->send(Messages::NetworkProcess::DisableServiceWorkerEntitlement(), 0);
+    protect(websiteDataStore())->protectedNetworkProcess()->send(Messages::NetworkProcess::DisableServiceWorkerEntitlement(), 0);
 #endif
 }
 
@@ -5018,7 +4992,7 @@ void WebPageProxy::clearServiceWorkerEntitlementOverride(CompletionHandler<void(
 #if ENABLE(APP_BOUND_DOMAINS) && !PLATFORM(MACCATALYST)
     auto callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
     sendWithAsyncReply(Messages::WebPage::ClearServiceWorkerEntitlementOverride(), [callbackAggregator] { });
-    protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearServiceWorkerEntitlementOverride(), [callbackAggregator] { });
+    protect(websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearServiceWorkerEntitlementOverride(), [callbackAggregator] { });
 #else
     completionHandler();
 #endif
@@ -5036,7 +5010,7 @@ Expected<WebPageProxy::DataStoreUpdateResult, WebCore::ResourceError> WebPagePro
 {
     RefPtr<WebsiteDataStore> updatedWebsiteDataStore;
     LoadedWebArchive loadedWebArchive { LoadedWebArchive::No };
-    if (!protectedPreferences()->loadWebArchiveWithEphemeralStorageEnabled())
+    if (!protect(preferences())->loadWebArchiveWithEphemeralStorageEnabled())
         return DataStoreUpdateResult { updatedWebsiteDataStore, loadedWebArchive };
 
     if (policyAction != PolicyAction::Use || navigationType == NavigationType::Reload)
@@ -5053,7 +5027,7 @@ Expected<WebPageProxy::DataStoreUpdateResult, WebCore::ResourceError> WebPagePro
     if (!isLoadingWebArchive) {
         // If data store is changed for archive load, switch back to original data store.
         if (m_replacedDataStoreForWebArchiveLoad) {
-            m_configuration->protectedProcessPool()->pageEndUsingWebsiteDataStore(*this, protectedWebsiteDataStore());
+            m_configuration->protectedProcessPool()->pageEndUsingWebsiteDataStore(*this, protect(websiteDataStore()));
             if (auto replacedDataStoreForWebArchiveLoad = std::exchange(m_replacedDataStoreForWebArchiveLoad, nullptr))
                 m_websiteDataStore = *replacedDataStoreForWebArchiveLoad;
             updatedWebsiteDataStore = m_websiteDataStore.ptr();
@@ -5077,7 +5051,7 @@ Expected<WebPageProxy::DataStoreUpdateResult, WebCore::ResourceError> WebPagePro
 
     m_websiteDataStore = WebsiteDataStore::createNonPersistent();
     updatedWebsiteDataStore = m_websiteDataStore.ptr();
-    m_configuration->protectedProcessPool()->pageBeginUsingWebsiteDataStore(*this, protectedWebsiteDataStore());
+    m_configuration->protectedProcessPool()->pageBeginUsingWebsiteDataStore(*this, protect(websiteDataStore()));
     return DataStoreUpdateResult { updatedWebsiteDataStore, loadedWebArchive };
 }
 #endif
@@ -5136,7 +5110,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
     bool navigatingIFrameWithoutSiteIsolation = !frame.isMainFrame() && !preferences->siteIsolationEnabled();
     if (policyAction != PolicyAction::Use || navigatingIFrameWithoutSiteIsolation) {
         auto previousPendingNavigationID = pageLoadState().pendingAPIRequest().navigationID;
-        receivedPolicyDecision(policyAction, &navigation, navigatingIFrameWithoutSiteIsolation ? websitePoliciesAndProcess(websitePolicies.get(), protectedLegacyMainFrameProcess()) : std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, WTF::move(message), WTF::move(completionHandler));
+        receivedPolicyDecision(policyAction, &navigation, navigatingIFrameWithoutSiteIsolation ? websitePoliciesAndProcess(websitePolicies.get(), protect(legacyMainFrameProcess())) : std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, WTF::move(message), WTF::move(completionHandler));
 #if HAVE(APP_SSO)
         if (policyAction == PolicyAction::Ignore && navigation.navigationID() == previousPendingNavigationID && wasNavigationIntercepted == WasNavigationIntercepted::Yes) {
             WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "receivedNavigationActionPolicyDecision: Failing navigation because decision was intercepted and policy action is Ignore.");
@@ -5184,13 +5158,13 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
     m_isLockdownModeExplicitlySet = (websitePolicies && websitePolicies->isLockdownModeExplicitlySet()) || m_configuration->isLockdownModeExplicitlySet();
     auto lockdownMode = (websitePolicies ? websitePolicies->lockdownModeEnabled() : shouldEnableLockdownMode()) ? WebProcessProxy::LockdownMode::Enabled : WebProcessProxy::LockdownMode::Disabled;
 
-    if (frame.isMainFrame() && protectedPreferences()->enhancedSecurityHeuristicsEnabled())
+    if (frame.isMainFrame() && preferences->enhancedSecurityHeuristicsEnabled())
         internals().enhancedSecurityTracker.trackNavigation(navigation, hasOpenedPage());
 
     auto enhancedSecurity = currentEnhancedSecurityState(websitePolicies.get());
 
-    if (protectedPreferences()->enhancedSecurityHeuristicsEnabled())
-        protectedWebsiteDataStore()->trackEnhancedSecurityForDomain(RegistrableDomain { navigation.currentRequest().url() }, enhancedSecurity);
+    if (preferences->enhancedSecurityHeuristicsEnabled())
+        protect(this->websiteDataStore())->trackEnhancedSecurityForDomain(RegistrableDomain { navigation.currentRequest().url() }, enhancedSecurity);
 
     Ref browsingContextGroup = m_browsingContextGroup;
     bool usesSameWebsiteDataStore = websiteDataStore.ptr() == &this->websiteDataStore();
@@ -5207,12 +5181,12 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         protectedThis = Ref { *this },
         policyAction,
         browsingContextGroup = browsingContextGroup.copyRef(),
-        navigation = Ref { navigation },
+        navigation = protect(navigation),
         navigationAction = WTF::move(navigationAction),
         completionHandler = WTF::move(completionHandler),
         processSwapRequestedByClient,
-        frame = Ref { frame },
-        processInitiatingNavigation = Ref { processInitiatingNavigation },
+        frame = protect(frame),
+        processInitiatingNavigation = protect(processInitiatingNavigation),
         message = WTF::move(message),
         loadedWebArchive,
         replacedDataStoreForWebArchiveLoad,
@@ -5233,7 +5207,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         RefPtr pageClientProtector = pageClient();
         Ref processNavigatingFrom = [&] {
             RefPtr provisionalPage = m_provisionalPage;
-            return Ref { protectedPreferences()->siteIsolationEnabled() && frame->isMainFrame() && provisionalPage ? provisionalPage->process() : frame->process() };
+            return protect(preferences->siteIsolationEnabled() && frame->isMainFrame() && provisionalPage ? provisionalPage->process() : frame->process());
         }();
 
         const bool navigationChangesFrameProcess = processNavigatingTo->coreProcessIdentifier() != processNavigatingFrom->coreProcessIdentifier();
@@ -5279,7 +5253,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             // If re-using the same process for navigation and the site is changing, call ensureProcessForSite for the new site, but don't InjectBrowsingContextIntoProcess
             // since BrowsingContextGroup is already keeping track of the process under the previous site.
             if (frameProcessSite != site)
-                frame->setProcess(protectedBrowsingContextGroup()->ensureProcessForSite(site, mainFrameSite, frame->frameProcess().process(), preferences, LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcess));
+                frame->setProcess(protect(this->browsingContextGroup())->ensureProcessForSite(site, mainFrameSite, frame->frameProcess().process(), preferences, LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcess));
         }
 
         if (loadContinuingInNonInitiatingProcess) {
@@ -5327,11 +5301,11 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
         receivedPolicyDecision(policyAction, navigation.ptr(), websitePoliciesAndProcess(navigation->websitePolicies(), processNavigatingTo), WTF::move(navigationAction), WillContinueLoadInNewProcess::No, WTF::move(optionalHandle), WTF::move(message), WTF::move(completionHandler));
     };
 
-    browsingContextGroup->sharedProcessForSite(websiteDataStore, policies.get(), preferences, site, mainFrameSite, lockdownMode, enhancedSecurity, Ref { m_configuration }, frame.isMainFrame() ? IsMainFrame::Yes : IsMainFrame::No, [
+    browsingContextGroup->sharedProcessForSite(websiteDataStore, policies.get(), preferences, site, mainFrameSite, lockdownMode, enhancedSecurity, protect(m_configuration), frame.isMainFrame() ? IsMainFrame::Yes : IsMainFrame::No, [
         this,
         protectedThis = Ref { *this },
-        frame = Ref { frame },
-        navigation = Ref { navigation },
+        frame = protect(frame),
+        navigation = protect(navigation),
         browsingContextGroup = browsingContextGroup.copyRef(),
         site,
         mainFrameSite,
@@ -5350,7 +5324,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
             if (frame->isMainFrame()) {
                 Ref process { sharedProcess->process() };
                 auto shutdownPreventingScope = process->shutdownPreventingScope();
-                protectedWebsiteDataStore()->protectedNetworkProcess()->addAllowedFirstPartyForCookies(sharedProcess->process(), site.domain(), LoadedWebArchive::No, [
+                websiteDataStore->protectedNetworkProcess()->addAllowedFirstPartyForCookies(sharedProcess->process(), site.domain(), LoadedWebArchive::No, [
                     process = WTF::move(process),
                     shutdownPreventingScope = WTF::move(shutdownPreventingScope),
                     continueWithProcessForNavigation = WTF::move(continueWithProcessForNavigation)
@@ -5423,7 +5397,7 @@ void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* 
 
     std::optional<WebsitePoliciesData> websitePoliciesData;
     if (websitePoliciesAndProcess)
-        websitePoliciesData = Ref { websitePoliciesAndProcess->first }->dataForProcess(websitePoliciesAndProcess->second);
+        websitePoliciesData = protect(websitePoliciesAndProcess->first)->dataForProcess(websitePoliciesAndProcess->second);
     auto isSafeBrowsingCheckOngoing = SafeBrowsingCheckOngoing::No;
     if (navigation)
         isSafeBrowsingCheckOngoing = navigation->safeBrowsingCheckOngoing() ? SafeBrowsingCheckOngoing::Yes : SafeBrowsingCheckOngoing::No;
@@ -5489,7 +5463,7 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
 #if ENABLE(TILED_CA_DRAWING_AREA)
     // On macOS, when not using UI-side compositing, we need to make sure we do not close the page in the previous process until we've
     // entered accelerated compositing for the new page or we will flash on navigation.
-    if (protectedDrawingArea()->type() == DrawingAreaType::TiledCoreAnimation)
+    if (protect(drawingArea())->type() == DrawingAreaType::TiledCoreAnimation)
         shouldDelayClosingUntilFirstLayerFlush = ShouldDelayClosingUntilFirstLayerFlush::Yes;
 #endif
 
@@ -5502,8 +5476,8 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
     RefPtr navigation = m_navigationState->navigation(provisionalPage->navigationID());
     bool didSuspendPreviousPage = navigation ? suspendCurrentPageIfPossible(*navigation, WTF::move(mainFrameInPreviousProcess), shouldDelayClosingUntilFirstLayerFlush) : false;
     // Defer shutting down old process as it might lead WebPageProxy to be closed and removeWebPage to be invoked again.
-    auto preventProcessShutdownScope = protectedLegacyMainFrameProcess()->shutdownPreventingScope();
-    protectedLegacyMainFrameProcess()->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);
+    auto preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope();
+    protect(legacyMainFrameProcess())->removeWebPage(*this, m_websiteDataStore.ptr() == provisionalPage->process().websiteDataStore() ? WebProcessProxy::EndsUsingDataStore::No : WebProcessProxy::EndsUsingDataStore::Yes);
 
     if (RefPtr mainFrameWebsitePolicies = provisionalPage->mainFrameWebsitePolicies())
         m_mainFrameWebsitePolicies = mainFrameWebsitePolicies->copy();
@@ -5529,12 +5503,12 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
 
 bool WebPageProxy::shouldClosePreviousPage(const ProvisionalPageProxy& provisionalPage)
 {
-    if (!protectedPreferences()->siteIsolationEnabled())
+    if (!protect(preferences())->siteIsolationEnabled())
         return true;
 
     // Ownership has been transferred to RemotePageProxy.
     Ref provisionalBrowsingContextGroup = provisionalPage.browsingContextGroup();
-    return !provisionalBrowsingContextGroup->remotePageInProcess(*this, protectedLegacyMainFrameProcess().get());
+    return !provisionalBrowsingContextGroup->remotePageInProcess(*this, protect(legacyMainFrameProcess()).get());
 }
 
 void WebPageProxy::destroyProvisionalPage()
@@ -5608,7 +5582,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
     }
 
     // FIXME: Assert the equality of data stores regardless of whether site isolation is enabled or not.
-    ASSERT(!protectedPreferences()->siteIsolationEnabled() || newProcess->websiteDataStore() == &websiteDataStore());
+    ASSERT(!preferences->siteIsolationEnabled() || newProcess->websiteDataStore() == &websiteDataStore());
     Ref frameProcess = browsingContextGroup.ensureProcessForSite(navigationSite, Site { mainFrame()->url() }, newProcess, preferences, loadedWebArchive, BrowsingContextGroupUpdate::None);
     // Make sure we destroy any existing ProvisionalPageProxy object *before* we construct a new one.
     // It is important from the previous provisional page to unregister itself before we register a
@@ -5618,7 +5592,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
     m_provisionalPage = provisionalPage.copyRef();
 
     // FIXME: This should be a CompletionHandler, but http/tests/inspector/target/provisional-load-cancels-previous-load.html doesn't call it.
-    Function<void()> continuation = [this, protectedThis = Ref { *this }, navigation = Ref { navigation }, shouldTreatAsContinuingLoad, websitePolicies = WTF::move(websitePolicies), existingNetworkResourceLoadIdentifierToResume, navigationUpgradeToHTTPSBehavior, processSwapDisposition]() mutable {
+    Function<void()> continuation = [this, protectedThis = Ref { *this }, navigation = protect(navigation), shouldTreatAsContinuingLoad, websitePolicies = WTF::move(websitePolicies), existingNetworkResourceLoadIdentifierToResume, navigationUpgradeToHTTPSBehavior, processSwapDisposition]() mutable {
         RefPtr provisionalPage = m_provisionalPage;
         if (RefPtr item = navigation->targetItem()) {
             LOG(Loading, "WebPageProxy %p continueNavigationInNewProcess to back item URL %s", this, item->url().utf8().data());
@@ -5651,7 +5625,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
 
     if (provisionalPage->needsCookieAccessAddedInNetworkProcess()) {
         continuation = [
-            networkProcess = Ref { protectedWebsiteDataStore()->networkProcess() },
+            networkProcess = protect(Ref { websiteDataStore() }->networkProcess()),
             continuation = WTF::move(continuation),
             navigationDomain = RegistrableDomain(navigation.currentRequest().url()),
             process,
@@ -6003,7 +5977,7 @@ void WebPageProxy::windowScreenDidChange(PlatformDisplayID displayID)
 {
 #if HAVE(DISPLAY_LINK)
     if (hasRunningProcess() && m_displayID && m_registeredForFullSpeedUpdates)
-        protectedLegacyMainFrameProcess()->setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_displayID, false);
+        protect(legacyMainFrameProcess())->setDisplayLinkForDisplayWantsFullSpeedUpdates(*m_displayID, false);
 
     m_registeredForFullSpeedUpdates = false;
 #endif
@@ -6053,7 +6027,7 @@ void WebPageProxy::setCustomDeviceScaleFactor(float customScaleFactor, Completio
     }
 
     if (deviceScaleFactor() != oldScaleFactor)
-        protectedDrawingArea()->deviceScaleFactorDidChange(WTF::move(completionHandler));
+        protect(drawingArea())->deviceScaleFactorDidChange(WTF::move(completionHandler));
     else
         completionHandler();
 }
@@ -6473,11 +6447,11 @@ void WebPageProxy::findString(const String& string, OptionSet<FindOptions> optio
     };
 
 #if ENABLE(IMAGE_ANALYSIS)
-    if (protectedPreferences()->imageAnalysisDuringFindInPageEnabled())
+    if (protect(preferences())->imageAnalysisDuringFindInPageEnabled())
         sendAndAggregateFindStringMessage(Messages::WebPage::FindStringIncludingImages(string, options | FindOptions::DoNotSetSelection, maxMatchCount), [](bool) { });
 #endif
 
-    if (!protectedBrowsingContextGroup()->hasRemotePages(*this)) {
+    if (!protect(browsingContextGroup())->hasRemotePages(*this)) {
         auto completionHandler = [protectedThis = Ref { *this }, string, callbackFunction = WTF::move(callbackFunction)](std::optional<FrameIdentifier> frameID, Vector<IntRect>&& matchRects, uint32_t matchCount, int32_t matchIndex, bool didWrap) mutable {
             if (!frameID)
                 protectedThis->findClient().didFailToFindString(protectedThis.ptr(), string);
@@ -6640,7 +6614,7 @@ void WebPageProxy::replaceMatches(Vector<uint32_t>&& matchIndices, const String&
 
 void WebPageProxy::launchInitialProcessIfNecessary()
 {
-    if (protectedLegacyMainFrameProcess()->isDummyProcessProxy())
+    if (protect(legacyMainFrameProcess())->isDummyProcessProxy())
         launchProcess(Site(aboutBlankURL()), ProcessLaunchReason::InitialProcess);
 }
 
@@ -6922,7 +6896,7 @@ void WebPageProxy::preferencesDidChange()
             webProcess.send(Messages::WebPage::PreferencesDidChange(preferencesStore(), sharedPreferencesVersion), pageID);
     });
 
-    protectedWebsiteDataStore()->propagateSettingUpdates();
+    protect(websiteDataStore())->propagateSettingUpdates();
 }
 
 void WebPageProxy::didCreateSubframe(FrameIdentifier parentID, FrameIdentifier newFrameID, String&& frameName, SandboxFlags sandboxFlags, ReferrerPolicy referrerPolicy, ScrollbarMode scrollingMode)
@@ -6936,7 +6910,7 @@ void WebPageProxy::didCreateSubframe(FrameIdentifier parentID, FrameIdentifier n
 void WebPageProxy::didDestroyFrame(IPC::Connection& connection, FrameIdentifier frameID)
 {
 #if ENABLE(WEB_AUTHN)
-    protectedWebsiteDataStore()->protectedAuthenticatorManager()->cancelRequest(webPageIDInMainFrameProcess(), frameID);
+    protect(websiteDataStore())->protectedAuthenticatorManager()->cancelRequest(webPageIDInMainFrameProcess(), frameID);
 #endif
     if (RefPtr automationSession = m_configuration->processPool().automationSession())
         automationSession->didDestroyFrame(frameID);
@@ -7011,7 +6985,7 @@ void WebPageProxy::setNetworkRequestsInProgress(bool networkRequestsInProgress)
 
     Ref pageLoadState = internals().pageLoadState;
     auto transaction = pageLoadState->transaction();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&] (auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&] (auto& remotePageProxy) {
         networkRequestsInProgress |= remotePageProxy.hasNetworkRequestsInProgress();
     });
 
@@ -7249,7 +7223,7 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
     }
 
     // If a provisional load has since been started in another process, ignore this message.
-    if (protectedPreferences()->siteIsolationEnabled()) {
+    if (protect(preferences())->siteIsolationEnabled()) {
         if (frame->provisionalLoadProcess().coreProcessIdentifier() != process->coreProcessIdentifier()) {
             // FIXME: The API test ProcessSwap.DoSameSiteNavigationAfterCrossSiteProvisionalLoadStarted
             // is probably not handled correctly with site isolation on.
@@ -7311,7 +7285,7 @@ void WebPageProxy::didStartProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& 
     }
 
 #if ENABLE(WEB_AUTHN)
-    protectedWebsiteDataStore()->protectedAuthenticatorManager()->cancelRequest(m_webPageID, frameID);
+    protect(websiteDataStore())->protectedAuthenticatorManager()->cancelRequest(m_webPageID, frameID);
 #endif
 }
 
@@ -7460,7 +7434,7 @@ void WebPageProxy::didFailProvisionalLoadForFrame(IPC::Connection& connection, F
     }
 
     Ref process = WebProcessProxy::fromConnection(connection);
-    if (protectedPreferences()->siteIsolationEnabled() && process != frame->process()) {
+    if (protect(preferences())->siteIsolationEnabled() && process != frame->process()) {
         RefPtr provisionalFrame = frame->provisionalFrame();
         if (!provisionalFrame || provisionalFrame->process() != process)
             return;
@@ -7519,7 +7493,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
     m_failingProvisionalLoadURL = WTF::move(provisionalURL);
 
     if (willInternallyHandleFailure == WillInternallyHandleFailure::No) {
-        auto callClientFunctions = [this, protectedThis = Ref { *this }, frame = Ref { frame }, navigation, error, process, request = WTF::move(request), frameInfo = WTF::move(frameInfo), protectedObject = userData.protectedObject()]() mutable {
+        auto callClientFunctions = [this, protectedThis = Ref { *this }, frame = protect(frame), navigation, error, process, request = WTF::move(request), frameInfo = WTF::move(frameInfo), protectedObject = userData.protectedObject()]() mutable {
             if (m_loaderClient)
                 m_loaderClient->didFailProvisionalLoadWithErrorForFrame(*this, frame, navigation.get(), error, process->transformHandlesToObjects(protectedObject.get()).get());
             else {
@@ -7566,7 +7540,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
             callClientFunctions();
     } else {
         if (RefPtr websitePolicies = navigation ? navigation->websitePolicies() : nullptr; websitePolicies
-            && (websitePolicies->isUpgradeWithAutomaticFallbackEnabled() || protectedPreferences()->httpSByDefaultEnabled())) {
+            && (websitePolicies->isUpgradeWithAutomaticFallbackEnabled() || protect(preferences())->httpSByDefaultEnabled())) {
             URL failedURL { m_failingProvisionalLoadURL };
             if (frame.isMainFrame() && error.errorRecoveryMethod() == ResourceError::ErrorRecoveryMethod::HTTPFallback && failedURL.protocolIs("https"_s)) {
                 failedURL.setProtocol("http"_s);
@@ -7578,7 +7552,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
     m_failingProvisionalLoadURL = { };
 
     // If the provisional page's load fails then we destroy the provisional page.
-    if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame && (willContinueLoading == WillContinueLoading::No || protectedPreferences()->siteIsolationEnabled()))
+    if (m_provisionalPage && m_provisionalPage->mainFrame() == &frame && (willContinueLoading == WillContinueLoading::No || protect(preferences())->siteIsolationEnabled()))
         m_provisionalPage = nullptr;
 
     if (auto provisionalFrame = frame.takeProvisionalFrame()) {
@@ -7709,7 +7683,7 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
             privateClickMeasurement = *navigation->privateClickMeasurement();
         if (privateClickMeasurement) {
             if (privateClickMeasurement->destinationSite().matches(frame->url()) || privateClickMeasurement->isSKAdNetworkAttribution())
-                protectedWebsiteDataStore()->storePrivateClickMeasurement(*privateClickMeasurement);
+                protect(websiteDataStore())->storePrivateClickMeasurement(*privateClickMeasurement);
         }
         if (RefPtr screenOrientationManager = m_screenOrientationManager)
             screenOrientationManager->unlockIfNecessary();
@@ -7850,15 +7824,15 @@ HashSet<Ref<WebProcessProxy>> WebPageProxy::webContentProcessesWithFrame()
 
 void WebPageProxy::forEachWebContentProcess(NOESCAPE Function<void(WebProcessProxy&, PageIdentifier)>&& function)
 {
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&] (auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&] (auto& remotePageProxy) {
         function(remotePageProxy.process(), remotePageProxy.pageID());
     });
-    function(protectedLegacyMainFrameProcess(), webPageIDInMainFrameProcess());
+    function(protect(legacyMainFrameProcess()), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::observeAndCreateRemoteSubframesInOtherProcesses(WebFrameProxy& newFrame, const String& frameName)
 {
-    if (!protectedPreferences()->siteIsolationEnabled())
+    if (!protect(preferences())->siteIsolationEnabled())
         return;
 
     RefPtr parent = newFrame.parentFrame();
@@ -7963,7 +7937,7 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
         return;
 
     // If a provisional load has since been started in another process, ignore this message.
-    if (protectedPreferences()->siteIsolationEnabled() && !frame->provisionalLoadProcess().hasConnection(connection))
+    if (protect(preferences())->siteIsolationEnabled() && !frame->provisionalLoadProcess().hasConnection(connection))
         return;
 
     WEBPAGEPROXY_RELEASE_LOG(Loading, "didFinishLoadForFrame: frameID=%" PRIu64 ", isMainFrame=%d", frameID.toUInt64(), frame->isMainFrame());
@@ -7993,7 +7967,7 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
         protectedPageLoadState->commitChanges();
     }
 
-    if (protectedPreferences()->siteIsolationEnabled())
+    if (protect(preferences())->siteIsolationEnabled())
         frame->broadcastFrameTreeSyncData(frame->calculateFrameTreeSyncData());
 
     Ref process = WebProcessProxy::fromConnection(connection);
@@ -8022,7 +7996,7 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
         }
     }
 
-    if (isMainFrame || protectedPreferences()->siteIsolationEnabled())
+    if (isMainFrame || protect(preferences())->siteIsolationEnabled())
         notifyProcessPoolToPrewarm();
 
     m_isLoadingAlternateHTMLStringForFailingProvisionalLoad = false;
@@ -8084,7 +8058,7 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
     }
 
     RefPtr parentFrame = frame->parentFrame();
-    if (protectedPreferences()->siteIsolationEnabled()) {
+    if (protect(preferences())->siteIsolationEnabled()) {
         if (parentFrame && parentFrame->process().coreProcessIdentifier() != process->coreProcessIdentifier())
             frame->notifyParentOfLoadCompletion(process);
 
@@ -8229,7 +8203,7 @@ void WebPageProxy::didChangeMainDocument(IPC::Connection& connection, FrameIdent
 void WebPageProxy::viewIsBecomingVisible()
 {
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "viewIsBecomingVisible:");
-    protectedLegacyMainFrameProcess()->markProcessAsRecentlyUsed();
+    protect(legacyMainFrameProcess())->markProcessAsRecentlyUsed();
     if (RefPtr drawingAreaProxy = drawingArea())
         drawingAreaProxy->viewIsBecomingVisible();
 #if ENABLE(MEDIA_STREAM)
@@ -8244,7 +8218,7 @@ void WebPageProxy::viewIsBecomingVisible()
 void WebPageProxy::viewIsBecomingInvisible()
 {
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "viewIsBecomingInvisible:");
-    protectedLegacyMainFrameProcess()->pageIsBecomingInvisible(m_webPageID);
+    protect(legacyMainFrameProcess())->pageIsBecomingInvisible(m_webPageID);
     if (RefPtr drawingAreaProxy = drawingArea())
         drawingAreaProxy->viewIsBecomingInvisible();
 
@@ -8494,7 +8468,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
 
     bool sourceAndDestinationEqual = originatingFrame == &frame
         || (originatingFrame == mainFrame() && m_provisionalPage && m_provisionalPage->mainFrame() == &frame);
-    Ref destinationFrameInfo = sourceAndDestinationEqual ? Ref { *sourceFrameInfo } : API::FrameInfo::create(FrameInfoData { frameInfo });
+    Ref destinationFrameInfo = sourceAndDestinationEqual ? protect(*sourceFrameInfo) : API::FrameInfo::create(FrameInfoData { frameInfo });
 
 #if PLATFORM(COCOA)
     if (fromAPI && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NavigationActionSourceFrameNonNull))
@@ -8515,7 +8489,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
 #if ENABLE(CONTENT_FILTERING)
     if (frame.didHandleContentFilterUnblockNavigation(request)) {
         WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "Ignoring request to load this main resource because it was handled by content filter");
-        return receivedPolicyDecision(PolicyAction::Ignore, RefPtr { m_navigationState->navigation(*navigationID) }.get(), std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTF::move(completionHandler));
+        return receivedPolicyDecision(PolicyAction::Ignore, protect(m_navigationState->navigation(*navigationID)).get(), std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, std::nullopt, WTF::move(completionHandler));
     }
 #endif
 
@@ -8526,14 +8500,14 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     // Sandboxed iframes should be allowed to open external apps via custom protocols unless explicitely allowed (https://html.spec.whatwg.org/#hand-off-to-external-software).
     bool canHandleRequest = navigationAction->data().canHandleRequest || m_urlSchemeHandlersByScheme.contains<StringViewHashTranslator>(request.url().protocol());
     if (!canHandleRequest && !destinationFrameInfo->isMainFrame() && !frameSandboxAllowsOpeningExternalCustomProtocols(navigationAction->data().effectiveSandboxFlags, !!navigationAction->data().userGestureTokenIdentifier)) {
-        if (!sourceFrameInfo || !protectedPreferences()->needsSiteSpecificQuirks() || !Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture(request.url().protocol(), sourceFrameInfo->securityOrigin())) {
+        if (!sourceFrameInfo || !protect(preferences())->needsSiteSpecificQuirks() || !Quirks::shouldAllowNavigationToCustomProtocolWithoutUserGesture(request.url().protocol(), sourceFrameInfo->securityOrigin())) {
             WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "Ignoring request to load this main resource because it has a custom protocol and comes from a sandboxed iframe");
             PolicyDecisionConsoleMessage errorMessage {
                 MessageLevel::Error,
                 MessageSource::Security,
                 "Ignoring request to load this main resource because it has a custom protocol and comes from a sandboxed iframe"_s
             };
-            return receivedPolicyDecision(PolicyAction::Ignore, RefPtr { m_navigationState->navigation(*navigationID) }.get(), std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, WTF::move(errorMessage), WTF::move(completionHandler));
+            return receivedPolicyDecision(PolicyAction::Ignore, protect(m_navigationState->navigation(*navigationID)).get(), std::nullopt, WTF::move(navigationAction), WillContinueLoadInNewProcess::No, std::nullopt, WTF::move(errorMessage), WTF::move(completionHandler));
         }
         message = PolicyDecisionConsoleMessage {
             MessageLevel::Warning,
@@ -8544,11 +8518,11 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
 #endif
 
     ShouldExpectSafeBrowsingResult shouldExpectSafeBrowsingResult = ShouldExpectSafeBrowsingResult::Yes;
-    if (!protectedPreferences()->safeBrowsingEnabled())
+    if (!protect(preferences())->safeBrowsingEnabled())
         shouldExpectSafeBrowsingResult = ShouldExpectSafeBrowsingResult::No;
 
     ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck = ShouldWaitForSiteHasStorageCheck::Yes;
-    if (!frame.isMainFrame() || !protectedPreferences()->enhancedSecurityHeuristicsEnabled())
+    if (!frame.isMainFrame() || !protect(preferences())->enhancedSecurityHeuristicsEnabled())
         shouldWaitForSiteHasStorageCheck = ShouldWaitForSiteHasStorageCheck::No;
 
     ShouldExpectAppBoundDomainResult shouldExpectAppBoundDomainResult = ShouldExpectAppBoundDomainResult::No;
@@ -8570,13 +8544,13 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         this,
         protectedThis = Ref { *this },
         processInitiatingNavigation = process,
-        frame = Ref { frame },
+        frame = protect(frame),
         completionHandler = WTF::move(completionHandler),
         navigation,
         navigationAction,
         message = WTF::move(message),
         frameInfo,
-        protectedPageClient = RefPtr { pageClient() }
+        protectedPageClient = protect(pageClient())
     ] (PolicyAction policyAction, API::WebsitePolicies* policies, ProcessSwapRequestedByClient processSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain> isAppBoundDomain, WasNavigationIntercepted wasNavigationIntercepted) mutable {
         WEBPAGEPROXY_RELEASE_LOG(Loading, "decidePolicyForNavigationAction: listener called: frameID=%" PRIu64 ", isMainFrame=%d, navigationID=%" PRIu64  ", policyAction=%" PUBLIC_LOG_STRING ", isAppBoundDomain=%d, wasNavigationIntercepted=%d", frame->frameID().toUInt64(), frame->isMainFrame(), navigation ? navigation->navigationID().toUInt64() : 0, toString(policyAction).characters(), !!isAppBoundDomain, wasNavigationIntercepted == WasNavigationIntercepted::Yes);
 
@@ -8591,7 +8565,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
             frame,
             frameInfo,
             completionHandler = WTF::move(completionHandler),
-            navigation = Ref { *navigation },
+            navigation = protect(*navigation),
             navigationAction = WTF::move(navigationAction),
             wasNavigationIntercepted,
             processSwapRequestedByClient,
@@ -8688,7 +8662,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
     bool shouldSendSecurityOriginData = !frame.isMainFrame() && shouldTreatURLProtocolAsAppBound(request.url(), websiteDataStore().configuration().enableInAppBrowserPrivacyForTesting());
     auto host = shouldSendSecurityOriginData ? frameInfo.securityOrigin.host() : request.url().host();
     auto protocol = shouldSendSecurityOriginData ? frameInfo.securityOrigin.protocol() : request.url().protocol();
-    protectedWebsiteDataStore()->beginAppBoundDomainCheck(host.toString(), protocol.toString(), listener);
+    protect(websiteDataStore())->beginAppBoundDomainCheck(host.toString(), protocol.toString(), listener);
 #endif
 
 #if ENABLE(SWIFT_DEMO_URI_SCHEME)
@@ -8717,7 +8691,7 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         m_policyClient->decidePolicyForNavigationAction(*this, &frame, WTF::move(navigationAction), originatingFrame.get(), originalRequest, WTF::move(request), WTF::move(listener));
     else {
 #if HAVE(APP_SSO)
-        if (m_shouldSuppressSOAuthorizationInNextNavigationPolicyDecision || !protectedPreferences()->isExtensibleSSOEnabled())
+        if (m_shouldSuppressSOAuthorizationInNextNavigationPolicyDecision || !protect(preferences())->isExtensibleSSOEnabled())
             navigationAction->unsetShouldPerformSOAuthorization();
 #endif
 
@@ -8733,10 +8707,10 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
 
 void WebPageProxy::adjustAdvancedPrivacyProtectionsIfNeeded(API::WebsitePolicies& policies)
 {
-    if (!protectedWebsiteDataStore()->trackingPreventionEnabled())
+    if (!protect(websiteDataStore())->trackingPreventionEnabled())
         return;
 
-    if (!protectedPreferences()->scriptTrackingPrivacyProtectionsEnabled())
+    if (!protect(preferences())->scriptTrackingPrivacyProtectionsEnabled())
         return;
 
     policies.setAdvancedPrivacyProtections(policies.advancedPrivacyProtections() | AdvancedPrivacyProtections::ScriptTrackingPrivacy);
@@ -8781,7 +8755,7 @@ void WebPageProxy::logFrameNavigation(const WebFrameProxy& frame, const URL& pag
     if (targetHost.isEmpty() || mainFrameHost.isEmpty() || targetHost == sourceURL.host())
         return;
 
-    protectedWebsiteDataStore()->protectedNetworkProcess()->send(Messages::NetworkProcess::LogFrameNavigation(m_websiteDataStore->sessionID(), RegistrableDomain { targetURL }, RegistrableDomain { pageURL }, RegistrableDomain { sourceURL }, isRedirect, frame.isMainFrame(), MonotonicTime::now() - internals().didFinishDocumentLoadForMainFrameTimestamp, wasPotentiallyInitiatedByUser), 0);
+    protect(websiteDataStore())->protectedNetworkProcess()->send(Messages::NetworkProcess::LogFrameNavigation(m_websiteDataStore->sessionID(), RegistrableDomain { targetURL }, RegistrableDomain { pageURL }, RegistrableDomain { sourceURL }, isRedirect, frame.isMainFrame(), MonotonicTime::now() - internals().didFinishDocumentLoadForMainFrameTimestamp, wasPotentiallyInitiatedByUser), 0);
 }
 
 void WebPageProxy::decidePolicyForNavigationActionSync(IPC::Connection& connection, NavigationActionData&& data, CompletionHandler<void(PolicyDecision&&)>&& reply)
@@ -8878,7 +8852,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
 
     // COOP only applies to top-level browsing contexts.
     if (frameInfo.isMainFrame && coopValuesRequireBrowsingContextGroupSwitch(isShowingInitialAboutBlank, activeDocumentCOOPValue, frameInfo.securityOrigin.securityOrigin().get(), obtainCrossOriginOpenerPolicy(response).value, SecurityOrigin::create(response.url()).get())) {
-        protectedMainFrame()->disownOpener();
+        protect(mainFrame())->disownOpener();
         m_openedMainFrameName = { };
     }
 
@@ -8949,7 +8923,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
             auto transaction = protectedPageLoadState->transaction();
             protectedPageLoadState->setTitleFromBrowsingWarning(transaction, safeBrowsingWarning->title());
             navigation->setSafeBrowsingWarning(nullptr);
-            protectedThis->protectedPageClient()->showBrowsingWarning(*safeBrowsingWarning, [protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandlerWrapper), policyAction] (auto&& result) mutable {
+            protect(protectedThis->pageClient())->showBrowsingWarning(*safeBrowsingWarning, [protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandlerWrapper), policyAction] (auto&& result) mutable {
 
                 Ref protectedPageLoadState = protectedThis->pageLoadState();
                 auto transaction = protectedPageLoadState->transaction();
@@ -9003,7 +8977,7 @@ void WebPageProxy::showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&& safeBro
     Ref protectedPageLoadState = pageLoadState();
     auto transaction = protectedPageLoadState->transaction();
     protectedPageLoadState->setTitleFromBrowsingWarning(transaction, safeBrowsingWarning->title());
-    protectedPageClient()->showBrowsingWarning(*safeBrowsingWarning, [protectedThis = Ref { *this }] (auto&& result) mutable {
+    protect(pageClient())->showBrowsingWarning(*safeBrowsingWarning, [protectedThis = Ref { *this }] (auto&& result) mutable {
         Ref protectedPageLoadState = protectedThis->pageLoadState();
         auto transaction = protectedPageLoadState->transaction();
         protectedPageLoadState->setTitleFromBrowsingWarning(transaction, { });
@@ -9014,7 +8988,7 @@ void WebPageProxy::showBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&& safeBro
             if (continueUnsafeLoad == ContinueUnsafeLoad::No)
                 protectedThis->goBack();
             else
-                protectedThis->protectedPageClient()->clearBrowsingWarning();
+                protect(protectedThis->pageClient())->clearBrowsingWarning();
         });
     });
     m_uiClient->didShowSafeBrowsingWarning();
@@ -9037,13 +9011,13 @@ void WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation(WebCore::Navig
     auto lockdownMode = provisionalPage ? provisionalPage->process().lockdownMode() : m_legacyMainFrameProcess->lockdownMode();
     auto enhancedSecurity = provisionalPage ? provisionalPage->process().enhancedSecurity() : m_legacyMainFrameProcess->enhancedSecurity();
     if (browsingContextGroupSwitchDecision == BrowsingContextGroupSwitchDecision::NewIsolatedGroup)
-        processForNavigation = m_configuration->protectedProcessPool()->createNewWebProcess(protectedWebsiteDataStore().ptr(), lockdownMode, enhancedSecurity, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated);
+        processForNavigation = m_configuration->protectedProcessPool()->createNewWebProcess(protect(websiteDataStore()).ptr(), lockdownMode, enhancedSecurity, WebProcessProxy::IsPrewarmed::No, CrossOriginMode::Isolated);
     else
-        processForNavigation = m_configuration->protectedProcessPool()->processForSite(protectedWebsiteDataStore(), WebProcessPool::IsSharedProcess::No, responseSite, responseSite, { }, lockdownMode, enhancedSecurity, m_configuration, WebCore::ProcessSwapDisposition::COOP);
+        processForNavigation = m_configuration->protectedProcessPool()->processForSite(protect(websiteDataStore()), WebProcessPool::IsSharedProcess::No, responseSite, responseSite, { }, lockdownMode, enhancedSecurity, m_configuration, WebCore::ProcessSwapDisposition::COOP);
 
     ASSERT(processForNavigation);
     auto domain = RegistrableDomain { navigation->currentRequest().url() };
-    protectedWebsiteDataStore()->protectedNetworkProcess()->addAllowedFirstPartyForCookies(*processForNavigation, domain, LoadedWebArchive::No, [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), processForNavigation = processForNavigation, preventProcessShutdownScope = processForNavigation->shutdownPreventingScope(), existingNetworkResourceLoadIdentifierToResume, navigationID]() mutable {
+    protect(websiteDataStore())->protectedNetworkProcess()->addAllowedFirstPartyForCookies(*processForNavigation, domain, LoadedWebArchive::No, [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), processForNavigation = processForNavigation, preventProcessShutdownScope = processForNavigation->shutdownPreventingScope(), existingNetworkResourceLoadIdentifierToResume, navigationID]() mutable {
         RefPtr navigation = m_navigationState->navigation(navigationID);
         RefPtr mainFrame = m_mainFrame;
         if (!navigation || !mainFrame)
@@ -9193,8 +9167,8 @@ using UIClientCallback = Function<void(Ref<API::NavigationAction>&&, NewPageCall
 static void trySOAuthorization(Ref<API::PageConfiguration>&& configuration, Ref<API::NavigationAction>&& navigationAction, WebPageProxy& page, NewPageCallback&& newPageCallback, UIClientCallback&& uiClientCallback)
 {
 #if HAVE(APP_SSO)
-    if (page.protectedPreferences()->isExtensibleSSOEnabled()) {
-        page.protectedWebsiteDataStore()->soAuthorizationCoordinator(page).tryAuthorize(WTF::move(configuration), WTF::move(navigationAction), page, WTF::move(newPageCallback), WTF::move(uiClientCallback));
+    if (protect(page.preferences())->isExtensibleSSOEnabled()) {
+        protect(page.websiteDataStore())->soAuthorizationCoordinator(page).tryAuthorize(WTF::move(configuration), WTF::move(navigationAction), page, WTF::move(newPageCallback), WTF::move(uiClientCallback));
         return;
     }
 #endif
@@ -9280,7 +9254,7 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
             newPage->internals().privateClickMeasurement = { { WTF::move(*privateClickMeasurement), { }, { } } };
 
         // When site isolation is enabled, blobs get a dedicated process if its opener process is cross-site from the main process.
-        if (navigationDataForNewProcess && (protectedPreferences()->siteIsolationEnabled() || !openedBlobURL))  {
+        if (navigationDataForNewProcess && (protect(preferences())->siteIsolationEnabled() || !openedBlobURL))  {
             bool isRequestFromClientOrUserInput = navigationDataForNewProcess->isRequestFromClientOrUserInput;
 
             reply(std::nullopt, std::nullopt);
@@ -9289,7 +9263,7 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
         }
 
         ASSERT(newPage->m_mainFrame);
-        reply(newPage->webPageIDInProcess(process), newPage->creationParameters(process, *newPage->protectedDrawingArea().get(), newPage->m_mainFrame->frameID(), std::nullopt));
+        reply(newPage->webPageIDInProcess(process), newPage->creationParameters(process, *protect(newPage->drawingArea()).get(), newPage->m_mainFrame->frameID(), std::nullopt));
 
 #if HAVE(APP_SSO)
         newPage->m_shouldSuppressSOAuthorizationInNextNavigationPolicyDecision = true;
@@ -9302,7 +9276,7 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
 
     RefPtr userInitiatedActivity = process->userInitiatedActivity(navigationActionData.userGestureTokenIdentifier);
 
-    if (userInitiatedActivity && protectedPreferences()->verifyWindowOpenUserGestureFromUIProcess())
+    if (userInitiatedActivity && protect(preferences())->verifyWindowOpenUserGestureFromUIProcess())
         process->consumeIfNotVerifiablyFromUIProcess(webPageIDInProcess(process), *userInitiatedActivity, navigationActionData.userGestureAuthorizationToken);
 
     bool shouldOpenAppLinks = originatingFrameInfo->request().url().host() != request.url().host();
@@ -9331,7 +9305,7 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
         WebCore::Site openedSite { navigationAction->request().url() };
         configuration->setOpenedSite(openedSite);
         WebCore::Site originatingSite { originatingFrameInfo->request().url() };
-        if ((openedBlobURL && !protectedPreferences()->siteIsolationEnabled()) || openedSite == originatingSite)
+        if ((openedBlobURL && !protect(preferences())->siteIsolationEnabled()) || openedSite == originatingSite)
             configuration->setRelatedPage(*this);
     }
 
@@ -9507,7 +9481,7 @@ void WebPageProxy::closePage()
 
 void WebPageProxy::runModalJavaScriptDialog(RefPtr<WebFrameProxy>&& frame, FrameInfoData&& frameInfo, String&& message, CompletionHandler<void(WebPageProxy&, WebFrameProxy* frame, FrameInfoData&& frameInfo, String&& message2, CompletionHandler<void()>&&)>&& runDialogCallback)
 {
-    protectedPageClient()->runModalJavaScriptDialog([weakThis = WeakPtr { *this }, frameInfo = WTF::move(frameInfo), frame = WTF::move(frame), message = WTF::move(message), runDialogCallback = WTF::move(runDialogCallback)]() mutable {
+    protect(pageClient())->runModalJavaScriptDialog([weakThis = WeakPtr { *this }, frameInfo = WTF::move(frameInfo), frame = WTF::move(frame), message = WTF::move(message), runDialogCallback = WTF::move(runDialogCallback)]() mutable {
         RefPtr protectedThis { weakThis.get() };
         if (!protectedThis)
             return;
@@ -9802,7 +9776,7 @@ void WebPageProxy::runOpenPanel(IPC::Connection& connection, FrameIdentifier fra
 void WebPageProxy::showShareSheet(IPC::Connection& connection, ShareDataWithParsedURL&& shareData, CompletionHandler<void(bool)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION_BASE(!shareData.url || shareData.url->protocolIsInHTTPFamily() || shareData.url->protocolIsData(), connection, completionHandler(false));
-    MESSAGE_CHECK_COMPLETION_BASE(shareData.files.isEmpty() || protectedPreferences()->webShareFileAPIEnabled(), connection, completionHandler(false));
+    MESSAGE_CHECK_COMPLETION_BASE(shareData.files.isEmpty() || protect(preferences())->webShareFileAPIEnabled(), connection, completionHandler(false));
     MESSAGE_CHECK_COMPLETION_BASE(shareData.originator == ShareDataOriginator::Web, connection, completionHandler(false));
     if (RefPtr pageClient = this->pageClient())
         pageClient->showShareSheet(WTF::move(shareData), WTF::move(completionHandler));
@@ -9812,7 +9786,7 @@ void WebPageProxy::showShareSheet(IPC::Connection& connection, ShareDataWithPars
 
 void WebPageProxy::showContactPicker(IPC::Connection& connection, ContactsRequestData&& requestData, CompletionHandler<void(std::optional<Vector<ContactInfo>>&&)>&& completionHandler)
 {
-    MESSAGE_CHECK_COMPLETION_BASE(protectedPreferences()->contactPickerAPIEnabled(), connection, completionHandler(std::nullopt));
+    MESSAGE_CHECK_COMPLETION_BASE(protect(preferences())->contactPickerAPIEnabled(), connection, completionHandler(std::nullopt));
     if (RefPtr pageClient = this->pageClient())
         pageClient->showContactPicker(WTF::move(requestData), WTF::move(completionHandler));
     else
@@ -9823,19 +9797,19 @@ void WebPageProxy::showContactPicker(IPC::Connection& connection, ContactsReques
 void WebPageProxy::showDigitalCredentialsPicker(IPC::Connection& connection, const WebCore::DigitalCredentialsRequestData& requestData, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION_BASE(
-        protectedPreferences()->digitalCredentialsEnabled(),
+        protect(preferences())->digitalCredentialsEnabled(),
         connection,
         completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::SecurityError, "Digital credentials feature is disabled by preference."_s }))
     );
 
 #if ENABLE(WEB_AUTHN)
     MESSAGE_CHECK_COMPLETION_BASE(
-        requestData.topOrigin.securityOrigin()->isSameOriginDomain(SecurityOrigin::create(protectedMainFrame()->url())),
+        requestData.topOrigin.securityOrigin()->isSameOriginDomain(SecurityOrigin::create(protect(mainFrame())->url())),
         connection,
         completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::SecurityError, "Digital credentials request is not same-origin with main frame."_s }))
     );
 
-    protectedPageClient()->showDigitalCredentialsPicker(requestData, WTF::move(completionHandler));
+    protect(pageClient())->showDigitalCredentialsPicker(requestData, WTF::move(completionHandler));
 #else
     completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Digital credentials UI is not supported."_s }));
 #endif
@@ -9853,12 +9827,12 @@ void WebPageProxy::fetchRawDigitalCredentialRequests(CompletionHandler<void(Vect
 void WebPageProxy::dismissDigitalCredentialsPicker(IPC::Connection& connection, CompletionHandler<void(bool)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION_BASE(
-        protectedPreferences()->digitalCredentialsEnabled(),
+        protect(preferences())->digitalCredentialsEnabled(),
         connection,
         completionHandler(false)
     );
 #if ENABLE(WEB_AUTHN)
-    protectedPageClient()->dismissDigitalCredentialsPicker(WTF::move(completionHandler));
+    protect(pageClient())->dismissDigitalCredentialsPicker(WTF::move(completionHandler));
 #else
     completionHandler(false);
 #endif
@@ -10074,12 +10048,12 @@ void WebPageProxy::resumeAllMediaPlayback(CompletionHandler<void()>&& completion
 
 void WebPageProxy::processWillSuspend()
 {
-    Ref { m_legacyMainFrameProcess }->send(Messages::WebPage::ProcessWillSuspend(), webPageIDInMainFrameProcess());
+    protect(m_legacyMainFrameProcess)->send(Messages::WebPage::ProcessWillSuspend(), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::processDidResume()
 {
-    Ref { m_legacyMainFrameProcess }->send(Messages::WebPage::ProcessDidResume(), webPageIDInMainFrameProcess());
+    protect(m_legacyMainFrameProcess)->send(Messages::WebPage::ProcessDidResume(), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::setMayStartMediaWhenInWindow(bool mayStartMedia)
@@ -10097,20 +10071,20 @@ void WebPageProxy::setMayStartMediaWhenInWindow(bool mayStartMedia)
 
 void WebPageProxy::resumeDownload(const API::Data& resumeData, const String& path, CompletionHandler<void(DownloadProxy*)>&& completionHandler)
 {
-    Ref download = configuration().protectedProcessPool()->resumeDownload(protectedWebsiteDataStore(), this, resumeData, path, CallDownloadDidStart::Yes);
+    Ref download = configuration().protectedProcessPool()->resumeDownload(protect(websiteDataStore()), this, resumeData, path, CallDownloadDidStart::Yes);
     download->setDestinationFilename(path);
     download->setDidStartCallback(WTF::move(completionHandler));
 }
 
 void WebPageProxy::downloadRequest(WebCore::ResourceRequest&& request, CompletionHandler<void(DownloadProxy*)>&& completionHandler)
 {
-    Ref download = configuration().protectedProcessPool()->download(protectedWebsiteDataStore(), this, request, { });
+    Ref download = configuration().protectedProcessPool()->download(protect(websiteDataStore()), this, request, { });
     download->setDidStartCallback(WTF::move(completionHandler));
 }
 
 void WebPageProxy::dataTaskWithRequest(WebCore::ResourceRequest&& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, bool shouldRunAtForegroundPriority, CompletionHandler<void(API::DataTask&)>&& completionHandler)
 {
-    protectedWebsiteDataStore()->protectedNetworkProcess()->dataTaskWithRequest(*this, sessionID(), WTF::move(request), topOrigin, shouldRunAtForegroundPriority, WTF::move(completionHandler));
+    protect(websiteDataStore())->protectedNetworkProcess()->dataTaskWithRequest(*this, sessionID(), WTF::move(request), topOrigin, shouldRunAtForegroundPriority, WTF::move(completionHandler));
 }
 
 void WebPageProxy::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::optional<WebCore::FloatSize> sizeConstraint, size_t maximumBytesFromNetwork, CompletionHandler<void(Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&&)>&& completionHandler)
@@ -10120,7 +10094,7 @@ void WebPageProxy::loadAndDecodeImage(WebCore::ResourceRequest&& request, std::o
 
     if (!hasRunningProcess())
         launchProcess(Site(aboutBlankURL()), ProcessLaunchReason::InitialProcess);
-    sendWithAsyncReply(Messages::WebPage::LoadAndDecodeImage(request, sizeConstraint, maximumBytesFromNetwork), [preventProcessShutdownScope = protectedLegacyMainFrameProcess()->shutdownPreventingScope(), completionHandler = WTF::move(completionHandler)] (Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&& result) mutable {
+    sendWithAsyncReply(Messages::WebPage::LoadAndDecodeImage(request, sizeConstraint, maximumBytesFromNetwork), [preventProcessShutdownScope = protect(legacyMainFrameProcess())->shutdownPreventingScope(), completionHandler = WTF::move(completionHandler)] (Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&& result) mutable {
         completionHandler(WTF::move(result));
     });
 }
@@ -10154,7 +10128,7 @@ void WebPageProxy::restartXRSessionActivityOnProcessResumeIfNeeded()
 
 void WebPageProxy::showColorPicker(IPC::Connection& connection, const WebCore::Color& initialColor, const IntRect& elementRect, ColorControlSupportsAlpha supportsAlpha, Vector<WebCore::Color>&& suggestions, std::optional<WebCore::FrameIdentifier>&& rootFrameID)
 {
-    MESSAGE_CHECK_BASE(supportsAlpha == ColorControlSupportsAlpha::No || protectedPreferences()->inputTypeColorEnhancementsEnabled(), connection);
+    MESSAGE_CHECK_BASE(supportsAlpha == ColorControlSupportsAlpha::No || protect(preferences())->inputTypeColorEnhancementsEnabled(), connection);
 
     convertRectToMainFrameCoordinates(elementRect, rootFrameID, [weakThis = WeakPtr { *this }, initialColor, supportsAlpha, suggestions = WTF::move(suggestions)](std::optional<FloatRect> convertedRect) mutable {
         RefPtr protectedThis = weakThis.get();
@@ -10198,7 +10172,7 @@ void WebPageProxy::hasVideoInPictureInPictureDidChange(bool value)
 {
     uiClient().hasVideoInPictureInPictureDidChange(this, value);
 #if ENABLE(SCREEN_TIME)
-    protectedPageClient()->setURLIsPictureInPictureForScreenTime(value);
+    protect(pageClient())->setURLIsPictureInPictureForScreenTime(value);
 #endif
 }
 
@@ -10235,7 +10209,7 @@ void WebPageProxy::showDataListSuggestions(WebCore::DataListSuggestionInformatio
     if (!internals().dataListSuggestionsDropdown)
         return;
 
-    Ref { *internals().dataListSuggestionsDropdown }->show(WTF::move(info));
+    protect(*internals().dataListSuggestionsDropdown)->show(WTF::move(info));
 }
 
 void WebPageProxy::handleKeydownInDataList(const String& key)
@@ -10279,7 +10253,7 @@ void WebPageProxy::showDateTimePicker(WebCore::DateTimeChooserParameters&& param
     if (!m_dateTimePicker)
         return;
 
-    Ref { *m_dateTimePicker }->showDateTimePicker(WTF::move(params));
+    protect(*m_dateTimePicker)->showDateTimePicker(WTF::move(params));
 }
 
 void WebPageProxy::endDateTimePicker()
@@ -10287,7 +10261,7 @@ void WebPageProxy::endDateTimePicker()
     if (!m_dateTimePicker)
         return;
 
-    Ref { *m_dateTimePicker }->endPicker();
+    protect(*m_dateTimePicker)->endPicker();
 }
 
 void WebPageProxy::didChooseDate(StringView date)
@@ -10314,11 +10288,6 @@ WebInspectorUIProxy* WebPageProxy::inspector() const
     if (isClosed())
         return nullptr;
     return m_inspector.get();
-}
-
-RefPtr<WebInspectorUIProxy> WebPageProxy::protectedInspector() const
-{
-    return inspector();
 }
 
 void WebPageProxy::resourceLoadDidSendRequest(ResourceLoadInfo&& loadInfo, WebCore::ResourceRequest&& request)
@@ -10447,15 +10416,15 @@ RefPtr<WebDeviceOrientationUpdateProviderProxy> WebPageProxy::protectedWebDevice
 void WebPageProxy::addRemoteMediaSessionManager(WebCore::PageIdentifier localPageIdentifier)
 {
     if (!m_mediaSessionManagerProxy)
-        m_mediaSessionManagerProxy = RemoteMediaSessionManagerProxy::create(webPageIDInMainFrameProcess(), Ref { siteIsolatedProcess() });
+        m_mediaSessionManagerProxy = RemoteMediaSessionManagerProxy::create(webPageIDInMainFrameProcess(), protect(siteIsolatedProcess()));
 
-    Ref { *m_mediaSessionManagerProxy }->addRemoteMediaSessionManager(localPageIdentifier);
+    protect(*m_mediaSessionManagerProxy)->addRemoteMediaSessionManager(localPageIdentifier);
 }
 
 void WebPageProxy::removeRemoteMediaSessionManager(WebCore::PageIdentifier pageIdentifier)
 {
     if (m_mediaSessionManagerProxy)
-        Ref { *m_mediaSessionManagerProxy }->removeRemoteMediaSessionManager(pageIdentifier);
+        protect(*m_mediaSessionManagerProxy)->removeRemoteMediaSessionManager(pageIdentifier);
 }
 
 #endif
@@ -10528,7 +10497,7 @@ void WebPageProxy::requestDOMPasteAccess(IPC::Connection& connection, DOMPasteAc
         }
     }
 
-    protectedPageClient()->requestDOMPasteAccess(pasteAccessCategory, requiresInteraction, elementRect, originIdentifier, WTF::move(completionHandler));
+    protect(pageClient())->requestDOMPasteAccess(pasteAccessCategory, requiresInteraction, elementRect, originIdentifier, WTF::move(completionHandler));
 }
 
 // BackForwardList
@@ -10761,7 +10730,7 @@ void WebPageProxy::postMessageToInjectedBundle(const String& messageName, API::O
         return;
     }
 
-    send(Messages::WebPage::PostInjectedBundleMessage(messageName, UserData(protectedLegacyMainFrameProcess()->transformObjectsToHandles(messageBody).get())));
+    send(Messages::WebPage::PostInjectedBundleMessage(messageName, UserData(protect(legacyMainFrameProcess())->transformObjectsToHandles(messageBody).get())));
 }
 
 #if PLATFORM(GTK)
@@ -10777,7 +10746,7 @@ void WebPageProxy::showPopupMenuFromFrame(IPC::Connection& connection, FrameIden
     if (!frame)
         return;
 
-    convertRectToMainFrameCoordinates(rect, frame->rootFrame()->frameID(), [weakThis = WeakPtr { *this }, textDirection, selectedIndex, data, items = WTF::move(items), connection = Ref { connection }] (std::optional<FloatRect> convertedRect) {
+    convertRectToMainFrameCoordinates(rect, frame->rootFrame()->frameID(), [weakThis = WeakPtr { *this }, textDirection, selectedIndex, data, items = WTF::move(items), connection = protect(connection)] (std::optional<FloatRect> convertedRect) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis || !convertedRect)
             return;
@@ -10919,32 +10888,32 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item, c
 
     case ContextMenuItemTagSmartQuotes:
         TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticQuoteSubstitutionEnabled));
-            protectedLegacyMainFrameProcess()->updateTextCheckerState();
+            protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagSmartDashes:
         TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticDashSubstitutionEnabled));
-            protectedLegacyMainFrameProcess()->updateTextCheckerState();
+            protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagSmartLinks:
         TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticLinkDetectionEnabled));
-            protectedLegacyMainFrameProcess()->updateTextCheckerState();
+            protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagSmartLists:
         TextChecker::setSmartListsEnabled(!TextChecker::state().contains(TextCheckerState::SmartListsEnabled));
-        protectedLegacyMainFrameProcess()->updateTextCheckerState();
+        protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagTextReplacement:
         TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticTextReplacementEnabled));
-            protectedLegacyMainFrameProcess()->updateTextCheckerState();
+            protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagCorrectSpellingAutomatically:
         TextChecker::setAutomaticSpellingCorrectionEnabled(!TextChecker::state().contains(TextCheckerState::AutomaticSpellingCorrectionEnabled));
-            protectedLegacyMainFrameProcess()->updateTextCheckerState();
+            protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagShowSubstitutions:
@@ -10967,12 +10936,12 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item, c
 
     case ContextMenuItemTagCheckSpellingWhileTyping:
         TextChecker::setContinuousSpellCheckingEnabled(!TextChecker::state().contains(TextCheckerState::ContinuousSpellCheckingEnabled));
-            protectedLegacyMainFrameProcess()->updateTextCheckerState();
+            protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
     case ContextMenuItemTagCheckGrammarWithSpelling:
         TextChecker::setGrammarCheckingEnabled(!TextChecker::state().contains(TextCheckerState::GrammarCheckingEnabled));
-            protectedLegacyMainFrameProcess()->updateTextCheckerState();
+            protect(legacyMainFrameProcess())->updateTextCheckerState();
         return;
 
 #if PLATFORM(MAC)
@@ -11108,7 +11077,7 @@ void WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vect
     if (!hasRunningProcess())
         return;
 
-    auto completionHandler = [weakThis = WeakPtr { *this }, fileURLs, displayString, iconData = RefPtr { iconData }] () mutable {
+    auto completionHandler = [weakThis = WeakPtr { *this }, fileURLs, displayString, iconData = protect(iconData)] () mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -11125,7 +11094,7 @@ void WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vect
 
         openPanelResultListener->invalidate();
     };
-    protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(m_legacyMainFrameProcess->coreProcessIdentifier(), fileURLs), WTF::move(completionHandler));
+    protect(websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(m_legacyMainFrameProcess->coreProcessIdentifier(), fileURLs), WTF::move(completionHandler));
 }
 #endif
 
@@ -11137,7 +11106,7 @@ bool WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding(const Vector<S
     if (transcodingMIMEType.isNull()) {
         // For designated sites which are sending "image/*", we need to force the mimetype
         // to be able to transcode from HEIC to JPEG.
-        if (protectedPreferences()->needsSiteSpecificQuirks() && Quirks::shouldTranscodeHeicImagesForURL(URL { currentURL() }))
+        if (protect(preferences())->needsSiteSpecificQuirks() && Quirks::shouldTranscodeHeicImagesForURL(URL { currentURL() }))
             transcodingMIMEType = "image/jpeg"_s;
         else
             return false;
@@ -11204,7 +11173,7 @@ void WebPageProxy::didChooseFilesForOpenPanel(const Vector<String>& fileURLs, co
 
         openPanelResultListener->invalidate();
     };
-    protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(process->coreProcessIdentifier(), fileURLs), WTF::move(completionHandler));
+    protect(websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(process->coreProcessIdentifier(), fileURLs), WTF::move(completionHandler));
 }
 
 void WebPageProxy::didCancelForOpenPanel()
@@ -11537,7 +11506,7 @@ void WebPageProxy::didReceiveEventIPC(IPC::Connection& connection, WebEventType 
 
 void WebPageProxy::didReceiveEvent(IPC::Connection* connection, WebEventType eventType, bool handled, std::optional<RemoteUserInputEventData>&& remoteUserInputEventData)
 {
-    MESSAGE_CHECK_BASE(!remoteUserInputEventData || protectedPreferences()->siteIsolationEnabled(), connection);
+    MESSAGE_CHECK_BASE(!remoteUserInputEventData || protect(preferences())->siteIsolationEnabled(), connection);
     switch (eventType) {
     case WebEventType::MouseMove:
     case WebEventType::Wheel:
@@ -11910,7 +11879,7 @@ void WebPageProxy::resetStateAfterProcessTermination(ProcessTerminationReason re
         WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "processDidTerminate: (pid %d), reason=%" PUBLIC_LOG_STRING, legacyMainFrameProcessID(), processTerminationReasonToString(reason).characters());
 
     resetStateAfterProcessExited(reason);
-    stopAllURLSchemeTasks(protectedLegacyMainFrameProcess().ptr());
+    stopAllURLSchemeTasks(protect(legacyMainFrameProcess()).ptr());
 #if ENABLE(PDF_HUD)
     if (RefPtr pageClient = this->pageClient())
         pageClient->removeAllPDFHUDs();
@@ -11966,9 +11935,9 @@ void WebPageProxy::dispatchProcessDidTerminate(WebProcessProxy& process, Process
 {
     WEBPAGEPROXY_RELEASE_LOG_ERROR(Loading, "dispatchProcessDidTerminate: reason=%" PUBLIC_LOG_STRING, processTerminationReasonToString(reason).characters());
 
-    if (protectedPreferences()->siteIsolationEnabled()) {
+    if (protect(preferences())->siteIsolationEnabled()) {
         processDidBecomeResponsive(process); // Check if all other processes are responsive.
-        protectedBrowsingContextGroup()->processDidTerminate(*this, process);
+        protect(browsingContextGroup())->processDidTerminate(*this, process);
     }
 
     bool handledByClient = false;
@@ -12052,13 +12021,12 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
     }
     closeOverlayedViews();
 
-    // Do not call inspector() / protectedInspector() since they return
-    // null after the page has closed.
-    RefPtr { m_inspector }->reset();
+    // Do not call inspector() since it returns null after the page has closed.
+    protect(m_inspector)->reset();
 
 #if ENABLE(FULLSCREEN_API)
     if (m_fullScreenManager) {
-        RefPtr { m_fullScreenManager }->detachFromClient();
+        protect(m_fullScreenManager)->detachFromClient();
         m_fullScreenManager = nullptr;
     }
 #endif
@@ -12169,7 +12137,7 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 #endif
 
 #if ENABLE(WEB_AUTHN)
-    protectedWebsiteDataStore()->protectedAuthenticatorManager()->cancelRequest(m_webPageID, std::nullopt);
+    protect(websiteDataStore())->protectedAuthenticatorManager()->cancelRequest(m_webPageID, std::nullopt);
 #endif
 
     m_speechRecognitionPermissionManager = nullptr;
@@ -12301,7 +12269,7 @@ void WebPageProxy::resetStateAfterProcessExited(ProcessTerminationReason termina
 #endif
 
     // FIXME: <rdar://problem/38676604> In case of process swaps, the old process should gracefully suspend instead of terminating.
-    protectedLegacyMainFrameProcess()->processTerminated();
+    protect(legacyMainFrameProcess())->processTerminated();
 
 #if ENABLE(MODEL_PROCESS)
     m_hasModelElement = false;
@@ -12383,7 +12351,7 @@ static bool shouldBlockIOKit(const WebPreferences& preferences)
 #if !PLATFORM(COCOA)
 bool WebPageProxy::useGPUProcessForDOMRenderingEnabled() const
 {
-    return protectedPreferences()->useGPUProcessForDOMRenderingEnabled();
+    return protect(preferences())->useGPUProcessForDOMRenderingEnabled();
 }
 #endif
 
@@ -12706,15 +12674,15 @@ WebPageCreationParameters WebPageProxy::creationParametersForRemotePage(WebProce
 void WebPageProxy::isJITEnabled(CompletionHandler<void(bool)>&& completionHandler)
 {
     launchInitialProcessIfNecessary();
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebProcess::IsJITEnabled(), WTF::move(completionHandler), 0);
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebProcess::IsJITEnabled(), WTF::move(completionHandler), 0);
 }
 
 void WebPageProxy::isEnhancedSecurityEnabled(CompletionHandler<void(bool)>&& completionHandler)
 {
-    if (protectedLegacyMainFrameProcess()->isDummyProcessProxy())
+    if (protect(legacyMainFrameProcess())->isDummyProcessProxy())
         return completionHandler(false);
 
-    protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebProcess::IsEnhancedSecurityEnabled(), WTF::move(completionHandler), 0);
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebProcess::IsEnhancedSecurityEnabled(), WTF::move(completionHandler), 0);
 }
 
 void WebPageProxy::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
@@ -13155,7 +13123,7 @@ void WebPageProxy::requestUserMediaPermissionForFrame(IPC::Connection& connectio
 {
     MESSAGE_CHECK_BASE(WebFrameProxy::webFrame(frameInfo.frameID), connection);
 #if PLATFORM(MAC)
-    CoreAudioCaptureDeviceManager::singleton().setFilterTapEnabledDevices(!protectedPreferences()->captureAudioInGPUProcessEnabled());
+    CoreAudioCaptureDeviceManager::singleton().setFilterTapEnabledDevices(!protect(preferences())->captureAudioInGPUProcessEnabled());
 #endif
     protectedUserMediaPermissionRequestManager()->requestUserMediaPermissionForFrame(userMediaID, WTF::move(frameInfo), userMediaDocumentOriginData.securityOrigin(), topLevelDocumentOriginData.securityOrigin(), WTF::move(request));
 }
@@ -13307,7 +13275,7 @@ void WebPageProxy::setShouldListenToVoiceActivity(bool value)
     m_shouldListenToVoiceActivity = value;
 #if ENABLE(GPU_PROCESS)
     RefPtr gpuProcess = m_configuration->processPool().gpuProcess();
-    if (gpuProcess && protectedPreferences()->captureAudioInGPUProcessEnabled())
+    if (gpuProcess && protect(preferences())->captureAudioInGPUProcessEnabled())
         gpuProcess->setShouldListenToVoiceActivity(*this, m_shouldListenToVoiceActivity);
 #endif
 }
@@ -13403,7 +13371,7 @@ void WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess(IPC::Connection& 
     if (!frame)
         return completionHandler(DeviceOrientationOrMotionPermissionState::Denied);
 
-    protectedWebsiteDataStore()->protectedDeviceOrientationAndMotionAccessController()->shouldAllowAccess(*this, *frame, WTF::move(frameInfo), mayPrompt, WTF::move(completionHandler));
+    protect(websiteDataStore())->protectedDeviceOrientationAndMotionAccessController()->shouldAllowAccess(*this, *frame, WTF::move(frameInfo), mayPrompt, WTF::move(completionHandler));
 }
 
 #endif
@@ -13413,7 +13381,7 @@ void WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess(IPC::Connection& 
 
 void WebPageProxy::requestTextRecognition(const URL& imageURL, ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(TextRecognitionResult&&)>&& completionHandler)
 {
-    protectedPageClient()->requestTextRecognition(imageURL, WTF::move(imageData), sourceLanguageIdentifier, targetLanguageIdentifier, WTF::move(completionHandler));
+    protect(pageClient())->requestTextRecognition(imageURL, WTF::move(imageData), sourceLanguageIdentifier, targetLanguageIdentifier, WTF::move(completionHandler));
 }
 
 void WebPageProxy::computeHasVisualSearchResults(const URL& imageURL, ShareableBitmap& imageBitmap, CompletionHandler<void(bool)>&& completion)
@@ -13893,7 +13861,7 @@ void WebPageProxy::endPrinting(CompletionHandler<void()>&& callback)
     m_isInPrintingMode = false;
 
     if (m_isPerformingDOMPrintOperation)
-        protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebPage::EndPrintingDuringDOMPrintOperation(), WTF::move(callback), webPageIDInMainFrameProcess(), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);
+        protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::EndPrintingDuringDOMPrintOperation(), WTF::move(callback), webPageIDInMainFrameProcess(), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);
     else
         sendWithAsyncReply(Messages::WebPage::EndPrinting(), WTF::move(callback));
 }
@@ -14031,10 +13999,10 @@ void WebPageProxy::updateBackingStoreDiscardableState()
 
     bool isDiscardable;
 
-    if (!protectedLegacyMainFrameProcess()->isResponsive())
+    if (!protect(legacyMainFrameProcess())->isResponsive())
         isDiscardable = false;
     else
-        isDiscardable = !protectedPageClient()->isViewWindowActive() || !isViewVisible();
+        isDiscardable = !protect(pageClient())->isViewWindowActive() || !isViewVisible();
 
     drawingArea->setBackingStoreIsDiscardable(isDiscardable);
 }
@@ -14064,7 +14032,7 @@ void WebPageProxy::setMinimumSizeForAutoLayout(const IntSize& size)
         return;
 
     send(Messages::WebPage::SetMinimumSizeForAutoLayout(size));
-    protectedDrawingArea()->minimumSizeForAutoLayoutDidChange();
+    protect(drawingArea())->minimumSizeForAutoLayoutDidChange();
 
 #if USE(APPKIT)
     if (internals().minimumSizeForAutoLayout.width() <= 0)
@@ -14083,7 +14051,7 @@ void WebPageProxy::setSizeToContentAutoSizeMaximumSize(const IntSize& size)
         return;
 
     send(Messages::WebPage::SetSizeToContentAutoSizeMaximumSize(size));
-    protectedDrawingArea()->sizeToContentAutoSizeMaximumSizeDidChange();
+    protect(drawingArea())->sizeToContentAutoSizeMaximumSizeDidChange();
 
 #if USE(APPKIT)
     if (internals().sizeToContentAutoSizeMaximumSize.width() <= 0)
@@ -14176,7 +14144,7 @@ void WebPageProxy::dictationAlternatives(WebCore::DictationContext dictationCont
     RefPtr pageClient = this->pageClient();
     if (!pageClient)
         return completionHandler({ });
-    completionHandler(protectedPageClient()->dictationAlternatives(dictationContext));
+    completionHandler(pageClient->dictationAlternatives(dictationContext));
 }
 
 #endif
@@ -14212,7 +14180,7 @@ void WebPageProxy::dismissCorrectionPanelSoon(ReasonForDismissingAlternativeText
     RefPtr pageClient = this->pageClient();
     if (!pageClient)
         return completionHandler({ });
-    completionHandler(protectedPageClient()->dismissCorrectionPanelSoon(reason));
+    completionHandler(pageClient->dismissCorrectionPanelSoon(reason));
 }
 
 void WebPageProxy::recordAutocorrectionResponse(AutocorrectionResponse response, const String& replacedString, const String& replacementString)
@@ -14242,7 +14210,7 @@ RefPtr<ViewSnapshot> WebPageProxy::takeViewSnapshot(std::optional<WebCore::IntRe
     RefPtr pageClient = this->pageClient();
     if (!pageClient)
         return nullptr;
-    return protectedPageClient()->takeViewSnapshot(WTF::move(clipRect));
+    return pageClient->takeViewSnapshot(WTF::move(clipRect));
 }
 
 RefPtr<ViewSnapshot> WebPageProxy::takeViewSnapshot(std::optional<WebCore::IntRect>&& clipRect, ForceSoftwareCapturingViewportSnapshot forceSoftwareCapturing)
@@ -14309,7 +14277,7 @@ void WebPageProxy::setOverlayScrollbarStyle(std::optional<WebCore::ScrollbarOver
     m_scrollbarOverlayStyle = scrollbarStyle;
 
     if (hasRunningProcess())
-        protectedLegacyMainFrameProcess()->send(Messages::WebPage::SetScrollbarOverlayStyle(scrollbarStyle), m_webPageID);
+        protect(legacyMainFrameProcess())->send(Messages::WebPage::SetScrollbarOverlayStyle(scrollbarStyle), m_webPageID);
 }
 
 void WebPageProxy::getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)
@@ -14476,7 +14444,7 @@ void WebPageProxy::setScrollPerformanceDataCollectionEnabled(bool enabled)
     m_scrollPerformanceDataCollectionEnabled = enabled;
 
     if (m_scrollPerformanceDataCollectionEnabled && !m_scrollingPerformanceData)
-        m_scrollingPerformanceData = makeUnique<RemoteLayerTreeScrollingPerformanceData>(Ref { downcast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea) });
+        m_scrollingPerformanceData = makeUnique<RemoteLayerTreeScrollingPerformanceData>(protect(downcast<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea)));
     else if (!m_scrollPerformanceDataCollectionEnabled)
         m_scrollingPerformanceData = nullptr;
 }
@@ -14668,7 +14636,7 @@ MediaProducerMediaStateFlags WebPageProxy::reportedMediaState() const
 void WebPageProxy::updatePlayingMediaDidChange(CanDelayNotification canDelayNotification)
 {
     MediaProducerMediaStateFlags newState = internals().mainFrameMediaState;
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&newState](auto& remotePage) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&newState](auto& remotePage) {
         newState.add(remotePage.mediaState());
     });
 
@@ -14726,7 +14694,7 @@ void WebPageProxy::updatePlayingMediaDidChange(CanDelayNotification canDelayNoti
             userMediaPermissionRequestManager->captureStateChanged(oldMediaCaptureState, newMediaCaptureState);
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(GPU_PROCESS)
-        if (protectedPreferences()->captureAudioInGPUProcessEnabled() && newMediaCaptureState & WebCore::MediaProducerMediaState::HasActiveAudioCaptureDevice)
+        if (protect(preferences())->captureAudioInGPUProcessEnabled() && newMediaCaptureState & WebCore::MediaProducerMediaState::HasActiveAudioCaptureDevice)
             configuration().protectedProcessPool()->ensureProtectedGPUProcess()->setPageUsingMicrophone(identifier());
 #endif
     }
@@ -14759,7 +14727,7 @@ void WebPageProxy::updatePlayingMediaDidChange(CanDelayNotification canDelayNoti
 
 #if ENABLE(SCREEN_TIME)
     if (oldState.contains(MediaProducerMediaState::IsPlayingVideo) != newState.contains(MediaProducerMediaState::IsPlayingVideo))
-        protectedPageClient()->setURLIsPlayingVideoForScreenTime(newState.contains(MediaProducerMediaState::IsPlayingVideo));
+        pageClient->setURLIsPlayingVideoForScreenTime(newState.contains(MediaProducerMediaState::IsPlayingVideo));
 #endif
 }
 
@@ -14911,7 +14879,7 @@ void WebPageProxy::immediateActionDidComplete()
 
 void WebPageProxy::didPerformImmediateActionHitTest(IPC::Connection& connection, WebHitTestResultData&& result, bool contentPreventsDefault, const UserData& userData)
 {
-    if (protectedPreferences()->siteIsolationEnabled()) {
+    if (protect(preferences())->siteIsolationEnabled()) {
         if (result.remoteUserInputEventData) {
             performImmediateActionHitTestAtLocation(result.remoteUserInputEventData->targetFrameID, FloatPoint(result.remoteUserInputEventData->transformedPoint));
             return;
@@ -14936,7 +14904,7 @@ NSObject *WebPageProxy::immediateActionAnimationControllerForHitTestResult(RefPt
     RefPtr pageClient = this->pageClient();
     if (!pageClient)
         return nullptr;
-    return protectedPageClient()->immediateActionAnimationControllerForHitTestResult(hitTestResult, type, userData);
+    return pageClient->immediateActionAnimationControllerForHitTestResult(hitTestResult, type, userData);
 }
 
 void WebPageProxy::handleAcceptedCandidate(WebCore::TextCheckingResult acceptedCandidate)
@@ -15023,7 +14991,7 @@ void WebPageProxy::removePlaybackTargetPickerClient(PlaybackTargetClientContextI
 void WebPageProxy::showPlaybackTargetPicker(PlaybackTargetClientContextIdentifier contextId, const WebCore::FloatRect& rect, bool hasVideo)
 {
     if (RefPtr pageClient = this->pageClient())
-        pageClient->checkedMediaSessionManager()->showPlaybackTargetPicker(internals(), contextId, protectedPageClient()->rootViewToScreen(IntRect(rect)), hasVideo, useDarkAppearance());
+        pageClient->checkedMediaSessionManager()->showPlaybackTargetPicker(internals(), contextId, pageClient->rootViewToScreen(IntRect(rect)), hasVideo, useDarkAppearance());
 }
 
 void WebPageProxy::playbackTargetPickerClientStateDidChange(PlaybackTargetClientContextIdentifier contextId, WebCore::MediaProducerMediaStateFlags state)
@@ -15113,7 +15081,7 @@ void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& c
     for (Ref process : webContentProcessesWithFrame()) {
         auto callbackID = process->sendWithAsyncReply(Messages::DrawingArea::DispatchAfterEnsuringDrawing(), [aggregator] { }, drawingAreaIdentifier);
         if (callbackID && process->hasConnection())
-            protectedDrawingArea()->addOutstandingPresentationUpdateCallback(process->protectedConnection(), *callbackID);
+            protect(drawingArea())->addOutstandingPresentationUpdateCallback(process->protectedConnection(), *callbackID);
     }
 #elif USE(COORDINATED_GRAPHICS)
     downcast<DrawingAreaProxyCoordinatedGraphics>(*m_drawingArea).dispatchAfterEnsuringDrawing(WTF::move(callback));
@@ -15166,7 +15134,7 @@ void WebPageProxy::getLoadDecisionForIcon(const WebCore::LinkIcon& icon, Callbac
 
 WebCore::UserInterfaceLayoutDirection WebPageProxy::userInterfaceLayoutDirection()
 {
-    return protectedPageClient()->userInterfaceLayoutDirection();
+    return protect(pageClient())->userInterfaceLayoutDirection();
 }
 
 void WebPageProxy::setUserInterfaceLayoutDirection(WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection)
@@ -15277,7 +15245,7 @@ void WebPageProxy::clearWebContentPointerLockProcess()
 
 void WebPageProxy::resetPointerLockState()
 {
-    requestPointerUnlock([this, protectedThis = RefPtr { *this }](bool result) {
+    requestPointerUnlock([this, protectedThis = Ref { *this }](bool result) {
         if (result) {
             RefPtr<WebProcessProxy> webContentPointerLock = webContentPointerLockProcess();
             webContentPointerLock->send(Messages::WebPage::DidLosePointerLock(), webPageIDInProcess(*webContentPointerLock));
@@ -15336,7 +15304,7 @@ void WebPageProxy::startURLSchemeTaskShared(IPC::Connection& connection, Ref<Web
     auto iterator = internals().urlSchemeHandlersByIdentifier.find(parameters.handlerIdentifier);
     MESSAGE_CHECK(process, iterator != internals().urlSchemeHandlersByIdentifier.end());
 
-    Ref { iterator->value }->startTask(*this, process, webPageID, WTF::move(parameters), nullptr);
+    protect(iterator->value)->startTask(*this, process, webPageID, WTF::move(parameters), nullptr);
 }
 
 void WebPageProxy::stopURLSchemeTask(IPC::Connection& connection, WebURLSchemeHandlerIdentifier handlerIdentifier, WebCore::ResourceLoaderIdentifier taskIdentifier)
@@ -15345,7 +15313,7 @@ void WebPageProxy::stopURLSchemeTask(IPC::Connection& connection, WebURLSchemeHa
     auto iterator = internals().urlSchemeHandlersByIdentifier.find(handlerIdentifier);
     MESSAGE_CHECK_BASE(iterator != internals().urlSchemeHandlersByIdentifier.end(), connection);
 
-    Ref { iterator->value }->stopTask(*this, taskIdentifier);
+    protect(iterator->value)->stopTask(*this, taskIdentifier);
 }
 
 void WebPageProxy::loadSynchronousURLSchemeTask(IPC::Connection& connection, URLSchemeTaskParameters&& parameters, CompletionHandler<void(const WebCore::ResourceResponse&, const WebCore::ResourceError&, Vector<uint8_t>&&)>&& reply)
@@ -15354,7 +15322,7 @@ void WebPageProxy::loadSynchronousURLSchemeTask(IPC::Connection& connection, URL
     auto iterator = internals().urlSchemeHandlersByIdentifier.find(parameters.handlerIdentifier);
     MESSAGE_CHECK_COMPLETION_BASE(iterator != internals().urlSchemeHandlersByIdentifier.end(), connection, reply({ }, { }, { }));
 
-    Ref { iterator->value }->startTask(*this, m_legacyMainFrameProcess, m_webPageID, WTF::move(parameters), WTF::move(reply));
+    protect(iterator->value)->startTask(*this, m_legacyMainFrameProcess, m_webPageID, WTF::move(parameters), WTF::move(reply));
 }
 
 void WebPageProxy::requestStorageAccessConfirm(const RegistrableDomain& subFrameDomain, const RegistrableDomain& topFrameDomain, FrameIdentifier frameID, std::optional<OrganizationStorageAccessPromptQuirk>&& organizationStorageAccessPromptQuirk, CompletionHandler<void(bool)>&& completionHandler)
@@ -15405,7 +15373,7 @@ void WebPageProxy::effectiveAppearanceDidChange()
 
 DataOwnerType WebPageProxy::dataOwnerForPasteboard(PasteboardAccessIntent intent) const
 {
-    return protectedPageClient()->dataOwnerForPasteboard(intent);
+    return protect(pageClient())->dataOwnerForPasteboard(intent);
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -15422,7 +15390,7 @@ void WebPageProxy::writePromisedAttachmentToPasteboard(IPC::Connection& connecti
 
 void WebPageProxy::requestAttachmentIcon(IPC::Connection& connection, const String& identifier, const String& contentType, const String& fileName, const String& title, const FloatSize& requestedSize)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
 
     auto updateAttachmentIcon = [&, protectedThis = Ref { *this }] {
         FloatSize size = requestedSize;
@@ -15435,7 +15403,7 @@ void WebPageProxy::requestAttachmentIcon(IPC::Connection& connection, const Stri
         }
 #endif
 
-        protectedLegacyMainFrameProcess()->send(Messages::WebPage::UpdateAttachmentIcon(identifier, WTF::move(handle), size), webPageIDInMainFrameProcess());
+        protect(legacyMainFrameProcess())->send(Messages::WebPage::UpdateAttachmentIcon(identifier, WTF::move(handle), size), webPageIDInMainFrameProcess());
     };
 
 #if PLATFORM(MAC)
@@ -15475,7 +15443,7 @@ void WebPageProxy::updateAttachmentAttributes(const API::Attachment& attachment,
 
 void WebPageProxy::registerAttachmentIdentifierFromData(IPC::Connection& connection, const String& identifier, const String& contentType, const String& preferredFileName, const IPC::SharedBufferReference& data)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(identifier), connection);
 
     if (attachmentForIdentifier(identifier))
@@ -15490,7 +15458,7 @@ void WebPageProxy::registerAttachmentIdentifierFromData(IPC::Connection& connect
 
 void WebPageProxy::registerAttachmentIdentifierFromFilePath(IPC::Connection& connection, const String& identifier, const String& contentType, const String& filePath)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(identifier), connection);
 
     if (attachmentForIdentifier(identifier))
@@ -15505,7 +15473,7 @@ void WebPageProxy::registerAttachmentIdentifierFromFilePath(IPC::Connection& con
 
 void WebPageProxy::registerAttachmentIdentifier(IPC::Connection& connection, const String& identifier)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(identifier), connection);
 
     if (!attachmentForIdentifier(identifier))
@@ -15514,7 +15482,7 @@ void WebPageProxy::registerAttachmentIdentifier(IPC::Connection& connection, con
 
 void WebPageProxy::registerAttachmentsFromSerializedData(IPC::Connection& connection, Vector<SerializedAttachmentData>&& data)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
 
     for (auto& serializedData : data) {
         auto identifier = WTF::move(serializedData.identifier);
@@ -15527,7 +15495,7 @@ void WebPageProxy::registerAttachmentsFromSerializedData(IPC::Connection& connec
 
 void WebPageProxy::cloneAttachmentData(IPC::Connection& connection, const String& fromIdentifier, const String& toIdentifier)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(fromIdentifier), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(toIdentifier), connection);
 
@@ -15549,7 +15517,7 @@ void WebPageProxy::invalidateAllAttachments()
     for (auto& attachment : m_attachmentIdentifierToAttachmentMap.values()) {
         if (attachment->insertionState() == API::Attachment::InsertionState::Inserted)
             didRemoveAttachment(attachment.get());
-        Ref { attachment }->invalidate();
+        protect(attachment)->invalidate();
     }
     m_attachmentIdentifierToAttachmentMap.clear();
 }
@@ -15558,7 +15526,7 @@ void WebPageProxy::serializedAttachmentDataForIdentifiers(const Vector<String>& 
 {
     Vector<WebCore::SerializedAttachmentData> serializedData;
 
-    MESSAGE_CHECK_COMPLETION(protectedLegacyMainFrameProcess(), protectedPreferences()->attachmentElementEnabled(), completionHandler(WTF::move(serializedData)));
+    MESSAGE_CHECK_COMPLETION(protect(legacyMainFrameProcess()), protect(preferences())->attachmentElementEnabled(), completionHandler(WTF::move(serializedData)));
 
     for (const auto& identifier : identifiers)
         MESSAGE_CHECK_COMPLETION(m_legacyMainFrameProcess, IdentifierToAttachmentMap::isValidKey(identifier), completionHandler(WTF::move(serializedData)));
@@ -15606,7 +15574,7 @@ void WebPageProxy::platformCloneAttachment(Ref<API::Attachment>&&, Ref<API::Atta
 
 void WebPageProxy::didInsertAttachmentWithIdentifier(IPC::Connection& connection, const String& identifier, const String& source, WebCore::AttachmentAssociatedElementType associatedElementType)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(identifier), connection);
 
     Ref attachment = ensureAttachment(identifier);
@@ -15621,7 +15589,7 @@ void WebPageProxy::didInsertAttachmentWithIdentifier(IPC::Connection& connection
 
 void WebPageProxy::didRemoveAttachmentWithIdentifier(IPC::Connection& connection, const String& identifier)
 {
-    MESSAGE_CHECK_BASE(protectedPreferences()->attachmentElementEnabled(), connection);
+    MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(identifier), connection);
 
     if (RefPtr attachment = attachmentForIdentifier(identifier))
@@ -15850,7 +15818,7 @@ void WebPageProxy::setPrivateClickMeasurement(std::nullopt_t)
 
 void WebPageProxy::setPrivateClickMeasurementImmediately(PrivateClickMeasurement&& measurement)
 {
-    protectedWebsiteDataStore()->storePrivateClickMeasurement(WTF::move(measurement));
+    protect(websiteDataStore())->storePrivateClickMeasurement(WTF::move(measurement));
 }
 
 auto WebPageProxy::privateClickMeasurementEventAttribution() const -> std::optional<EventAttribution>
@@ -15863,7 +15831,7 @@ auto WebPageProxy::privateClickMeasurementEventAttribution() const -> std::optio
 
 void WebPageProxy::simulatePrivateClickMeasurementConversion(int priority, int triggerData, const URL& sourceURL, const URL& destinationURL)
 {
-    protectedWebsiteDataStore()->simulatePrivateClickMeasurementConversion(priority, triggerData, sourceURL, destinationURL);
+    protect(websiteDataStore())->simulatePrivateClickMeasurementConversion(priority, triggerData, sourceURL, destinationURL);
 }
 
 #if ENABLE(APPLE_PAY)
@@ -16047,7 +16015,7 @@ void WebPageProxy::decidePolicyForSOAuthorizationLoad(const String& extension, C
 #if ENABLE(WEB_AUTHN)
 void WebPageProxy::setMockWebAuthenticationConfiguration(MockWebAuthenticationConfiguration&& configuration)
 {
-    protectedWebsiteDataStore()->setMockWebAuthenticationConfiguration(WTF::move(configuration));
+    protect(websiteDataStore())->setMockWebAuthenticationConfiguration(WTF::move(configuration));
 }
 #endif
 
@@ -16213,7 +16181,7 @@ void WebPageProxy::setOrientationForMediaCapture(WebCore::IntDegrees orientation
 #if ENABLE(MEDIA_STREAM)
 #if PLATFORM(COCOA)
     RefPtr gpuProcess = m_configuration->processPool().gpuProcess();
-    if (gpuProcess && protectedPreferences()->captureVideoInGPUProcessEnabled())
+    if (gpuProcess && protect(preferences())->captureVideoInGPUProcessEnabled())
         gpuProcess->setOrientationForMediaCapture(orientation);
 #elif USE(GSTREAMER)
     send(Messages::WebPage::SetOrientationForMediaCapture(orientation));
@@ -16374,8 +16342,8 @@ WebCore::CaptureSourceOrError WebPageProxy::createRealtimeMediaSourceForSpeechRe
     if (!captureDevice)
         return CaptureSourceOrError { { "No device is available for capture"_s, WebCore::MediaAccessDenialReason::PermissionDenied } };
 
-    Ref speechRecognitionRemoteRealtimeMediaSourceManager = protectedLegacyMainFrameProcess()->ensureSpeechRecognitionRemoteRealtimeMediaSourceManager();
-    if (protectedPreferences()->captureAudioInGPUProcessEnabled())
+    Ref speechRecognitionRemoteRealtimeMediaSourceManager = protect(legacyMainFrameProcess())->ensureSpeechRecognitionRemoteRealtimeMediaSourceManager();
+    if (protect(preferences())->captureAudioInGPUProcessEnabled())
         return CaptureSourceOrError { SpeechRecognitionRemoteRealtimeMediaSource::create(speechRecognitionRemoteRealtimeMediaSourceManager, *captureDevice, m_webPageID) };
 
 #if PLATFORM(IOS_FAMILY)
@@ -16580,7 +16548,7 @@ bool WebPageProxy::shouldEnableLockdownMode() const
 
 EnhancedSecurity WebPageProxy::currentEnhancedSecurityState(const API::WebsitePolicies* websitePolicies) const
 {
-    if (protectedPreferences()->forceEnhancedSecurity())
+    if (protect(preferences())->forceEnhancedSecurity())
         return EnhancedSecurity::EnabledPolicy;
 
     if (websitePolicies && websitePolicies->isEnhancedSecurityExplicitlySet()) {
@@ -16694,7 +16662,7 @@ void WebPageProxy::generateTestReport(const String& message, const String& group
 
 WebProcessProxy* WebPageProxy::processForSite(const Site& site)
 {
-    if (RefPtr process = protectedBrowsingContextGroup()->processForSite(site))
+    if (RefPtr process = protect(browsingContextGroup())->processForSite(site))
         return &process->process();
 
     return nullptr;
@@ -16750,7 +16718,7 @@ void WebPageProxy::sendCachedLinkDecorationFilteringData()
 void WebPageProxy::waitForInitialLinkDecorationFilteringData(WebFramePolicyListenerProxy& listener)
 {
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    LinkDecorationFilteringController::sharedSingleton().updateList([listener = Ref { listener }] {
+    LinkDecorationFilteringController::sharedSingleton().updateList([listener = protect(listener)] {
         listener->didReceiveInitialLinkDecorationFilteringData();
     });
 #else
@@ -16760,7 +16728,7 @@ void WebPageProxy::waitForInitialLinkDecorationFilteringData(WebFramePolicyListe
 
 void WebPageProxy::beginSiteHasStorageCheck(const URL& url, API::Navigation& navigation, WebFramePolicyListenerProxy& listener)
 {
-    protectedWebsiteDataStore()->hasLocalStorageOrCookies(url, [navigation = Ref { navigation }, url, listener = Ref { listener }] (bool hasStorage) mutable {
+    protect(websiteDataStore())->hasLocalStorageOrCookies(url, [navigation = protect(navigation), url, listener = protect(listener)] (bool hasStorage) mutable {
         if (url == navigation->currentRequest().url()) {
             navigation->setHasStorageForCurrentSite(hasStorage);
             listener->didReceiveSiteHasStorageResults();
@@ -16792,7 +16760,7 @@ void WebPageProxy::playAllAnimations(CompletionHandler<void()>&& completionHandl
 
 void WebPageProxy::stickyScrollingTreeNodeBeganSticking()
 {
-    if (!protectedPreferences()->contentInsetBackgroundFillEnabled())
+    if (!protect(preferences())->contentInsetBackgroundFillEnabled())
         return;
 
     internals().needsFixedContainerEdgesUpdateAfterNextCommit = true;
@@ -16817,7 +16785,7 @@ String WebPageProxy::scrollbarStateForScrollingNodeID(std::optional<ScrollingNod
 
 WebCore::PageIdentifier WebPageProxy::webPageIDInProcess(const WebProcessProxy& process) const
 {
-    if (RefPtr remotePage = protectedBrowsingContextGroup()->remotePageInProcess(*this, process))
+    if (RefPtr remotePage = protect(browsingContextGroup())->remotePageInProcess(*this, process))
         return remotePage->pageID();
     return m_webPageID;
 }
@@ -16981,16 +16949,6 @@ void WebPageProxy::broadcastFocusedFrameToOtherProcesses(IPC::Connection& connec
     });
 }
 
-Ref<WebPreferences> WebPageProxy::protectedPreferences() const
-{
-    return m_preferences;
-}
-
-Ref<WebsiteDataStore> WebPageProxy::protectedWebsiteDataStore() const
-{
-    return m_websiteDataStore;
-}
-
 Ref<WebProcessProxy> WebPageProxy::processContainingFrame(std::optional<WebCore::FrameIdentifier> frameID)
 {
     if (RefPtr frame = WebFrameProxy::webFrame(frameID))
@@ -17002,7 +16960,7 @@ template<typename F>
 decltype(auto) WebPageProxy::sendToWebPage(std::optional<FrameIdentifier> frameID, F&& sendFunction)
 {
     if (RefPtr frame = WebFrameProxy::webFrame(frameID)) {
-        if (RefPtr remotePage = protectedBrowsingContextGroup()->remotePageInProcess(*this, frame->protectedProcess()))
+        if (RefPtr remotePage = protect(browsingContextGroup())->remotePageInProcess(*this, frame->protectedProcess()))
             return sendFunction(*remotePage);
     }
     return sendFunction(*this);
@@ -17303,7 +17261,7 @@ void WebPageProxy::reportMixedContentViolation(FrameIdentifier frameID, bool blo
     if (!frame)
         return;
 
-    auto isUpgradingLocalhostDisabled = !protectedPreferences()->iPAddressAndLocalhostMixedContentUpgradeTestingEnabled() && shouldTreatAsPotentiallyTrustworthy(target);
+    auto isUpgradingLocalhostDisabled = !protect(preferences())->iPAddressAndLocalhostMixedContentUpgradeTestingEnabled() && shouldTreatAsPotentiallyTrustworthy(target);
     ASCIILiteral errorString = [&] {
         if (blocked)
             return "blocked and must"_s;
@@ -17469,7 +17427,7 @@ Ref<BrowsingContextGroup> WebPageProxy::protectedBrowsingContextGroup() const
 
 bool WebPageProxy::isAlwaysOnLoggingAllowed() const
 {
-    return sessionID().isAlwaysOnLoggingAllowed() || protectedPreferences()->allowPrivacySensitiveOperationsInNonPersistentDataStores();
+    return sessionID().isAlwaysOnLoggingAllowed() || protect(preferences())->allowPrivacySensitiveOperationsInNonPersistentDataStores();
 }
 
 #if PLATFORM(COCOA)
@@ -17494,7 +17452,7 @@ void WebPageProxy::fetchSessionStorage(CompletionHandler<void(std::optional<Hash
 
 void WebPageProxy::restoreSessionStorage(HashMap<WebCore::ClientOrigin, HashMap<String, String>>&& sessionStorage, CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::RestoreSessionStorage(sessionID(), identifier(), WTF::move(sessionStorage)), WTF::move(completionHandler));
+    protect(websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::RestoreSessionStorage(sessionID(), identifier(), WTF::move(sessionStorage)), WTF::move(completionHandler));
 }
 
 #if HAVE(AUDIT_TOKEN)
@@ -17511,7 +17469,7 @@ void WebPageProxy::setPresentingApplicationAuditToken(const audit_token_t& prese
         send(Messages::WebPage::SetPresentingApplicationAuditTokenAndBundleIdentifier(presentingApplicationAuditToken, presentingApplicationBundleIdentifier()));
 
     if (RefPtr gpuProcess = GPUProcessProxy::singletonIfCreated())
-        gpuProcess->setPresentingApplicationAuditToken(protectedLegacyMainFrameProcess()->coreProcessIdentifier(), m_webPageID, presentingApplicationAuditToken);
+        gpuProcess->setPresentingApplicationAuditToken(protect(legacyMainFrameProcess())->coreProcessIdentifier(), m_webPageID, presentingApplicationAuditToken);
 }
 #endif
 
@@ -17535,7 +17493,7 @@ bool WebPageProxy::isRemoteFrameNavigation(Ref<WebProcessProxy> process)
 void WebPageProxy::networkRequestsInProgressDidChange()
 {
     bool hasNetworkRequestsInProgress = m_hasNetworkRequestsInProgress;
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [&] (auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [&] (auto& remotePageProxy) {
         hasNetworkRequestsInProgress |= remotePageProxy.hasNetworkRequestsInProgress();
     });
 
@@ -17570,7 +17528,7 @@ UniqueRef<TextExtractionAssertionScope> WebPageProxy::createTextExtractionAssert
 void WebPageProxy::takeTextExtractionAssertion()
 {
     m_mainFrameProcessActivityState->takeTextExtractionAssertion();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePage) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePage) {
         remotePage.processActivityState().takeTextExtractionAssertion();
     });
 }
@@ -17578,7 +17536,7 @@ void WebPageProxy::takeTextExtractionAssertion()
 void WebPageProxy::dropTextExtractionAssertion()
 {
     m_mainFrameProcessActivityState->dropTextExtractionAssertion();
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [](auto& remotePage) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [](auto& remotePage) {
         remotePage.processActivityState().dropTextExtractionAssertion();
     });
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -715,19 +715,15 @@ public:
     PAL::SessionID sessionID() const;
 
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
-    RefPtr<WebFrameProxy> protectedMainFrame() const;
     WebFrameProxy* focusedFrame() const { return m_focusedFrame.get(); }
-    RefPtr<WebFrameProxy> protectedFocusedFrame() const;
     WebFrameProxy* focusedOrMainFrame() const { return m_focusedFrame ? m_focusedFrame.get() : m_mainFrame.get(); }
 
     DrawingAreaProxy* drawingArea() const { return m_drawingArea.get(); }
-    RefPtr<DrawingAreaProxy> protectedDrawingArea() const;
     DrawingAreaProxy* provisionalDrawingArea() const;
 
     WebNavigationState& navigationState() { return m_navigationState; }
 
     WebsiteDataStore& websiteDataStore() { return m_websiteDataStore; }
-    Ref<WebsiteDataStore> protectedWebsiteDataStore() const;
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
 
@@ -770,7 +766,6 @@ public:
     bool isSuspended() const { return m_isSuspended; }
 
     WebInspectorUIProxy* inspector() const;
-    RefPtr<WebInspectorUIProxy> protectedInspector() const;
 
     GeolocationPermissionRequestManagerProxy& geolocationPermissionRequestManager();
     Ref<GeolocationPermissionRequestManagerProxy> protectedGeolocationPermissionRequestManager();
@@ -1054,7 +1049,6 @@ public:
     void restoreSelectionInFocusedEditableElement();
 
     PageClient* pageClient() const;
-    RefPtr<PageClient> protectedPageClient() const;
 
     void setViewNeedsDisplay(const WebCore::Region&);
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated);
@@ -1799,7 +1793,6 @@ public:
     Ref<WebProcessProxy> ensureProtectedRunningProcess();
     WebProcessProxy& siteIsolatedProcess() const { return m_legacyMainFrameProcess; }
     WebProcessProxy& legacyMainFrameProcess() const { return m_legacyMainFrameProcess; }
-    Ref<WebProcessProxy> protectedLegacyMainFrameProcess() const;
     ProcessID legacyMainFrameProcessID() const;
 
     ProcessID gpuProcessID() const;
@@ -1810,7 +1803,6 @@ public:
 
     const WebPreferences& preferences() const { return m_preferences; }
     WebPreferences& preferences() { return m_preferences; }
-    Ref<WebPreferences> protectedPreferences() const;
 
     void setPreferences(WebPreferences&);
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -56,12 +56,12 @@ WebPageProxyTesting::WebPageProxyTesting(WebPageProxy& page)
 
 bool WebPageProxyTesting::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
-    return protectedPage()->protectedLegacyMainFrameProcess()->sendMessage(WTF::move(encoder), sendOptions);
+    return protect(protectedPage()->legacyMainFrameProcess())->sendMessage(WTF::move(encoder), sendOptions);
 }
 
 bool WebPageProxyTesting::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
 {
-    return protectedPage()->protectedLegacyMainFrameProcess()->sendMessage(WTF::move(encoder), sendOptions, WTF::move(handler));
+    return protect(protectedPage()->legacyMainFrameProcess())->sendMessage(WTF::move(encoder), sendOptions, WTF::move(handler));
 }
 
 IPC::Connection* WebPageProxyTesting::messageSenderConnection() const
@@ -89,7 +89,7 @@ void WebPageProxyTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& comp
 
 void WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->setCrossSiteLoadWithLinkDecorationForTesting(protectedPage()->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->setCrossSiteLoadWithLinkDecorationForTesting(protectedPage()->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPermissionLevel(const String& origin, bool allowed)
@@ -112,62 +112,62 @@ bool WebPageProxyTesting::isEditingCommandEnabled(const String& commandName)
 
 void WebPageProxyTesting::dumpPrivateClickMeasurement(CompletionHandler<void(const String&)>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::clearPrivateClickMeasurement(CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart(CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs(const URL& sourceURL, const URL& destinationURL, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::markPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPCMFraudPreventionValues(const String& unlinkableToken, const String& secretToken, const String& signature, const String& keyID, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAppBundleID(const String& appBundleIDForTesting, CompletionHandler<void()>&& completionHandler)
 {
-    protectedPage()->protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTF::move(completionHandler));
+    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTF::move(completionHandler));
 }
 
 #if ENABLE(NOTIFICATIONS)
@@ -208,7 +208,7 @@ Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const
 
 void WebPageProxyTesting::resetStateBetweenTests()
 {
-    protectedPage()->protectedLegacyMainFrameProcess()->resetState();
+    protect(protectedPage()->legacyMainFrameProcess())->resetState();
 
     if (RefPtr mainFrame = m_page->mainFrame())
         mainFrame->disownOpener();
@@ -221,7 +221,7 @@ void WebPageProxyTesting::resetStateBetweenTests()
 void WebPageProxyTesting::clearBackForwardList(CompletionHandler<void()>&& completionHandler)
 {
     Ref page = m_page.get();
-    Ref { page->backForwardList() }->clear();
+    protect(page->backForwardList())->clear();
 
     Ref callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
     page->forEachWebContentProcess([&](auto& webProcess, auto pageID) {

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -42,7 +42,7 @@ static Seconds webProcessSuspensionDelay(const WebPageProxy* page)
     if (!page)
         return WebProcessPool::defaultWebProcessSuspensionDelay();
 
-    RefPtr processPool = page->protectedLegacyMainFrameProcess()->processPoolIfExists();
+    RefPtr processPool = protect(page->legacyMainFrameProcess())->processPoolIfExists();
     if (!processPool)
         return WebProcessPool::defaultWebProcessSuspensionDelay();
 
@@ -234,7 +234,7 @@ bool WebProcessActivityState::hasValidOpeningAppLinkActivity() const
 void WebProcessActivityState::updateWebProcessSuspensionDelay()
 {
     Seconds timeout = WTF::visit(WTF::makeVisitor([&](const WeakRef<WebPageProxy>& page) {
-        return webProcessSuspensionDelay(Ref { page.get() }.ptr());
+        return webProcessSuspensionDelay(protect(page.get()).ptr());
     }, [&] (const WeakRef<RemotePageProxy>& page) {
         return webProcessSuspensionDelay(page->protectedPage().get());
     }), m_page);

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -49,7 +49,7 @@ WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy&
     : m_page(page)
     , m_currentOrientation(orientation)
 {
-    page.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
+    protect(page.legacyMainFrameProcess())->addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
 }
 
 WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy()
@@ -57,7 +57,7 @@ WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy()
     unlockIfNecessary();
 
     Ref page = m_page.get();
-    page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
+    protect(page->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
 std::optional<SharedPreferencesForWebProcess> WebScreenOrientationManagerProxy::sharedPreferencesForWebProcess(IPC::Connection& connection) const

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -50,7 +50,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformXRSystem);
 PlatformXRSystem::PlatformXRSystem(WebPageProxy& page)
     : m_page(page)
 {
-    page.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
+    protect(page.legacyMainFrameProcess())->addMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
 }
 
 PlatformXRSystem::~PlatformXRSystem()
@@ -59,7 +59,7 @@ PlatformXRSystem::~PlatformXRSystem()
     if (!page)
         return;
 
-    page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), page->webPageIDInMainFrameProcess());
+    protect(page->legacyMainFrameProcess())->removeMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
 std::optional<SharedPreferencesForWebProcess> PlatformXRSystem::sharedPreferencesForWebProcess(IPC::Connection& connection) const
@@ -94,7 +94,7 @@ void PlatformXRSystem::ensureImmersiveSessionActivity()
     if (m_immersiveSessionActivity && m_immersiveSessionActivity->isValid())
         return;
 
-    m_immersiveSessionActivity = page->protectedLegacyMainFrameProcess()->protectedThrottler()->foregroundActivity("XR immersive session"_s);
+    m_immersiveSessionActivity = protect(page->legacyMainFrameProcess())->protectedThrottler()->foregroundActivity("XR immersive session"_s);
 }
 
 void PlatformXRSystem::enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&& completionHandler)
@@ -354,7 +354,7 @@ void PlatformXRSystem::sessionDidEnd(XRDeviceIdentifier deviceIdentifier)
         if (!page)
             return;
 
-        page->protectedLegacyMainFrameProcess()->send(Messages::PlatformXRSystemProxy::SessionDidEnd(deviceIdentifier), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::PlatformXRSystemProxy::SessionDidEnd(deviceIdentifier), page->webPageIDInMainFrameProcess());
         protectedThis->m_immersiveSessionActivity = nullptr;
         // If this is called when the session is running, the ending of the session is triggered by the system side
         // and we should set the state to SessionEndingFromSystem. We expect the web process to send a
@@ -375,7 +375,7 @@ void PlatformXRSystem::sessionDidUpdateVisibilityState(XRDeviceIdentifier device
         if (!page)
             return;
 
-        page->protectedLegacyMainFrameProcess()->send(Messages::PlatformXRSystemProxy::SessionDidUpdateVisibilityState(deviceIdentifier, visibilityState), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::PlatformXRSystemProxy::SessionDidUpdateVisibilityState(deviceIdentifier, visibilityState), page->webPageIDInMainFrameProcess());
     });
 }
 
@@ -417,7 +417,7 @@ void PlatformXRSystem::invalidateImmersiveSessionState(ImmersiveSessionState nex
 bool PlatformXRSystem::webXREnabled() const
 {
     RefPtr page = m_page.get();
-    return page && page->protectedPreferences()->webXREnabled();
+    return page && protect(page->preferences())->webXREnabled();
 }
 
 #if !USE(APPLE_INTERNAL_SDK) && !USE(OPENXR)

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -87,7 +87,7 @@ void OpenXRCoordinator::getPrimaryDeviceInfo(WebPageProxy& page, DeviceInfoCallb
 {
     ASSERT(RunLoop::isMain());
 
-    initializeDevice(page.protectedPreferences()->openXRDMABufRelaxedForTesting());
+    initializeDevice(protect(page.preferences())->openXRDMABufRelaxedForTesting());
     if (m_instance == XR_NULL_HANDLE || m_systemId == XR_NULL_SYSTEM_ID) {
         LOG(XR, "Failed to initialize OpenXR system");
         callback(std::nullopt);
@@ -249,7 +249,7 @@ void OpenXRCoordinator::startSession(WebPageProxy& page, WeakPtr<PlatformXRCoord
     ASSERT(RunLoop::isMain());
     LOG(XR, "OpenXRCoordinator::startSession");
 
-    initializeDevice(page.protectedPreferences()->openXRDMABufRelaxedForTesting());
+    initializeDevice(protect(page.preferences())->openXRDMABufRelaxedForTesting());
 
     WTF::switchOn(m_state,
         [&](Idle&) {

--- a/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
+++ b/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
@@ -62,19 +62,19 @@ void WebPageProxy::Internals::didResumeSpeaking(WebCore::PlatformSpeechSynthesis
 void WebPageProxy::Internals::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&)
 {
     Ref protectedPage = page.get();
-    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::SpeakingErrorOccurred(), protectedPage->webPageIDInMainFrameProcess());
+    protect(protectedPage->legacyMainFrameProcess())->send(Messages::WebPage::SpeakingErrorOccurred(), protectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)
 {
     Ref protectedPage = page.get();
-    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), protectedPage->webPageIDInMainFrameProcess());
+    protect(protectedPage->legacyMainFrameProcess())->send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), protectedPage->webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::voicesDidChange()
 {
     Ref protectedPage = page.get();
-    protectedPage->protectedLegacyMainFrameProcess()->send(Messages::WebPage::VoicesDidChange(), protectedPage->webPageIDInMainFrameProcess());
+    protect(protectedPage->legacyMainFrameProcess())->send(Messages::WebPage::VoicesDidChange(), protectedPage->webPageIDInMainFrameProcess());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -62,19 +62,19 @@ SmartMagnificationController::SmartMagnificationController(WKContentView *conten
     : m_webPageProxy(*contentView.page)
     , m_contentView(contentView)
 {
-    m_webPageProxy->protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
+    protect(m_webPageProxy->legacyMainFrameProcess())->addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess(), *this);
 }
 
 SmartMagnificationController::~SmartMagnificationController()
 {
     if (RefPtr page = m_webPageProxy.get())
-        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
 void SmartMagnificationController::handleSmartMagnificationGesture(FloatPoint origin)
 {
     if (RefPtr page = m_webPageProxy.get())
-        page->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(origin), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(origin), page->webPageIDInMainFrameProcess());
 }
 
 void SmartMagnificationController::handleResetMagnificationGesture(FloatPoint origin)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4400,7 +4400,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKWEBVIEW)
         return nil;
     auto& dictationContextsForSelection = _page->editorState().postLayoutData->dictationContextsForSelection;
     return createNSArray(dictationContextsForSelection, [&] (auto& dictationContext) -> NSObject * {
-        RetainPtr alternatives = _page->protectedPageClient()->platformDictationAlternatives(dictationContext);
+        RetainPtr alternatives = protect(_page->pageClient())->platformDictationAlternatives(dictationContext);
 #if USE(BROWSERENGINEKIT)
         if (!self.shouldUseAsyncInteractions)
             return [[alternatives _nsTextAlternative] autorelease];
@@ -7022,7 +7022,7 @@ static WebKit::WritingDirection coreWritingDirection(NSWritingDirection directio
         RefPtr page = strongSelf->_page;
         Vector<WebCore::DictationContext> contextsToRemove;
         for (auto context : contexts) {
-            auto alternatives = page->protectedPageClient()->platformDictationAlternatives(context);
+            auto alternatives = protect(page->pageClient())->platformDictationAlternatives(context);
             if (!alternatives)
                 continue;
 

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -48,13 +48,13 @@ Ref<WebDeviceOrientationUpdateProviderProxy> WebDeviceOrientationUpdateProviderP
 WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy(WebPageProxy& page)
     : m_page(page)
 {
-    page.protectedLegacyMainFrameProcess()->addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
+    protect(page.legacyMainFrameProcess())->addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page.webPageIDInMainFrameProcess(), *this);
 }
 
 WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy()
 {
     if (RefPtr page = m_page.get())
-        page->protectedLegacyMainFrameProcess()->removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), page->webPageIDInMainFrameProcess());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation()

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -352,7 +352,7 @@ void WebPageProxy::setDeviceOrientation(IntDegrees deviceOrientation)
     if (m_screenOrientationManager)
         m_screenOrientationManager->setCurrentOrientation(orientation);
 
-    protectedBrowsingContextGroup()->forEachRemotePage(*this, [orientation](auto& remotePageProxy) {
+    protect(browsingContextGroup())->forEachRemotePage(*this, [orientation](auto& remotePageProxy) {
         remotePageProxy.setCurrentOrientation(orientation);
     });
 
@@ -788,7 +788,7 @@ void WebPageProxy::registerWebProcessAccessibilityToken(std::span<const uint8_t>
 {
     // Note: The WebFrameProxy with this FrameIdentifier might not exist in the UI process. See rdar://130998804.
     if (RefPtr pageClient = this->pageClient())
-        pageClient->accessibilityWebProcessTokenReceived(data, protectedLegacyMainFrameProcess()->protectedConnection()->remoteProcessID());
+        pageClient->accessibilityWebProcessTokenReceived(data, protect(legacyMainFrameProcess())->protectedConnection()->remoteProcessID());
 }
 
 void WebPageProxy::relayAccessibilityNotification(String&& notificationName, std::span<const uint8_t> data)
@@ -1926,7 +1926,7 @@ void WebPageProxy::setPromisedDataForImage(IPC::Connection&, const String&, Shar
 
 void WebPageProxy::isPotentialTapInProgress(CompletionHandler<void(bool)>&& completion)
 {
-    completion(protectedPageClient()->isPotentialTapInProgress());
+    completion(protect(pageClient())->isPotentialTapInProgress());
 }
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -209,7 +209,7 @@ void DisplayCaptureSessionManager::promptForGetDisplayMedia(UserMediaPermissionR
     }
 
     if (WebCore::ScreenCaptureKitSharingSessionManager::isAvailable()) {
-        if (!page.protectedPreferences()->useGPUProcessForDisplayCapture()) {
+        if (!protect(page.preferences())->useGPUProcessForDisplayCapture()) {
             WebCore::ScreenCaptureKitSharingSessionManager::singleton().promptForGetDisplayMedia(toScreenCaptureKitPromptType(promptType), WTF::move(completionHandler));
             return;
         }
@@ -252,7 +252,7 @@ void DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt(WebPageProxy& pag
     if (!isAvailable() || !WebCore::ScreenCaptureKitSharingSessionManager::isAvailable())
         return;
 
-    if (!page.protectedPreferences()->useGPUProcessForDisplayCapture()) {
+    if (!protect(page.preferences())->useGPUProcessForDisplayCapture()) {
         WebCore::ScreenCaptureKitSharingSessionManager::singleton().cancelGetDisplayMediaPrompt();
         return;
     }

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
@@ -95,7 +95,7 @@ bool UserMediaPermissionRequestProxyMac::canRequestDisplayCapturePermission()
     if (!manager)
         return false;
     RefPtr page = manager->page();
-    if (!page || (!overridePreference && page->protectedPreferences()->requireUAGetDisplayMediaPrompt()))
+    if (!page || (!overridePreference && protect(page->preferences())->requireUAGetDisplayMediaPrompt()))
         return false;
 
     return DisplayCaptureSessionManager::singleton().canRequestDisplayCapturePermission();

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -168,7 +168,7 @@ void ViewGestureController::handleSmartMagnificationGesture(FloatPoint gestureLo
     LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::handleSmartMagnificationGesture - gesture location " << gestureLocationInViewCoordinates);
 
     if (RefPtr page = m_webPageProxy.get())
-        page->protectedLegacyMainFrameProcess()->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates), page->webPageIDInMainFrameProcess());
 }
 
 static float maximumRectangleComponentDelta(FloatRect a, FloatRect b)
@@ -470,7 +470,7 @@ void ViewGestureController::beginSwipeGesture(WebBackForwardListItem* targetItem
 
     [m_swipeLayer addSublayer:m_swipeSnapshotLayer.get()];
 
-    if (page->protectedPreferences()->viewGestureDebuggingEnabled())
+    if (protect(page->preferences())->viewGestureDebuggingEnabled())
         applyDebuggingPropertiesToSwipeViews();
 
     m_didCallEndSwipeGesture = false;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -145,7 +145,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     RefPtr page = _page.get();
     if (!page)
         return;
-    bool panGestureEnabled = page->protectedPreferences()->useAppKitGestures();
+    bool panGestureEnabled = protect(page->preferences())->useAppKitGestures();
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->identifier().toUInt64(), "%@ setEnabled:%d", _panGestureRecognizer.get(), static_cast<int>(panGestureEnabled));
     [_panGestureRecognizer setEnabled:panGestureEnabled];
 }

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -113,7 +113,7 @@
 - (void)_clearImmediateActionState
 {
     if (_page)
-        RefPtr { _page.get() }->clearTextIndicator();
+        protect(_page.get())->clearTextIndicator();
 
     if (_currentActionContext && _hasActivatedActionContext) {
         _hasActivatedActionContext = NO;
@@ -150,7 +150,7 @@
 
 - (void)dismissContentRelativeChildWindows
 {
-    RefPtr { _page.get() }->setMaintainsInactiveSelection(false);
+    protect(_page.get())->setMaintainsInactiveSelection(false);
     [_currentQLPreviewMenuItem close];
 }
 
@@ -172,7 +172,7 @@
         viewImpl->dismissContentRelativeChildWindowsWithAnimation(true);
     }
 
-    RefPtr { _page.get() }->setMaintainsInactiveSelection(true);
+    protect(_page.get())->setMaintainsInactiveSelection(true);
 
     _state = WebKit::ImmediateActionState::Pending;
     immediateActionRecognizer.animationController = nil;
@@ -180,7 +180,7 @@
     if (!_page->mainFrame())
         return;
 
-    RefPtr { _page.get() }->performImmediateActionHitTestAtLocation(_page->mainFrame()->frameID(), [immediateActionRecognizer locationInView:retainPtr(immediateActionRecognizer.view).get()]);
+    protect(_page.get())->performImmediateActionHitTestAtLocation(_page->mainFrame()->frameID(), [immediateActionRecognizer locationInView:retainPtr(immediateActionRecognizer.view).get()]);
 }
 
 - (void)immediateActionRecognizerWillBeginAnimation:(NSImmediateActionGestureRecognizer *)immediateActionRecognizer
@@ -188,7 +188,7 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    Ref mainFrameProcess = RefPtr { _page.get() }->legacyMainFrameProcess();
+    Ref mainFrameProcess = protect(_page.get())->legacyMainFrameProcess();
     if (_state == WebKit::ImmediateActionState::None || !mainFrameProcess->hasConnection())
         return;
 
@@ -198,7 +198,7 @@
     // FIXME: Connection can be null if the process is closed; we should clean up better in that case.
     if (_state == WebKit::ImmediateActionState::Pending) {
         Ref connection = mainFrameProcess->connection();
-        bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(RefPtr { _page.get() }->webPageIDInMainFrameProcess(), 500_ms) == IPC::Error::NoError;
+        bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(protect(_page.get())->webPageIDInMainFrameProcess(), 500_ms) == IPC::Error::NoError;
         if (!receivedReply)
             _state = WebKit::ImmediateActionState::TimedOut;
     }
@@ -222,11 +222,11 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    RefPtr { _page.get() }->immediateActionDidUpdate();
+    protect(_page.get())->immediateActionDidUpdate();
     if (_contentPreventsDefault)
         return;
 
-    RefPtr { _page.get() }->setTextIndicatorAnimationProgress([immediateActionRecognizer animationProgress]);
+    protect(_page.get())->setTextIndicatorAnimationProgress([immediateActionRecognizer animationProgress]);
 }
 
 - (void)immediateActionRecognizerDidCancelAnimation:(NSImmediateActionGestureRecognizer *)immediateActionRecognizer
@@ -234,13 +234,13 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    RefPtr { _page.get() }->immediateActionDidCancel();
+    protect(_page.get())->immediateActionDidCancel();
 
     CheckedPtr { _viewImpl.get() }->cancelImmediateActionAnimation();
 
-    RefPtr { _page.get() }->setTextIndicatorAnimationProgress(0);
+    protect(_page.get())->setTextIndicatorAnimationProgress(0);
     [self _clearImmediateActionState];
-    RefPtr { _page.get() }->setMaintainsInactiveSelection(false);
+    protect(_page.get())->setMaintainsInactiveSelection(false);
 }
 
 - (void)immediateActionRecognizerDidCompleteAnimation:(NSImmediateActionGestureRecognizer *)immediateActionRecognizer
@@ -248,11 +248,11 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    RefPtr { _page.get() }->immediateActionDidComplete();
+    protect(_page.get())->immediateActionDidComplete();
 
     CheckedPtr { _viewImpl.get() }->completeImmediateActionAnimation();
 
-    RefPtr { _page.get() }->setTextIndicatorAnimationProgress(1);
+    protect(_page.get())->setTextIndicatorAnimationProgress(1);
 }
 
 - (RefPtr<API::HitTestResult>)_webHitTestResult
@@ -305,7 +305,7 @@
             _currentQLPreviewMenuItem = item.get();
 
             if (RefPtr textIndicator = _hitTestResultData.linkTextIndicator)
-                RefPtr { _page.get() }->setTextIndicator(WTF::move(textIndicator), WebCore::TextIndicatorLifetime::Permanent);
+                protect(_page.get())->setTextIndicator(WTF::move(textIndicator), WebCore::TextIndicatorLifetime::Permanent);
 
             return (id<NSImmediateActionAnimationController>)item.autorelease();
         }
@@ -343,7 +343,7 @@
         return;
     }
 
-    RetainPtr<id> customClientAnimationController = RefPtr { _page.get() }->immediateActionAnimationControllerForHitTestResult(hitTestResult, _type, _userData);
+    RetainPtr<id> customClientAnimationController = protect(_page.get())->immediateActionAnimationControllerForHitTestResult(hitTestResult, _type, _userData);
     if (customClientAnimationController.get() == [NSNull null]) {
         [self _cancelImmediateAction];
         return;
@@ -432,13 +432,13 @@
     RetainPtr view = _view.get();
     WebCore::PageOverlay::PageOverlayID overlayID = _hitTestResultData.platformData.detectedDataOriginatingPageOverlay;
     _currentActionContext = (WKDDActionContext *)[actionContext contextForView:view.get() altMode:YES interactionStartedHandler:^() {
-        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::DataDetectorsDidPresentUI(overlayID), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::WebPage::DataDetectorsDidPresentUI(overlayID), page->webPageIDInMainFrameProcess());
     } interactionChangedHandler:^() {
         if (RefPtr detectedDataTextIndicator = _hitTestResultData.platformData.detectedDataTextIndicator)
             page->setTextIndicator(WTF::move(detectedDataTextIndicator), WebCore::TextIndicatorLifetime::Permanent);
-        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::DataDetectorsDidChangeUI(overlayID), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::WebPage::DataDetectorsDidChangeUI(overlayID), page->webPageIDInMainFrameProcess());
     } interactionStoppedHandler:^() {
-        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::DataDetectorsDidHideUI(overlayID), page->webPageIDInMainFrameProcess());
+        protect(page->legacyMainFrameProcess())->send(Messages::WebPage::DataDetectorsDidHideUI(overlayID), page->webPageIDInMainFrameProcess());
         [self _clearImmediateActionState];
     }];
 
@@ -507,9 +507,9 @@
 
     CheckedPtr { _viewImpl.get() }->prepareForDictionaryLookup();
     return WebCore::DictionaryLookup::animationControllerForPopup(dictionaryPopupInfo, _view.get().get(), [self](WebCore::TextIndicator& textIndicator) {
-        RefPtr { _page.get() }->setTextIndicator(textIndicator, WebCore::TextIndicatorLifetime::Permanent);
+        protect(_page.get())->setTextIndicator(textIndicator, WebCore::TextIndicatorLifetime::Permanent);
     }, nullptr, [strongSelf = retainPtr(self)]() {
-        RefPtr { strongSelf->_page.get() }->clearTextIndicatorWithAnimation(WebCore::TextIndicatorDismissalAnimation::None);
+        protect(strongSelf->_page.get())->clearTextIndicatorWithAnimation(WebCore::TextIndicatorDismissalAnimation::None);
     });
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -240,7 +240,7 @@ public:
     ~WebViewImpl();
 
     NSWindow *window();
-    RetainPtr<NSWindow> protectedWindow();
+    NSInteger windowNumber();
 
     WebPageProxy& page() { return m_page.get(); }
 


### PR DESCRIPTION
#### 15a28eab0c5a5e914a6ae9f70eb924998daf94df
<pre>
Reduce use of protected functions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=305911">https://bugs.webkit.org/show_bug.cgi?id=305911</a>

Reviewed by Ryosuke Niwa and Geoffrey Garen.

Introduce new `protect()` functions that return smart pointers and reduce
the use of `protectedFoo()` getter functions in WebKit by adopting them.

* Source/WTF/wtf/CheckedPtr.h:
(WTF::protect):
* Source/WTF/wtf/CheckedRef.h:
(WTF::protect):
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/Ref.h:
(WTF::protect):
* Source/WTF/wtf/RefPtr.h:
(WTF::protect):
* Source/WTF/wtf/RetainPtr.h:
(WTF::protect):
* Source/WebKit/UIProcess/API/APIDataTask.cpp:
(API::DataTask::DataTask):
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::Navigation):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetMainFrame):
(WKPageGetFocusedFrame):
(WKPageGetWebsiteDataStore):
(WKPageGetInspector):
(WKPageSetPageLoaderClient):
(WKPageCopyRelatedPages):
(WKPageClearBackForwardCache):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState dealloc]):
(-[WKObservablePageState _webProcessIsResponsive]):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction sourceFrame]):
(-[WKNavigationAction _originalURL]):
(-[WKNavigationAction _storeSKAdNetworkAttribution]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView _setupPageConfiguration:withPool:]):
(-[WKWebView goToBackForwardListItem:]):
(-[WKWebView _evaluateJavaScript:asAsyncFunction:withSourceURL:withArguments:forceUserGesture:inFrame:inWorld:completionHandler:]):
(-[WKWebView takeSnapshotWithConfiguration:completionHandler:]):
(-[WKWebView _storeAppHighlight:]):
(-[WKWebView _updateFixedColorExtensionViews]):
(-[WKWebView _updateFixedColorExtensionViewFrames]):
(-[WKWebView _frames:]):
(-[WKWebView _frameTrees:]):
(-[WKWebView _startImageAnalysis:target:]):
(-[WKWebView _requestTargetedElementInfo:completionHandler:]):
(-[WKWebView _webProcessIsResponsive]):
(-[WKWebView _killWebContentProcess]):
(-[WKWebView _updateWebpagePreferences:]):
(-[WKWebView _saveResources:suggestedFileName:completionHandler:]):
(-[WKWebView _archiveWithConfiguration:completionHandler:]):
(-[WKWebView _getMainResourceDataWithCompletionHandler:]):
(-[WKWebView _saveBackForwardSnapshotForItem:]):
(-[WKWebView _serviceWorkersEnabled:]):
(elementsFromWKElements):
(-[WKWebView _webProcessState]):
(-[WKWebView _extractDebugTextWithConfiguration:completionHandler:]):
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
(-[WKWebView _performInteraction:completionHandler:]):
(-[WKWebView _describeInteraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _caLayerTreeAsTextForLayerWithID:]):
(-[WKWebView _processWillSuspendForTesting:]):
(-[WKWebView _processWillSuspendImminentlyForTesting]):
(-[WKWebView _processDidResumeForTesting]):
(-[WKWebView _setThrottleStateForTesting:]):
(-[WKWebView _getNotifyStateForTesting:completionHandler:]):
(-[WKWebView _propertiesOfLayerWithID:]):
(-[WKWebView _animationStackForLayerWithID:]):
(-[WKMediaSessionCoordinatorHelper seekSessionToTime:withCompletion:]):
(-[WKMediaSessionCoordinatorHelper playSessionWithCompletion:]):
(-[WKMediaSessionCoordinatorHelper pauseSessionWithCompletion:]):
(-[WKMediaSessionCoordinatorHelper setSessionTrack:withCompletion:]):
(-[WKMediaSessionCoordinatorHelper coordinatorStateChanged:]):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleRequest):
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _uiViewTreeAsTextForViewWithLayerID:]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _holdWindowResizeSnapshotIfNeeded]):
* Source/WebKit/UIProcess/Automation/BidiStorageAgent.cpp:
(WebKit::BidiStorageAgent::cookieStoreForPartition):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::getBrowsingContext):
(WebKit::WebAutomationSession::switchToBrowsingContext):
(WebKit::WebAutomationSession::setWindowFrameOfBrowsingContext):
(WebKit::WebAutomationSession::maximizeWindowOfBrowsingContext):
(WebKit::WebAutomationSession::hideWindowOfBrowsingContext):
(WebKit::WebAutomationSession::willShowJavaScriptDialog):
(WebKit::WebAutomationSession::getAllCookies):
(WebKit::WebAutomationSession::deleteSingleCookie):
(WebKit::WebAutomationSession::addSingleCookie):
(WebKit::WebAutomationSession::deleteAllCookies):
(WebKit::WebAutomationSession::removeVirtualAuthenticator):
(WebKit::WebAutomationSession::simulateMouseInteraction):
(WebKit::WebAutomationSession::simulateWheelInteraction):
(WebKit::WebAutomationSession::performMouseInteraction):
(WebKit::WebAutomationSession::performKeyboardInteractions):
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
(WebKit::BrowsingContextGroup::transitionPageToRemotePage):
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
(WebKit::auxiliaryProcessesForPage):
(WebKit::ExtensionCapabilityGranter::revoke):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelViewForModelIdentifier):
(WebKit::ModelElementController::takeModelElementFullscreen):
(WebKit::ModelElementController::previewForModelIdentifier):
(WebKit::ModelElementController::modelElementCreateRemotePreview):
(WebKit::ModelElementController::modelElementLoadRemotePreview):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::trySOAuthorization):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::didReceiveAuthenticationChallenge):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::PlaybackSessionManagerProxy):
(WebKit::PlaybackSessionManagerProxy::invalidate):
(WebKit::PlaybackSessionManagerProxy::requestControlledElementID):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
(WebKit::PopUpSOAuthorizationSession::initSecretWebView):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::complete):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::backgroundActivity):
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm:
(WebKit::UserMediaPermissionRequestManagerProxy::requestSystemValidation):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::loggerPtr const):
(WebKit::VideoPresentationManagerProxy::VideoPresentationManagerProxy):
(WebKit::VideoPresentationManagerProxy::invalidate):
(WebKit::VideoPresentationManagerProxy::audioSessionCategoryChanged):
(WebKit::VideoPresentationManagerProxy::routingContextUIDChanged):
(WebKit::VideoPresentationManagerProxy::setHasVideo):
(WebKit::VideoPresentationManagerProxy::performCaptionDisplaySettingsAction):
(WebKit::VideoPresentationManagerProxy::bestVideoForElementFullscreen):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitMainFrameData):
(WebKit::WebPageProxy::saveRecentSearches):
(WebKit::WebPageProxy::loadRecentSearches):
(WebKit::WebPageProxy::beginSafeBrowsingCheck):
(WebKit::WebPageProxy::createSandboxExtensionsIfNeeded):
(WebKit::WebPageProxy::performDictionaryLookupAtLocation):
(WebKit::WebPageProxy::insertDictatedTextAsync):
(WebKit::WebPageProxy::addDictationAlternative):
(WebKit::WebPageProxy::dictationAlternativesAtSelection):
(WebKit::WebPageProxy::clearDictationAlternatives):
(WebKit::WebPageProxy::Internals::sharedPreferencesForWebPaymentMessages const):
(WebKit::WebPageProxy::Internals::paymentCoordinatorAddMessageReceiver):
(WebKit::WebPageProxy::Internals::paymentCoordinatorRemoveMessageReceiver):
(WebKit::WebPageProxy::Internals::speakingErrorOccurred):
(WebKit::WebPageProxy::Internals::boundaryEventOccurred):
(WebKit::WebPageProxy::Internals::voicesDidChange):
(WebKit::WebPageProxy::updateIconForDirectory):
(WebKit::WebPageProxy::createTextFragmentDirectiveFromSelection):
(WebKit::WebPageProxy::getTextFragmentRanges):
(WebKit::WebPageProxy::createAppHighlightInSelectedRange):
(WebKit::WebPageProxy::restoreAppHighlightsAndScrollToIndex):
(WebKit::WebPageProxy::setAppHighlightsVisibility):
(WebKit::WebPageProxy::requestActiveNowPlayingSessionInfo):
(WebKit::WebPageProxy::lastNavigationWasAppInitiated):
(WebKit::WebPageProxy::grantAccessToAssetServices):
(WebKit::WebPageProxy::revokeAccessToAssetServices):
(WebKit::WebPageProxy::disableURLSchemeCheckInDataDetectors const):
(WebKit::WebPageProxy::switchFromStaticFontRegistryToUserFontRegistry):
(WebKit::WebPageProxy::insertMultiRepresentationHEIC):
(WebKit::WebPageProxy::replaceSelectionWithPasteboardData):
(WebKit::WebPageProxy::replaceImageForRemoveBackground):
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):
(WebKit::WebPageProxy::setMediaCapability):
(WebKit::WebPageProxy::deactivateMediaCapability):
(WebKit::WebPageProxy::updateMediaCapability):
(WebKit::WebPageProxy::willBeginWritingToolsSession):
(WebKit::WebPageProxy::didBeginWritingToolsSession):
(WebKit::WebPageProxy::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion):
(WebKit::WebPageProxy::willEndWritingToolsSession):
(WebKit::WebPageProxy::didEndWritingToolsSession):
(WebKit::WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange):
(WebKit::WebPageProxy::writingToolsSessionDidReceiveAction):
(WebKit::WebPageProxy::proofreadingSessionSuggestionTextRectsInRootViewCoordinates const):
(WebKit::WebPageProxy::updateTextVisibilityForActiveWritingToolsSession):
(WebKit::WebPageProxy::textPreviewDataForActiveWritingToolsSession):
(WebKit::WebPageProxy::decorateTextReplacementsForActiveWritingToolsSession):
(WebKit::WebPageProxy::setSelectionForActiveWritingToolsSession):
(WebKit::WebPageProxy::getTextIndicatorForID):
(WebKit::WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::WebPageProxy::intelligenceTextAnimationsDidComplete):
(WebKit::WebPageProxy::createTextIndicatorForElementWithID):
(WebKit::WebPageProxy::playPredominantOrNowPlayingMediaSession):
(WebKit::WebPageProxy::tryToSendCommandToActiveControlledVideo):
(WebKit::WebPageProxy::getInformationFromImageData):
(WebKit::WebPageProxy::createIconDataFromImageData):
(WebKit::WebPageProxy::decodeImageData):
(WebKit::WebPageProxy::getWebArchiveData):
(WebKit::WebPageProxy::getWebArchiveDataWithSelectedFrames):
(WebKit::WebPageProxy::getAccessibilityWebProcessDebugInfo):
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp:
(WebKit::RemoteWebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::RemoteWebInspectorUIProxy::initialize):
(WebKit::RemoteWebInspectorUIProxy::showConsole):
(WebKit::RemoteWebInspectorUIProxy::showResources):
(WebKit::RemoteWebInspectorUIProxy::sendMessageToFrontend):
(WebKit::RemoteWebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled):
(WebKit::RemoteWebInspectorUIProxy::createFrontendPageAndWindow):
(WebKit::RemoteWebInspectorUIProxy::closeFrontendPageAndWindow):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy):
(WebKit::WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose):
(WebKit::WebInspectorUIExtensionControllerProxy::registerExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::unregisterExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::createTabForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::reloadForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::showExtensionTab):
(WebKit::WebInspectorUIExtensionControllerProxy::navigateTabForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::sendMessageToFrontend):
(WebKit::WebInspectorUIProxy::connect):
(WebKit::WebInspectorUIProxy::close):
(WebKit::WebInspectorUIProxy::reset):
(WebKit::WebInspectorUIProxy::updateForNewPageProcess):
(WebKit::WebInspectorUIProxy::setFrontendConnection):
(WebKit::WebInspectorUIProxy::showConsole):
(WebKit::WebInspectorUIProxy::showResources):
(WebKit::WebInspectorUIProxy::attach):
(WebKit::WebInspectorUIProxy::detach):
(WebKit::WebInspectorUIProxy::togglePageProfiling):
(WebKit::WebInspectorUIProxy::toggleElementSelection):
(WebKit::WebInspectorUIProxy::createFrontendPage):
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::open):
(WebKit::WebInspectorUIProxy::attachAvailabilityChanged):
(WebKit::WebInspectorUIProxy::setInspectorPageDeveloperExtrasEnabled):
(WebKit::WebInspectorUIProxy::setDeveloperPreferenceOverride):
(WebKit::WebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::WebInspectorUIProxy::save):
(WebKit::WebInspectorUIProxy::load):
(WebKit::WebInspectorUIProxy::pickColorFromScreen):
(WebKit::WebInspectorUIProxy::evaluateInFrontendForTesting):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorTargetProxy.cpp:
(WebKit::WebPageInspectorTargetProxy::connect):
(WebKit::WebPageInspectorTargetProxy::disconnect):
(WebKit::WebPageInspectorTargetProxy::sendMessageToTargetBackend):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::didBecomeActive):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::didBecomeActive):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
(WebKit::RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::seekSessionToTime):
(WebKit::RemoteMediaSessionCoordinatorProxy::playSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::pauseSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::setSessionTrack):
(WebKit::RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::logger const):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::denyRequest):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::grantRequest):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::createRequestForFrame):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::allNetworkProcesses):
(WebKit::NetworkProcessProxy::ensureDefaultNetworkProcess):
(WebKit::NetworkProcessProxy::createDownloadProxy):
(WebKit::NetworkProcessProxy::deleteWebsiteDataInUIProcessForRegistrableDomains):
(WebKit::NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::initializeWebPage):
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
(WebKit::ProvisionalPageProxy::didFailProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::allowMultipleCommitLayerTreePending):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStore const):
(WebKit::RemoteLayerTreeHost::cssUnprefixedBackdropFilterEnabled const):
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::clearLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange):
(WebKit::RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
(WebKit::SpeechRecognitionPermissionManager::~SpeechRecognitionPermissionManager):
(WebKit::SpeechRecognitionPermissionManager::startProcessingRequest):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::grantRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::finishGrantingRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::hasGrantedRequest const):
(WebKit::isMatchingDeniedRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionInvalidRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionValidRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList):
(WebKit::UserMediaPermissionRequestManagerProxy::enumerateMediaDevicesForFrame):
(WebKit::UserMediaPermissionRequestManagerProxy::mockCaptureDevicesEnabled const):
(WebKit::UserMediaPermissionRequestManagerProxy::captureStateChanged):
(WebKit::UserMediaPermissionRequestManagerProxy::logger const):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::connectToProcess):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::requestRenderTreeSizeNotificationIfNeeded):
(WebKit::ViewGestureController::prepareMagnificationGesture):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::WebAuthenticatorCoordinatorProxy::performRequest):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp:
(WebKit::WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy):
(WebKit::WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy):
(WebKit::WebAuthenticatorCoordinatorProxy::sharedPreferencesForWebProcess const):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardAddItemShared):
(WebKit::WebBackForwardList::backForwardUpdateItem):
(WebKit::WebBackForwardList::backForwardGoToItemShared):
* Source/WebKit/UIProcess/WebContextMenuProxy.cpp:
(WebKit::WebContextMenuProxy::show):
(WebKit::WebContextMenuProxy::useContextMenuItems):
* Source/WebKit/UIProcess/WebEditCommandProxy.cpp:
(WebKit::WebEditCommandProxy::unapply):
(WebKit::WebEditCommandProxy::reapply):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didCommitLoad):
(WebKit::WebFrameProxy::didHandleContentFilterUnblockNavigation):
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
(WebKit::WebFrameProxy::getFrameTree):
(WebKit::WebFrameProxy::broadcastFrameTreeSyncData):
(WebKit::WebFrameProxy::traverseNext const):
(WebKit::WebFrameProxy::updateOpener):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::~WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::startUpdatingWithProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::takeVisibleActivity):
(WebKit::WebPageProxy::takeAudibleActivity):
(WebKit::WebPageProxy::takeCapturingActivity):
(WebKit::WebPageProxy::takeMutedCaptureAssertion):
(WebKit::WebPageProxy::takeNetworkActivity):
(WebKit::WebPageProxy::takeAccessibilityActivityWhenInWindow):
(WebKit::WebPageProxy::hasAccessibilityActivityForTesting):
(WebKit::WebPageProxy::resetActivityState):
(WebKit::WebPageProxy::dropVisibleActivity):
(WebKit::WebPageProxy::dropAudibleActivity):
(WebKit::WebPageProxy::dropCapturingActivity):
(WebKit::WebPageProxy::dropMutedCaptureAssertion):
(WebKit::WebPageProxy::dropNetworkActivity):
(WebKit::WebPageProxy::hasValidVisibleActivity const):
(WebKit::WebPageProxy::hasValidAudibleActivity const):
(WebKit::WebPageProxy::hasValidCapturingActivity const):
(WebKit::WebPageProxy::hasValidMutedCaptureAssertion const):
(WebKit::WebPageProxy::hasValidNetworkActivity const):
(WebKit::WebPageProxy::takeOpeningAppLinkActivity):
(WebKit::WebPageProxy::dropOpeningAppLinkActivity):
(WebKit::WebPageProxy::hasValidOpeningAppLinkActivity const):
(WebKit::WebPageProxy::updateWebProcessSuspensionDelay):
(WebKit::WebPageProxy::removeAllMessageReceivers):
(WebKit::WebPageProxy::attachmentElementEnabled):
(WebKit::WebPageProxy::modelElementEnabled):
(WebKit::WebPageProxy::setPreferences):
(WebKit::WebPageProxy::send):
(WebKit::WebPageProxy::sendWithAsyncReply):
(WebKit::WebPageProxy::hasSameGPUAndNetworkProcessPreferencesAs const):
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::setBrowsingContextGroup):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::didAttachToRunningProcess):
(WebKit::WebPageProxy::setDrawingArea):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadData):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::stopLoading):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::canShowMIMEType):
(WebKit::WebPageProxy::setControlledByAutomation):
(WebKit::WebPageProxy::setInspectable):
(WebKit::WebPageProxy::setObscuredContentInsets):
(WebKit::WebPageProxy::viewWillStartLiveResize):
(WebKit::WebPageProxy::viewWillEndLiveResize):
(WebKit::WebPageProxy::viewDidLeaveWindow):
(WebKit::WebPageProxy::viewDidEnterWindow):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::updateThrottleState):
(WebKit::WebPageProxy::updateHiddenPageThrottlingAutoIncreases):
(WebKit::WebPageProxy::waitForDidUpdateActivityState):
(WebKit::WebPageProxy::executeEditCommand):
(WebKit::WebPageProxy::propagateDragAndDrop):
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::performDragControllerAction):
(WebKit::WebPageProxy::handleWheelEvent):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::cacheWheelEventScrollingAccelerationCurve):
(WebKit::WebPageProxy::updateDisplayLinkFrequency):
(WebKit::WebPageProxy::sendPreventableTouchEvent):
(WebKit::WebPageProxy::sendUnpreventableTouchEvent):
(WebKit::WebPageProxy::handleTouchEvent):
(WebKit::WebPageProxy::disableServiceWorkerEntitlementInNetworkProcess):
(WebKit::WebPageProxy::clearServiceWorkerEntitlementOverride):
(WebKit::WebPageProxy::updateDataStoreForWebArchiveLoad):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::shouldClosePreviousPage):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::windowScreenDidChange):
(WebKit::WebPageProxy::setCustomDeviceScaleFactor):
(WebKit::WebPageProxy::findString):
(WebKit::WebPageProxy::launchInitialProcessIfNecessary):
(WebKit::WebPageProxy::preferencesDidChange):
(WebKit::WebPageProxy::didDestroyFrame):
(WebKit::WebPageProxy::setNetworkRequestsInProgress):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrame):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::forEachWebContentProcess):
(WebKit::WebPageProxy::observeAndCreateRemoteSubframesInOtherProcesses):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::viewIsBecomingVisible):
(WebKit::WebPageProxy::viewIsBecomingInvisible):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::adjustAdvancedPrivacyProtectionsIfNeeded):
(WebKit::WebPageProxy::logFrameNavigation):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::showBrowsingWarning):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::trySOAuthorization):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::runModalJavaScriptDialog):
(WebKit::WebPageProxy::showShareSheet):
(WebKit::WebPageProxy::showContactPicker):
(WebKit::WebPageProxy::showDigitalCredentialsPicker):
(WebKit::WebPageProxy::dismissDigitalCredentialsPicker):
(WebKit::WebPageProxy::processWillSuspend):
(WebKit::WebPageProxy::processDidResume):
(WebKit::WebPageProxy::resumeDownload):
(WebKit::WebPageProxy::downloadRequest):
(WebKit::WebPageProxy::dataTaskWithRequest):
(WebKit::WebPageProxy::loadAndDecodeImage):
(WebKit::WebPageProxy::showColorPicker):
(WebKit::WebPageProxy::hasVideoInPictureInPictureDidChange):
(WebKit::WebPageProxy::showDataListSuggestions):
(WebKit::WebPageProxy::showDateTimePicker):
(WebKit::WebPageProxy::endDateTimePicker):
(WebKit::WebPageProxy::addRemoteMediaSessionManager):
(WebKit::WebPageProxy::removeRemoteMediaSessionManager):
(WebKit::WebPageProxy::requestDOMPasteAccess):
(WebKit::WebPageProxy::postMessageToInjectedBundle):
(WebKit::WebPageProxy::showPopupMenuFromFrame):
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithImageTranscoding):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
(WebKit::WebPageProxy::dispatchProcessDidTerminate):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::useGPUProcessForDOMRenderingEnabled const):
(WebKit::WebPageProxy::isJITEnabled):
(WebKit::WebPageProxy::isEnhancedSecurityEnabled):
(WebKit::WebPageProxy::requestUserMediaPermissionForFrame):
(WebKit::WebPageProxy::setShouldListenToVoiceActivity):
(WebKit::WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::WebPageProxy::requestTextRecognition):
(WebKit::WebPageProxy::endPrinting):
(WebKit::WebPageProxy::updateBackingStoreDiscardableState):
(WebKit::WebPageProxy::setMinimumSizeForAutoLayout):
(WebKit::WebPageProxy::setSizeToContentAutoSizeMaximumSize):
(WebKit::WebPageProxy::dictationAlternatives):
(WebKit::WebPageProxy::dismissCorrectionPanelSoon):
(WebKit::WebPageProxy::takeViewSnapshot):
(WebKit::WebPageProxy::setOverlayScrollbarStyle):
(WebKit::WebPageProxy::setScrollPerformanceDataCollectionEnabled):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
(WebKit::WebPageProxy::immediateActionAnimationControllerForHitTestResult):
(WebKit::WebPageProxy::showPlaybackTargetPicker):
(WebKit::WebPageProxy::callAfterNextPresentationUpdate):
(WebKit::WebPageProxy::userInterfaceLayoutDirection):
(WebKit::WebPageProxy::resetPointerLockState):
(WebKit::WebPageProxy::startURLSchemeTaskShared):
(WebKit::WebPageProxy::stopURLSchemeTask):
(WebKit::WebPageProxy::loadSynchronousURLSchemeTask):
(WebKit::WebPageProxy::dataOwnerForPasteboard const):
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromData):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromFilePath):
(WebKit::WebPageProxy::registerAttachmentIdentifier):
(WebKit::WebPageProxy::registerAttachmentsFromSerializedData):
(WebKit::WebPageProxy::cloneAttachmentData):
(WebKit::WebPageProxy::invalidateAllAttachments):
(WebKit::WebPageProxy::serializedAttachmentDataForIdentifiers):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
(WebKit::WebPageProxy::didRemoveAttachmentWithIdentifier):
(WebKit::WebPageProxy::setPrivateClickMeasurementImmediately):
(WebKit::WebPageProxy::simulatePrivateClickMeasurementConversion):
(WebKit::WebPageProxy::setMockWebAuthenticationConfiguration):
(WebKit::WebPageProxy::setOrientationForMediaCapture):
(WebKit::WebPageProxy::createRealtimeMediaSourceForSpeechRecognition):
(WebKit::WebPageProxy::currentEnhancedSecurityState const):
(WebKit::WebPageProxy::processForSite):
(WebKit::WebPageProxy::waitForInitialLinkDecorationFilteringData):
(WebKit::WebPageProxy::beginSiteHasStorageCheck):
(WebKit::WebPageProxy::stickyScrollingTreeNodeBeganSticking):
(WebKit::WebPageProxy::webPageIDInProcess const):
(WebKit::WebPageProxy::sendToWebPage):
(WebKit::WebPageProxy::reportMixedContentViolation):
(WebKit::WebPageProxy::isAlwaysOnLoggingAllowed const):
(WebKit::WebPageProxy::restoreSessionStorage):
(WebKit::WebPageProxy::setPresentingApplicationAuditToken):
(WebKit::WebPageProxy::networkRequestsInProgressDidChange):
(WebKit::WebPageProxy::takeTextExtractionAssertion):
(WebKit::WebPageProxy::dropTextExtractionAssertion):
(WebKit::WebPageProxy::protectedPageClient const): Deleted.
(WebKit::WebPageProxy::protectedMainFrame const): Deleted.
(WebKit::WebPageProxy::protectedFocusedFrame const): Deleted.
(WebKit::WebPageProxy::protectedDrawingArea const): Deleted.
(WebKit::WebPageProxy::protectedLegacyMainFrameProcess const): Deleted.
(WebKit::WebPageProxy::protectedInspector const): Deleted.
(WebKit::WebPageProxy::protectedPreferences const): Deleted.
(WebKit::WebPageProxy::protectedWebsiteDataStore const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::sendMessage):
(WebKit::WebPageProxyTesting::sendMessageWithAsyncReply):
(WebKit::WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::WebPageProxyTesting::dumpPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::clearPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer):
(WebKit::WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement):
(WebKit::WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs):
(WebKit::WebPageProxyTesting::markPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPCMFraudPreventionValues):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAppBundleID):
(WebKit::WebPageProxyTesting::resetStateBetweenTests):
(WebKit::WebPageProxyTesting::clearBackForwardList):
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::webProcessSuspensionDelay):
(WebKit::WebProcessActivityState::updateWebProcessSuspensionDelay):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::handleSynchronousMessage):
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::prepareProcessForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
(WebKit::WebProcessPool::loadOrUpdateResourceMonitorRuleList):
(WebKit::WebProcessPool::setResourceMonitorURLsForTesting):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::create):
(WebKit::WebProcessProxy::audioCapturingWebPage):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::removeWebPage):
(WebKit::WebProcessProxy::createSpeechRecognitionServer):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::forEachWebsiteDataStore):
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
(WebKit::WebsiteDataStore::soAuthorizationCoordinator):
(WebKit::WebsiteDataStore::fetchDomainsWithUserInteraction):
(WebKit::WebsiteDataStore::fetchDataForRegistrableDomains):
(WebKit::WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::forwardManagedDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::builtInNotificationsEnabled const):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::PlatformXRSystem):
(WebKit::PlatformXRSystem::~PlatformXRSystem):
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
(WebKit::PlatformXRSystem::sessionDidEnd):
(WebKit::PlatformXRSystem::sessionDidUpdateVisibilityState):
(WebKit::PlatformXRSystem::webXREnabled const):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::getPrimaryDeviceInfo):
(WebKit::OpenXRCoordinator::startSession):
* Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp:
(WebKit::WebPageProxy::Internals::speakingErrorOccurred):
(WebKit::WebPageProxy::Internals::boundaryEventOccurred):
(WebKit::WebPageProxy::Internals::voicesDidChange):
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
(WebKit::SmartMagnificationController::SmartMagnificationController):
(WebKit::SmartMagnificationController::~SmartMagnificationController):
(WebKit::SmartMagnificationController::handleSmartMagnificationGesture):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView alternativesForSelectedText]):
(-[WKContentView removeEmojiAlternatives]):
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy):
(WebKit::WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::setDeviceOrientation):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::isPotentialTapInProgress):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::promptForGetDisplayMedia):
(WebKit::DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt):
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm:
(WebKit::UserMediaPermissionRequestProxyMac::canRequestDisplayCapturePermission):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleSmartMagnificationGesture):
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController enableGestureIfNeeded:]):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _clearImmediateActionState]):
(-[WKImmediateActionController dismissContentRelativeChildWindows]):
(-[WKImmediateActionController immediateActionRecognizerWillPrepare:]):
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidUpdateAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidCancelAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidCompleteAnimation:]):
(-[WKImmediateActionController _defaultAnimationController]):
(-[WKImmediateActionController _updateImmediateActionItem]):
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
(-[WKImmediateActionController _animationControllerForText]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(-[WKMenuTarget forwardContextMenuAction:]):
(-[WKMenuDelegate menuWillOpen:]):
(-[WKMenuDelegate menuDidClose:]):
(-[WKMenuDelegate captionStyleMenuWillOpen:]):
(-[WKMenuDelegate captionStyleMenuDidClose:]):
(WebKit::WebContextMenuProxyMac::appendRemoveBackgroundItemToControlledImageMenuIfNeeded):
(WebKit::WebContextMenuProxyMac::createShareMenuItem):
(WebKit::WebContextMenuProxyMac::showAfterPostProcessingContextData):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::windowAndViewFramesChanged):
(WebKit::WebPageProxy::updateMouseEventTargetAfterWindowAndViewFramesChanged):
(WebKit::WebPageProxy::setMainFrameIsScrollable):
(WebKit::WebPageProxy::attributedSubstringForCharacterRangeAsync):
(WebKit::WebPageProxy::stringSelectionForPasteboard):
(WebKit::WebPageProxy::dataSelectionForPasteboard):
(WebKit::WebPageProxy::readSelectionFromPasteboard):
(WebKit::WebPageProxy::setSmartInsertDeleteEnabled):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::semanticContextDidChange):
(WebKit::WebPageProxy::colorSpace):
(WebKit::WebPageProxy::registerUIProcessAccessibilityTokens):
(WebKit::WebPageProxy::shouldDelayWindowOrderingForEvent):
(WebKit::WebPageProxy::setOverflowHeightForTopScrollEdgeEffect):
(WebKit::WebPageProxy::showValidationMessage):
(WebKit::WebPageProxy::createSyntheticEventForContextMenu const):
(WebKit::WebPageProxy::setScrollbarAvoidanceCornerRadii):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::windowNumber):
(WebKit::WebViewImpl::resignFirstResponder):
(WebKit::WebViewImpl::windowDidBecomeKey):
(WebKit::WebViewImpl::windowDidResignKey):
(WebKit::WebViewImpl::shouldDelayWindowOrderingForEvent):
(WebKit::WebViewImpl::viewDidChangeBackingProperties):
(WebKit::WebViewImpl::updateSecureInputState):
(WebKit::WebViewImpl::setContinuousSpellCheckingEnabled):
(WebKit::WebViewImpl::toggleContinuousSpellChecking):
(WebKit::WebViewImpl::setGrammarCheckingEnabled):
(WebKit::WebViewImpl::toggleGrammarChecking):
(WebKit::WebViewImpl::toggleAutomaticSpellingCorrection):
(WebKit::WebViewImpl::setAutomaticQuoteSubstitutionEnabled):
(WebKit::WebViewImpl::toggleAutomaticQuoteSubstitution):
(WebKit::WebViewImpl::setAutomaticDashSubstitutionEnabled):
(WebKit::WebViewImpl::toggleAutomaticDashSubstitution):
(WebKit::WebViewImpl::setAutomaticLinkDetectionEnabled):
(WebKit::WebViewImpl::toggleAutomaticLinkDetection):
(WebKit::WebViewImpl::setAutomaticTextReplacementEnabled):
(WebKit::WebViewImpl::toggleAutomaticTextReplacement):
(WebKit::WebViewImpl::isSmartListsEnabled):
(WebKit::WebViewImpl::setSmartListsEnabled):
(WebKit::WebViewImpl::toggleSmartLists):
(WebKit::WebViewImpl::sendToolTipMouseExited):
(WebKit::WebViewImpl::sendToolTipMouseEntered):
(WebKit::WebViewImpl::sendDragEndToPage):
(WebKit::performDragWithLegacyFiles):
(WebKit::handleLegacyFilesPasteboard):
(WebKit::WebViewImpl::startWindowDrag):
(WebKit::WebViewImpl::startDrag):
(WebKit::WebViewImpl::addTextAnimationForAnimationID):
(WebKit::WebViewImpl::removeTextAnimationForAnimationID):
(WebKit::WebViewImpl::updateTouchBar):
(WebKit::WebViewImpl::updateMediaPlaybackControlsManager):
(WebKit::WebViewImpl::updateMediaTouchBar):
(WebKit::WebViewImpl::protectedWindow): Deleted.

Canonical link: <a href="https://commits.webkit.org/306158@main">https://commits.webkit.org/306158@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/453418e4e680b94fb077a70b74cdf9d813f8c74b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140521 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93608 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107741 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125791 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88640 "run-api-tests (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10111 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7668 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8954 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132499 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151484 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1319 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12591 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116047 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116383 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29596 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11999 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67639 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12633 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171794 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76333 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12571 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->