### PR TITLE
[JSC][GreedyRegAlloc] Add --airGreedyRegAllocSpillsEverything option

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -759,6 +759,16 @@ private:
         });
     }
 
+    bool shouldSpillEverything()
+    {
+        if (!Options::airGreedyRegAllocSpillsEverything())
+            return false;
+
+        // You're meant to hack this so that you selectively spill everything depending on reasons.
+        // That's super useful for debugging.
+        return true;
+    }
+
     void buildRegisterSets()
     {
         forEachBank([&] (Bank bank) {
@@ -1552,7 +1562,8 @@ private:
                 return;
             }
             m_stats[bank].maxLiveRangeSize = std::max(m_stats[bank].maxLiveRangeSize, static_cast<unsigned>(tmpData.liveRange.size()));
-            setStageAndEnqueue(tmp, tmpData, Stage::TryAllocate);
+            Stage initialStage = shouldSpillEverything() ? Stage::Spill : Stage::TryAllocate;
+            setStageAndEnqueue(tmp, tmpData, initialStage);
         });
 
         do {

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1143,7 +1143,7 @@ void testCallSimpleDouble(double, double);
 void testCallSimpleFloat(float, float);
 void testCallFunctionWithHellaDoubleArguments();
 void testCallFunctionWithHellaFloatArguments();
-void testLinearScanWithCalleeOnStack();
+void testForcedSpillCalleeOnStack();
 void testChillDiv(int num, int den, int res);
 void testChillDivTwice(int num1, int den1, int num2, int den2, int res);
 void testChillDiv64(int64_t num, int64_t den, int64_t res);

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -589,7 +589,7 @@ void run(const TestConfig* config)
 
     addCallTests(config, tasks);
 
-    RUN(testLinearScanWithCalleeOnStack());
+    RUN(testForcedSpillCalleeOnStack());
 
     RUN(testChillDiv(4, 2, 2));
     RUN(testChillDiv(1, 0, 0));

--- a/Source/JavaScriptCore/b3/testb3_5.cpp
+++ b/Source/JavaScriptCore/b3/testb3_5.cpp
@@ -2430,10 +2430,10 @@ void testCallFunctionWithHellaFloatArguments()
     CHECK_EQ(compileAndRun<float>(proc), functionWithHellaFloatArguments(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26));
 }
 
-void testLinearScanWithCalleeOnStack()
+void testForcedSpillCalleeOnStack()
 {
-    // This tests proper CCall generation when compiling with a lower optimization
-    // level and operating with a callee argument that's spilt on the stack.
+    // This tests proper CCall generation when compiling with forced spilling
+    // to operate with a callee argument that's spilt on the stack.
     // On ARM64, this caused an assert in MacroAssemblerARM64 because of disallowed
     // use of the scratch register.
     // https://bugs.webkit.org/show_bug.cgi?id=170672
@@ -2450,16 +2450,14 @@ void testLinearScanWithCalleeOnStack()
             arguments[0],
             arguments[1]));
 
-    // Force the linear scan algorithm to spill everything.
-    auto original = Options::airLinearScanSpillsEverything();
-    Options::airLinearScanSpillsEverything() = true;
+    // Force the greedy register allocator to spill everything.
+    auto original = Options::airGreedyRegAllocSpillsEverything();
+    Options::airGreedyRegAllocSpillsEverything() = true;
 
-    // Compiling with 1 as the optimization level enforces the use of linear scan
-    // for register allocation.
     auto code = compileProc(proc);
     CHECK_EQ(invoke<int>(*code, 41, 1), 42);
 
-    Options::airLinearScanSpillsEverything() = original;
+    Options::airGreedyRegAllocSpillsEverything() = original;
 }
 
 void testChillDiv(int num, int den, int res)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -501,6 +501,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, airGreedyRegAllocVerbose, false, Normal, nullptr) \
     v(Bool, airUseGreedyRegAlloc, true, Normal, nullptr) \
     v(Double, airGreedyRegAllocSplitMultiplier, 2.0, Normal, nullptr) \
+    v(Bool, airGreedyRegAllocSpillsEverything, false, Normal, nullptr) \
     v(Bool, airDumpRegAllocStats, false, Normal, nullptr) \
     v(Bool, airValidateGreedRegAlloc, ASSERT_ENABLED, Normal, nullptr) \
     v(Bool, airRandomizeRegs, false, Normal, nullptr) \


### PR DESCRIPTION
#### 2fa6472ab7caddc0cefcc5a38bf8a90fb91dc693
<pre>
[JSC][GreedyRegAlloc] Add --airGreedyRegAllocSpillsEverything option
<a href="https://bugs.webkit.org/show_bug.cgi?id=305952">https://bugs.webkit.org/show_bug.cgi?id=305952</a>
<a href="https://rdar.apple.com/168599535">rdar://168599535</a>

Reviewed by Yusuke Suzuki.

In preparation for removing the linear scan register allocator,
add the option --airGreedyRegAllocSpillsEverything which is analogous
to the soon-to-be-removed option --airLinearScanSpillsEverything.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_5.cpp

Canonical link: <a href="https://commits.webkit.org/305960@main">https://commits.webkit.org/305960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc2bb721bd821d8dbc31307ece912b0a081b95c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148067 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/92994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9955d39-61e5-41cd-b07f-5a14e6c85bb9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12457 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/92994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e763f29-77fe-45b4-870c-ff08d8c89d62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125312 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/88025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1cd3e453-ed14-4bb4-bad1-6f4992798538) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7197 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8356 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/131898 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/118909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150853 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/720 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/11990 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1380 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115877 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10672 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121792 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/66995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21582 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12032 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1267 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171196 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11772 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11968 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11820 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->