### PR TITLE
Parental Controls should use mainframe's URL as criteria to check if a download is allowed.

### DIFF
--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -56,7 +56,7 @@ public:
     WEBCORE_EXPORT virtual ~ParentalControlsURLFilter();
     virtual bool isEnabledImpl() const;
     void isURLAllowed(const URL& mainDocumentURL, const URL&, ParentalControlsContentFilter&);
-    WEBCORE_EXPORT void isURLAllowed(const URL&, CompletionHandler<void(bool, NSData *)>&&);
+    WEBCORE_EXPORT void isURLAllowed(const URL& mainDocumentURL, const URL&, CompletionHandler<void(bool, NSData *)>&&);
     virtual void allowURL(const URL&, CompletionHandler<void(bool)>&&);
 
 protected:

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -172,10 +172,9 @@ void ParentalControlsURLFilter::isURLAllowed(const URL& mainDocumentURL, const U
     }, CompletionHandlerCallThread::AnyThread });
 }
 
-void ParentalControlsURLFilter::isURLAllowed(const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
+void ParentalControlsURLFilter::isURLAllowed(const URL& mainDocumentURL, const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
 {
-    // FIXME: rdar://168622817, remove URL { } parameter eventually
-    isURLAllowedImpl(URL { }, url, { [protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (bool allowed, NSData *replacementData) mutable {
+    isURLAllowedImpl(mainDocumentURL, url, { [protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (bool allowed, NSData *replacementData) mutable {
         ASSERT(!isMainThread());
         callOnMainRunLoop([completionHandler = WTF::move(completionHandler), allowed, replacementData = RetainPtr { replacementData }]() mutable {
             completionHandler(allowed, replacementData.get());

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -75,7 +75,7 @@ PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, Netwo
     send(Messages::DownloadProxy::DidStart(m_networkLoad->currentRequest(), suggestedName));
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    protect(m_urlFilter)->isURLAllowed(m_networkLoad->currentRequest().url(), [this, protectedThis = Ref { *this }, startNetworkLoad = WTF::move(startNetworkLoad)] (bool allowed, NSData *) mutable {
+    protect(m_urlFilter)->isURLAllowed(mainDocumentURL(), m_networkLoad->currentRequest().url(), [this, protectedThis = Ref { *this }, startNetworkLoad = WTF::move(startNetworkLoad)] (bool allowed, NSData *) mutable {
         if (!allowed) {
             blockDueToContentFilter(ResourceResponse { m_networkLoad->currentRequest().url(), "application/octet-stream"_s, 0, ""_s }, nullptr);
             return;
@@ -132,7 +132,7 @@ void PendingDownload::willSendRedirectedRequest(WebCore::ResourceRequest&&, WebC
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     auto requestURL = redirectRequest.url();
-    protect(m_urlFilter)->isURLAllowed(requestURL, [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), redirectRequest = WTF::move(redirectRequest), redirectResponse = WTF::move(redirectResponse)] (bool allowed, NSData *) mutable {
+    protect(m_urlFilter)->isURLAllowed(mainDocumentURL(), requestURL, [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), redirectRequest = WTF::move(redirectRequest), redirectResponse = WTF::move(redirectResponse)] (bool allowed, NSData *) mutable {
         if (allowed) {
             sendWithAsyncReply(Messages::DownloadProxy::WillSendRequest(WTF::move(redirectRequest), WTF::move(redirectResponse)), WTF::move(completionHandler));
             return;
@@ -206,6 +206,22 @@ void PendingDownload::didReceiveResponse(WebCore::ResourceResponse&& response, P
 uint64_t PendingDownload::messageSenderDestinationID() const
 {
     return m_downloadID.toUInt64();
+}
+
+URL PendingDownload::mainDocumentURL() const
+{
+    auto firstParty = m_networkLoad->currentRequest().firstPartyForCookies();
+    if (!firstParty.isEmpty())
+        return firstParty;
+
+    RefPtr topOrigin = m_networkLoad->parameters().topOrigin;
+    if (topOrigin)
+        return topOrigin->toURL();
+
+    if (m_networkLoad->parameters().mainResourceNavigationDataForAnyFrame)
+        return m_networkLoad->parameters().mainResourceNavigationDataForAnyFrame->request.url();
+
+    return { };
 }
 
 #if HAVE(WEBCONTENTRESTRICTIONS)

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.h
@@ -111,6 +111,8 @@ private:
 #endif
 
 private:
+    URL mainDocumentURL() const;
+
     const Ref<NetworkLoad> m_networkLoad;
     DownloadID m_downloadID;
     RefPtr<IPC::Connection> m_parentProcessConnection;


### PR DESCRIPTION
#### 5a8fe384cf60da92aba7b1a1d87bbd514495b6fe
<pre>
Parental Controls should use mainframe&apos;s URL as criteria to check if a download is allowed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306002">https://bugs.webkit.org/show_bug.cgi?id=306002</a>
<a href="https://rdar.apple.com/168636046">rdar://168636046</a>

Reviewed by Sihui Liu.

PendingDownloads should also check the mainframe URL in its criteria to allow downloads or not.

No new tests needed.

* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::isURLAllowed):
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::PendingDownload):
(WebKit::PendingDownload::willSendRedirectedRequest):
(WebKit::PendingDownload::mainDocumentURL const):
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.h:

Canonical link: <a href="https://commits.webkit.org/306870@main">https://commits.webkit.org/306870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eae936729b8da270257d59cc94d1f10b83d8f409

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15011 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95735 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc4ce0ca-acfd-4ff7-88ac-92b4bfbe7eee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109627 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08487ff5-a85c-403a-8817-d45dba12ec55) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90536 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dc6af69-e5ee-4cac-983e-df2eb245c92b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9283 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1216 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153531 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14644 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117650 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117986 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14007 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124856 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70335 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21992 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14686 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3812 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14631 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->