### PR TITLE
[WGSL] api,operation,compute_pipeline,overrides:computed:* does not pass

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/compute_pipeline/overrides-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/compute_pipeline/overrides-expected.txt
@@ -3,10 +3,7 @@ PASS :basic:isAsync=true
 PASS :basic:isAsync=false
 PASS :numeric_id:isAsync=true
 PASS :numeric_id:isAsync=false
-FAIL :computed: assert_unreached:
-  - EXCEPTION: GPUPipelineError: Failed to evaluate override value
-    _
- Reached unreachable code
+PASS :computed:
 PASS :precision:isAsync=true
 PASS :precision:isAsync=false
 PASS :workgroup_size:isAsync=true;type="u32";size=3;v="x"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/shader_io/workgroup_size-expected.txt
@@ -479,271 +479,55 @@ PASS :workgroup_size:wgx=256;wgy=256;wgz=11
 PASS :workgroup_size:wgx=256;wgy=256;wgz=16
 PASS :workgroup_size:wgx=256;wgy=256;wgz=128
 PASS :workgroup_size:wgx=256;wgy=256;wgz=256
-FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      3
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      4
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=1;override2=1;override3=4 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      6
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=1;override2=1;override3=1
+PASS :workgroup_size_override_exp:override1=1;override2=1;override3=2
+PASS :workgroup_size_override_exp:override1=1;override2=1;override3=4
 PASS :workgroup_size_override_exp:override1=1;override2=1;override3=8
-FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      4
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      5
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=1;override2=2;override3=4 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      7
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=1;override2=2;override3=1
+PASS :workgroup_size_override_exp:override1=1;override2=2;override3=2
+PASS :workgroup_size_override_exp:override1=1;override2=2;override3=4
 PASS :workgroup_size_override_exp:override1=1;override2=2;override3=8
-FAIL :workgroup_size_override_exp:override1=1;override2=3;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      5
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=1;override2=3;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      6
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=1;override2=3;override3=1
+PASS :workgroup_size_override_exp:override1=1;override2=3;override3=2
 PASS :workgroup_size_override_exp:override1=1;override2=3;override3=4
 PASS :workgroup_size_override_exp:override1=1;override2=3;override3=8
-FAIL :workgroup_size_override_exp:override1=1;override2=4;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      6
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=1;override2=4;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      7
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=1;override2=4;override3=1
+PASS :workgroup_size_override_exp:override1=1;override2=4;override3=2
 PASS :workgroup_size_override_exp:override1=1;override2=4;override3=4
 PASS :workgroup_size_override_exp:override1=1;override2=4;override3=8
-FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      5
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      6
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=3;override2=1;override3=4 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      8
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=3;override2=1;override3=1
+PASS :workgroup_size_override_exp:override1=3;override2=1;override3=2
+PASS :workgroup_size_override_exp:override1=3;override2=1;override3=4
 PASS :workgroup_size_override_exp:override1=3;override2=1;override3=8
-FAIL :workgroup_size_override_exp:override1=3;override2=2;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      6
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=3;override2=2;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      7
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=3;override2=2;override3=1
+PASS :workgroup_size_override_exp:override1=3;override2=2;override3=2
 PASS :workgroup_size_override_exp:override1=3;override2=2;override3=4
 PASS :workgroup_size_override_exp:override1=3;override2=2;override3=8
-FAIL :workgroup_size_override_exp:override1=3;override2=3;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      7
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=3;override2=3;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      8
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=3;override2=3;override3=1
+PASS :workgroup_size_override_exp:override1=3;override2=3;override3=2
 PASS :workgroup_size_override_exp:override1=3;override2=3;override3=4
 PASS :workgroup_size_override_exp:override1=3;override2=3;override3=8
-FAIL :workgroup_size_override_exp:override1=3;override2=4;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      8
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=3;override2=4;override3=1
 PASS :workgroup_size_override_exp:override1=3;override2=4;override3=2
 PASS :workgroup_size_override_exp:override1=3;override2=4;override3=4
 PASS :workgroup_size_override_exp:override1=3;override2=4;override3=8
-FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      6
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      7
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=4;override2=1;override3=4 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      9
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=4;override2=1;override3=1
+PASS :workgroup_size_override_exp:override1=4;override2=1;override3=2
+PASS :workgroup_size_override_exp:override1=4;override2=1;override3=4
 PASS :workgroup_size_override_exp:override1=4;override2=1;override3=8
-FAIL :workgroup_size_override_exp:override1=4;override2=2;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      7
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=4;override2=2;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      8
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=4;override2=2;override3=1
+PASS :workgroup_size_override_exp:override1=4;override2=2;override3=2
 PASS :workgroup_size_override_exp:override1=4;override2=2;override3=4
 PASS :workgroup_size_override_exp:override1=4;override2=2;override3=8
-FAIL :workgroup_size_override_exp:override1=4;override2=3;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      8
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :workgroup_size_override_exp:override1=4;override2=3;override3=2 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      9
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=4;override2=3;override3=1
+PASS :workgroup_size_override_exp:override1=4;override2=3;override3=2
 PASS :workgroup_size_override_exp:override1=4;override2=3;override3=4
 PASS :workgroup_size_override_exp:override1=4;override2=3;override3=8
-FAIL :workgroup_size_override_exp:override1=4;override2=4;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      9
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=4;override2=4;override3=1
 PASS :workgroup_size_override_exp:override1=4;override2=4;override3=2
 PASS :workgroup_size_override_exp:override1=4;override2=4;override3=4
 PASS :workgroup_size_override_exp:override1=4;override2=4;override3=8
-FAIL :workgroup_size_override_exp:override1=8;override2=1;override3=1 assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Incorrect workgroup size x dimension for wg 0:
-    - expected: 0
-    - got:      10
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size_override_exp:override1=8;override2=1;override3=1
 PASS :workgroup_size_override_exp:override1=8;override2=1;override3=2
 PASS :workgroup_size_override_exp:override1=8;override2=1;override3=4
 PASS :workgroup_size_override_exp:override1=8;override2=1;override3=8

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
@@ -1194,25 +1194,9 @@ PASS :invalid_array_count_on_rhs:op="%7C%7C";rhs="nested";control=false
 PASS :array_override:op="%26%26";a_val=0;b_val=0
 PASS :array_override:op="%26%26";a_val=0;b_val=1
 PASS :array_override:op="%26%26";a_val=1;b_val=0
-FAIL :array_override:op="%26%26";a_val=1;b_val=1 assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :array_override:op="%26%26";a_val=1;b_val=1
 PASS :array_override:op="%7C%7C";a_val=0;b_val=0
-FAIL :array_override:op="%7C%7C";a_val=0;b_val=1 assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :array_override:op="%7C%7C";a_val=1;b_val=0 assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :array_override:op="%7C%7C";a_val=1;b_val=1 assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :array_override:op="%7C%7C";a_val=0;b_val=1
+PASS :array_override:op="%7C%7C";a_val=1;b_val=0
+PASS :array_override:op="%7C%7C";a_val=1;b_val=1
 

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/workgroup_size-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/workgroup_size-expected.txt
@@ -28,10 +28,7 @@ PASS :workgroup_size:attr="override_no_default_pipe_fail"
 PASS :workgroup_size:attr="trailing_comma_x"
 PASS :workgroup_size:attr="trailing_comma_y"
 PASS :workgroup_size:attr="trailing_comma_z"
-FAIL :workgroup_size:attr="override_expr" assert_unreached:
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate overrides
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :workgroup_size:attr="override_expr"
 PASS :workgroup_size:attr="mixed_abstract_signed"
 PASS :workgroup_size:attr="mixed_abstract_unsigned"
 PASS :workgroup_size:attr="mixed_signed_unsigned"

--- a/Source/WebGPU/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebGPU/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,6 +1,4 @@
 ComputePipeline.mm
-Pipeline.mm
-WGSL/AST/ASTExpression.h
 WGSL/AST/ASTStringDumper.h
 WGSL/CallGraph.h
 WGSL/Types.h

--- a/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
@@ -78,7 +78,9 @@ public:
     NodeKind kind() const override;
     BinaryOperation operation() const { return m_operation; }
     Expression& leftExpression() { return m_lhs.get(); }
+    const Expression& leftExpression() const { return m_lhs.get(); }
     Expression& rightExpression() { return m_rhs.get(); }
+    const Expression& rightExpression() const { return m_rhs.get(); }
 
 private:
     BinaryExpression(SourceSpan span, Expression::Ref&& lhs, Expression::Ref&& rhs, BinaryOperation operation)

--- a/Source/WebGPU/WGSL/AST/ASTCallExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallExpression.h
@@ -51,8 +51,12 @@ public:
     using Ref = std::reference_wrapper<CallExpression>;
 
     NodeKind kind() const override;
+
     Expression& target() { return m_target.get(); }
+    const Expression& target() const { return m_target.get(); }
+
     Expression::List& arguments() { return m_arguments; }
+    const Expression::List& arguments() const { return m_arguments; }
 
     bool isConstructor() const { return m_isConstructor; }
 
@@ -90,6 +94,8 @@ public:
 
     const OptionSet<ShaderStage>& visibility() const { return m_visibility; }
 
+    const String& resolvedTarget() const { return m_resolvedTarget; }
+
 private:
     CallExpression(SourceSpan span, Expression::Ref&& target, Expression::List&& arguments)
         : Expression(span)
@@ -103,6 +109,7 @@ private:
     //   * Identifier that refers to a function.
     Expression::Ref m_target;
     Expression::List m_arguments;
+    String m_resolvedTarget;
 
     bool m_isConstructor { false };
     OptionSet<ShaderStage> m_visibility { ShaderStage::Compute, ShaderStage::Vertex, ShaderStage::Fragment };

--- a/Source/WebGPU/WGSL/AST/ASTFieldAccessExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTFieldAccessExpression.h
@@ -36,7 +36,11 @@ public:
     NodeKind kind() const override;
 
     Expression& base() { return m_base.get(); }
+    const Expression& base() const { return m_base.get(); }
+
     Identifier& fieldName() { return m_fieldName; }
+    const Identifier& fieldName() const { return m_fieldName; }
+
     const Identifier& originalFieldName() const { return m_originalFieldName; }
 
 private:

--- a/Source/WebGPU/WGSL/AST/ASTIndexAccessExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIndexAccessExpression.h
@@ -33,8 +33,12 @@ class IndexAccessExpression final : public Expression {
     WGSL_AST_BUILDER_NODE(IndexAccessExpression);
 public:
     NodeKind kind() const override;
+
     Expression& base() { return m_base.get(); }
+    const Expression& base() const { return m_base.get(); }
+
     Expression& index() { return m_index.get(); }
+    const Expression& index() const { return m_index.get(); }
 
 private:
     IndexAccessExpression(SourceSpan span, Expression::Ref&& base, Expression::Ref&& index)

--- a/Source/WebGPU/WGSL/AST/ASTUnaryExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTUnaryExpression.h
@@ -63,8 +63,9 @@ class UnaryExpression final : public Expression {
     WGSL_AST_BUILDER_NODE(UnaryExpression);
 public:
     NodeKind kind() const final;
-    Expression& expression() { return m_expression.get(); }
     UnaryOperation operation() const { return m_operation; }
+    Expression& expression() { return m_expression.get(); }
+    const Expression& expression() const { return m_expression.get(); }
 
 private:
     UnaryExpression(SourceSpan span, Expression::Ref&& expression, UnaryOperation operation)

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -310,13 +310,13 @@ void AttributeValidator::visit(AST::Variable& variable)
             }
 
             auto uintIdValue = static_cast<unsigned>(idValue);
-            if (m_shaderModule.containsOverride(uintIdValue)) [[unlikely]] {
+            if (m_shaderModule.containsOverrideID(uintIdValue)) [[unlikely]] {
                 error(attribute.span(), "@id value must be unique"_s);
                 return;
             }
 
             update(attribute.span(), variable.m_id, uintIdValue);
-            m_shaderModule.addOverride(uintIdValue);
+            m_shaderModule.addOverrideID(uintIdValue);
             continue;
         }
 

--- a/Source/WebGPU/WGSL/BoundsCheck.cpp
+++ b/Source/WebGPU/WGSL/BoundsCheck.cpp
@@ -46,12 +46,20 @@ public:
         return std::nullopt;
     }
 
+    void visit(AST::Variable&) override;
     void visit(AST::IndexAccessExpression&) override;
 
 private:
     ShaderModule& m_shaderModule;
 };
 
+
+void BoundsCheckVisitor::visit(AST::Variable& variable)
+{
+    if (variable.flavor() == AST::VariableFlavor::Override)
+        return;
+    AST::Visitor::visit(variable);
+}
 
 void BoundsCheckVisitor::visit(AST::IndexAccessExpression& access)
 {

--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -42,7 +42,7 @@ using ConstantResult = Expected<ConstantValue, String>;
 using ConstantFunction = ConstantResult(*)(const Type*, const FixedVector<ConstantValue>&);
 
 #define CONSTANT_FUNCTION(name) \
-    static Expected<ConstantValue, String>(constant ## name)(const Type* resultType, const FixedVector<ConstantValue>& arguments)
+    [[maybe_unused]] static Expected<ConstantValue, String>(constant ## name)(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 
 #define CALL_(__tmp, __variable, __fnName, ...) \
     auto __tmp = constant##__fnName(__VA_ARGS__); \
@@ -65,7 +65,7 @@ using ConstantFunction = ConstantResult(*)(const Type*, const FixedVector<Consta
     CALL_MOVE_(tmp ## __COUNTER__, __target, __fnName, __VA_ARGS__)
 
 
-static ConstantValue zeroValue(const Type* type)
+[[maybe_unused]] static ConstantValue zeroValue(const Type* type)
 {
     return WTF::switchOn(*type,
         [&](const Types::Primitive& primitive) -> ConstantValue {
@@ -156,7 +156,7 @@ static ConstantValue zeroValue(const Type* type)
 // Helpers
 
 template<Constraint constraint, typename Functor>
-static ConstantResult constantUnaryOperation(const FixedVector<ConstantValue>& arguments, const Functor& fn)
+[[maybe_unused]] static ConstantResult constantUnaryOperation(const FixedVector<ConstantValue>& arguments, const Functor& fn)
 {
     ASSERT(arguments.size() == 1);
     return scalarOrVector([&](auto& arg) -> ConstantResult {
@@ -193,7 +193,7 @@ static ConstantResult constantUnaryOperation(const FixedVector<ConstantValue>& a
 }
 
 template<Constraint constraint, typename Functor>
-static ConstantResult constantBinaryOperation(const FixedVector<ConstantValue>& arguments, const Functor& fn)
+[[maybe_unused]] static ConstantResult constantBinaryOperation(const FixedVector<ConstantValue>& arguments, const Functor& fn)
 {
     ASSERT(arguments.size() == 2);
     return scalarOrVector([&](auto& left, auto& right) -> ConstantResult {
@@ -230,7 +230,7 @@ static ConstantResult constantBinaryOperation(const FixedVector<ConstantValue>& 
 }
 
 template<Constraint constraint, typename Functor>
-static ConstantResult constantTernaryOperation(const FixedVector<ConstantValue>& arguments, const Functor& fn)
+[[maybe_unused]] static ConstantResult constantTernaryOperation(const FixedVector<ConstantValue>& arguments, const Functor& fn)
 {
     ASSERT(arguments.size() == 3);
     return scalarOrVector([&](auto& first, auto& second, auto& third) -> ConstantResult {
@@ -279,7 +279,7 @@ struct BitwiseCast {
 };
 
 template<typename DestinationType, template <typename U> typename Cast = StaticCast>
-static ConstantValue convertValue(ConstantValue value)
+[[maybe_unused]] static ConstantValue convertValue(ConstantValue value)
 {
     if constexpr (std::is_same_v<Cast<DestinationType>, StaticCast<DestinationType>> || sizeof(DestinationType) == 4) {
         if (auto* i32 = std::get_if<int32_t>(&value))
@@ -307,7 +307,7 @@ static ConstantValue convertValue(ConstantValue value)
 }
 
 template<template <typename U> typename Cast = StaticCast>
-static ConstantValue convertValue(const Type* targetType, ConstantValue value)
+[[maybe_unused]] static ConstantValue convertValue(const Type* targetType, ConstantValue value)
 {
     ASSERT(std::holds_alternative<Types::Primitive>(*targetType));
     auto& primitive = std::get<Types::Primitive>(*targetType);
@@ -332,7 +332,7 @@ static ConstantValue convertValue(const Type* targetType, ConstantValue value)
 }
 
 template<typename DestinationType>
-static ConstantValue constantConstructor(const Type* resultType, const FixedVector<ConstantValue>& arguments)
+[[maybe_unused]] static ConstantValue constantConstructor(const Type* resultType, const FixedVector<ConstantValue>& arguments)
 {
     if (arguments.isEmpty())
         return zeroValue(resultType);
@@ -343,7 +343,7 @@ static ConstantValue constantConstructor(const Type* resultType, const FixedVect
 
 
 template<typename Functor, typename... Arguments>
-static ConstantResult scalarOrVector(const Functor& functor, Arguments&&... unpackedArguments)
+[[maybe_unused]] static ConstantResult scalarOrVector(const Functor& functor, Arguments&&... unpackedArguments)
 {
     unsigned vectorSize = 0;
     std::initializer_list<ConstantValue> arguments { unpackedArguments... };
@@ -375,7 +375,7 @@ static ConstantResult scalarOrVector(const Functor& functor, Arguments&&... unpa
     return { { result } };
 }
 
-static ConstantValue constantVector(const Type* resultType, const FixedVector<ConstantValue>& arguments, unsigned size)
+[[maybe_unused]] static ConstantValue constantVector(const Type* resultType, const FixedVector<ConstantValue>& arguments, unsigned size)
 {
     ConstantVector result(size);
     auto argumentCount = arguments.size();
@@ -414,7 +414,7 @@ static ConstantValue constantVector(const Type* resultType, const FixedVector<Co
     return { result };
 }
 
-static ConstantValue constantMatrix(const Type* resultType, const FixedVector<ConstantValue>& arguments, unsigned columns, unsigned rows)
+[[maybe_unused]] static ConstantValue constantMatrix(const Type* resultType, const FixedVector<ConstantValue>& arguments, unsigned columns, unsigned rows)
 {
     if (arguments.isEmpty())
         return zeroValue(resultType);
@@ -1754,7 +1754,7 @@ CONSTANT_FUNCTION(Bitcast)
 
 // Type checker helpers
 
-static bool containsZero(ConstantValue value, const Type* valueType)
+[[maybe_unused]] static bool containsZero(ConstantValue value, const Type* valueType)
 {
     auto wrapped = [&]() -> Expected<bool, String> {
         auto zero = zeroValue(valueType);

--- a/Source/WebGPU/WGSL/ConstantValue.cpp
+++ b/Source/WebGPU/WGSL/ConstantValue.cpp
@@ -31,17 +31,17 @@
 
 namespace WGSL {
 
-ConstantValue ConstantArray::operator[](unsigned index)
+ConstantValue ConstantArray::operator[](unsigned index) const
 {
     return elements[index];
 }
 
-ConstantValue ConstantVector::operator[](unsigned index)
+ConstantValue ConstantVector::operator[](unsigned index) const
 {
     return elements[index];
 }
 
-ConstantVector ConstantMatrix::operator[](unsigned index)
+ConstantVector ConstantMatrix::operator[](unsigned index) const
 {
     ConstantVector result(rows);
     for (unsigned i = 0; i < rows; ++i)

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -30,11 +30,13 @@
 #include "WGSLEnums.h"
 #include <array>
 #include <functional>
+#include <variant>
 #include <wtf/FixedVector.h>
 #include <wtf/HashMap.h>
 #include <wtf/Markable.h>
 #include <wtf/PrintStream.h>
 #include <wtf/SortedArrayMap.h>
+#include <wtf/Variant.h>
 #include <wtf/text/WTFString.h>
 
 namespace WGSL {

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -242,6 +242,6 @@ Variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPointNam
 
 Variant<String, Error> generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&, DeviceState&&);
 
-std::optional<ConstantValue> evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
+std::optional<ConstantValue> evaluate(ShaderModule&, const AST::Expression&, const HashMap<String, ConstantValue>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -178,25 +178,8 @@ static int runWGSL(const CommandLine& options)
         return EXIT_FAILURE;
     }
 
-    HashMap<String, WGSL::ConstantValue> constantValues;
-    for (const auto& [entrypointName, _] : pipelineLayouts) {
-        const auto& entryPointInformation = result.entryPoints.get(entrypointName);
-        for (const auto& [originalName, constant] : entryPointInformation.specializationConstants) {
-            if (!constant.defaultValue) {
-                dataLogLn("Cannot use override without default value in wgslc: '", originalName, "'");
-                return EXIT_FAILURE;
-            }
-
-            auto defaultValue = WGSL::evaluate(*constant.defaultValue, constantValues);
-            if (!defaultValue) {
-                dataLogLn("Failed to evaluate override's default value: '", originalName, "'");
-                return EXIT_FAILURE;
-            }
-
-            constantValues.add(constant.mangledName, *defaultValue);
-        }
-    }
-    auto generationResult = WGSL::generate(shaderModule, result, constantValues, WGSL::DeviceState {
+    HashMap<String, WGSL::ConstantValue> userDefinedValues;
+    auto generationResult = WGSL::generate(shaderModule, result, userDefinedValues, WGSL::DeviceState {
         .appleGPUFamily = options.appleGPUFamily(),
         .shaderValidationEnabled = options.shaderValidationEnabled(),
     });

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -265,9 +265,10 @@
 			isEditable = 1;
 			outputFiles = (
 				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WGSL/TypeDeclarations.h",
+				"$(BUILT_PRODUCTS_DIR)/DerivedSources/WGSL/TypeOverloads.h",
 			);
 			runOncePerArchitecture = 0;
-			script = "/usr/bin/env ruby \"${SCRIPT_INPUT_FILE_0}\" \"${INPUT_FILE_PATH}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			script = "/usr/bin/env ruby \"${SCRIPT_INPUT_FILE_0}\" \"${INPUT_FILE_PATH}\" \"${SCRIPT_OUTPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_1}\"\n";
 		};
 /* End PBXBuildRule section */
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -680,6 +680,7 @@
 		97A826862DF8B677004EA039 /* JavaScriptCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BC90964D1255620C00083756 /* JavaScriptCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		97B250AD2E26F36F0056806C /* switch.wgsl in CopyFiles */ = {isa = PBXBuildFile; fileRef = 97FB431F2E1D633600C63F41 /* switch.wgsl */; };
 		97B250AE2E2701AB0056806C /* const-assert.wgsl in CopyFiles */ = {isa = PBXBuildFile; fileRef = 97FB42E52E1D633600C63F41 /* const-assert.wgsl */; };
+		97CB27B42F29190B0024DD32 /* override-complex-expression.wgsl in CopyFiles */ = {isa = PBXBuildFile; fileRef = 97CB27AC2F2918DA0024DD32 /* override-complex-expression.wgsl */; };
 		97DAA8CE2DF1F325004B3040 /* MetalCompilationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 97DAA8CD2DF1F325004B3040 /* MetalCompilationTests.mm */; };
 		97DAA8D02DF70B91004B3040 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97DAA8CF2DF70B91004B3040 /* Metal.framework */; };
 		97FB432E2E1D637C00C63F41 /* access-expression.wgsl in CopyFiles */ = {isa = PBXBuildFile; fileRef = 97FB42D52E1D633600C63F41 /* access-expression.wgsl */; };
@@ -1808,6 +1809,7 @@
 				97FB43632E1D637C00C63F41 /* minus-minus-ambiguity.wgsl in CopyFiles */,
 				97FB43652E1D637C00C63F41 /* name-mangling.wgsl in CopyFiles */,
 				97FB43662E1D637C00C63F41 /* overload.wgsl in CopyFiles */,
+				97CB27B42F29190B0024DD32 /* override-complex-expression.wgsl in CopyFiles */,
 				97FB43682E1D637C00C63F41 /* override.wgsl in CopyFiles */,
 				97FB43692E1D637C00C63F41 /* pack-unpack.wgsl in CopyFiles */,
 				97FB436B2E1D637C00C63F41 /* packing-nested-array.wgsl in CopyFiles */,
@@ -3361,6 +3363,7 @@
 		63CAD04F2C478A55009CE119 /* GetMatchedCSSRules.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = GetMatchedCSSRules.mm; sourceTree = "<group>"; };
 		63D138CF2D90B08E0072E181 /* HistoryDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = HistoryDelegate.mm; sourceTree = "<group>"; };
 		63F668201F97C3AA0032EE51 /* ApplicationManifest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ApplicationManifest.mm; sourceTree = "<group>"; };
+		6869316B2E69A1B000121550 /* WebAVPlayerControllerLeakTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebAVPlayerControllerLeakTests.mm; sourceTree = "<group>"; };
 		6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PrivateClickMeasurement.cpp; sourceTree = "<group>"; };
 		6B25A75125DC8D4E0070744F /* EventAttribution.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EventAttribution.mm; sourceTree = "<group>"; };
 		6B306105218A372900F5A802 /* ClosingWebView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ClosingWebView.mm; sourceTree = "<group>"; };
@@ -3624,6 +3627,7 @@
 		95C52728275F35E100DA7E40 /* FontShadowTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontShadowTests.cpp; sourceTree = "<group>"; };
 		96E05A012DF7B66F00285827 /* WKWebExtensionAPIBookmarks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIBookmarks.mm; sourceTree = "<group>"; };
 		9739F73F2E5C548E002E7C61 /* ExponentialRampAtTimeTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExponentialRampAtTimeTest.cpp; sourceTree = "<group>"; };
+		97CB27AC2F2918DA0024DD32 /* override-complex-expression.wgsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "override-complex-expression.wgsl"; sourceTree = "<group>"; };
 		97DAA8CD2DF1F325004B3040 /* MetalCompilationTests.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MetalCompilationTests.mm; sourceTree = "<group>"; };
 		97DAA8CF2DF70B91004B3040 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
 		97FB42D52E1D633600C63F41 /* access-expression.wgsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "access-expression.wgsl"; sourceTree = "<group>"; };
@@ -3812,7 +3816,6 @@
 		A1798B862243446B000764BD /* apple-pay-availability.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "apple-pay-availability.html"; sourceTree = "<group>"; };
 		A1798B8822435D2E000764BD /* apple-pay-availability-in-iframe.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "apple-pay-availability-in-iframe.html"; sourceTree = "<group>"; };
 		A17991861E1C994E00A505ED /* SharedBuffer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SharedBuffer.mm; sourceTree = "<group>"; };
-		6869316B2E69A1B000121550 /* WebAVPlayerControllerLeakTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebAVPlayerControllerLeakTests.mm; sourceTree = "<group>"; };
 		A17991891E1CA24100A505ED /* SharedBufferTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedBufferTest.cpp; sourceTree = "<group>"; };
 		A179918A1E1CA24100A505ED /* SharedBufferTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharedBufferTest.h; sourceTree = "<group>"; };
 		A17A5A3422A887EC0065C5F0 /* AppKitTestSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppKitTestSPI.h; sourceTree = "<group>"; };
@@ -5708,6 +5711,7 @@
 				97FB430C2E1D633600C63F41 /* name-mangling.wgsl */,
 				97FB430E2E1D633600C63F41 /* overload-errors.wgsl */,
 				97FB430D2E1D633600C63F41 /* overload.wgsl */,
+				97CB27AC2F2918DA0024DD32 /* override-complex-expression.wgsl */,
 				97FB430F2E1D633600C63F41 /* override.wgsl */,
 				97FB43102E1D633600C63F41 /* pack-unpack.wgsl */,
 				97FB43122E1D633600C63F41 /* packing-nested-array.wgsl */,

--- a/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WGSL/MetalCompilationTests.mm
@@ -513,6 +513,11 @@ TEST_F(WGSLMetalCompilationTests, Override)
     expectGenerateError(file("override.wgsl"_s), "array count must be greater than 0"_s);
 }
 
+TEST_F(WGSLMetalCompilationTests, OverrideComplexExpression)
+{
+    testCompilation(file("override-complex-expression.wgsl"_s));
+}
+
 TEST_F(WGSLMetalCompilationTests, PackUnpack)
 {
     testCompilation(file("pack-unpack.wgsl"_s),

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -136,16 +136,6 @@ inline Variant<String, WGSL::Error> generate(const WGSL::SuccessfulCheck& static
 {
     auto& shaderModule = staticCheckResult.ast;
     HashMap<String, WGSL::ConstantValue> constantValues;
-    for (auto& entryPoint : shaderModule->callGraph().entrypoints()) {
-        const auto& entryPointInformation = prepareResult.entryPoints.get(entryPoint.originalName);
-        for (const auto& [originalName, constant] : entryPointInformation.specializationConstants) {
-            EXPECT_TRUE(constant.defaultValue);
-            auto defaultValue = WGSL::evaluate(*constant.defaultValue, constantValues);
-            EXPECT_TRUE(defaultValue.has_value());
-            constantValues.add(constant.mangledName, *defaultValue);
-        }
-    }
-
     return WGSL::generate(shaderModule, prepareResult, constantValues, { });
 }
 

--- a/Tools/TestWebKitAPI/Tests/WGSL/shaders/override-complex-expression.wgsl
+++ b/Tools/TestWebKitAPI/Tests/WGSL/shaders/override-complex-expression.wgsl
@@ -1,0 +1,13 @@
+override a_val:i32 = 1;
+override b_val:i32 = 1;
+override bad_size = (a_val - 10);
+override good_size = (b_val + 10);
+struct S { x: f32 };
+override v = S(pow(2.f, vec2f(array(modf(f32(b_val)).whole)[0]).xy[0])).x;
+var<workgroup> zero_array:array<i32, select(bad_size, good_size, a_val == 1 && b_val == 1 )>;
+
+@workgroup_size(1)
+@compute fn main() {
+    var x = v;
+    let foo = zero_array[0];
+}


### PR DESCRIPTION
#### 98bebfefcf9271c90f28480c98c936a7b2f58e04
<pre>
[WGSL] api,operation,compute_pipeline,overrides:computed:* does not pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=275010">https://bugs.webkit.org/show_bug.cgi?id=275010</a>
<a href="https://rdar.apple.com/129090786">rdar://129090786</a>

Reviewed by Mike Wyrzykowski.

Add support for override expressions, including:
- Add support for evaluating calls, binary and unary expressions, member and index access
  to the current evaluator
- Move the logic for evaluating and mangling names of overrides into WGSL instead of
  duplicating it across the WebGPU API and wgslc
- Fix the order in which overrides are evaluated: previously they were evaluated in the
  order they were marked used, but it should be in the order that they are defined (since
  that is already ordered by the compiler so that uses come after defs)

* LayoutTests/http/tests/webgpu/webgpu/api/operation/compute_pipeline/overrides-expected.txt:
* Source/WebGPU/WGSL/AST/ASTBinaryExpression.h:
(WGSL::AST::BinaryExpression::leftExpression const):
(WGSL::AST::BinaryExpression::rightExpression const):
* Source/WebGPU/WGSL/AST/ASTUnaryExpression.h:
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::zeroValue):
(WGSL::constantUnaryOperation):
(WGSL::constantBinaryOperation):
(WGSL::constantTernaryOperation):
(WGSL::convertValue):
(WGSL::constantConstructor):
(WGSL::scalarOrVector):
(WGSL::constantVector):
(WGSL::constantMatrix):
(WGSL::containsZero):
* Source/WebGPU/WGSL/TypeCheck.cpp:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::evaluate):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WGSL/WGSLShaderModule.cpp:
(WGSL::ShaderModule::validateOverrides):
(WGSL::ShaderModule::initializeOverloads):
(WGSL::ShaderModule::lookupOverload):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::ShaderModule):
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::metalSize):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):

Canonical link: <a href="https://commits.webkit.org/306328@main">https://commits.webkit.org/306328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57934510a2ca307fdb1ddb1c8a5a72362a2f5cef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140904 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93992 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142777 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78426 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89058 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7985 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12974 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116350 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116689 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12753 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122797 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68135 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13017 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12756 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76718 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->