### PR TITLE
[GFC] Introduce GridItemSizingFunctions.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -328,13 +328,15 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
     auto columnSpanList = placedGridItems.map([](const PlacedGridItem& gridItem) {
         return WTF::Range<size_t> { gridItem.columnStartLine(), gridItem.columnEndLine() };
     });
-    auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, columnSpanList, columnTrackSizingFunctionsList, layoutConstraints.inlineAxisAvailableSpace, integrationUtils);
+    auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, columnSpanList, columnTrackSizingFunctionsList, layoutConstraints.inlineAxisAvailableSpace,
+        GridLayoutUtils::inlineAxisGridItemSizingFunctions(), integrationUtils);
 
     auto rowSpanList = placedGridItems.map([](const PlacedGridItem& gridItem) {
         return WTF::Range<size_t> { gridItem.rowStartLine(), gridItem.rowEndLine() };
     });
     // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
-    auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, rowSpanList, rowTrackSizingFunctionsList, layoutConstraints.blockAxisAvailableSpace, integrationUtils);
+    auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, rowSpanList, rowTrackSizingFunctionsList, layoutConstraints.blockAxisAvailableSpace,
+        GridLayoutUtils::blockAxisGridItemSizingFunctions(), integrationUtils);
 
     // 3. Then, if the min-content contribution of any grid item has changed based on the
     // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -160,6 +160,38 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
     return endPosition - startPosition;
 }
 
+LayoutUnit inlineAxisMinContentContribution(const ElementBox& gridItem, const IntegrationUtils& integrationUtils)
+{
+    return integrationUtils.preferredMinWidth(gridItem);
+}
+
+LayoutUnit inlineAxisMaxContentContribution(const ElementBox& gridItem, const IntegrationUtils& integrationUtils)
+{
+    return integrationUtils.preferredMaxWidth(gridItem);
+}
+
+GridItemSizingFunctions inlineAxisGridItemSizingFunctions()
+{
+    return { inlineAxisMinContentContribution, inlineAxisMaxContentContribution };
+}
+
+LayoutUnit blockAxisMinContentContribution(const ElementBox&, const IntegrationUtils&)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
+LayoutUnit blockAxisMaxContentContribution(const ElementBox&, const IntegrationUtils&)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
+GridItemSizingFunctions blockAxisGridItemSizingFunctions()
+{
+    return { blockAxisMinContentContribution, blockAxisMaxContentContribution };
+}
+
 }
 }
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -32,6 +32,7 @@ class LayoutUnit;
 namespace Layout {
 
 class PlacedGridItem;
+struct GridItemSizingFunctions;
 
 namespace GridLayoutUtils {
 
@@ -42,6 +43,14 @@ LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndP
 
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSizes&, LayoutUnit gap);
+
+LayoutUnit inlineAxisMinContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
+LayoutUnit inlineAxisMaxContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
+GridItemSizingFunctions inlineAxisGridItemSizingFunctions();
+
+LayoutUnit blockAxisMinContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
+LayoutUnit blockAxisMaxContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
+GridItemSizingFunctions blockAxisGridItemSizingFunctions();
 
 } // namespace GridLayoutUtils
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -188,7 +188,7 @@ static void resolveIntrinsicTrackSizes(UnsizedTracks& unsizedTracks, const Place
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-track-sizing
-TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions, std::optional<LayoutUnit> availableSpace, const IntegrationUtils& integrationUtils)
+TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions&, const IntegrationUtils& integrationUtils)
 {
     ASSERT(gridItems.size() == gridItemSpanList.size());
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -34,9 +34,20 @@ namespace Layout {
 
 class IntegrationUtils;
 
+struct GridItemSizingFunctions {
+    GridItemSizingFunctions(Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> minContentContributionFunction, Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> maxContentContributionFunction)
+        : minContentContribution(WTF::move(minContentContributionFunction))
+        , maxContentContribution(WTF::move(maxContentContributionFunction))
+    {
+    }
+
+    Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> minContentContribution;
+    Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> maxContentContribution;
+};
+
 class TrackSizingAlgorithm {
 public:
-    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const IntegrationUtils&);
+    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions&, const IntegrationUtils&);
 
 private:
 


### PR DESCRIPTION
#### cfd340d39b1abaf102ae3e7e8566d9b17f5c684b
<pre>
[GFC] Introduce GridItemSizingFunctions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306045">https://bugs.webkit.org/show_bug.cgi?id=306045</a>
<a href="https://rdar.apple.com/problem/168686652">rdar://problem/168686652</a>

Reviewed by Alan Baradlay.

During the track sizing algorithm we may need to get different types of
sizes for a grid item depending on what they track sizing functions are.
For example, we may need to get the item&apos;s min-content contributions
when we are in the &quot;Resolve Intrinsic Track Sizes,&quot; step of the track
sizing algorithm.

Currently, the track sizing algorithm does not care about which
direction (columns vs rows) it is running and it would be nice to keep
it this way to maintain simplicity. When it comes to the size
contributions of an item, we need to know which dimension to get the
contribution from (width vs height). To be able to do this while keeping
TrackSizingAlgorithm agnostic of the direction we can allow the caller
to pass in the set of functions that will be used to get the size of the
item.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h:
(WebCore::Layout::GridItemSizingFunctions::GridItemSizingFunctions):
New struct that will be populated by the caller with the functions that
will be used to get the grid items&apos; min and max content contributions.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::performGridSizingAlgorithm):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::inlineAxisMaxContentContribution):
For the inline axis we get the min and max content contributions for
grid items using the min and max preferred widths API which is what
RenderTree currently uses (see GridTrackSizingAlgorithm).

(WebCore::Layout::GridLayoutUtils::inlineAxisGridItemSizingFunctions):
Just makes it easy to get the GridItemSizingFunctions for the inline
axis when passing it into TrackSizingAlgorithm::sizeTracks.

(WebCore::Layout::GridLayoutUtils::blockAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::blockAxisMaxContentContribution):
Empty stubs that we will implement later.
(WebCore::Layout::GridLayoutUtils::blockAxisGridItemSizingFunctions):
Same idea as the inline axis equivalent.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
Since the API for getting the min and max content contribution relies on
IntegrationUtils we need to plumb it into the TrackSizingAlgorithm.

Canonical link: <a href="https://commits.webkit.org/306234@main">https://commits.webkit.org/306234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/142ac955568301ebb871506d0e965deb743b0e33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2286 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/149120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13274 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107927 "1 flakes") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143689 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88829 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9171 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151701 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116222 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116560 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29639 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/12550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67948 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12850 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76550 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->