### PR TITLE
Add linear display P3 support to DestinationColorSpace

### DIFF
--- a/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.cpp
@@ -94,6 +94,24 @@ const DestinationColorSpace& DestinationColorSpace::ExtendedDisplayP3()
     return knownColorSpace<PlatformColorSpace::Name::ExtendedDisplayP3>();
 #endif
 }
+
+const DestinationColorSpace& DestinationColorSpace::LinearDisplayP3()
+{
+#if USE(CG) || USE(SKIA)
+    return knownColorSpace<linearDisplayP3ColorSpaceSingleton>();
+#else
+    return knownColorSpace<PlatformColorSpace::Name::LinearDisplayP3>();
+#endif
+}
+
+const DestinationColorSpace& DestinationColorSpace::ExtendedLinearDisplayP3()
+{
+#if USE(CG) || USE(SKIA)
+    return knownColorSpace<extendedLinearDisplayP3ColorSpaceSingleton>();
+#else
+    return knownColorSpace<PlatformColorSpace::Name::ExtendedLinearDisplayP3>();
+#endif
+}
 #endif
 
 #if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
@@ -103,6 +121,15 @@ const DestinationColorSpace& DestinationColorSpace::ExtendedSRGB()
     return knownColorSpace<extendedSRGBColorSpaceSingleton>();
 #else
     return knownColorSpace<PlatformColorSpace::Name::ExtendedSRGB>();
+#endif
+}
+
+const DestinationColorSpace& DestinationColorSpace::ExtendedLinearSRGB()
+{
+#if USE(CG) || USE(SKIA)
+    return knownColorSpace<extendedLinearSRGBColorSpaceSingleton>();
+#else
+    return knownColorSpace<PlatformColorSpace::Name::ExtendedLinearSRGB>();
 #endif
 }
 #endif

--- a/Source/WebCore/platform/graphics/DestinationColorSpace.h
+++ b/Source/WebCore/platform/graphics/DestinationColorSpace.h
@@ -42,9 +42,12 @@ public:
 #if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
     WEBCORE_EXPORT static const DestinationColorSpace& DisplayP3();
     WEBCORE_EXPORT static const DestinationColorSpace& ExtendedDisplayP3();
+    WEBCORE_EXPORT static const DestinationColorSpace& LinearDisplayP3();
+    WEBCORE_EXPORT static const DestinationColorSpace& ExtendedLinearDisplayP3();
 #endif
 #if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_SRGB)
     WEBCORE_EXPORT static const DestinationColorSpace& ExtendedSRGB();
+    WEBCORE_EXPORT static const DestinationColorSpace& ExtendedLinearSRGB();
 #endif
 #if ENABLE(DESTINATION_COLOR_SPACE_EXTENDED_REC_2020)
     WEBCORE_EXPORT static const DestinationColorSpace& ExtendedRec2020();


### PR DESCRIPTION
#### e0bbc340f0fb92ac80122e58ddf2effccac12775
<pre>
Add linear display P3 support to DestinationColorSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=305950">https://bugs.webkit.org/show_bug.cgi?id=305950</a>
<a href="https://rdar.apple.com/168597729">rdar://168597729</a>

Reviewed by Simon Fraser.

Support for these color spaces was already added in <a href="https://bugs.webkit.org/show_bug.cgi?id=298163">https://bugs.webkit.org/show_bug.cgi?id=298163</a>
we were just missing named constants in DestinationColorSpace for extendedLinearSRGB,
linearDisplayP3, and extendedLinearDisplayP3.

Adding the named constants allows the usage of these color spaces on
underlying IOSurfaces.

* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::ExtendedLinearSRGB):
(WebCore::DestinationColorSpace::LinearDisplayP3):
(WebCore::DestinationColorSpace::ExtendedLinearDisplayP3):
* Source/WebCore/platform/graphics/DestinationColorSpace.h:

Canonical link: <a href="https://commits.webkit.org/305978@main">https://commits.webkit.org/305978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0da3cec3f2a672042e3094a5c1d79d19aa7f5b26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148079 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83c3823f-71ee-4483-8643-92dfc3da1550) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12469 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/859c2d80-af3e-4447-a7ec-d7e4f6abda81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88032 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edceedf2-1cb1-49ed-80a8-9f21fe5f3a33) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9695 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7207 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8368 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150865 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115567 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10682 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121803 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12044 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1278 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11784 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11980 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->