### PR TITLE
[AutoFill Debugging] Limit version number in text extraction to JSON output format

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
@@ -18,4 +18,3 @@ root
         input,'text',uid=…,placeholder='Full name'
         'User Profile\n\n        \n\n            Username:'
         input,'text',uid=…,label='Username:'
-version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -51,4 +51,3 @@ root
         'Footer content with',[…]
         role='img',aria-label='copyright symbol','©',[…]
         '2024',[…]
-version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-data-detectors-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-data-detectors-expected.txt
@@ -7,4 +7,3 @@ $79.99
 You save $20.00
 
 In Stock - Ships within 24 hours
-<!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -41,7 +41,6 @@ root
         'Footer content with'
         role='img',aria-label='copyright symbol','©'
         '2024'
-version=2
 
 -- html
 
@@ -104,7 +103,6 @@ version=2
         2024
     </footer>
 </body>
-<!-- version=2 -->
 
 -- json
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt
@@ -2,4 +2,3 @@ root
 	input,'email',placeholder='Enter your email'
 	input,'password',placeholder='Enter your password',secure
 	input,'number',placeholder='Security code','123456'
-version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -23,4 +23,3 @@ root
         'Ready'
         button,'Update Status'
     'The quick brown fox jumped…\n\n\n\n\n    \nFooter content with © 2024'
-version=2

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt
@@ -8,4 +8,3 @@ This is a list:
 - baz
 On [sale](https://webkit.org/) for
 £10.99 This ~~text~~ has a ~~line through it~~. The price ~~was \~\~$50~~
-<!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt
@@ -66,4 +66,3 @@
         2024 &amp; 2025
     </footer>
 </body>
-<!-- version=2 -->

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -21,4 +21,3 @@ root
 		image,src='image.gif',alt='Image with high entropy name'
 		image,src='image2.gif',alt='Image with high entropy name 2'
 		image,src='image2.gif',alt='Image with high entropy name (duplicate)'
-version=2

--- a/LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt
+++ b/LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt
@@ -18,4 +18,3 @@ root
 			iframe,title='Cross origin iframe',origin='http://localhost:8000'
 		button,aria-label='Submit','After subframes'
 		link,url='webkit.org','Link in mainframe'
-version=2

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -520,16 +520,10 @@ private:
 
     void addVersionNumberIfNeeded()
     {
-        if (onlyIncludeText())
+        if (!useJSONOutput())
             return;
 
-        if (useJSONOutput()) {
-            protectedRootJSONObject()->setInteger("version"_s, version());
-            return;
-        }
-
-        auto versionText = (useHTMLOutput() || useMarkdownOutput()) ? makeString("<!-- version="_s, version(), " -->"_s) : makeString("version="_s, version());
-        addResult({ advanceToNextLine(), 0 }, { WTF::move(versionText) });
+        protectedRootJSONObject()->setInteger("version"_s, version());
     }
 
     uint32_t version() const

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -479,7 +479,7 @@ TEST(TextExtractionTests, NodesToSkip)
     }()];
 
     NSArray<NSString *> *lines = [debugText componentsSeparatedByString:@"\n"];
-    EXPECT_EQ([lines count], 2u);
+    EXPECT_EQ([lines count], 1u);
     EXPECT_WK_STREQ("Test 0", lines[0]);
 }
 
@@ -511,7 +511,7 @@ TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)
         return configuration.autorelease();
     }()];
 
-    EXPECT_WK_STREQ(debugTextForSubject.get(), @"root\n\taria-label='Heading','Subject'\nversion=2");
+    EXPECT_WK_STREQ(debugTextForSubject.get(), @"root\n\taria-label='Heading','Subject'");
 
     RetainPtr debugTextForBody = [webView synchronouslyGetDebugText:^{
         RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
@@ -522,7 +522,7 @@ TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)
         return configuration.autorelease();
     }()];
 
-    EXPECT_WK_STREQ(debugTextForBody.get(), @"root,'“The quick brown fox jumped over the lazy dog”'\nversion=2");
+    EXPECT_WK_STREQ(debugTextForBody.get(), @"root,'“The quick brown fox jumped over the lazy dog”'");
 }
 
 TEST(TextExtractionTests, ResolveTargetNodeFromSelectorData)
@@ -561,7 +561,7 @@ TEST(TextExtractionTests, ResolveTargetNodeFromSelectorData)
         return configuration.autorelease();
     }()];
 
-    EXPECT_WK_STREQ(debugText.get(), @"root\n\taria-label='Heading','Subject'\nversion=2");
+    EXPECT_WK_STREQ(debugText.get(), @"root\n\taria-label='Heading','Subject'");
 }
 
 #if HAVE(SAFARI_SAFE_BROWSING_NAMESPACED_LISTS)


### PR DESCRIPTION
#### 1af7e972dc64eb44115c489f69aae923dabddb9b
<pre>
[AutoFill Debugging] Limit version number in text extraction to JSON output format
<a href="https://bugs.webkit.org/show_bug.cgi?id=305920">https://bugs.webkit.org/show_bug.cgi?id=305920</a>
<a href="https://rdar.apple.com/168584568">rdar://168584568</a>

Reviewed by Abrar Rahman Protyasha.

Only include `version` directly in the text extraction output, if the client asks for JSON data.

* LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-data-detectors-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-ignore-autofilled-fields-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-markdown-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* LayoutTests/http/tests/text-extraction/debug-text-extraction-subframes-expected.txt:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::addVersionNumberIfNeeded):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, NodesToSkip)):
(TestWebKitAPI::TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)):
(TestWebKitAPI::TEST(TextExtractionTests, ResolveTargetNodeFromSelectorData)):

Rebaseline several layout and API tests.

Canonical link: <a href="https://commits.webkit.org/305944@main">https://commits.webkit.org/305944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac313914397334b3acb6bff981a5c15cc43a5098

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148033 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d241d936-33b2-4091-95fd-89678cda8221) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107116 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a6b157f-c627-4ef8-8020-10c03724cdff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/87996 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83ab27dc-7d36-4d30-a3b4-0482f19ddc3c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7168 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8323 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150817 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11957 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115529 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115844 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10635 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121763 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/11999 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1238 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11739 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11787 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->