### PR TITLE
Web Inspector broken and shows up blank

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -279,19 +279,15 @@ AllowMultiElementImplicitSubmission:
 AllowMultipleCommitLayerTreePending:
   type: bool
   status: internal
-  category: dom
   humanReadableName: "Allow requesting CommitLayerTree before the previous has completed"
   humanReadableDescription: "Allow requesting CommitLayerTree before the previous has completed"
   defaultValue:
     WebKitLegacy:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
+      default: false
     WebKit:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
+      default: false
     WebCore:
-      "PLATFORM(IOS_FAMILY)": false
-      default: true
+      default: false
 
 AllowPrivacySensitiveOperationsInNonPersistentDataStores:
   type: bool

--- a/Source/WebKit/Shared/MonotonicObjectIdentifier.h
+++ b/Source/WebKit/Shared/MonotonicObjectIdentifier.h
@@ -46,7 +46,6 @@ public:
     { }
 
     bool isHashTableDeletedValue() const { return m_identifier == hashTableDeletedValue(); }
-    bool isHashTableEmptyValue() const { return !*this; }
 
     friend auto operator<=>(MonotonicObjectIdentifier, MonotonicObjectIdentifier) = default;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -52,60 +52,6 @@ class RemoteAnimationStack;
 class RemoteAnimationTimeline;
 #endif
 
-enum class PendingCommitMessage {
-    NotifyPendingCommitLayerTree,
-    NotifyFlushingLayerTree,
-    CommitLayerTree,
-};
-
-enum class CommitDelayState {
-    Pending,
-    Delayed,
-    IntentionallyDeferred,
-};
-
-struct PendingCommit {
-    TransactionID transactionID;
-    PendingCommitMessage pendingMessage;
-    CommitDelayState delayState;
-};
-
-struct ProcessState {
-    WTF_MAKE_NONCOPYABLE(ProcessState);
-    ProcessState(WebProcessProxy&);
-    ProcessState(WTF::HashTableDeletedValueType)
-        : nextLayerTreeTransactionID(WTF::HashTableDeletedValue)
-    {
-    }
-    ProcessState(TransactionID transactionID)
-        : nextLayerTreeTransactionID(transactionID)
-    {
-    }
-    ProcessState(ProcessState&&) = default;
-    ProcessState& operator=(ProcessState&&) = default;
-
-    bool canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy&);
-
-    Vector<PendingCommit, 2> pendingCommits;
-    TransactionID nextLayerTreeTransactionID;
-    std::optional<TransactionID> committedLayerTreeTransactionID;
-    uint32_t delayedCommits { 0 };
-};
-
-} // namespace WebKit
-
-namespace WTF {
-
-template<> struct HashTraits<WebKit::ProcessState> : SimpleClassHashTraits<WebKit::ProcessState> {
-    static constexpr bool emptyValueIsZero = HashTraits<WebKit::TransactionID>::emptyValueIsZero;
-    static WebKit::ProcessState emptyValue() { return { HashTraits<WebKit::TransactionID>::emptyValue() }; }
-    static bool isEmptyValue(const WebKit::ProcessState& value) { return HashTraits<WebKit::TransactionID>::isEmptyValue(value.nextLayerTreeTransactionID); }
-};
-
-} // namespace WTF
-
-namespace WebKit {
-
 class RemoteLayerTreeDrawingAreaProxy : public DrawingAreaProxy, public RefCounted<RemoteLayerTreeDrawingAreaProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteLayerTreeDrawingAreaProxy);
     WTF_MAKE_NONCOPYABLE(RemoteLayerTreeDrawingAreaProxy);
@@ -154,6 +100,14 @@ public:
 
     void drawSlowFrameIndicator(WebCore::GraphicsContext&);
 
+    struct CommitLayerTreePending {
+        size_t requestedNotifyPendingCommitLayerTree { 1 };
+        size_t requestedCommitLayerTree { 1 };
+        bool missedDisplayDidRefresh { false };
+    };
+    struct NeedsDisplayDidRefresh { };
+    struct Idle { };
+
     bool allowMultipleCommitLayerTreePending();
 
 protected:
@@ -162,6 +116,23 @@ protected:
     void updateDebugIndicatorPosition();
 
     bool shouldCoalesceVisualEditorStateUpdates() const override { return true; }
+
+    // displayDidRefresh is sent to the WebProcess, and it responds
+    // with a commitLayerTree message (ideally before the next
+    // displayDidRefresh, otherwise we mark it as missed and send
+    // it when commitLayerTree does arrive).
+    struct ProcessState {
+        WTF_MAKE_NONCOPYABLE(ProcessState);
+        ProcessState() = default;
+        ProcessState(ProcessState&&) = default;
+        ProcessState& operator=(ProcessState&&) = default;
+
+        bool canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy&);
+
+        Variant<Idle, CommitLayerTreePending, NeedsDisplayDidRefresh> commitLayerTreeMessageState;
+        std::optional<TransactionID> pendingLayerTreeTransactionID;
+        std::optional<TransactionID> committedLayerTreeTransactionID;
+    };
 
     ProcessState& processStateForConnection(IPC::Connection&);
     const ProcessState& processStateForIdentifier(WebCore::ProcessIdentifier) const;
@@ -220,7 +191,6 @@ private:
     virtual void setPreferredFramesPerSecond(IPC::Connection&, WebCore::FramesPerSecond) { }
 
     void notifyPendingCommitLayerTree(IPC::Connection&, std::optional<TransactionID>);
-    void notifyFlushingLayerTree(IPC::Connection&, TransactionID);
     void commitLayerTree(IPC::Connection&, const RemoteLayerTreeCommitBundle&, HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&&);
     void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&);
     virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&, const TransactionID&) { }
@@ -257,9 +227,9 @@ private:
     unsigned m_countOfTransactionsWithNonEmptyLayerChanges { 0 };
 };
 
-TextStream& operator<<(TextStream&, const CommitDelayState&);
-TextStream& operator<<(TextStream&, const PendingCommitMessage&);
-TextStream& operator<<(TextStream&, const PendingCommit&);
+TextStream& operator<<(TextStream&, const RemoteLayerTreeDrawingAreaProxy::Idle&);
+TextStream& operator<<(TextStream&, const RemoteLayerTreeDrawingAreaProxy::NeedsDisplayDidRefresh&);
+TextStream& operator<<(TextStream&, const RemoteLayerTreeDrawingAreaProxy::CommitLayerTreePending&);
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -28,7 +28,6 @@
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
     void NotifyPendingCommitLayerTree(std::optional<WebKit::TransactionID> transactionID) CanDispatchOutOfOrder
-    void NotifyFlushingLayerTree(WebKit::TransactionID transactionID) CanDispatchOutOfOrder
     void CommitLayerTree(struct WebKit::RemoteLayerTreeCommitBundle bundle, HashMap<WebKit::ImageBufferSetIdentifier, std::unique_ptr<WebKit::BufferSetBackendHandle>> handlesMap) CanDispatchOutOfOrder
     void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::RemoteLayerBackingStoreProperties properties)
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -98,7 +98,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxy);
 RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy(WebPageProxy& pageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(pageProxy, webProcessProxy)
     , m_remoteLayerTreeHost(makeUnique<RemoteLayerTreeHost>(*this))
-    , m_webPageProxyProcessState(webProcessProxy)
 {
     // We don't want to pool surfaces in the UI process.
     // FIXME: We should do this somewhere else.
@@ -121,18 +120,13 @@ std::span<IPC::ReceiverName> RemoteLayerTreeDrawingAreaProxy::messageReceiverNam
 
 void RemoteLayerTreeDrawingAreaProxy::addRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy& proxy)
 {
-    m_remotePageProcessState.add(proxy.process().coreProcessIdentifier(), ProcessState(proxy.process()));
+    m_remotePageProcessState.add(proxy.process().coreProcessIdentifier(), ProcessState { });
 }
 
 void RemoteLayerTreeDrawingAreaProxy::removeRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy& proxy)
 {
     ASSERT(m_remotePageProcessState.contains(proxy.process().coreProcessIdentifier()));
     m_remotePageProcessState.remove(proxy.process().coreProcessIdentifier());
-}
-
-ProcessState::ProcessState(WebProcessProxy& webProcess)
-    : nextLayerTreeTransactionID(TransactionID(TransactionIdentifier(), webProcess.coreProcessIdentifier()).next())
-{
 }
 
 std::unique_ptr<RemoteLayerTreeHost> RemoteLayerTreeDrawingAreaProxy::detachRemoteLayerTreeHost()
@@ -156,11 +150,7 @@ void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
 
 TransactionID RemoteLayerTreeDrawingAreaProxy::nextMainFrameLayerTreeTransactionID() const
 {
-    for (int i = m_webPageProxyProcessState.pendingCommits.size() - 1; i >= 0; i--) {
-        if (m_webPageProxyProcessState.pendingCommits[i].pendingMessage > PendingCommitMessage::NotifyPendingCommitLayerTree)
-            return m_webPageProxyProcessState.pendingCommits[i].transactionID;
-    }
-    return lastCommittedMainFrameLayerTreeTransactionID();
+    return m_webPageProxyProcessState.pendingLayerTreeTransactionID.value_or(TransactionID(TransactionIdentifier(), webProcessProxy().coreProcessIdentifier())).next();
 }
 
 TransactionID RemoteLayerTreeDrawingAreaProxy::lastCommittedMainFrameLayerTreeTransactionID() const
@@ -240,7 +230,7 @@ void RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry()
     });
 }
 
-ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForConnection(IPC::Connection& connection)
+RemoteLayerTreeDrawingAreaProxy::ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForConnection(IPC::Connection& connection)
 {
     for (auto& [key, value] : m_remotePageProcessState) {
         RefPtr webProcess = WebProcessProxy::processForIdentifier(key);
@@ -262,7 +252,7 @@ void RemoteLayerTreeDrawingAreaProxy::forEachProcessState(NOESCAPE Function<void
     }
 }
 
-const ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForIdentifier(WebCore::ProcessIdentifier identifier) const
+const RemoteLayerTreeDrawingAreaProxy::ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForIdentifier(WebCore::ProcessIdentifier identifier) const
 {
     if (webProcessProxy().coreProcessIdentifier() == identifier)
         return m_webPageProxyProcessState;
@@ -283,25 +273,32 @@ IPC::Connection* RemoteLayerTreeDrawingAreaProxy::connectionForIdentifier(WebCor
 void RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree(IPC::Connection& connection, std::optional<TransactionID> transactionID)
 {
     ProcessState& state = processStateForConnection(connection);
-    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree " << transactionID << " old state: " << state.pendingCommits);
+    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree " << transactionID << " old state: " << state.commitLayerTreeMessageState);
     if (transactionID) {
-        if (state.pendingCommits.isEmpty()) {
-            // The very first commit is initiated by WebContent, all others get
-            // started in response to displayDidRefresh.
-            MESSAGE_CHECK_BASE(state.nextLayerTreeTransactionID.object() == TransactionIdentifier().next(), connection);
-            MESSAGE_CHECK_BASE(state.nextLayerTreeTransactionID == *transactionID, connection);
-            state.pendingCommits.insert(0, { *transactionID, PendingCommitMessage::NotifyFlushingLayerTree, CommitDelayState::Pending });
-            state.nextLayerTreeTransactionID = transactionID->next();
-        } else {
-            MESSAGE_CHECK_BASE(state.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyPendingCommitLayerTree && state.pendingCommits[0].transactionID == *transactionID, connection);
-            state.pendingCommits[0].pendingMessage = PendingCommitMessage::NotifyFlushingLayerTree;
-        }
+        MESSAGE_CHECK_BASE(std::holds_alternative<CommitLayerTreePending>(state.commitLayerTreeMessageState) || std::holds_alternative<Idle>(state.commitLayerTreeMessageState), connection);
+        MESSAGE_CHECK_BASE(!state.pendingLayerTreeTransactionID || *transactionID == state.pendingLayerTreeTransactionID->next(), connection);
+        state.pendingLayerTreeTransactionID = *transactionID;
+        if (auto* commitLayerTreePending = std::get_if<CommitLayerTreePending>(&state.commitLayerTreeMessageState)) {
+            MESSAGE_CHECK_BASE(commitLayerTreePending->requestedNotifyPendingCommitLayerTree, connection);
+            commitLayerTreePending->requestedNotifyPendingCommitLayerTree--;
+
+            if (state.canSendDisplayDidRefresh(*this) && commitLayerTreePending->missedDisplayDidRefresh) {
+                LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree - sending missed didRefreshDisplay");
+                commitLayerTreePending->missedDisplayDidRefresh = false;
+                didRefreshDisplay(&connection);
+            }
+        } else
+            state.commitLayerTreeMessageState = CommitLayerTreePending { 0, 1, false };
     } else {
-        // This frame is still pending, it'll be sent when the WebProcess decides it's ready.
-        // Use the IntentionallyDeferred state so that we don't think that it's late
-        // when displayDidRefresh arrives.
-        MESSAGE_CHECK_BASE(state.pendingCommits.size() && state.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyPendingCommitLayerTree, connection);
-        state.pendingCommits[0].delayState = CommitDelayState::IntentionallyDeferred;
+        MESSAGE_CHECK_BASE(std::holds_alternative<CommitLayerTreePending>(state.commitLayerTreeMessageState), connection);
+        auto& commitLayerTreePending = std::get<CommitLayerTreePending>(state.commitLayerTreeMessageState);
+        MESSAGE_CHECK_BASE(commitLayerTreePending.requestedNotifyPendingCommitLayerTree, connection);
+
+        commitLayerTreePending.requestedNotifyPendingCommitLayerTree--;
+        if (!--commitLayerTreePending.requestedCommitLayerTree) {
+            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTre all pending commits received, becoming idle");
+            state.commitLayerTreeMessageState = Idle { };
+        }
 
         maybePauseDisplayRefreshCallbacks();
 
@@ -312,32 +309,19 @@ void RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree(IPC::Connecti
     }
 }
 
-void RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree(IPC::Connection& connection, TransactionID transactionID)
-{
-    ProcessState& state = processStateForConnection(connection);
-    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree " << transactionID << " old state: " << state.pendingCommits);
-
-    MESSAGE_CHECK_BASE(state.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyFlushingLayerTree && state.pendingCommits[0].transactionID == transactionID, connection);
-    state.pendingCommits[0].pendingMessage = PendingCommitMessage::CommitLayerTree;
-
-    if (state.canSendDisplayDidRefresh(*this) && state.pendingCommits[0].delayState == CommitDelayState::Delayed) {
-        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree - sending missed didRefreshDisplay");
-        didRefreshDisplay(&connection);
-    }
-}
-
 void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connection, const RemoteLayerTreeCommitBundle& bundle, HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&& handlesMap)
 {
     {
         ProcessState& state = processStateForConnection(connection);
-        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree old state: " << state.pendingCommits);
+        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree old state: " << state.commitLayerTreeMessageState);
         LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree page data: " << bundle.pageData.description());
         if (bundle.mainFrameData)
             LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree main frame data: " << bundle.mainFrameData->description());
         LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree bundle data: " << bundle.description());
-        MESSAGE_CHECK_BASE(state.pendingCommits.size(), connection);
-        MESSAGE_CHECK_BASE(state.pendingCommits.last().pendingMessage == PendingCommitMessage::CommitLayerTree, connection);
-        MESSAGE_CHECK_BASE(state.pendingCommits.last().transactionID == bundle.transactionID, connection);
+        MESSAGE_CHECK_BASE(std::holds_alternative<CommitLayerTreePending>(state.commitLayerTreeMessageState), connection);
+        MESSAGE_CHECK_BASE(std::get<CommitLayerTreePending>(state.commitLayerTreeMessageState).requestedCommitLayerTree, connection);
+        MESSAGE_CHECK_BASE(state.pendingLayerTreeTransactionID, connection);
+        MESSAGE_CHECK_BASE(bundle.transactionID.lessThanOrEqualSameProcess(*state.pendingLayerTreeTransactionID), connection);
         MESSAGE_CHECK_BASE(!state.committedLayerTreeTransactionID || bundle.transactionID == state.committedLayerTreeTransactionID->next(), connection);
     }
 
@@ -365,12 +349,6 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
         }
     }
 
-    PendingCommit completedCommit = [&]() {
-        ProcessState& state = processStateForConnection(connection);
-        state.committedLayerTreeTransactionID = bundle.transactionID;
-        return state.pendingCommits.takeLast();
-    }();
-
     RefPtr page = this->page();
     if (!page)
         return;
@@ -396,6 +374,11 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
 
         if (auto milestones = bundle.mainFrameData->newlyReachedPaintingMilestones)
             page->didReachLayoutMilestone(milestones, WallTime::now());
+    }
+
+    {
+        ProcessState& state = processStateForConnection(connection);
+        state.committedLayerTreeTransactionID = bundle.transactionID;
     }
 
     WeakPtr weakThis { *this };
@@ -427,14 +410,16 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
 
     {
         ProcessState& state = processStateForConnection(connection);
-        if (state.canSendDisplayDidRefresh(*this) && completedCommit.delayState == CommitDelayState::Delayed) {
+        auto& commitLayerTreePending = std::get<CommitLayerTreePending>(state.commitLayerTreeMessageState);
+        ASSERT(commitLayerTreePending.requestedCommitLayerTree);
+        commitLayerTreePending.requestedCommitLayerTree--;
+        if (state.canSendDisplayDidRefresh(*this) && commitLayerTreePending.missedDisplayDidRefresh) {
             LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree - sending missed didRefreshDisplay");
             didRefreshDisplay(&connection);
-        } else if (!state.pendingCommits.size()) {
+        } else if (!commitLayerTreePending.requestedCommitLayerTree) {
             LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree all pending commits received, waiting for display did refresh");
+            state.commitLayerTreeMessageState = NeedsDisplayDidRefresh { };
         }
-        if (completedCommit.delayState != CommitDelayState::Delayed && state.delayedCommits)
-            state.delayedCommits--;
     }
 
     updateSlowFrameIndicator();
@@ -730,11 +715,11 @@ void RemoteLayerTreeDrawingAreaProxy::drawSlowFrameIndicator(WebCore::GraphicsCo
 
 bool RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks()
 {
-    if (!m_webPageProxyProcessState.pendingCommits.size() || m_webPageProxyProcessState.pendingCommits[0].delayState != CommitDelayState::IntentionallyDeferred)
+    if (!std::holds_alternative<Idle>(m_webPageProxyProcessState.commitLayerTreeMessageState))
         return false;
 
     for (auto& pair : m_remotePageProcessState) {
-        if (!pair.value.pendingCommits.size() || pair.value.pendingCommits[0].delayState != CommitDelayState::IntentionallyDeferred)
+        if (std::holds_alternative<Idle>(pair.value.commitLayerTreeMessageState))
             return false;
     }
 
@@ -747,27 +732,19 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()
     didRefreshDisplay(nullptr);
 }
 
-TextStream& operator<<(TextStream& ts, const PendingCommitMessage& state)
+TextStream& operator<<(TextStream& ts, const RemoteLayerTreeDrawingAreaProxy::Idle&)
 {
-    if (state == PendingCommitMessage::NotifyPendingCommitLayerTree)
-        return ts << "NotifyPendingCommitLayerTree";
-    if (state == PendingCommitMessage::NotifyFlushingLayerTree)
-        return ts << "NotifyFlushingLayerTree";
-    return ts << "CommitLayerTree";
+    return ts << "Idle";
 }
 
-TextStream& operator<<(TextStream& ts, const CommitDelayState& state)
+TextStream& operator<<(TextStream& ts, const RemoteLayerTreeDrawingAreaProxy::NeedsDisplayDidRefresh&)
 {
-    switch (state) {
-    case CommitDelayState::Pending: return ts << "Pending";
-    case CommitDelayState::Delayed: return ts << "Delayed";
-    case CommitDelayState::IntentionallyDeferred: return ts << "IntentionallyDeferred";
-    }
+    return ts << "NeedsDisplayDidRefresh";
 }
 
-TextStream& operator<<(TextStream& ts, const PendingCommit& pendingCommit)
+TextStream& operator<<(TextStream& ts, const RemoteLayerTreeDrawingAreaProxy::CommitLayerTreePending& commitLayerTreePending)
 {
-    return ts << "{ " << pendingCommit.transactionID << ", pending(" << pendingCommit.pendingMessage << "), delay(" << pendingCommit.delayState << ") } ";
+    return ts << "CommitLayerTreePending(" << commitLayerTreePending.requestedNotifyPendingCommitLayerTree << ", " << commitLayerTreePending.requestedCommitLayerTree << ", " << commitLayerTreePending.missedDisplayDidRefresh << ")";
 }
 
 bool RemoteLayerTreeDrawingAreaProxy::allowMultipleCommitLayerTreePending()
@@ -777,34 +754,39 @@ bool RemoteLayerTreeDrawingAreaProxy::allowMultipleCommitLayerTreePending()
     return false;
 }
 
-bool ProcessState::canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy& drawingArea)
+bool RemoteLayerTreeDrawingAreaProxy::ProcessState::canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy& drawingArea)
 {
-    if (pendingCommits.size() >= 2)
-        return false;
-    if (pendingCommits.size() == 1)
-        return drawingArea.allowMultipleCommitLayerTreePending() && pendingCommits[0].pendingMessage == PendingCommitMessage::CommitLayerTree && delayedCommits >= 4;
-    return true;
+    return WTF::switchOn(commitLayerTreeMessageState,
+        [&](const CommitLayerTreePending& commitLayerTreePending) {
+            if (commitLayerTreePending.requestedNotifyPendingCommitLayerTree)
+                return false;
+            if (drawingArea.allowMultipleCommitLayerTreePending())
+                return commitLayerTreePending.requestedCommitLayerTree <= 1;
+            return !commitLayerTreePending.requestedCommitLayerTree;
+        },
+        [](const NeedsDisplayDidRefresh&) { return true; },
+        [](const Idle&) { return false; }
+    );
 }
 
 IPC::Error RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& state, IPC::Connection& connection)
 {
     if (!state.canSendDisplayDidRefresh(*this)) {
-        ASSERT(state.pendingCommits.size());
-        if (state.pendingCommits.last().delayState == CommitDelayState::Pending) {
-            state.pendingCommits.last().delayState = CommitDelayState::Delayed;
-            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay still waiting on commit, marked as delayed");
-            state.delayedCommits++;
+        if (auto* commitLayerTreePending = std::get_if<CommitLayerTreePending>(&state.commitLayerTreeMessageState)) {
+            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay stil waiting on commit, marked as missed");
+            commitLayerTreePending->missedDisplayDidRefresh = true;
         }
         return IPC::Error::NoError;
     }
-    // The very first commit is initiated by WebContent, so don't send a didRefreshDisplay until we've received that.
-    if (state.nextLayerTreeTransactionID.object() == TransactionIdentifier().next())
-        return IPC::Error::NoError;
 
-    state.pendingCommits.insert(0, { state.nextLayerTreeTransactionID, PendingCommitMessage::NotifyPendingCommitLayerTree, CommitDelayState::Pending });
-    state.nextLayerTreeTransactionID.increment();
+    if (auto* commitLayerTreePending = std::get_if<CommitLayerTreePending>(&state.commitLayerTreeMessageState)) {
+        commitLayerTreePending->requestedNotifyPendingCommitLayerTree++;
+        commitLayerTreePending->requestedCommitLayerTree++;
+        commitLayerTreePending->missedDisplayDidRefresh = false;
+    } else
+        state.commitLayerTreeMessageState = CommitLayerTreePending { };
 
-    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay new state " << state.pendingCommits);
+    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay new state " << state.commitLayerTreeMessageState);
 
     if (&state == &m_webPageProxyProcessState) {
         if (RefPtr page = this->page())
@@ -859,18 +841,17 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
     auto startTime = MonotonicTime::now();
 
     do {
-        IPC::Error error;
-        if (!m_webPageProxyProcessState.pendingCommits.size())
-            error = didRefreshDisplay(m_webPageProxyProcessState, connection.get());
-        else {
-            // Only the most recent outstanding frame can be in NotifyPendingCommitLayerTree state
-            if (m_webPageProxyProcessState.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyPendingCommitLayerTree)
-                error = connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
-            else if (m_webPageProxyProcessState.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyFlushingLayerTree)
-                error = connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyFlushingLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
-            else
-                error = connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
-        }
+        IPC::Error error = WTF::switchOn(m_webPageProxyProcessState.commitLayerTreeMessageState,
+            [&](const CommitLayerTreePending& commitLayerTreePending) {
+                if (commitLayerTreePending.requestedNotifyPendingCommitLayerTree)
+                    return connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+                return connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+            }, [&](const NeedsDisplayDidRefresh&) {
+                return didRefreshDisplay(m_webPageProxyProcessState, connection.get());
+            }, [&](const Idle&) {
+                return connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+            }
+        );
 
         if (error != IPC::Error::NoError)
             return;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -530,7 +530,6 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
     if (displayID == m_displayID)
         return;
 
-    bool hadDisplayRefreshObserver = m_displayRefreshObserverID.has_value();
     bool hadFullSpeedOberver = m_fullSpeedUpdateObserverID.has_value();
     if (hadFullSpeedOberver)
         removeObserver(m_fullSpeedUpdateObserverID);
@@ -547,8 +546,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
     if (page)
         page->checkedScrollingCoordinatorProxy()->windowScreenDidChange(displayID, m_displayNominalFramesPerSecond);
 
-    if (hadDisplayRefreshObserver)
-        scheduleDisplayRefreshCallbacks();
+    scheduleDisplayRefreshCallbacks();
     if (hadFullSpeedOberver) {
         m_fullSpeedUpdateObserverID = DisplayLinkObserverID::generate();
         if (auto* displayLink = existingDisplayLink())

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -422,8 +422,6 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
     m_backingStoreFlusher->markHasPendingFlush();
 
-    send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyFlushingLayerTree(transactionID));
-
     auto pageID = webPage->identifier();
     m_commitQueue->dispatch([backingStoreFlusher = m_backingStoreFlusher, commitEncoder = WTF::move(commitEncoder), flushers = WTF::move(flushers), pageID] () mutable {
         bool flushSucceeded = backingStoreFlusher->flush(WTF::move(commitEncoder), WTF::move(flushers));


### PR DESCRIPTION
#### 7f648983fdd68cbb19cb5caaaf16f17e569f1540
<pre>
Web Inspector broken and shows up blank
<a href="https://rdar.apple.com/168607298">rdar://168607298</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305961">https://bugs.webkit.org/show_bug.cgi?id=305961</a>

Reviewed by Pascoe and BJ Burg.

305784@main caused Web Inspector to show up blank. Revert it and the
patch made on top, 305899@main.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/MonotonicObjectIdentifier.h:
(WebKit::MonotonicObjectIdentifier::isHashTableDeletedValue const):
(WebKit::MonotonicObjectIdentifier::isHashTableEmptyValue const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::ProcessState::ProcessState): Deleted.
(WTF::HashTraits&lt;WebKit::ProcessState&gt;::emptyValue): Deleted.
(WTF::HashTraits&lt;WebKit::ProcessState&gt;::isEmptyValue): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::addRemotePageDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::nextMainFrameLayerTreeTransactionID const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::processStateForConnection):
(WebKit::RemoteLayerTreeDrawingAreaProxy::processStateForIdentifier const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks):
(WebKit::operator&lt;&lt;):
(WebKit::RemoteLayerTreeDrawingAreaProxy::ProcessState::canSendDisplayDidRefresh):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
(WebKit::ProcessState::ProcessState): Deleted.
(WebKit::RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree): Deleted.
(WebKit::ProcessState::canSendDisplayDidRefresh): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

This commit include:

Revert &quot;Change RemoteLayerTreeDrawingAreaProxy::ProcessState to track a set of pending commits, rather than a single state machine.&quot;

This reverts commit a327fd79c613902d96e90b7cf8c43e92e6885835.

Revert &quot;Enable AllowMultipleLayerTreeCommitPending by default.&quot;

This reverts commit 4bc6712902a298016f5000a6581900239830e6fc.

Canonical link: <a href="https://commits.webkit.org/306030@main">https://commits.webkit.org/306030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a91fa62f4f5f9e3f1a53204c2386b75046d10718

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12505 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148275 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30873a47-1086-44de-b7d9-fa3bf478df82) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcaaa1c0-399d-4d47-9ef7-5018f40c7d87) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88169 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60e4e140-3a69-431d-8fcf-85f79eb706d0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9818 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7353 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8554 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132096 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151060 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/919 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12190 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115709 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116034 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29482 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11004 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121948 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12232 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1424 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171395 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11973 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75929 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12168 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12018 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->