### PR TITLE
Address unsafe cast warnings in generated bindings code

### DIFF
--- a/Source/WebCore/Modules/entriesapi/ErrorCallback.h
+++ b/Source/WebCore/Modules/entriesapi/ErrorCallback.h
@@ -42,6 +42,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSErrorCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(DOMException&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(DOMException&) = 0;
 

--- a/Source/WebCore/Modules/entriesapi/FileCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileCallback.h
@@ -42,6 +42,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSFileCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(File&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(File&) = 0;
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h
@@ -42,6 +42,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSFileSystemEntriesCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(const Vector<Ref<FileSystemEntry>>&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const Vector<Ref<FileSystemEntry>>&) = 0;
 

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h
@@ -42,6 +42,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSFileSystemEntryCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(FileSystemEntry&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(FileSystemEntry&) = 0;
 

--- a/Source/WebCore/Modules/geolocation/PositionCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionCallback.h
@@ -41,6 +41,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSPositionCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(GeolocationPosition*) = 0;
     virtual CallbackResult<void> invokeRethrowingException(GeolocationPosition*) = 0;
 

--- a/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
+++ b/Source/WebCore/Modules/geolocation/PositionErrorCallback.h
@@ -41,6 +41,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSPositionErrorCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(GeolocationPositionError&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(GeolocationPositionError&) = 0;
 

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
@@ -43,6 +43,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSMediaSessionActionHandler() const { return false; }
+
     virtual CallbackResult<void> invoke(const MediaSessionActionDetails&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const MediaSessionActionDetails&) = 0;
 

--- a/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
+++ b/Source/WebCore/Modules/notifications/NotificationPermissionCallback.h
@@ -43,6 +43,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSNotificationPermissionCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(Notification::Permission) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Notification::Permission) = 0;
 

--- a/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h
@@ -42,6 +42,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSRemotePlaybackAvailabilityCallback() const { return false; }
+
     virtual CallbackResult<bool> invoke(bool) = 0;
     virtual CallbackResult<bool> invokeRethrowingException(bool) = 0;
 

--- a/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
@@ -47,6 +47,7 @@ public:
     virtual CallbackResult<void> invokeRethrowingException(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSReportingObserverCallback() const { return false; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/QueuingStrategySize.h
+++ b/Source/WebCore/Modules/streams/QueuingStrategySize.h
@@ -44,6 +44,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSQueuingStrategySize() const { return false; }
+
     virtual CallbackResult<double> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<double> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h
@@ -44,6 +44,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSUnderlyingSourceCancelCallback() const { return false; }
     virtual CallbackResult<Ref<DOMPromise>> invoke(JSC::JSValue thisValue, JSC::JSValue reason) = 0;
 
 private:

--- a/Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h
@@ -46,6 +46,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSUnderlyingSourcePullCallback() const { return false; }
     virtual CallbackResult<Ref<DOMPromise>> invoke(JSC::JSValue, ReadableByteStreamController&) = 0;
 
 private:

--- a/Source/WebCore/Modules/streams/UnderlyingSourceStartCallback.h
+++ b/Source/WebCore/Modules/streams/UnderlyingSourceStartCallback.h
@@ -46,6 +46,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSUnderlyingSourceStartCallback() const { return false; }
+
     virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, ReadableByteStreamController&) = 0;
     virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, ReadableByteStreamController&) = 0;
 

--- a/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
+++ b/Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h
@@ -43,6 +43,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSWebLockGrantedCallback() const { return false; }
     virtual CallbackResult<Ref<DOMPromise>> invoke(WebLock*) = 0;
 
 private:

--- a/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
+++ b/Source/WebCore/Modules/webaudio/AudioBufferCallback.h
@@ -42,6 +42,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSAudioBufferCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(AudioBuffer*) = 0;
     virtual CallbackResult<void> invokeRethrowingException(AudioBuffer*) = 0;
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h
@@ -47,6 +47,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSAudioWorkletProcessorConstructor() const { return false; }
     virtual CallbackResult<Ref<AudioWorkletProcessor>> invoke(JSC::Strong<JSC::JSObject> options) = 0;
     virtual CallbackResult<Ref<AudioWorkletProcessor>> invokeRethrowingException(JSC::Strong<JSC::JSObject> options) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h
@@ -45,6 +45,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSWebCodecsAudioDataOutputCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(WebCodecsAudioData&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsAudioData&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h
@@ -46,6 +46,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSWebCodecsEncodedAudioChunkOutputCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsEncodedAudioChunk&, const WebCodecsEncodedAudioChunkMetadata&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h
@@ -45,6 +45,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSWebCodecsEncodedVideoChunkOutputCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsEncodedVideoChunk&, const WebCodecsEncodedVideoChunkMetadata&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h
@@ -44,6 +44,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSWebCodecsErrorCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(DOMException&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(DOMException&) = 0;
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h
@@ -44,6 +44,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSWebCodecsVideoFrameOutputCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(WebCodecsVideoFrame&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(WebCodecsVideoFrame&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
@@ -46,6 +46,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
+    virtual bool isJSDatabaseCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(Database&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Database&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
@@ -45,6 +45,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
+    virtual bool isJSSQLStatementCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(SQLTransaction&, SQLResultSet&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(SQLTransaction&, SQLResultSet&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
@@ -45,6 +45,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
+    virtual bool isJSSQLStatementErrorCallback() const { return false; }
+
     virtual CallbackResult<bool> invoke(SQLTransaction&, SQLError&) = 0;
     virtual CallbackResult<bool> invokeRethrowingException(SQLTransaction&, SQLError&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
@@ -44,6 +44,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
+    virtual bool isJSSQLTransactionCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(SQLTransaction&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(SQLTransaction&) = 0;
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
@@ -44,6 +44,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
+    virtual bool isJSSQLTransactionErrorCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(SQLError&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(SQLError&) = 0;
 

--- a/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
+++ b/Source/WebCore/Modules/webxr/XRFrameRequestCallback.h
@@ -43,6 +43,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSXRFrameRequestCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(double highResTimeMs, WebXRFrame&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double highResTimeMs, WebXRFrame&) = 0;
 

--- a/Source/WebCore/animation/CustomEffectCallback.h
+++ b/Source/WebCore/animation/CustomEffectCallback.h
@@ -40,6 +40,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSCustomEffectCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(double progress) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double progress) = 0;
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -128,10 +128,10 @@ void JSTestCallbackFunction::visitJSFunction(JSC::SlotVisitor& visitor)
 
 JSC::JSValue toJS(TestCallbackFunction& impl)
 {
-    if (!static_cast<JSTestCallbackFunction&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestCallbackFunction>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestCallbackFunction&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestCallbackFunction::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -24,6 +24,7 @@
 #include "JSCallbackData.h"
 #include "TestCallbackFunction.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -48,6 +49,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestCallbackFunction() const final { return true; }
+
     void visitJSFunction(JSC::AbstractSlotVisitor&) override;
 
     void visitJSFunction(JSC::SlotVisitor&) override;
@@ -62,3 +65,7 @@ template<> struct JSDOMCallbackConverterTraits<JSTestCallbackFunction> {
     using Base = TestCallbackFunction;
 };
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestCallbackFunction)
+    static bool isType(const WebCore::TestCallbackFunction& callback) { return callback.isJSTestCallbackFunction(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -118,10 +118,10 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
 
 JSC::JSValue toJS(TestCallbackFunctionGenerateIsReachable& impl)
 {
-    if (!static_cast<JSTestCallbackFunctionGenerateIsReachable&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestCallbackFunctionGenerateIsReachable>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestCallbackFunctionGenerateIsReachable&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestCallbackFunctionGenerateIsReachable::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
@@ -25,6 +25,7 @@
 #include "TestCallbackFunctionGenerateIsReachable.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -49,6 +50,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestCallbackFunctionGenerateIsReachable() const final { return true; }
+
     JSCallbackData* m_data;
 };
 
@@ -59,3 +62,7 @@ template<> struct JSDOMCallbackConverterTraits<JSTestCallbackFunctionGenerateIsR
     using Base = TestCallbackFunctionGenerateIsReachable;
 };
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestCallbackFunctionGenerateIsReachable)
+    static bool isType(const WebCore::TestCallbackFunctionGenerateIsReachable& callback) { return callback.isJSTestCallbackFunctionGenerateIsReachable(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -124,10 +124,10 @@ void JSTestCallbackFunctionWithThisObject::visitJSFunction(JSC::SlotVisitor& vis
 
 JSC::JSValue toJS(TestCallbackFunctionWithThisObject& impl)
 {
-    if (!static_cast<JSTestCallbackFunctionWithThisObject&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestCallbackFunctionWithThisObject>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestCallbackFunctionWithThisObject&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestCallbackFunctionWithThisObject::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -24,6 +24,7 @@
 #include "JSCallbackData.h"
 #include "TestCallbackFunctionWithThisObject.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -48,6 +49,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestCallbackFunctionWithThisObject() const final { return true; }
+
     void visitJSFunction(JSC::AbstractSlotVisitor&) override;
 
     void visitJSFunction(JSC::SlotVisitor&) override;
@@ -62,3 +65,7 @@ template<> struct JSDOMCallbackConverterTraits<JSTestCallbackFunctionWithThisObj
     using Base = TestCallbackFunctionWithThisObject;
 };
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestCallbackFunctionWithThisObject)
+    static bool isType(const WebCore::TestCallbackFunctionWithThisObject& callback) { return callback.isJSTestCallbackFunctionWithThisObject(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -126,10 +126,10 @@ void JSTestCallbackFunctionWithTypedefs::visitJSFunction(JSC::SlotVisitor& visit
 
 JSC::JSValue toJS(TestCallbackFunctionWithTypedefs& impl)
 {
-    if (!static_cast<JSTestCallbackFunctionWithTypedefs&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestCallbackFunctionWithTypedefs>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestCallbackFunctionWithTypedefs&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestCallbackFunctionWithTypedefs::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -24,6 +24,7 @@
 #include "JSCallbackData.h"
 #include "TestCallbackFunctionWithTypedefs.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -48,6 +49,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestCallbackFunctionWithTypedefs() const final { return true; }
+
     void visitJSFunction(JSC::AbstractSlotVisitor&) override;
 
     void visitJSFunction(JSC::SlotVisitor&) override;
@@ -62,3 +65,7 @@ template<> struct JSDOMCallbackConverterTraits<JSTestCallbackFunctionWithTypedef
     using Base = TestCallbackFunctionWithTypedefs;
 };
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestCallbackFunctionWithTypedefs)
+    static bool isType(const WebCore::TestCallbackFunctionWithTypedefs& callback) { return callback.isJSTestCallbackFunctionWithTypedefs(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -131,10 +131,10 @@ void JSTestCallbackFunctionWithVariadic::visitJSFunction(JSC::SlotVisitor& visit
 
 JSC::JSValue toJS(TestCallbackFunctionWithVariadic& impl)
 {
-    if (!static_cast<JSTestCallbackFunctionWithVariadic&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestCallbackFunctionWithVariadic>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestCallbackFunctionWithVariadic&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestCallbackFunctionWithVariadic::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -26,6 +26,7 @@
 #include "JSDOMConvertVariadic.h"
 #include "TestCallbackFunctionWithVariadic.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -50,6 +51,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestCallbackFunctionWithVariadic() const final { return true; }
+
     void visitJSFunction(JSC::AbstractSlotVisitor&) override;
 
     void visitJSFunction(JSC::SlotVisitor&) override;
@@ -64,3 +67,7 @@ template<> struct JSDOMCallbackConverterTraits<JSTestCallbackFunctionWithVariadi
     using Base = TestCallbackFunctionWithVariadic;
 };
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestCallbackFunctionWithVariadic)
+    static bool isType(const WebCore::TestCallbackFunctionWithVariadic& callback) { return callback.isJSTestCallbackFunctionWithVariadic(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -774,10 +774,10 @@ void JSTestCallbackInterface::visitJSFunction(JSC::SlotVisitor& visitor)
 
 JSC::JSValue toJS(TestCallbackInterface& impl)
 {
-    if (!static_cast<JSTestCallbackInterface&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestCallbackInterface>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestCallbackInterface&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestCallbackInterface::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -28,6 +28,7 @@
 #include "JSDOMConvertEnumeration.h"
 #include "TestCallbackInterface.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -72,6 +73,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestCallbackInterface() const final { return true; }
+
     void visitJSFunction(JSC::AbstractSlotVisitor&) override;
 
     void visitJSFunction(JSC::SlotVisitor&) override;
@@ -95,5 +98,9 @@ template<> ASCIILiteral expectedEnumerationValues<TestCallbackInterface::Enum>()
 template<> ConversionResult<IDLDictionary<TestCallbackInterface::Dictionary>> convertDictionary<TestCallbackInterface::Dictionary>(JSC::JSGlobalObject&, JSC::JSValue);
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestCallbackInterface)
+    static bool isType(const WebCore::TestCallbackInterface& callback) { return callback.isJSTestCallbackInterface(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(TEST_CONDITIONAL)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -126,10 +126,10 @@ void JSTestCallbackWithFunctionOrDict::visitJSFunction(JSC::SlotVisitor& visitor
 
 JSC::JSValue toJS(TestCallbackWithFunctionOrDict& impl)
 {
-    if (!static_cast<JSTestCallbackWithFunctionOrDict&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestCallbackWithFunctionOrDict>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestCallbackWithFunctionOrDict&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestCallbackWithFunctionOrDict::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
@@ -24,6 +24,7 @@
 #include "JSCallbackData.h"
 #include "TestCallbackWithFunctionOrDict.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -48,6 +49,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestCallbackWithFunctionOrDict() const final { return true; }
+
     void visitJSFunction(JSC::AbstractSlotVisitor&) override;
 
     void visitJSFunction(JSC::SlotVisitor&) override;
@@ -62,3 +65,7 @@ template<> struct JSDOMCallbackConverterTraits<JSTestCallbackWithFunctionOrDict>
     using Base = TestCallbackWithFunctionOrDict;
 };
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestCallbackWithFunctionOrDict)
+    static bool isType(const WebCore::TestCallbackWithFunctionOrDict& callback) { return callback.isJSTestCallbackWithFunctionOrDict(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -142,10 +142,10 @@ void JSTestVoidCallbackFunction::visitJSFunction(JSC::SlotVisitor& visitor)
 
 JSC::JSValue toJS(TestVoidCallbackFunction& impl)
 {
-    if (!static_cast<JSTestVoidCallbackFunction&>(impl).callbackData())
-        return jsNull();
+    if (auto* callbackData = downcast<JSTestVoidCallbackFunction>(impl).callbackData())
+        return callbackData->callback();
+    return jsNull();
 
-    return static_cast<JSTestVoidCallbackFunction&>(impl).callbackData()->callback();
 }
 
 ScriptExecutionContext* JSTestVoidCallbackFunction::scriptExecutionContext() const

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -26,6 +26,7 @@
 #include "JSCallbackData.h"
 #include "TestVoidCallbackFunction.h"
 #include <wtf/Forward.h>
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -50,6 +51,8 @@ private:
 
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
+    bool isJSTestVoidCallbackFunction() const final { return true; }
+
     void visitJSFunction(JSC::AbstractSlotVisitor&) override;
 
     void visitJSFunction(JSC::SlotVisitor&) override;
@@ -64,5 +67,9 @@ template<> struct JSDOMCallbackConverterTraits<JSTestVoidCallbackFunction> {
     using Base = TestVoidCallbackFunction;
 };
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::JSTestVoidCallbackFunction)
+    static bool isType(const WebCore::TestVoidCallbackFunction& callback) { return callback.isJSTestVoidCallbackFunction(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(TEST_CONDITIONAL)

--- a/Source/WebCore/css/CSSPaintCallback.h
+++ b/Source/WebCore/css/CSSPaintCallback.h
@@ -47,6 +47,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSCSSPaintCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue, PaintRenderingContext2D&, CSSPaintSize&, StylePropertyMapReadOnly&, const Vector<String>&) = 0;
 

--- a/Source/WebCore/dom/AbortAlgorithm.h
+++ b/Source/WebCore/dom/AbortAlgorithm.h
@@ -43,6 +43,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
+    virtual bool isJSAbortAlgorithm() const { return false; }
+
     virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/dom/CreateHTMLCallback.h
+++ b/Source/WebCore/dom/CreateHTMLCallback.h
@@ -41,6 +41,7 @@ public:
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSCreateHTMLCallback() const { return false; }
 
     virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
     virtual CallbackResult<String> invokeRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;

--- a/Source/WebCore/dom/CreateScriptCallback.h
+++ b/Source/WebCore/dom/CreateScriptCallback.h
@@ -41,6 +41,7 @@ public:
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSCreateScriptCallback() const { return false; }
 
     virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
     virtual CallbackResult<String> invokeRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;

--- a/Source/WebCore/dom/CreateScriptURLCallback.h
+++ b/Source/WebCore/dom/CreateScriptURLCallback.h
@@ -41,6 +41,7 @@ public:
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSCreateScriptURLCallback() const { return false; }
 
     virtual CallbackResult<String> invoke(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;
     virtual CallbackResult<String> invokeRethrowingException(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments) = 0;

--- a/Source/WebCore/dom/IdleRequestCallback.h
+++ b/Source/WebCore/dom/IdleRequestCallback.h
@@ -41,6 +41,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSIdleRequestCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(IdleDeadline&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(IdleDeadline&) = 0;
 

--- a/Source/WebCore/dom/MapperCallback.h
+++ b/Source/WebCore/dom/MapperCallback.h
@@ -39,6 +39,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSMapperCallback() const { return false; }
+
     virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/dom/MutationCallback.h
+++ b/Source/WebCore/dom/MutationCallback.h
@@ -51,6 +51,8 @@ public:
 
     virtual bool hasCallback() const = 0;
 
+    virtual bool isJSMutationCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(MutationObserver&, const Vector<Ref<MutationRecord>>&, MutationObserver&) = 0;
 };

--- a/Source/WebCore/dom/NodeFilter.h
+++ b/Source/WebCore/dom/NodeFilter.h
@@ -45,6 +45,7 @@ public:
     virtual CallbackResult<unsigned short> acceptNodeRethrowingException(Node&) = 0;
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSNodeFilter() const { return false; }
 
     /*
      * The following constants are returned by the acceptNode()

--- a/Source/WebCore/dom/ObservableInspectorAbortCallback.h
+++ b/Source/WebCore/dom/ObservableInspectorAbortCallback.h
@@ -39,6 +39,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSObservableInspectorAbortCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/dom/PredicateCallback.h
+++ b/Source/WebCore/dom/PredicateCallback.h
@@ -39,6 +39,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSPredicateCallback() const { return false; }
+
     virtual CallbackResult<bool> invoke(JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<bool> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/dom/ReducerCallback.h
+++ b/Source/WebCore/dom/ReducerCallback.h
@@ -39,6 +39,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSReducerCallback() const { return false; }
+
     virtual CallbackResult<JSC::JSValue> invoke(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<JSC::JSValue> invokeRethrowingException(JSC::JSValue, JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/dom/RequestAnimationFrameCallback.h
+++ b/Source/WebCore/dom/RequestAnimationFrameCallback.h
@@ -46,6 +46,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSRequestAnimationFrameCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(double highResTimeMs) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double highResTimeMs) = 0;
 

--- a/Source/WebCore/dom/StringCallback.h
+++ b/Source/WebCore/dom/StringCallback.h
@@ -47,6 +47,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSStringCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(const String& data) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const String& data) = 0;
 

--- a/Source/WebCore/dom/SubscriberCallback.h
+++ b/Source/WebCore/dom/SubscriberCallback.h
@@ -41,6 +41,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSSubscriberCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(Subscriber&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Subscriber&) = 0;
 

--- a/Source/WebCore/dom/SubscriptionObserverCallback.h
+++ b/Source/WebCore/dom/SubscriptionObserverCallback.h
@@ -39,6 +39,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSSubscriptionObserverCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(JSC::JSValue) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue) = 0;
 

--- a/Source/WebCore/dom/ViewTransitionUpdateCallback.h
+++ b/Source/WebCore/dom/ViewTransitionUpdateCallback.h
@@ -42,6 +42,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSViewTransitionUpdateCallback() const { return false; }
     virtual CallbackResult<Ref<DOMPromise>> invoke() = 0;
 
 private:

--- a/Source/WebCore/dom/VisitorCallback.h
+++ b/Source/WebCore/dom/VisitorCallback.h
@@ -39,6 +39,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSVisitorCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(JSC::JSValue, uint64_t) = 0;
     virtual CallbackResult<void> invokeRethrowingException(JSC::JSValue, uint64_t) = 0;
 

--- a/Source/WebCore/fileapi/BlobCallback.h
+++ b/Source/WebCore/fileapi/BlobCallback.h
@@ -43,6 +43,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSBlobCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(Blob*) = 0;
     virtual CallbackResult<void> invokeRethrowingException(Blob*) = 0;
 

--- a/Source/WebCore/html/VideoFrameRequestCallback.h
+++ b/Source/WebCore/html/VideoFrameRequestCallback.h
@@ -44,6 +44,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSVideoFrameRequestCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(double, const VideoFrameMetadata&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(double, const VideoFrameMetadata&) = 0;
 

--- a/Source/WebCore/html/VoidCallback.h
+++ b/Source/WebCore/html/VoidCallback.h
@@ -39,6 +39,8 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
+    virtual bool isJSVoidCallback() const { return false; }
+
     virtual CallbackResult<void> invoke() = 0;
     virtual CallbackResult<void> invokeRethrowingException() = 0;
 

--- a/Source/WebCore/inspector/RTCLogsCallback.h
+++ b/Source/WebCore/inspector/RTCLogsCallback.h
@@ -46,6 +46,8 @@ public:
         RefPtr<RTCPeerConnection> connection;
     };
 
+    virtual bool isJSRTCLogsCallback() const { return false; }
+
     virtual CallbackResult<void> invoke(const Logs&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(const Logs&) = 0;
 

--- a/Source/WebCore/page/IntersectionObserverCallback.h
+++ b/Source/WebCore/page/IntersectionObserverCallback.h
@@ -44,6 +44,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSIntersectionObserverCallback() const { return false; }
 
     virtual CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>&, IntersectionObserver&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>&, IntersectionObserver&) = 0;

--- a/Source/WebCore/page/NavigationInterceptHandler.h
+++ b/Source/WebCore/page/NavigationInterceptHandler.h
@@ -39,6 +39,7 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
+    virtual bool isJSNavigationInterceptHandler() const { return false; }
     virtual CallbackResult<Ref<DOMPromise>> invoke() = 0;
 
 private:

--- a/Source/WebCore/page/PerformanceObserverCallback.h
+++ b/Source/WebCore/page/PerformanceObserverCallback.h
@@ -43,6 +43,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSPerformanceObserverCallback() const { return false; }
 
     virtual CallbackResult<void> invoke(PerformanceObserver&, PerformanceObserverEntryList&, PerformanceObserver&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(PerformanceObserver&, PerformanceObserverEntryList&, PerformanceObserver&) = 0;

--- a/Source/WebCore/page/ResizeObserverCallback.h
+++ b/Source/WebCore/page/ResizeObserverCallback.h
@@ -43,6 +43,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     virtual bool hasCallback() const = 0;
+    virtual bool isJSResizeObserverCallback() const { return false; }
 
     virtual CallbackResult<void> invoke(ResizeObserver&, const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&) = 0;
     virtual CallbackResult<void> invokeRethrowingException(ResizeObserver&, const Vector<Ref<ResizeObserverEntry>>&, ResizeObserver&) = 0;

--- a/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h
+++ b/Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h
@@ -49,6 +49,8 @@ public:
 
     void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&) override;
 
+    virtual bool isJSMockCaptionDisplaySettingsClientCallback() const { return false; }
+
 private:
     virtual bool hasCallback() const = 0;
 };

--- a/Source/WebCore/testing/XRSimulateUserActivationFunction.h
+++ b/Source/WebCore/testing/XRSimulateUserActivationFunction.h
@@ -46,6 +46,8 @@ public:
     virtual CallbackResult<void> invoke(void) = 0;
     virtual CallbackResult<void> invokeRethrowingException(void) = 0;
 
+    virtual bool isJSXRSimulateUserActivationFunction() const { return false; }
+
 private:
     virtual bool hasCallback() const = 0;
 };

--- a/Source/WebCore/xml/CustomXPathNSResolver.h
+++ b/Source/WebCore/xml/CustomXPathNSResolver.h
@@ -45,6 +45,8 @@ public:
 
     AtomString lookupNamespaceURI(const AtomString& prefix);
 
+    virtual bool isJSCustomXPathNSResolver() const { return false; }
+
 private:
     virtual bool hasCallback() const = 0;
 };


### PR DESCRIPTION
#### d486ede80cf68c610f7ba22d93c430ae830c3cb4
<pre>
Address unsafe cast warnings in generated bindings code
<a href="https://bugs.webkit.org/show_bug.cgi?id=306012">https://bugs.webkit.org/show_bug.cgi?id=306012</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/entriesapi/ErrorCallback.h:
(WebCore::ErrorCallback::isJSErrorCallback const):
* Source/WebCore/Modules/entriesapi/FileCallback.h:
(WebCore::FileCallback::isJSFileCallback const):
* Source/WebCore/Modules/entriesapi/FileSystemEntriesCallback.h:
(WebCore::FileSystemEntriesCallback::isJSFileSystemEntriesCallback const):
* Source/WebCore/Modules/entriesapi/FileSystemEntryCallback.h:
(WebCore::FileSystemEntryCallback::isJSFileSystemEntryCallback const):
* Source/WebCore/Modules/geolocation/PositionCallback.h:
(WebCore::PositionCallback::isJSPositionCallback const):
* Source/WebCore/Modules/geolocation/PositionErrorCallback.h:
(WebCore::PositionErrorCallback::isJSPositionErrorCallback const):
* Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h:
(WebCore::MediaSessionActionHandler::isJSMediaSessionActionHandler const):
* Source/WebCore/Modules/notifications/NotificationPermissionCallback.h:
(WebCore::NotificationPermissionCallback::isJSNotificationPermissionCallback const):
* Source/WebCore/Modules/remoteplayback/RemotePlaybackAvailabilityCallback.h:
(WebCore::RemotePlaybackAvailabilityCallback::isJSRemotePlaybackAvailabilityCallback const):
* Source/WebCore/Modules/reporting/ReportingObserverCallback.h:
(WebCore::ReportingObserverCallback::isJSReportingObserverCallback const):
* Source/WebCore/Modules/streams/QueuingStrategySize.h:
(WebCore::QueuingStrategySize::isJSQueuingStrategySize const):
* Source/WebCore/Modules/streams/UnderlyingSourceCancelCallback.h:
(WebCore::UnderlyingSourceCancelCallback::isJSUnderlyingSourceCancelCallback const):
* Source/WebCore/Modules/streams/UnderlyingSourcePullCallback.h:
(WebCore::UnderlyingSourcePullCallback::isJSUnderlyingSourcePullCallback const):
* Source/WebCore/Modules/streams/UnderlyingSourceStartCallback.h:
(WebCore::UnderlyingSourceStartCallback::isJSUnderlyingSourceStartCallback const):
* Source/WebCore/Modules/web-locks/WebLockGrantedCallback.h:
(WebCore::WebLockGrantedCallback::isJSWebLockGrantedCallback const):
* Source/WebCore/Modules/webaudio/AudioBufferCallback.h:
(WebCore::AudioBufferCallback::isJSAudioBufferCallback const):
* Source/WebCore/Modules/webaudio/AudioWorkletProcessorConstructor.h:
(WebCore::AudioWorkletProcessorConstructor::isJSAudioWorkletProcessorConstructor const):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDataOutputCallback.h:
(WebCore::WebCodecsAudioDataOutputCallback::isJSWebCodecsAudioDataOutputCallback const):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunkOutputCallback.h:
(WebCore::WebCodecsEncodedAudioChunkOutputCallback::isJSWebCodecsEncodedAudioChunkOutputCallback const):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunkOutputCallback.h:
(WebCore::WebCodecsEncodedVideoChunkOutputCallback::isJSWebCodecsEncodedVideoChunkOutputCallback const):
* Source/WebCore/Modules/webcodecs/WebCodecsErrorCallback.h:
(WebCore::WebCodecsErrorCallback::isJSWebCodecsErrorCallback const):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrameOutputCallback.h:
(WebCore::WebCodecsVideoFrameOutputCallback::isJSWebCodecsVideoFrameOutputCallback const):
* Source/WebCore/Modules/webdatabase/DatabaseCallback.h:
(WebCore::DatabaseCallback::isJSDatabaseCallback const):
* Source/WebCore/Modules/webdatabase/SQLStatementCallback.h:
(WebCore::SQLStatementCallback::isJSSQLStatementCallback const):
* Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h:
(WebCore::SQLStatementErrorCallback::isJSSQLStatementErrorCallback const):
* Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h:
(WebCore::SQLTransactionCallback::isJSSQLTransactionCallback const):
* Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h:
(WebCore::SQLTransactionErrorCallback::isJSSQLTransactionErrorCallback const):
* Source/WebCore/Modules/webxr/XRFrameRequestCallback.h:
(WebCore::XRFrameRequestCallback::isJSXRFrameRequestCallback const):
* Source/WebCore/animation/CustomEffectCallback.h:
(WebCore::CustomEffectCallback::isJSCustomEffectCallback const):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackFunctionHeader):
(GenerateCallbackInterfaceHeader):
(GenerateCallbackHeaderContent):
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h:
(isType):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h:
(isType):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h:
(isType):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h:
(isType):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h:
(isType):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
(isType):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h:
(isType):
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
(WebCore::toJS):
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h:
(isType):
* Source/WebCore/css/CSSPaintCallback.h:
(WebCore::CSSPaintCallback::isJSCSSPaintCallback const):
* Source/WebCore/dom/AbortAlgorithm.h:
(WebCore::AbortAlgorithm::isJSAbortAlgorithm const):
* Source/WebCore/dom/CreateHTMLCallback.h:
(WebCore::CreateHTMLCallback::isJSCreateHTMLCallback const):
* Source/WebCore/dom/CreateScriptCallback.h:
(WebCore::CreateScriptCallback::isJSCreateScriptCallback const):
* Source/WebCore/dom/CreateScriptURLCallback.h:
(WebCore::CreateScriptURLCallback::isJSCreateScriptURLCallback const):
* Source/WebCore/dom/IdleRequestCallback.h:
(WebCore::IdleRequestCallback::isJSIdleRequestCallback const):
* Source/WebCore/dom/MapperCallback.h:
(WebCore::MapperCallback::isJSMapperCallback const):
* Source/WebCore/dom/MutationCallback.h:
(WebCore::MutationCallback::isJSMutationCallback const):
* Source/WebCore/dom/NodeFilter.h:
(WebCore::NodeFilter::isJSNodeFilter const):
* Source/WebCore/dom/ObservableInspectorAbortCallback.h:
(WebCore::ObservableInspectorAbortCallback::isJSObservableInspectorAbortCallback const):
* Source/WebCore/dom/PredicateCallback.h:
(WebCore::PredicateCallback::isJSPredicateCallback const):
* Source/WebCore/dom/ReducerCallback.h:
(WebCore::ReducerCallback::isJSReducerCallback const):
* Source/WebCore/dom/RequestAnimationFrameCallback.h:
(WebCore::RequestAnimationFrameCallback::isJSRequestAnimationFrameCallback const):
* Source/WebCore/dom/StringCallback.h:
(WebCore::StringCallback::isJSStringCallback const):
* Source/WebCore/dom/SubscriberCallback.h:
(WebCore::SubscriberCallback::isJSSubscriberCallback const):
* Source/WebCore/dom/SubscriptionObserverCallback.h:
(WebCore::SubscriptionObserverCallback::isJSSubscriptionObserverCallback const):
* Source/WebCore/dom/ViewTransitionUpdateCallback.h:
(WebCore::ViewTransitionUpdateCallback::isJSViewTransitionUpdateCallback const):
* Source/WebCore/dom/VisitorCallback.h:
(WebCore::VisitorCallback::isJSVisitorCallback const):
* Source/WebCore/fileapi/BlobCallback.h:
(WebCore::BlobCallback::isJSBlobCallback const):
* Source/WebCore/html/VideoFrameRequestCallback.h:
(WebCore::VideoFrameRequestCallback::isJSVideoFrameRequestCallback const):
* Source/WebCore/html/VoidCallback.h:
(WebCore::VoidCallback::isJSVoidCallback const):
* Source/WebCore/inspector/RTCLogsCallback.h:
(WebCore::RTCLogsCallback::isJSRTCLogsCallback const):
* Source/WebCore/page/IntersectionObserverCallback.h:
(WebCore::IntersectionObserverCallback::isJSIntersectionObserverCallback const):
* Source/WebCore/page/NavigationInterceptHandler.h:
(WebCore::NavigationInterceptHandler::isJSNavigationInterceptHandler const):
* Source/WebCore/page/PerformanceObserverCallback.h:
(WebCore::PerformanceObserverCallback::isJSPerformanceObserverCallback const):
* Source/WebCore/page/ResizeObserverCallback.h:
(WebCore::ResizeObserverCallback::isJSResizeObserverCallback const):
* Source/WebCore/testing/MockCaptionDisplaySettingsClientCallback.h:
(WebCore::MockCaptionDisplaySettingsClientCallback::isJSMockCaptionDisplaySettingsClientCallback const):
* Source/WebCore/testing/XRSimulateUserActivationFunction.h:
(WebCore::XRSimulateUserActivationFunction::isJSXRSimulateUserActivationFunction const):
* Source/WebCore/xml/CustomXPathNSResolver.h:
(WebCore::CustomXPathNSResolver::isJSCustomXPathNSResolver const):

Canonical link: <a href="https://commits.webkit.org/306141@main">https://commits.webkit.org/306141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7e3f4b05b8bb19de7a5880cd8416735eeb5b952

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93284 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12743 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107523 "The step "layout-tests-repeat-failures-without-change" failed to generate any list of failures or flakies and returned an error code.
Reached the maximum number of retries (3). Unable to determine if change is bad or there is a pre-existent infrastructure issue. (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78087 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88403 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9874 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7410 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8641 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151146 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12277 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115769 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116100 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29566 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11101 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67284 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12317 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1483 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12103 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->