### PR TITLE
Modify BrowsingWarning according to internal requirements

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/SafeBrowsingSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/SafeBrowsingSPI.h
@@ -31,6 +31,18 @@ DECLARE_SYSTEM_HEADER
 
 #import <Foundation/Foundation.h>
 
+#if __has_include(<WebKitAdditions/SafeBrowsingAdditions.h>)
+#include <WebKitAdditions/SafeBrowsingAdditions.h>
+#endif
+
+#if !defined(SAFE_BROWSING_PROVIDER_ADDITIONS)
+#define SAFE_BROWSING_PROVIDER_ADDITIONS
+#endif
+
+#if !defined(SAFE_BROWSING_LOOKUP_RESULT_ADDITIONS)
+#define SAFE_BROWSING_LOOKUP_RESULT_ADDITIONS
+#endif
+
 #if 0 && USE(APPLE_INTERNAL_SDK)
 
 #import <SafariSafeBrowsing/SafariSafeBrowsing.h>
@@ -45,6 +57,7 @@ WTF_EXTERN_C_BEGIN
 extern SSBProvider const SSBProviderGoogle;
 extern SSBProvider const SSBProviderTencent;
 extern SSBProvider const SSBProviderApple;
+SAFE_BROWSING_PROVIDER_ADDITIONS
 
 WTF_EXTERN_C_END
 
@@ -61,6 +74,8 @@ WTF_EXTERN_C_END
 @property (nonatomic, readonly) NSString *reportAnErrorBaseURLString;
 @property (nonatomic, readonly) NSString *localizedProviderDisplayName;
 @property (nonatomic, readonly) NSString *localizedProviderShortName;
+
+SAFE_BROWSING_LOOKUP_RESULT_ADDITIONS
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm
@@ -33,9 +33,26 @@
 #import <wtf/StdLibExtras.h>
 #import <wtf/text/MakeString.h>
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/BrowsingWarningAdditions.mm>)
+#import <WebKitAdditions/BrowsingWarningAdditions.mm>
+#endif
+
+#if !defined(BROWSING_WARNING_PROVIDER_ADDITIONS)
+#define BROWSING_WARNING_PROVIDER_ADDITIONS
+#endif
+
+#if !defined(BROWSING_WARNING_PROVIDER_SHORT_NAME_ADDITIONS)
+#define BROWSING_WARNING_PROVIDER_SHORT_NAME_ADDITIONS
+#endif
+
+#if !defined(BROWSING_WARNING_DETAILS_TEXT_ADDITIONS)
+#define BROWSING_WARNING_DETAILS_TEXT_ADDITIONS
+#endif
+
 NSString * const SSBProviderGoogle = @"SSBProviderGoogle";
 NSString * const SSBProviderTencent = @"SSBProviderTencent";
 NSString * const SSBProviderApple = @"SSBProviderApple";
+BROWSING_WARNING_PROVIDER_ADDITIONS
 
 namespace WebKit {
 
@@ -71,10 +88,10 @@ static String localizedProviderShortName(SSBServiceLookupResult *result)
         return "Tencent"_s;
     if ([result.provider isEqual:SSBProviderApple])
         return "Apple"_s;
+    BROWSING_WARNING_PROVIDER_SHORT_NAME_ADDITIONS
     ASSERT_NOT_REACHED();
     return ""_s;
 }
-
 
 static void replace(NSMutableAttributedString *string, NSString *toReplace, NSString *replaceWith)
 {
@@ -142,6 +159,8 @@ static NSString *browsingWarningText(BrowsingWarning::Data data)
 
 static NSMutableAttributedString *browsingDetailsText(const URL& url, SSBServiceLookupResult *result)
 {
+    BROWSING_WARNING_DETAILS_TEXT_ADDITIONS
+
     if (result.isPhishing) {
         RetainPtr phishingDescription = WEB_UI_NSSTRING(@"Warnings are shown for websites that have been reported as deceptive. Deceptive websites try to trick you into believing they are legitimate websites you trust.", "Phishing warning description");
         RetainPtr learnMore = WEB_UI_NSSTRING(@"Learn more…", "Action from safe browsing warning");

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -109,6 +109,10 @@
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
+#if !defined(SAFE_BROWSING_RESULT_CHECK_ADDITIONS)
+#define SAFE_BROWSING_RESULT_CHECK_ADDITIONS false
+#endif
+
 #if ENABLE(MEDIA_USAGE)
 #import "MediaUsageManagerCocoa.h"
 #endif
@@ -275,6 +279,8 @@ std::optional<IPC::AsyncReplyID> WebPageProxy::grantAccessToCurrentPasteboardDat
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebPageProxyCocoaAdditions.mm>)
 #import <WebKitAdditions/WebPageProxyCocoaAdditions.mm>
 #else
+// Redefine as function-like macro for statement context
+#undef SAFE_BROWSING_LOOKUP_RESULT_ADDITIONS
 #define SAFE_BROWSING_LOOKUP_RESULT_ADDITIONS(lookupResult)
 #endif
 
@@ -313,7 +319,7 @@ void WebPageProxy::beginSafeBrowsingCheck(const URL& url, API::Navigation& navig
 
             for (SSBServiceLookupResult *lookupResult in [result serviceLookupResults]) {
                 SAFE_BROWSING_LOOKUP_RESULT_ADDITIONS(lookupResult);
-                if (lookupResult.isPhishing || lookupResult.isMalware || lookupResult.isUnwantedSoftware) {
+                if (lookupResult.isPhishing || lookupResult.isMalware || lookupResult.isUnwantedSoftware || SAFE_BROWSING_RESULT_CHECK_ADDITIONS) {
                     navigation->setSafeBrowsingWarning(BrowsingWarning::create(url, forMainFrameNavigation, BrowsingWarning::SafeBrowsingWarningData { lookupResult }));
                     break;
                 }


### PR DESCRIPTION
#### d24975dccc262a55daf209aa5abfa6c89b83b6cb
<pre>
Modify BrowsingWarning according to internal requirements
<a href="https://rdar.apple.com/168615890">rdar://168615890</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305971">https://bugs.webkit.org/show_bug.cgi?id=305971</a>

Reviewed by Charlie Wolfe.

This change modifies the red screen in certain situations.

More information is available in radar.

* Source/WebKit/Platform/spi/Cocoa/SafeBrowsingSPI.h:
* Source/WebKit/UIProcess/Cocoa/BrowsingWarningCocoa.mm:
(WebKit::localizedProviderShortName):
(WebKit::browsingDetailsText):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::beginSafeBrowsingCheck):

Canonical link: <a href="https://commits.webkit.org/307123@main">https://commits.webkit.org/307123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa19dfcb434a04c28aef91f8ee76045a1e63b4de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151636 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96155 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/143e8d0d-87a8-446a-9644-b1e382fe5a8a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79198 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e40e1fb4-c88c-4b66-a519-df0f3cede161) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90854 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3906caf7-cc08-40ef-8a61-c31f43c1ebf5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11888 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9568 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1635 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121273 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153949 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15060 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117954 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30413 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14258 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125248 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70767 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15103 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4148 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->