### PR TITLE
Follow-up: address more comments after the 305290@main upstream

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if HAVE_CORE_ANIMATION_SEPARATED_LAYERS && compiler(>=6.0)
+#if HAVE_CORE_ANIMATION_SEPARATED_LAYERS && compiler(>=6.2)
 
 #if canImport(CoreRE)
 @_weakLinked internal import CoreRE
@@ -74,7 +74,7 @@ extension WKSeparatedImageView {
 
         var duration = SeparatedImageViewConstants.longFadeAnimationDuration
         #if canImport(RealityFoundation, _version: 387)
-        if let imageHash, ImagePresentationCache.shared.get(for: imageHash) != nil {
+        if let imageHash, ImagePresentationCache.shared[imageHash] != nil {
             duration = SeparatedImageViewConstants.shortFadeAnimationDuration
         }
         #endif
@@ -163,8 +163,7 @@ extension WKSeparatedImageView {
 
     func updateUI() {
         #if canImport(RealityFoundation, _version: 387)
-        if isSeparated, viewMode == .portal, spatial3DImage == nil, let imageHash, ImagePresentationCache.shared.get(for: imageHash) == nil
-        {
+        if isSeparated, viewMode == .portal, spatial3DImage == nil, let imageHash, ImagePresentationCache.shared[imageHash] == nil {
             if spinner == nil {
                 spinner = WKSeparatedImageView.generationQueueSpinnerView()
                 spinner?.alpha = 0

--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift
@@ -41,7 +41,7 @@ extension WKSeparatedImageView {
             self.portalEntity?.components[ImagePresentationComponent.self]?.desiredViewingMode =
                 desiredViewingModeSpatial ? .spatial3D : .mono
             if let imageHash = self.imageHash {
-                ImagePresentationCache.shared.updateDesiredViewingMode(for: imageHash, desiredViewingModeSpatial)
+                ImagePresentationCache.shared[imageHash]?.desiredViewingModeSpatial = desiredViewingModeSpatial
             }
             #endif
         }

--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageViewConstants.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageViewConstants.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if HAVE_CORE_ANIMATION_SEPARATED_LAYERS && compiler(>=6.0)
+#if HAVE_CORE_ANIMATION_SEPARATED_LAYERS && compiler(>=6.2)
 
 enum SeparatedImageViewConstants {
     static let cancellationDelay = Duration.seconds(0.4)


### PR DESCRIPTION
#### 05091ff70c574740e36fa7afe89f76375ade2cc6
<pre>
Follow-up: address more comments after the 305290@main upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=305923">https://bugs.webkit.org/show_bug.cgi?id=305923</a>
&lt;<a href="https://rdar.apple.com/167010240">rdar://167010240</a>&gt;

Reviewed by Richard Robinson.

Remove the `Task.detached` and `@unchecked Sendable` uses and
address style comments now that the upstream patch has landed.
Bump the compiler guard to 6.2 because of the `@concurrent` use.

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Analysis.swift:
(WKSeparatedImageView.pickViewMode):
(WKSeparatedImageView.analyze):
Break out the analysis in a `@concurrent` async function.
Keep a simple Task (not detached) for the cancellation support.
(scoreImage(_:)):
(WKSeparatedImageView.startImageAnalysis): Deleted.
Code clean-up.

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift:
(WKSeparatedImageView.startImage3DGeneration):
(WKSeparatedImageView.generate):
Break out the generation in a `@concurrent` async function.
Keep a simple Task (not detached) for the cancellation support.
(makeVoidPromise() -&gt; (promise: Task&lt;Void:Never:fulfill:)):
(ContinuationBox.continuation): Deleted.
Use an AsyncStream instead of the `@unchecked Sendable` ContinuationBox.

(set(for:spatial3DImage:desiredViewingModeSpatial:)): Deleted.
(updateDesiredViewingMode(for:_:)): Deleted.
(get(for:)): Deleted.
(forget(_:)): Deleted.
* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift:
(WKSeparatedImageView.updateContents):
(WKSeparatedImageView.updateUI):
* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift:
(WKSeparatedImageView.desiredViewingModeSpatial):
Add subscript support to the ImagePresentationCache.

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Surface.swift:
(WKSeparatedImageView.didReceiveImage):
(WKSeparatedImageView.computeHash() async -&gt; (Data:NSString:)):
Break out the hash computation in a `@concurrent` async function.
Keep a simple Task (not detached) for the cancellation support.

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageViewConstants.swift:

Canonical link: <a href="https://commits.webkit.org/306335@main">https://commits.webkit.org/306335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bd4f8d635571cc665a3816cef8b5ee007bf649f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148041 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92968 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb450db6-0d9c-4a62-b3c8-190bfbcb2342) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77968 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3616247-08ea-4ccb-accd-dd451e6de3f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc60dcd3-e18c-461f-893c-874da8cbac49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7172 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8330 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118878 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150825 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11964 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115535 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11977 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10638 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121768 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66969 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12006 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1243 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11942 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->