### PR TITLE
Remove temporary SPI usage of AVLegibleMediaOptionsMenuController from WebKit

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h
@@ -745,26 +745,3 @@ NS_ASSUME_NONNULL_END
 
 #endif // HAVE(AVKIT_CONTENT_SOURCE)
 
-// CLEANUP(rdar://164667890)
-#if HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
-#if __has_include(<AVKit/AVLegibleMediaOptionsMenuController_Private.h>)
-#import <AVKit/AVLegibleMediaOptionsMenuController_Private.h>
-#else
-// SDK does not have -menuWithContents:. Redeclare:
-#import <AVKit/AVLegibleMediaOptionsMenuController.h>
-typedef NS_OPTIONS(NSInteger, AVLegibleMediaOptionsMenuContents) {
-    AVLegibleMediaOptionsMenuContentsLegible = 1 << 0,
-    AVLegibleMediaOptionsMenuContentsCaptionAppearance = 1 << 1,
-    AVLegibleMediaOptionsMenuContentsAll = (AVLegibleMediaOptionsMenuContentsLegible | AVLegibleMediaOptionsMenuContentsCaptionAppearance)
-} API_AVAILABLE(ios(26.4), macos(26.4), visionos(26.4)) API_UNAVAILABLE(tvos, watchos);
-
-@interface AVLegibleMediaOptionsMenuController (MenuWithContents)
-#if TARGET_OS_OSX && !TARGET_OS_MACCATALYST
-- (nullable NSMenu *)menuWithContents:(AVLegibleMediaOptionsMenuContents)contents;
-#else
-- (nullable UIMenu *)menuWithContents:(AVLegibleMediaOptionsMenuContents)contents;
-#endif
-@end
-
-#endif // __has_include(<AVKit/AVLegibleMediaOptionsMenuController_Private.h>)
-#endif // HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER) && USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm
@@ -36,7 +36,6 @@
 
 #import <UIKit/UIKit.h>
 #import <WebCore/CaptionUserPreferencesMediaAF.h>
-#import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
@@ -50,12 +49,6 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVLegibleMediaOptionsMenuController)
 
 using namespace WebCore;
 using namespace WTF;
-
-// CLEANUP(rdar://164667890)
-@interface AVLegibleMediaOptionsMenuController (WebKitSPI)
-- (nullable UIMenu *)buildMenuOfType:(NSInteger)type;
-- (nullable UIMenu *)menuWithContents:(NSInteger)contents;
-@end
 
 @interface _WKCaptionStyleMenuControllerAVKit () <AVLegibleMediaOptionsMenuControllerDelegate> {
     RetainPtr<AVLegibleMediaOptionsMenuController> _menuController;
@@ -81,12 +74,7 @@ using namespace WTF;
 
 - (void)rebuildMenu
 {
-    if ([_menuController respondsToSelector:@selector(menuWithContents:)])
-        self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
-    else
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
 }
 
 #pragma mark - AVLegibleMediaOptionsMenuControllerDelegate

--- a/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
+++ b/Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm
@@ -36,7 +36,6 @@
 
 #import <AppKit/AppKit.h>
 #import <WebCore/CaptionUserPreferencesMediaAF.h>
-#import <pal/spi/cocoa/AVKitSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
@@ -47,12 +46,6 @@
 
 SOFTLINK_AVKIT_FRAMEWORK()
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVLegibleMediaOptionsMenuController)
-
-// CLEANUP(rdar://164667890)
-@interface AVLegibleMediaOptionsMenuController (WebKitSPI)
-- (nullable NSMenu *)buildMenuOfType:(NSInteger)type;
-- (nullable NSMenu *)menuWithContents:(NSInteger)contents;
-@end
 
 using namespace WebCore;
 using namespace WTF;
@@ -81,12 +74,7 @@ using namespace WTF;
 
 - (void)rebuildMenu
 {
-    if ([_menuController respondsToSelector:@selector(menuWithContents:)])
-        self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
-    else
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        self.menu = [_menuController buildMenuOfType:AVLegibleMediaOptionsMenuTypeCaptionAppearance];
-ALLOW_DEPRECATED_DECLARATIONS_END
+    self.menu = [_menuController menuWithContents:AVLegibleMediaOptionsMenuContentsCaptionAppearance];
 }
 
 - (NSMenu *)captionStyleMenu

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm
@@ -42,7 +42,6 @@
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIAction.h>
 #if HAVE(AVLEGIBLEMEDIAOPTIONSMENUCONTROLLER)
-#import <pal/spi/cocoa/AVKitSPI.h>
 #if __has_include(<AVKit/AVLegibleMediaOptionsMenuController.h>)
 #import <AVKit/AVLegibleMediaOptionsMenuController.h>
 #endif


### PR DESCRIPTION
#### e8b18f33015595b0995231d91c70ec21ad2c6fac
<pre>
Remove temporary SPI usage of AVLegibleMediaOptionsMenuController from WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=305993">https://bugs.webkit.org/show_bug.cgi?id=305993</a>
<a href="https://rdar.apple.com/164667890">rdar://164667890</a>

Reviewed by Jer Noble.

AVLegibleMediaOptionsMenuController has been promoted to public API - remove the temporary SPI
declarations and workarounds that were added while waiting for API availability.

* Source/WebCore/PAL/pal/spi/cocoa/AVKitSPI.h:
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerAVKit.mm:
(-[_WKCaptionStyleMenuControllerAVKit rebuildMenu]):
* Source/WebKit/UIProcess/mac/_WKCaptionStyleMenuControllerAVKitMac.mm:
(-[_WKCaptionStyleMenuControllerAVKitMac rebuildMenu]):
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CaptionPreferencesTests.mm:

Canonical link: <a href="https://commits.webkit.org/306497@main">https://commits.webkit.org/306497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3667f9dd0e58600ce366bf13de151487bb2f45e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/051c2865-0370-418c-91bb-2bbdac7da9dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143165 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108552 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78590 "7 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b94f8661-9c84-4b1e-8cf0-8c6d0434d847) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89457 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37372c6e-33a3-4b04-a804-79e065a22f67) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10677 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8288 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119940 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152260 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2883 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116650 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/basic/error-after-response.any.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116990 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13044 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123105 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68536 "The change is no longer eligible for processing.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13405 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2469 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13343 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->