### PR TITLE
WebCore classes should be able to iterate over a JS asynchronous iterable

### DIFF
--- a/LayoutTests/streams/domAsyncIterator-expected.txt
+++ b/LayoutTests/streams/domAsyncIterator-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Test asnc iterator error cases
+PASS Test async iterator from asyncIterator
+PASS Test async iterator from syncIterator
+

--- a/LayoutTests/streams/domAsyncIterator.html
+++ b/LayoutTests/streams/domAsyncIterator.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script src='../resources/testharness.js'></script>
+<script src='../resources/testharnessreport.js'></script>
+<script>
+promise_test(async t => {
+
+    return promise_rejects_js(t, TypeError, internals.testAsyncIterator(1));
+    return promise_rejects_js(t, TypeError, internals.testAsyncIterator({ }));
+
+    const error = new Error("test");
+    await promise_rejects_exactly(t, error, internals.testAsyncIterator({
+        [Symbol.asyncIterator]: () => { throw error; }
+    }));
+
+    await promise_rejects_exactly(t, error, internals.testAsyncIterator({
+        [Symbol.iterator]: () => { throw error; }
+    }));
+
+    await promise_rejects_exactly(t, error, internals.testAsyncIterator({
+        [Symbol.asyncIterator]: () => { return {
+            next() {
+                return Promise.rejects(error);
+            }
+        };}
+    }));
+}, "Test asnc iterator error cases");
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const chunks = ["a", 1];
+    const asyncIterator = {
+        next() {
+            return Promise.resolve({
+                done: chunks.length === 0,
+                value: chunks.shift()
+            });
+        }
+    };
+
+    const results = await internals.testAsyncIterator({
+        [Symbol.asyncIterator]: () => asyncIterator
+    });
+
+    assert_equals(JSON.stringify(results), '[{"done":false,"value":"a"},{"done":false,"value":1},{"done":true}]');
+}, "Test async iterator from asyncIterator");
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const results = await internals.testAsyncIterator(["a", 1]);
+
+    assert_equals(JSON.stringify(results), '[{"value":"a","done":false},{"value":1,"done":false},{"done":true}]');
+}, "Test async iterator from syncIterator");
+</script>

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -48,6 +48,7 @@ struct IterationRecord {
 };
 
 JSValue iteratorNext(JSGlobalObject*, IterationRecord, JSValue argument = JSValue());
+JS_EXPORT_PRIVATE JSValue iteratorNextExported(JSGlobalObject*, IterationRecord, JSValue argument = JSValue());
 JSValue iteratorNextWithCachedCall(JSGlobalObject*, IterationRecord, CachedCall*, JSValue argument = JSValue());
 JS_EXPORT_PRIVATE JSValue iteratorValue(JSGlobalObject*, JSValue iterResult);
 bool iteratorComplete(JSGlobalObject*, JSValue iterResult);
@@ -62,6 +63,8 @@ JS_EXPORT_PRIVATE JSValue iteratorMethod(JSGlobalObject*, JSObject*);
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSObject*, JSValue iteratorMethod);
 JS_EXPORT_PRIVATE IterationRecord iteratorForIterable(JSGlobalObject*, JSValue iterable);
 JS_EXPORT_PRIVATE IterationRecord iteratorDirect(JSGlobalObject*, JSValue);
+IterationRecord getAsyncIterator(JSGlobalObject&, JSValue);
+JS_EXPORT_PRIVATE IterationRecord getAsyncIteratorExported(JSGlobalObject&, JSValue);
 
 JS_EXPORT_PRIVATE JSValue iteratorMethod(JSGlobalObject*, JSObject*);
 JS_EXPORT_PRIVATE bool hasIteratorMethod(JSGlobalObject*, JSValue);

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -658,6 +658,7 @@ bindings/js/BindingsJSTZoneImpls.cpp
 bindings/js/CachedModuleScriptLoader.cpp
 bindings/js/CachedScriptFetcher.cpp
 bindings/js/CommonVM.cpp
+bindings/js/DOMAsyncIterator.cpp
 bindings/js/DOMGCOutputConstraint.cpp
 bindings/js/DOMWrapperWorld.cpp
 bindings/js/GarbageCollectionController.cpp

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DOMAsyncIterator.h"
+
+#include "JSDOMGlobalObjectInlines.h"
+#include "JSDOMPromise.h"
+#include <JavaScriptCore/IteratorOperations.h>
+#include <JavaScriptCore/JSPromise.h>
+#include <JavaScriptCore/TopExceptionScope.h>
+
+namespace WebCore {
+
+ExceptionOr<Ref<DOMAsyncIterator>> DOMAsyncIterator::create(JSDOMGlobalObject& globalObject, JSC::JSValue iterable)
+{
+    Ref vm = globalObject.vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto iteratorRecord = JSC::getAsyncIteratorExported(globalObject, iterable);
+    RETURN_IF_EXCEPTION(throwScope, Exception { ExceptionCode::ExistingExceptionError });
+
+    auto* iteratorObject = iteratorRecord.iterator.getObject();
+    if (!iteratorObject)
+        return Exception { ExceptionCode::TypeError, "iterator should be an object"_s };
+    if (!iteratorRecord.nextMethod.isCell())
+        return Exception { ExceptionCode::TypeError, "iterator next should be callable"_s };
+
+    return adoptRef(*new DOMAsyncIterator(globalObject, *iteratorObject, *iteratorRecord.nextMethod.asCell()));
+}
+
+void DOMAsyncIterator::handleCallbackWithPromise(JSDOMGlobalObject& globalObject, Callback&& callback, JSC::JSPromise& promise)
+{
+    bool shouldStoreCallback = DOMPromise::whenPromiseIsSettled(&globalObject, &promise, [weakThis = WeakPtr { *this }](auto* globalObject, bool isOK, auto value) {
+        if (RefPtr protectedThis = weakThis.get())
+            std::exchange(protectedThis->m_callback, { })(globalObject, isOK, value);
+    }) == DOMPromise::IsCallbackRegistered::Yes;
+
+    if (!shouldStoreCallback) {
+        callback(&globalObject, false, { });
+        return;
+    }
+
+    m_callback = WTF::move(callback);
+}
+
+void DOMAsyncIterator::callNext(Callback&& callback)
+{
+    ASSERT(!m_callback);
+    auto* globalObject = this->globalObject();
+    if (!globalObject) {
+        callback(nullptr, false, { });
+        return;
+    }
+
+    Ref vm = globalObject->vm();
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto result = JSC::iteratorNextExported(globalObject, { m_iterator->guardedObject(), guardedObject() }, { });
+    if (auto* exception = scope.exception()) {
+        scope.clearException();
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    auto* promise = JSC::JSPromise::resolvedPromise(globalObject, result);
+    if (auto* exception = scope.exception()) {
+        scope.clearException();
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    // FIXME: Is it needed?
+    if (!promise) {
+        callback(globalObject, false, { });
+        return;
+    }
+
+    handleCallbackWithPromise(*globalObject, WTF::move(callback), *promise);
+}
+
+void DOMAsyncIterator::callReturn(JSC::JSValue reason, Callback&& callback)
+{
+    ASSERT(!m_callback);
+    auto* globalObject = this->globalObject();
+    if (!globalObject) {
+        callback(nullptr, false, { });
+        return;
+    }
+
+    Ref vm = globalObject->vm();
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSC::CallData callData;
+    auto returnMethod = m_iterator->object()->getMethod(globalObject, callData, vm->propertyNames->returnKeyword, "return property should be callable"_s);
+    if (auto* exception = scope.exception()) {
+        scope.clearException();
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    if (!returnMethod || returnMethod.isUndefined()) {
+        // FIXME: We should queue a microtask to call the callback.
+        callback(globalObject, true, { });
+        return;
+    }
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(reason);
+
+    callData = JSC::getCallData(returnMethod);
+    auto result = JSC::call(globalObject, returnMethod, callData, m_iterator->guardedObject(), arguments);
+    if (auto* exception = scope.exception()) {
+        scope.clearException();
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    auto* promise = JSC::JSPromise::resolvedPromise(globalObject, result);
+    if (auto* exception = scope.exception()) {
+        scope.clearException();
+        callback(globalObject, false, exception);
+        return;
+    }
+
+    // FIXME: Is it needed?
+    if (!promise) {
+        callback(globalObject, false, { });
+        return;
+    }
+
+    handleCallbackWithPromise(*globalObject, WTF::move(callback), *promise);
+}
+
+}

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/ExceptionOr.h>
+#include <WebCore/JSDOMGuardedObject.h>
+
+namespace WebCore {
+
+class DOMAsyncIterator final : public DOMGuardedObject {
+public:
+    WEBCORE_EXPORT static ExceptionOr<Ref<DOMAsyncIterator>> create(JSDOMGlobalObject&, JSC::JSValue /* iterable */);
+    using Callback = Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>;
+    WEBCORE_EXPORT void callNext(Callback&&);
+    WEBCORE_EXPORT void callReturn(JSC::JSValue reason, Callback&&);
+
+private:
+    class IteratorObject final : public DOMGuarded<JSC::JSObject> {
+    public:
+        static Ref<IteratorObject> create(JSDOMGlobalObject& globalObject, JSC::JSObject& iterator) { return adoptRef(*new IteratorObject(globalObject, iterator)); }
+
+        JSC::JSObject* object() const { return guarded(); }
+
+    private:
+        IteratorObject(JSDOMGlobalObject& globalObject, JSC::JSObject& iterator)
+            : DOMGuarded<JSC::JSObject>(globalObject, iterator)
+        {
+        }
+    };
+
+    DOMAsyncIterator(JSDOMGlobalObject& globalObject, JSC::JSObject& iteratorObject, JSC::JSCell& method)
+        : DOMGuardedObject(globalObject, method)
+        , m_iterator(IteratorObject::create(globalObject, iteratorObject))
+    {
+    }
+
+    void handleCallbackWithPromise(JSDOMGlobalObject&, Callback&&, JSC::JSPromise&);
+
+    const Ref<IteratorObject> m_iterator;
+    Callback m_callback;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1684,6 +1684,9 @@ public:
 
     size_t fileConnectionHandleCount(const FileSystemHandle&) const;
 
+    using IteratorResultPromise = DOMPromiseDeferred<IDLSequence<IDLAny>>;
+    void testAsyncIterator(JSDOMGlobalObject&, JSC::JSValue, IteratorResultPromise&&);
+
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     MockMediaDeviceRouteController& mockMediaDeviceRouteController();
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1532,6 +1532,8 @@ enum ContentsFormat {
 
     unsigned long fileConnectionHandleCount(FileSystemHandle handle);
 
+    [CallWith=CurrentGlobalObject] Promise<sequence<any>> testAsyncIterator(any value);
+
     // Navigation API rate limiter testing
     undefined setNavigationRateLimiterParameters(DOMWindow window, unsigned long maxNavigations, double windowDurationSeconds);
     undefined resetNavigationRateLimiter(DOMWindow window);


### PR DESCRIPTION
#### d99c4d092f9d0c196bf03fa143af3ad61f7065c3
<pre>
WebCore classes should be able to iterate over a JS asynchronous iterable
<a href="https://rdar.apple.com/168664049">rdar://168664049</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306024">https://bugs.webkit.org/show_bug.cgi?id=306024</a>

Reviewed by Chris Dumez.

We implement DOMAsyncIterator which is a wrapper around a JS async iterator.
This allows WebCore code to easily manipulate iterable values, like for ReadableStream.from.
It is implemented by storing the next method directly in DOMAsyncIterator which derives from DOMGuarded and the iterator object as a separate DOMGuardedObject.
We export some new methods from JSC, while keeping existing JSC equivalents to allow LTO.

Covered by added tests using new dedicated internals API.

Canonical link: <a href="https://commits.webkit.org/306339@main">https://commits.webkit.org/306339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9903813306426b779d4155c0f2f6e62677e1b14d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93743 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1db64ba4-7f80-42e3-97b4-b32d167c26d1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107853 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78302 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e2dfa16-e8dc-4eef-a866-875fce9efb2a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8551e54-a287-48e1-93a5-77e48fa53080) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10232 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7789 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9089 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132634 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151619 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1454 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12726 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116162 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116498 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12399 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122532 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67826 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12768 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1984 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171948 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76468 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44623 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12706 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->