### PR TITLE
A service worker created from an imported registration as empty static service worker routes

### DIFF
--- a/LayoutTests/http/wpt/service-workers/service-worker-add-skip-fetch-event-routes.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-add-skip-fetch-event-routes.js
@@ -1,0 +1,17 @@
+oninstall = e => {
+    e.addRoutes([{
+        condition: {
+            urlPattern: new URLPattern({pathname: '*'}),
+        },
+        source: 'network'
+    }]);
+}
+
+var fetchCount = 0;
+onfetch = () => {
+    fetchCount++;
+}
+
+onmessage = e => {
+    e.source.postMessage(!fetchCount ? "OK" : "KO: " + fetchCount);
+}

--- a/LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt
@@ -3,4 +3,5 @@ PASS Try to register too many routes in one call
 PASS Try to register too many routes incrementally
 PASS add route when not installing
 PASS add route extend installation of service worker
+PASS routes should be set when service worker restarts
 

--- a/LayoutTests/http/wpt/service-workers/service-worker-routes.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-routes.html
@@ -72,6 +72,42 @@ promise_test(async (test) => {
     worker.postMessage("getResult");
     assert_equals(await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data)), "OK");
 }, "add route extend installation of service worker");
+
+promise_test(async (test) => {
+    let registration = await navigator.serviceWorker.getRegistration("5");
+    if (registration)
+        await registration.unregister();
+    registration = await navigator.serviceWorker.register("service-worker-add-skip-fetch-event-routes.js", { scope : "5" });
+    const worker = registration.installing;
+
+    await waitForState(worker, "activated");
+
+    const frame1 = await withIframe("5/a");
+    frame1.contentWindow.navigator.serviceWorker.controller.postMessage("getResult");
+    assert_equals(await new Promise(resolve => frame1.contentWindow.navigator.serviceWorker.onmessage = e => resolve(e.data)), "OK", "Validate route of frame1");
+    frame1.remove();
+
+    if (window.internals)
+        await internals.storeRegistrationsOnDisk();
+    await waitFor(100);
+    if (window.testRunner && window.testRunner.terminateNetworkProcess)
+        testRunner.terminateNetworkProcess();
+
+    let frame2
+    let counter = 0;
+    while (++counter < 10) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        frame2 = await withIframe("5/b");
+        if (frame2.contentWindow.navigator.serviceWorker.controller)
+            break;
+        frame2.remove();
+    }
+    assert_less_than(counter, 10);
+
+    frame2.contentWindow.navigator.serviceWorker.controller.postMessage("getResult");
+    assert_equals(await new Promise(resolve => frame2.contentWindow.navigator.serviceWorker.onmessage = e => resolve(e.data)), "OK", "Validate route of frame2");
+    frame2.remove();
+}, "routes should be set when service worker restarts");
 </script>
 </body>
 </html>

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -902,10 +902,13 @@ void Coder<WebCore::ServiceWorkerRouteCondition>::encodeForPersistence(Encoder& 
     encoder << condition.requestDestination;
     encoder << condition.runningStatus;
     encoder << condition.orConditions;
-    if (condition.notCondition) {
-        encoder << true;
-        encoder << *condition.notCondition;
+
+    if (!condition.notCondition) {
+        encoder << false;
+        return;
     }
+    encoder << true;
+    encoder << *condition.notCondition;
 }
 
 std::optional<WebCore::ServiceWorkerRouteCondition> Coder<WebCore::ServiceWorkerRouteCondition>::decodeForPersistence(Decoder& decoder)

--- a/Source/WebCore/workers/service/RouterSourceEnum.h
+++ b/Source/WebCore/workers/service/RouterSourceEnum.h
@@ -38,7 +38,8 @@ template<> struct EnumTraitsForPersistence<WebCore::RouterSourceEnum> {
         WebCore::RouterSourceEnum,
         WebCore::RouterSourceEnum::Cache,
         WebCore::RouterSourceEnum::FetchEvent,
-        WebCore::RouterSourceEnum::Network
+        WebCore::RouterSourceEnum::Network,
+        WebCore::RouterSourceEnum::RaceNetworkAndFetchHandler
     >;
 };
 

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -226,7 +226,7 @@ void SWServer::addRegistrationFromStore(ServiceWorkerContextData&& data, Complet
             registration->setLastUpdateTime(data.registration.lastUpdateTime);
             protectedThis->addRegistration(registration.copyRef());
 
-            Ref worker = SWServerWorker::create(*protectedThis, registration, data.scriptURL, data.script, data.certificateInfo, data.contentSecurityPolicy, data.crossOriginEmbedderPolicy, WTF::move(data.referrerPolicy), data.workerType, data.serviceWorkerIdentifier, WTF::move(data.scriptResourceMap));
+            Ref worker = SWServerWorker::create(*protectedThis, registration, data.scriptURL, data.script, data.certificateInfo, data.contentSecurityPolicy, data.crossOriginEmbedderPolicy, WTF::move(data.referrerPolicy), data.workerType, data.serviceWorkerIdentifier, WTF::move(data.scriptResourceMap), WTF::move(data.routes));
             registration->updateRegistrationState(ServiceWorkerRegistrationState::Active, worker.ptr());
             worker->setState(ServiceWorkerState::Activated);
         }

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -51,7 +51,7 @@ SWServerWorker* SWServerWorker::existingWorkerForIdentifier(ServiceWorkerIdentif
 }
 
 // FIXME: Use r-value references for script and contentSecurityPolicy
-SWServerWorker::SWServerWorker(SWServer& server, SWServerRegistration& registration, const URL& scriptURL, const ScriptBuffer& script, const CertificateInfo& certificateInfo, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy, const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy, String&& referrerPolicy, WorkerType type, ServiceWorkerIdentifier identifier, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&& scriptResourceMap)
+SWServerWorker::SWServerWorker(SWServer& server, SWServerRegistration& registration, const URL& scriptURL, const ScriptBuffer& script, const CertificateInfo& certificateInfo, const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy, const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy, String&& referrerPolicy, WorkerType type, ServiceWorkerIdentifier identifier, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&& scriptResourceMap, Vector<ServiceWorkerRoute>&& routes)
     : m_server(server)
     , m_registrationKey(registration.key())
     , m_registration(registration)
@@ -66,6 +66,7 @@ SWServerWorker::SWServerWorker(SWServer& server, SWServerRegistration& registrat
     , m_terminationTimer(*this, &SWServerWorker::terminationTimerFired)
     , m_terminationIfPossibleTimer(*this, &SWServerWorker::terminationIfPossibleTimerFired)
     , m_lastNavigationWasAppInitiated(server.clientIsAppInitiatedForRegistrableDomain(m_topSite.domain()))
+    , m_routes(WTF::move(routes))
 {
     m_data.scriptURL.removeFragmentIdentifier();
 

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -164,7 +164,7 @@ public:
     std::optional<ExceptionData> addRoutes(Vector<ServiceWorkerRoute>&&);
 
 private:
-    SWServerWorker(SWServer&, SWServerRegistration&, const URL&, const ScriptBuffer&, const CertificateInfo&, const ContentSecurityPolicyResponseHeaders&, const CrossOriginEmbedderPolicy&, String&& referrerPolicy, WorkerType, ServiceWorkerIdentifier, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&&);
+    SWServerWorker(SWServer&, SWServerRegistration&, const URL&, const ScriptBuffer&, const CertificateInfo&, const ContentSecurityPolicyResponseHeaders&, const CrossOriginEmbedderPolicy&, String&& referrerPolicy, WorkerType, ServiceWorkerIdentifier, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&&, Vector<ServiceWorkerRoute>&& = { });
 
     void callWhenActivatedHandler(bool success);
 


### PR DESCRIPTION
#### aedfff25b4a3baccf41c5f2f4857185aa818a6f5
<pre>
A service worker created from an imported registration as empty static service worker routes
<a href="https://rdar.apple.com/168577666">rdar://168577666</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305918">https://bugs.webkit.org/show_bug.cgi?id=305918</a>

Reviewed by Chris Dumez.

The persistency code path had a few bugs that are fixed here:
- When creating a SWServerWorker from disk, we need to set the routes at creation time.
- Serialization needs to handle RaceFetchAndEventHandler source value
- Serialization needs to handle the case of a route without any or condition.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/305999@main">https://commits.webkit.org/305999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/384a68d8b81eb438cc609851f5b8db4239d7bf41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92947 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/655b4d60-489d-4865-a49c-495655547a45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107108 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77957 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd4fa2c2-9d56-4792-922e-987cd3b0588c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/9988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87987 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab0f0398-bff8-4a32-a7a4-f91ef56248f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9641 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7156 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150804 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11944 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115521 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/12171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115836 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29463 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11986 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1223 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11726 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75673 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->