### PR TITLE
Remove implicit "= {}" and "= []" default values for IDL optionals

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.idl
+++ b/Source/WebCore/Modules/WebGPU/GPU.idl
@@ -31,7 +31,7 @@
     SecureContext
 ]
 interface GPU {
-    Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options);
+    Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
     GPUTextureFormat getPreferredCanvasFormat();
     [SameObject] readonly attribute WGSLLanguageFeatures wgslLanguageFeatures;
 };

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
@@ -36,5 +36,5 @@ interface GPUAdapter {
     [SameObject] readonly attribute GPUAdapterInfo info;
     readonly attribute boolean isFallbackAdapter;
 
-    [CallWith=CurrentScriptExecutionContext] Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor);
+    [CallWith=CurrentScriptExecutionContext] Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
@@ -37,7 +37,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
     SecureContext
 ] interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
-    GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor);
+    GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
     undefined copyBufferToBuffer(
         GPUBuffer source,
@@ -78,7 +78,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
         GPUBuffer destination,
         GPUSize64 destinationOffset);
 
-    GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor);
+    GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {});
 };
 GPUCommandEncoder includes GPUObjectBase;
 GPUCommandEncoder includes GPUCommandsMixin;

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -41,7 +41,7 @@
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
-    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor);
+    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
     GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor);
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
@@ -54,7 +54,7 @@
     Promise<GPUComputePipeline> createComputePipelineAsync(GPUComputePipelineDescriptor descriptor);
     Promise<GPURenderPipeline> createRenderPipelineAsync(GPURenderPipelineDescriptor descriptor);
 
-    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor);
+    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
 
     GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
@@ -31,7 +31,7 @@
     SecureContext
 ]
 interface GPURenderBundleEncoder {
-    GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor);
+    GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 };
 GPURenderBundleEncoder includes GPUObjectBase;
 GPURenderBundleEncoder includes GPUCommandsMixin;

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.idl
@@ -31,7 +31,7 @@
     SecureContext
 ]
 interface GPUTexture {
-    GPUTextureView createView(optional GPUTextureViewDescriptor descriptor);
+    GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
     undefined destroy();
 

--- a/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.idl
+++ b/Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.idl
@@ -28,7 +28,7 @@
     Conditional=WIRELESS_PLAYBACK_TARGET_AVAILABILITY_API,
     Exposed=Window
 ] interface WebKitPlaybackTargetAvailabilityEvent : Event {
-    constructor([AtomString] DOMString type, optional WebKitPlaybackTargetAvailabilityEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional WebKitPlaybackTargetAvailabilityEventInit eventInitDict = {});
 
     readonly attribute DOMString availability;
 };

--- a/Source/WebCore/Modules/cache/DOMCache.idl
+++ b/Source/WebCore/Modules/cache/DOMCache.idl
@@ -32,11 +32,11 @@ typedef (FetchRequest or USVString) RequestInfo;
     EnabledBySetting=CacheAPIEnabled,
     InterfaceName=Cache,
 ] interface DOMCache {
-    [NewObject] Promise<any> match(RequestInfo request, optional CacheQueryOptions options);
-    [NewObject] Promise<sequence<FetchResponse>> matchAll(optional RequestInfo request, optional CacheQueryOptions options);
+    [NewObject] Promise<any> match(RequestInfo request, optional CacheQueryOptions options = {});
+    [NewObject] Promise<sequence<FetchResponse>> matchAll(optional RequestInfo request, optional CacheQueryOptions options = {});
     [NewObject] Promise<undefined> add(RequestInfo request);
     [NewObject] Promise<undefined> addAll(sequence<RequestInfo> requests);
     [NewObject] Promise<undefined> put(RequestInfo request, FetchResponse response);
-    [NewObject, ImplementedAs=remove] Promise<boolean> delete(RequestInfo request, optional CacheQueryOptions options);
-    [NewObject] Promise<sequence<FetchRequest>> keys(optional RequestInfo request, optional CacheQueryOptions options);
+    [NewObject, ImplementedAs=remove] Promise<boolean> delete(RequestInfo request, optional CacheQueryOptions options = {});
+    [NewObject] Promise<sequence<FetchRequest>> keys(optional RequestInfo request, optional CacheQueryOptions options = {});
 };

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.idl
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.idl
@@ -32,7 +32,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     EnabledBySetting=CacheAPIEnabled,
     InterfaceName=CacheStorage,
 ] interface DOMCacheStorage {
-    [NewObject] Promise<any> match(RequestInfo request, optional MultiCacheQueryOptions options);
+    [NewObject] Promise<any> match(RequestInfo request, optional MultiCacheQueryOptions options = {});
     [NewObject] Promise<boolean> has(DOMString cacheName);
     [NewObject] Promise<DOMCache> open(DOMString cacheName);
     [NewObject, ImplementedAs=remove] Promise<boolean> delete(DOMString cacheName);

--- a/Source/WebCore/Modules/contact-picker/ContactsManager.idl
+++ b/Source/WebCore/Modules/contact-picker/ContactsManager.idl
@@ -32,5 +32,5 @@
     SecureContext
 ] interface ContactsManager {
     Promise<sequence<ContactProperty>> getProperties();
-    Promise<sequence<ContactInfo>> select(sequence<ContactProperty> properties, optional ContactsSelectOptions options);
+    Promise<sequence<ContactInfo>> select(sequence<ContactProperty> properties, optional ContactsSelectOptions options = {});
 };

--- a/Source/WebCore/Modules/cookie-consent/Navigator+CookieConsent.idl
+++ b/Source/WebCore/Modules/cookie-consent/Navigator+CookieConsent.idl
@@ -27,5 +27,5 @@
     EnabledBySetting=CookieConsentAPIEnabled,
     ImplementedBy=NavigatorCookieConsent,
 ] partial interface Navigator {
-    Promise<boolean> requestCookieConsent(optional RequestCookieConsentOptions options);
+    Promise<boolean> requestCookieConsent(optional RequestCookieConsentOptions options = {});
 };

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl
@@ -31,8 +31,8 @@
     SecureContext,
     SkipVTableValidation,
 ] interface CredentialsContainer {
-    Promise<BasicCredential?> get(optional CredentialRequestOptions options);
+    Promise<BasicCredential?> get(optional CredentialRequestOptions options = {});
     Promise<BasicCredential> store(BasicCredential credential);
-    Promise<BasicCredential?> create(optional CredentialCreationOptions options);
+    Promise<BasicCredential?> create(optional CredentialCreationOptions options = {});
     Promise<undefined> preventSilentAccess();
 };

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=LegacyEncryptedMediaAPIEnabled,
     Exposed=Window
 ] interface WebKitMediaKeyMessageEvent : Event {
-    constructor([AtomString] DOMString type, optional WebKitMediaKeyMessageEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional WebKitMediaKeyMessageEventInit eventInitDict = {});
 
     readonly attribute Uint8Array message;
     readonly attribute DOMString destinationURL;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=LegacyEncryptedMediaAPIEnabled,
     Exposed=Window
 ] interface WebKitMediaKeyNeededEvent : Event {
-    constructor([AtomString] DOMString type, optional WebKitMediaKeyNeededEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional WebKitMediaKeyNeededEventInit eventInitDict = {});
 
     readonly attribute Uint8Array initData;
 };

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl
@@ -30,12 +30,12 @@
     [CallWith=CurrentScriptExecutionContext] FileSystemDirectoryReader createReader();
 
     [CallWith=CurrentScriptExecutionContext] undefined getFile(optional USVString? path,
-        optional FileSystemFlags options,
+        optional FileSystemFlags options = {},
         optional FileSystemEntryCallback? successCallback,
         optional ErrorCallback? errorCallback);
 
     [CallWith=CurrentScriptExecutionContext] undefined getDirectory(optional USVString? path,
-        optional FileSystemFlags options,
+        optional FileSystemFlags options = {},
         optional FileSystemEntryCallback? successCallback,
         optional ErrorCallback? errorCallback);
 };

--- a/Source/WebCore/Modules/fetch/FetchRequest.idl
+++ b/Source/WebCore/Modules/fetch/FetchRequest.idl
@@ -35,7 +35,7 @@ typedef (FetchRequest or USVString) RequestInfo;
     GenerateIsReachable=Impl,
     InterfaceName=Request,
 ] interface FetchRequest {
-    [CallWith=CurrentScriptExecutionContext] constructor(RequestInfo input, optional FetchRequestInit init);
+    [CallWith=CurrentScriptExecutionContext] constructor(RequestInfo input, optional FetchRequestInit init = {});
 
     readonly attribute ByteString method;
     [ImplementedAs=urlString] readonly attribute USVString url;

--- a/Source/WebCore/Modules/fetch/FetchResponse.idl
+++ b/Source/WebCore/Modules/fetch/FetchResponse.idl
@@ -43,11 +43,11 @@ dictionary FetchResponseInit {
     Exposed=(Window,Worker),
     InterfaceName=Response,
 ] interface FetchResponse {
-    [CallWith=CurrentScriptExecutionContext] constructor(optional BodyInit? body = null, optional FetchResponseInit init);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional BodyInit? body = null, optional FetchResponseInit init = {});
 
     [CallWith=CurrentScriptExecutionContext, NewObject] static FetchResponse error();
     [CallWith=CurrentScriptExecutionContext, NewObject] static FetchResponse redirect(USVString url, optional unsigned short status = 302);
-    [CallWith=CurrentScriptExecutionContext, NewObject, ImplementedAs=jsonForBindings] static FetchResponse json(any data, optional FetchResponseInit init);
+    [CallWith=CurrentScriptExecutionContext, NewObject, ImplementedAs=jsonForBindings] static FetchResponse json(any data, optional FetchResponseInit init = {});
 
     readonly attribute FetchResponseType type;
 

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScope+Fetch.idl
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScope+Fetch.idl
@@ -29,5 +29,5 @@ typedef (FetchRequest or USVString) RequestInfo;
 [
     ImplementedBy=WindowOrWorkerGlobalScopeFetch
 ] partial interface mixin WindowOrWorkerGlobalScope {
-    [NewObject] Promise<FetchResponse> fetch(RequestInfo input, optional FetchRequestInit init);
+    [NewObject] Promise<FetchResponse> fetch(RequestInfo input, optional FetchRequestInit init = {});
 };

--- a/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl
+++ b/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl
@@ -42,8 +42,8 @@ dictionary FileSystemRemoveOptions {
 ] interface FileSystemDirectoryHandle : FileSystemHandle {
     async iterable<USVString, FileSystemHandle>;
 
-    Promise<FileSystemFileHandle> getFileHandle(USVString name, optional FileSystemGetFileOptions options);
-    Promise<FileSystemDirectoryHandle> getDirectoryHandle(USVString name, optional FileSystemGetDirectoryOptions options);
-    Promise<undefined> removeEntry(USVString name, optional FileSystemRemoveOptions options);
+    Promise<FileSystemFileHandle> getFileHandle(USVString name, optional FileSystemGetFileOptions options = {});
+    Promise<FileSystemDirectoryHandle> getDirectoryHandle(USVString name, optional FileSystemGetDirectoryOptions options = {});
+    Promise<undefined> removeEntry(USVString name, optional FileSystemRemoveOptions options = {});
     Promise<sequence<USVString>?> resolve(FileSystemHandle possibleDescendant);
 };

--- a/Source/WebCore/Modules/gamepad/GamepadEvent.idl
+++ b/Source/WebCore/Modules/gamepad/GamepadEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=GamepadsEnabled,
     Exposed=Window
 ] interface GamepadEvent : Event {
-    constructor([AtomString] DOMString type, optional GamepadEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional GamepadEventInit eventInitDict = {});
 
     readonly attribute Gamepad? gamepad;
 };

--- a/Source/WebCore/Modules/geolocation/Geolocation.idl
+++ b/Source/WebCore/Modules/geolocation/Geolocation.idl
@@ -33,11 +33,11 @@
 ] interface Geolocation {
     undefined getCurrentPosition(PositionCallback successCallback,
                             optional PositionErrorCallback? errorCallback,
-                            optional PositionOptions options);
+                            optional PositionOptions options = {});
 
     long watchPosition(PositionCallback successCallback,
                        optional PositionErrorCallback? errorCallback,
-                       optional PositionOptions options);
+                       optional PositionOptions options = {});
 
     undefined clearWatch(long watchId);
 };

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.idl
@@ -34,10 +34,10 @@
     readonly attribute unsigned long long version;
     readonly attribute DOMStringList objectStoreNames;
 
-    [NewObject] IDBTransaction transaction((DOMString or sequence<DOMString>) storeNames, optional IDBTransactionMode mode = "readonly", optional IDBTransactionOptions options);
+    [NewObject] IDBTransaction transaction((DOMString or sequence<DOMString>) storeNames, optional IDBTransactionMode mode = "readonly", optional IDBTransactionOptions options = {});
     undefined close();
 
-    [NewObject] IDBObjectStore createObjectStore(DOMString name, optional IDBObjectStoreParameters parameters);
+    [NewObject] IDBObjectStore createObjectStore(DOMString name, optional IDBObjectStoreParameters parameters = {});
     undefined deleteObjectStore(DOMString name);
 
     // Event handlers:

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.idl
@@ -64,7 +64,7 @@ typedef (DOMString or sequence<DOMString>) IDBKeyPath;
 
     IDBIndex index(DOMString name);
 
-    [NewObject] IDBIndex createIndex(DOMString name, (DOMString or sequence<DOMString>) keyPath, optional IDBIndexParameters options);
+    [NewObject] IDBIndex createIndex(DOMString name, (DOMString or sequence<DOMString>) keyPath, optional IDBIndexParameters options = {});
     undefined deleteIndex(DOMString name);
 };
 

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=IndexedDBAPIEnabled,
     Exposed=(Window,Worker)
 ] interface IDBVersionChangeEvent : Event {
-    constructor([AtomString] DOMString type, optional IDBVersionChangeEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional IDBVersionChangeEventInit eventInitDict = {});
     readonly attribute unsigned long long oldVersion;
     readonly attribute unsigned long long? newVersion;
 };

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.idl
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.idl
@@ -30,7 +30,7 @@ enum RecordingState { "inactive", "recording", "paused" };
     EnabledBySetting=MediaRecorderEnabled,
     Exposed=Window
 ] interface MediaRecorder : EventTarget {
-    [CallWith=CurrentDocument] constructor(MediaStream stream, optional MediaRecorderOptions options);
+    [CallWith=CurrentDocument] constructor(MediaStream stream, optional MediaRecorderOptions options = {});
 
     readonly attribute MediaStream stream;
     readonly attribute DOMString mimeType;

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.idl
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.idl
@@ -27,7 +27,7 @@
     Conditional=MEDIA_SESSION,
     Exposed=Window,
 ] interface MediaMetadata {
-    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaMetadataInit init);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaMetadataInit init = {});
     attribute DOMString title;
     attribute DOMString artist;
     attribute DOMString album;

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
@@ -37,7 +37,7 @@ enum PreferredQuality {
     EnabledForContext,
     Exposed=(Window,DedicatedWorker)
 ] interface ManagedMediaSource : MediaSource {
-    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaSourceInit init);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaSourceInit init = {});
 
     readonly attribute PreferredQuality quality;
     attribute EventHandler onqualitychange;

--- a/Source/WebCore/Modules/mediasource/MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/MediaSource.idl
@@ -48,7 +48,7 @@ enum ReadyState {
     EnabledForContext,
     Exposed=(Window,DedicatedWorker)
 ] interface MediaSource : EventTarget {
-    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaSourceInit init = { });
+    [CallWith=CurrentScriptExecutionContext] constructor(optional MediaSourceInit init = {});
 
     [EnabledBySetting=DetachableMediaSourceEnabled] readonly attribute boolean detachable;
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.idl
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.idl
@@ -40,8 +40,8 @@ typedef (MediaDeviceInfo or InputDeviceInfo) DeviceInfo;
     Promise<sequence<DeviceInfo>> enumerateDevices();
 
     MediaTrackSupportedConstraints getSupportedConstraints();
-    [PrivateIdentifier, PublicIdentifier] Promise<MediaStream> getUserMedia(optional MediaStreamConstraints constraints);
-    [EnabledBySetting=ScreenCaptureEnabled] Promise<MediaStream> getDisplayMedia(optional DisplayMediaStreamConstraints constraints);
+    [PrivateIdentifier, PublicIdentifier] Promise<MediaStream> getUserMedia(optional MediaStreamConstraints constraints = {});
+    [EnabledBySetting=ScreenCaptureEnabled] Promise<MediaStream> getDisplayMedia(optional DisplayMediaStreamConstraints constraints = {});
 };
 
 [

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -53,7 +53,7 @@ enum MediaStreamTrackState { "live", "ended" };
     MediaTrackCapabilities getCapabilities();
     MediaTrackConstraints getConstraints();
     MediaTrackSettings getSettings();
-    Promise<undefined> applyConstraints(optional MediaTrackConstraints constraints);
+    Promise<undefined> applyConstraints(optional MediaTrackConstraints constraints = {});
 };
 
 [

--- a/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl
@@ -30,7 +30,7 @@
     Conditional=MEDIA_STREAM,
     Exposed=Window
 ] interface OverconstrainedErrorEvent : Event {
-    constructor([AtomString] DOMString type, optional OverconstrainedErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional OverconstrainedErrorEventInit eventInitDict = {});
 
     readonly attribute OverconstrainedError? error;
 };

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.idl
@@ -29,7 +29,7 @@
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCDTMFToneChangeEvent : Event {
-    constructor([AtomString] DOMString type, optional RTCDTMFToneChangeEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional RTCDTMFToneChangeEventInit eventInitDict = {});
 
     readonly attribute DOMString tone;
 };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -452,9 +452,8 @@ void RTCPeerConnection::setRemoteDescription(RTCSessionDescriptionInit&& remoteD
 void RTCPeerConnection::addIceCandidate(Candidate&& rtcCandidate, Ref<DeferredPromise>&& promise)
 {
     std::optional<Exception> exception;
-    RefPtr<RTCIceCandidate> candidate;
-    if (rtcCandidate) {
-        candidate = WTF::switchOn(*rtcCandidate, [&exception](RTCIceCandidateInit& init) -> RefPtr<RTCIceCandidate> {
+    RefPtr candidate = WTF::switchOn(rtcCandidate,
+        [&exception](RTCIceCandidateInit& init) -> RefPtr<RTCIceCandidate> {
             if (init.candidate.isEmpty())
                 return nullptr;
 
@@ -464,10 +463,11 @@ void RTCPeerConnection::addIceCandidate(Candidate&& rtcCandidate, Ref<DeferredPr
                 return nullptr;
             }
             return result.releaseReturnValue();
-        }, [](RefPtr<RTCIceCandidate>& iceCandidate) {
+        },
+        [](RefPtr<RTCIceCandidate>& iceCandidate) -> RefPtr<RTCIceCandidate> {
             return WTF::move(iceCandidate);
-        });
-    }
+        }
+    );
 
     ALWAYS_LOG(LOGIDENTIFIER, "Received ice candidate:\n", candidate ? candidate->candidate() : "null"_s);
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -128,7 +128,7 @@ public:
     RTCSessionDescription* currentRemoteDescription() const { return m_currentRemoteDescription.get(); }
     RTCSessionDescription* pendingRemoteDescription() const { return m_pendingRemoteDescription.get(); }
 
-    using Candidate = std::optional<Variant<RTCIceCandidateInit, RefPtr<RTCIceCandidate>>>;
+    using Candidate = Variant<RTCIceCandidateInit, RefPtr<RTCIceCandidate>>;
     void addIceCandidate(Candidate&&, Ref<DeferredPromise>&&);
 
     RTCSignalingState signalingState() const { return m_signalingState; }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
@@ -83,13 +83,13 @@ typedef (object or DOMString) AlgorithmIdentifier;
     ExportMacro=WEBCORE_EXPORT,
     Exposed=Window
 ] interface RTCPeerConnection : EventTarget {
-    [CallWith=CurrentDocument] constructor(optional RTCConfiguration configuration);
+    [CallWith=CurrentDocument] constructor(optional RTCConfiguration configuration = {});
 
     // 4.3.2 Interface Definition
-    Promise<RTCSessionDescriptionInit> createOffer(optional RTCOfferOptions offerOptions);
-    Promise<RTCSessionDescriptionInit> createAnswer(optional RTCAnswerOptions answerOptions);
+    Promise<RTCSessionDescriptionInit> createOffer(optional RTCOfferOptions offerOptions = {});
+    Promise<RTCSessionDescriptionInit> createAnswer(optional RTCAnswerOptions answerOptions = {});
 
-    Promise<undefined> setLocalDescription(optional RTCLocalSessionDescriptionInit description);
+    Promise<undefined> setLocalDescription(optional RTCLocalSessionDescriptionInit description = {});
     readonly attribute RTCSessionDescription? localDescription;
     readonly attribute RTCSessionDescription? currentLocalDescription;
     readonly attribute RTCSessionDescription? pendingLocalDescription;
@@ -99,7 +99,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
     readonly attribute RTCSessionDescription? currentRemoteDescription;
     readonly attribute RTCSessionDescription? pendingRemoteDescription;
 
-    Promise<undefined> addIceCandidate(optional (RTCIceCandidateInit or RTCIceCandidate) candidate);
+    Promise<undefined> addIceCandidate(optional (RTCIceCandidateInit or RTCIceCandidate) candidate = {});
 
     readonly attribute RTCSignalingState signalingState;
     readonly attribute RTCIceGatheringState iceGatheringState;
@@ -132,7 +132,7 @@ typedef (object or DOMString) AlgorithmIdentifier;
     RTCRtpSender addTrack(MediaStreamTrack track, MediaStream... streams);
     undefined removeTrack(RTCRtpSender sender);
 
-    RTCRtpTransceiver addTransceiver((MediaStreamTrack or DOMString) track, optional RTCRtpTransceiverInit init);
+    RTCRtpTransceiver addTransceiver((MediaStreamTrack or DOMString) track, optional RTCRtpTransceiverInit init = {});
 
     attribute EventHandler ontrack;
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl
@@ -35,7 +35,7 @@
     EnabledBySetting=PeerConnectionEnabled,
     Exposed=Window
 ] interface RTCPeerConnectionIceEvent : Event {
-    constructor([AtomString] DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional RTCPeerConnectionIceEventInit eventInitDict = {});
 
     readonly attribute RTCIceCandidate? candidate;
     readonly attribute DOMString? url;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.idl
@@ -51,7 +51,7 @@ enum RTCRtpSFrameTransformCompatibilityMode {
     InterfaceName=SFrameTransform,
     JSGenerateToNativeObject,
 ] interface RTCRtpSFrameTransform : EventTarget {
-    [CallWith=CurrentScriptExecutionContext] constructor(optional RTCRtpSFrameTransformOptions options);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional RTCRtpSFrameTransformOptions options = {});
 
     [Custom] Promise<undefined> setEncryptionKey(CryptoKey key, optional any keyID);
     // FIXME: Add support for missing methods.

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.idl
@@ -30,5 +30,5 @@
     Exposed=Window,
     JSGenerateToNativeObject,
 ] interface RTCRtpScriptTransform {
-    [CallWith=CurrentGlobalObject] constructor(Worker worker, optional any options, optional sequence<object> transfer);
+    [CallWith=CurrentGlobalObject] constructor(Worker worker, optional any options, optional sequence<object> transfer = []);
 };

--- a/Source/WebCore/Modules/notifications/Notification.idl
+++ b/Source/WebCore/Modules/notifications/Notification.idl
@@ -38,7 +38,7 @@
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,DedicatedWorker,ServiceWorker)
 ] interface Notification : EventTarget {
-    [CallWith=CurrentScriptExecutionContext] constructor(DOMString title, optional NotificationOptions options);
+    [CallWith=CurrentScriptExecutionContext] constructor(DOMString title, optional NotificationOptions options = {});
 
     [CallWith=CurrentScriptExecutionContext] static readonly attribute NotificationPermission permission;
     [Exposed=Window, CallWith=CurrentDocument] static Promise<NotificationPermission> requestPermission(optional NotificationPermissionCallback? deprecatedCallback);

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl
@@ -29,7 +29,7 @@
     Exposed=Window,
     SecureContext,
 ] interface MerchantValidationEvent : Event {
-    [CallWith=CurrentDocument] constructor([AtomString] DOMString type, optional MerchantValidationEventInit eventInitDict);
+    [CallWith=CurrentDocument] constructor([AtomString] DOMString type, optional MerchantValidationEventInit eventInitDict = {});
 
     readonly attribute DOMString methodName;
     readonly attribute USVString validationURL;

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl
@@ -30,7 +30,7 @@
     JSCustomMarkFunction,
     SecureContext,
 ] interface PaymentMethodChangeEvent : PaymentRequestUpdateEvent {
-    constructor([AtomString] DOMString type, optional PaymentMethodChangeEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PaymentMethodChangeEventInit eventInitDict = {});
 
     readonly attribute DOMString methodName;
     [CustomGetter] readonly attribute object? methodDetails;

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.idl
@@ -30,7 +30,7 @@
     SecureContext,
     Exposed=Window
 ] interface PaymentRequest : EventTarget {
-    [CallWith=CurrentDocument] constructor(sequence<PaymentMethodData> methodData, PaymentDetailsInit details, optional PaymentOptions options);
+    [CallWith=CurrentDocument] constructor(sequence<PaymentMethodData> methodData, PaymentDetailsInit details, optional PaymentOptions options = {});
 
     [CallWith=RelevantDocument] Promise<PaymentResponse> show(optional Promise<PaymentDetailsUpdate> detailsPromise);
     Promise<undefined> abort();

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.idl
@@ -29,7 +29,7 @@
     Exposed=Window,
     SecureContext
 ] interface PaymentRequestUpdateEvent : Event {
-    constructor([AtomString] DOMString type, optional PaymentRequestUpdateEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PaymentRequestUpdateEventInit eventInitDict = {});
 
     undefined updateWith(Promise<PaymentDetailsUpdate> detailsPromise);
 };

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.idl
@@ -42,8 +42,8 @@
     readonly attribute DOMString? payerEmail;
     readonly attribute DOMString? payerPhone;
 
-    [CallWith=CurrentDocument, NewObject] Promise<undefined> complete(optional PaymentComplete result = "unknown", optional PaymentCompleteDetails details);
-    [NewObject] Promise<undefined> retry(optional PaymentValidationErrors errorFields);
+    [CallWith=CurrentDocument, NewObject] Promise<undefined> complete(optional PaymentComplete result = "unknown", optional PaymentCompleteDetails details = {});
+    [NewObject] Promise<undefined> retry(optional PaymentValidationErrors errorFields = {});
 
     attribute EventHandler onpayerdetailchange;
 };

--- a/Source/WebCore/Modules/push-api/PushEvent.idl
+++ b/Source/WebCore/Modules/push-api/PushEvent.idl
@@ -30,7 +30,7 @@
     JSGenerateToNativeObject,
     SecureContext
 ] interface PushEvent : ExtendableEvent {
-    constructor([AtomString] DOMString type, optional PushEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PushEventInit eventInitDict = {});
     readonly attribute PushMessageData? data;
     [Conditional=DECLARATIVE_WEB_PUSH&NOTIFICATIONS, EnabledBySetting=DeclarativeWebPush] readonly attribute Notification? notification;
     [Conditional=DECLARATIVE_WEB_PUSH&NOTIFICATIONS, EnabledBySetting=DeclarativeWebPush] readonly attribute unsigned long long? appBadge;

--- a/Source/WebCore/Modules/push-api/PushManager.idl
+++ b/Source/WebCore/Modules/push-api/PushManager.idl
@@ -32,7 +32,7 @@
 ] interface PushManager {
     [SameObject] static readonly attribute FrozenArray<DOMString> supportedContentEncodings;
 
-    [CallWith=CurrentScriptExecutionContext] Promise<PushSubscription> subscribe(optional PushSubscriptionOptionsInit options);
+    [CallWith=CurrentScriptExecutionContext] Promise<PushSubscription> subscribe(optional PushSubscriptionOptionsInit options = {});
     [CallWith=CurrentScriptExecutionContext] Promise<PushSubscription?> getSubscription();
-    [CallWith=CurrentScriptExecutionContext] Promise<PushPermissionState> permissionState(optional PushSubscriptionOptionsInit options);
+    [CallWith=CurrentScriptExecutionContext] Promise<PushPermissionState> permissionState(optional PushSubscriptionOptionsInit options = {});
 };

--- a/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.idl
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.idl
@@ -30,7 +30,7 @@
     JSGenerateToNativeObject,
     SecureContext
 ] interface PushSubscriptionChangeEvent : ExtendableEvent {
-    constructor([AtomString] DOMString type, optional PushSubscriptionChangeEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PushSubscriptionChangeEventInit eventInitDict = {});
     readonly attribute PushSubscription? newSubscription;
     readonly attribute PushSubscription? oldSubscription;
 };

--- a/Source/WebCore/Modules/reporting/ReportingObserver.idl
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.idl
@@ -32,7 +32,7 @@ typedef sequence<Report> ReportList;
     ActiveDOMObject,
     JSCustomMarkFunction
 ] interface ReportingObserver {
-    [CallWith=CurrentScriptExecutionContext] constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options);
+    [CallWith=CurrentScriptExecutionContext] constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options = {});
     undefined observe();
     undefined disconnect();
     ReportList takeRecords();

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -58,7 +58,7 @@ typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStream
     [ImplementedAs=isLocked] readonly attribute boolean locked;
 
     [CallWith=CurrentGlobalObject, ReturnsOwnPromise, ImplementedAs=cancelForBindings] Promise<undefined> cancel(optional any reason);
-    [CallWith=CurrentGlobalObject] ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = { });
+    [CallWith=CurrentGlobalObject] ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
     [CallWith=CurrentGlobalObject] Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
     [CallWith=CurrentGlobalObject] ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
     [CallWith=CurrentGlobalObject] sequence<ReadableStream> tee();

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -268,12 +268,9 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
 }
 
 // https://urlpattern.spec.whatwg.org/#urlpattern-initialize
-ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, URLPatternOptions&& options)
+ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, URLPatternInput&& input, URLPatternOptions&& options)
 {
-    if (!input)
-        input = URLPatternInit { };
-
-    return create(context, WTF::move(*input), String { }, WTF::move(options));
+    return create(context, WTF::move(input), String { }, WTF::move(options));
 }
 
 // https://urlpattern.spec.whatwg.org/#build-a-url-pattern-from-a-web-idl-value
@@ -293,12 +290,9 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
 URLPattern::~URLPattern() = default;
 
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-test
-ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
+ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, URLPatternInput&& input, String&& baseURL) const
 {
-    if (!input)
-        input = URLPatternInit { };
-
-    auto maybeResult = match(context, WTF::move(*input), WTF::move(baseURL));
+    auto maybeResult = match(context, WTF::move(input), WTF::move(baseURL));
     if (maybeResult.hasException())
         return maybeResult.releaseException();
 
@@ -306,12 +300,9 @@ ExceptionOr<bool> URLPattern::test(ScriptExecutionContext& context, std::optiona
 }
 
 // https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec
-ExceptionOr<std::optional<URLPatternResult>> URLPattern::exec(ScriptExecutionContext& context, std::optional<URLPatternInput>&& input, String&& baseURL) const
+ExceptionOr<std::optional<URLPatternResult>> URLPattern::exec(ScriptExecutionContext& context, URLPatternInput&& input, String&& baseURL) const
 {
-    if (!input)
-        input = URLPatternInit { };
-
-    return match(context, WTF::move(*input), WTF::move(baseURL));
+    return match(context, WTF::move(input), WTF::move(baseURL));
 }
 
 ExceptionOr<void> URLPattern::compileAllComponents(ScriptExecutionContext& context, URLPatternInit&& processedInit)

--- a/Source/WebCore/Modules/url-pattern/URLPattern.h
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.h
@@ -52,16 +52,16 @@ public:
     using URLPatternInput = Variant<String, URLPatternInit>;
 
     static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL, URLPatternOptions&&);
-    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, std::optional<URLPatternInput>&&, URLPatternOptions&&);
+    static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, URLPatternInput&&, URLPatternOptions&&);
 
     using Compatible = Variant<String, URLPatternInit, RefPtr<URLPattern>>;
     static ExceptionOr<Ref<URLPattern>> create(ScriptExecutionContext&, Compatible&&, const String&);
 
     ~URLPattern();
 
-    ExceptionOr<bool> test(ScriptExecutionContext&, std::optional<URLPatternInput>&&, String&& baseURL) const;
+    ExceptionOr<bool> test(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL) const;
 
-    ExceptionOr<std::optional<URLPatternResult>> exec(ScriptExecutionContext&, std::optional<URLPatternInput>&&, String&& baseURL) const;
+    ExceptionOr<std::optional<URLPatternResult>> exec(ScriptExecutionContext&, URLPatternInput&&, String&& baseURL) const;
 
     const String& protocol() const { return m_protocolComponent.patternString(); }
     const String& username() const { return m_usernameComponent.patternString(); }

--- a/Source/WebCore/Modules/url-pattern/URLPattern.idl
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.idl
@@ -34,12 +34,12 @@ typedef (USVString or URLPatternInit) URLPatternInput;
     EnabledBySetting=URLPatternAPIEnabled,
     Exposed=(Window,Worker)
 ] interface URLPattern {
-    [CallWith=CurrentScriptExecutionContext] constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options);
-    [CallWith=CurrentScriptExecutionContext] constructor(optional URLPatternInput input, optional URLPatternOptions options);
+    [CallWith=CurrentScriptExecutionContext] constructor(URLPatternInput input, USVString baseURL, optional URLPatternOptions options = {});
+    [CallWith=CurrentScriptExecutionContext] constructor(optional URLPatternInput input = {}, optional URLPatternOptions options = {});
 
-    [CallWith=CurrentScriptExecutionContext] boolean test(optional URLPatternInput input, optional USVString baseURL);
+    [CallWith=CurrentScriptExecutionContext] boolean test(optional URLPatternInput input = {}, optional USVString baseURL);
 
-    [CallWith=CurrentScriptExecutionContext] URLPatternResult? exec(optional URLPatternInput input, optional USVString baseURL);
+    [CallWith=CurrentScriptExecutionContext] URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
 
     readonly attribute USVString protocol;
     readonly attribute USVString username;

--- a/Source/WebCore/Modules/webaudio/AnalyserNode.idl
+++ b/Source/WebCore/Modules/webaudio/AnalyserNode.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface AnalyserNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional AnalyserOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional AnalyserOptions options = {});
 
     attribute unsigned long fftSize;
     readonly attribute unsigned long frequencyBinCount;

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.idl
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.idl
@@ -30,7 +30,7 @@
     JSCustomMarkFunction,
     Exposed=Window
 ] interface AudioBufferSourceNode : AudioScheduledSourceNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional AudioBufferSourceOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional AudioBufferSourceOptions options = {});
 
     [ImplementedAs=bufferForBindings] attribute AudioBuffer? buffer;
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.idl
+++ b/Source/WebCore/Modules/webaudio/AudioContext.idl
@@ -31,7 +31,7 @@
     JSGenerateToNativeObject,
     Exposed=Window
 ] interface AudioContext : BaseAudioContext {
-    [CallWith=CurrentDocument] constructor(optional AudioContextOptions contextOptions);
+    [CallWith=CurrentDocument] constructor(optional AudioContextOptions contextOptions = {});
 
     readonly attribute double baseLatency;
     readonly attribute double outputLatency;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.idl
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.idl
@@ -33,7 +33,7 @@
     Exposed=Window,
     SecureContext
 ] interface AudioWorkletNode : AudioNode {
-    [CallWith=CurrentGlobalObject] constructor (BaseAudioContext context, DOMString name, optional AudioWorkletNodeOptions options);
+    [CallWith=CurrentGlobalObject] constructor (BaseAudioContext context, DOMString name, optional AudioWorkletNodeOptions options = {});
     readonly attribute AudioParamMap parameters;
     readonly attribute MessagePort port;
     attribute EventHandler onprocessorerror;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.idl
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.idl
@@ -66,7 +66,7 @@
     AnalyserNode createAnalyser();
     ScriptProcessorNode createScriptProcessor(optional unsigned long bufferSize = 0, optional unsigned long numberOfInputChannels = 2, optional unsigned long numberOfOutputChannels = 2);
     OscillatorNode createOscillator();
-    PeriodicWave createPeriodicWave(sequence<float> real, sequence<float> imag, optional PeriodicWaveOptions options);
+    PeriodicWave createPeriodicWave(sequence<float> real, sequence<float> imag, optional PeriodicWaveOptions options = {});
     ConstantSourceNode createConstantSource();
     StereoPannerNode createStereoPanner();
     [CallWith=CurrentScriptExecutionContext] IIRFilterNode createIIRFilter(sequence<double> feedforward, sequence<double> feedback);

--- a/Source/WebCore/Modules/webaudio/BiquadFilterNode.idl
+++ b/Source/WebCore/Modules/webaudio/BiquadFilterNode.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface BiquadFilterNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional BiquadFilterOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional BiquadFilterOptions options = {});
 
     attribute BiquadFilterType type;
     

--- a/Source/WebCore/Modules/webaudio/ChannelMergerNode.idl
+++ b/Source/WebCore/Modules/webaudio/ChannelMergerNode.idl
@@ -31,5 +31,5 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface ChannelMergerNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ChannelMergerOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ChannelMergerOptions options = {});
 };

--- a/Source/WebCore/Modules/webaudio/ChannelSplitterNode.idl
+++ b/Source/WebCore/Modules/webaudio/ChannelSplitterNode.idl
@@ -27,5 +27,5 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface ChannelSplitterNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ChannelSplitterOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ChannelSplitterOptions options = {});
 };

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.idl
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.idl
@@ -28,6 +28,6 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface ConstantSourceNode : AudioScheduledSourceNode {
-    constructor (BaseAudioContext context, optional ConstantSourceOptions options);
+    constructor (BaseAudioContext context, optional ConstantSourceOptions options = {});
     readonly attribute AudioParam offset;
 };

--- a/Source/WebCore/Modules/webaudio/ConvolverNode.idl
+++ b/Source/WebCore/Modules/webaudio/ConvolverNode.idl
@@ -29,7 +29,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface ConvolverNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ConvolverOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional ConvolverOptions options = {});
 
     [ImplementedAs=bufferForBindings] attribute AudioBuffer? buffer;
     [ImplementedAs=normalizeForBindings] attribute boolean normalize;

--- a/Source/WebCore/Modules/webaudio/DelayNode.idl
+++ b/Source/WebCore/Modules/webaudio/DelayNode.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface DelayNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional DelayOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional DelayOptions options = {});
 
     readonly attribute AudioParam delayTime;
 };

--- a/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl
+++ b/Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface DynamicsCompressorNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional DynamicsCompressorOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional DynamicsCompressorOptions options = {});
 
     readonly attribute AudioParam threshold; // in Decibels
     readonly attribute AudioParam knee; // in Decibels

--- a/Source/WebCore/Modules/webaudio/GainNode.idl
+++ b/Source/WebCore/Modules/webaudio/GainNode.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface GainNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional GainOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional GainOptions options = {});
 
     readonly attribute AudioParam gain;
 };

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.idl
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.idl
@@ -27,6 +27,6 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface MediaStreamAudioDestinationNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (AudioContext context, optional AudioNodeOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (AudioContext context, optional AudioNodeOptions options = {});
     readonly attribute MediaStream stream;
 };

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.idl
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.idl
@@ -29,7 +29,7 @@
     ActiveDOMObject,
     Exposed=Window
 ] interface OscillatorNode : AudioScheduledSourceNode {
-    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional OscillatorOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor (BaseAudioContext context, optional OscillatorOptions options = {});
 
     [ImplementedAs=typeForBindings] attribute OscillatorType type;
 

--- a/Source/WebCore/Modules/webaudio/PannerNode.idl
+++ b/Source/WebCore/Modules/webaudio/PannerNode.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface PannerNode : AudioNode {
-    constructor (BaseAudioContext context, optional PannerOptions options);
+    constructor (BaseAudioContext context, optional PannerOptions options = {});
 
     // Default model for stereo is equalpower
     [ImplementedAs=panningModelForBindings] attribute PanningModelType panningModel;

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.idl
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.idl
@@ -28,5 +28,5 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface PeriodicWave {
-    [EnabledBySetting=WebAudioEnabled] constructor(BaseAudioContext context, optional PeriodicWaveOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor(BaseAudioContext context, optional PeriodicWaveOptions options = {});
 };

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.idl
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.idl
@@ -28,6 +28,6 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface StereoPannerNode : AudioNode {
-    constructor (BaseAudioContext context, optional StereoPannerOptions options);
+    constructor (BaseAudioContext context, optional StereoPannerOptions options = {});
     readonly attribute AudioParam pan;
 };

--- a/Source/WebCore/Modules/webaudio/WaveShaperNode.idl
+++ b/Source/WebCore/Modules/webaudio/WaveShaperNode.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=WebAudioEnabled,
     Exposed=Window
 ] interface WaveShaperNode : AudioNode {
-    [EnabledBySetting=WebAudioEnabled] constructor(BaseAudioContext context, optional WaveShaperOptions options);
+    [EnabledBySetting=WebAudioEnabled] constructor(BaseAudioContext context, optional WaveShaperOptions options = {});
 
     [ImplementedAs=curveForBindings] attribute Float32Array? curve;
     [ImplementedAs=oversampleForBindings] attribute OverSampleType oversample;

--- a/Source/WebCore/Modules/websockets/CloseEvent.idl
+++ b/Source/WebCore/Modules/websockets/CloseEvent.idl
@@ -31,7 +31,7 @@
 [
     Exposed=(Window,Worker),
 ] interface CloseEvent : Event {
-    constructor([AtomString] DOMString type, optional CloseEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional CloseEventInit eventInitDict = {});
 
     readonly attribute boolean wasClean;
     readonly attribute unsigned short code;

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.idl
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.idl
@@ -32,7 +32,7 @@
     JSCustomMarkFunction,
     InterfaceName=XRRigidTransform
 ] interface WebXRRigidTransform {
-    constructor(optional DOMPointInit position, optional DOMPointInit orientation);
+    constructor(optional DOMPointInit position = {}, optional DOMPointInit orientation = {});
 
     [SameObject] readonly attribute DOMPointReadOnly position;
     [SameObject] readonly attribute DOMPointReadOnly orientation;

--- a/Source/WebCore/Modules/webxr/WebXRSession.idl
+++ b/Source/WebCore/Modules/webxr/WebXRSession.idl
@@ -40,7 +40,7 @@
     [SameObject] readonly attribute sequence<DOMString> enabledFeatures;
 
     // Methods
-    undefined updateRenderState(optional XRRenderStateInit stateInit);
+    undefined updateRenderState(optional XRRenderStateInit stateInit = {});
     [NewObject] Promise<WebXRReferenceSpace> requestReferenceSpace(XRReferenceSpaceType type);
 
     unsigned long requestAnimationFrame(XRFrameRequestCallback callback);

--- a/Source/WebCore/Modules/webxr/WebXRSystem.idl
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.idl
@@ -36,7 +36,7 @@
     // Methods
     // FIXME: Spec says this should return Promise<boolean>.
     Promise<undefined> isSessionSupported(XRSessionMode mode);
-    [NewObject, CallWith=CurrentDocument] Promise<WebXRSession> requestSession(XRSessionMode mode, optional XRSessionInit options);
+    [NewObject, CallWith=CurrentDocument] Promise<WebXRSession> requestSession(XRSessionMode mode, optional XRSessionInit options = {});
 
     // Events
     attribute EventHandler ondevicechange;

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl
@@ -35,7 +35,7 @@ typedef (WebGLRenderingContext or WebGL2RenderingContext) WebXRWebGLRenderingCon
     JSGenerateToNativeObject,
     InterfaceName=XRWebGLLayer
 ] interface WebXRWebGLLayer : WebXRLayer {
-    constructor(WebXRSession session, WebXRWebGLRenderingContext context, optional XRWebGLLayerInit layerInit);
+    constructor(WebXRSession session, WebXRWebGLRenderingContext context, optional XRWebGLLayerInit layerInit = {});
 
     // Attributes
     readonly attribute boolean antialias;

--- a/Source/WebCore/animation/Animatable.idl
+++ b/Source/WebCore/animation/Animatable.idl
@@ -25,6 +25,6 @@
 
 // https://drafts.csswg.org/web-animations-1/#the-animatable-interface-mixin
 interface mixin Animatable {
-    [CallWith=CurrentGlobalObject] WebAnimation animate(object? keyframes, optional (unrestricted double or KeyframeAnimationOptions) options);
-    sequence<WebAnimation> getAnimations(optional GetAnimationsOptions options);
+    [CallWith=CurrentGlobalObject] WebAnimation animate(object? keyframes, optional (unrestricted double or KeyframeAnimationOptions) options = {});
+    sequence<WebAnimation> getAnimations(optional GetAnimationsOptions options = {});
 };

--- a/Source/WebCore/animation/AnimationEffect.h
+++ b/Source/WebCore/animation/AnimationEffect.h
@@ -60,8 +60,8 @@ public:
     BasicEffectTiming getBasicTiming();
     ComputedEffectTiming getBindingsComputedTiming();
     ComputedEffectTiming getComputedTiming(UseCachedCurrentTime = UseCachedCurrentTime::Yes, EndpointInclusiveActiveInterval = EndpointInclusiveActiveInterval::No);
-    ExceptionOr<void> bindingsUpdateTiming(Document&, std::optional<OptionalEffectTiming>);
-    ExceptionOr<void> updateTiming(Document&, std::optional<OptionalEffectTiming>);
+    ExceptionOr<void> bindingsUpdateTiming(Document&, const OptionalEffectTiming&);
+    ExceptionOr<void> updateTiming(Document&, const OptionalEffectTiming&);
 
     virtual void animationDidTick() { };
     virtual void animationBecameReady() { };

--- a/Source/WebCore/animation/AnimationEffect.idl
+++ b/Source/WebCore/animation/AnimationEffect.idl
@@ -28,5 +28,5 @@
 ] interface AnimationEffect {
     [ImplementedAs=getBindingsTiming] EffectTiming getTiming();
     [ImplementedAs=getBindingsComputedTiming] ComputedEffectTiming getComputedTiming();
-    [ImplementedAs=bindingsUpdateTiming, CallWith=CurrentDocument] undefined updateTiming(optional OptionalEffectTiming timing);
+    [ImplementedAs=bindingsUpdateTiming, CallWith=CurrentDocument] undefined updateTiming(optional OptionalEffectTiming timing = {});
 };

--- a/Source/WebCore/animation/AnimationPlaybackEvent.idl
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.idl
@@ -28,7 +28,7 @@ typedef (double or CSSNumericValue) CSSNumberish;
 [
     Exposed=Window
 ] interface AnimationPlaybackEvent : Event {
-    constructor([AtomString] DOMString type, optional AnimationPlaybackEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional AnimationPlaybackEventInit eventInitDict = {});
 
     readonly attribute CSSNumberish? currentTime;
     readonly attribute CSSNumberish? timelineTime;

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -339,7 +339,7 @@ ExceptionOr<void> CSSAnimation::bindingsReverse()
     return retVal;
 }
 
-void CSSAnimation::effectTimingWasUpdatedUsingBindings(OptionalEffectTiming timing)
+void CSSAnimation::effectTimingWasUpdatedUsingBindings(const OptionalEffectTiming& timing)
 {
     // https://drafts.csswg.org/css-animations-2/#animations
 

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -46,7 +46,7 @@ public:
     const String& animationName() const { return m_animationName.name; }
     const Style::ScopedName& scopedAnimationName() const { return m_animationName; }
 
-    void effectTimingWasUpdatedUsingBindings(OptionalEffectTiming);
+    void effectTimingWasUpdatedUsingBindings(const OptionalEffectTiming&);
     void effectKeyframesWereSetUsingBindings();
     void effectCompositeOperationWasSetUsingBindings();
     void keyframesRuleDidChange();

--- a/Source/WebCore/animation/CSSAnimationEvent.idl
+++ b/Source/WebCore/animation/CSSAnimationEvent.idl
@@ -27,7 +27,7 @@
     Exposed=Window,
     InterfaceName=AnimationEvent
 ] interface CSSAnimationEvent : Event {
-    constructor([AtomString] DOMString type, optional AnimationEventInit animationEventInitDict);
+    constructor([AtomString] DOMString type, optional AnimationEventInit animationEventInitDict = {});
 
     readonly attribute DOMString animationName;
     readonly attribute double elapsedTime;

--- a/Source/WebCore/animation/CSSTransitionEvent.idl
+++ b/Source/WebCore/animation/CSSTransitionEvent.idl
@@ -28,7 +28,7 @@
     Exposed=Window,
     InterfaceName=TransitionEvent
 ] interface CSSTransitionEvent : Event {
-    constructor([AtomString] DOMString type, optional TransitionEventInit transitionEventInitDict);
+    constructor([AtomString] DOMString type, optional TransitionEventInit transitionEventInitDict = {});
 
     readonly attribute DOMString propertyName;
     readonly attribute double elapsedTime;

--- a/Source/WebCore/animation/CustomEffect.h
+++ b/Source/WebCore/animation/CustomEffect.h
@@ -35,7 +35,7 @@ namespace WebCore {
 class CustomEffect final : public AnimationEffect {
     WTF_MAKE_TZONE_ALLOCATED(CustomEffect);
 public:
-    static ExceptionOr<Ref<CustomEffect>> create(Document&, Ref<CustomEffectCallback>&&, std::optional<Variant<double, EffectTiming>>&&);
+    static ExceptionOr<Ref<CustomEffect>> create(Document&, Ref<CustomEffectCallback>&&, Variant<double, EffectTiming>&&);
     ~CustomEffect() { }
 
 private:

--- a/Source/WebCore/animation/CustomEffect.idl
+++ b/Source/WebCore/animation/CustomEffect.idl
@@ -28,5 +28,5 @@
     Exposed=Window,
     JSGenerateToNativeObject,
 ] interface CustomEffect : AnimationEffect {
-    [CallWith=CurrentDocument] constructor(CustomEffectCallback callback, optional (unrestricted double or EffectTiming) options);
+    [CallWith=CurrentDocument] constructor(CustomEffectCallback callback, optional (unrestricted double or EffectTiming) options = {});
 };

--- a/Source/WebCore/animation/DocumentTimeline.h
+++ b/Source/WebCore/animation/DocumentTimeline.h
@@ -58,7 +58,7 @@ public:
     Document* document() const { return m_document.get(); }
 
     std::optional<WebAnimationTime> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes) override;
-    ExceptionOr<Ref<WebAnimation>> animate(Ref<CustomEffectCallback>&&, std::optional<Variant<double, CustomAnimationOptions>>&&);
+    ExceptionOr<Ref<WebAnimation>> animate(Ref<CustomEffectCallback>&&, Variant<double, CustomAnimationOptions>&&);
 
     void animationTimingDidChange(WebAnimation&) override;
     void removeAnimation(WebAnimation&) override;

--- a/Source/WebCore/animation/DocumentTimeline.idl
+++ b/Source/WebCore/animation/DocumentTimeline.idl
@@ -28,7 +28,7 @@ typedef unsigned long FramesPerSecond;
 [
     Exposed=Window
 ] interface DocumentTimeline : AnimationTimeline {
-    [CallWith=CurrentDocument] constructor(optional DocumentTimelineOptions options);
-    [EnabledBySetting=WebAnimationsCustomEffectsEnabled] WebAnimation animate(CustomEffectCallback callback, optional (unrestricted double or CustomAnimationOptions) options);
+    [CallWith=CurrentDocument] constructor(optional DocumentTimelineOptions options = {});
+    [EnabledBySetting=WebAnimationsCustomEffectsEnabled] WebAnimation animate(CustomEffectCallback callback, optional (unrestricted double or CustomAnimationOptions) options = {});
     [EnabledBySetting=WebAnimationsCustomFrameRateEnabled] readonly attribute FramesPerSecond? maximumFrameRate;
 };

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -64,7 +64,7 @@ struct ResolutionContext;
 class KeyframeEffect final : public AnimationEffect, public Style::Interpolation::Client, public KeyframeInterpolation {
     WTF_MAKE_TZONE_ALLOCATED(KeyframeEffect);
 public:
-    static ExceptionOr<Ref<KeyframeEffect>> create(JSC::JSGlobalObject&, Document&, Element*, JSC::Strong<JSC::JSObject>&&, std::optional<Variant<double, KeyframeEffectOptions>>&&);
+    static ExceptionOr<Ref<KeyframeEffect>> create(JSC::JSGlobalObject&, Document&, Element*, JSC::Strong<JSC::JSObject>&&, Variant<double, KeyframeEffectOptions>&&);
     static Ref<KeyframeEffect> create(Ref<KeyframeEffect>&&);
     static Ref<KeyframeEffect> create(const Element&, const std::optional<Style::PseudoElementIdentifier>&);
 

--- a/Source/WebCore/animation/KeyframeEffect.idl
+++ b/Source/WebCore/animation/KeyframeEffect.idl
@@ -30,7 +30,7 @@ typedef (double? or TimelineRangeOffset or DOMString) KeyframeOffset;
     Exposed=Window,
     JSGenerateToNativeObject,
 ] interface KeyframeEffect : AnimationEffect {
-    [CallWith=CurrentGlobalObject&CurrentDocument] constructor(Element? target, object? keyframes, optional (unrestricted double or KeyframeEffectOptions) options);
+    [CallWith=CurrentGlobalObject&CurrentDocument] constructor(Element? target, object? keyframes, optional (unrestricted double or KeyframeEffectOptions) options = {});
     constructor(KeyframeEffect source);
 
     attribute Element? target;

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -273,7 +273,7 @@ template<typename T> struct IDLCallbackFunction : IDLWrapper<T> {
 
 template<typename T> struct IDLDictionary : IDLType<T> {
     using ParameterType = const T&;
-    using NullableParameterType = const T&;
+    using NullableParameterType = const std::optional<T>&;
 };
 
 template<typename T> struct IDLEnumeration : IDLType<T> { };

--- a/Source/WebCore/bindings/scripts/IDLParser.pm
+++ b/Source/WebCore/bindings/scripts/IDLParser.pm
@@ -70,7 +70,7 @@ struct( IDLInterface => {
     isMixin => '$', # Used for mixin interfaces
     isPartial => '$', # Used for partial interfaces
     iterable => '$', # Used for iterable interfaces, of type 'IDLIterable'
-    asyncIterable => '$', # Used for asycn iterable interfaces, of type 'IDLAsyncIterable'
+    asyncIterable => '$', # Used for async iterable interfaces, of type 'IDLAsyncIterable'
     mapLike => '$', # Used for mapLike interfaces, of type 'IDLMapLike'
     setLike => '$', # Used for setLike interfaces, of type 'IDLSetLike'
     extendedAttributes => '%',
@@ -1460,10 +1460,9 @@ sub parseDefaultValue
         return "[]";
     }
     if ($next->value() eq "{") {
-        # Accept {} but just ignore it.
         $self->assertTokenValue($self->getToken(), "{", __LINE__);
         $self->assertTokenValue($self->getToken(), "}", __LINE__);
-        return undef;
+        return "{}";
     }
     $self->assertUnexpectedToken($next->value(), __LINE__);
 }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
@@ -228,9 +228,10 @@ const JSC::ClassInfo TestAsyncIterableIteratorPrototype::s_info = { "TestAsyncIt
 
 static inline EncodedJSValue jsTestAsyncIterablePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncIterable* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     EnsureStillAliveScope argument0 = callFrame->argument(0);
     auto optionConversionResult = convert<IDLOptional<IDLInterface<TestNode>>>(*lexicalGlobalObject, argument0.value(), [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentTypeError(lexicalGlobalObject, scope, 0, "option"_s, "TestAsyncIterable"_s, "jsTestAsyncIterablePrototypeFunction_values"_s, "TestNode"_s); });
     if (optionConversionResult.hasException(throwScope)) [[unlikely]]

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp
@@ -227,9 +227,10 @@ const JSC::ClassInfo TestAsyncIterableWithoutFlagsIteratorPrototype::s_info = { 
 
 static inline EncodedJSValue jsTestAsyncIterableWithoutFlagsPrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncIterableWithoutFlags* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncIterableWithoutFlagsIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
@@ -232,9 +232,10 @@ const JSC::ClassInfo TestAsyncKeyValueIterableIteratorPrototype::s_info = { "Tes
 
 static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncKeyValueIterable* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Entries)));
 }
 
@@ -245,9 +246,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestAsyncKeyValueIterablePrototypeFunction_entries, (
 
 static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncKeyValueIterable* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
@@ -258,9 +260,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestAsyncKeyValueIterablePrototypeFunction_keys, (JSC
 
 static inline EncodedJSValue jsTestAsyncKeyValueIterablePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestAsyncKeyValueIterable* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestAsyncKeyValueIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
@@ -502,7 +502,7 @@ static inline JSC::EncodedJSValue jsTestCallTracerPrototypeFunction_testOperatio
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto variantDefaultArgConversionResult = convertOptionalWithDefault<IDLUnion<IDLBoolean, IDLFloat, IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLUnion<IDLBoolean, IDLFloat, IDLDOMString>> { return Converter<IDLUnion<IDLBoolean, IDLFloat, IDLDOMString>>::ReturnType { emptyString() }; });
+    auto variantDefaultArgConversionResult = convertOptionalWithDefault<IDLUnion<IDLBoolean, IDLFloat, IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLUnion<IDLBoolean, IDLFloat, IDLDOMString>> { return Converter<IDLUnion<IDLBoolean, IDLFloat, IDLDOMString>>::ReturnType { emptyString() }; });
     if (variantDefaultArgConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     if (impl.hasActiveTestInterfaceCallTracer()) [[unlikely]]

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -82,7 +82,7 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
         bubblesValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "bubbles"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto bubblesConversionResult = convertOptionalWithDefault<IDLBoolean>(lexicalGlobalObject, bubblesValue, [&]() -> ConversionResult<IDLBoolean> { return Converter<IDLBoolean>::ReturnType { false }; });
+    auto bubblesConversionResult = convert<IDLBoolean>(lexicalGlobalObject, bubblesValue);
     if (bubblesConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue cancelableValue;
@@ -92,7 +92,7 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
         cancelableValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "cancelable"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto cancelableConversionResult = convertOptionalWithDefault<IDLBoolean>(lexicalGlobalObject, cancelableValue, [&]() -> ConversionResult<IDLBoolean> { return Converter<IDLBoolean>::ReturnType { false }; });
+    auto cancelableConversionResult = convert<IDLBoolean>(lexicalGlobalObject, cancelableValue);
     if (cancelableConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue composedValue;
@@ -102,7 +102,7 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
         composedValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "composed"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto composedConversionResult = convertOptionalWithDefault<IDLBoolean>(lexicalGlobalObject, composedValue, [&]() -> ConversionResult<IDLBoolean> { return Converter<IDLBoolean>::ReturnType { false }; });
+    auto composedConversionResult = convert<IDLBoolean>(lexicalGlobalObject, composedValue);
     if (composedConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue attr2Value;
@@ -112,7 +112,7 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
         attr2Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "attr2"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto attr2ConversionResult = convertOptionalWithDefault<IDLDOMString>(lexicalGlobalObject, attr2Value, [&]() -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { emptyString() }; });
+    auto attr2ConversionResult = convertOptionalWithDefault<IDLDOMString>(lexicalGlobalObject, attr2Value, [&] -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { emptyString() }; });
     if (attr2ConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
 #if ENABLE(SPECIAL_EVENT)
@@ -123,7 +123,7 @@ template<> ConversionResult<IDLDictionary<TestEventConstructor::Init>> convertDi
         attr3Value = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "attr3"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto attr3ConversionResult = convertOptionalWithDefault<IDLDOMString>(lexicalGlobalObject, attr3Value, [&]() -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { emptyString() }; });
+    auto attr3ConversionResult = convertOptionalWithDefault<IDLDOMString>(lexicalGlobalObject, attr3Value, [&] -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { emptyString() }; });
     if (attr3ConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
 #endif

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
@@ -282,7 +282,7 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTestInterfaceDOMConstructor
     if (str1ConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     EnsureStillAliveScope argument1 = callFrame->argument(1);
-    auto str2ConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument1.value(), [&]() -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "defaultString"_s }; });
+    auto str2ConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument1.value(), [&] -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "defaultString"_s }; });
     if (str2ConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     auto object = TestInterface::create(*context, str1ConversionResult.releaseReturnValue(), str2ConversionResult.releaseReturnValue());
@@ -1156,9 +1156,10 @@ const JSC::ClassInfo TestInterfaceIteratorPrototype::s_info = { "TestInterface I
 
 static inline EncodedJSValue jsTestInterfacePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestInterface* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Entries)));
 }
 
@@ -1169,9 +1170,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestInterfacePrototypeFunction_entries, (JSC::JSGloba
 
 static inline EncodedJSValue jsTestInterfacePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestInterface* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
@@ -1182,9 +1184,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestInterfacePrototypeFunction_keys, (JSC::JSGlobalOb
 
 static inline EncodedJSValue jsTestInterfacePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestInterface* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestInterfaceIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
@@ -229,9 +229,10 @@ const JSC::ClassInfo TestIterableIteratorPrototype::s_info = { "TestIterable Ite
 
 static inline EncodedJSValue jsTestIterablePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestIterable* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
@@ -242,9 +243,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestIterablePrototypeFunction_entries, (JSC::JSGlobal
 
 static inline EncodedJSValue jsTestIterablePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestIterable* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
@@ -255,9 +257,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestIterablePrototypeFunction_keys, (JSC::JSGlobalObj
 
 static inline EncodedJSValue jsTestIterablePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestIterable* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestIterableIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
@@ -124,11 +124,11 @@ template<> EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSTestLegacyFactoryFunctionLe
     if (str1ConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     EnsureStillAliveScope argument1 = callFrame->argument(1);
-    auto str2ConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument1.value(), [&]() -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "defaultString"_s }; });
+    auto str2ConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument1.value(), [&] -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "defaultString"_s }; });
     if (str2ConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     EnsureStillAliveScope argument2 = callFrame->argument(2);
-    auto str3ConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument2.value(), [&]() -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
+    auto str3ConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument2.value(), [&] -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
     if (str3ConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     auto object = TestLegacyFactoryFunction::createForLegacyFactoryFunction(document.get(), str1ConversionResult.releaseReturnValue(), str2ConversionResult.releaseReturnValue(), str3ConversionResult.releaseReturnValue());

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
@@ -442,9 +442,10 @@ const JSC::ClassInfo TestNodeIteratorPrototype::s_info = { "TestNode Iterator"_s
 
 static inline EncodedJSValue jsTestNodePrototypeFunction_entriesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestNode* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 
@@ -455,9 +456,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestNodePrototypeFunction_entries, (JSC::JSGlobalObje
 
 static inline EncodedJSValue jsTestNodePrototypeFunction_keysCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestNode* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Keys)));
 }
 
@@ -468,9 +470,10 @@ JSC_DEFINE_HOST_FUNCTION(jsTestNodePrototypeFunction_keys, (JSC::JSGlobalObject*
 
 static inline EncodedJSValue jsTestNodePrototypeFunction_valuesCaller(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, JSTestNode* thisObject)
 {
-    UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(iteratorCreate<TestNodeIterator>(*thisObject, *lexicalGlobalObject, throwScope, IterationKind::Values)));
 }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -893,7 +893,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         anyTypedefValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "anyTypedefValue"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto anyTypedefValueConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, anyTypedefValueValue, [&]() -> ConversionResult<IDLAny> { return Converter<IDLAny>::ReturnType { jsUndefined() }; });
+    auto anyTypedefValueConversionResult = convert<IDLAny>(lexicalGlobalObject, anyTypedefValueValue);
     if (anyTypedefValueConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue anyValueValue;
@@ -903,7 +903,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         anyValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "anyValue"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto anyValueConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, anyValueValue, [&]() -> ConversionResult<IDLAny> { return Converter<IDLAny>::ReturnType { jsUndefined() }; });
+    auto anyValueConversionResult = convert<IDLAny>(lexicalGlobalObject, anyValueValue);
     if (anyValueConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue anyValueWithNullDefaultValue;
@@ -913,7 +913,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         anyValueWithNullDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "anyValueWithNullDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto anyValueWithNullDefaultConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, anyValueWithNullDefaultValue, [&]() -> ConversionResult<IDLAny> { return typename Converter<IDLAny>::ReturnType { jsNull() }; });
+    auto anyValueWithNullDefaultConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, anyValueWithNullDefaultValue, [&] -> ConversionResult<IDLAny> { return typename Converter<IDLAny>::ReturnType { jsNull() }; });
     if (anyValueWithNullDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue booleanWithDefaultValue;
@@ -923,7 +923,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         booleanWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "booleanWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto booleanWithDefaultConversionResult = convertOptionalWithDefault<IDLBoolean>(lexicalGlobalObject, booleanWithDefaultValue, [&]() -> ConversionResult<IDLBoolean> { return Converter<IDLBoolean>::ReturnType { false }; });
+    auto booleanWithDefaultConversionResult = convert<IDLBoolean>(lexicalGlobalObject, booleanWithDefaultValue);
     if (booleanWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue booleanWithoutDefaultValue;
@@ -963,7 +963,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         dictionaryMemberWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "dictionaryMemberWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto dictionaryMemberWithDefaultConversionResult = convert<IDLOptional<IDLDictionary<TestObj::ParentDictionary>>>(lexicalGlobalObject, dictionaryMemberWithDefaultValue);
+    auto dictionaryMemberWithDefaultConversionResult = convert<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, dictionaryMemberWithDefaultValue);
     if (dictionaryMemberWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue enumerationValueWithDefaultValue;
@@ -973,7 +973,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         enumerationValueWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "enumerationValueWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto enumerationValueWithDefaultConversionResult = convertOptionalWithDefault<IDLEnumeration<TestObj::EnumType>>(lexicalGlobalObject, enumerationValueWithDefaultValue, [&]() -> ConversionResult<IDLEnumeration<TestObj::EnumType>> { return Converter<IDLEnumeration<TestObj::EnumType>>::ReturnType { TestObj::EnumType::EnumValue1 }; });
+    auto enumerationValueWithDefaultConversionResult = convertOptionalWithDefault<IDLEnumeration<TestObj::EnumType>>(lexicalGlobalObject, enumerationValueWithDefaultValue, [&] -> ConversionResult<IDLEnumeration<TestObj::EnumType>> { return Converter<IDLEnumeration<TestObj::EnumType>>::ReturnType { TestObj::EnumType::EnumValue1 }; });
     if (enumerationValueWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue enumerationValueWithEmptyStringDefaultValue;
@@ -983,7 +983,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         enumerationValueWithEmptyStringDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "enumerationValueWithEmptyStringDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto enumerationValueWithEmptyStringDefaultConversionResult = convertOptionalWithDefault<IDLEnumeration<TestObj::EnumType>>(lexicalGlobalObject, enumerationValueWithEmptyStringDefaultValue, [&]() -> ConversionResult<IDLEnumeration<TestObj::EnumType>> { return Converter<IDLEnumeration<TestObj::EnumType>>::ReturnType { TestObj::EnumType::EmptyString }; });
+    auto enumerationValueWithEmptyStringDefaultConversionResult = convertOptionalWithDefault<IDLEnumeration<TestObj::EnumType>>(lexicalGlobalObject, enumerationValueWithEmptyStringDefaultValue, [&] -> ConversionResult<IDLEnumeration<TestObj::EnumType>> { return Converter<IDLEnumeration<TestObj::EnumType>>::ReturnType { TestObj::EnumType::EmptyString }; });
     if (enumerationValueWithEmptyStringDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue enumerationValueWithoutDefaultValue;
@@ -1003,7 +1003,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         fooAliasValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "fooAlias"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto fooConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, fooAliasValue, [&]() -> ConversionResult<IDLAny> { return Converter<IDLAny>::ReturnType { jsUndefined() }; });
+    auto fooConversionResult = convert<IDLAny>(lexicalGlobalObject, fooAliasValue);
     if (fooConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue fooWithDefaultAliasValue;
@@ -1013,7 +1013,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         fooWithDefaultAliasValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "fooWithDefaultAlias"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto fooWithDefaultConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, fooWithDefaultAliasValue, [&]() -> ConversionResult<IDLAny> { return Converter<IDLAny>::ReturnType { 0 }; });
+    auto fooWithDefaultConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, fooWithDefaultAliasValue, [&] -> ConversionResult<IDLAny> { return Converter<IDLAny>::ReturnType { 0 }; });
     if (fooWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue integerValue;
@@ -1033,7 +1033,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         integerWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "integerWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto integerWithDefaultConversionResult = convertOptionalWithDefault<IDLLong>(lexicalGlobalObject, integerWithDefaultValue, [&]() -> ConversionResult<IDLLong> { return Converter<IDLLong>::ReturnType { 0 }; });
+    auto integerWithDefaultConversionResult = convert<IDLLong>(lexicalGlobalObject, integerWithDefaultValue);
     if (integerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue largeIntegerValue;
@@ -1053,7 +1053,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         largeIntegerWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "largeIntegerWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto largeIntegerWithDefaultConversionResult = convertOptionalWithDefault<IDLLongLong>(lexicalGlobalObject, largeIntegerWithDefaultValue, [&]() -> ConversionResult<IDLLongLong> { return Converter<IDLLongLong>::ReturnType { 0 }; });
+    auto largeIntegerWithDefaultConversionResult = convert<IDLLongLong>(lexicalGlobalObject, largeIntegerWithDefaultValue);
     if (largeIntegerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue nullableEnumValue;
@@ -1063,7 +1063,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         nullableEnumValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableEnum"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto nullableEnumConversionResult = convertOptionalWithDefault<IDLNullable<IDLEnumeration<TestObj::EnumType>>>(lexicalGlobalObject, nullableEnumValue, [&]() -> ConversionResult<IDLNullable<IDLEnumeration<TestObj::EnumType>>> { return typename Converter<IDLNullable<IDLEnumeration<TestObj::EnumType>>>::ReturnType { std::nullopt }; });
+    auto nullableEnumConversionResult = convertOptionalWithDefault<IDLNullable<IDLEnumeration<TestObj::EnumType>>>(lexicalGlobalObject, nullableEnumValue, [&] -> ConversionResult<IDLNullable<IDLEnumeration<TestObj::EnumType>>> { return typename Converter<IDLNullable<IDLEnumeration<TestObj::EnumType>>>::ReturnType { std::nullopt }; });
     if (nullableEnumConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue nullableIntegerWithDefaultValue;
@@ -1073,7 +1073,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         nullableIntegerWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableIntegerWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto nullableIntegerWithDefaultConversionResult = convertOptionalWithDefault<IDLNullable<IDLLong>>(lexicalGlobalObject, nullableIntegerWithDefaultValue, [&]() -> ConversionResult<IDLNullable<IDLLong>> { return typename Converter<IDLNullable<IDLLong>>::ReturnType { std::nullopt }; });
+    auto nullableIntegerWithDefaultConversionResult = convertOptionalWithDefault<IDLNullable<IDLLong>>(lexicalGlobalObject, nullableIntegerWithDefaultValue, [&] -> ConversionResult<IDLNullable<IDLLong>> { return typename Converter<IDLNullable<IDLLong>>::ReturnType { std::nullopt }; });
     if (nullableIntegerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue nullableNodeValue;
@@ -1083,7 +1083,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         nullableNodeValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableNode"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto nullableNodeConversionResult = convertOptionalWithDefault<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, nullableNodeValue, [&]() -> ConversionResult<IDLNullable<IDLInterface<Node>>> { return typename Converter<IDLNullable<IDLInterface<Node>>>::ReturnType { nullptr }; });
+    auto nullableNodeConversionResult = convert<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, nullableNodeValue);
     if (nullableNodeConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue nullableStringWithDefaultValue;
@@ -1093,7 +1093,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         nullableStringWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableStringWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto nullableStringWithDefaultConversionResult = convertOptionalWithDefault<IDLNullable<IDLDOMString>>(lexicalGlobalObject, nullableStringWithDefaultValue, [&]() -> ConversionResult<IDLNullable<IDLDOMString>> { return typename Converter<IDLNullable<IDLDOMString>>::ReturnType { String() }; });
+    auto nullableStringWithDefaultConversionResult = convertOptionalWithDefault<IDLNullable<IDLDOMString>>(lexicalGlobalObject, nullableStringWithDefaultValue, [&] -> ConversionResult<IDLNullable<IDLDOMString>> { return typename Converter<IDLNullable<IDLDOMString>>::ReturnType { String() }; });
     if (nullableStringWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue nullableUnionMemberValue;
@@ -1103,7 +1103,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         nullableUnionMemberValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableUnionMember"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto nullableUnionMemberConversionResult = convertOptionalWithDefault<IDLNullable<IDLUnion<IDLLong, IDLInterface<Node>>>>(lexicalGlobalObject, nullableUnionMemberValue, [&]() -> ConversionResult<IDLNullable<IDLUnion<IDLLong, IDLInterface<Node>>>> { return typename Converter<IDLNullable<IDLUnion<IDLLong, IDLInterface<Node>>>>::ReturnType { std::nullopt }; });
+    auto nullableUnionMemberConversionResult = convertOptionalWithDefault<IDLNullable<IDLUnion<IDLLong, IDLInterface<Node>>>>(lexicalGlobalObject, nullableUnionMemberValue, [&] -> ConversionResult<IDLNullable<IDLUnion<IDLLong, IDLInterface<Node>>>> { return typename Converter<IDLNullable<IDLUnion<IDLLong, IDLInterface<Node>>>>::ReturnType { std::nullopt }; });
     if (nullableUnionMemberConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue requiredBufferSourceValueValue;
@@ -1137,7 +1137,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         restrictedDoubleWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "restrictedDoubleWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto restrictedDoubleWithDefaultConversionResult = convertOptionalWithDefault<IDLDouble>(lexicalGlobalObject, restrictedDoubleWithDefaultValue, [&]() -> ConversionResult<IDLDouble> { return Converter<IDLDouble>::ReturnType { 0 }; });
+    auto restrictedDoubleWithDefaultConversionResult = convertOptionalWithDefault<IDLDouble>(lexicalGlobalObject, restrictedDoubleWithDefaultValue, [&] -> ConversionResult<IDLDouble> { return Converter<IDLDouble>::ReturnType { 0 }; });
     if (restrictedDoubleWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue restrictedFloatValue;
@@ -1157,7 +1157,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         restrictedFloatWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "restrictedFloatWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto restrictedFloatWithDefaultConversionResult = convertOptionalWithDefault<IDLFloat>(lexicalGlobalObject, restrictedFloatWithDefaultValue, [&]() -> ConversionResult<IDLFloat> { return Converter<IDLFloat>::ReturnType { 0 }; });
+    auto restrictedFloatWithDefaultConversionResult = convertOptionalWithDefault<IDLFloat>(lexicalGlobalObject, restrictedFloatWithDefaultValue, [&] -> ConversionResult<IDLFloat> { return Converter<IDLFloat>::ReturnType { 0 }; });
     if (restrictedFloatWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue sequenceOfStringsValue;
@@ -1207,7 +1207,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         smallUnsignedIntegerWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "smallUnsignedIntegerWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto smallUnsignedIntegerWithDefaultConversionResult = convertOptionalWithDefault<IDLOctet>(lexicalGlobalObject, smallUnsignedIntegerWithDefaultValue, [&]() -> ConversionResult<IDLOctet> { return Converter<IDLOctet>::ReturnType { 0 }; });
+    auto smallUnsignedIntegerWithDefaultConversionResult = convert<IDLOctet>(lexicalGlobalObject, smallUnsignedIntegerWithDefaultValue);
     if (smallUnsignedIntegerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue stringTreatNullAsEmptyStringValue;
@@ -1227,7 +1227,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         stringWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "stringWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto stringWithDefaultConversionResult = convertOptionalWithDefault<IDLDOMString>(lexicalGlobalObject, stringWithDefaultValue, [&]() -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "defaultString"_s }; });
+    auto stringWithDefaultConversionResult = convertOptionalWithDefault<IDLDOMString>(lexicalGlobalObject, stringWithDefaultValue, [&] -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "defaultString"_s }; });
     if (stringWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue stringWithoutDefaultValue;
@@ -1277,7 +1277,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         unrestrictedDoubleWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "unrestrictedDoubleWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto unrestrictedDoubleWithDefaultConversionResult = convertOptionalWithDefault<IDLUnrestrictedDouble>(lexicalGlobalObject, unrestrictedDoubleWithDefaultValue, [&]() -> ConversionResult<IDLUnrestrictedDouble> { return Converter<IDLUnrestrictedDouble>::ReturnType { 0 }; });
+    auto unrestrictedDoubleWithDefaultConversionResult = convertOptionalWithDefault<IDLUnrestrictedDouble>(lexicalGlobalObject, unrestrictedDoubleWithDefaultValue, [&] -> ConversionResult<IDLUnrestrictedDouble> { return Converter<IDLUnrestrictedDouble>::ReturnType { 0 }; });
     if (unrestrictedDoubleWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue unrestrictedFloatValue;
@@ -1297,7 +1297,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         unrestrictedFloatWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "unrestrictedFloatWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto unrestrictedFloatWithDefaultConversionResult = convertOptionalWithDefault<IDLUnrestrictedFloat>(lexicalGlobalObject, unrestrictedFloatWithDefaultValue, [&]() -> ConversionResult<IDLUnrestrictedFloat> { return Converter<IDLUnrestrictedFloat>::ReturnType { 0 }; });
+    auto unrestrictedFloatWithDefaultConversionResult = convertOptionalWithDefault<IDLUnrestrictedFloat>(lexicalGlobalObject, unrestrictedFloatWithDefaultValue, [&] -> ConversionResult<IDLUnrestrictedFloat> { return Converter<IDLUnrestrictedFloat>::ReturnType { 0 }; });
     if (unrestrictedFloatWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue unsignedIntegerValue;
@@ -1317,7 +1317,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         unsignedIntegerWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "unsignedIntegerWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto unsignedIntegerWithDefaultConversionResult = convertOptionalWithDefault<IDLUnsignedLong>(lexicalGlobalObject, unsignedIntegerWithDefaultValue, [&]() -> ConversionResult<IDLUnsignedLong> { return Converter<IDLUnsignedLong>::ReturnType { 0 }; });
+    auto unsignedIntegerWithDefaultConversionResult = convert<IDLUnsignedLong>(lexicalGlobalObject, unsignedIntegerWithDefaultValue);
     if (unsignedIntegerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue unsignedLargeIntegerValue;
@@ -1337,7 +1337,7 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         unsignedLargeIntegerWithDefaultValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "unsignedLargeIntegerWithDefault"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto unsignedLargeIntegerWithDefaultConversionResult = convertOptionalWithDefault<IDLUnsignedLongLong>(lexicalGlobalObject, unsignedLargeIntegerWithDefaultValue, [&]() -> ConversionResult<IDLUnsignedLongLong> { return Converter<IDLUnsignedLongLong>::ReturnType { 0 }; });
+    auto unsignedLargeIntegerWithDefaultConversionResult = convert<IDLUnsignedLongLong>(lexicalGlobalObject, unsignedLargeIntegerWithDefaultValue);
     if (unsignedLargeIntegerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     return TestObj::Dictionary {
@@ -1435,11 +1435,9 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
         RETURN_IF_EXCEPTION(throwScope, { });
         result->putDirect(vm, JSC::Identifier::fromString(vm, "dictionaryMember"_s), dictionaryMemberValue);
     }
-    if (!IDLDictionary<TestObj::ParentDictionary>::isNullValue(dictionary.dictionaryMemberWithDefault)) {
-        auto dictionaryMemberWithDefaultValue = toJS<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, globalObject, throwScope, IDLDictionary<TestObj::ParentDictionary>::extractValueFromNullable(dictionary.dictionaryMemberWithDefault));
-        RETURN_IF_EXCEPTION(throwScope, { });
-        result->putDirect(vm, JSC::Identifier::fromString(vm, "dictionaryMemberWithDefault"_s), dictionaryMemberWithDefaultValue);
-    }
+    auto dictionaryMemberWithDefaultValue = toJS<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, globalObject, throwScope, dictionary.dictionaryMemberWithDefault);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "dictionaryMemberWithDefault"_s), dictionaryMemberWithDefaultValue);
     auto enumerationValueWithDefaultValue = toJS<IDLEnumeration<TestObj::EnumType>>(lexicalGlobalObject, throwScope, dictionary.enumerationValueWithDefault);
     RETURN_IF_EXCEPTION(throwScope, { });
     result->putDirect(vm, JSC::Identifier::fromString(vm, "enumerationValueWithDefault"_s), enumerationValueWithDefaultValue);
@@ -2236,6 +2234,7 @@ static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalNu
 static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalXPathNSResolver);
 static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalRecord);
 static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalPromise);
+static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalDictNoDefault);
 static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalDictIsDefault);
 static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithCallbackInterfaceArg);
 static JSC_DECLARE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithNullableCallbackInterfaceArg);
@@ -2810,7 +2809,7 @@ template<> void JSTestObjDOMConstructor::initializeProperties(VM& vm, JSDOMGloba
 
 /* Hash table for prototype */
 
-static const std::array<HashTableValue, 300> JSTestObjPrototypeTableValues {
+static const std::array<HashTableValue, 301> JSTestObjPrototypeTableValues {
     HashTableValue { "constructor"_s, static_cast<unsigned>(PropertyAttribute::DontEnum), NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObjConstructor, 0 } },
     HashTableValue { "readOnlyLongAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyLongAttr, 0 } },
     HashTableValue { "readOnlyStringAttr"_s, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::CustomAccessor | JSC::PropertyAttribute::DOMAttribute, NoIntrinsic, { HashTableValue::GetterSetterType, jsTestObj_readOnlyStringAttr, 0 } },
@@ -3068,6 +3067,7 @@ static const std::array<HashTableValue, 300> JSTestObjPrototypeTableValues {
     HashTableValue { "methodWithOptionalXPathNSResolver"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestObjPrototypeFunction_methodWithOptionalXPathNSResolver, 0 } },
     HashTableValue { "methodWithOptionalRecord"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestObjPrototypeFunction_methodWithOptionalRecord, 0 } },
     HashTableValue { "methodWithOptionalPromise"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestObjPrototypeFunction_methodWithOptionalPromise, 0 } },
+    HashTableValue { "methodWithOptionalDictNoDefault"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestObjPrototypeFunction_methodWithOptionalDictNoDefault, 0 } },
     HashTableValue { "methodWithOptionalDictIsDefault"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestObjPrototypeFunction_methodWithOptionalDictIsDefault, 0 } },
     HashTableValue { "methodWithCallbackInterfaceArg"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestObjPrototypeFunction_methodWithCallbackInterfaceArg, 1 } },
     HashTableValue { "methodWithNullableCallbackInterfaceArg"_s, static_cast<unsigned>(JSC::PropertyAttribute::Function), NoIntrinsic, { HashTableValue::NativeFunctionType, jsTestObjPrototypeFunction_methodWithNullableCallbackInterfaceArg, 1 } },
@@ -8176,7 +8176,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalE
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto enumArgConversionResult = convertOptionalWithDefault<IDLEnumeration<TestObj::EnumType>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLEnumeration<TestObj::EnumType>> { return Converter<IDLEnumeration<TestObj::EnumType>>::ReturnType { TestObj::EnumType::EnumValue1 }; }, [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentMustBeEnumError(lexicalGlobalObject, scope, 0, "enumArg"_s, "TestObject"_s, "methodWithOptionalEnumArgAndDefaultValue"_s, expectedEnumerationValues<TestObj::EnumType>()); });
+    auto enumArgConversionResult = convertOptionalWithDefault<IDLEnumeration<TestObj::EnumType>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLEnumeration<TestObj::EnumType>> { return Converter<IDLEnumeration<TestObj::EnumType>>::ReturnType { TestObj::EnumType::EnumValue1 }; }, [](JSC::JSGlobalObject& lexicalGlobalObject, JSC::ThrowScope& scope) { throwArgumentMustBeEnumError(lexicalGlobalObject, scope, 0, "enumArg"_s, "TestObject"_s, "methodWithOptionalEnumArgAndDefaultValue"_s, expectedEnumerationValues<TestObj::EnumType>()); });
     if (enumArgConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalEnumArgAndDefaultValue(enumArgConversionResult.releaseReturnValue()); })));
@@ -8704,7 +8704,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalA
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto optConversionResult = convertOptionalWithDefault<IDLLong>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLLong> { return Converter<IDLLong>::ReturnType { 666 }; });
+    auto optConversionResult = convertOptionalWithDefault<IDLLong>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLLong> { return Converter<IDLLong>::ReturnType { 666 }; });
     if (optConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalArgAndDefaultValue(optConversionResult.releaseReturnValue()); })));
@@ -8777,7 +8777,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalS
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalString(strConversionResult.releaseReturnValue()); })));
@@ -8796,7 +8796,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalU
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLUSVString>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLUSVString> { return typename Converter<IDLUSVString>::ReturnType { String() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLUSVString>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLUSVString> { return typename Converter<IDLUSVString>::ReturnType { String() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalUSVString(strConversionResult.releaseReturnValue()); })));
@@ -8815,7 +8815,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalA
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return typename Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { nullAtom() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return typename Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { nullAtom() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalAtomString(strConversionResult.releaseReturnValue()); })));
@@ -8834,7 +8834,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalS
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "foo"_s }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { "foo"_s }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalStringAndDefaultValue(strConversionResult.releaseReturnValue()); })));
@@ -8853,7 +8853,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalA
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { AtomString("foo"_s) }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { AtomString("foo"_s) }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalAtomStringAndDefaultValue(strConversionResult.releaseReturnValue()); })));
@@ -8872,7 +8872,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalS
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalStringIsNull(strConversionResult.releaseReturnValue()); })));
@@ -8910,7 +8910,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalA
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return typename Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { nullAtom() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return typename Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { nullAtom() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalAtomStringIsNull(strConversionResult.releaseReturnValue()); })));
@@ -8929,7 +8929,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalS
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { emptyString() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLDOMString> { return Converter<IDLDOMString>::ReturnType { emptyString() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalStringIsEmptyString(strConversionResult.releaseReturnValue()); })));
@@ -8948,7 +8948,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalU
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLUSVString>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLUSVString> { return Converter<IDLUSVString>::ReturnType { emptyString() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLUSVString>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLUSVString> { return Converter<IDLUSVString>::ReturnType { emptyString() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalUSVStringIsEmptyString(strConversionResult.releaseReturnValue()); })));
@@ -8967,7 +8967,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalA
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { emptyAtom() }; });
+    auto strConversionResult = convertOptionalWithDefault<IDLAtomStringAdaptor<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLAtomStringAdaptor<IDLDOMString>> { return Converter<IDLAtomStringAdaptor<IDLDOMString>>::ReturnType { emptyAtom() }; });
     if (strConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalAtomStringIsEmptyString(strConversionResult.releaseReturnValue()); })));
@@ -9100,7 +9100,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalS
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto arrayConversionResult = convertOptionalWithDefault<IDLSequence<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLSequence<IDLDOMString>> { return Converter<IDLSequence<IDLDOMString>>::ReturnType { }; });
+    auto arrayConversionResult = convert<IDLOptional<IDLSequence<IDLDOMString>>>(*lexicalGlobalObject, argument0.value());
     if (arrayConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalSequence(arrayConversionResult.releaseReturnValue()); })));
@@ -9119,7 +9119,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalS
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto arrayConversionResult = convertOptionalWithDefault<IDLSequence<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLSequence<IDLDOMString>> { return Converter<IDLSequence<IDLDOMString>>::ReturnType { }; });
+    auto arrayConversionResult = convertOptionalWithDefault<IDLSequence<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLSequence<IDLDOMString>> { return Converter<IDLSequence<IDLDOMString>>::ReturnType { }; });
     if (arrayConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalSequenceIsEmpty(arrayConversionResult.releaseReturnValue()); })));
@@ -9290,7 +9290,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalR
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto recordConversionResult = convertOptionalWithDefault<IDLNullable<IDLRecord<IDLDOMString, IDLLong>>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLNullable<IDLRecord<IDLDOMString, IDLLong>>> { return typename Converter<IDLNullable<IDLRecord<IDLDOMString, IDLLong>>>::ReturnType { std::nullopt }; });
+    auto recordConversionResult = convertOptionalWithDefault<IDLNullable<IDLRecord<IDLDOMString, IDLLong>>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLNullable<IDLRecord<IDLDOMString, IDLLong>>> { return typename Converter<IDLNullable<IDLRecord<IDLDOMString, IDLLong>>>::ReturnType { std::nullopt }; });
     if (recordConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalRecord(recordConversionResult.releaseReturnValue()); })));
@@ -9318,6 +9318,25 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalP
 JSC_DEFINE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalPromise, (JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame))
 {
     return IDLOperation<JSTestObj>::call<jsTestObjPrototypeFunction_methodWithOptionalPromiseBody>(*lexicalGlobalObject, *callFrame, "methodWithOptionalPromise");
+}
+
+static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalDictNoDefaultBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSTestObj>::ClassParameter castedThis)
+{
+    SUPPRESS_UNCOUNTED_LOCAL auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    UNUSED_PARAM(throwScope);
+    UNUSED_PARAM(callFrame);
+    SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
+    EnsureStillAliveScope argument0 = callFrame->argument(0);
+    auto dictConversionResult = convert<IDLOptional<IDLDictionary<TestObj::DictionaryThatShouldNotTolerateNull>>>(*lexicalGlobalObject, argument0.value());
+    if (dictConversionResult.hasException(throwScope)) [[unlikely]]
+       return encodedJSValue();
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.methodWithOptionalDictNoDefault(dictConversionResult.releaseReturnValue()); })));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsTestObjPrototypeFunction_methodWithOptionalDictNoDefault, (JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame))
+{
+    return IDLOperation<JSTestObj>::call<jsTestObjPrototypeFunction_methodWithOptionalDictNoDefaultBody>(*lexicalGlobalObject, *callFrame, "methodWithOptionalDictNoDefault");
 }
 
 static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_methodWithOptionalDictIsDefaultBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSTestObj>::ClassParameter castedThis)
@@ -10181,7 +10200,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_overloadWithOptiona
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto objectOrNodeConversionResult = convertOptionalWithDefault<IDLUnion<IDLDOMString, IDLBoolean>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLUnion<IDLDOMString, IDLBoolean>> { return Converter<IDLUnion<IDLDOMString, IDLBoolean>>::ReturnType { true }; });
+    auto objectOrNodeConversionResult = convertOptionalWithDefault<IDLUnion<IDLDOMString, IDLBoolean>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLUnion<IDLDOMString, IDLBoolean>> { return Converter<IDLUnion<IDLDOMString, IDLBoolean>>::ReturnType { true }; });
     if (objectOrNodeConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.overloadWithOptionalUnion(objectOrNodeConversionResult.releaseReturnValue()); })));
@@ -10501,7 +10520,7 @@ static inline JSC::EncodedJSValue jsTestObjPrototypeFunction_classMethodWithEnfo
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto objArgsLongConversionResult = convertOptionalWithDefault<IDLEnforceRangeAdaptor<IDLLong>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLEnforceRangeAdaptor<IDLLong>> { return Converter<IDLEnforceRangeAdaptor<IDLLong>>::ReturnType { 0 }; });
+    auto objArgsLongConversionResult = convertOptionalWithDefault<IDLEnforceRangeAdaptor<IDLLong>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLEnforceRangeAdaptor<IDLLong>> { return Converter<IDLEnforceRangeAdaptor<IDLLong>>::ReturnType { 0 }; });
     if (objArgsLongConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.classMethodWithEnforceRangeOnOptional(objArgsLongConversionResult.releaseReturnValue()); })));

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
@@ -97,7 +97,7 @@ static inline EncodedJSValue constructJSTestOverloadedConstructorsWithSequence1(
     auto* castedThis = jsCast<JSTestOverloadedConstructorsWithSequenceDOMConstructor*>(callFrame->jsCallee());
     ASSERT(castedThis);
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto sequenceOfStringsConversionResult = convertOptionalWithDefault<IDLSequence<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLSequence<IDLDOMString>> { return Converter<IDLSequence<IDLDOMString>>::ReturnType { }; });
+    auto sequenceOfStringsConversionResult = convertOptionalWithDefault<IDLSequence<IDLDOMString>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLSequence<IDLDOMString>> { return Converter<IDLSequence<IDLDOMString>>::ReturnType { }; });
     if (sequenceOfStringsConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     auto object = TestOverloadedConstructorsWithSequence::create(sequenceOfStringsConversionResult.releaseReturnValue());

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -32,7 +32,6 @@
 #include "JSDOMConvertAny.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertInterface.h"
-#include "JSDOMConvertOptional.h"
 #include "JSDOMConvertPromise.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
@@ -84,7 +83,7 @@ template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> conv
         bubblesValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "bubbles"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto bubblesConversionResult = convertOptionalWithDefault<IDLBoolean>(lexicalGlobalObject, bubblesValue, [&]() -> ConversionResult<IDLBoolean> { return Converter<IDLBoolean>::ReturnType { false }; });
+    auto bubblesConversionResult = convert<IDLBoolean>(lexicalGlobalObject, bubblesValue);
     if (bubblesConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue cancelableValue;
@@ -94,7 +93,7 @@ template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> conv
         cancelableValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "cancelable"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto cancelableConversionResult = convertOptionalWithDefault<IDLBoolean>(lexicalGlobalObject, cancelableValue, [&]() -> ConversionResult<IDLBoolean> { return Converter<IDLBoolean>::ReturnType { false }; });
+    auto cancelableConversionResult = convert<IDLBoolean>(lexicalGlobalObject, cancelableValue);
     if (cancelableConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue composedValue;
@@ -104,7 +103,7 @@ template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> conv
         composedValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "composed"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto composedConversionResult = convertOptionalWithDefault<IDLBoolean>(lexicalGlobalObject, composedValue, [&]() -> ConversionResult<IDLBoolean> { return Converter<IDLBoolean>::ReturnType { false }; });
+    auto composedConversionResult = convert<IDLBoolean>(lexicalGlobalObject, composedValue);
     if (composedConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue promiseValue;
@@ -128,7 +127,7 @@ template<> ConversionResult<IDLDictionary<TestPromiseRejectionEvent::Init>> conv
         reasonValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "reason"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto reasonConversionResult = convertOptionalWithDefault<IDLAny>(lexicalGlobalObject, reasonValue, [&]() -> ConversionResult<IDLAny> { return Converter<IDLAny>::ReturnType { jsUndefined() }; });
+    auto reasonConversionResult = convert<IDLAny>(lexicalGlobalObject, reasonValue);
     if (reasonConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     return TestPromiseRejectionEvent::Init {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -138,7 +138,7 @@ template<> ConversionResult<IDLDictionary<DictionaryImplName>> convertDictionary
         nullableUnionWithNullDefaultValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableUnionWithNullDefaultValue"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto nullableUnionWithNullDefaultValueConversionResult = convertOptionalWithDefault<IDLNullable<IDLUnion<IDLDOMString, IDLBoolean>>>(lexicalGlobalObject, nullableUnionWithNullDefaultValueValue, [&]() -> ConversionResult<IDLNullable<IDLUnion<IDLDOMString, IDLBoolean>>> { return typename Converter<IDLNullable<IDLUnion<IDLDOMString, IDLBoolean>>>::ReturnType { std::nullopt }; });
+    auto nullableUnionWithNullDefaultValueConversionResult = convertOptionalWithDefault<IDLNullable<IDLUnion<IDLDOMString, IDLBoolean>>>(lexicalGlobalObject, nullableUnionWithNullDefaultValueValue, [&] -> ConversionResult<IDLNullable<IDLUnion<IDLDOMString, IDLBoolean>>> { return typename Converter<IDLNullable<IDLUnion<IDLDOMString, IDLBoolean>>>::ReturnType { std::nullopt }; });
     if (nullableUnionWithNullDefaultValueConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
 #if ENABLE(Conditional13) || ENABLE(Conditional14)
@@ -274,7 +274,7 @@ template<> ConversionResult<IDLDictionary<DictionaryImplName>> convertDictionary
         unionMemberWithDefaultValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "unionMemberWithDefaultValue"_s));
         RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
     }
-    auto unionMemberWithDefaultValueConversionResult = convertOptionalWithDefault<IDLUnion<IDLEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>, IDLDouble>>(lexicalGlobalObject, unionMemberWithDefaultValueValue, [&]() -> ConversionResult<IDLUnion<IDLEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>, IDLDouble>> { return Converter<IDLUnion<IDLEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>, IDLDouble>>::ReturnType { TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1 }; });
+    auto unionMemberWithDefaultValueConversionResult = convertOptionalWithDefault<IDLUnion<IDLEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>, IDLDouble>>(lexicalGlobalObject, unionMemberWithDefaultValueValue, [&] -> ConversionResult<IDLUnion<IDLEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>, IDLDouble>> { return Converter<IDLUnion<IDLEnumeration<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>, IDLDouble>>::ReturnType { TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1 }; });
     if (unionMemberWithDefaultValueConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     return DictionaryImplName {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
@@ -502,7 +502,7 @@ static inline JSC::EncodedJSValue jsTestTypedefsPrototypeFunction_funcBody(JSC::
     UNUSED_PARAM(callFrame);
     SUPPRESS_UNCOUNTED_LOCAL auto& impl = castedThis->wrapped();
     EnsureStillAliveScope argument0 = callFrame->argument(0);
-    auto xConversionResult = convertOptionalWithDefault<IDLSequence<IDLLong>>(*lexicalGlobalObject, argument0.value(), [&]() -> ConversionResult<IDLSequence<IDLLong>> { return Converter<IDLSequence<IDLLong>>::ReturnType { }; });
+    auto xConversionResult = convertOptionalWithDefault<IDLSequence<IDLLong>>(*lexicalGlobalObject, argument0.value(), [&] -> ConversionResult<IDLSequence<IDLLong>> { return Converter<IDLSequence<IDLLong>>::ReturnType { }; });
     if (xConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.func(xConversionResult.releaseReturnValue()); })));
@@ -535,7 +535,7 @@ static inline JSC::EncodedJSValue jsTestTypedefsPrototypeFunction_setShadowBody(
     if (blurConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     EnsureStillAliveScope argument3 = callFrame->argument(3);
-    auto colorConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument3.value(), [&]() -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
+    auto colorConversionResult = convertOptionalWithDefault<IDLDOMString>(*lexicalGlobalObject, argument3.value(), [&] -> ConversionResult<IDLDOMString> { return typename Converter<IDLDOMString>::ReturnType { String() }; });
     if (colorConversionResult.hasException(throwScope)) [[unlikely]]
        return encodedJSValue();
     EnsureStillAliveScope argument4 = callFrame->argument(4);

--- a/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
+++ b/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
@@ -26,6 +26,6 @@
 [
     Exposed=TestGlobalObject
 ] interface TestAsyncIterable {
-    async iterable<TestNode>(optional TestNode option = { });
+    async iterable<TestNode>(optional TestNode option);
 };
 

--- a/Source/WebCore/bindings/scripts/test/TestEventConstructor.idl
+++ b/Source/WebCore/bindings/scripts/test/TestEventConstructor.idl
@@ -31,7 +31,7 @@
 [
     Exposed=TestGlobalObject
 ] interface TestEventConstructor : Event {
-    constructor(DOMString type, optional TestEventConstructorInit eventInitDict);
+    constructor(DOMString type, optional TestEventConstructorInit eventInitDict = {});
 
     // Attributes
     readonly attribute DOMString attr1;

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -284,6 +284,7 @@ enum TestConfidence { "high", "kinda-low" };
     undefined    methodWithOptionalXPathNSResolver(optional XPathNSResolver? resolver);
     undefined    methodWithOptionalRecord(optional record<DOMString, long>? record = null);
     undefined    methodWithOptionalPromise(optional Promise<undefined> promise);
+    undefined    methodWithOptionalDictNoDefault(optional TestDictionaryThatShouldNotTolerateNull dict);
     undefined    methodWithOptionalDictIsDefault(optional TestDictionary dict = {});
 
     // Callback interface parameters.

--- a/Source/WebCore/css/DOMMatrix.idl
+++ b/Source/WebCore/css/DOMMatrix.idl
@@ -34,7 +34,7 @@
 ] interface DOMMatrix : DOMMatrixReadOnly {
     [CallWith=CurrentScriptExecutionContext] constructor(optional (DOMString or sequence<unrestricted double>) init);
 
-    [NewObject] static DOMMatrix fromMatrix(optional DOMMatrixInit other);
+    [NewObject] static DOMMatrix fromMatrix(optional DOMMatrixInit other = {});
     [NewObject] static DOMMatrix fromFloat32Array(Float32Array array32);
     [NewObject] static DOMMatrix fromFloat64Array(Float64Array array64);
 
@@ -64,8 +64,8 @@
     inherit attribute unrestricted double m44;
 
     // Mutable transform methods
-    DOMMatrix multiplySelf(optional DOMMatrixInit other);
-    DOMMatrix preMultiplySelf(optional DOMMatrixInit other);
+    DOMMatrix multiplySelf(optional DOMMatrixInit other = {});
+    DOMMatrix preMultiplySelf(optional DOMMatrixInit other = {});
     DOMMatrix translateSelf(optional unrestricted double tx = 0,
                             optional unrestricted double ty = 0,
                             optional unrestricted double tz = 0);

--- a/Source/WebCore/css/DOMMatrixReadOnly.idl
+++ b/Source/WebCore/css/DOMMatrixReadOnly.idl
@@ -33,7 +33,7 @@
 ] interface DOMMatrixReadOnly {
     [CallWith=CurrentScriptExecutionContext] constructor(optional (DOMString or sequence<unrestricted double>) init);
 
-    [NewObject] static DOMMatrixReadOnly fromMatrix(optional DOMMatrixInit other);
+    [NewObject] static DOMMatrixReadOnly fromMatrix(optional DOMMatrixInit other = {});
     [NewObject] static DOMMatrixReadOnly fromFloat32Array(Float32Array array32);
     [NewObject] static DOMMatrixReadOnly fromFloat64Array(Float64Array array64);
 
@@ -92,12 +92,12 @@
                                           optional unrestricted double angle = 0); // Angle is in degrees.
     [NewObject] DOMMatrix skewX(optional unrestricted double sx = 0); // Angle is in degrees.
     [NewObject] DOMMatrix skewY(optional unrestricted double sy = 0); // Angle is in degrees.
-    [NewObject] DOMMatrix multiply(optional DOMMatrixInit other);
+    [NewObject] DOMMatrix multiply(optional DOMMatrixInit other = {});
     [NewObject] DOMMatrix flipX();
     [NewObject] DOMMatrix flipY();
     [NewObject] DOMMatrix inverse();
 
-    [NewObject] DOMPoint transformPoint(optional DOMPointInit point);
+    [NewObject] DOMPoint transformPoint(optional DOMPointInit point = {});
     Float32Array toFloat32Array();
     Float64Array toFloat64Array();
 

--- a/Source/WebCore/css/MediaQueryListEvent.idl
+++ b/Source/WebCore/css/MediaQueryListEvent.idl
@@ -29,7 +29,6 @@
 [
     Exposed=Window
 ] interface MediaQueryListEvent : Event {
-    // FIXME: `mediaQueryListEventInit` should be `eventInitDict`.
     constructor([AtomString] DOMString type, optional MediaQueryListEventInit eventInitDict = {});
     readonly attribute DOMString media;
     readonly attribute boolean matches;

--- a/Source/WebCore/dom/ClipboardEvent.idl
+++ b/Source/WebCore/dom/ClipboardEvent.idl
@@ -27,7 +27,7 @@
 [
     Exposed=Window
 ] interface ClipboardEvent : Event {
-    constructor([AtomString] DOMString type, optional ClipboardEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional ClipboardEventInit eventInitDict = {});
 
     readonly attribute DataTransfer? clipboardData;
 };

--- a/Source/WebCore/dom/CommandEvent.idl
+++ b/Source/WebCore/dom/CommandEvent.idl
@@ -27,7 +27,7 @@
     EnabledBySetting=CommandAttributesEnabled,
     Exposed=Window
 ] interface CommandEvent : Event {
-    constructor([AtomString] DOMString type, optional CommandEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional CommandEventInit eventInitDict = {});
 
     readonly attribute Element? source;
     readonly attribute DOMString command;

--- a/Source/WebCore/dom/CustomEvent.idl
+++ b/Source/WebCore/dom/CustomEvent.idl
@@ -28,7 +28,7 @@
     Exposed=*,
     JSCustomMarkFunction,
 ] interface CustomEvent : Event {
-    constructor([AtomString] DOMString type, optional CustomEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional CustomEventInit eventInitDict = {});
 
     [CustomGetter] readonly attribute any detail;
 

--- a/Source/WebCore/dom/DOMPoint.idl
+++ b/Source/WebCore/dom/DOMPoint.idl
@@ -36,7 +36,7 @@
 ] interface DOMPoint : DOMPointReadOnly {
     constructor(optional unrestricted double x = 0, optional unrestricted double y = 0, optional unrestricted double z = 0, optional unrestricted double w = 1);
 
-    [NewObject] static DOMPoint fromPoint(optional DOMPointInit other);
+    [NewObject] static DOMPoint fromPoint(optional DOMPointInit other = {});
 
     inherit attribute unrestricted double x;
     inherit attribute unrestricted double y;

--- a/Source/WebCore/dom/DOMPointReadOnly.idl
+++ b/Source/WebCore/dom/DOMPointReadOnly.idl
@@ -38,14 +38,14 @@
 ] interface DOMPointReadOnly {
     constructor(optional unrestricted double x = 0, optional unrestricted double y = 0, optional unrestricted double z = 0, optional unrestricted double w = 1);
 
-    [NewObject] static DOMPointReadOnly fromPoint(optional DOMPointInit other);
+    [NewObject] static DOMPointReadOnly fromPoint(optional DOMPointInit other = {});
 
     readonly attribute unrestricted double x;
     readonly attribute unrestricted double y;
     readonly attribute unrestricted double z;
     readonly attribute unrestricted double w;
 
-    DOMPoint matrixTransform(optional DOMMatrixInit matrix);
+    DOMPoint matrixTransform(optional DOMMatrixInit matrix = {});
 
     [Default] object toJSON();
 };

--- a/Source/WebCore/dom/DOMQuad.idl
+++ b/Source/WebCore/dom/DOMQuad.idl
@@ -30,10 +30,10 @@
     JSCustomMarkFunction,
     TaggedWrapper,
 ] interface DOMQuad {
-    constructor(optional DOMPointInit p1, optional DOMPointInit p2, optional DOMPointInit p3, optional DOMPointInit p4);
+    constructor(optional DOMPointInit p1 = {}, optional DOMPointInit p2 = {}, optional DOMPointInit p3 = {}, optional DOMPointInit p4 = {});
 
-    [NewObject] static DOMQuad fromRect(optional DOMRectInit other);
-    [NewObject] static DOMQuad fromQuad(optional DOMQuadInit other);
+    [NewObject] static DOMQuad fromRect(optional DOMRectInit other = {});
+    [NewObject] static DOMQuad fromQuad(optional DOMQuadInit other = {});
 
     [SameObject] readonly attribute DOMPoint p1;
     [SameObject] readonly attribute DOMPoint p2;

--- a/Source/WebCore/dom/DOMRect.idl
+++ b/Source/WebCore/dom/DOMRect.idl
@@ -31,7 +31,7 @@
 ] interface DOMRect : DOMRectReadOnly {
     constructor(optional unrestricted double x = 0, optional unrestricted double y = 0, optional unrestricted double width = 0, optional unrestricted double height = 0);
 
-    [NewObject] static DOMRect fromRect(optional DOMRectInit other);
+    [NewObject] static DOMRect fromRect(optional DOMRectInit other = {});
 
     inherit attribute unrestricted double x;
     inherit attribute unrestricted double y;

--- a/Source/WebCore/dom/DOMRectReadOnly.idl
+++ b/Source/WebCore/dom/DOMRectReadOnly.idl
@@ -34,7 +34,7 @@
 ] interface DOMRectReadOnly {
     constructor(optional unrestricted double x = 0, optional unrestricted double y = 0, optional unrestricted double width = 0, optional unrestricted double height = 0);
 
-    [NewObject] static DOMRectReadOnly fromRect(optional DOMRectInit other);
+    [NewObject] static DOMRectReadOnly fromRect(optional DOMRectInit other = {});
 
     readonly attribute unrestricted double x;
     readonly attribute unrestricted double y;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -432,8 +432,6 @@ using RenderingContext = Variant<
     RefPtr<CanvasRenderingContext2D>
 >;
 
-using StartViewTransitionCallbackOptions = std::optional<Variant<RefPtr<JSViewTransitionUpdateCallback>, StartViewTransitionOptions>>;
-
 class DocumentParserYieldToken {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(DocumentParserYieldToken, WEBCORE_EXPORT);
 public:
@@ -555,7 +553,7 @@ public:
     void whenVisible(Function<void()>&&);
 
     WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName);
-    ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName, std::optional<Variant<String, ElementCreationOptions>>&&);
+    ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName, Variant<String, ElementCreationOptions>&&);
     WEBCORE_EXPORT Ref<DocumentFragment> createDocumentFragment();
     WEBCORE_EXPORT Ref<Text> createTextNode(String&& data);
     WEBCORE_EXPORT Ref<Comment> createComment(String&& data);
@@ -565,7 +563,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, bool shouldIgnoreNamespaceChecks = false);
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, Variant<bool, ImportNodeOptions>&&);
     WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
-    ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName, std::optional<Variant<String, ElementCreationOptions>>&&);
+    ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName, Variant<String, ElementCreationOptions>&&);
 
     WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser, CustomElementRegistry* = nullptr);
 
@@ -1789,6 +1787,7 @@ public:
     void unobserveForContainIntrinsicSize(Element&);
     void resetObservationSizeForContainIntrinsicSize(Element&);
 
+    using StartViewTransitionCallbackOptions = Variant<RefPtr<JSViewTransitionUpdateCallback>, StartViewTransitionOptions>;
     RefPtr<ViewTransition> startViewTransition(StartViewTransitionCallbackOptions&&);
     ViewTransition* activeViewTransition() const;
     bool activeViewTransitionCapturedDocumentElement() const;

--- a/Source/WebCore/dom/DragEvent.idl
+++ b/Source/WebCore/dom/DragEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=Window
 ] interface DragEvent : MouseEvent {
-    constructor([AtomString] DOMString type, optional DragEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional DragEventInit eventInitDict = {});
 
     readonly attribute DataTransfer? dataTransfer;
 };

--- a/Source/WebCore/dom/Element+CSSOMView.idl
+++ b/Source/WebCore/dom/Element+CSSOMView.idl
@@ -30,12 +30,12 @@ partial interface Element {
 
     boolean checkVisibility(optional CheckVisibilityOptions options = {});
 
-    undefined scrollIntoView(optional (boolean or ScrollIntoViewOptions) arg);
-    [ImplementedAs=scrollTo] undefined scroll(optional ScrollToOptions options);
+    undefined scrollIntoView(optional (boolean or ScrollIntoViewOptions) arg = {});
+    [ImplementedAs=scrollTo] undefined scroll(optional ScrollToOptions options = {});
     [ImplementedAs=scrollTo] undefined scroll(unrestricted double x, unrestricted double y);
-    undefined scrollTo(optional ScrollToOptions options);
+    undefined scrollTo(optional ScrollToOptions options = {});
     undefined scrollTo(unrestricted double x, unrestricted double y);
-    undefined scrollBy(optional ScrollToOptions options);
+    undefined scrollBy(optional ScrollToOptions options = {});
     undefined scrollBy(unrestricted double x, unrestricted double y);
     attribute long scrollTop; // FIXME(webkit.org/b/188045): should be unrestricted double.
     attribute long scrollLeft; // FIXME(webkit.org/b/188045): should be unrestricted double.

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -302,7 +302,7 @@ public:
 
     bool checkVisibility(const CheckVisibilityOptions&);
 
-    WEBCORE_EXPORT void scrollIntoView(std::optional<Variant<bool, ScrollIntoViewOptions>>&& arg);
+    WEBCORE_EXPORT void scrollIntoView(Variant<bool, ScrollIntoViewOptions>&&);
     WEBCORE_EXPORT void scrollIntoView(bool alignToTop = true);
     WEBCORE_EXPORT void scrollIntoViewIfNeeded(bool centerIfNeeded = true);
     WEBCORE_EXPORT void scrollIntoViewIfNotVisible(bool centerIfNotVisible = true, AllowScrollingOverflowHidden = AllowScrollingOverflowHidden::Yes);
@@ -882,7 +882,7 @@ public:
 
     RefPtr<Element> findAnchorElementForLink(String& outAnchorName);
 
-    ExceptionOr<Ref<WebAnimation>> animate(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>&&, std::optional<Variant<double, KeyframeAnimationOptions>>&&);
+    ExceptionOr<Ref<WebAnimation>> animate(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>&&, Variant<double, KeyframeAnimationOptions>&&);
     Vector<Ref<WebAnimation>> getAnimations(std::optional<GetAnimationsOptions>);
 
     String description() const override;

--- a/Source/WebCore/dom/ErrorEvent.idl
+++ b/Source/WebCore/dom/ErrorEvent.idl
@@ -33,7 +33,7 @@
     Exposed=*,
     JSCustomMarkFunction,
 ] interface ErrorEvent : Event {
-    constructor([AtomString] DOMString type, optional ErrorEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional ErrorEventInit eventInitDict = {});
 
     readonly attribute DOMString message;
     readonly attribute USVString filename;

--- a/Source/WebCore/dom/Event.idl
+++ b/Source/WebCore/dom/Event.idl
@@ -27,7 +27,7 @@ typedef double DOMHighResTimeStamp;
     Exposed=*,
     JSCustomHeader,
 ] interface Event {
-    constructor([AtomString] DOMString type, optional EventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional EventInit eventInitDict = {});
 
     readonly attribute DOMString type;
     readonly attribute EventTarget? target;

--- a/Source/WebCore/dom/FocusEvent.idl
+++ b/Source/WebCore/dom/FocusEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=Window
 ] interface FocusEvent : UIEvent {
-    constructor([AtomString] DOMString type, optional FocusEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional FocusEventInit eventInitDict = {});
 
     readonly attribute EventTarget? relatedTarget;
 };

--- a/Source/WebCore/dom/InputEvent.idl
+++ b/Source/WebCore/dom/InputEvent.idl
@@ -28,7 +28,7 @@
 [
     Exposed=Window
 ] interface InputEvent : UIEvent {
-    constructor([AtomString] DOMString type, optional InputEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional InputEventInit eventInitDict = {});
 
     readonly attribute DOMString inputType;
     readonly attribute USVString? data;

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -64,7 +64,7 @@ public:
 
             SubscribeOptions options;
             options.signal = subscriber.signal();
-            m_sourceObservable->subscribeInternal(*context, InternalObserverDrop::create(*context, subscriber, m_amount), options);
+            m_sourceObservable->subscribeInternal(*context, InternalObserverDrop::create(*context, subscriber, m_amount), WTF::move(options));
 
             return { };
         }

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -118,13 +118,13 @@ private:
     const Ref<DeferredPromise> m_promise;
 };
 
-void createInternalObserverOperatorEvery(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+void createInternalObserverOperatorEvery(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, SubscribeOptions&& options, Ref<DeferredPromise>&& promise)
 {
     Ref signal = AbortSignal::create(&context);
 
     Vector<Ref<AbortSignal>> dependentSignals = { signal };
     if (options.signal)
-        dependentSignals.append(Ref { *options.signal });
+        dependentSignals.append(options.signal.releaseNonNull());
     Ref dependentSignal = AbortSignal::any(context, dependentSignals);
 
     if (dependentSignal->aborted())

--- a/Source/WebCore/dom/InternalObserverEvery.h
+++ b/Source/WebCore/dom/InternalObserverEvery.h
@@ -35,6 +35,6 @@ class ScriptExecutionContext;
 class PredicateCallback;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorEvery(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorEvery(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -65,7 +65,7 @@ public:
 
             SubscribeOptions options;
             options.signal = subscriber.signal();
-            m_sourceObservable->subscribeInternal(*context, InternalObserverFilter::create(*context, subscriber, m_predicate), options);
+            m_sourceObservable->subscribeInternal(*context, InternalObserverFilter::create(*context, subscriber, m_predicate), WTF::move(options));
 
             return { };
         }

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -119,13 +119,13 @@ private:
     const Ref<DeferredPromise> m_promise;
 };
 
-void createInternalObserverOperatorFind(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+void createInternalObserverOperatorFind(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, SubscribeOptions&& options, Ref<DeferredPromise>&& promise)
 {
     Ref signal = AbortSignal::create(&context);
 
     Vector<Ref<AbortSignal>> dependentSignals = { signal };
     if (options.signal)
-        dependentSignals.append(Ref { *options.signal });
+        dependentSignals.append(options.signal.releaseNonNull());
     Ref dependentSignal = AbortSignal::any(context, dependentSignals);
 
     if (dependentSignal->aborted())

--- a/Source/WebCore/dom/InternalObserverFind.h
+++ b/Source/WebCore/dom/InternalObserverFind.h
@@ -35,6 +35,6 @@ class ScriptExecutionContext;
 class PredicateCallback;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorFind(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorFind(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -84,13 +84,13 @@ private:
     const Ref<DeferredPromise> m_promise;
 };
 
-void createInternalObserverOperatorFirst(ScriptExecutionContext& context, Observable& observable, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+void createInternalObserverOperatorFirst(ScriptExecutionContext& context, Observable& observable, SubscribeOptions&& options, Ref<DeferredPromise>&& promise)
 {
     Ref signal = AbortSignal::create(&context);
 
     Vector<Ref<AbortSignal>> dependentSignals = { signal };
     if (options.signal)
-        dependentSignals.append(Ref { *options.signal });
+        dependentSignals.append(options.signal.releaseNonNull());
     Ref dependentSignal = AbortSignal::any(context, dependentSignals);
 
     if (dependentSignal->aborted())

--- a/Source/WebCore/dom/InternalObserverFirst.h
+++ b/Source/WebCore/dom/InternalObserverFirst.h
@@ -34,6 +34,6 @@ class Observable;
 class ScriptExecutionContext;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorFirst(ScriptExecutionContext&, Observable&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorFirst(ScriptExecutionContext&, Observable&, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -109,13 +109,13 @@ private:
     const Ref<DeferredPromise> m_promise;
 };
 
-void createInternalObserverOperatorForEach(ScriptExecutionContext& context, Observable& observable, Ref<VisitorCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+void createInternalObserverOperatorForEach(ScriptExecutionContext& context, Observable& observable, Ref<VisitorCallback>&& callback, SubscribeOptions&& options, Ref<DeferredPromise>&& promise)
 {
     Ref signal = AbortSignal::create(&context);
 
     Vector<Ref<AbortSignal>> dependentSignals = { signal };
     if (options.signal)
-        dependentSignals.append(Ref { *options.signal });
+        dependentSignals.append(options.signal.releaseNonNull());
     Ref dependentSignal = AbortSignal::any(context, dependentSignals);
 
     if (dependentSignal->aborted())

--- a/Source/WebCore/dom/InternalObserverForEach.h
+++ b/Source/WebCore/dom/InternalObserverForEach.h
@@ -35,6 +35,6 @@ class ScriptExecutionContext;
 class VisitorCallback;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorForEach(ScriptExecutionContext&, Observable&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorForEach(ScriptExecutionContext&, Observable&, Ref<VisitorCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFromScript.cpp
+++ b/Source/WebCore/dom/InternalObserverFromScript.cpp
@@ -39,9 +39,9 @@ Ref<InternalObserverFromScript> InternalObserverFromScript::create(ScriptExecuti
     return internalObserver;
 }
 
-Ref<InternalObserverFromScript> InternalObserverFromScript::create(ScriptExecutionContext& context, SubscriptionObserver& subscription)
+Ref<InternalObserverFromScript> InternalObserverFromScript::create(ScriptExecutionContext& context, SubscriptionObserver&& subscription)
 {
-    Ref internalObserver = adoptRef(*new InternalObserverFromScript(context, subscription));
+    Ref internalObserver = adoptRef(*new InternalObserverFromScript(context, WTF::move(subscription)));
     internalObserver->suspendIfNeeded();
     return internalObserver;
 }
@@ -86,12 +86,16 @@ InternalObserverFromScript::InternalObserverFromScript(ScriptExecutionContext& c
     : InternalObserver(context)
     , m_next(callback)
     , m_error(nullptr)
-    , m_complete(nullptr) { }
+    , m_complete(nullptr)
+{
+}
 
-InternalObserverFromScript::InternalObserverFromScript(ScriptExecutionContext& context, SubscriptionObserver& subscription)
+InternalObserverFromScript::InternalObserverFromScript(ScriptExecutionContext& context, SubscriptionObserver&& subscription)
     : InternalObserver(context)
-    , m_next(subscription.next)
-    , m_error(subscription.error)
-    , m_complete(subscription.complete) { }
+    , m_next(WTF::move(subscription.next))
+    , m_error(WTF::move(subscription.error))
+    , m_complete(WTF::move(subscription.complete))
+{
+}
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverFromScript.h
+++ b/Source/WebCore/dom/InternalObserverFromScript.h
@@ -39,10 +39,10 @@ struct SubscriptionObserver;
 class InternalObserverFromScript final : public InternalObserver {
 public:
     static Ref<InternalObserverFromScript> create(ScriptExecutionContext&, RefPtr<JSSubscriptionObserverCallback>);
-    static Ref<InternalObserverFromScript> create(ScriptExecutionContext&, SubscriptionObserver&);
+    static Ref<InternalObserverFromScript> create(ScriptExecutionContext&, SubscriptionObserver&&);
 
     explicit InternalObserverFromScript(ScriptExecutionContext&, RefPtr<JSSubscriptionObserverCallback>);
-    explicit InternalObserverFromScript(ScriptExecutionContext&, SubscriptionObserver&);
+    explicit InternalObserverFromScript(ScriptExecutionContext&, SubscriptionObserver&&);
 
     void next(JSC::JSValue) final;
     void error(JSC::JSValue) final;

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -89,7 +89,7 @@ private:
     const Ref<DeferredPromise> m_promise;
 };
 
-void createInternalObserverOperatorLast(ScriptExecutionContext& context, Observable& observable, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+void createInternalObserverOperatorLast(ScriptExecutionContext& context, Observable& observable, SubscribeOptions&& options, Ref<DeferredPromise>&& promise)
 {
     if (RefPtr signal = options.signal) {
         if (signal->aborted())
@@ -102,7 +102,7 @@ void createInternalObserverOperatorLast(ScriptExecutionContext& context, Observa
 
     Ref observer = InternalObserverLast::create(context, WTF::move(promise));
 
-    observable.subscribeInternal(context, WTF::move(observer), options);
+    observable.subscribeInternal(context, WTF::move(observer), WTF::move(options));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverLast.h
+++ b/Source/WebCore/dom/InternalObserverLast.h
@@ -34,6 +34,6 @@ class Observable;
 class ScriptExecutionContext;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorLast(ScriptExecutionContext&, Observable&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorLast(ScriptExecutionContext&, Observable&, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -65,7 +65,7 @@ public:
 
             SubscribeOptions options;
             options.signal = subscriber.signal();
-            m_sourceObservable->subscribeInternal(*context, InternalObserverMap::create(*context, subscriber, m_mapper), options);
+            m_sourceObservable->subscribeInternal(*context, InternalObserverMap::create(*context, subscriber, m_mapper), WTF::move(options));
 
             return { };
         }

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -126,13 +126,13 @@ private:
     const Ref<DeferredPromise> m_promise;
 };
 
-void createInternalObserverOperatorReduce(ScriptExecutionContext& context, Observable& observable, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+void createInternalObserverOperatorReduce(ScriptExecutionContext& context, Observable& observable, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, SubscribeOptions&& options, Ref<DeferredPromise>&& promise)
 {
     Ref signal = AbortSignal::create(&context);
 
     Vector<Ref<AbortSignal>> dependentSignals = { signal };
     if (options.signal)
-        dependentSignals.append(Ref { *options.signal });
+        dependentSignals.append(options.signal.releaseNonNull());
     Ref dependentSignal = AbortSignal::any(context, dependentSignals);
 
     if (dependentSignal->aborted())

--- a/Source/WebCore/dom/InternalObserverReduce.h
+++ b/Source/WebCore/dom/InternalObserverReduce.h
@@ -39,6 +39,6 @@ class ReducerCallback;
 class ScriptExecutionContext;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorReduce(ScriptExecutionContext&, Observable&, Ref<ReducerCallback>&&, JSC::JSValue, const SubscribeOptions&, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorReduce(ScriptExecutionContext&, Observable&, Ref<ReducerCallback>&&, JSC::JSValue, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -122,13 +122,13 @@ private:
     const Ref<DeferredPromise> m_promise;
 };
 
-void createInternalObserverOperatorSome(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, const SubscribeOptions& options, Ref<DeferredPromise>&& promise)
+void createInternalObserverOperatorSome(ScriptExecutionContext& context, Observable& observable, Ref<PredicateCallback>&& callback, SubscribeOptions&& options, Ref<DeferredPromise>&& promise)
 {
     Ref signal = AbortSignal::create(&context);
 
     Vector<Ref<AbortSignal>> dependentSignals = { signal };
     if (options.signal)
-        dependentSignals.append(Ref { *options.signal });
+        dependentSignals.append(options.signal.releaseNonNull());
     Ref dependentSignal = AbortSignal::any(context, dependentSignals);
 
     if (dependentSignal->aborted())

--- a/Source/WebCore/dom/InternalObserverSome.h
+++ b/Source/WebCore/dom/InternalObserverSome.h
@@ -35,6 +35,6 @@ class ScriptExecutionContext;
 class PredicateCallback;
 struct SubscribeOptions;
 
-void createInternalObserverOperatorSome(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
+void createInternalObserverOperatorSome(ScriptExecutionContext&, Observable&, Ref<PredicateCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -64,7 +64,7 @@ public:
 
             SubscribeOptions options;
             options.signal = subscriber.signal();
-            m_sourceObservable->subscribeInternal(*context, InternalObserverTake::create(*context, subscriber, m_amount), options);
+            m_sourceObservable->subscribeInternal(*context, InternalObserverTake::create(*context, subscriber, m_amount), WTF::move(options));
 
             return { };
         }

--- a/Source/WebCore/dom/KeyboardEvent.idl
+++ b/Source/WebCore/dom/KeyboardEvent.idl
@@ -24,7 +24,7 @@
 [
     Exposed=Window
 ] interface KeyboardEvent : UIEvent {
-    constructor([AtomString] DOMString type, optional KeyboardEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional KeyboardEventInit eventInitDict = {});
 
     const unsigned long DOM_KEY_LOCATION_STANDARD = 0x00;
     const unsigned long DOM_KEY_LOCATION_LEFT = 0x01;

--- a/Source/WebCore/dom/MessageEvent.idl
+++ b/Source/WebCore/dom/MessageEvent.idl
@@ -33,7 +33,7 @@ typedef (WindowProxy or MessagePort or ServiceWorker) MessageEventSource;
     JSCustomMarkFunction,
     ReportExtraMemoryCost,
 ] interface MessageEvent : Event {
-    constructor([AtomString] DOMString type, optional MessageEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional MessageEventInit eventInitDict = {});
 
     readonly attribute USVString origin;
     readonly attribute DOMString lastEventId;

--- a/Source/WebCore/dom/MessagePort.idl
+++ b/Source/WebCore/dom/MessagePort.idl
@@ -33,7 +33,7 @@
     JSCustomMarkFunction,
 ] interface MessagePort : EventTarget {
     [CallWith=CurrentGlobalObject] undefined postMessage(any message, sequence<object> transfer);
-    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options);
+    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options = {});
     undefined start();
     undefined close();
 

--- a/Source/WebCore/dom/MouseEvent.idl
+++ b/Source/WebCore/dom/MouseEvent.idl
@@ -21,7 +21,7 @@
     DoNotCheckConstants,
     Exposed=Window
 ] interface MouseEvent : UIEvent {
-    constructor([AtomString] DOMString type, optional MouseEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional MouseEventInit eventInitDict = {});
 
     const double WEBKIT_FORCE_AT_MOUSE_DOWN = 1;
     const double WEBKIT_FORCE_AT_FORCE_MOUSE_DOWN = 2;

--- a/Source/WebCore/dom/MutationObserver.idl
+++ b/Source/WebCore/dom/MutationObserver.idl
@@ -36,7 +36,7 @@
 ] interface MutationObserver {
     constructor(MutationCallback callback);
 
-    undefined observe(Node target, optional MutationObserverInit options);
+    undefined observe(Node target, optional MutationObserverInit options = {});
     undefined disconnect();
     [ResultField=records] sequence<MutationRecord> takeRecords();
 };

--- a/Source/WebCore/dom/Node.idl
+++ b/Source/WebCore/dom/Node.idl
@@ -46,7 +46,7 @@
 
     readonly attribute boolean isConnected;
     [DOMJIT=Getter] readonly attribute Document? ownerDocument;
-    Node getRootNode(optional GetRootNodeOptions options);
+    Node getRootNode(optional GetRootNodeOptions options = {});
     [DOMJIT=Getter] readonly attribute Node? parentNode;
     readonly attribute Element? parentElement;
     boolean hasChildNodes();

--- a/Source/WebCore/dom/Observable.h
+++ b/Source/WebCore/dom/Observable.h
@@ -58,24 +58,24 @@ public:
 
     ~Observable();
 
-    void subscribe(ScriptExecutionContext&, std::optional<ObserverUnion>, SubscribeOptions);
-    void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);
+    void subscribe(ScriptExecutionContext&, ObserverUnion&&, SubscribeOptions&&);
+    void subscribeInternal(ScriptExecutionContext&, Ref<InternalObserver>&&, SubscribeOptions&&);
 
     Ref<Observable> map(ScriptExecutionContext&, MapperCallback&);
     Ref<Observable> filter(ScriptExecutionContext&, PredicateCallback&);
     Ref<Observable> take(ScriptExecutionContext&, uint64_t);
     Ref<Observable> drop(ScriptExecutionContext&, uint64_t);
-    Ref<Observable> inspect(ScriptExecutionContext&, std::optional<InspectorUnion>&&);
+    Ref<Observable> inspect(ScriptExecutionContext&, InspectorUnion&&);
 
     // Promise-returning operators.
 
-    void first(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
-    void forEach(ScriptExecutionContext&, Ref<VisitorCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
-    void last(ScriptExecutionContext&, const SubscribeOptions&, Ref<DeferredPromise>&&);
-    void find(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
-    void every(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
-    void some(ScriptExecutionContext&, Ref<PredicateCallback>&&, const SubscribeOptions&, Ref<DeferredPromise>&&);
-    void reduce(ScriptExecutionContext&, Ref<ReducerCallback>&&, JSC::JSValue, const SubscribeOptions&, Ref<DeferredPromise>&&);
+    void first(ScriptExecutionContext&, SubscribeOptions&&, Ref<DeferredPromise>&&);
+    void forEach(ScriptExecutionContext&, Ref<VisitorCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
+    void last(ScriptExecutionContext&, SubscribeOptions&&, Ref<DeferredPromise>&&);
+    void find(ScriptExecutionContext&, Ref<PredicateCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
+    void every(ScriptExecutionContext&, Ref<PredicateCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
+    void some(ScriptExecutionContext&, Ref<PredicateCallback>&&, SubscribeOptions&&, Ref<DeferredPromise>&&);
+    void reduce(ScriptExecutionContext&, Ref<ReducerCallback>&&, JSC::JSValue, SubscribeOptions&&, Ref<DeferredPromise>&&);
 
 private:
     const Ref<SubscriberCallback> m_subscriberCallback;

--- a/Source/WebCore/dom/PageTransitionEvent.idl
+++ b/Source/WebCore/dom/PageTransitionEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=Window
 ] interface PageTransitionEvent : Event {
-    constructor([AtomString] DOMString type, optional PageTransitionEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PageTransitionEventInit eventInitDict = {});
 
     readonly attribute boolean persisted;
 };

--- a/Source/WebCore/dom/PointerEvent.idl
+++ b/Source/WebCore/dom/PointerEvent.idl
@@ -48,7 +48,7 @@
     JSGenerateToNativeObject,
     ExportToWrappedFunction
 ] interface PointerEvent : MouseEvent {
-    constructor([AtomString] DOMString type, optional PointerEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PointerEventInit eventInitDict = {});
 
     readonly attribute long pointerId;
     readonly attribute double width;

--- a/Source/WebCore/dom/PopStateEvent.idl
+++ b/Source/WebCore/dom/PopStateEvent.idl
@@ -28,7 +28,7 @@
     JSCustomMarkFunction,
     Exposed=Window
 ] interface PopStateEvent : Event {
-    constructor([AtomString] DOMString type, optional PopStateEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional PopStateEventInit eventInitDict = {});
 
     [CachedAttribute, CustomGetter] readonly attribute any state;
     [EnabledBySetting=UAVisualTransitionDetectionEnabled] readonly attribute boolean hasUAVisualTransition;

--- a/Source/WebCore/dom/ProgressEvent.idl
+++ b/Source/WebCore/dom/ProgressEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=(Window,Worker),
 ] interface ProgressEvent : Event {
-    constructor([AtomString] DOMString type, optional ProgressEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional ProgressEventInit eventInitDict = {});
 
     readonly attribute boolean lengthComputable;
     readonly attribute double loaded;

--- a/Source/WebCore/dom/TextDecoder.idl
+++ b/Source/WebCore/dom/TextDecoder.idl
@@ -39,10 +39,10 @@
 [
     Exposed=*,
 ] interface TextDecoder {
-    constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options);
+    constructor(optional DOMString label = "utf-8", optional TextDecoderOptions options = {});
 
     readonly attribute DOMString encoding;
     readonly attribute boolean fatal;
     readonly attribute boolean ignoreBOM;
-    USVString decode(optional [AllowShared] (ArrayBufferView or ArrayBuffer)? input, optional TextDecodeOptions options);
+    USVString decode(optional [AllowShared] (ArrayBufferView or ArrayBuffer)? input, optional TextDecodeOptions options = {});
 };

--- a/Source/WebCore/dom/TouchEvent.idl
+++ b/Source/WebCore/dom/TouchEvent.idl
@@ -29,7 +29,7 @@
     Conditional=TOUCH_EVENTS,
     Exposed=Window
 ] interface TouchEvent : UIEvent {
-    constructor([AtomString] DOMString type, optional TouchEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional TouchEventInit eventInitDict = {});
 
     // FIXME: `touches` should not be nullable.
     readonly attribute TouchList? touches;

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -79,7 +79,7 @@ public:
         return blob;
     }
 
-    static Ref<Blob> create(ScriptExecutionContext& context, Vector<BlobPartVariant>&& blobPartVariants, const BlobPropertyBag& propertyBag)
+    static Ref<Blob> create(ScriptExecutionContext& context, std::optional<Vector<BlobPartVariant>>&& blobPartVariants, const BlobPropertyBag& propertyBag)
     {
         Ref blob = adoptRef(*new Blob(context, WTF::move(blobPartVariants), propertyBag));
         blob->suspendIfNeeded();
@@ -144,7 +144,7 @@ public:
 
 protected:
     WEBCORE_EXPORT explicit Blob(ScriptExecutionContext*);
-    Blob(ScriptExecutionContext&, Vector<BlobPartVariant>&&, const BlobPropertyBag&);
+    Blob(ScriptExecutionContext&, std::optional<Vector<BlobPartVariant>>&&, const BlobPropertyBag&);
     Blob(ScriptExecutionContext*, Vector<uint8_t>&&, const String& contentType);
     Blob(ScriptExecutionContext*, Ref<FragmentedSharedBuffer>&&, const String& contentType);
 

--- a/Source/WebCore/fileapi/Blob.idl
+++ b/Source/WebCore/fileapi/Blob.idl
@@ -38,7 +38,7 @@ typedef (BufferSource or Blob or USVString) BlobPart;
     GenerateIsReachable=Impl,
     ReportExtraMemoryCost
 ] interface Blob {
-    [CallWith=CurrentScriptExecutionContext] constructor(optional sequence<BlobPart> blobParts, optional BlobPropertyBag options);
+    [CallWith=CurrentScriptExecutionContext] constructor(optional sequence<BlobPart> blobParts, optional BlobPropertyBag options = {});
 
     readonly attribute unsigned long long size;
     readonly attribute DOMString type;

--- a/Source/WebCore/fileapi/File.idl
+++ b/Source/WebCore/fileapi/File.idl
@@ -30,7 +30,7 @@ typedef (BufferSource or Blob or USVString) BlobPart;
     Exposed=(Window,Worker),
     JSGenerateToNativeObject,
 ] interface File : Blob {
-    [CallWith=CurrentScriptExecutionContext] constructor(sequence<BlobPart> fileBits, USVString fileName, optional FilePropertyBag options);
+    [CallWith=CurrentScriptExecutionContext] constructor(sequence<BlobPart> fileBits, USVString fileName, optional FilePropertyBag options = {});
 
     readonly attribute DOMString name;
     readonly attribute long long lastModified;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1275,22 +1275,20 @@ ExceptionOr<void> HTMLElement::hidePopover()
     return hidePopoverInternal(FocusPreviousElement::Yes, FireEvents::Yes);
 }
 
-ExceptionOr<bool> HTMLElement::togglePopover(std::optional<Variant<WebCore::HTMLElement::TogglePopoverOptions, bool>> options)
+ExceptionOr<bool> HTMLElement::togglePopover(Variant<WebCore::HTMLElement::TogglePopoverOptions, bool> options)
 {
     std::optional<bool> force;
     HTMLElement* invoker = nullptr;
 
-    if (options.has_value()) {
-        WTF::switchOn(options.value(),
-            [&](TogglePopoverOptions options) {
-                force = options.force;
-                invoker = options.source.get();
-            },
-            [&](bool value) {
-                force = value;
-            }
-        );
-    }
+    WTF::switchOn(options,
+        [&](TogglePopoverOptions options) {
+            force = options.force;
+            invoker = options.source.get();
+        },
+        [&](bool value) {
+            force = value;
+        }
+    );
 
     if (isPopoverShowing() && !force.value_or(false)) {
         auto returnValue = hidePopover();

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -156,7 +156,7 @@ public:
     ExceptionOr<void> showPopoverInternal(HTMLElement* = nullptr);
     ExceptionOr<void> hidePopover();
     ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);
-    ExceptionOr<bool> togglePopover(std::optional<Variant<WebCore::HTMLElement::TogglePopoverOptions, bool>>);
+    ExceptionOr<bool> togglePopover(Variant<WebCore::HTMLElement::TogglePopoverOptions, bool>);
 
     const AtomString& popover() const;
     void setPopover(const AtomString& value);

--- a/Source/WebCore/html/HTMLOrForeignElement.idl
+++ b/Source/WebCore/html/HTMLOrForeignElement.idl
@@ -32,7 +32,7 @@ interface mixin HTMLOrForeignElement {
 
     [CEReactions=NotNeeded, Reflect] attribute boolean autofocus;
     [CEReactions=Needed, ImplementedAs=tabIndexForBindings] attribute long tabIndex;
-    [ImplementedAs=focusForBindings] undefined focus(optional FocusOptions options);
+    [ImplementedAs=focusForBindings] undefined focus(optional FocusOptions options = {});
     undefined blur();
 };
 

--- a/Source/WebCore/html/HTMLSlotElement.idl
+++ b/Source/WebCore/html/HTMLSlotElement.idl
@@ -28,8 +28,8 @@
     Exposed=Window
 ] interface HTMLSlotElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
-    sequence<Node> assignedNodes(optional AssignedNodesOptions options);
-    sequence<Element> assignedElements(optional AssignedNodesOptions options);
+    sequence<Node> assignedNodes(optional AssignedNodesOptions options = {});
+    sequence<Element> assignedElements(optional AssignedNodesOptions options = {});
     undefined assign((Element or Text)... nodes);
 };
 

--- a/Source/WebCore/html/HTMLVideoElement+CaptionDisplaySettings.idl
+++ b/Source/WebCore/html/HTMLVideoElement+CaptionDisplaySettings.idl
@@ -29,5 +29,5 @@
     Exposed=Window,
     ImplementedBy=HTMLVideoElementCaptionDisplaySettings,
 ] partial interface HTMLVideoElement {
-    Promise<undefined> showCaptionDisplaySettings(optional CaptionDisplaySettingsOptions options);
+    Promise<undefined> showCaptionDisplaySettings(optional CaptionDisplaySettingsOptions options = {});
 };

--- a/Source/WebCore/html/ImageData.idl
+++ b/Source/WebCore/html/ImageData.idl
@@ -33,9 +33,9 @@ typedef (Uint8ClampedArray or Float16Array) ImageDataArray;
     ExportMacro=WEBCORE_EXPORT,
     Exposed=(Window,Worker),
 ] interface ImageData {
-    constructor(unsigned long sw, unsigned long sh, optional ImageDataSettings settings);
-    constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings);
-    [EnabledBySetting=CanvasColorTypeEnabled] constructor(Float16Array data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings);
+    constructor(unsigned long sw, unsigned long sh, optional ImageDataSettings settings = {});
+    constructor(Uint8ClampedArray data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings = {});
+    [EnabledBySetting=CanvasColorTypeEnabled] constructor(Float16Array data, unsigned long sw, optional unsigned long sh, optional ImageDataSettings settings = {});
 
     readonly attribute unsigned long width;
     readonly attribute unsigned long height;

--- a/Source/WebCore/html/MediaEncryptedEvent.idl
+++ b/Source/WebCore/html/MediaEncryptedEvent.idl
@@ -39,7 +39,7 @@
     DisabledByQuirk=hasBrokenEncryptedMediaAPISupport,
     Exposed=Window
 ] interface MediaEncryptedEvent : Event {
-    constructor([AtomString] DOMString type, optional MediaEncryptedEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional MediaEncryptedEventInit eventInitDict = {});
 
     readonly attribute DOMString initDataType;
     readonly attribute ArrayBuffer? initData;

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -68,6 +68,6 @@ enum OffscreenRenderingContextType
     [CallWith=CurrentGlobalObject] OffscreenRenderingContext? getContext(OffscreenRenderingContextType contextType, any... arguments);
     // FIXME: `transferToImageBitmap` should not return a nullable type.
     ImageBitmap? transferToImageBitmap();
-    Promise<Blob> convertToBlob(optional ImageEncodeOptions options);
+    Promise<Blob> convertToBlob(optional ImageEncodeOptions options = {});
 
 };

--- a/Source/WebCore/html/SubmitEvent.idl
+++ b/Source/WebCore/html/SubmitEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=Window
 ] interface SubmitEvent : Event {
-    constructor([AtomString] DOMString type, optional SubmitEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional SubmitEventInit eventInitDict = {});
 
     readonly attribute HTMLElement? submitter;
 };

--- a/Source/WebCore/html/canvas/CanvasImageData.idl
+++ b/Source/WebCore/html/canvas/CanvasImageData.idl
@@ -26,9 +26,9 @@
 // https://html.spec.whatwg.org/multipage/canvas.html#canvasimagedata
 interface mixin CanvasImageData {
     // pixel manipulation
-    ImageData createImageData([EnforceRange] long sw, [EnforceRange] long sh, optional ImageDataSettings settings);
+    ImageData createImageData([EnforceRange] long sw, [EnforceRange] long sh, optional ImageDataSettings settings = {});
     ImageData createImageData(ImageData imagedata);
-    ImageData getImageData([EnforceRange] long sx, [EnforceRange] long sy, [EnforceRange] long sw, [EnforceRange] long sh, optional ImageDataSettings settings);
+    ImageData getImageData([EnforceRange] long sx, [EnforceRange] long sy, [EnforceRange] long sw, [EnforceRange] long sh, optional ImageDataSettings settings = {});
     undefined putImageData(ImageData imagedata, [EnforceRange] long dx, [EnforceRange] long dy);
     undefined putImageData(ImageData imagedata, [EnforceRange] long dx, [EnforceRange] long dy, [EnforceRange] long dirtyX, [EnforceRange] long dirtyY, [EnforceRange] long dirtyWidth, [EnforceRange] long dirtyHeight);
 };

--- a/Source/WebCore/html/canvas/CanvasPattern.idl
+++ b/Source/WebCore/html/canvas/CanvasPattern.idl
@@ -27,5 +27,5 @@
     Exposed=(Window,Worker),
 ] interface CanvasPattern {
     // opaque object
-    undefined setTransform(optional DOMMatrix2DInit transform);
+    undefined setTransform(optional DOMMatrix2DInit transform = {});
 };

--- a/Source/WebCore/html/canvas/CanvasTransform.idl
+++ b/Source/WebCore/html/canvas/CanvasTransform.idl
@@ -33,6 +33,6 @@ interface mixin CanvasTransform {
 
     [NewObject] DOMMatrix getTransform();
     undefined setTransform(unrestricted double a, unrestricted double b, unrestricted double c, unrestricted double d, unrestricted double e, unrestricted double f);
-    undefined setTransform(optional DOMMatrix2DInit transform);
+    undefined setTransform(optional DOMMatrix2DInit transform = {});
     undefined resetTransform();
 };

--- a/Source/WebCore/html/canvas/Path2D.idl
+++ b/Source/WebCore/html/canvas/Path2D.idl
@@ -36,7 +36,7 @@
     // constructor(sequence<Path2D> paths, optional CanvasFillRule fillRule = "nonzero");
     constructor(DOMString d);
 
-    undefined addPath(Path2D path, optional DOMMatrix2DInit transform);
+    undefined addPath(Path2D path, optional DOMMatrix2DInit transform = {});
 };
 
 Path2D includes CanvasPath;

--- a/Source/WebCore/html/canvas/WebGLContextEvent.idl
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.idl
@@ -28,7 +28,7 @@
     EnabledBySetting=WebGLEnabled,
     Exposed=(Window,Worker)
 ] interface WebGLContextEvent : Event {
-    constructor([AtomString] DOMString type, optional WebGLContextEventInit eventInit);
+    constructor([AtomString] DOMString type, optional WebGLContextEventInit eventInit = {});
 
     readonly attribute DOMString statusMessage;
 };

--- a/Source/WebCore/page/DOMSelection.h
+++ b/Source/WebCore/page/DOMSelection.h
@@ -75,7 +75,7 @@ public:
     void addRange(Range&);
     ExceptionOr<void> removeRange(Range&);
 
-    Vector<Ref<StaticRange>> getComposedRanges(std::optional<Variant<RefPtr<ShadowRoot>, GetComposedRangesOptions>>&& options = std::nullopt, FixedVector<std::reference_wrapper<ShadowRoot>>&& = { });
+    Vector<Ref<StaticRange>> getComposedRanges(Variant<RefPtr<ShadowRoot>, GetComposedRangesOptions>&& options, FixedVector<std::reference_wrapper<ShadowRoot>>&& = { });
 
     void deleteFromDocument();
     bool containsNode(Node&, bool partlyContained) const;

--- a/Source/WebCore/page/DOMSelection.idl
+++ b/Source/WebCore/page/DOMSelection.idl
@@ -49,7 +49,7 @@
     undefined removeRange(Range range);
     undefined removeAllRanges();
 
-    sequence<StaticRange> getComposedRanges(optional (ShadowRoot or GetComposedRangesOptions) options, ShadowRoot... shadowRoots);
+    sequence<StaticRange> getComposedRanges(optional (ShadowRoot or GetComposedRangesOptions) options = {}, ShadowRoot... shadowRoots);
 
     undefined empty();
 

--- a/Source/WebCore/page/DOMWindow+CSSOMView.idl
+++ b/Source/WebCore/page/DOMWindow+CSSOMView.idl
@@ -46,11 +46,11 @@ partial interface DOMWindow {
     [Replaceable, ImplementedAs=scrollX] readonly attribute double pageXOffset;
     [Replaceable] readonly attribute double scrollY;
     [Replaceable, ImplementedAs=scrollY] readonly attribute double pageYOffset;
-    [ImplementedAs=scrollTo] undefined scroll(optional ScrollToOptions options);
+    [ImplementedAs=scrollTo] undefined scroll(optional ScrollToOptions options = {});
     [ImplementedAs=scrollTo] undefined scroll(unrestricted double x, unrestricted double y);
-    undefined scrollTo(optional ScrollToOptions options);
+    undefined scrollTo(optional ScrollToOptions options = {});
     undefined scrollTo(unrestricted double x, unrestricted double y);
-    undefined scrollBy(optional ScrollToOptions option);
+    undefined scrollBy(optional ScrollToOptions option = {});
     undefined scrollBy(unrestricted double x, unrestricted double y);
 
     // client

--- a/Source/WebCore/page/DOMWindow+RequestIdleCallback.idl
+++ b/Source/WebCore/page/DOMWindow+RequestIdleCallback.idl
@@ -27,6 +27,6 @@
 [
     EnabledBySetting=requestIdleCallbackEnabled
 ] partial interface DOMWindow {
-    unsigned long requestIdleCallback(IdleRequestCallback callback, optional IdleRequestOptions options);
+    unsigned long requestIdleCallback(IdleRequestCallback callback, optional IdleRequestOptions options = {});
     undefined cancelIdleCallback(unsigned long handle);
 };

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -53,7 +53,7 @@
     [DoNotCheckSecurity, CallWith=IncumbentWindow] undefined focus();
     [DoNotCheckSecurity] undefined blur();
     [DoNotCheckSecurity, CallWith=CurrentGlobalObject&IncumbentWindow] undefined postMessage(any message, USVString targetOrigin, optional sequence<object> transfer = []);
-    [DoNotCheckSecurity, CallWith=CurrentGlobalObject&IncumbentWindow] undefined postMessage(any message, optional WindowPostMessageOptions options);
+    [DoNotCheckSecurity, CallWith=CurrentGlobalObject&IncumbentWindow] undefined postMessage(any message, optional WindowPostMessageOptions options = {});
     [DoNotCheckSecurity, PutForwards=href, LegacyUnforgeable] readonly attribute Location location;
     [DoNotCheckSecurity, LegacyUnforgeable, CustomGetter] readonly attribute WindowProxy window;
     [DoNotCheckSecurityOnGetter, Replaceable, CustomGetter] readonly attribute WindowProxy self;

--- a/Source/WebCore/page/EventSource.idl
+++ b/Source/WebCore/page/EventSource.idl
@@ -35,7 +35,7 @@
     Exposed=(Window,Worker),
     ActiveDOMObject,
 ] interface EventSource : EventTarget {
-    [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional EventSourceInit eventSourceInitDict);
+    [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional EventSourceInit eventSourceInitDict = {});
 
     readonly attribute USVString url;
     readonly attribute boolean withCredentials;

--- a/Source/WebCore/page/IntersectionObserver.idl
+++ b/Source/WebCore/page/IntersectionObserver.idl
@@ -30,7 +30,7 @@
     JSCustomMarkFunction,
     CustomIsReachable,
 ] interface IntersectionObserver {
-    [CallWith=CurrentDocument] constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options);
+    [CallWith=CurrentDocument] constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options = {});
 
     readonly attribute Node? root;
     readonly attribute DOMString rootMargin;

--- a/Source/WebCore/page/NavigatorShare.idl
+++ b/Source/WebCore/page/NavigatorShare.idl
@@ -27,6 +27,6 @@
 [
     EnabledBySetting=WebShareEnabled
 ] interface mixin NavigatorShare {
-    [CallWith=CurrentDocument, SecureContext] boolean canShare(optional ShareData shareData);
-    [CallWith=CurrentDocument, SecureContext] Promise<undefined> share(optional ShareData shareData);
+    [CallWith=CurrentDocument, SecureContext] boolean canShare(optional ShareData shareData = {});
+    [CallWith=CurrentDocument, SecureContext] Promise<undefined> share(optional ShareData shareData = {});
 };

--- a/Source/WebCore/page/Performance+UserTiming.idl
+++ b/Source/WebCore/page/Performance+UserTiming.idl
@@ -25,8 +25,8 @@
 
 // https://w3c.github.io/user-timing/#extensions-performance-interface
 partial interface Performance {
-    [CallWith=CurrentGlobalObject] PerformanceMark mark(DOMString markName, optional PerformanceMarkOptions markOptions);
+    [CallWith=CurrentGlobalObject] PerformanceMark mark(DOMString markName, optional PerformanceMarkOptions markOptions = {});
     undefined clearMarks(optional DOMString markName);
-    [CallWith=CurrentGlobalObject] PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions, optional DOMString endMark);
+    [CallWith=CurrentGlobalObject] PerformanceMeasure measure(DOMString measureName, optional (DOMString or PerformanceMeasureOptions) startOrMeasureOptions = {}, optional DOMString endMark);
     undefined clearMeasures(optional DOMString measureName);
 };

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -511,7 +511,7 @@ void Performance::clearMarks(const String& markName)
     m_userTiming->clearMarks(markName);
 }
 
-ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& globalObject, const String& measureName, std::optional<StartOrMeasureOptions>&& startOrMeasureOptions, const String& endMark)
+ExceptionOr<Ref<PerformanceMeasure>> Performance::measure(JSC::JSGlobalObject& globalObject, const String& measureName, StartOrMeasureOptions&& startOrMeasureOptions, const String& endMark)
 {
     if (!m_userTiming)
         m_userTiming = makeUnique<PerformanceUserTiming>(*this);

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -111,7 +111,7 @@ public:
     void clearMarks(const String& markName);
 
     using StartOrMeasureOptions = Variant<String, PerformanceMeasureOptions>;
-    ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, std::optional<StartOrMeasureOptions>&&, const String& endMark);
+    ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, StartOrMeasureOptions&&, const String& endMark);
     void clearMeasures(const String& measureName);
 
     void addNavigationTiming(DocumentLoader&, Document&, CachedResource&, const DocumentLoadTiming&, const NetworkLoadMetrics&);

--- a/Source/WebCore/page/PerformanceMark.idl
+++ b/Source/WebCore/page/PerformanceMark.idl
@@ -27,6 +27,6 @@
 [
     Exposed=*,
 ] interface PerformanceMark : PerformanceEntry {
-    [CallWith=CurrentGlobalObject&CurrentScriptExecutionContext] constructor(DOMString markName, optional PerformanceMarkOptions markOptions);
+    [CallWith=CurrentGlobalObject&CurrentScriptExecutionContext] constructor(DOMString markName, optional PerformanceMarkOptions markOptions = {});
     [CallWith=CurrentGlobalObject, CachedAttribute] readonly attribute any detail;
 };

--- a/Source/WebCore/page/PerformanceObserver.idl
+++ b/Source/WebCore/page/PerformanceObserver.idl
@@ -34,7 +34,7 @@ typedef double DOMHighResTimeStamp;
 ] interface PerformanceObserver {
     [CallWith=CurrentScriptExecutionContext] constructor(PerformanceObserverCallback callback);
 
-    undefined observe(optional PerformanceObserverInit options);
+    undefined observe(optional PerformanceObserverInit options = {});
     undefined disconnect();
     sequence<PerformanceEntry> takeRecords();
     [CallWith=CurrentScriptExecutionContext] static readonly attribute FrozenArray<DOMString> supportedEntryTypes;

--- a/Source/WebCore/page/PerformanceUserTiming.h
+++ b/Source/WebCore/page/PerformanceUserTiming.h
@@ -54,7 +54,7 @@ public:
     void clearMarks(const String& markName);
 
     using StartOrMeasureOptions = Variant<String, PerformanceMeasureOptions>;
-    ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, std::optional<StartOrMeasureOptions>&&, const String& endMark);
+    ExceptionOr<Ref<PerformanceMeasure>> measure(JSC::JSGlobalObject&, const String& measureName, StartOrMeasureOptions&&, const String& endMark);
     void clearMeasures(const String& measureName);
 
     Vector<Ref<PerformanceEntry>> getMarks() const;

--- a/Source/WebCore/page/ResizeObserver.idl
+++ b/Source/WebCore/page/ResizeObserver.idl
@@ -32,7 +32,7 @@
 ] interface ResizeObserver {
     [CallWith=CurrentDocument] constructor(ResizeObserverCallback callback);
 
-    undefined observe(Element target, optional ResizeObserverOptions options);
+    undefined observe(Element target, optional ResizeObserverOptions options = {});
     undefined unobserve(Element target);
     undefined disconnect();
 };

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -33,7 +33,7 @@
     readonly attribute UserMessageHandlersNamespace? messageHandlers;
     readonly attribute WebKitBufferNamespace buffers;
     [EnabledForGlobalObject=allowsJSHandleCreation] WebKitJSHandle createJSHandle(object object);
-    [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init);
+    [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init = {});
 };
 
 [

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.idl
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.idl
@@ -69,9 +69,9 @@ interface mixin WindowOrWorkerGlobalScope {
     [Custom] undefined queueMicrotask(VoidCallback callback);
 
     // ImageBitmap.
-    Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, optional ImageBitmapOptions options);
-    Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, long sx, long sy, long sw, long sh, optional ImageBitmapOptions options);
+    Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, optional ImageBitmapOptions options = {});
+    Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, long sx, long sy, long sw, long sh, optional ImageBitmapOptions options = {});
 
     // structured cloning
-    [CallWith=CurrentGlobalObject&RelevantGlobalObject] any structuredClone(any value, optional StructuredSerializeOptions options);
+    [CallWith=CurrentGlobalObject&RelevantGlobalObject] any structuredClone(any value, optional StructuredSerializeOptions options = {});
 };

--- a/Source/WebCore/storage/StorageEvent.idl
+++ b/Source/WebCore/storage/StorageEvent.idl
@@ -26,7 +26,7 @@
 [
     Exposed=Window
 ] interface StorageEvent : Event {
-    constructor([AtomString] DOMString type, optional StorageEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional StorageEventInit eventInitDict = {});
 
     readonly attribute DOMString? key;
     readonly attribute DOMString? oldValue;

--- a/Source/WebCore/svg/SVGGeometryElement.idl
+++ b/Source/WebCore/svg/SVGGeometryElement.idl
@@ -28,8 +28,8 @@
 ] interface SVGGeometryElement : SVGGraphicsElement {
     [SameObject] readonly attribute SVGAnimatedNumber pathLength;
 
-    boolean isPointInFill(optional DOMPointInit point);
-    boolean isPointInStroke(optional DOMPointInit point);
+    boolean isPointInFill(optional DOMPointInit point = {});
+    boolean isPointInStroke(optional DOMPointInit point = {});
     unrestricted float getTotalLength();
     [NewObject] SVGPoint getPointAtLength(float distance);
 };

--- a/Source/WebCore/svg/SVGSVGElement.idl
+++ b/Source/WebCore/svg/SVGSVGElement.idl
@@ -52,7 +52,7 @@
     [NewObject] SVGMatrix createSVGMatrix();
     [NewObject] SVGRect createSVGRect();
     [NewObject] SVGTransform createSVGTransform();
-    [NewObject] SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix);
+    [NewObject] SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix = {});
 
     Element? getElementById([RequiresExistingAtomString] DOMString elementId);
 

--- a/Source/WebCore/svg/SVGTransformList.idl
+++ b/Source/WebCore/svg/SVGTransformList.idl
@@ -39,6 +39,6 @@
     SVGTransform appendItem(SVGTransform newItem);
     setter undefined (unsigned long index, SVGTransform newItem);
 
-    [NewObject] SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix);
+    [NewObject] SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix = {});
     SVGTransform? consolidate();
 };

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.idl
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.idl
@@ -38,7 +38,7 @@
     [Replaceable] readonly attribute DOMString name;
 
     [CallWith=CurrentGlobalObject] undefined postMessage(any message, sequence<object> transfer);
-    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options);
+    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options = {});
 
     undefined close();
 

--- a/Source/WebCore/workers/Worker.idl
+++ b/Source/WebCore/workers/Worker.idl
@@ -28,12 +28,12 @@
     ActiveDOMObject,
     Exposed=(Window,DedicatedWorker)
 ] interface Worker : EventTarget {
-    [CallWith=CurrentScriptExecutionContext&RuntimeFlags] constructor((TrustedScriptURL or USVString) scriptURL, optional WorkerOptions options);
+    [CallWith=CurrentScriptExecutionContext&RuntimeFlags] constructor((TrustedScriptURL or USVString) scriptURL, optional WorkerOptions options = {});
 
     undefined terminate();
 
     [CallWith=CurrentGlobalObject] undefined postMessage(any message, sequence<object> transfer);
-    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options);
+    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options = {});
     attribute EventHandler onmessage;
     attribute EventHandler onmessageerror;
 };

--- a/Source/WebCore/workers/service/ExtendableEvent.idl
+++ b/Source/WebCore/workers/service/ExtendableEvent.idl
@@ -29,7 +29,7 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToNativeObject,
 ] interface ExtendableEvent : Event {
-    constructor([AtomString] DOMString type, optional ExtendableEventInit eventInitDict);
+    constructor([AtomString] DOMString type, optional ExtendableEventInit eventInitDict = {});
 
     undefined waitUntil(Promise<any> f);
 };

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.idl
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.idl
@@ -28,7 +28,7 @@
     Exposed=ServiceWorker,
     JSCustomMarkFunction
 ] interface ExtendableMessageEvent : ExtendableEvent {
-    [Custom] constructor([AtomString] DOMString type, optional ExtendableMessageEventInit eventInitDict);
+    [Custom] constructor([AtomString] DOMString type, optional ExtendableMessageEventInit eventInitDict = {});
 
     readonly attribute any data;
     readonly attribute USVString origin;

--- a/Source/WebCore/workers/service/ServiceWorker.idl
+++ b/Source/WebCore/workers/service/ServiceWorker.idl
@@ -36,7 +36,7 @@
     readonly attribute USVString scriptURL;
     readonly attribute ServiceWorkerState state;
     [CallWith=CurrentGlobalObject] undefined postMessage(any message, sequence<object> transfer);
-    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options);
+    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options = {});
 
     // event
     attribute EventHandler onstatechange;

--- a/Source/WebCore/workers/service/ServiceWorkerClient.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.idl
@@ -35,7 +35,7 @@
     readonly attribute DOMString id;
 
     [CallWith=CurrentGlobalObject] undefined postMessage(any message, sequence<object> transfer);
-    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options);
+    [CallWith=CurrentGlobalObject] undefined postMessage(any message, optional StructuredSerializeOptions options = {});
 };
 
 enum FrameType {

--- a/Source/WebCore/workers/service/ServiceWorkerClients.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerClients.idl
@@ -31,7 +31,7 @@
 ] interface ServiceWorkerClients {
     // The objects returned will be new instances every time
     [NewObject, CallWith=CurrentScriptExecutionContext] Promise<any> get(DOMString id);
-    [NewObject, CallWith=CurrentScriptExecutionContext] Promise<sequence<ServiceWorkerClient>> matchAll(optional ClientQueryOptions options);
+    [NewObject, CallWith=CurrentScriptExecutionContext] Promise<sequence<ServiceWorkerClient>> matchAll(optional ClientQueryOptions options = {});
     [NewObject, CallWith=CurrentScriptExecutionContext] Promise<ServiceWorkerWindowClient?> openWindow(USVString url);
     [NewObject, CallWith=CurrentScriptExecutionContext] Promise<undefined> claim();
 };

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.idl
@@ -36,7 +36,7 @@
     readonly attribute ServiceWorker? controller;
     readonly attribute Promise<ServiceWorkerRegistration> ready;
 
-    [NewObject, ImplementedAs=addRegistration] Promise<ServiceWorkerRegistration> register((TrustedScriptURL or USVString) scriptURL, optional RegistrationOptions options);
+    [NewObject, ImplementedAs=addRegistration] Promise<ServiceWorkerRegistration> register((TrustedScriptURL or USVString) scriptURL, optional RegistrationOptions options = {});
     [NewObject] Promise<any> getRegistration(optional USVString clientURL = "");
     [NewObject] Promise<sequence<ServiceWorkerRegistration>> getRegistrations();
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.idl
@@ -46,8 +46,8 @@
     [NewObject] Promise<ServiceWorkerRegistration> update();
     [NewObject] Promise<boolean> unregister();
 
-    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled, CallWith=CurrentScriptExecutionContext] Promise<undefined> showNotification(DOMString title, optional NotificationOptions options);
-    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled] Promise<sequence<Notification>> getNotifications(optional GetNotificationOptions filter);
+    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled, CallWith=CurrentScriptExecutionContext] Promise<undefined> showNotification(DOMString title, optional NotificationOptions options = {});
+    [Conditional=NOTIFICATION_EVENT, EnabledBySetting=NotificationEventEnabled] Promise<sequence<Notification>> getNotifications(optional GetNotificationOptions filter = {});
 
     // event
     attribute EventHandler onupdatefound;

--- a/Source/WebCore/worklets/Worklet.idl
+++ b/Source/WebCore/worklets/Worklet.idl
@@ -28,5 +28,5 @@
     Exposed=Window,
     SkipVTableValidation
 ] interface Worklet {
-    Promise<undefined> addModule(USVString moduleURL, optional WorkletOptions options);
+    Promise<undefined> addModule(USVString moduleURL, optional WorkletOptions options = {});
 };


### PR DESCRIPTION
#### 7df3a28c9e9bd63d4588f4d036ac03fcbf06e86f
<pre>
Remove implicit &quot;= {}&quot; and &quot;= []&quot; default values for IDL optionals
<a href="https://bugs.webkit.org/show_bug.cgi?id=305957">https://bugs.webkit.org/show_bug.cgi?id=305957</a>

Reviewed by Chris Dumez.

Removes support for implicitly assuming all optional dictionaries
have an implied &quot; = {}&quot; and all optional sequences have an implied
&quot;= []&quot;. Instead, match the spec and require putting the default
value in the IDL files.

Most of the change is updating IDL files that were missing these.

Additionally, refactored the argument conversion code in CodeGeneratorJS
so it could be used for the async iterator argument list. This was
needed to get proper default value conversions.

* Source/WebCore/Modules/WebGPU/GPU.idl:
* Source/WebCore/Modules/WebGPU/GPUAdapter.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUDevice.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUTexture.idl:
* Source/WebCore/Modules/airplay/WebKitPlaybackTargetAvailabilityEvent.idl:
* Source/WebCore/Modules/applepay/ApplePayError.idl:
* Source/WebCore/Modules/cache/DOMCache.idl:
* Source/WebCore/Modules/cache/DOMCacheStorage.idl:
* Source/WebCore/Modules/contact-picker/ContactsManager.idl:
* Source/WebCore/Modules/cookie-consent/Navigator+CookieConsent.idl:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl:
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryEntry.idl:
* Source/WebCore/Modules/fetch/FetchRequest.idl:
* Source/WebCore/Modules/fetch/FetchResponse.idl:
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScope+Fetch.idl:
* Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl:
* Source/WebCore/Modules/gamepad/GamepadEvent.idl:
* Source/WebCore/Modules/geolocation/Geolocation.idl:
* Source/WebCore/Modules/indexeddb/IDBDatabase.idl:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.idl:
* Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.idl:
* Source/WebCore/Modules/mediasession/MediaMetadata.idl:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.idl:
* Source/WebCore/Modules/mediasource/MediaSource.idl:
* Source/WebCore/Modules/mediastream/MediaDevices.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.idl:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.idl:
* Source/WebCore/Modules/notifications/Notification.idl:
* Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl:
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.idl:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.idl:
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.idl:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.idl:
* Source/WebCore/Modules/push-api/PushEvent.idl:
* Source/WebCore/Modules/push-api/PushManager.idl:
* Source/WebCore/Modules/push-api/PushSubscriptionChangeEvent.idl:
* Source/WebCore/Modules/reporting/ReportingObserver.idl:
* Source/WebCore/Modules/streams/ReadableStream.idl:
* Source/WebCore/Modules/url-pattern/URLPattern.idl:
* Source/WebCore/Modules/webaudio/AnalyserNode.idl:
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.idl:
* Source/WebCore/Modules/webaudio/AudioContext.idl:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.idl:
* Source/WebCore/Modules/webaudio/BaseAudioContext.idl:
* Source/WebCore/Modules/webaudio/BiquadFilterNode.idl:
* Source/WebCore/Modules/webaudio/ChannelMergerNode.idl:
* Source/WebCore/Modules/webaudio/ChannelSplitterNode.idl:
* Source/WebCore/Modules/webaudio/ConstantSourceNode.idl:
* Source/WebCore/Modules/webaudio/ConvolverNode.idl:
* Source/WebCore/Modules/webaudio/DelayNode.idl:
* Source/WebCore/Modules/webaudio/DynamicsCompressorNode.idl:
* Source/WebCore/Modules/webaudio/GainNode.idl:
* Source/WebCore/Modules/webaudio/MediaStreamAudioDestinationNode.idl:
* Source/WebCore/Modules/webaudio/OscillatorNode.idl:
* Source/WebCore/Modules/webaudio/PannerNode.idl:
* Source/WebCore/Modules/webaudio/PeriodicWave.idl:
* Source/WebCore/Modules/webaudio/StereoPannerNode.idl:
* Source/WebCore/Modules/webaudio/WaveShaperNode.idl:
* Source/WebCore/Modules/websockets/CloseEvent.idl:
* Source/WebCore/Modules/webxr/WebXRRigidTransform.idl:
* Source/WebCore/Modules/webxr/WebXRSession.idl:
* Source/WebCore/Modules/webxr/WebXRSystem.idl:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.idl:
* Source/WebCore/animation/Animatable.idl:
* Source/WebCore/animation/AnimationEffect.idl:
* Source/WebCore/animation/AnimationPlaybackEvent.idl:
* Source/WebCore/animation/CSSAnimationEvent.idl:
* Source/WebCore/animation/CSSTransitionEvent.idl:
* Source/WebCore/animation/CustomEffect.idl:
* Source/WebCore/animation/DocumentTimeline.idl:
* Source/WebCore/animation/KeyframeEffect.idl:
* Source/WebCore/bindings/IDLTypes.h:
* Source/WebCore/bindings/js/JSDOMConvertOptional.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/bindings/scripts/IDLParser.pm:
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
* Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl:
* Source/WebCore/bindings/scripts/test/TestEventConstructor.idl:
* Source/WebCore/bindings/scripts/test/TestObj.idl:
* Source/WebCore/css/DOMMatrix.idl:
* Source/WebCore/css/DOMMatrixReadOnly.idl:
* Source/WebCore/css/FontFaceSetLoadEvent.idl:
* Source/WebCore/css/MediaQueryListEvent.idl:
* Source/WebCore/dom/ClipboardEvent.idl:
* Source/WebCore/dom/CommandEvent.idl:
* Source/WebCore/dom/CustomEvent.idl:
* Source/WebCore/dom/DOMPoint.idl:
* Source/WebCore/dom/DOMPointReadOnly.idl:
* Source/WebCore/dom/DOMQuad.idl:
* Source/WebCore/dom/DOMRect.idl:
* Source/WebCore/dom/DOMRectReadOnly.idl:
* Source/WebCore/dom/DragEvent.idl:
* Source/WebCore/dom/Element+CSSOMView.idl:
* Source/WebCore/dom/ErrorEvent.idl:
* Source/WebCore/dom/Event.idl:
* Source/WebCore/dom/FocusEvent.idl:
* Source/WebCore/dom/InputEvent.idl:
* Source/WebCore/dom/KeyboardEvent.idl:
* Source/WebCore/dom/MessageEvent.idl:
* Source/WebCore/dom/MessagePort.idl:
* Source/WebCore/dom/MouseEvent.idl:
* Source/WebCore/dom/MutationObserver.idl:
* Source/WebCore/dom/Node.idl:
* Source/WebCore/dom/PageTransitionEvent.idl:
* Source/WebCore/dom/PointerEvent.idl:
* Source/WebCore/dom/PopStateEvent.idl:
* Source/WebCore/dom/ProgressEvent.idl:
* Source/WebCore/dom/TextDecoder.idl:
* Source/WebCore/dom/TouchEvent.idl:
* Source/WebCore/fileapi/Blob.cpp:
* Source/WebCore/fileapi/Blob.h:
* Source/WebCore/fileapi/Blob.idl:
* Source/WebCore/fileapi/File.idl:
* Source/WebCore/html/HTMLOrForeignElement.idl:
* Source/WebCore/html/HTMLSlotElement.idl:
* Source/WebCore/html/HTMLVideoElement+CaptionDisplaySettings.idl:
* Source/WebCore/html/ImageData.idl:
* Source/WebCore/html/MediaEncryptedEvent.idl:
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/SubmitEvent.idl:
* Source/WebCore/html/canvas/CanvasImageData.idl:
* Source/WebCore/html/canvas/CanvasPattern.idl:
* Source/WebCore/html/canvas/CanvasTransform.idl:
* Source/WebCore/html/canvas/Path2D.idl:
* Source/WebCore/html/canvas/WebGLContextEvent.idl:
* Source/WebCore/page/DOMSelection.idl:
* Source/WebCore/page/DOMWindow+CSSOMView.idl:
* Source/WebCore/page/DOMWindow+RequestIdleCallback.idl:
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/EventSource.idl:
* Source/WebCore/page/IntersectionObserver.idl:
* Source/WebCore/page/NavigatorShare.idl:
* Source/WebCore/page/Performance+UserTiming.idl:
* Source/WebCore/page/PerformanceMark.idl:
* Source/WebCore/page/PerformanceObserver.idl:
* Source/WebCore/page/ResizeObserver.idl:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebCore/page/WindowOrWorkerGlobalScope.idl:
* Source/WebCore/storage/StorageEvent.idl:
* Source/WebCore/svg/SVGGeometryElement.idl:
* Source/WebCore/svg/SVGSVGElement.idl:
* Source/WebCore/svg/SVGTransformList.idl:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.idl:
* Source/WebCore/workers/Worker.idl:
* Source/WebCore/workers/service/ExtendableEvent.idl:
* Source/WebCore/workers/service/ExtendableMessageEvent.idl:
* Source/WebCore/workers/service/ServiceWorker.idl:
* Source/WebCore/workers/service/ServiceWorkerClient.idl:
* Source/WebCore/workers/service/ServiceWorkerClients.idl:
* Source/WebCore/workers/service/ServiceWorkerContainer.idl:
* Source/WebCore/workers/service/ServiceWorkerRegistration.idl:
* Source/WebCore/worklets/Worklet.idl:

Canonical link: <a href="https://commits.webkit.org/306102@main">https://commits.webkit.org/306102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/627706c1dedd0364fd1cf9c90560635e48051034

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148658 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12873 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9969 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151284 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115876 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116211 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29535 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11350 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122121 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12450 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1577 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76150 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->