### PR TITLE
Colspan not working correctly when block type element in <td>

### DIFF
--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -457,6 +457,19 @@ float AutoTableLayout::calcEffectiveLogicalWidth()
                 ASSERT(allocatedMinLogicalWidth < cellMinLogicalWidth || WTF::areEssentiallyEqual(allocatedMinLogicalWidth, cellMinLogicalWidth));
                 ASSERT(allocatedMaxLogicalWidth < cellMaxLogicalWidth || WTF::areEssentiallyEqual(allocatedMaxLogicalWidth, cellMaxLogicalWidth));
                 cellMaxLogicalWidth -= allocatedMaxLogicalWidth;
+            } else if (!allColsAreFixed && fixedWidth <= 0 && totalPercent >= 100 && haveAuto) {
+                // Mixed columns where one has width >= 100% and others are auto
+                for (unsigned pos = effCol; pos < lastCol; ++pos) {
+                    auto percentageLogicalWidth = m_layoutStruct[pos].logicalWidth.tryPercentage();
+                    if (percentageLogicalWidth && percentageLogicalWidth->value >= 100) {
+                        // This column should absorb the colspan width requirement
+                        float colMinLogicalWidth = cellMinLogicalWidth;
+                        m_layoutStruct[pos].effectiveMinLogicalWidth = std::max(m_layoutStruct[pos].effectiveMinLogicalWidth, colMinLogicalWidth);
+                        // Don't distribute across other columns
+                        cellMinLogicalWidth = 0;
+                        break;
+                    }
+                }
             } else if (!allColsAreFixed && fixedWidth <= 0 && totalPercent > 0 && haveAuto) {
                 // By this point, the earlier code has converted auto columns to effectiveLogicalWidth percentages,
                 // so we can use the same percentage-based distribution as the allColsArePercent case.


### PR DESCRIPTION
#### e8920ac4219a81207f922c257919560b5d9489ce
<pre>
Colspan not working correctly when block type element in &lt;td&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=3820">https://bugs.webkit.org/show_bug.cgi?id=3820</a>
<a href="https://rdar.apple.com/96534555">rdar://96534555</a>

Reviewed by NOBODY (OOPS!).

AutoTableLayout computes the layout of the table and distribute the
required width and heights. In this file, the function
calcEffectiveLogicalWidth() is in charge of computing the colspan cells,
aka cells being distributed over multiple columns.

After initializing the core structure of the table, the function will
collect the number of spanned cells in m_spanCells and then will
initialize the effective values, before processing each spanning cells
in:

    for (size_t i = 0; i &lt; m_spanCells.size(); ++i) { }

1. after getting the information for each cell including width and
its width type (auto, percent, fixed), and the width of the content, the
number of columns it spans.
2. This will result in flags that will help determine what to apply later.
3. handle percentage spanning cells.
4. distribute min width requirements
4.1 all fixed columns
4.2 all percentage columns
4.3 100% column with auto (THIS BUG!)
4.4 mixed percent and auto
4.5 general mixed case

Then it will finish handling a couple of special cases for colspan, like
empty cells.

The NEW CASE, this is fixing is about:
Mixed columns where one has width &gt;= 100% and others are auto

&lt;table&gt;
  &lt;tr&gt;
    &lt;td colspan=&quot;2&quot;&gt;&lt;div style=&quot;width: 200px&quot;&gt;Wide&lt;/div&gt;&lt;/td&gt;
  &lt;/tr&gt;
  &lt;tr&gt;
    &lt;td&gt;A&lt;/td&gt;              &lt;!-- Auto width --&gt;
    &lt;td width=&quot;100%&quot;&gt;B&lt;/td&gt; &lt;!-- 100% width --&gt;
  &lt;/tr&gt;
&lt;/table&gt;

Safari was giving more space than to the cell with A, than in other
browsers. With this patch the cell with B will occupy all the maximum
space possible and constraint the width of the cell with A to its
minimum possible size conditioned by its content, and not larger.

This will match the behavior of Chrome and Firefox.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8920ac4219a81207f922c257919560b5d9489ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92944 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0ad0c36-ad93-4518-9a19-e7b2fa3e69d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107106 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77956 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e366247-a63c-423c-b7a7-94b196549424) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87985 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afada866-f3a1-41bf-93a1-835defd069c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9639 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7152 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8307 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150801 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115518 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115833 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10621 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121743 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66946 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11983 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1218 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->