### PR TITLE
Support instantiating multiple wasm memories

### DIFF
--- a/JSTests/wasm/stress/error-duplicate-memory-sections.js
+++ b/JSTests/wasm/stress/error-duplicate-memory-sections.js
@@ -1,0 +1,14 @@
+//@ requireOptions("--useWasmMultiMemory=1")
+
+import * as assert from "../assert.js";
+
+const bytearray = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, // "\0asm"
+    0x01, 0x00, 0x00, 0x00,
+    0x05, 0x03, 0x01, 0x00, 0x0a, // memory section, length 3
+    0x05, 0x03, 0x01, 0x00, 0x0a, // duplicate memory section
+]);
+
+WebAssembly.instantiate(bytearray).then($vm.abort, function (error) {
+    assert.eq(String(error), `CompileError: WebAssembly.Module doesn't parse at byte 13: invalid section order, Memory followed by Memory`);
+}).then(function() {}, $vm.abort);

--- a/JSTests/wasm/stress/import-export-multimemory.js
+++ b/JSTests/wasm/stress/import-export-multimemory.js
@@ -1,0 +1,64 @@
+//@ requireOptions("--useWasmMultiMemory=1")
+
+import * as assert from "../assert.js";
+import { instantiate } from "../wabt-wrapper.js";
+
+// exercise code paths dealing with imported and exported memories
+
+let watExEx = `
+(module
+  (memory (export "mem0") 2 3)
+  (memory (export "mem1") 2 4)
+)
+`
+
+let watImEx = `
+(module
+  (import "js" "mem0" (memory 1))
+  (memory (export "mem1") 1)
+)
+`
+
+let watImIm = `
+(module
+  (import "js" "mem0" (memory 1))
+  (import "js" "mem1" (memory 1))
+)
+`
+
+let watNoMemories = `
+(module
+  (func (export "unused") (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add
+  )
+)
+`
+
+const importedMemory0 = new WebAssembly.Memory({ initial: 1 });
+const importedMemory1 = new WebAssembly.Memory({ initial: 1 });
+
+async function testMultipleExportedMemories() {
+    const instance = await instantiate(watExEx, {}, { multi_memory: true });
+    if(instance.exports.mem0 == undefined) { throw new Error('mem0 undefined'); }
+    if(instance.exports.mem1 == undefined) { throw new Error('mem1 undefined'); }
+}
+
+async function testImportAndExportMemories() {
+    const instance = await instantiate(watImEx, { js: { mem0: importedMemory0 } }, { multi_memory: true });
+    if(instance.exports.mem1 == undefined) { throw new Error('mem1 undefined'); }
+}
+
+async function testMultipleImportedMemories() {
+    const instance = await instantiate(watImIm, { js: { mem0: importedMemory0, mem1: importedMemory1 } }, { multi_memory: true });
+}
+
+async function testNoMemories() {
+    const instance = await instantiate(watNoMemories, {}, { multi_memory: true });
+}
+
+await assert.asyncTest(testMultipleExportedMemories());
+await assert.asyncTest(testImportAndExportMemories());
+await assert.asyncTest(testMultipleImportedMemories());
+await assert.asyncTest(testNoMemories());

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -13973,7 +13973,7 @@ IGNORE_CLANG_WARNINGS_END
         bool wasmBaseMemoryPointerConfiguredAsInputContraints = false;
         auto* instance = wasmFunction->instance();
         arguments.append(ConstrainedValue(frozenPointer(m_graph.freeze(instance)), ValueRep::reg(GPRInfo::wasmContextInstancePointer)));
-        if (!!instance->module().moduleInformation().memory) {
+        if (instance->module().moduleInformation().memoryCount()) {
             auto mode = instance->memoryMode();
             if (mode == MemoryMode::Signaling || (mode == MemoryMode::BoundsChecking && instance->memory()->sharingMode() == MemorySharingMode::Shared)) {
                 // Capacity and basePointer will not be changed.
@@ -14057,7 +14057,7 @@ IGNORE_CLANG_WARNINGS_END
                 constexpr GPRReg scratchGPR = GPRInfo::nonPreservedNonArgumentGPR0;
                 static_assert(noOverlap(GPRInfo::wasmBoundsCheckingSizeRegister, GPRInfo::wasmBaseMemoryPointer, scratchGPR));
                 ASSERT(!RegisterSetBuilder::macroClobberedGPRs().contains(scratchGPR, IgnoreVectors));
-                if (!!instance->module().moduleInformation().memory) {
+                if (instance->module().moduleInformation().memoryCount()) {
                     auto mode = instance->memoryMode();
                     if (!(mode == MemoryMode::Signaling || (mode == MemoryMode::BoundsChecking && instance->memory()->sharingMode() == MemorySharingMode::Shared))) {
                         // We always clobber GPRInfo::wasmBoundsCheckingSizeRegister regardless of mode. It is OK since patchpoint already said it is clobbered.

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -664,6 +664,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
     v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \
+    v(Bool, useWasmMultiMemory, false, Normal, "Allow wasm code to access multiple memories") \
 
 
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1186,7 +1186,7 @@ public:
             // than the declared 'maximum' will trap, so we can compare against that number. If there was no declared 'maximum' then we still know that
             // any access equal to or greater than 4GiB will trap, no need to add the redzone.
             if (uoffset >= Memory::fastMappedRedzoneBytes()) {
-                uint64_t maximum = m_info.memory.maximum() ? m_info.memory.maximum().bytes() : std::numeric_limits<uint32_t>::max();
+                uint64_t maximum = m_info.theOnlyMemory().maximum() ? m_info.theOnlyMemory().maximum().bytes() : std::numeric_limits<uint32_t>::max();
                 m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
                 if (boundary)
                     m_jit.addPtr(TrustedImmPtr(boundary), wasmScratchGPR);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -2978,7 +2978,7 @@ void BBQJIT::emitCatchPrologue()
     m_jit.subPtr(GPRInfo::callFrameRegister, GPRInfo::nonPreservedNonArgumentGPR0, GPRInfo::nonPreservedNonArgumentGPR0);
     m_jit.move(GPRInfo::nonPreservedNonArgumentGPR0, CCallHelpers::stackPointerRegister);
 #endif
-    if (!!m_info.memory)
+    if (m_info.memoryCount())
         loadWebAssemblyGlobalState(wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister);
     static_assert(noOverlap(GPRInfo::nonPreservedNonArgumentGPR0, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR2));
 }
@@ -3308,13 +3308,13 @@ void BBQJIT::restoreWebAssemblyGlobalState()
 {
     restoreWebAssemblyContextInstance();
     // FIXME: We should just store these registers on stack and load them.
-    if (!!m_info.memory)
+    if (m_info.memoryCount())
         loadWebAssemblyGlobalState(wasmBaseMemoryPointer, wasmBoundsCheckingSizeRegister);
 }
 
 void BBQJIT::restoreWebAssemblyGlobalStateAfterWasmCall()
 {
-    if (!!m_info.memory && (m_mode == MemoryMode::Signaling || m_info.memory.isShared())) {
+    if (m_info.memoryCount() && (m_mode == MemoryMode::Signaling || m_info.theOnlyMemory().isShared())) {
         // If memory is signaling or shared, then memoryBase and memorySize will not change. This means that only thing we should check here is GPRInfo::wasmContextInstancePointer is the same or not.
         // Let's consider the case, this was calling a JS function. So it can grow / modify memory whatever. But memoryBase and memorySize are kept the same in this case.
         m_jit.loadPtr(Address(GPRInfo::callFrameRegister, CallFrameSlot::codeBlock * sizeof(Register)), wasmScratchGPR);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -61,7 +61,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint32
             }
             case MemoryMode::Signaling: {
                 if (uoffset >= Memory::fastMappedRedzoneBytes()) {
-                    uint64_t maximum = m_info.memory.maximum() ? m_info.memory.maximum().bytes() : std::numeric_limits<uint32_t>::max();
+                    uint64_t maximum = m_info.theOnlyMemory().maximum() ? m_info.theOnlyMemory().maximum().bytes() : std::numeric_limits<uint32_t>::max();
                     if ((constantPointer + boundary) >= maximum)
                         recordJumpToThrowException(ExceptionType::OutOfBoundsMemoryAccess, m_jit.jump());
                 }
@@ -99,7 +99,7 @@ auto BBQJIT::emitCheckAndPrepareAndMaterializePointerApply(Value pointer, uint32
         // than the declared 'maximum' will trap, so we can compare against that number. If there was no declared 'maximum' then we still know that
         // any access equal to or greater than 4GiB will trap, no need to add the redzone.
         if (uoffset >= Memory::fastMappedRedzoneBytes()) {
-            uint64_t maximum = m_info.memory.maximum() ? m_info.memory.maximum().bytes() : std::numeric_limits<uint32_t>::max();
+            uint64_t maximum = m_info.theOnlyMemory().maximum() ? m_info.theOnlyMemory().maximum().bytes() : std::numeric_limits<uint32_t>::max();
             m_jit.zeroExtend32ToWord(pointerLocation.asGPR(), wasmScratchGPR);
             if (boundary)
                 m_jit.addPtr(TrustedImmPtr(boundary), wasmScratchGPR);

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -704,14 +704,14 @@ auto FunctionParser<Context>::unaryCompareCase(OpType op, UnaryOperationHandler 
 template<typename Context>
 auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "load instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "load instruction without memory"_s);
 
     uint32_t alignment;
     uint64_t offset;
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);
     WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds load's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
-    if (m_info.memory.isMemory64())
+    if (m_info.theOnlyMemory().isMemory64())
         WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get load offset"_s);
     else {
         uint32_t offset32;
@@ -721,7 +721,7 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "load pointer"_s);
 
-    if (m_info.memory.isMemory64())
+    if (m_info.theOnlyMemory().isMemory64())
         WASM_VALIDATOR_FAIL_IF(!pointer.type().isI64(), m_currentOpcode, " pointer type mismatch"_s);
     else
         WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
@@ -735,7 +735,7 @@ auto FunctionParser<Context>::load(Type memoryType) -> PartialResult
 template<typename Context>
 auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "store instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "store instruction without memory"_s);
 
     uint32_t alignment;
     uint64_t offset;
@@ -743,7 +743,7 @@ auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
     TypedExpression pointer;
     WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get store alignment"_s);
     WASM_PARSER_FAIL_IF(alignment > memoryLog2Alignment(m_currentOpcode), "byte alignment "_s, 1ull << alignment, " exceeds store's natural alignment "_s, 1ull << memoryLog2Alignment(m_currentOpcode));
-    if (m_info.memory.isMemory64())
+    if (m_info.theOnlyMemory().isMemory64())
         WASM_PARSER_FAIL_IF(!parseVarUInt64(offset), "can't get store offset"_s);
     else {
         uint32_t offset32;
@@ -753,7 +753,7 @@ auto FunctionParser<Context>::store(Type memoryType) -> PartialResult
     WASM_TRY_POP_EXPRESSION_STACK_INTO(value, "store value"_s);
     WASM_TRY_POP_EXPRESSION_STACK_INTO(pointer, "store pointer"_s);
 
-    if (m_info.memory.isMemory64())
+    if (m_info.theOnlyMemory().isMemory64())
         WASM_VALIDATOR_FAIL_IF(!pointer.type().isI64(), m_currentOpcode, " pointer type mismatch"_s);
     else
         WASM_VALIDATOR_FAIL_IF(!pointer.type().isI32(), m_currentOpcode, " pointer type mismatch"_s);
@@ -781,7 +781,7 @@ auto FunctionParser<Context>::truncSaturated(Ext1OpType op, Type returnType, Typ
 template<typename Context>
 auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
@@ -802,7 +802,7 @@ auto FunctionParser<Context>::atomicLoad(ExtAtomicOpType op, Type memoryType) ->
 template<typename Context>
 auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
@@ -824,7 +824,7 @@ auto FunctionParser<Context>::atomicStore(ExtAtomicOpType op, Type memoryType) -
 template<typename Context>
 auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
@@ -848,7 +848,7 @@ auto FunctionParser<Context>::atomicBinaryRMW(ExtAtomicOpType op, Type memoryTyp
 template<typename Context>
 auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
@@ -875,7 +875,7 @@ auto FunctionParser<Context>::atomicCompareExchange(ExtAtomicOpType op, Type mem
 template<typename Context>
 auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
@@ -902,7 +902,7 @@ auto FunctionParser<Context>::atomicWait(ExtAtomicOpType op, Type memoryType) ->
 template<typename Context>
 auto FunctionParser<Context>::atomicNotify(ExtAtomicOpType op) -> PartialResult
 {
-    WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
+    WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
 
     uint32_t alignment;
     uint32_t offset;
@@ -990,7 +990,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
         default: RELEASE_ASSERT_NOT_REACHED();
         }
 
-        WASM_VALIDATOR_FAIL_IF(!m_info.memory, "simd memory instructions need a memory defined in the module"_s);
+        WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "simd memory instructions need a memory defined in the module"_s);
 
         uint32_t alignment;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get simd memory op alignment"_s);
@@ -2202,7 +2202,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(targetValue, "memory.fill");
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstAddress, "memory.fill");
 
-            if (m_info.memory.isMemory64()) {
+            if (m_info.theOnlyMemory().isMemory64()) {
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind, "memory.fill dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I64);
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != targetValue.type().kind, "memory.fill targetValue to type ", targetValue.type(), " expected ", TypeKind::I32);
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != count.type().kind, "memory.fill size to type ", count.type(), " expected ", TypeKind::I64);
@@ -2228,7 +2228,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(srcAddress, "memory.copy");
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstAddress, "memory.copy");
 
-            if (m_info.memory.isMemory64()) {
+            if (m_info.theOnlyMemory().isMemory64()) {
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind, "memory.copy dstAddress to type ", dstAddress.type(), " expected ", TypeKind::I64);
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != srcAddress.type().kind, "memory.copy targetValue to type ", srcAddress.type(), " expected ", TypeKind::I64);
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != count.type().kind, "memory.copy size to type ", count.type(), " expected ", TypeKind::I64);
@@ -2252,7 +2252,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_TRY_POP_EXPRESSION_STACK_INTO(srcAddress, "memory.init");
             WASM_TRY_POP_EXPRESSION_STACK_INTO(dstAddress, "memory.init");
 
-            if (m_info.memory.isMemory64())
+            if (m_info.theOnlyMemory().isMemory64())
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I64 != dstAddress.type().kind, "memory.init dst address to type ", dstAddress.type(), " expected ", TypeKind::I64);
             else
                 WASM_VALIDATOR_FAIL_IF(TypeKind::I32 != dstAddress.type().kind, "memory.init dst address to type ", dstAddress.type(), " expected ", TypeKind::I32);
@@ -3744,14 +3744,14 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case GrowMemory: {
-        WASM_PARSER_FAIL_IF(!m_info.memory, "grow_memory is only valid if a memory is defined or imported"_s);
+        WASM_PARSER_FAIL_IF(!m_info.memoryCount(), "grow_memory is only valid if a memory is defined or imported"_s);
 
         uint8_t reserved;
         WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for grow_memory"_s);
         WASM_PARSER_FAIL_IF(reserved, "reserved byte for grow_memory must be zero"_s);
 
         TypedExpression delta;
-        bool isMemory64 = m_info.memory.isMemory64();
+        bool isMemory64 = m_info.theOnlyMemory().isMemory64();
         if (isMemory64) {
             WASM_TRY_POP_EXPRESSION_STACK_INTO(delta, "expect an i64 argument to grow_memory on the stack"_s);
             WASM_VALIDATOR_FAIL_IF(!delta.type().isI64(), "grow_memory with non-i64 delta argument has type: ", delta.type());
@@ -3768,7 +3768,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
     }
 
     case CurrentMemory: {
-        WASM_PARSER_FAIL_IF(!m_info.memory, "current_memory is only valid if a memory is defined or imported"_s);
+        WASM_PARSER_FAIL_IF(!m_info.memoryCount(), "current_memory is only valid if a memory is defined or imported"_s);
 
         uint8_t reserved;
         WASM_PARSER_FAIL_IF(!parseUInt8(reserved), "can't parse reserved byte for current_memory"_s);
@@ -3776,7 +3776,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addCurrentMemory(result));
-        m_expressionStack.constructAndAppend(m_info.memory.isMemory64() ? Types::I64 : Types::I32, result);
+        m_expressionStack.constructAndAppend(m_info.theOnlyMemory().isMemory64() ? Types::I64 : Types::I32, result);
 
         return { };
     }
@@ -3999,7 +3999,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE) {
         uint32_t unused;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for "_s, m_currentOpcode, " in unreachable context"_s);
-        if (m_info.memory.isMemory64()) {
+        if (m_info.theOnlyMemory().isMemory64()) {
             uint64_t unused64;
             WASM_PARSER_FAIL_IF(!parseVarUInt64(unused64), "can't get second immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         } else
@@ -4370,7 +4370,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
         case ExtAtomicOpType::I64AtomicRmw32CmpxchgU:
         case ExtAtomicOpType::I64AtomicRmwCmpxchg:
         {
-            WASM_VALIDATOR_FAIL_IF(!m_info.memory, "atomic instruction without memory"_s);
+            WASM_VALIDATOR_FAIL_IF(!m_info.memoryCount(), "atomic instruction without memory"_s);
             uint32_t alignment;
             uint32_t unused;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(alignment), "can't get load alignment"_s);

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -1073,7 +1073,7 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 
 [[nodiscard]] PartialResult IPIntGenerator::load(LoadOpType, ExpressionType, ExpressionType&, uint64_t offset)
 {
-    if (m_info.memory.isMemory64())
+    if (m_info.theOnlyMemory().isMemory64())
         m_metadata->addLEB128ConstantInt64AndLength(offset, getCurrentInstructionLength());
     else
         m_metadata->addLEB128ConstantInt32AndLength(static_cast<uint32_t>(offset), getCurrentInstructionLength());
@@ -1083,7 +1083,7 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 [[nodiscard]] PartialResult IPIntGenerator::store(StoreOpType, ExpressionType, ExpressionType, uint64_t offset)
 {
     changeStackSize(-2);
-    if (m_info.memory.isMemory64())
+    if (m_info.theOnlyMemory().isMemory64())
         m_metadata->addLEB128ConstantInt64AndLength(offset, getCurrentInstructionLength());
     else
         m_metadata->addLEB128ConstantInt32AndLength(static_cast<uint32_t>(offset), getCurrentInstructionLength());

--- a/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
+++ b/Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h
@@ -184,7 +184,7 @@ static inline void SYSV_ABI buildEntryBufferForCatch(Probe::Context& context)
     context.gpr(GPRInfo::argumentGPR2) = std::bit_cast<uintptr_t>(payload);
 
     context.gpr(GPRInfo::wasmContextInstancePointer) = std::bit_cast<uintptr_t>(instance);
-    if (!!instance->moduleInformation().memory) {
+    if (instance->moduleInformation().memoryCount()) {
         context.gpr(GPRInfo::wasmBaseMemoryPointer) = std::bit_cast<uintptr_t>(instance->cachedMemory());
         context.gpr(GPRInfo::wasmBoundsCheckingSizeRegister) = instance->cachedBoundsCheckingSize();
     }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -154,7 +154,8 @@ static JSObject* createTypeReflectionObject(JSGlobalObject* globalObject, JSWebA
         break;
     }
     case Wasm::ExternalKind::Memory: {
-        const auto& memory = module->moduleInformation().memory;
+        // FIXME(wasm-multimemory): double check this code
+        const auto& memory = module->moduleInformation().memory(impOrExp.kindIndex);
         PageCount maximum = memory.maximum();
         if (maximum.isValid()) {
             typeObj = constructEmptyObject(globalObject, globalObject->objectPrototype(), 3);


### PR DESCRIPTION
#### bdf26416947e24f70079c092059353e11569ef94
<pre>
Support instantiating multiple wasm memories
<a href="https://bugs.webkit.org/show_bug.cgi?id=277743">https://bugs.webkit.org/show_bug.cgi?id=277743</a>
<a href="https://rdar.apple.com/133394285">rdar://133394285</a>

Reviewed by Yusuke Suzuki.

Add support for instantiating multiple memories in wasm, but not for
executing instructions that use memories other than index 0. This patch
is gated behind a feature flag &apos;useWasmMultiMemory&apos;.

Tests: JSTests/wasm/stress/error-duplicate-memory-sections.js
       JSTests/wasm/stress/import-export-multimemory.js

* JSTests/wasm/stress/error-duplicate-memory-sections.js: Added.
(then):
* JSTests/wasm/stress/import-export-multimemory.js: Added.
(async testMultipleExportedMemories):
(async testImportAndExportMemories):
(async testMultipleImportedMemories):
(async testNoMemories):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPreparePointer):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCatchPrologue):
(JSC::Wasm::BBQJITImpl::BBQJIT::restoreWebAssemblyGlobalState):
(JSC::Wasm::BBQJITImpl::BBQJIT::restoreWebAssemblyGlobalStateAfterWasmCall):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCheckAndPrepareAndMaterializePointerApply):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::load):
(JSC::Wasm::FunctionParser&lt;Context&gt;::store):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicLoad):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicStore):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicBinaryRMW):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicCompareExchange):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicWait):
(JSC::Wasm::FunctionParser&lt;Context&gt;::atomicNotify):
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::load):
(JSC::Wasm::IPIntGenerator::store):
* Source/JavaScriptCore/wasm/WasmIRGeneratorHelpers.h:
(JSC::Wasm::buildEntryBufferForCatch):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::OMGIRGenerator):
(JSC::Wasm::OMGIRGenerator::restoreWebAssemblyGlobalState):
(JSC::Wasm::OMGIRGenerator::emitIndirectCall):
(JSC::Wasm::OMGIRGenerator::addGrowMemory):
(JSC::Wasm::OMGIRGenerator::emitCheckAndPreparePointer):
(JSC::Wasm::OMGIRGenerator::memoryKind):
(JSC::Wasm::OMGIRGenerator::emitDirectCall):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseImport):
(JSC::Wasm::SectionParser::parseMemoryHelper):
(JSC::Wasm::SectionParser::parseMemory):
(JSC::Wasm::SectionParser::parseExport):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::JSWebAssemblyInstance):
(JSC::JSWebAssemblyInstance::visitChildrenImpl):
(JSC::JSWebAssemblyInstance::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::createTypeReflectionObject):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeImports):
(JSC::WebAssemblyModuleRecord::initializeExports):

Canonical link: <a href="https://commits.webkit.org/307103@main">https://commits.webkit.org/307103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/583f0edc398be2438dd106a559db1ed2b368d9dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95949 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97f635a6-b821-422f-8990-8e68b4636c5e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109796 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79123 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c71e65e-7b98-4f2d-9ef0-d2363cdcf5d5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127723 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90705 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9680722a-04c4-4107-90d8-265e84c4ac5c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9433 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1433 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134749 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153747 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3567 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117812 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118145 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14138 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125009 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70555 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22113 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14901 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3970 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174049 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78610 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44983 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14844 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14698 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->