### PR TITLE
Address unsafe cast warnings in BidiRun.cpp & BidiRun.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -15,8 +15,6 @@ html/InputType.cpp
 [ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
 [ iOS ] platform/ios/wak/WAKView.mm
 [ iOS ] platform/ios/wak/WAKWindow.mm
-rendering/BidiRun.cpp
-rendering/BidiRun.h
 rendering/cocoa/RenderThemeCocoa.mm
 rendering/svg/SVGRenderTreeAsText.cpp
 svg/properties/SVGAnimatedDecoratedProperty.h

--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -190,20 +190,20 @@ void GraphicsContext::drawEmphasisMarks(const FontCascade& font, const TextRun& 
 
 void GraphicsContext::drawBidiText(const FontCascade& font, const TextRun& run, const FloatPoint& point, FontCascade::CustomFontNotReadyAction customFontNotReadyAction)
 {
-    BidiResolver<TextRunIterator, BidiCharacterRun> bidiResolver;
+    BidiResolver<TextRunIterator, SimpleBidiCharacterRun> bidiResolver;
     bidiResolver.setStatus(BidiStatus(run.direction(), run.directionalOverride()));
     bidiResolver.setPositionIgnoringNestedIsolates(TextRunIterator(&run, 0));
 
     // FIXME: This ownership should be reversed. We should pass BidiRunList
     // to BidiResolver in createBidiRunsForLine.
-    BidiRunList<BidiCharacterRun>& bidiRuns = bidiResolver.runs();
+    auto& bidiRuns = bidiResolver.runs();
     bidiResolver.createBidiRunsForLine(TextRunIterator(&run, run.length()));
 
     if (!bidiRuns.runCount())
         return;
 
     FloatPoint currPoint = point;
-    BidiCharacterRun* bidiRun = bidiRuns.firstRun();
+    auto* bidiRun = bidiRuns.firstRun();
     while (bidiRun) {
         TextRun subrun = run.subRun(bidiRun->start(), bidiRun->stop() - bidiRun->start());
         bool isRTL = bidiRun->level() % 2;

--- a/Source/WebCore/platform/text/BidiResolver.h
+++ b/Source/WebCore/platform/text/BidiResolver.h
@@ -124,6 +124,7 @@ inline bool operator==(const BidiStatus& status1, const BidiStatus& status2)
     return status1.eor == status2.eor && status1.last == status2.last && status1.lastStrong == status2.lastStrong && *(status1.context) == *(status2.context);
 }
 
+template<typename ConcreteRunType>
 struct BidiCharacterRun {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(BidiCharacterRun);
 public:
@@ -163,18 +164,23 @@ public:
     bool reversed(bool visuallyOrdered) { return m_level % 2 && !visuallyOrdered; }
     bool dirOverride(bool visuallyOrdered) { return m_override || visuallyOrdered; }
 
-    BidiCharacterRun* next() const { return m_next.get(); }
-    std::unique_ptr<BidiCharacterRun> takeNext() { return WTF::move(m_next); }
-    void setNext(std::unique_ptr<BidiCharacterRun>&& next) { m_next = WTF::move(next); }
+    ConcreteRunType* next() const { return m_next.get(); }
+    std::unique_ptr<ConcreteRunType> takeNext() { return WTF::move(m_next); }
+    void setNext(std::unique_ptr<ConcreteRunType>&& next) { m_next = WTF::move(next); }
 
 private:
-    std::unique_ptr<BidiCharacterRun> m_next;
+    std::unique_ptr<ConcreteRunType> m_next;
 
 public:
     unsigned m_start;
     unsigned m_stop;
     unsigned char m_level;
     bool m_override : 1;
+};
+
+// Standalone BidiCharacterRun for cases that don't need a derived class.
+struct SimpleBidiCharacterRun : BidiCharacterRun<SimpleBidiCharacterRun> {
+    using BidiCharacterRun<SimpleBidiCharacterRun>::BidiCharacterRun;
 };
 
 enum VisualDirectionOverride {

--- a/Source/WebCore/rendering/BidiRun.cpp
+++ b/Source/WebCore/rendering/BidiRun.cpp
@@ -32,7 +32,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiRun);
 
 BidiRun::BidiRun(unsigned start, unsigned stop, RenderObject& renderer, BidiContext* context, UCharDirection dir)
-    : BidiCharacterRun(start, stop, context, dir)
+    : BidiCharacterRun<BidiRun>(start, stop, context, dir)
     , m_renderer(renderer)
     , m_box(nullptr)
 {
@@ -41,14 +41,6 @@ BidiRun::BidiRun(unsigned start, unsigned stop, RenderObject& renderer, BidiCont
 
 BidiRun::~BidiRun()
 {
-}
-
-std::unique_ptr<BidiRun> BidiRun::takeNext()
-{
-    std::unique_ptr<BidiCharacterRun> next = BidiCharacterRun::takeNext();
-    BidiCharacterRun* raw = next.release();
-    std::unique_ptr<BidiRun> result = std::unique_ptr<BidiRun>(static_cast<BidiRun*>(raw));
-    return result;
 }
 
 }

--- a/Source/WebCore/rendering/BidiRun.h
+++ b/Source/WebCore/rendering/BidiRun.h
@@ -33,14 +33,12 @@ class BidiContext;
 class LegacyInlineBox;
 class RenderObject;
 
-struct BidiRun : BidiCharacterRun {
+struct BidiRun : BidiCharacterRun<BidiRun> {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(BidiRun);
 public:
     BidiRun(unsigned start, unsigned stop, RenderObject&, BidiContext*, UCharDirection);
     ~BidiRun();
 
-    BidiRun* next() { return static_cast<BidiRun*>(BidiCharacterRun::next()); }
-    std::unique_ptr<BidiRun> takeNext();
     RenderObject& renderer() { return m_renderer; }
     LegacyInlineBox* box() { return m_box; }
     void setBox(LegacyInlineBox* box) { m_box = box; }


### PR DESCRIPTION
#### 30a5956fe40f7bbeba786e580f37a903c1713e67
<pre>
Address unsafe cast warnings in BidiRun.cpp &amp; BidiRun.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=305914">https://bugs.webkit.org/show_bug.cgi?id=305914</a>

Reviewed by Darin Adler.

Make BidiCharacterRun templated to avoid unsafe-looking static casts
in the BidiRun subclass.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawBidiText):
* Source/WebCore/platform/text/BidiResolver.h:
(WebCore::BidiCharacterRun::next const):
(WebCore::BidiCharacterRun::takeNext):
(WebCore::BidiCharacterRun::setNext):
* Source/WebCore/rendering/BidiRun.cpp:
(WebCore::BidiRun::BidiRun):
(WebCore::BidiRun::takeNext): Deleted.
* Source/WebCore/rendering/BidiRun.h:
(WebCore::BidiRun::next): Deleted.

Canonical link: <a href="https://commits.webkit.org/305991@main">https://commits.webkit.org/305991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff2e957f2ee201d1b076295943e14504d152d00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148182 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12571 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10100 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88091 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7280 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8470 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150971 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1469 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29457 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10759 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121881 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12147 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1353 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/11934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->