### PR TITLE
Temporarily disable CopyOnWrite by default for ShareableBitmap

### DIFF
--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -47,12 +47,7 @@ class GraphicsContext;
 class Image;
 class NativeImage;
 
-#if OS(DARWIN)
-inline constexpr auto defaultCopyOnWrite = SharedMemory::CopyOnWrite::Yes;
-#else
-// FIXME: https://bugs.webkit.org/show_bug.cgi?id=305633
 inline constexpr auto defaultCopyOnWrite = SharedMemory::CopyOnWrite::No;
-#endif
 
 class ShareableBitmapConfiguration {
 public:

--- a/Tools/TestWebKitAPI/Tests/WebCore/ShareableBitmap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ShareableBitmap.cpp
@@ -59,7 +59,7 @@ static void expectTestPattern(std::span<uint8_t> data, size_t seed)
     EXPECT_EQ(data[mid], static_cast<uint8_t>(seed + 99));
 }
 
-TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWrite)
+TEST(ShareableBitmap, DISABLED_ensureCOWBothMapsRWSenderWrite)
 {
     WebCore::ShareableBitmapConfiguration configuration = { WebCore::IntSize(100, 100) };
     auto bitmap = WebCore::ShareableBitmap::create(configuration);
@@ -74,7 +74,7 @@ TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWrite)
     expectTestPattern(bitmap2->mutableSpan(), 0);
 }
 
-TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWriteReceiverWrite)
+TEST(ShareableBitmap, DISABLED_ensureCOWBothMapsRWSenderWriteReceiverWrite)
 {
     WebCore::ShareableBitmapConfiguration configuration = { WebCore::IntSize(100, 100) };
     auto bitmap = WebCore::ShareableBitmap::create(configuration);
@@ -89,7 +89,7 @@ TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWriteReceiverWrite)
     expectTestPattern(bitmap2->mutableSpan(), 1);
 }
 
-TEST(ShareableBitmap, ensureCOWBothMapsROSenderWrite)
+TEST(ShareableBitmap, DISABLED_ensureCOWBothMapsROSenderWrite)
 {
     WebCore::ShareableBitmapConfiguration configuration = { WebCore::IntSize(100, 100) };
     auto bitmap = WebCore::ShareableBitmap::create(configuration);


### PR DESCRIPTION
#### 7646e55e60a6bf66d692be7c1b42bf7294dd8799
<pre>
Temporarily disable CopyOnWrite by default for ShareableBitmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=305954">https://bugs.webkit.org/show_bug.cgi?id=305954</a>
<a href="https://rdar.apple.com/168603373">rdar://168603373</a>

Reviewed by Kimmo Kinnunen and Anne van Kesteren.

Temporarily disable CopyOnWrite by default for ShareableBitmap.
This will be re-enabled once the memory is being correctly attributed.

* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Tools/TestWebKitAPI/Tests/WebCore/ShareableBitmap.cpp:
(TestWebKitAPI::TEST(ShareableBitmap, DISABLED_ensureCOWBothMapsRWSenderWrite)):
(TestWebKitAPI::TEST(ShareableBitmap, DISABLED_ensureCOWBothMapsRWSenderWriteReceiverWrite)):
(TestWebKitAPI::TEST(ShareableBitmap, DISABLED_ensureCOWBothMapsROSenderWrite)):
(TestWebKitAPI::TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWrite)): Deleted.
(TestWebKitAPI::TEST(ShareableBitmap, ensureCOWBothMapsRWSenderWriteReceiverWrite)): Deleted.
(TestWebKitAPI::TEST(ShareableBitmap, ensureCOWBothMapsROSenderWrite)): Deleted.

Canonical link: <a href="https://commits.webkit.org/306089@main">https://commits.webkit.org/306089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ced5cf7fcc305604718edf27fda69824c1dd2316

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139985 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148128 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a39070fe-900e-4f59-ad44-6e09ba3cc106) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107180 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77994 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94ca6d1a-93c1-4da8-a5d2-2941432b5dd4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88059 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5facebf-03c1-4b4a-84ae-f1ad2d9fe1e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7242 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8417 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150916 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115600 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115916 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10730 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121842 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67056 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12421 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1316 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75780 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12029 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11881 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->