### PR TITLE
Adopt LIFETIME_BOUND for WTF::Expected

### DIFF
--- a/Source/WTF/wtf/Expected.h
+++ b/Source/WTF/wtf/Expected.h
@@ -322,22 +322,22 @@ public:
         std::swap(base::s, o.s);
     }
 
-    constexpr const value_type* operator->() const { return &std::get<0>(base::s); }
-    value_type* operator->() { return &std::get<0>(base::s); }
-    constexpr const value_type& operator*() const & { return std::get<0>(base::s); }
-    value_type& operator*() & { return std::get<0>(base::s); }
-    constexpr const value_type&& operator*() const && { return WTF::move(std::get<0>(base::s)); }
-    constexpr value_type&& operator*() && { return WTF::move(std::get<0>(base::s)); }
+    constexpr const value_type* operator->() const LIFETIME_BOUND { return &std::get<0>(base::s); }
+    value_type* operator->() LIFETIME_BOUND { return &std::get<0>(base::s); }
+    constexpr const value_type& operator*() const & LIFETIME_BOUND { return std::get<0>(base::s); }
+    value_type& operator*() & LIFETIME_BOUND { return std::get<0>(base::s); }
+    constexpr const value_type&& operator*() const && LIFETIME_BOUND { return WTF::move(std::get<0>(base::s)); }
+    constexpr value_type&& operator*() && LIFETIME_BOUND { return WTF::move(std::get<0>(base::s)); }
     constexpr explicit operator bool() const { return has_value(); }
     constexpr bool has_value() const { return !base::s.index(); }
-    constexpr const value_type& value() const & { return std::get<0>(base::s); }
-    constexpr value_type& value() & { return std::get<0>(base::s); }
-    constexpr const value_type&& value() const && { return WTF::move(std::get<0>(base::s)); }
-    constexpr value_type&& value() && { return WTF::move(std::get<0>(base::s)); }
-    constexpr const error_type& error() const & { return std::get<1>(base::s); }
-    error_type& error() & { return std::get<1>(base::s); }
-    constexpr error_type&& error() && { return WTF::move(std::get<1>(base::s)); }
-    constexpr const error_type&& error() const && { return WTF::move(std::get<1>(base::s)); }
+    constexpr const value_type& value() const & LIFETIME_BOUND { return std::get<0>(base::s); }
+    constexpr value_type& value() & LIFETIME_BOUND { return std::get<0>(base::s); }
+    constexpr const value_type&& value() const && LIFETIME_BOUND { return WTF::move(std::get<0>(base::s)); }
+    constexpr value_type&& value() && LIFETIME_BOUND { return WTF::move(std::get<0>(base::s)); }
+    constexpr const error_type& error() const & LIFETIME_BOUND { return std::get<1>(base::s); }
+    error_type& error() & LIFETIME_BOUND { return std::get<1>(base::s); }
+    constexpr error_type&& error() && LIFETIME_BOUND { return WTF::move(std::get<1>(base::s)); }
+    constexpr const error_type&& error() const && LIFETIME_BOUND { return WTF::move(std::get<1>(base::s)); }
     template<class U> constexpr value_type value_or(U&& u) const & { return has_value() ? **this : static_cast<value_type>(std::forward<U>(u)); }
     template<class U> value_type value_or(U&& u) && { return has_value() ? WTF::move(**this) : static_cast<value_type>(std::forward<U>(u)); }
 };


### PR DESCRIPTION
#### fb63b305a9c2ea11c4a65e896eb6ceaaa33792ad
<pre>
Adopt LIFETIME_BOUND for WTF::Expected
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306043">https://bugs.webkit.org/show_bug.cgi?id=306043</a>&gt;
&lt;<a href="https://rdar.apple.com/168699050">rdar://168699050</a>&gt;

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/Expected.h:
(std::experimental::fundamentals_v3::expected::operator-&gt; const):
(std::experimental::fundamentals_v3::expected::operator-&gt;):
(std::experimental::fundamentals_v3::expected::operator* const):
(std::experimental::fundamentals_v3::expected::operator*):
(std::experimental::fundamentals_v3::expected::value const):
(std::experimental::fundamentals_v3::expected::value):
(std::experimental::fundamentals_v3::expected::error const):
(std::experimental::fundamentals_v3::expected::error):
- Add LIFETIME_BOUND to methods returning pointers or references.

Canonical link: <a href="https://commits.webkit.org/306108@main">https://commits.webkit.org/306108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/813c879d2520dcf3826dc74f2bfbffbaae4c87d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148322 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93242 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107316 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78073 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d12c5401-c909-44a1-97a3-b16bd9644aff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88205 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/606dede1-6d43-48d8-a896-9bc3d6f9fd08) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7381 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8599 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132139 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119074 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151104 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/962 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115738 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116066 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11058 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121981 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21659 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12275 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1454 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171438 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/75973 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44496 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12211 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->