### PR TITLE
Address unsafe cast warning in DOMGCOutputConstraint.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,4 +1,3 @@
-bindings/js/DOMGCOutputConstraint.cpp
 bindings/js/JSDOMGlobalObject.cpp
 bindings/js/JSDOMWindowBase.cpp
 bindings/js/JSDOMWindowCustom.h

--- a/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
+++ b/Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp
@@ -65,10 +65,12 @@ void DOMGCOutputConstraint::executeImplImpl(Visitor& visitor)
     m_lastExecutionVersion = heap.mutatorExecutionVersion();
     
     m_heapData.forEachOutputConstraintSpace(
-        [&] (Subspace& subspace) {
-            auto func = [] (Visitor& visitor, HeapCell* heapCell, HeapCell::Kind) {
+        [&](Subspace& subspace) {
+            auto func = [](Visitor& visitor, HeapCell* heapCell, HeapCell::Kind kind) {
                 SetRootMarkReasonScope rootScope(visitor, RootMarkReason::DOMGCOutput);
-                JSCell* cell = static_cast<JSCell*>(heapCell);
+                RELEASE_ASSERT(kind == HeapCell::Kind::JSCell || kind == HeapCell::Kind::JSCellWithIndexingHeader);
+                // This cast is guaranteed safe by the RELEASE_ASSERT above.
+                SUPPRESS_MEMORY_UNSAFE_CAST auto* cell = static_cast<JSCell*>(heapCell);
                 cell->methodTable()->visitOutputConstraints(cell, visitor);
             };
             


### PR DESCRIPTION
#### 833c565b9021db9861b52c256f395147c7cfaa20
<pre>
Address unsafe cast warning in DOMGCOutputConstraint.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=306007">https://bugs.webkit.org/show_bug.cgi?id=306007</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/bindings/js/DOMGCOutputConstraint.cpp:
(WebCore::DOMGCOutputConstraint::executeImplImpl):

Canonical link: <a href="https://commits.webkit.org/306043@main">https://commits.webkit.org/306043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d18f4d9299368be20ae3095e9d98ffe9e23066c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148218 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93148 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107226 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78029 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88117 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9767 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7299 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8503 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/118989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151006 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12137 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115658 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/115982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10815 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67147 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12180 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1374 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11921 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11967 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->