### PR TITLE
[Tools] Update webkit-test-results script to account for multiple configurations

### DIFF
--- a/Tools/Scripts/webkit-test-results
+++ b/Tools/Scripts/webkit-test-results
@@ -22,12 +22,14 @@
 
 import argparse
 from datetime import datetime
+import functools
 import json
 import logging
 import os
 import pathlib
 import sys
 import textwrap
+from typing import Optional
 from urllib.parse import urljoin, urlencode, parse_qs
 from urllib.request import urlopen
 from urllib.error import HTTPError
@@ -107,17 +109,10 @@ class Query:
 
 
 BOTS = {
-    "gtk-release-x11": Query(
-        platform="GTK", style="release", version_name="Xvfb", version="5.5.0"
-    ),
-    "gtk-release-gtk3": Query(
-        platform="GTK", style="release", version_name="Xvfb", version="4.19.0"
-    ),
-    "gtk-release-wayland": Query(
-        platform="GTK", style="release", version_name="Wayland"
-    ),
-    "wpe-release": Query(platform="WPE", style="release"),
-    "wpe-debug": Query(platform="WPE", style="release"),
+    "gtk-release": Query(platform="GTK", style="release", version_name="Xvfb"),
+    "gtk-debug": Query(platform="GTK", style="debug", version_name="Xvfb"),
+    "wpe-release": Query(platform="WPE", style="release", flavor="wk2"),
+    "wpe-debug": Query(platform="WPE", style="debug", flavor="wk2"),
 }
 
 
@@ -148,10 +143,10 @@ def load_commit_cache(force_reset=False):
 
 
 def reset_commit_cache():
-    """Fetches the last 5000 commits and store their info to be reused in later calls."""
+    """Fetches the last 1000 commits and store their info to be reused in later calls."""
     # TODO Append to existing instead of resetting
     logging.info("Resetting commit cache")
-    limit = 5000
+    limit = 1000
     command = "/api/commits"
 
     query = {"limit": limit, "branch": "main"}
@@ -214,6 +209,23 @@ def get_latest_commit(commits):
     return latest["identifier"], latest["timestamp"]
 
 
+@functools.cache
+def version_string(platform: str, version_number: int, version_name: Optional[str]) -> str:
+    """Translates the version number into a version string, following the resultsdb rules"""
+
+    if platform.lower() not in ('wpe', 'gtk') and version_name:
+        return version_name
+
+    if not version_number:
+        return "0.0.0"
+
+    micro = version_number % 1000
+    minor = (version_number // 1000) % 1000
+    major = version_number // 1000_000
+
+    return f"{major}.{minor}.{micro}"
+
+
 def report_test(args):
     """Reports the test history for a single testcase in a single configuration"""
     endpoint = "api/results/layout-tests"
@@ -225,14 +237,26 @@ def report_test(args):
     url = urljoin(BASE_URL, endpoint + "/" + args.test) + "?" + query
 
     logging.info("Loading test data from %s", url)
-    try:
-        with urlopen(url) as response:
-            data = json.load(response)[0]
-    except IndexError:
+    with urlopen(url) as response:
+        data = json.load(response)
+
+    if not data:
         logging.error("No results returned. Exiting.")
         return 1
 
-    results = sorted(data["results"], key=lambda result: result["uuid"])
+    # Until early 2026 the linux bots used the kernel x.y.z version as the test result version,
+    # resulting in multiple configurations in a short timeframe, so we need to flatten them.
+    all_results = []
+    for configuration_result in data:
+        config_data = configuration_result["configuration"]
+        for result in configuration_result["results"]:
+            result.update(config_data)
+            result["version"] = version_string(result['platform'], result.get("version", 0), result.get('version_name'))
+            all_results.append(result)
+    results = sorted(all_results, key=lambda result: result["uuid"])
+
+    if args.limit > 0:
+        results = results[-args.limit :]
 
     commits = load_commit_cache(force_reset=args.reset_cache)
     logging.info("Found %d cached commits", len(commits))
@@ -246,6 +270,10 @@ def report_test(args):
         expected = result["expected"]
         start_time = datetime.fromtimestamp(result["start_time"])
         uuid = result["uuid"]
+
+        config_str = (
+            "{platform} {version} {flavor} {style} with {architecture}".format(**result)
+        )
 
         try:
             commit = commits[str(uuid)]
@@ -261,8 +289,8 @@ def report_test(args):
             if actual == expected:
                 continue
 
-        msg = "commit {} expected {} actual {} time {}".format(
-            commit["identifier"], expected, actual, start_time
+        msg = "{} '{}' {}: expected {} actual {} ".format(
+            commit.get("identifier", 'UNKNOWN'), config_str, start_time, expected, actual
         )
 
         if args.color:
@@ -294,14 +322,14 @@ def parse_args():
                 test run registered, alongside commit information, expected and actual outcomes,
                 and timestamp of the run. For example:
 
-                $ wk-test-result --bot wpe-release ietestcenter/css3/text/textshadow-001.htm --limit=5
-                commit 244781@main expected PASS actual TEXT time 2021-12-02 18:02:13
-                commit 244787@main expected PASS actual TEXT time 2021-12-02 19:43:10
-                commit 244796@main expected PASS actual TEXT time 2021-12-02 20:41:52
-                commit 244797@main expected PASS actual TEXT time 2021-12-02 21:40:29
-                commit 244803@main expected PASS actual TEXT time 2021-12-02 23:13:19
+                ./Tools/Scripts/webkit-test-results --bot wpe-debug css3/filters/drop-shadow-current-color.html --limit=5
+                305904@main 'WPE 2.51.0 wk2 debug with x86' 2026-01-20 21:30:13: expected PASS actual CRASH
+                305907@main 'WPE 2.51.0 wk2 debug with x86' 2026-01-21 00:24:09: expected PASS actual CRASH
+                305913@main 'WPE 2.51.0 wk2 debug with x86' 2026-01-21 03:16:45: expected PASS actual CRASH
+                305923@main 'WPE 2.51.0 wk2 debug with x86' 2026-01-21 06:01:24: expected PASS actual CRASH
+                305928@main 'WPE 2.51.0 wk2 debug with x86' 2026-01-21 08:44:56: expected PASS actual CRASH
 
-                To avoid querying the commit data at each invocation, the last 5000 commits
+                To avoid querying the commit data at each invocation, the last 1000 commits
                 are cached (by default, to $XDG_CACHE_HOME/wk-gardening-tools/commits.json).
 
                 Currently, only GLIB-based bots and layout-test suite are supported.


### PR DESCRIPTION
#### 0119ae5a00f039256603a10669517654183a6bee
<pre>
[Tools] Update webkit-test-results script to account for multiple configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=305921">https://bugs.webkit.org/show_bug.cgi?id=305921</a>

Reviewed by Carlos Alberto Lopez Perez.

In order to handle multiple configurations, merge the list of results
received before sorting by uuid.

As resultsdbpy removes stale configurations from the cache after two
weeks, the amount of data to merge and sort won&apos;t be a problem. When we
add support to retrieve older results through the `recent=False`
query parameter we can revisit this approach.

This fixes the issue where, after rolling back the GTK/WPE test result
version in 305707@main, only older results using the kernel version were
shown due to appearing earlier in the configuration array.

Also, small drive-by fixes:

- Avoid exception when new results arrive and we don&apos;t have the commit
  info cached. In a follow-up commit we&apos;ll make the script fetch the
  required information.
- Reduce amount of cached commits to the last 1000 commits, as it covers
  the two week cache period.
- Print the configuration for a given result as it&apos;s meaningful.
- Update the list of default bot configurations.

* Tools/Scripts/webkit-test-results:
(reset_commit_cache):
(get_latest_commit):
(translate_version): Added.
(report_test): Updated logic to fetch and process results.
(parse_args):

Canonical link: <a href="https://commits.webkit.org/306096@main">https://commits.webkit.org/306096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5391679f48974a81697ed2ac938b3452e3e4926

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148656 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12871 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107575 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9967 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7513 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8769 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12405 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1715 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115874 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116209 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11334 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122119 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21653 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12448 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1575 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12188 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->