### PR TITLE
Refactor WidthCache into TextMeasurementCache<float>

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2756,6 +2756,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/SystemFontDatabase.h
     platform/graphics/SystemImage.h
     platform/graphics/TabSize.h
+    platform/graphics/TextMeasurementCache.h
     platform/graphics/TextRun.h
     platform/graphics/TextRunHash.h
     platform/graphics/TextTrackRepresentation.h
@@ -2771,7 +2772,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/VideoTarget.h
     platform/graphics/VideoTrackPrivate.h
     platform/graphics/VideoTrackPrivateClient.h
-    platform/graphics/WidthCache.h
     platform/graphics/WidthIterator.h
     platform/graphics/WindRule.h
 

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -437,7 +437,7 @@ void FontCache::invalidateAllFontCaches(ShouldRunInvalidationCallback shouldRunI
 void FontCache::releaseNoncriticalMemory()
 {
     purgeInactiveFontData();
-    m_fontCascadeCache.clearWidthCaches();
+    m_fontCascadeCache.clearMeasurementCaches();
     platformReleaseNoncriticalMemory();
 }
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -296,7 +296,7 @@ float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>
     }
 
     bool hasWordSpacingOrLetterSpacing = wordSpacing() || letterSpacing();
-    float* cacheEntry = fonts()->widthCache().add(run, std::numeric_limits<float>::quiet_NaN(), enableKerning() || requiresShaping(), hasWordSpacingOrLetterSpacing, !textAutospace().isNoAutospace(), glyphOverflow);
+    float* cacheEntry = glyphOverflow ? nullptr : fonts()->widthCache().add(run, std::numeric_limits<float>::quiet_NaN(), enableKerning() || requiresShaping(), hasWordSpacingOrLetterSpacing, !textAutospace().isNoAutospace());
     if (cacheEntry && !std::isnan(*cacheEntry))
         return *cacheEntry;
 

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -75,7 +75,7 @@ void FontCascadeCache::invalidate()
     m_entries.clear();
 }
 
-void FontCascadeCache::clearWidthCaches()
+void FontCascadeCache::clearMeasurementCaches()
 {
     for (auto& value : m_entries.values())
         value->fonts.get().widthCache().clear();

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -256,7 +256,7 @@ public:
     static FontCascadeCache& forCurrentThread();
 
     void invalidate();
-    void clearWidthCaches();
+    void clearMeasurementCaches();
     void pruneUnreferencedEntries();
     void pruneSystemFallbackFonts();
     Ref<FontCascadeFonts> retrieveOrAddCachedFonts(const FontCascadeDescription&, FontSelector*);

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -25,7 +25,7 @@
 #include <WebCore/FontRanges.h>
 #include <WebCore/FontSelector.h>
 #include <WebCore/GlyphPage.h>
-#include <WebCore/WidthCache.h>
+#include <WebCore/TextMeasurementCache.h>
 #include <wtf/EnumeratedArray.h>
 #include <wtf/Forward.h>
 #include <wtf/HashFunctions.h>
@@ -73,6 +73,7 @@ public:
     // FIXME: It should be possible to combine fontSelectorVersion and generation.
     unsigned generation() const { return m_generation; }
 
+    using WidthCache = TextMeasurementCache<float>;
     WidthCache& widthCache() { return m_widthCache; }
     const WidthCache& widthCache() const { return m_widthCache; }
 
@@ -106,7 +107,7 @@ private:
 
         bool isNull() const { return !m_singleFont && !m_mixedFont; }
         bool isMixedFont() const { return !!m_mixedFont; }
-    
+
     private:
         // Only one of these is non-null.
         RefPtr<GlyphPage> m_singleFont;


### PR DESCRIPTION
#### ed20cc0620d3c827a1b6feca9bee3fa2e8fb7c23
<pre>
Refactor WidthCache into TextMeasurementCache&lt;float&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=306059">https://bugs.webkit.org/show_bug.cgi?id=306059</a>
<a href="https://rdar.apple.com/168702176">rdar://168702176</a>

Reviewed by Simon Fraser.

This shouldn&apos;t change actual code (yet), and will allow future changes
to what the cache actually stores.

Remove references to GlyphOverflow from this now-generic code, as it&apos;s
not currently cached.
FontCascade::width() now only use the WidthCache when there&apos;s no need
for GlyphOverflow; even if the cache had been updated to return cached
values, in case of cache misses the following FontCascade::width() code
wouldn&apos;t store new computed values, so something needed to change anyway.

Existing WidthCache tests already cover this code.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::releaseNoncriticalMemory):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::width const): Only use WidthCache when there&apos;s no GlyphOverflow; even if the cache had been updated to
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::FontCascadeCache::clearMeasurementCaches):
(WebCore::FontCascadeCache::clearWidthCaches): Deleted.
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
* Source/WebCore/platform/graphics/TextMeasurementCache.h: Renamed from Source/WebCore/platform/graphics/WidthCache.h.
(WebCore::TextMeasurementCache::TextMeasurementCache):
(WebCore::TextMeasurementCache::add):
(WebCore::TextMeasurementCache::addSlowCase):

Canonical link: <a href="https://commits.webkit.org/306069@main">https://commits.webkit.org/306069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6d420ec2eb29d3ecf172321132163f281f127b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93251 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d9c6a99-02ae-472a-8961-7488fbc5e4c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12710 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78075 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/850ed8ed-3121-47f7-93d6-a793e14b507c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143125 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88376 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66a0c103-a7ec-4cc4-9259-4a62de184fad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9857 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7384 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8608 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151113 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115743 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116071 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29510 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11065 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121986 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67251 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12284 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1458 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12220 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12070 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->