### PR TITLE
Support using Ref for IDLInterfaces in IDL callback return types

### DIFF
--- a/Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h
@@ -44,7 +44,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    virtual CallbackResult<RefPtr<DOMPromise>> invoke(JSC::JSValue thisValue, JSC::JSValue reason) = 0;
+    virtual CallbackResult<Ref<DOMPromise>> invoke(JSC::JSValue thisValue, JSC::JSValue reason) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h
@@ -46,7 +46,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    virtual CallbackResult<RefPtr<DOMPromise>> invoke(JSC::JSValue, ReadableByteStreamController&) = 0;
+    virtual CallbackResult<Ref<DOMPromise>> invoke(JSC::JSValue, ReadableByteStreamController&) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
+++ b/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
@@ -43,7 +43,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    virtual CallbackResult<RefPtr<DOMPromise>> invoke(WebLock*) = 0;
+    virtual CallbackResult<Ref<DOMPromise>> invoke(WebLock*) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
@@ -47,8 +47,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    virtual CallbackResult<RefPtr<AudioWorkletProcessor>> invoke(JSC::Strong<JSC::JSObject> options) = 0;
-    virtual CallbackResult<RefPtr<AudioWorkletProcessor>> invokeRethrowingException(JSC::Strong<JSC::JSObject> options) = 0;
+    virtual CallbackResult<Ref<AudioWorkletProcessor>> invoke(JSC::Strong<JSC::JSObject> options) = 0;
+    virtual CallbackResult<Ref<AudioWorkletProcessor>> invokeRethrowingException(JSC::Strong<JSC::JSObject> options) = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -210,10 +210,8 @@ template<typename T> struct IDLWrapper : IDLType<Ref<T>> {
     // See "Support using Ref for IDLInterfaces in IDL unions (https://bugs.webkit.org/show_bug.cgi?id=274729)".
     using UnionStorageType = RefPtr<T>;
 
-    // FIXME: These are needed to work around callback return types storing non-nullable interfaces using RefPtr rather than Ref<>.
-    // See "Support using Ref for IDLInterfaces in IDL callback return types (https://bugs.webkit.org/show_bug.cgi?id=305412)".
-    using CallbackReturnType = RefPtr<T>;
-    using NullableCallbackReturnType = std::optional<RefPtr<T>>;
+    using CallbackReturnType = Ref<T>;
+    using NullableCallbackReturnType = RefPtr<T>;
 
     using ConversionResultType = std::reference_wrapper<T>;
     using NullableConversionResultType = T*;

--- a/Source/WebCore/dom/CallbackResult.h
+++ b/Source/WebCore/dom/CallbackResult.h
@@ -41,6 +41,7 @@ public:
     CallbackResult(ReturnType&&);
 
     CallbackResultType type() const;
+    const ReturnType& returnValue() const LIFETIME_BOUND;
     ReturnType&& releaseReturnValue();
 
 private:
@@ -74,12 +75,17 @@ template<typename ReturnType> inline CallbackResultType CallbackResult<ReturnTyp
     return m_value.has_value() ? CallbackResultType::Success : m_value.error();
 }
 
+template<typename ReturnType> inline auto CallbackResult<ReturnType>::returnValue() const LIFETIME_BOUND -> const ReturnType&
+{
+    ASSERT(m_value.has_value());
+    return m_value.value();
+}
+
 template<typename ReturnType> inline auto CallbackResult<ReturnType>::releaseReturnValue() -> ReturnType&&
 {
     ASSERT(m_value.has_value());
     return WTF::move(m_value.value());
 }
-
 
 // Void specialization
 

--- a/Source/WebCore/dom/ViewTransitionUpdateCallback.h
+++ b/Source/WebCore/dom/ViewTransitionUpdateCallback.h
@@ -42,7 +42,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    virtual CallbackResult<RefPtr<DOMPromise>> invoke() = 0;
+    virtual CallbackResult<Ref<DOMPromise>> invoke() = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1167,7 +1167,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
         for (auto& handler : event->handlers()) {
             auto callbackResult = handler->invoke();
             if (callbackResult.type() != CallbackResultType::UnableToExecute) {
-                Ref promise = callbackResult.releaseReturnValue().releaseNonNull();
+                Ref promise = callbackResult.releaseReturnValue();
                 // Because rejection is reported as `navigateerror` event, we can mark this as handled.
                 if (!promise->isSuspended())
                     promise->markAsHandled();

--- a/Source/WebCore/page/NavigationInterceptHandler.h
+++ b/Source/WebCore/page/NavigationInterceptHandler.h
@@ -39,7 +39,7 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
-    virtual CallbackResult<WTF::RefPtr<DOMPromise>> invoke() = 0;
+    virtual CallbackResult<Ref<DOMPromise>> invoke() = 0;
 
 private:
     virtual bool hasCallback() const = 0;

--- a/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h
+++ b/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h
@@ -45,7 +45,7 @@ public:
     void ref() const override { RefCounted::ref(); }
     void deref() const override { RefCounted::deref(); }
 
-    virtual CallbackResult<RefPtr<DOMPromise>> invoke(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptionsWrapper&) = 0;
+    virtual CallbackResult<Ref<DOMPromise>> invoke(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptionsWrapper&) = 0;
 
     void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&) override;
 


### PR DESCRIPTION
#### e8320555bf3a0f6cf4fe339a8fa20210949f4e47
<pre>
Support using Ref for IDLInterfaces in IDL callback return types
<a href="https://bugs.webkit.org/show_bug.cgi?id=305412">https://bugs.webkit.org/show_bug.cgi?id=305412</a>
<a href="https://rdar.apple.com/168524228">rdar://168524228</a>

Reviewed by Darin Adler and Chris Dumez.

Switches to using Ref for non-nullable callback return values of
IDL wrappers, including interfaces and promises.

* Source/WebCore/bindings/IDLTypes.h:
    - Update aliases to use Ref for non-nullable and RefPtr
      for nullable.

* Source/WebCore/dom/CallbackResult.h:
    - Add non-releasing `returnValue()` function (mirroring the API of
      `ConversionResult`).

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    - Add some missing derived sources that I needed to look at while
      making this change.

* Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h:
* Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h:
* Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/dom/ViewTransitionUpdateCallback.h:
* Source/WebCore/page/Navigation.cpp:
* Source/WebCore/page/NavigationInterceptHandler.h:
* Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h:
    - Update to use Ref instead of RefPtr.

Canonical link: <a href="https://commits.webkit.org/306025@main">https://commits.webkit.org/306025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb7fc6352b11e22eef3fadd04465a17d164d8aa4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140116 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148267 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107274 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125459 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88165 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7343 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151053 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12183 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115701 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116026 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29480 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10990 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121941 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12224 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1417 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11966 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75922 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->