### PR TITLE
[iOS] ManagedMediaSource videos should fall back to an AirPlay-compatible source when a MediaDeviceRoute activates

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/remote-playback-connect-mms-fallback-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/remote-playback-connect-mms-fallback-expected.txt
@@ -1,0 +1,10 @@
+Test that a 'connect' event is dispatched when a MediaDeviceRoute activates for a video element with an MMS source and an AirPlay-compatible source.
+
+EXPECTED (video.remote.state == 'disconnected') OK
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EVENT(connect)
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/remote-playback-connect-mms-fallback.html
+++ b/LayoutTests/media/wireless-playback-media-player/remote-playback-connect-mms-fallback.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.createElement('video');
+                testExpected('video.remote.state', 'disconnected');
+
+                const mediaType = 'video/mp4';
+                const mediaURL = findMediaFile('video', '../content/test');
+                const mediaSource = new ManagedMediaSource();
+
+                const firstSource = document.createElement('source');
+                firstSource.type = mediaType;
+                firstSource.src = URL.createObjectURL(mediaSource);
+                video.appendChild(firstSource);
+
+                const secondSource = document.createElement('source');
+                secondSource.src = mediaURL;
+                secondSource.type = mediaType;
+                video.appendChild(secondSource);
+
+                await new Promise((resolve) => {
+                    mediaSource.addEventListener('sourceopen', resolve, { once: true });
+                    document.body.appendChild(video);
+                });
+
+                await new Promise((resolve) => {
+                    mediaSource.onstartstreaming = async () => {
+                        const sourceBuffer = mediaSource.addSourceBuffer(mediaType);
+                        const mediaResource = await fetch(mediaURL);
+                        const mediaBuffer = await mediaResource.arrayBuffer();
+                        sourceBuffer.addEventListener('updateend', resolve, { once: true });
+                        sourceBuffer.appendBuffer(mediaBuffer);
+                    };
+                });
+
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                const connectPromise = waitFor(video.remote, 'connect');
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+                await connectPromise;
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <p>Test that a 'connect' event is dispatched when a MediaDeviceRoute activates for a video element with an MMS source and an AirPlay-compatible source.</p> 
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7240,6 +7240,11 @@ bool HTMLMediaElement::isWirelessPlaybackTargetDisabled() const
     return m_wirelessPlaybackTargetDisabled;
 }
 
+MediaPlaybackTargetType HTMLMediaElement::playbackTargetType() const
+{
+    return protectedMediaSession()->playbackTargetType();
+}
+
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)
 
 void HTMLMediaElement::dispatchEvent(Event& event)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -490,6 +490,7 @@ public:
     void isWirelessPlaybackTargetDisabledChanged();
     bool hasTargetAvailabilityListeners();
     bool hasEnabledTargetAvailabilityListeners();
+    MediaPlaybackTargetType playbackTargetType() const final;
 #endif
 
     bool isPlayingToWirelessPlaybackTarget() const override { return m_isPlayingToWirelessTarget; };

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -32,6 +32,7 @@
 #import "MediaDeviceRoute.h"
 #import "MediaPlaybackTargetCocoa.h"
 #import "MediaPlaybackTargetWirelessPlayback.h"
+#import "MediaPlayerEnums.h"
 #import "PlatformMediaSessionManager.h"
 #import "WebCoreThreadRun.h"
 #import <AVFoundation/AVAudioSession.h>

--- a/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
@@ -27,18 +27,11 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 
+#include <WebCore/MediaPlayerEnums.h>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
-
-enum class MediaPlaybackTargetType : uint8_t {
-    None = 0,
-    AVOutputContext = 1 << 0,
-    Mock = 1 << 1,
-    WirelessPlayback = 1 << 2,
-    Serialized = 1 << 3,
-};
 
 class MediaPlaybackTarget : public ThreadSafeRefCounted<MediaPlaybackTarget> {
 public:

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -34,12 +34,12 @@
 
 namespace WebCore {
 
-Ref<MediaPlaybackTargetWirelessPlayback> MediaPlaybackTargetWirelessPlayback::create(std::optional<WTF::UUID> identifier)
+Ref<MediaPlaybackTargetWirelessPlayback> MediaPlaybackTargetWirelessPlayback::create(std::optional<WTF::UUID> identifier, bool hasActiveRoute)
 {
 #if HAVE(AVROUTING_FRAMEWORK)
-    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(MediaDeviceRouteController::singleton().routeForIdentifier(identifier)));
+    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(MediaDeviceRouteController::singleton().routeForIdentifier(identifier), hasActiveRoute));
 #else
-    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(WTF::move(identifier)));
+    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(WTF::move(identifier), hasActiveRoute));
 #endif
 }
 
@@ -47,20 +47,22 @@ Ref<MediaPlaybackTargetWirelessPlayback> MediaPlaybackTargetWirelessPlayback::cr
 
 Ref<MediaPlaybackTargetWirelessPlayback> MediaPlaybackTargetWirelessPlayback::create(MediaDeviceRoute& route)
 {
-    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(route));
+    return adoptRef(*new MediaPlaybackTargetWirelessPlayback(route, true));
 }
 
-MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&& route)
+MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&& route, bool hasActiveRoute)
     : MediaPlaybackTarget { Type::WirelessPlayback }
     , m_route { WTF::move(route) }
+    , m_hasActiveRoute { hasActiveRoute }
 {
 }
 
 #else
 
-MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback(std::optional<WTF::UUID> identifier)
+MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback(std::optional<WTF::UUID> identifier, bool hasActiveRoute)
     : MediaPlaybackTarget { Type::WirelessPlayback }
     , m_identifier { WTF::move(identifier) }
+    , m_hasActiveRoute { hasActiveRoute }
 {
 }
 
@@ -79,21 +81,21 @@ std::optional<WTF::UUID> MediaPlaybackTargetWirelessPlayback::identifier() const
 #endif
 }
 
+MediaDeviceRoute* MediaPlaybackTargetWirelessPlayback::route() const
+{
+#if HAVE(AVROUTING_FRAMEWORK)
+    return m_route.get();
+#else
+    return nil;
+#endif
+}
+
 String MediaPlaybackTargetWirelessPlayback::deviceName() const
 {
     // FIXME: provide a real device name
     if (auto identifier = this->identifier())
         return identifier->toString();
     return { };
-}
-
-bool MediaPlaybackTargetWirelessPlayback::hasActiveRoute() const
-{
-#if HAVE(AVROUTING_FRAMEWORK)
-    return !!m_route;
-#else
-    return !!m_identifier;
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -36,7 +36,7 @@ class MediaDeviceRoute;
 
 class MediaPlaybackTargetWirelessPlayback final : public MediaPlaybackTarget {
 public:
-    WEBCORE_EXPORT static Ref<MediaPlaybackTargetWirelessPlayback> create(std::optional<WTF::UUID> identifier);
+    WEBCORE_EXPORT static Ref<MediaPlaybackTargetWirelessPlayback> create(std::optional<WTF::UUID> identifier, bool hasActiveRoute);
 #if HAVE(AVROUTING_FRAMEWORK)
     static Ref<MediaPlaybackTargetWirelessPlayback> create(MediaDeviceRoute&);
 #endif
@@ -45,16 +45,18 @@ public:
 
     WEBCORE_EXPORT std::optional<WTF::UUID> identifier() const;
 
+    MediaDeviceRoute* route() const;
+
 private:
 #if HAVE(AVROUTING_FRAMEWORK)
-    explicit MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&&);
+    MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&&, bool hasActiveRoute);
 #else
-    explicit MediaPlaybackTargetWirelessPlayback(std::optional<WTF::UUID> identifier);
+    MediaPlaybackTargetWirelessPlayback(std::optional<WTF::UUID> identifier, bool hasActiveRoute);
 #endif
 
     // MediaPlaybackTarget
     String deviceName() const final;
-    bool hasActiveRoute() const final;
+    bool hasActiveRoute() const final { return m_hasActiveRoute; }
     bool supportsRemoteVideoPlayback() const final { return hasActiveRoute(); }
 
 #if HAVE(AVROUTING_FRAMEWORK)
@@ -62,6 +64,7 @@ private:
 #else
     std::optional<WTF::UUID> m_identifier;
 #endif
+    bool m_hasActiveRoute;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -257,6 +257,10 @@ private:
 
     MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const final { return identifier(); }
 
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    MediaPlaybackTargetType playbackTargetType() const final { return MediaPlaybackTargetType::None; }
+#endif
+
     class NullMediaResourceLoader final : public PlatformMediaResourceLoader {
         WTF_MAKE_TZONE_ALLOCATED_INLINE(NullMediaResourceLoader);
         void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&& completionHandler) final
@@ -607,6 +611,9 @@ CheckedPtr<const MediaPlayerFactory> MediaPlayer::nextBestMediaEngine(const Medi
     parameters.allowedMediaVideoCodecIDs = allowedMediaVideoCodecIDs();
     parameters.allowedMediaAudioCodecIDs = allowedMediaAudioCodecIDs();
     parameters.allowedMediaCaptionFormatTypes = allowedMediaCaptionFormatTypes();
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    parameters.playbackTargetType = playbackTargetType();
+#endif
 
     if (m_activeEngineIdentifier) {
         if (current)
@@ -2106,6 +2113,13 @@ void MediaPlayer::elementIdChanged(const String& id) const
     if (RefPtr playerPrivate = m_private)
         playerPrivate->elementIdChanged(id);
 }
+
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+MediaPlaybackTargetType MediaPlayer::playbackTargetType() const
+{
+    return protectedClient()->playbackTargetType();
+}
+#endif
 
 String convertEnumerationToString(MediaPlayer::ReadyState enumerationValue)
 {

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -122,6 +122,9 @@ struct MediaEngineSupportParameters {
     std::optional<Vector<FourCC>> allowedMediaVideoCodecIDs;
     std::optional<Vector<FourCC>> allowedMediaAudioCodecIDs;
     std::optional<Vector<FourCC>> allowedMediaCaptionFormatTypes;
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    MediaPlaybackTargetType playbackTargetType { MediaPlaybackTargetType::None };
+#endif
 };
 
 struct SeekTarget {
@@ -352,6 +355,10 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     virtual bool canShowWhileLocked() const { return false; }
+#endif
+
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    virtual MediaPlaybackTargetType playbackTargetType() const = 0;
 #endif
 };
 
@@ -820,6 +827,10 @@ private:
     void loadWithNextMediaEngine(const MediaPlayerFactory*);
     CheckedPtr<const MediaPlayerFactory> nextMediaEngine(const MediaPlayerFactory*);
     void reloadTimerFired();
+
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    MediaPlaybackTargetType playbackTargetType() const;
+#endif
 
     WeakPtr<MediaPlayerClient> m_client;
     Timer m_reloadTimer;

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -164,6 +164,14 @@ enum class VideoRendererPreference : uint8_t {
 };
 using VideoRendererPreferences = OptionSet<VideoRendererPreference>;
 
+enum class MediaPlaybackTargetType : uint8_t {
+    None = 0,
+    AVOutputContext = 1 << 0,
+    Mock = 1 << 1,
+    WirelessPlayback = 1 << 2,
+    Serialized = 1 << 3,
+};
+
 } // namespace WebCore
 
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -38,6 +38,8 @@
 
 namespace WebCore {
 
+class MediaPlaybackTarget;
+
 class MediaPlayerPrivateWirelessPlayback final
     : public MediaPlayerPrivateInterface
 #if !RELEASE_LOG_DISABLED
@@ -61,6 +63,7 @@ private:
 
     // MediaPlayerPrivateInterface
     constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::WirelessPlayback; }
+    void load(const String&) final;
 #if ENABLE(MEDIA_SOURCE)
     void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) final { }
 #endif
@@ -84,6 +87,20 @@ private:
     void paint(GraphicsContext&, const FloatRect&) final { }
     DestinationColorSpace colorSpace() final { return DestinationColorSpace::SRGB(); }
 
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    static OptionSet<MediaPlaybackTargetType> playbackTargetTypes();
+    String wirelessPlaybackTargetName() const final;
+    MediaPlayer::WirelessPlaybackTargetType wirelessPlaybackTargetType() const final;
+    bool wirelessVideoPlaybackDisabled() const final { return !m_allowsWirelessVideoPlayback; }
+    void setWirelessVideoPlaybackDisabled(bool disabled) final { m_allowsWirelessVideoPlayback = !disabled; }
+    OptionSet<MediaPlaybackTargetType> supportedPlaybackTargetTypes() const final;
+    bool isCurrentPlaybackTargetWireless() const final;
+    void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) final;
+    void setShouldPlayToPlaybackTarget(bool) final;
+#endif
+
+    void updateURLStringIfNeeded();
+
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper
     const Logger& logger() const final { return m_logger.get(); }
@@ -94,6 +111,12 @@ private:
 
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     PlatformTimeRanges m_buffered;
+    String m_urlString;
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    bool m_allowsWirelessVideoPlayback { true };
+    bool m_shouldPlayToTarget { false };
+    RefPtr<MediaPlaybackTarget> m_playbackTarget;
+#endif
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -311,10 +311,11 @@ private:
     bool wirelessVideoPlaybackDisabled() const final;
     void setWirelessVideoPlaybackDisabled(bool) final;
     OptionSet<MediaPlaybackTargetType> supportedPlaybackTargetTypes() const final;
+    static OptionSet<MediaPlaybackTargetType> playbackTargetTypes();
     void updateDisableExternalPlayback();
 #endif
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET) && PLATFORM(MAC)
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
     void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) final;
     void setShouldPlayToPlaybackTarget(bool) final;
 #endif
@@ -444,9 +445,11 @@ private:
 
     MemoryCompactRobinHoodHashMap<String, Ref<InbandChapterTrackPrivateAVFObjC>> m_chapterTracks;
 
-#if ENABLE(WIRELESS_PLAYBACK_TARGET) && PLATFORM(MAC)
-    RetainPtr<AVOutputContext> m_outputContext;
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
+#if PLATFORM(MAC)
+    RetainPtr<AVOutputContext> m_outputContext;
+#endif
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -184,6 +184,12 @@ MediaPlayer::SupportsType MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndC
     if (!parameters.isMediaSource)
         return MediaPlayer::SupportsType::IsNotSupported;
 
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    // This engine does not support wireless playback.
+    if (parameters.playbackTargetType != MediaPlaybackTargetType::None)
+        return MediaPlayer::SupportsType::IsNotSupported;
+#endif
+
     if (!contentTypeMeetsContainerAndCodecTypeRequirements(parameters.type, parameters.allowedMediaContainerTypes, parameters.allowedMediaCodecTypes))
         return MediaPlayer::SupportsType::IsNotSupported;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -232,6 +232,12 @@ void MediaPlayerPrivateMediaStreamAVFObjC::getSupportedTypes(HashSet<String>& ty
 
 MediaPlayer::SupportsType MediaPlayerPrivateMediaStreamAVFObjC::supportsType(const MediaEngineSupportParameters& parameters)
 {
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    // This engine does not support wireless playback.
+    if (parameters.playbackTargetType != MediaPlaybackTargetType::None)
+        return MediaPlayer::SupportsType::IsNotSupported;
+#endif
+
     return (parameters.isMediaStream && !parameters.requiresRemotePlayback) ? MediaPlayer::SupportsType::IsSupported : MediaPlayer::SupportsType::IsNotSupported;
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -151,6 +151,12 @@ MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngine
     if (parameters.isMediaSource || parameters.isMediaStream || parameters.requiresRemotePlayback)
         return MediaPlayer::SupportsType::IsNotSupported;
 
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    // This engine does not support wireless playback.
+    if (parameters.playbackTargetType != MediaPlaybackTargetType::None)
+        return MediaPlayer::SupportsType::IsNotSupported;
+#endif
+
     return SourceBufferParserWebM::isContentTypeSupported(parameters.type, parameters.supportsLimitedMatroska);
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -77,6 +77,10 @@
 #include "VideoReceiverEndpointManager.h"
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+#include <WebCore/MediaSessionHelperIOS.h>
+#endif
+
 #include <wtf/NativePromise.h>
 
 namespace WebKit {
@@ -885,6 +889,15 @@ void RemoteMediaPlayerProxy::setShouldPlayToPlaybackTarget(bool shouldPlay)
 void RemoteMediaPlayerProxy::setWirelessPlaybackTarget(MediaPlaybackTargetContextSerialized&& targetContext)
 {
     Ref { *m_player }->setWirelessPlaybackTarget(targetContext.playbackTarget());
+}
+
+MediaPlaybackTargetType RemoteMediaPlayerProxy::playbackTargetType() const
+{
+#if PLATFORM(IOS_FAMILY)
+    if (RefPtr playbackTarget = MediaSessionHelper::protectedSharedHelper()->playbackTarget())
+        return playbackTarget->type();
+#endif
+    return MediaPlaybackTargetType::None;
 }
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -197,6 +197,7 @@ public:
     void setShouldPlayToPlaybackTarget(bool);
     void setWirelessPlaybackTarget(MediaPlaybackTargetContextSerialized&&);
     void mediaPlayerCurrentPlaybackTargetIsWirelessChanged(bool) final;
+    WebCore::MediaPlaybackTargetType playbackTargetType() const final;
 #endif
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -111,7 +111,7 @@ Ref<MediaPlaybackTarget> MediaPlaybackTargetContextSerialized::playbackTarget() 
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     if (m_targetType == MediaPlaybackTargetType::WirelessPlayback)
-        return MediaPlaybackTargetWirelessPlayback::create(m_identifier);
+        return MediaPlaybackTargetWirelessPlayback::create(m_identifier, m_hasActiveRoute);
 #endif
 
     ASSERT(m_targetType == MediaPlaybackTargetType::AVOutputContext);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4512,6 +4512,9 @@ header: <WebCore/MediaPlayer.h>
     std::optional<Vector<WebCore::FourCC>> allowedMediaVideoCodecIDs;
     std::optional<Vector<WebCore::FourCC>> allowedMediaAudioCodecIDs;
     std::optional<Vector<WebCore::FourCC>> allowedMediaCaptionFormatTypes;
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    WebCore::MediaPlaybackTargetType playbackTargetType;
+#endif
 };
 
 header: <WebCore/MediaPlayer.h>

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -143,7 +143,7 @@ void WebPreferences::update()
         m_needUpdateAfterBatch = true;
         return;
     }
-        
+
     for (Ref page : m_pages)
         page->preferencesDidChange();
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp
@@ -75,7 +75,13 @@ MediaPlayerEnums::SupportsType RemoteMediaPlayerMIMETypeCache::supportsTypeAndCo
     if (parameters.type.raw().isEmpty())
         return MediaPlayerEnums::SupportsType::MayBeSupported;
 
-    SupportedTypesAndCodecsKey searchKey { parameters.type.raw(), parameters.isMediaSource, parameters.isMediaStream, parameters.requiresRemotePlayback };
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+    MediaPlaybackTargetType targetType = parameters.playbackTargetType;
+#else
+    MediaPlaybackTargetType targetType = MediaPlaybackTargetType::None;
+#endif
+
+    SupportedTypesAndCodecsKey searchKey { parameters.type.raw(), parameters.isMediaSource, parameters.isMediaStream, parameters.requiresRemotePlayback, targetType };
 
     if (m_supportsTypeAndCodecsCache) {
         auto it = m_supportsTypeAndCodecsCache->find(searchKey);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h
@@ -60,7 +60,7 @@ private:
     ThreadSafeWeakRef<RemoteMediaPlayerManager> m_manager;
     WebCore::MediaPlayerEnums::MediaEngineIdentifier m_engineIdentifier;
 
-    using SupportedTypesAndCodecsKey = std::tuple<String, bool, bool, bool>;
+    using SupportedTypesAndCodecsKey = std::tuple<String, bool, bool, bool, WebCore::MediaPlaybackTargetType>;
     std::optional<HashMap<SupportedTypesAndCodecsKey, WebCore::MediaPlayerEnums::SupportsType>> m_supportsTypeAndCodecsCache;
     HashSet<String> m_supportedTypesCache;
     bool m_hasPopulatedSupportedTypesCacheFromGPUProcess { false };


### PR DESCRIPTION
#### bbbe0dd620c3e17ee2b7c1b2be04fd449b42d4f7
<pre>
[iOS] ManagedMediaSource videos should fall back to an AirPlay-compatible source when a MediaDeviceRoute activates
<a href="https://bugs.webkit.org/show_bug.cgi?id=306052">https://bugs.webkit.org/show_bug.cgi?id=306052</a>
<a href="https://rdar.apple.com/168692949">rdar://168692949</a>

Reviewed by Jer Noble.

When a video has a ManagedMediaSource source and a MediaDeviceRoute activates, we should fall back
to an AirPlay-compatible source. This change makes it so.

Test: media/wireless-playback-media-player/remote-playback-connect-mms-fallback.html

* LayoutTests/media/wireless-playback-media-player/remote-playback-connect-mms-fallback-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/remote-playback-connect-mms-fallback.html: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::playbackTargetType const):
  Implemented to conform to MediaPlayerClient so that MediaPlayer::nextBestMediaEngine can populate
  MediaEngineSupportParameters::playbackTargetType.

* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:

* Source/WebCore/platform/graphics/MediaPlaybackTarget.h:
  Moved MediaPlaybackTargetType to MediaPlayerEnums.h so that MediaPlayer.h doesn&apos;t need to include
  MediaPlaybackTarget.h.

* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp:
(WebCore::MediaPlaybackTargetWirelessPlayback::create):
(WebCore::MediaPlaybackTargetWirelessPlayback::MediaPlaybackTargetWirelessPlayback):
(WebCore::MediaPlaybackTargetWirelessPlayback::route const):
(WebCore::MediaPlaybackTargetWirelessPlayback::hasActiveRoute const): Deleted.
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h:

* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::nextBestMediaEngine):
  Populated MediaEngineSupportParameters::playbackTargetType with the required playback target type
  from the client.

(WebCore::MediaPlayer::playbackTargetType const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
  Implemented supportsTypeAndCodecs such that MediaPlayer::SupportsType::IsSupported is returned
  iff the playback target type is WirelessPlayback.

(WebCore::MediaPlayerPrivateWirelessPlayback::load):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackTargetTypes):
(WebCore::MediaPlayerPrivateWirelessPlayback::wirelessPlaybackTargetName const):
(WebCore::MediaPlayerPrivateWirelessPlayback::wirelessPlaybackTargetType const):
(WebCore::MediaPlayerPrivateWirelessPlayback::supportedPlaybackTargetTypes const):
(WebCore::MediaPlayerPrivateWirelessPlayback::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLStringIfNeeded):
  Implemented MediaPlayerPrivateInterface methods guarded by ENABLE(WIRELESS_PLAYBACK_TARGET) and
  provided a stub implementation of MediaPlayerPrivateInterface::load.

* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::supportsTypeAndCodecs):
  Returned MediaPlayer::SupportsType::IsNotSupported if parameters.playbackTargetType is not in
  playbackTargetTypes().

(WebCore::MediaPlayerPrivateAVFoundationObjC::isCurrentPlaybackTargetWireless const):
(WebCore::externalDeviceDisplayNameForPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::wirelessPlaybackTargetName const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::supportedPlaybackTargetTypes const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::playbackTargetTypes):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setShouldPlayToPlaybackTarget):
  Modified to work properly on iOS when HAVE(AVROUTING_FRAMEWORK) is true.

(WebCore::exernalDeviceDisplayNameForPlayer):
  Fixed a typo in the function name.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::supportsTypeAndCodecs):
  Returned MediaPlayer::SupportsType::IsNotSupported if parameters.playbackTargetType is
  WirelessPlayback.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::supportsType):
  Ditto.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::supportsType):
  Ditto.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::playbackTargetType const):
  Implemented to conform to MediaPlayerClient so that MediaPlayer::nextBestMediaEngine can populate
  MediaEngineSupportParameters::playbackTargetType.

* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:
(WebKit::MediaPlaybackTargetContextSerialized::playbackTarget const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPreferences.cpp:
(WebKit::WebPreferences::update):

* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.cpp:
(WebKit::RemoteMediaPlayerMIMETypeCache::supportsTypeAndCodecs):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerMIMETypeCache.h:
  Added a WebCore::MediaPlaybackTargetType to the SupportedTypesAndCodecsKey tuple so that
  playbackTargetType can be considered when invalidating the RemoteMediaPlayer MIME type cache.

Canonical link: <a href="https://commits.webkit.org/306107@main">https://commits.webkit.org/306107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eea3c34041e0ff7511dc53738bce341584ec2dc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148526 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93245 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107470 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78072 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47ecf6b4-bc0c-49f5-b9ab-8b0064e87940) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88361 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa1de770-ee9f-4b22-a849-13a4cb958954) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9854 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7382 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8602 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151107 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115744 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116072 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29540 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11066 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67245 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12278 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1456 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->