### PR TITLE
WebCore classes should be able to iterate over a JS asynchronous iterable

### DIFF
--- a/LayoutTests/streams/domAsyncIterator-expected.txt
+++ b/LayoutTests/streams/domAsyncIterator-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Test asnc iterator error cases
+PASS Test async iterator from asyncIterator
+PASS Test async iterator from syncIterator
+

--- a/LayoutTests/streams/domAsyncIterator.html
+++ b/LayoutTests/streams/domAsyncIterator.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script src='../resources/testharness.js'></script>
+<script src='../resources/testharnessreport.js'></script>
+<script>
+promise_test(async t => {
+
+    return promise_rejects_js(t, TypeError, internals.testAsyncIterator(1));
+    return promise_rejects_js(t, TypeError, internals.testAsyncIterator({ }));
+
+    const error = new Error("test");
+    await promise_rejects_exactly(t, error, internals.testAsyncIterator({
+        [Symbol.asyncIterator]: () => { throw error; }
+    }));
+
+    await promise_rejects_exactly(t, error, internals.testAsyncIterator({
+        [Symbol.iterator]: () => { throw error; }
+    }));
+
+    await promise_rejects_exactly(t, error, internals.testAsyncIterator({
+        [Symbol.asyncIterator]: () => { return {
+            next() {
+                return Promise.rejects(error);
+            }
+        };}
+    }));
+}, "Test asnc iterator error cases");
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const chunks = ["a", 1];
+    const asyncIterator = {
+        next() {
+            return Promise.resolve({
+                done: chunks.length === 0,
+                value: chunks.shift()
+            });
+        }
+    };
+
+    const results = await internals.testAsyncIterator({
+        [Symbol.asyncIterator]: () => asyncIterator
+    });
+
+    assert_equals(JSON.stringify(results), '[{"done":false,"value":"a"},{"done":false,"value":1},{"done":true}]');
+}, "Test async iterator from asyncIterator");
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const results = await internals.testAsyncIterator(["a", 1]);
+
+    assert_equals(JSON.stringify(results), '[{"value":"a","done":false},{"value":1,"done":false},{"done":true}]');
+}, "Test async iterator from syncIterator");
+</script>

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -29,6 +29,7 @@
 
 #include "CachedCall.h"
 #include "InterpreterInlines.h"
+#include "JSAsyncFromSyncIterator.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
 #include "VMEntryScopeInlines.h"
@@ -281,6 +282,61 @@ IterationRecord iteratorForIterable(JSGlobalObject* globalObject, JSValue iterab
 IterationRecord iteratorDirect(JSGlobalObject* globalObject, JSValue object)
 {
     return { object, object.get(globalObject, globalObject->vm().propertyNames->next) };
+}
+
+Expected<IterationRecord, ASCIILiteral> getAsyncIterator(JSGlobalObject& globalObject, JSValue iterable)
+{
+    auto* iterableObject = iterable.getObject();
+    if (!iterableObject)
+        return makeUnexpected("iterable should be an object"_s);
+
+    Ref vm = globalObject.vm();
+
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    CallData callData;
+    auto method = iterableObject->getMethod(&globalObject, callData, vm->propertyNames->asyncIteratorSymbol, "asyncIteratorSymbol property should be callable"_s);
+    RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+
+    if (method.isUndefined()) {
+        auto syncMethod = iteratorMethod(&globalObject, iterableObject);
+        RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+
+        if (syncMethod.isUndefined())
+            return makeUnexpected("iterable should have an iterator symbol"_s);
+
+        callData = getCallData(syncMethod);
+        auto iterator = call(&globalObject, syncMethod, callData, iterableObject, { });
+        RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+
+        auto* iteratorObject = iterator.getObject();
+        if (!iteratorObject)
+            return makeUnexpected("iterator method should return an object"_s);
+
+        auto syncRecord = iteratorDirect(&globalObject, iterator);
+        RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+
+        auto* asyncFromSyncIterator = JSAsyncFromSyncIterator::create(vm, globalObject.asyncFromSyncIteratorStructure(), syncRecord.iterator, syncRecord.nextMethod);
+        RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+
+        auto record = iteratorDirect(&globalObject, asyncFromSyncIterator);
+        RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+        return record;
+    }
+
+    if (method.isUndefined())
+        return makeUnexpected("iterable should have an iterator symbol"_s);
+
+    callData = getCallData(method);
+    auto iterator = call(&globalObject, method, callData, iterableObject, { });
+    RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+
+    auto* iteratorObject = iterator.getObject();
+    if (!iteratorObject)
+        return makeUnexpected("iterator method should return an object"_s);
+
+    auto record = iteratorDirect(&globalObject, iterator);
+    RETURN_IF_EXCEPTION(throwScope, makeUnexpected(ASCIILiteral { }));
+    return record;
 }
 
 IterableValidationResult validateIterable(VM&, JSValue iterable, JSValue symbolIterator)

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -47,7 +47,7 @@ struct IterationRecord {
     JSValue nextMethod;
 };
 
-JSValue iteratorNext(JSGlobalObject*, IterationRecord, JSValue argument = JSValue());
+JS_EXPORT_PRIVATE JSValue iteratorNext(JSGlobalObject*, IterationRecord, JSValue argument = JSValue());
 JSValue iteratorNextWithCachedCall(JSGlobalObject*, IterationRecord, CachedCall*, JSValue argument = JSValue());
 JS_EXPORT_PRIVATE JSValue iteratorValue(JSGlobalObject*, JSValue iterResult);
 bool iteratorComplete(JSGlobalObject*, JSValue iterResult);
@@ -62,6 +62,7 @@ JS_EXPORT_PRIVATE JSValue iteratorMethod(JSGlobalObject*, JSObject*);
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSObject*, JSValue iteratorMethod);
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSValue iterable);
 JS_EXPORT_PRIVATE IterationRecord iteratorDirect(JSGlobalObject*, JSValue);
+JS_EXPORT_PRIVATE Expected<IterationRecord, ASCIILiteral> getAsyncIterator(JSGlobalObject&, JSValue);
 
 JS_EXPORT_PRIVATE JSValue iteratorMethod(JSGlobalObject*, JSObject*);
 JS_EXPORT_PRIVATE bool hasIteratorMethod(JSGlobalObject*, JSValue);

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -657,6 +657,7 @@ bindings/js/BindingsJSTZoneImpls.cpp
 bindings/js/CachedModuleScriptLoader.cpp
 bindings/js/CachedScriptFetcher.cpp
 bindings/js/CommonVM.cpp
+bindings/js/DOMAsyncIterator.cpp
 bindings/js/DOMGCOutputConstraint.cpp
 bindings/js/DOMWrapperWorld.cpp
 bindings/js/GarbageCollectionController.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -1413,6 +1413,7 @@
 		4150F9F112B6E0E70008C860 /* SliderThumbElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 4150F9EF12B6E0E70008C860 /* SliderThumbElement.h */; };
 		41514FDB2E92DC40002074EA /* StreamPipeToUtilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 41E616F92E8427DD00662181 /* StreamPipeToUtilities.cpp */; };
 		41519CB81FD1F02E007F623C /* ServiceWorkerClientQueryOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 413FC4CD1FD1DD8C00541C4B /* ServiceWorkerClientQueryOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		4151AAE52F22426700E99C91 /* DOMAsyncIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = 4151AAE32F22425B00E99C91 /* DOMAsyncIterator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4151E5BB1FBA4C7A00E47E2D /* SWOriginStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 4151E5B71FBA4C7500E47E2D /* SWOriginStore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		415747471E3869A400E914D8 /* LibWebRTCMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 415747431E38699E00E914D8 /* LibWebRTCMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		415747481E3869A700E914D8 /* LibWebRTCProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 415747441E38699E00E914D8 /* LibWebRTCProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -10720,6 +10721,8 @@
 		415080351E3F00AA0051D75D /* LibWebRTCAudioModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibWebRTCAudioModule.h; path = libwebrtc/LibWebRTCAudioModule.h; sourceTree = "<group>"; };
 		4150F9EF12B6E0E70008C860 /* SliderThumbElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SliderThumbElement.h; sourceTree = "<group>"; };
 		4150F9F012B6E0E70008C860 /* SliderThumbElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SliderThumbElement.cpp; sourceTree = "<group>"; };
+		4151AAE32F22425B00E99C91 /* DOMAsyncIterator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DOMAsyncIterator.h; sourceTree = "<group>"; };
+		4151AAE42F22425B00E99C91 /* DOMAsyncIterator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DOMAsyncIterator.cpp; sourceTree = "<group>"; };
 		4151E5B71FBA4C7500E47E2D /* SWOriginStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SWOriginStore.h; sourceTree = "<group>"; };
 		4151E5B91FBA4C7600E47E2D /* SWOriginStore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SWOriginStore.cpp; sourceTree = "<group>"; };
 		415747431E38699E00E914D8 /* LibWebRTCMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LibWebRTCMacros.h; path = libwebrtc/LibWebRTCMacros.h; sourceTree = "<group>"; };
@@ -36243,6 +36246,8 @@
 				BCD533630ED6848900887468 /* CachedScriptSourceProvider.h */,
 				0F60F3291DFBB10400416D6C /* CommonVM.cpp */,
 				0F60F32A1DFBB10400416D6C /* CommonVM.h */,
+				4151AAE42F22425B00E99C91 /* DOMAsyncIterator.cpp */,
+				4151AAE32F22425B00E99C91 /* DOMAsyncIterator.h */,
 				0F9DAA0C1FD1C6630079C5B2 /* DOMGCOutputConstraint.cpp */,
 				0F9DAA0E1FD1C6640079C5B2 /* DOMGCOutputConstraint.h */,
 				7C516AD21F3525200034B6BF /* DOMPromiseProxy.h */,
@@ -43658,6 +43663,7 @@
 				CDFFB2122E8A52E20045D9F2 /* DocumentView.h in Headers */,
 				CD6115FC2E8B0E39002A1FBD /* DocumentWindow.h in Headers */,
 				973889A1116EA9DC00ADF313 /* DocumentWriter.h in Headers */,
+				4151AAE52F22426700E99C91 /* DOMAsyncIterator.h in Headers */,
 				412752D2294C7F2B00387637 /* DOMAudioSession.h in Headers */,
 				41380C271F3436AC00155FDA /* DOMCache.h in Headers */,
 				41FABD2D1F4DFE4A006A6C97 /* DOMCacheEngine.h in Headers */,

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DOMAsyncIterator.h"
+
+#include "JSDOMGlobalObjectInlines.h"
+#include "JSDOMPromise.h"
+#include <JavaScriptCore/IteratorOperations.h>
+#include <JavaScriptCore/JSPromise.h>
+
+namespace WebCore {
+
+ExceptionOr<Ref<DOMAsyncIterator>> DOMAsyncIterator::create(JSDOMGlobalObject& globalObject, JSC::JSValue iterable)
+{
+    auto iteratorRecordOrError = getAsyncIterator(globalObject, iterable);
+    if (!iteratorRecordOrError) {
+        auto errorMessage = iteratorRecordOrError.error();
+        if (errorMessage.isNull())
+            return Exception { ExceptionCode::ExistingExceptionError };
+        return Exception { ExceptionCode::TypeError, errorMessage };
+    }
+
+    auto iteratorRecord = iteratorRecordOrError.value();
+    auto* iteratorObject = iteratorRecord.iterator.getObject();
+    if (!iteratorObject)
+        return Exception { ExceptionCode::TypeError, "iterator should be an object"_s };
+    if (!iteratorRecord.nextMethod.isCell())
+        return Exception { ExceptionCode::TypeError, "iterator next should be callable"_s };
+
+    return adoptRef(*new DOMAsyncIterator(globalObject, *iteratorObject, *iteratorRecord.nextMethod.asCell()));
+}
+
+void DOMAsyncIterator::handleCallbackWithPromise(JSDOMGlobalObject& globalObject, Callback&& callback, JSC::JSPromise& promise)
+{
+    bool shouldStoreCallback = DOMPromise::whenPromiseIsSettled(&globalObject, &promise, [weakThis = WeakPtr { *this }](auto* globalObject, bool isOK, auto value) {
+        if (RefPtr protectedThis = weakThis.get())
+            std::exchange(protectedThis->m_callback, { })(globalObject, isOK, value);
+    }) == DOMPromise::IsCallbackRegistered::Yes;
+
+    if (!shouldStoreCallback) {
+        callback(&globalObject, false, { });
+        return;
+    }
+
+    m_callback = WTF::move(callback);
+}
+
+void DOMAsyncIterator::callNext(Callback&& callback)
+{
+    ASSERT(!m_callback);
+    auto* globalObject = this->globalObject();
+    if (!globalObject) {
+        callback(nullptr, false, { });
+        return;
+    }
+
+    Ref vm = globalObject->vm();
+
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    auto result = JSC::iteratorNext(globalObject, { m_iterator->guardedObject(), guardedObject() }, JSC::jsUndefined());
+    if (auto* exception = scope.exception()) {
+        callback(globalObject, false, exception);
+        return;
+    }
+    auto* promise = JSC::JSPromise::resolvedPromise(globalObject, result);
+    if (auto* exception = scope.exception()) {
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    handleCallbackWithPromise(*globalObject, WTF::move(callback), *promise);
+}
+
+void DOMAsyncIterator::callReturn(JSC::JSValue reason, Callback&& callback)
+{
+    ASSERT(!m_callback);
+    auto* globalObject = this->globalObject();
+    if (!globalObject) {
+        callback(nullptr, false, { });
+        return;
+    }
+
+    Ref vm = globalObject->vm();
+
+    auto scope = DECLARE_CATCH_SCOPE(vm);
+    JSC::CallData callData;
+    auto returnMethod = m_iterator->object()->getMethod(globalObject, callData, vm->propertyNames->returnKeyword, "return property should be callable"_s);
+    if (auto* exception = scope.exception()) {
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    if (!returnMethod) {
+        auto* promise = JSC::JSPromise::resolvedPromise(globalObject, JSC::jsUndefined());
+        if (auto* exception = scope.exception()) {
+            callback(globalObject, false, exception);
+            return;
+        }
+        // FIXME: Is it needed?
+        if (!promise) {
+            callback(globalObject, false, { });
+            return;
+        }
+
+        handleCallbackWithPromise(*globalObject, WTF::move(callback), *promise);
+        return;
+    }
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(reason);
+
+    callData = JSC::getCallData(returnMethod);
+    auto result = JSC::call(globalObject, returnMethod, callData, m_iterator->guardedObject(), arguments);
+    if (auto* exception = scope.exception()) {
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    auto* promise = JSC::JSPromise::resolvedPromise(globalObject, result);
+    if (auto* exception = scope.exception()) {
+        callback(globalObject, false, exception);
+        return;
+    }
+    // FIXME: Is it needed?
+    if (!promise) {
+        callback(globalObject, false, { });
+        return;
+    }
+
+    handleCallbackWithPromise(*globalObject, WTF::move(callback), *promise);
+}
+
+}

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/ExceptionOr.h>
+#include <WebCore/JSDOMGuardedObject.h>
+
+namespace WebCore {
+
+class DOMAsyncIterator : public DOMGuardedObject {
+public:
+    WEBCORE_EXPORT static ExceptionOr<Ref<DOMAsyncIterator>> create(JSDOMGlobalObject&, JSC::JSValue /* iterable */);
+    using Callback = Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>;
+    WEBCORE_EXPORT void callNext(Callback&&);
+    WEBCORE_EXPORT void callReturn(JSC::JSValue reason, Callback&&);
+
+private:
+    class IteratorObject : public DOMGuarded<JSC::JSObject> {
+    public:
+        static Ref<IteratorObject> create(JSDOMGlobalObject& globalObject, JSC::JSObject& iterator) { return adoptRef(*new IteratorObject(globalObject, iterator)); }
+
+        JSC::JSObject* object() { return guarded(); }
+
+    private:
+        IteratorObject(JSDOMGlobalObject& globalObject, JSC::JSObject& iterator)
+            : DOMGuarded<JSC::JSObject>(globalObject, iterator)
+        {
+        }
+    };
+
+    DOMAsyncIterator(JSDOMGlobalObject& globalObject, JSC::JSObject& iteratorObject, JSC::JSCell& method)
+        : DOMGuardedObject(globalObject, method)
+        , m_iterator(IteratorObject::create(globalObject, iteratorObject))
+    {
+    }
+
+    void handleCallbackWithPromise(JSDOMGlobalObject&, Callback&&, JSC::JSPromise&);
+
+    Ref<IteratorObject> m_iterator;
+    Callback m_callback;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -62,6 +62,7 @@
 #include "CookieJar.h"
 #include "CrossOriginPreflightResultCache.h"
 #include "Cursor.h"
+#include "DOMAsyncIterator.h"
 #include "DOMPointReadOnly.h"
 #include "DOMRect.h"
 #include "DOMRectList.h"
@@ -8240,6 +8241,54 @@ bool Internals::hasMediaSessionManager() const
 size_t Internals::fileConnectionHandleCount(const FileSystemHandle& handle) const
 {
     return handle.connectionHandleCount();
+}
+
+static void storeNextResults(DOMAsyncIterator& iterator, Vector<JSC::Strong<JSC::Unknown>>&& results, Internals::IteratorResultPromise&& promise)
+{
+    iterator.callNext([iterator = Ref { iterator }, results = WTF::move(results), promise = WTF::move(promise)](auto* globalObject, bool isOK, JSC::JSValue value) mutable {
+        if (!globalObject) {
+            promise.reject(Exception { ExceptionCode::InvalidStateError });
+            return;
+        }
+
+        if (!isOK) {
+            promise.rejectWithCallback([value](auto&) {
+                return value;
+            });
+            return;
+        }
+
+        Ref vm = globalObject->vm();
+        results.append({ vm.get(), value });
+
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto done = value.get(globalObject, vm->propertyNames->done);
+        if (scope.exception()) {
+            promise.reject(Exception { ExceptionCode::ExistingExceptionError });
+            return;
+        }
+
+        if (done.toBoolean(globalObject)) {
+            promise.resolve(WTF::move(results));
+            return;
+        }
+
+        storeNextResults(iterator.get(), WTF::move(results), WTF::move(promise));
+    });
+
+}
+
+void Internals::testAsyncIterator(JSDOMGlobalObject& globalObject, JSC::JSValue value, IteratorResultPromise&& promise)
+{
+    auto domIteratorOrException = DOMAsyncIterator::create(globalObject, value);
+    if (domIteratorOrException.hasException()) {
+        promise.reject(domIteratorOrException.releaseException());
+        return;
+    }
+
+    Vector<JSC::Strong<JSC::Unknown>> results;
+    Ref domIterator = domIteratorOrException.releaseReturnValue();
+    storeNextResults(domIterator.get(), WTF::move(results), WTF::move(promise));
 }
 
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1675,6 +1675,9 @@ public:
 
     size_t fileConnectionHandleCount(const FileSystemHandle&) const;
 
+    using IteratorResultPromise = DOMPromiseDeferred<IDLSequence<IDLAny>>;
+    void testAsyncIterator(JSDOMGlobalObject&, JSC::JSValue, IteratorResultPromise&&);
+
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     MockMediaDeviceRouteController& mockMediaDeviceRouteController();
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1526,6 +1526,8 @@ enum ContentsFormat {
 
     unsigned long fileConnectionHandleCount(FileSystemHandle handle);
 
+    [CallWith=CurrentGlobalObject] Promise<sequence<any>> testAsyncIterator(any value);
+
     // Navigation API rate limiter testing
     undefined setNavigationRateLimiterParameters(DOMWindow window, unsigned long maxNavigations, double windowDurationSeconds);
     undefined resetNavigationRateLimiter(DOMWindow window);


### PR DESCRIPTION
#### 54ca797ef49a8addfebf6271e75942ff6ca9012c
<pre>
WebCore classes should be able to iterate over a JS asynchronous iterable
<a href="https://rdar.apple.com/168664049">rdar://168664049</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306024">https://bugs.webkit.org/show_bug.cgi?id=306024</a>

Reviewed by NOBODY (OOPS!).

We implement DOMAsyncIterator which is a wrapper around a JS async iterator.
This allows WebCore code to easily manipulate iterable values, like for ReadableStream.from.
It is implemented via DOMGuarded.

Covered by added tests using new dedicated internals API.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54ca797ef49a8addfebf6271e75942ff6ca9012c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140099 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12480 "Failed to checkout and rebase branch from PR 57045") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/1610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/141972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/13192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/12633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/148248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/143049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/13192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/1610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/13192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/1610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/8531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/132073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/13192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/1610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/151036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/1610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/151036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/12180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/12633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/151036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/1610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/12208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/1610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/171372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/11950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/171372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/11995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->