### PR TITLE
Digital Credentials: IdentityCredentialProtocol was renamed DigitalCredentialPresentationProtocol

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -452,8 +452,8 @@ set(WebCore_NON_SVG_IDL_FILES
 
     Modules/identity/DigitalCredential.idl
     Modules/identity/DigitalCredentialGetRequest.idl
+    Modules/identity/DigitalCredentialPresentationProtocol.idl
     Modules/identity/DigitalCredentialRequestOptions.idl
-    Modules/identity/IdentityCredentialProtocol.idl
 
     Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl
 

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -519,7 +519,7 @@ $(PROJECT_DIR)/Modules/highlight/HighlightRegistry.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredential.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredentialGetRequest.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredentialRequestOptions.idl
-$(PROJECT_DIR)/Modules/identity/IdentityCredentialProtocol.idl
+$(PROJECT_DIR)/Modules/identity/DigitalCredentialPresentationProtocol.idl
 $(PROJECT_DIR)/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursor.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorDirection.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1747,8 +1747,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIPAddressSpace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIPAddressSpace.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdentityCredentialProtocol.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialPresentationProtocol.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialPresentationProtocol.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleRequestCallback.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -380,7 +380,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/identity/DigitalCredential.idl \
     $(WebCore)/Modules/identity/DigitalCredentialGetRequest.idl \
     $(WebCore)/Modules/identity/DigitalCredentialRequestOptions.idl \
-    $(WebCore)/Modules/identity/IdentityCredentialProtocol.idl \
+    $(WebCore)/Modules/identity/DigitalCredentialPresentationProtocol.idl \
     $(WebCore)/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl \
     $(WebCore)/Modules/indexeddb/IDBCursor.idl \
     $(WebCore)/Modules/indexeddb/IDBCursorDirection.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -494,10 +494,10 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/identity/CredentialRequestCoordinatorClient.h
     Modules/identity/DigitalCredential.h
     Modules/identity/DigitalCredentialGetRequest.h
+    Modules/identity/DigitalCredentialPresentationProtocol.h
     Modules/identity/DigitalCredentialRequestOptions.h
     Modules/identity/DigitalCredentialsRequestData.h
     Modules/identity/DigitalCredentialsResponseData.h
-    Modules/identity/IdentityCredentialProtocol.h
 
     Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -31,11 +31,11 @@
 #include "Chrome.h"
 #include "CredentialRequestCoordinator.h"
 #include "CredentialRequestOptions.h"
+#include "DigitalCredentialPresentationProtocol.h"
 #include "DocumentPage.h"
 #include "ExceptionOr.h"
 #include "FrameDestructionObserverInlines.h"
 #include "IDLTypes.h"
-#include "IdentityCredentialProtocol.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "MediationRequirement.h"
@@ -50,24 +50,24 @@
 
 namespace WebCore {
 
-Ref<DigitalCredential> DigitalCredential::create(JSC::Strong<JSC::JSObject>&& data, IdentityCredentialProtocol protocol)
+Ref<DigitalCredential> DigitalCredential::create(JSC::Strong<JSC::JSObject>&& data, DigitalCredentialPresentationProtocol protocol)
 {
     return adoptRef(*new DigitalCredential(WTF::move(data), protocol));
 }
 
 DigitalCredential::~DigitalCredential() = default;
 
-DigitalCredential::DigitalCredential(JSC::Strong<JSC::JSObject>&& data, IdentityCredentialProtocol protocol)
+DigitalCredential::DigitalCredential(JSC::Strong<JSC::JSObject>&& data, DigitalCredentialPresentationProtocol protocol)
     : BasicCredential(createVersion4UUIDString(), Type::DigitalCredential, Discovery::CredentialStore)
     , m_protocol(protocol)
     , m_data(WTF::move(data))
 {
 }
 
-static std::optional<IdentityCredentialProtocol> convertProtocolString(const String& protocolString)
+static std::optional<DigitalCredentialPresentationProtocol> convertProtocolString(const String& protocolString)
 {
     if (protocolString == "org-iso-mdoc"_s)
-        return IdentityCredentialProtocol::OrgIsoMdoc;
+        return DigitalCredentialPresentationProtocol::OrgIsoMdoc;
     return std::nullopt;
 }
 
@@ -86,7 +86,7 @@ static ExceptionOr<std::optional<UnvalidatedDigitalCredentialRequest>> jsToCrede
         return std::optional<UnvalidatedDigitalCredentialRequest> { std::nullopt }; // Return empty optional for unknown protocols
 
     switch (*protocol) {
-    case IdentityCredentialProtocol::OrgIsoMdoc: {
+    case DigitalCredentialPresentationProtocol::OrgIsoMdoc: {
         auto result = convertDictionary<MobileDocumentRequest>(*globalObject, request.data.get());
         if (result.hasException(scope)) [[unlikely]]
             return Exception { ExceptionCode::ExistingExceptionError };

--- a/Source/WebCore/Modules/identity/DigitalCredential.h
+++ b/Source/WebCore/Modules/identity/DigitalCredential.h
@@ -39,7 +39,7 @@
 namespace WebCore {
 
 class Document;
-enum class IdentityCredentialProtocol : uint8_t;
+enum class DigitalCredentialPresentationProtocol : uint8_t;
 struct CredentialRequestOptions;
 struct DigitalCredentialGetRequest;
 struct DigitalCredentialRequestOptions;
@@ -50,7 +50,7 @@ using CredentialPromise = DOMPromiseDeferred<IDLNullable<IDLInterface<BasicCrede
 
 class DigitalCredential final : public BasicCredential {
 public:
-    static Ref<DigitalCredential> create(JSC::Strong<JSC::JSObject>&&, IdentityCredentialProtocol);
+    static Ref<DigitalCredential> create(JSC::Strong<JSC::JSObject>&&, DigitalCredentialPresentationProtocol);
 
     virtual ~DigitalCredential();
 
@@ -59,7 +59,7 @@ public:
         return m_data;
     };
 
-    IdentityCredentialProtocol protocol() const
+    DigitalCredentialPresentationProtocol protocol() const
     {
         return m_protocol;
     }
@@ -72,7 +72,7 @@ public:
     }
 
 private:
-    DigitalCredential(JSC::Strong<JSC::JSObject>&&, IdentityCredentialProtocol);
+    DigitalCredential(JSC::Strong<JSC::JSObject>&&, DigitalCredentialPresentationProtocol);
 
     static ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateRequests(const Document&, Vector<UnvalidatedDigitalCredentialRequest>&&);
     static ExceptionOr<Vector<UnvalidatedDigitalCredentialRequest>> convertObjectsToDigitalPresentationRequests(const Document&, const Vector<DigitalCredentialGetRequest>&);
@@ -80,7 +80,7 @@ private:
 
     Type credentialType() const final { return Type::DigitalCredential; }
 
-    IdentityCredentialProtocol m_protocol;
+    DigitalCredentialPresentationProtocol m_protocol;
     const JSC::Strong<JSC::JSObject> m_data;
 };
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredential.idl
@@ -30,7 +30,7 @@
     Conditional=WEB_AUTHN,
 ] interface DigitalCredential : BasicCredential {
     [SameObject] readonly attribute object data;
-    readonly attribute IdentityCredentialProtocol protocol;
+    readonly attribute DigitalCredentialPresentationProtocol protocol;
     static boolean userAgentAllowsProtocol(DOMString protocol);
     [Default] object toJSON();
 };

--- a/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h
@@ -27,7 +27,7 @@
 
 namespace WebCore {
 
-enum class IdentityCredentialProtocol : uint8_t {
+enum class DigitalCredentialPresentationProtocol : uint8_t {
     OrgIsoMdoc,
 };
 

--- a/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.idl
@@ -23,6 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-enum IdentityCredentialProtocol {
+enum DigitalCredentialPresentationProtocol {
     "org-iso-mdoc",
 };

--- a/Source/WebCore/Modules/identity/DigitalCredentialsResponseData.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsResponseData.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
-#include <WebCore/IdentityCredentialProtocol.h>
+#include <WebCore/DigitalCredentialPresentationProtocol.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 struct DigitalCredentialsResponseData {
-    IdentityCredentialProtocol protocol;
+    DigitalCredentialPresentationProtocol protocol;
     String responseDataJSON;
 };
 

--- a/Source/WebCore/Modules/identity/protocols/DigitalCredentialsProtocols.h
+++ b/Source/WebCore/Modules/identity/protocols/DigitalCredentialsProtocols.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/IdentityCredentialProtocol.h>
+#include <WebCore/DigitalCredentialPresentationProtocol.h>
 #include <WebCore/MobileDocumentRequest.h>
 #include <WebCore/ValidatedMobileDocumentRequest.h>
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -4399,7 +4399,7 @@ JSIDBVersionChangeEvent.cpp
 JSIIRFilterNode.cpp
 JSIIRFilterOptions.cpp
 JSIPAddressSpace.cpp
-JSIdentityCredentialProtocol.cpp
+JSDigitalCredentialPresentationProtocol.cpp
 JSIdleDeadline.cpp
 JSIdleRequestCallback.cpp
 JSIdleRequestOptions.cpp

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6411,11 +6411,11 @@ struct WebCore::DigitalCredentialsRequestData {
 };
 
 struct WebCore::DigitalCredentialsResponseData {
-    WebCore::IdentityCredentialProtocol protocol;
+    WebCore::DigitalCredentialPresentationProtocol protocol;
     String responseDataJSON;
 };
 
-[Nested] enum class WebCore::IdentityCredentialProtocol : uint8_t {
+[Nested] enum class WebCore::DigitalCredentialPresentationProtocol : uint8_t {
     OrgIsoMdoc
 };
 

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm
@@ -69,7 +69,7 @@
 #import "WebKitSwiftSoftLink.h"
 
 using WebCore::ExceptionCode;
-using WebCore::IdentityCredentialProtocol;
+using WebCore::DigitalCredentialPresentationProtocol;
 
 #pragma mark - WKDigitalCredentialsPickerDelegate
 
@@ -99,15 +99,15 @@ using WebCore::IdentityCredentialProtocol;
 @interface WKRequestDataResult : NSObject
 
 @property (nonatomic, strong) NSData *requestDataBytes;
-@property (nonatomic, assign) IdentityCredentialProtocol protocol;
+@property (nonatomic, assign) DigitalCredentialPresentationProtocol protocol;
 
-- (instancetype)initWithRequestDataBytes:(NSData *)requestDataBytes protocol:(IdentityCredentialProtocol)protocol;
+- (instancetype)initWithRequestDataBytes:(NSData *)requestDataBytes protocol:(DigitalCredentialPresentationProtocol)protocol;
 
 @end
 
 @implementation WKRequestDataResult
 
-- (instancetype)initWithRequestDataBytes:(NSData *)requestDataBytes protocol:(IdentityCredentialProtocol)protocol
+- (instancetype)initWithRequestDataBytes:(NSData *)requestDataBytes protocol:(DigitalCredentialPresentationProtocol)protocol
 {
     self = [super init];
     if (self) {
@@ -372,7 +372,7 @@ static RetainPtr<NSArray<NSArray<WKIdentityDocumentPresentmentRequestAuthenticat
         if ([protocol isEqualToString:@"org.iso.mdoc"]) {
             Ref object = JSON::Object::create();
             object->setString("response"_s, responseData);
-            WebCore::DigitalCredentialsResponseData responseObject { IdentityCredentialProtocol::OrgIsoMdoc, object->toJSONString() };
+            WebCore::DigitalCredentialsResponseData responseObject { DigitalCredentialPresentationProtocol::OrgIsoMdoc, object->toJSONString() };
             [self completeWith:WTF::move(responseObject)];
         } else {
             LOG(DigitalCredentials, "Unknown protocol response from document provider. Can't convert it %s.", [protocol UTF8String]);


### PR DESCRIPTION
#### 54359107a183a10665189be1d26d3bf5ad172123
<pre>
Digital Credentials: IdentityCredentialProtocol was renamed DigitalCredentialPresentationProtocol
<a href="https://rdar.apple.com/168641111">rdar://168641111</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305989">https://bugs.webkit.org/show_bug.cgi?id=305989</a>

Reviewed by Anne van Kesteren.

Renamed IdentityCredentialProtocol to DigitalCredentialPresentationProtocol.
Spec change:
<a href="https://github.com/w3c-fedid/digital-credentials/pull/401/">https://github.com/w3c-fedid/digital-credentials/pull/401/</a>

Relies on existing tests.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::create):
(WebCore::DigitalCredential::DigitalCredential):
(WebCore::convertProtocolString):
(WebCore::jsToCredentialRequest):
* Source/WebCore/Modules/identity/DigitalCredential.h:
* Source/WebCore/Modules/identity/DigitalCredential.idl:
* Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.h: Renamed from Source/WebCore/Modules/identity/IdentityCredentialProtocol.h.
* Source/WebCore/Modules/identity/DigitalCredentialPresentationProtocol.idl: Renamed from Source/WebCore/Modules/identity/IdentityCredentialProtocol.idl.
* Source/WebCore/Modules/identity/DigitalCredentialsResponseData.h:
* Source/WebCore/Modules/identity/protocols/DigitalCredentialsProtocols.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKRequestDataResult initWithRequestDataBytes:protocol:]):
(-[WKDigitalCredentialsPicker handlePresentmentCompletionWithResponse:error:]):

Canonical link: <a href="https://commits.webkit.org/306123@main">https://commits.webkit.org/306123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03d5d69a144502134c38b9bc813c063b1fc2196

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93315 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5442e624-89f6-4a0f-979b-4abbfd371f5a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142112 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107547 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78108 "4 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb2b80fa-3db2-410c-a96d-fed1b3f3290b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88434 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca8c4126-cb41-4563-8b1d-2c60874cf962) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7432 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8672 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151178 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12308 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115790 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12319 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29552 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11141 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67315 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12348 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1503 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12090 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12284 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12134 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->