### PR TITLE
[Skia] Stop using legacy functions from SkGradientShader.h

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GradientSkia.cpp
@@ -35,7 +35,7 @@
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColor.h>
 #include <skia/core/SkScalar.h>
-#include <skia/effects/SkGradientShader.h>
+#include <skia/effects/SkGradient.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
@@ -49,52 +49,52 @@ inline SkScalar webCoreDoubleToSkScalar(double d)
     return SkDoubleToScalar(std::isfinite(d) ? d : 0);
 }
 
-static SkGradientShader::Interpolation toSkiaInterpolation(const ColorInterpolationMethod& method)
+static SkGradient::Interpolation toSkiaInterpolation(const ColorInterpolationMethod& method)
 {
-    SkGradientShader::Interpolation interpolation;
+    SkGradient::Interpolation interpolation;
 
     WTF::switchOn(method.colorSpace,
         [&] (const ColorInterpolationMethod::HSL&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kHSL;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kHSL;
         },
         [&] (const ColorInterpolationMethod::HWB&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kHWB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kHWB;
         },
         [&] (const ColorInterpolationMethod::LCH&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kLCH;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kLCH;
         },
         [&] (const ColorInterpolationMethod::Lab&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kLab;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kLab;
         },
         [&] (const ColorInterpolationMethod::OKLCH&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kOKLCH;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kOKLCH;
         },
         [&] (const ColorInterpolationMethod::OKLab&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kOKLab;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kOKLab;
         },
         [&] (const ColorInterpolationMethod::SRGB&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kSRGB;
         },
         [&] (const ColorInterpolationMethod::SRGBLinear&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGBLinear;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kSRGBLinear;
         },
         [&] (const ColorInterpolationMethod::DisplayP3&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kDisplayP3;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kDisplayP3;
         },
         [&] (const ColorInterpolationMethod::A98RGB&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kA98RGB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kA98RGB;
         },
         [&] (const ColorInterpolationMethod::ProPhotoRGB&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kProphotoRGB;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kProphotoRGB;
         },
         [&] (const ColorInterpolationMethod::Rec2020&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kRec2020;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kRec2020;
         },
         [&] (const ColorInterpolationMethod::XYZD50&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGBLinear;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kSRGBLinear;
         },
         [&] (const ColorInterpolationMethod::XYZD65&) {
-            interpolation.fColorSpace = SkGradientShader::Interpolation::ColorSpace::kSRGBLinear;
+            interpolation.fColorSpace = SkGradient::Interpolation::ColorSpace::kSRGBLinear;
         },
         [&] (const auto&) {
             // FIXME: Support other color spaces once skia has support for them.
@@ -105,16 +105,16 @@ static SkGradientShader::Interpolation toSkiaInterpolation(const ColorInterpolat
             if constexpr (hasHueInterpolationMethod<ColorSpace>) {
                 switch (colorSpace.hueInterpolationMethod) {
                 case HueInterpolationMethod::Shorter:
-                    interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kShorter;
+                    interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kShorter;
                     break;
                 case HueInterpolationMethod::Longer:
-                    interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kLonger;
+                    interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kLonger;
                     break;
                 case HueInterpolationMethod::Increasing:
-                    interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kIncreasing;
+                    interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kIncreasing;
                     break;
                 case HueInterpolationMethod::Decreasing:
-                    interpolation.fHueMethod = SkGradientShader::Interpolation::HueMethod::kDecreasing;
+                    interpolation.fHueMethod = SkGradient::Interpolation::HueMethod::kDecreasing;
                     break;
                 }
             }
@@ -123,10 +123,10 @@ static SkGradientShader::Interpolation toSkiaInterpolation(const ColorInterpolat
 
     switch (method.alphaPremultiplication) {
     case AlphaPremultiplication::Premultiplied:
-        interpolation.fInPremul = SkGradientShader::Interpolation::InPremul::kYes;
+        interpolation.fInPremul = SkGradient::Interpolation::InPremul::kYes;
         break;
     case AlphaPremultiplication::Unpremultiplied:
-        interpolation.fInPremul = SkGradientShader::Interpolation::InPremul::kNo;
+        interpolation.fInPremul = SkGradient::Interpolation::InPremul::kNo;
         break;
     }
 
@@ -145,7 +145,7 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
         if (stops.isEmpty()) {
             positions.append(webCoreDoubleToSkScalar(0));
             colors.append(SkColors::kTransparent);
-        } else if (stops.begin()->offset > 0 && interpolation.fHueMethod != SkGradientShader::Interpolation::HueMethod::kLonger) {
+        } else if (stops.begin()->offset > 0 && interpolation.fHueMethod != SkGradient::Interpolation::HueMethod::kLonger) {
             positions.append(webCoreDoubleToSkScalar(0));
             colors.append(stops.begin()->color.colorWithAlphaMultipliedBy(globalAlpha));
         }
@@ -155,7 +155,7 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
             colors.append(stops[i].color.colorWithAlphaMultipliedBy(globalAlpha));
         }
 
-        if (positions.last() < 1 && interpolation.fHueMethod != SkGradientShader::Interpolation::HueMethod::kLonger) {
+        if (positions.last() < 1 && interpolation.fHueMethod != SkGradient::Interpolation::HueMethod::kLonger) {
             positions.append(webCoreDoubleToSkScalar(1));
             colors.append(colors.last());
         }
@@ -182,7 +182,7 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
         [&](const LinearData& data) {
             SkPoint points[] = { SkPoint::Make(data.point0.x(), data.point0.y()), SkPoint::Make(data.point1.x(), data.point1.y()) };
 
-            return SkGradientShader::MakeLinear(points, colors.span().data(), nullptr, positions.span().data(), colors.size(), tileMode, interpolation, &matrix);
+            return SkShaders::LinearGradient(points, { { colors.span(), positions.span(), tileMode }, interpolation }, &matrix);
         },
         [&](const RadialData& data) {
             if (data.aspectRatio != 1)
@@ -193,13 +193,13 @@ sk_sp<SkShader> Gradient::shader(float globalAlpha, const AffineTransform& gradi
             SkScalar startRadius = std::max(webCoreDoubleToSkScalar(data.startRadius), 0.0f);
             SkScalar endRadius = std::max(webCoreDoubleToSkScalar(data.endRadius), 0.0f);
 
-            return SkGradientShader::MakeTwoPointConical(start, startRadius, end, endRadius, colors.span().data(), nullptr, positions.span().data(), colors.size(), tileMode, interpolation, &matrix);
+            return SkShaders::TwoPointConicalGradient(start, startRadius, end, endRadius, { { colors.span(), positions.span(), tileMode }, interpolation }, &matrix);
         },
         [&](const ConicData& data) {
             // Skia's renders it tilted by 90 degrees, so offset that rotation in the matrix
             matrix.preRotate(SkRadiansToDegrees(data.angleRadians) - 90.0f, data.point0.x(), data.point0.y());
 
-            return SkGradientShader::MakeSweep(data.point0.x(), data.point0.y(), colors.span().data(), nullptr, positions.span().data(), colors.size(), tileMode, 0, 360, interpolation, &matrix);
+            return SkShaders::SweepGradient(SkPoint::Make(data.point0.x(), data.point0.y()), { { colors.span(), positions.span(), tileMode }, interpolation }, &matrix);
         });
 
     return shader;


### PR DESCRIPTION
#### 9fd8a9e199740bda96bb81e8140d4b14f900c2b8
<pre>
[Skia] Stop using legacy functions from SkGradientShader.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=305963">https://bugs.webkit.org/show_bug.cgi?id=305963</a>

Reviewed by Nikolas Zimmermann.

Replace usage of the functionality defined in Skia&apos;s SkGradientShader.h
header, with equivalent functions from SkGradient.h: they are basically
equivalent, with the difference that the new API uses auxiliar Gradient
objects to specify some of the parameters and spans.

The old API has been guarded with SK_SUPPORT_LEGACY_UNSPANNED_GRADIENTS
for a while and has been already removed from upstream Skia. This change
prepares WebKit for the next Skia update that will not include them.

Covered by existing tests.

* Source/WebCore/platform/graphics/skia/GradientSkia.cpp:
(WebCore::toSkiaInterpolation): Rename SkGradientShader:: uses to SkGradient::.
(WebCore::Gradient::shader): Update to use functions from SkGradient.h

Canonical link: <a href="https://commits.webkit.org/306003@main">https://commits.webkit.org/306003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0487a492c94e393f3738846ceab705a68ef4940

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/139941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107150 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/77979 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/142891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10042 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88120 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9693 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8373 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/150870 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12007 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115569 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10289 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10686 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67012 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12049 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11789 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75736 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/11985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->