### PR TITLE
[GFC] Pass in GridDefinition into GridLayout from GridFormattingContext.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -42,6 +42,28 @@ class UnplacedGridItem;
 struct GridAreaLines;
 struct UnplacedGridItems;
 
+enum class PackingStrategy : bool {
+    Sparse,
+    Dense
+};
+
+enum class GridAutoFlowDirection : bool {
+    Row,
+    Column
+};
+
+struct GridAutoFlowOptions {
+    PackingStrategy strategy;
+    GridAutoFlowDirection direction;
+};
+
+// https://drafts.csswg.org/css-grid-1/#grid-definition
+struct GridDefinition {
+    Style::GridTemplateList gridTemplateColumns;
+    Style::GridTemplateList gridTemplateRows;
+    GridAutoFlowOptions autoFlowOptions;
+};
+
 class GridFormattingContext {
     WTF_MAKE_TZONE_ALLOCATED(GridFormattingContext);
 public:
@@ -62,6 +84,8 @@ public:
     const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
 
     const BoxGeometry& geometryForGridItem(const ElementBox&) const;
+
+    const Style::ZoomFactor zoomFactor() const { return m_gridBox->style().usedZoomForLength(); }
 
 private:
     UnplacedGridItems constructUnplacedGridItems() const;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -41,21 +41,6 @@ namespace Layout {
 
 class ImplicitGrid;
 
-enum class PackingStrategy : bool {
-    Sparse,
-    Dense
-};
-
-enum class GridAutoFlowDirection : bool {
-    Row,
-    Column
-};
-
-struct GridAutoFlowOptions {
-    PackingStrategy strategy;
-    GridAutoFlowDirection direction;
-};
-
 struct UsedTrackSizes;
 struct UsedMargins;
 
@@ -70,7 +55,7 @@ class GridLayout {
 public:
     GridLayout(const GridFormattingContext&);
 
-    std::pair<UsedTrackSizes, GridItemRects> layout(const GridFormattingContext::GridLayoutConstraints&, UnplacedGridItems&);
+    std::pair<UsedTrackSizes, GridItemRects> layout(const GridFormattingContext::GridLayoutConstraints&, UnplacedGridItems&, const GridDefinition&);
 
 private:
 
@@ -92,9 +77,6 @@ private:
     static BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&);
 
     const GridFormattingContext& formattingContext() const { return m_gridFormattingContext; }
-
-    const ElementBox& gridContainer() const;
-    const RenderStyle& gridContainerStyle() const;
 
     const GridFormattingContext& m_gridFormattingContext;
 };


### PR DESCRIPTION
#### 7d5b70c1e5533dda525d37423de93a5436fc3f7f
<pre>
[GFC] Pass in GridDefinition into GridLayout from GridFormattingContext.
<a href="https://bugs.webkit.org/show_bug.cgi?id=305987">https://bugs.webkit.org/show_bug.cgi?id=305987</a>
<a href="https://rdar.apple.com/problem/168625033">rdar://problem/168625033</a>

Reviewed by Vitor Roriz.

Currently, inside of GridLayout we query the formatting context root for
various style relating to the definition of the grid, such as
grid-template-columns. Instead of getting whatever information we need
by getting the RenderStyle off the formatting context root and getting
different values from the RenderStyle, we can pass in the exact
information that GridLayout will need. This new struct, GridDefinition,
should contain information from the &quot;Defining the Grid,&quot; portion of the
spec.

The biggest benefit this change brings is that is allows us to pass in
different values to GridLayout depending on the context. For example,
the grid spec has this little blurb with regards to percentage track
sizes:

&quot;&lt;percentage&gt; values are relative to the inner {inline, block} size of
the grid container in {column, row} grid tracks... If the size of the
grid container depends on the size of its tracks, then the &lt;percentage&gt;
must be treated as auto&quot;
<a href="https://drafts.csswg.org/css-grid-1/#track-sizing">https://drafts.csswg.org/css-grid-1/#track-sizing</a>

While in theory we could try to detect this state and implement whatever
logic is needed to accomplish this inside of GridLayout, this would
result in a bit of additional noise in code that is dedicated to
performing the layout algorithm. Instead we could perform this
transformation inside of GridFormattingContext so that GridLayout does
not need to worry about this minor detail. So in this patch we do a bit
of preparation by beginning to have the formatting context pass in the
GridDefinition and in a follow up we can slightly alter these values in
certain circumstances as described above.

Canonical link: <a href="https://commits.webkit.org/306041@main">https://commits.webkit.org/306041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/609f8c1f620991ef1680df3b39003ddcafbb3149

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140184 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/12565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1694 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9abef25-b7c7-4627-9d6d-8f05651a03f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/148343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48885bcb-b360-4002-bcab-0a0b12c07daa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143134 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/954ae8b2-4489-4ae0-9ce2-9293497abeb5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/8617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/151122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/151122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/12264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/151122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29490 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/121994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/12293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/12079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->