### PR TITLE
Relax OSRAvailability validation around phantom arguments-like objects

### DIFF
--- a/JSTests/stress/subclass-forward-varargs-rest-variadic-param-count.js
+++ b/JSTests/stress/subclass-forward-varargs-rest-variadic-param-count.js
@@ -1,0 +1,31 @@
+//@ requireOptions("--validateFTLOSRExitLiveness=true")
+
+function F(a2, ...a3) {
+    if (!new.target) { throw 'must be called with new'; }
+}
+class C extends F {
+}
+noInline(C);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    new C(1, 2, 5, 3);
+    new C(1, 2);
+    new C();
+}
+
+function F2(a, ...a2) {
+    if (!a)
+        throw a2;
+}
+class C2 extends F2 { }
+noInline(C2);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    try {
+        new C2(0, 2, 5, 3);
+    } catch { }
+    new C2(1, 2);
+    try {
+        new C2();
+    } catch { }
+}

--- a/JSTests/stress/subclass-forward-varargs-rest.js
+++ b/JSTests/stress/subclass-forward-varargs-rest.js
@@ -1,0 +1,21 @@
+//@ requireOptions("--validateFTLOSRExitLiveness=true")
+
+function F(a2, ...a3) {
+    if (!new.target) { throw 'must be called with new'; }
+}
+class C extends F {
+}
+noInline(C);
+
+for (let i = 0; i < testLoopCount; ++i)
+    new C();
+
+function F2(a, ...a2) {
+    if (a)
+        throw a2;
+}
+class C2 extends F2 { }
+noInline(C2);
+
+for (let i = 0; i < testLoopCount; ++i)
+    new C2();

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -254,7 +254,8 @@ inline KillStatus killStatusForDoesKill(bool doesKill)
 enum class PlanStage {
     Initial,
     AfterFixup,
-    LICMAndLater
+    LICMAndLater, // Inclusive of LICM
+    AfterStackLayout,
 };
 
 // If possible, this will acquire a lock to make sure that if multiple threads

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -72,6 +72,7 @@ public:
         for (BlockIndex blockIndex = 0; blockIndex < m_graph.numBlocks(); ++blockIndex)
             fixupChecksInBlock(m_graph.block(blockIndex));
 
+        ASSERT(m_graph.m_planStage < PlanStage::AfterFixup);
         m_graph.m_planStage = PlanStage::AfterFixup;
 
         return true;

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2614,6 +2614,18 @@ public:
         }
     }
 
+    bool isPhantomArgumentsAllocation()
+    {
+        switch (op()) {
+        case PhantomDirectArguments:
+        case PhantomCreateRest:
+        case PhantomClonedArguments:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     bool hasArrayModes()
     {
         switch (op()) {

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -296,7 +296,7 @@ void LocalOSRAvailabilityCalculator::executeNode(Node* node)
         if (!localAvailability.isFlushUseful() || localAvailability.flushedAt().virtualRegister() == VirtualRegister())
             return;
 
-        // In theory this is O(n) and we could have a seperate HashMap tracking Operand -> AbstractHeap's with relevant flushes. In practice, the availability heap is small (there's not usually a lot of phantom objects) so the O(n) search isn't bad.
+        // In theory this is O(n) and we could have a separate HashMap tracking Operand -> AbstractHeap's with relevant flushes. In practice, the availability heap is small (there's not usually a lot of phantom objects) so the O(n) search isn't bad.
         for (auto& heapPair : m_availability.m_heap) {
             if (heapPair.value.flushedAt().virtualRegister() == localAvailability.flushedAt().virtualRegister())
                 heapPair.value.setFlush(FlushedAt(ConflictingFlush));
@@ -347,7 +347,7 @@ void LocalOSRAvailabilityCalculator::executeNode(Node* node)
         const Vector<FlushFormat>& argumentFormats = m_graph.m_argumentFormats[entrypointIndex];
         for (unsigned argument = argumentFormats.size(); argument--; ) {
             FlushedAt flushedAt = FlushedAt(argumentFormats[argument], virtualRegisterForArgumentIncludingThis(argument));
-            m_availability.m_locals.argument(argument) = Availability(flushedAt);
+            m_availability.m_locals.argument(argument).setFlush(flushedAt);
         }
         break;
     }
@@ -359,7 +359,7 @@ void LocalOSRAvailabilityCalculator::executeNode(Node* node)
     case LoadVarargs:
     case ForwardVarargs: {
         LoadVarargsData* data = node->loadVarargsData();
-        m_availability.m_locals.operand(data->count) = Availability(FlushedAt(FlushedInt32, data->machineCount));
+        m_availability.m_locals.operand(data->count) = Availability(node->child1().node(), FlushedAt(FlushedInt32, data->machineCount));
         for (unsigned i = data->limit; i--;) {
             m_availability.m_locals.operand(data->start + i) =
                 Availability(FlushedAt(FlushedJSValue, data->machineStart.isValid() ? (data->machineStart + i) : VirtualRegister()));

--- a/Source/JavaScriptCore/dfg/DFGStackLayoutPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStackLayoutPhase.cpp
@@ -227,6 +227,8 @@ public:
             }
         }
         
+        ASSERT(m_graph.m_planStage < PlanStage::AfterStackLayout);
+        m_graph.m_planStage = PlanStage::AfterStackLayout;
         return true;
     }
 


### PR DESCRIPTION
#### 77c9af245a2e56ed14008bc4b4d2bee7ddbb4e8c
<pre>
Relax OSRAvailability validation around phantom arguments-like objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=304696">https://bugs.webkit.org/show_bug.cgi?id=304696</a>
<a href="https://rdar.apple.com/167179244">rdar://167179244</a>

Reviewed by Yusuke Suzuki.

When we added OSRAvailability validation, it was assumed that every node
would have a SSA know that it could get the recovery from. This is not
true for varargs arguments because we don&apos;t always know how many there
will be so we pass them on the stack. This change relaxes the validation
so that we can check for SSA availability for non-arguments while still
being correct for phantom arguments. To make the validation stronger,
the DFG graph now tracks whether it&apos;s done stack layout yet. After
stack layout, we validate that the stack recovery is available.

Tests: JSTests/stress/subclass-forward-varargs-rest-variadic-param-count.js
       JSTests/stress/subclass-forward-varargs-rest.js

Canonical link: <a href="https://commits.webkit.org/306033@main">https://commits.webkit.org/306033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f499f3c09c0fdb4fb42133b6c9dde7f5e56f947e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12500 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1630 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148271 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107275 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88166 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9814 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7347 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8551 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132093 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151057 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/916 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12187 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116028 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29485 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/10999 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67196 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12228 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1421 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171392 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/11970 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75926 "Built successfully") | [⏳ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->