### PR TITLE
Align computation of workerRouterEvaluationStart and workerCacheLookupStart with other resource timing timestamps

### DIFF
--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -49,7 +49,10 @@ static double networkLoadTimeToDOMHighResTimeStamp(MonotonicTime timeOrigin, Mon
     ASSERT(timeOrigin);
     if (timeStamp <= timeOrigin)
         return 0.0;
-    return Performance::reduceTimeResolution(timeStamp - timeOrigin).milliseconds();
+    auto result = Performance::reduceTimeResolution(timeStamp - timeOrigin);
+    if (!result)
+        result = Performance::timeResolution();
+    return result.milliseconds();
 }
 
 static double fetchStart(MonotonicTime timeOrigin, const ResourceTiming& resourceTiming)
@@ -341,22 +344,12 @@ uint64_t PerformanceResourceTiming::decodedBodySize() const
 
 double PerformanceResourceTiming::workerRouterEvaluationStart() const
 {
-    // FIXME: Align time computation with other timestamps.
-    Seconds difference = m_resourceTiming.networkLoadMetrics().workerRouterEvaluationStart - m_timeOrigin;
-    if (difference.value() <= 0)
-        return 0.0;
-    auto reducedPrecision = Performance::reduceTimeResolution(difference).milliseconds();
-    return reducedPrecision ? reducedPrecision : 1;
+    return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().workerRouterEvaluationStart);
 }
 
 double PerformanceResourceTiming::workerCacheLookupStart() const
 {
-    // FIXME: Align time computation with other timestamps.
-    Seconds difference = m_resourceTiming.networkLoadMetrics().workerCacheLookupStart - m_timeOrigin;
-    if (difference.value() <= 0)
-        return 0.0;
-    auto reducedPrecision = Performance::reduceTimeResolution(difference).milliseconds();
-    return reducedPrecision ? reducedPrecision : 1;
+    return networkLoadTimeToDOMHighResTimeStamp(m_timeOrigin, m_resourceTiming.networkLoadMetrics().workerCacheLookupStart);
 }
 
 const String& PerformanceResourceTiming::workerMatchedRouterSource() const


### PR DESCRIPTION
#### e97d460dbd395b746fa40c0243a9ab2bf2d23575
<pre>
Align computation of workerRouterEvaluationStart and workerCacheLookupStart with other resource timing timestamps
<a href="https://rdar.apple.com/168650854">rdar://168650854</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306010">https://bugs.webkit.org/show_bug.cgi?id=306010</a>

Reviewed by Chris Dumez.

A timestamp of 0.0 means that there is no timestamp.
To prevent timestamp resolution reduction to make some timestamp go to 0.0, we use 1ms instead whenever that would be the case.
We apply this to all resource timing timestamps, like was done for workerRouterEvaluationStart and workerCacheLookupStart.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/306074@main">https://commits.webkit.org/306074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c3e177762e72ef7af2210155c903368b1fed3d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93165 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107243 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78038 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88135 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/475ebe02-ee2f-4a77-9ae3-dd83d6fbc501) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9792 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7321 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8520 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119017 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151025 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115675 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10415 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116000 "Found 1 new API test failure: TestWTF:WTF.DragonBox (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10905 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121919 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67165 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12197 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1396 "Passed tests") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11938 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11984 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->