### PR TITLE
AX: Add a default to force accessibility to be enabled

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -303,6 +303,11 @@ AXObjectCache::AXObjectCache(LocalFrame& localFrame, Document* document)
 #endif
 
     AXTreeStore::add(m_id, WeakPtr { this });
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (shouldForceAccessibilityEnabled()) [[unlikely]]
+        buildIsolatedTreeIfNeeded();
+#endif
 }
 
 AXObjectCache::~AXObjectCache()

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -529,6 +529,7 @@ public:
 
     static void initializeUserDefaultValues();
     static bool accessibilityDOMIdentifiersEnabled() { return gAccessibilityDOMIdentifiersEnabled; }
+    WEBCORE_EXPORT static bool shouldForceAccessibilityEnabled();
 #endif
 
     static bool forceInitialFrameCaching() { return gForceInitialFrameCaching; }
@@ -1027,7 +1028,15 @@ private:
 
 inline bool AXObjectCache::accessibilityEnabled()
 {
-    return gAccessibilityEnabled;
+    if (gAccessibilityEnabled)
+        return true;
+#if PLATFORM(COCOA)
+    if (shouldForceAccessibilityEnabled()) [[unlikely]] {
+        enableAccessibility();
+        return true;
+    }
+#endif
+    return false;
 }
 
 inline void AXObjectCache::enableAccessibility()

--- a/Source/WebCore/accessibility/cocoa/AXObjectCacheCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXObjectCacheCocoa.mm
@@ -32,6 +32,16 @@
 
 namespace WebCore {
 
+bool AXObjectCache::shouldForceAccessibilityEnabled()
+{
+    // Cached to ensure we only read the preference once for performance.
+    static bool cachedValue = [] {
+        RetainPtr userDefaults = adoptNS([[NSUserDefaults alloc] initWithSuiteName:@"com.apple.Accessibility"]);
+        return [userDefaults boolForKey:@"ShouldForceWebKitAccessibilityEnabled"];
+    }();
+    return cachedValue;
+}
+
 RetainPtr<NSString> notifyPriorityToAXValueString(NotifyPriority priority)
 {
     switch (priority) {

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -753,15 +753,24 @@ bool AXObjectCache::isIsolatedTreeEnabled()
         return true;
 
     if (!isMainThread()) {
-        AX_ASSERT(_AXUIElementRequestServicedBySecondaryAXThread());
+        AX_ASSERT(clientIsInTestMode() || _AXUIElementRequestServicedBySecondaryAXThread());
         enabled = true;
     } else {
-        enabled = DeprecatedGlobalSettings::isAccessibilityIsolatedTreeEnabled() // Used to turn off in apps other than Safari, e.g., Mail.
-            && _AXSIsolatedTreeModeFunctionIsAvailable()
-            && _AXSIsolatedTreeMode_Soft() != AXSIsolatedTreeModeOff // Used to switch via system defaults.
-            && clientSupportsIsolatedTree();
-    }
+        // Used to turn off in apps other than Safari, e.g., Mail.
+        bool isSettingEnabled = DeprecatedGlobalSettings::isAccessibilityIsolatedTreeEnabled();
 
+        bool environmentAllowsITM = (isSettingEnabled && clientSupportsIsolatedTree());
+        if (AXObjectCache::shouldForceAccessibilityEnabled()) [[unlikely]] {
+            // We primarily use this forced-accessibility mode to test accessibility in Speedometer
+            // and other benchmarks, and ITM is a more useful configuration to test in those contexts.
+            environmentAllowsITM = true;
+        }
+
+        enabled = environmentAllowsITM
+            && _AXSIsolatedTreeModeFunctionIsAvailable()
+            // Used to switch via system defaults.
+            && _AXSIsolatedTreeMode_Soft() != AXSIsolatedTreeModeOff;
+    }
     return enabled;
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -755,6 +755,9 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
 
     if (!settings.mutationEventsEnabled())
         m_shouldNotFireMutationEvents = true;
+
+    if (AXObjectCache::shouldForceAccessibilityEnabled()) [[unlikely]]
+        createAXObjectCacheIfNeeded();
 }
 
 void Document::populateDocumentSyncDataForNewlyConstructedDocument(DocumentSyncDataType dataType)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -829,6 +829,7 @@ public:
     bool updateLayoutIfDimensionsOutOfDate(Element&, OptionSet<DimensionsCheck> = { DimensionsCheck::Width, DimensionsCheck::Height }, OptionSet<LayoutOptions> = { });
 
     inline AXObjectCache* existingAXObjectCache() const;
+    void createAXObjectCacheIfNeeded() const { std::ignore = axObjectCache(); }
     WEBCORE_EXPORT AXObjectCache* axObjectCache() const;
     WEBCORE_EXPORT CheckedPtr<AXObjectCache> checkedAXObjectCache() const;
     void clearAXObjectCache();


### PR DESCRIPTION
#### 632ef9070966dcbd81a7f0ea9c1183fa6ddbe46f
<pre>
AX: Add a default to force accessibility to be enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=305927">https://bugs.webkit.org/show_bug.cgi?id=305927</a>
<a href="https://rdar.apple.com/168589848">rdar://168589848</a>

Reviewed by NOBODY (OOPS!).

This will be useful when testing accessibility in benchmarks like Speedometer.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXObjectCache::accessibilityEnabled):
* Source/WebCore/accessibility/cocoa/AXObjectCacheCocoa.mm:
(WebCore::AXObjectCache::shouldForceAccessibilityEnabled):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::isIsolatedTreeEnabled):
* Source/WebCore/dom/Document.cpp:
(WebCore::m_syncData):
* Source/WebCore/dom/Document.h:
(WebCore::Document::createAXObjectCacheIfNeeded const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/632ef9070966dcbd81a7f0ea9c1183fa6ddbe46f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1412 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148044 "Hash 632ef907 for PR 56965 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/92971 "Hash 632ef907 for PR 56965 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6217d8ba-fa90-44c5-8688-d25f64e091b8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/12992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12434 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/148044 "Hash 632ef907 for PR 56965 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/92971 "Hash 632ef907 for PR 56965 does not build (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4d9d764-99be-42aa-b05c-e8ff1dd54406) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125291 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/148044 "Hash 632ef907 for PR 56965 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b488e1ba-1566-4734-aadb-83bf762863b4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9666 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7177 "Passed tests") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8333 "Hash 632ef907 for PR 56965 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1293 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150828 "Hash 632ef907 for PR 56965 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11967 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1359 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/150828 "Hash 632ef907 for PR 56965 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/11980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10256 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/150828 "Hash 632ef907 for PR 56965 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10649 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121771 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/66972 "Hash 632ef907 for PR 56965 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12009 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1246 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11749 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75696 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->