### PR TITLE
WIP Fix Screen Wake Lock in Site Isolation

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -7867,4 +7867,105 @@ TEST(SiteIsolation, CrossSiteIFrameCanReceiveDeviceMotionEvents)
 
 #endif // ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
 
+
+static RetainPtr<TestWKWebView> setUpWakeLockWebView()
+{
+    ASCIILiteral mainFrameHTML= "<iframe src='https://examplesubframe.com/subframe' allow='screen-wake-lock' id='subFrame'></iframe>";
+    ASCIILiteral subFrameHTML = "<script> let lock; alert('frame loaded'); </script>";
+
+    HTTPServer server({
+        { "/mainframe"_s, { mainFrameHTML } },
+        { "/subframe"_s, { subFrameHTML } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    // must create a rect, otherwise document state will be hidden, and wake lock request will fail
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://examplemainframe.com/mainframe"]]];
+
+    // wait for frame to load
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "frame loaded");
+    return webView;
+}
+
+TEST(SiteIsolation, WakeLock)
+{
+    RetainPtr webView = setUpWakeLockWebView();
+
+    // create a lock
+    __block RetainPtr<NSError> error;
+    __block bool done = false;
+    auto firstChildFrame = [webView firstChildFrame];
+    [webView callAsyncJavaScript:@"lock = await navigator.wakeLock.request('screen');" arguments:nil inFrame:firstChildFrame inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *err) {
+        error = err;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_FALSE(!!error) << [error description].UTF8String;
+
+    // make sure lock is not already released
+    ASSERT_FALSE([[webView objectByEvaluatingJavaScript:@"lock.released" inFrame:firstChildFrame] boolValue]);
+
+    // release the lock
+    [webView callAsyncJavaScript:@"return await lock.release()" arguments:nil inFrame:firstChildFrame inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *err) {
+        error = err;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_FALSE(!!error) << [error description].UTF8String;
+
+    // make sure the lock is realeased
+    ASSERT_TRUE([[webView objectByEvaluatingJavaScript:@"lock.released" inFrame:firstChildFrame] boolValue]);
+}
+
+TEST(SiteIsolation, WakeLockCloseChildFrame)
+{
+    RetainPtr webView = setUpWakeLockWebView();
+
+    // create a lock
+    __block RetainPtr<NSError> error;
+    __block bool done = false;
+    auto firstChildFrame = [webView firstChildFrame];
+    [webView callAsyncJavaScript:@"lock = await navigator.wakeLock.request('screen');" arguments:nil inFrame:firstChildFrame inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *err) {
+        error = err;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_FALSE(!!error) << [error description].UTF8String;
+
+    // make sure lock is not already released
+    ASSERT_FALSE([[webView objectByEvaluatingJavaScript:@"lock.released" inFrame:firstChildFrame] boolValue]);
+
+    [[firstChildFrame webView] removeFromSuperview];
+    [webView waitUntilActivityStateUpdateDone];
+
+    // make sure the lock is realeased
+    ASSERT_TRUE([[webView objectByEvaluatingJavaScript:@"lock.released" inFrame:firstChildFrame] boolValue]);
+}
+
+TEST(SiteIsolation, WakeLockCloseParentFrame)
+{
+    RetainPtr webView = setUpWakeLockWebView();
+
+    // create a lock
+    __block RetainPtr<NSError> error;
+    __block bool done = false;
+    auto firstChildFrame = [webView firstChildFrame];
+    [webView callAsyncJavaScript:@"lock = await navigator.wakeLock.request('screen');" arguments:nil inFrame:firstChildFrame inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *err) {
+        error = err;
+        done = true;
+    }];
+
+    TestWebKitAPI::Util::run(&done);
+    EXPECT_FALSE(!!error) << [error description].UTF8String;
+
+    // make sure lock is not already released
+    ASSERT_FALSE([[webView objectByEvaluatingJavaScript:@"lock.released" inFrame:firstChildFrame] boolValue]);
+
+    [webView removeFromSuperview];
+    [webView waitUntilActivityStateUpdateDone];
+
+    // make sure the lock is realeased
+    ASSERT_TRUE([[webView objectByEvaluatingJavaScript:@"lock.released" inFrame:firstChildFrame] boolValue]);
+}
+
 }


### PR DESCRIPTION
#### d9620302837a4eab203a412052e2bc1127eb7062
<pre>
WIP Fix Screen Wake Lock in Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=305988">https://bugs.webkit.org/show_bug.cgi?id=305988</a>
<a href="https://rdar.apple.com/163809691">rdar://163809691</a>

Reviewed by NOBODY (OOPS!).

This is a wip

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, WakeLock)):
(TestWebKitAPI::(SiteIsolation, WakeLockHideChildFrame)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9620302837a4eab203a412052e2bc1127eb7062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148475 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93303 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6fc03bd-5c8c-4779-b821-ea58ca36ef5c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107427 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78096 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea3bb38d-e396-452f-9cf1-6611fdfb5f9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88317 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/455ec330-8229-40ee-897c-391a37c38b2e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9884 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7423 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8660 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12296 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1614 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115779 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116112 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11115 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122020 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67303 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12336 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1492 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12078 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12272 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12122 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->