### PR TITLE
[CMake] Change FindATK.cmake to use an imported target

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -480,13 +480,9 @@ if (ANDROID)
 endif ()
 
 if (USE_ATK)
-    list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES
-        ${ATK_INCLUDE_DIRS}
-    )
-
-    list(APPEND WebKit_LIBRARIES
+    list(APPEND WebKit_PRIVATE_LIBRARIES
+        ATK::ATK
         ATK::Bridge
-        ${ATK_LIBRARIES}
     )
 endif ()
 

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -130,17 +130,9 @@ if (ANDROID)
 endif ()
 
 if (USE_ATK)
-    list(APPEND WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES
-        ${ATK_INCLUDE_DIRS}
-    )
-
-    list(APPEND WPEPlatform_PRIVATE_INCLUDE_DIRECTORIES
-        "${WEBKIT_DIR}/WPEPlatform/wpe/atk"
-    )
-
     list(APPEND WPEPlatform_LIBRARIES
+        ATK::ATK
         ATK::Bridge
-        ${ATK_LIBRARIES}
     )
 
     list(APPEND WPEPlatform_SOURCES
@@ -181,7 +173,7 @@ add_library(WPEPlatform OBJECT ${WPEPlatform_SOURCES})
 target_compile_options(WPEPlatform PRIVATE ${DEVELOPER_MODE_CXX_FLAGS})
 target_include_directories(WPEPlatform PRIVATE ${WPEPlatform_PRIVATE_INCLUDE_DIRECTORIES})
 target_include_directories(WPEPlatform SYSTEM PRIVATE ${WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES})
-target_link_libraries(WPEPlatform ${WPEPlatform_LIBRARIES})
+target_link_libraries(WPEPlatform PRIVATE ${WPEPlatform_LIBRARIES})
 add_dependencies(WPEPlatform WPEPlatformGeneratedEnumTypesHeader)
 
 GI_INTROSPECT(WPEPlatform ${WPE_API_VERSION} wpe/wpe-platform.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -36,8 +36,8 @@
 #include <wtf/text/WTFString.h>
 
 #if USE(ATK)
-#include "WPEApplicationAccessibleAtk.h"
-#include "WPEToplevelAccessibleAtk.h"
+#include "atk/WPEApplicationAccessibleAtk.h"
+#include "atk/WPEToplevelAccessibleAtk.h"
 #endif
 
 #if USE(LIBDRM)

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -40,7 +40,7 @@
 #include <wtf/glib/WTFGType.h>
 
 #if USE(ATK)
-#include "WPEViewAccessibleAtk.h"
+#include "atk/WPEViewAccessibleAtk.h"
 #endif
 
 /**

--- a/Source/cmake/FindATK.cmake
+++ b/Source/cmake/FindATK.cmake
@@ -1,9 +1,4 @@
-# - Try to find ATK
-# Once done, this will define
-#
-#  ATK_INCLUDE_DIRS - the ATK include drectories
-#  ATK_LIBRARIES - link these to use ATK
-#
+# Copyright (C) 2026 Igalia S.L.
 # Copyright (C) 2012 Samsung Electronics
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,26 +22,67 @@
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#[=======================================================================[.rst:
+FindATK
+-------
+
+Find the ATK headers and library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``ATK::ATK``
+  The ATK library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``ATK_FOUND``
+  true if (the requested version of) the ATK library is available.
+``ATK_VERSION``
+  the version of the ATK library.
+``ATK_LIBRARY``
+  path to the ATK library.
+``ATK_INCLUDE_DIR``
+  path where to find the ATK headers.
+``ATK_COMPILE_OPTIONS``
+  this should be passed to target_compile_options() of targets that use
+  the ATK library, if the ATK::ATK target is not used for linking.
+
+#]=======================================================================]
+
 find_package(PkgConfig QUIET)
 pkg_check_modules(PC_ATK QUIET atk)
+set(ATK_COMPILE_OPTIONS ${PC_ATK_CFLAGS_OTHER})
+set(ATK_VERSION ${PC_ATK_VERSION})
 
-find_path(ATK_INCLUDE_DIRS
+find_path(ATK_INCLUDE_DIR
     NAMES atk/atk.h
     HINTS ${PC_ATK_INCLUDEDIR}
           ${PC_ATK_INCLUDE_DIRS}
     PATH_SUFFIXES atk-1.0
 )
 
-find_library(ATK_LIBRARIES
+find_library(ATK_LIBRARY
     NAMES atk-1.0
-    HINTS ${PC_ATK_LIBRARY_DIRS}
-          ${PC_ATK_LIBDIR}
+    HINTS ${PC_ATK_LIBDIR}
+          ${PC_ATK_LIBRARY_DIRS}
 )
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(ATK REQUIRED_VARS ATK_INCLUDE_DIRS ATK_LIBRARIES
-                                      VERSION_VAR   PC_ATK_VERSION)
-mark_as_advanced(
-    ATK_INCLUDE_DIRS
-    ATK_LIBRARIES
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ATK
+    FOUND_VAR ATK_FOUND
+    REQUIRED_VARS ATK_LIBRARY ATK_INCLUDE_DIR
+    VERSION_VAR ATK_VERSION
 )
+
+if (ATK_LIBRARY AND NOT TARGET ATK::ATK)
+    add_library(ATK::ATK UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(ATK::ATK PROPERTIES
+        IMPORTED_LOCATION "${ATK_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${ATK_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${ATK_INCLUDE_DIR}"
+    )
+endif ()
+
+mark_as_advanced(ATK_INCLUDE_DIR ATK_LIBRARY)

--- a/Tools/MiniBrowser/wpe/CMakeLists.txt
+++ b/Tools/MiniBrowser/wpe/CMakeLists.txt
@@ -20,13 +20,7 @@ if (ENABLE_WPE_LEGACY_API)
 endif ()
 
 if (USE_ATK)
-    list(APPEND MiniBrowser_SYSTEM_INCLUDE_DIRECTORIES
-        ${ATK_INCLUDE_DIRS}
-    )
-
-    list(APPEND MiniBrowser_PRIVATE_LIBRARIES
-        ${ATK_LIBRARIES}
-    )
+    list(APPEND MiniBrowser_PRIVATE_LIBRARIES ATK::ATK)
 endif ()
 
 if (ENABLE_WPE_PLATFORM)

--- a/Tools/wpe/backends/PlatformWPE.cmake
+++ b/Tools/wpe/backends/PlatformWPE.cmake
@@ -39,17 +39,9 @@ if (USE_ATK)
         atk/WebKitAccessibleApplication.cpp
     )
 
-    list(APPEND WPEToolingBackends_PRIVATE_INCLUDE_DIRECTORIES
-        ${TOOLS_DIR}/wpe/backends/atk
-    )
-
-    list(APPEND WPEToolingBackends_SYSTEM_INCLUDE_DIRECTORIES
-        ${ATK_INCLUDE_DIRS}
-    )
-
-    list(APPEND WPEToolingBackends_LIBRARIES
+    list(APPEND WPEToolingBackends_PRIVATE_LIBRARIES
+        ATK::ATK
         ATK::Bridge
-        ${ATK_LIBRARIES}
     )
 
     list(APPEND WPEToolingBackends_DEFINITIONS USE_ATK=1)


### PR DESCRIPTION
#### 5eb6c60cbbb2adb554e5cc52ec0be2235e706800
<pre>
[CMake] Change FindATK.cmake to use an imported target
<a href="https://bugs.webkit.org/show_bug.cgi?id=306028">https://bugs.webkit.org/show_bug.cgi?id=306028</a>

Reviewed by Carlos Alberto Lopez Perez.

Change the FindATK.cmake module to define an ATK::ATK imported target,
and make use of it. As drive-by fixes, mark libraries linked into
WPEPlatform as PRIVATE, and avoid adding an additional include path
to the WPEPlatform::WPEPlatform target by using relative paths.

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
* Source/cmake/FindATK.cmake:
* Tools/MiniBrowser/wpe/CMakeLists.txt:
* Tools/wpe/backends/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/306044@main">https://commits.webkit.org/306044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f35adbdf3626e2e42c1d5e7c5dea8e39ac75162

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93175 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/141971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12632 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107252 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10154 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7326 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8530 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132072 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151035 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/895 "Found 1 new JSC stress test failure: stress/re-enter-resolve-rope-string.js.no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12165 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115681 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10918 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67175 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/12435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1402 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171370 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11949 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75905 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12144 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/11994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->