### PR TITLE
AX: propagate aria-hidden state between (local) frames

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -677,7 +677,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::contents()
     if (isTabList())
         return tabChildren();
 
-    if (isScrollView()) {
+    if (isScrollArea()) {
         // A scroll view's contents are everything except the scroll bars.
         AccessibilityChildrenVector nonScrollbarChildren;
         for (const auto& child : stitchedUnignoredChildren()) {

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -632,7 +632,7 @@ public:
 
     bool isListItem() const { return role() == AccessibilityRole::ListItem; }
     bool isCheckboxOrRadio() const { return isCheckbox() || isRadioButton(); }
-    bool isScrollView() const { return role() == AccessibilityRole::ScrollArea; }
+    bool isScrollArea() const { return role() == AccessibilityRole::ScrollArea; }
     bool isCanvas() const { return role() == AccessibilityRole::Canvas; }
     bool isPopUpButton() const { return role() == AccessibilityRole::PopUpButton; }
     bool isColorWell() const { return role() == AccessibilityRole::ColorWell; }
@@ -1797,7 +1797,7 @@ inline bool AXCoreObject::isAncestorOfObject(const AXCoreObject& axObject) const
 inline AXCoreObject* AXCoreObject::axScrollView() const
 {
     return Accessibility::findAncestor(*this, true, [] (const auto& ancestor) {
-        return ancestor.isScrollView();
+        return ancestor.isScrollArea();
     });
 }
 

--- a/Source/WebCore/accessibility/AXLocalFrame.cpp
+++ b/Source/WebCore/accessibility/AXLocalFrame.cpp
@@ -27,6 +27,7 @@
 #include "AXLocalFrame.h"
 
 #include "AccessibilityObjectInlines.h"
+#include "AccessibilityScrollView.h"
 #include "LocalFrameInlines.h"
 
 namespace WebCore {
@@ -47,7 +48,18 @@ LayoutRect AXLocalFrame::elementRect() const
     return parent ? parent->elementRect() : LayoutRect();
 }
 
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+
+bool AXLocalFrame::computeIsIgnored() const
+{
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (RefPtr hostingScrollView = dynamicDowncast<AccessibilityScrollView>(parentObject()))
+        return hostingScrollView->isHostingFrameHidden();
+#endif
+    return false;
+}
+
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 
 void AXLocalFrame::setLocalFrameView(LocalFrameView* localFrameView)
 {
@@ -75,6 +87,6 @@ AccessibilityObject* AXLocalFrame::crossFrameChildObject() const
     return downcast<AccessibilityObject>(cache->rootObjectForFrame(*localFrame.get()));
 }
 
-#endif // ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXLocalFrame.h
+++ b/Source/WebCore/accessibility/AXLocalFrame.h
@@ -37,22 +37,23 @@ class AXLocalFrame final : public AccessibilityMockObject {
 public:
     static Ref<AXLocalFrame> create(AXID, AXObjectCache&);
 
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     void setLocalFrameView(LocalFrameView*);
+    LocalFrameView* localFrameView() const { return m_localFrameView.get(); }
     AccessibilityObject* crossFrameChildObject() const final;
     std::optional<FrameIdentifier> frameID() const { return m_frameID; }
-#endif // ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME)
 
 private:
     virtual ~AXLocalFrame() = default;
     explicit AXLocalFrame(AXID, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::LocalFrame; }
-    bool computeIsIgnored() const final { return false; }
+    bool computeIsIgnored() const final;
     bool isAXLocalFrame() const final { return true; }
     LayoutRect elementRect() const final;
 
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     SingleThreadWeakPtr<LocalFrameView> m_localFrameView;
     std::optional<FrameIdentifier> m_frameID { };
 #endif

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5408,7 +5408,7 @@ AccessibilityObject* AXObjectCache::rootWebArea()
     if (!m_document)
         return nullptr;
     RefPtr root = getOrCreate(m_document->view());
-    if (!root || !root->isScrollView())
+    if (!root || !root->isScrollArea())
         return nullptr;
     return root->webAreaObject();
 }
@@ -6016,5 +6016,35 @@ bool AXObjectCache::isAppleInternalInstall()
     return isInternal;
 }
 #endif // PLATFORM(COCOA)
+
+void AXObjectCache::objectBecameIgnored(const AccessibilityObject& object)
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
+        tree->objectBecameIgnored(object);
+#endif
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(object); scrollView && scrollView->role() == AccessibilityRole::FrameHost)
+        const_cast<AccessibilityScrollView*>(scrollView.get())->updateHostedFrameInheritedState();
+#endif
+#if !ENABLE(ACCESSIBILITY_ISOLATED_TREE) && !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    UNUSED_PARAM(object);
+#endif
+}
+
+void AXObjectCache::objectBecameUnignored(const AccessibilityObject& object)
+{
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
+        tree->objectBecameUnignored(object);
+#endif
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(object); scrollView && scrollView->role() == AccessibilityRole::FrameHost)
+        const_cast<AccessibilityScrollView*>(scrollView.get())->updateHostedFrameInheritedState();
+#endif
+#if !ENABLE(ACCESSIBILITY_ISOLATED_TREE) && !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    UNUSED_PARAM(object);
+#endif
+}
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -645,10 +645,8 @@ public:
     RefPtr<Page> page() const;
     IntPoint mapScreenPointToPagePoint(const IntPoint&) const;
 
-#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    inline void objectBecameIgnored(const AccessibilityObject&);
-    inline void objectBecameUnignored(const AccessibilityObject&);
-#endif
+    void objectBecameIgnored(const AccessibilityObject&);
+    void objectBecameUnignored(const AccessibilityObject&);
 
 #if PLATFORM(COCOA)
     static void setShouldRepostNotificationsForTests(bool);

--- a/Source/WebCore/accessibility/AXObjectCacheInlines.h
+++ b/Source/WebCore/accessibility/AXObjectCacheInlines.h
@@ -95,18 +95,6 @@ inline void AXObjectCache::willUpdateObjectRegions()
     m_geometryManager->willUpdateObjectRegions();
 }
 
-inline void AXObjectCache::objectBecameIgnored(const AccessibilityObject& object)
-{
-    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
-        tree->objectBecameIgnored(object);
-}
-
-inline void AXObjectCache::objectBecameUnignored(const AccessibilityObject& object)
-{
-    if (RefPtr tree = AXIsolatedTree::treeForFrameID(m_frameID))
-        tree->objectBecameUnignored(object);
-}
-
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
 } // WebCore

--- a/Source/WebCore/accessibility/AXRemoteFrame.cpp
+++ b/Source/WebCore/accessibility/AXRemoteFrame.cpp
@@ -27,6 +27,7 @@
 #include "AXRemoteFrame.h"
 
 #include "AccessibilityObjectInlines.h"
+#include "AccessibilityScrollView.h"
 
 namespace WebCore {
 
@@ -38,6 +39,15 @@ AXRemoteFrame::AXRemoteFrame(AXID axID, AXObjectCache& cache)
 Ref<AXRemoteFrame> AXRemoteFrame::create(AXID axID, AXObjectCache& cache)
 {
     return adoptRef(*new AXRemoteFrame(axID, cache));
+}
+
+bool AXRemoteFrame::computeIsIgnored() const
+{
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    if (RefPtr hostingScrollView = dynamicDowncast<AccessibilityScrollView>(parentObject()))
+        return hostingScrollView->isHostingFrameHidden();
+#endif
+    return false;
 }
 
 LayoutRect AXRemoteFrame::elementRect() const

--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -50,7 +50,7 @@ private:
     explicit AXRemoteFrame(AXID, AXObjectCache&);
 
     AccessibilityRole determineAccessibilityRole() final { return AccessibilityRole::RemoteFrame; }
-    bool computeIsIgnored() const final { return false; }
+    bool computeIsIgnored() const final;
     bool isAXRemoteFrame() const final { return true; }
     LayoutRect elementRect() const final;
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -286,7 +286,7 @@ public:
     AccessibilityObjectInclusion defaultObjectInclusion() const;
     inline bool isIgnoredByDefault() const;
     bool includeIgnoredInCoreTree() const;
-    bool isARIAHidden() const;
+    virtual bool isARIAHidden() const;
 
     bool isShowingValidationMessage() const;
     String validationMessage() const;
@@ -756,7 +756,7 @@ public:
     void mathPostscripts(AccessibilityMathMultiscriptPairs&) override { }
 
     // Visibility.
-    bool isAXHidden() const;
+    virtual bool isAXHidden() const;
     bool isRenderHidden() const;
     inline bool isHidden() const;
     bool isOnScreen() const final;

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -3176,7 +3176,7 @@ ScrollableArea* AccessibilityRenderObject::getScrollableAreaIfScrollable() const
 {
     // If the parent is a scroll view, then this object isn't really scrollable, the parent ScrollView should handle the scrolling.
     if (RefPtr parent = parentObject()) {
-        if (parent->isScrollView())
+        if (parent->isScrollArea())
             return nullptr;
     }
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -37,6 +37,22 @@ class AccessibilityScrollbar;
 class Scrollbar;
 class ScrollView;
 
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+// Visibility/hidden state from the hosting frame element.
+struct InheritedFrameState {
+    InheritedFrameState()
+        : isAXHidden(false)
+    { }
+
+    InheritedFrameState(bool isAXHidden)
+        : isAXHidden(isAXHidden)
+    { }
+
+    bool isAXHidden;
+    // FIXME: include inert and visibility state.
+};
+#endif
+
 class AccessibilityScrollView final : public AccessibilityObject {
 public:
     static Ref<AccessibilityScrollView> create(AXID, ScrollView&, AXObjectCache&);
@@ -53,9 +69,19 @@ public:
     String ownerDebugDescription() const;
     String extraDebugInfo() const final;
 
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     AccessibilityObject* crossFrameParentObject() const final;
     AccessibilityObject* crossFrameChildObject() const final;
+
+    void setInheritedFrameState(InheritedFrameState state) { m_inheritedFrameState = state; }
+    bool isAXHidden() const final;
+    bool isARIAHidden() const final;
+    void updateHostedFrameInheritedState();
+
+    // Returns true if the iframe element (or ancestors) cause the content to be hidden.
+    // We can't use isIgnored() because FrameHost scroll views are always ignored (see computeIsIgnored).
+    // FIXME: This should also consider inert and visibility.
+    bool isHostingFrameHidden() const { return isAXHidden(); }
 #endif
 
 private:
@@ -105,14 +131,20 @@ private:
     WeakPtr<HTMLFrameOwnerElement, WeakPtrImplWithEventTargetData> m_frameOwnerElement;
     RefPtr<AccessibilityObject> m_horizontalScrollbar;
     RefPtr<AccessibilityObject> m_verticalScrollbar;
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     RefPtr<AXLocalFrame> m_localFrame;
+    InheritedFrameState m_inheritedFrameState;
 #endif
     RefPtr<AXRemoteFrame> m_remoteFrame;
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityScrollView) \
-    static bool isType(const WebCore::AccessibilityObject& object) { return object.isAccessibilityScrollViewInstance(); } \
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::AccessibilityScrollView)
+    static bool isType(const WebCore::AccessibilityObject& object) { return object.isAccessibilityScrollViewInstance(); }
+    static bool isType(const WebCore::AXCoreObject& object)
+    {
+        auto* accessibilityObject = dynamicDowncast<WebCore::AccessibilityObject>(object);
+        return accessibilityObject && accessibilityObject->isAccessibilityScrollViewInstance();
+    }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -53,7 +53,7 @@ void AXObjectCache::platformPerformDeferredCacheUpdate()
 
         auto* axParent = axObject.parentObjectUnignored();
         if (!axParent) {
-            if (axObject.isScrollView() && document() && axObject.scrollView() == document()->view())
+            if (axObject.isScrollArea() && document() && axObject.scrollView() == document()->view())
                 wrapper->setParent(nullptr); // nullptr means root.
             return;
         }

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -969,7 +969,7 @@ bool AccessibilityObjectAtspi::scrollToMakeVisible(int startOffset, int endOffse
 
     IntRect rect = m_coreObject->doAXBoundsForRange(CharacterRange(utf16StartOffset, utf16EndOffset - utf16StartOffset));
 
-    if (m_coreObject->isScrollView()) {
+    if (m_coreObject->isScrollArea()) {
         if (auto* parent = m_coreObject->parentObject())
             parent->scrollToMakeVisible();
     }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1869,7 +1869,7 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
         return nil;
 
     // The only object without a parent wrapper at this point should be a scroll view.
-    AX_ASSERT(self.axBackingObject->isScrollView());
+    AX_ASSERT(self.axBackingObject->isScrollArea());
 
     // Verify this is the top document. If not, we might need to go through the platform widget.
     auto* frameView = self.axBackingObject->documentFrameView();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -117,7 +117,7 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
 {
     AX_ASSERT(isMainThread());
     AX_ASSERT(!axRoot.isDetached());
-    AX_ASSERT(axRoot.isScrollView() && !axRoot.parentObject());
+    AX_ASSERT(axRoot.isScrollArea() && !axRoot.parentObject());
 
     // An empty content tree consists only of the ScrollView and WebArea objects.
     m_isEmptyContentTree = true;
@@ -1977,7 +1977,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::InputType, *inputType);
 
         bool isWebArea = axObject->isWebArea();
-        bool isScrollArea = axObject->isScrollView();
+        bool isScrollArea = axObject->isScrollArea();
         if (isScrollArea && !axObject->parentObject()) {
             // Eagerly cache the screen relative position for the root. AXIsolatedObject::screenRelativePosition()
             // of non-root objects depend on the root object's screen relative position, so make sure it's there

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -85,7 +85,7 @@ void appendPlatformProperties(AXPropertyVector& properties, OptionSet<AXProperty
         setProperty(AXProperty::CaretBrowsingEnabled, object->caretBrowsingEnabled());
     }
 
-    if (object->isScrollView()) {
+    if (object->isScrollArea()) {
         setProperty(AXProperty::PlatformWidget, RetainPtr(object->platformWidget()));
         setProperty(AXProperty::RemoteParent, object->remoteParent());
     }
@@ -115,7 +115,7 @@ AttributedStringStyle AXIsolatedObject::stylesForAttributedString() const
 RetainPtr<RemoteAXObjectRef> AXIsolatedObject::remoteParent() const
 {
     RefPtr scrollView = Accessibility::findAncestor<AXCoreObject>(*this, true, [] (const AXCoreObject& object) {
-        return object.isScrollView();
+        return object.isScrollArea();
     });
     RefPtr isolatedObject = dynamicDowncast<AXIsolatedObject>(scrollView);
     return isolatedObject ? isolatedObject->propertyValue<RetainPtr<id>>(AXProperty::RemoteParent) : nil;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -950,7 +950,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         objectAttributes = groupAttrs.get().get();
     else if (backingObject->isTabList())
         objectAttributes = tabListAttrs.get().get();
-    else if (backingObject->isScrollView())
+    else if (backingObject->isScrollArea())
         objectAttributes = scrollViewAttrs.get().get();
     else if (backingObject->isSpinButton()) {
         if (backingObject->spinButtonType() == SpinButtonType::Composite)
@@ -1101,7 +1101,7 @@ static NSArray *transformSpecialChildrenCases(AXCoreObject& backingObject, const
 
 static NSArray *children(AXCoreObject& backingObject)
 {
-    const auto& unignoredChildren = backingObject.stitchedUnignoredChildren();
+    const auto& unignoredChildren = backingObject.crossFrameUnignoredChildren();
     RetainPtr<NSArray> specialChildren = transformSpecialChildrenCases(backingObject, unignoredChildren);
     if ([specialChildren count])
         return specialChildren.unsafeGet();
@@ -1155,7 +1155,7 @@ static RetainPtr<NSString> roleDescription(AXCoreObject& backingObject)
 
 static id scrollViewParent(AXCoreObject& axObject)
 {
-    if (!axObject.isScrollView())
+    if (!axObject.isScrollArea())
         return nil;
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
@@ -2452,7 +2452,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (frameView) {
         // Find the appropriate scroll view to convert the coordinates to window space.
         RefPtr axScrollView = Accessibility::findAncestor(*backingObject, false, [] (const auto& ancestor) {
-            return ancestor.isScrollView() && ancestor.scrollView();
+            return ancestor.isScrollArea() && ancestor.scrollView();
         });
 
         if (RefPtr scrollView = axScrollView ? axScrollView->scrollView() : nullptr) {
@@ -3678,7 +3678,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!backingObject)
         return nil;
 
-    const auto& unignoredChildren = backingObject->stitchedUnignoredChildren();
+    const auto& unignoredChildren = backingObject->crossFrameUnignoredChildren();
     if (unignoredChildren.isEmpty()) {
         RetainPtr<NSArray> children = transformSpecialChildrenCases(*backingObject, unignoredChildren);
         if (!children)


### PR DESCRIPTION
#### bb58abdbbee5c361b465e1e99bc0eb921281f3f1
<pre>
AX: propagate aria-hidden state between (local) frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=306057">https://bugs.webkit.org/show_bug.cgi?id=306057</a>
<a href="https://rdar.apple.com/168699629">rdar://168699629</a>

Reviewed by Tyler Wilcock.

This patch lays the groundwork for propagating the aria-hidden state of an iframe to its
hosted frame/children, which live in a separate cache when ENABLE_ACCESSIBILITY_LOCAL_FRAME
is enabled. To do this, whenever the aria-hidden state of the FrameHost changes, we send
an update to the child frame (via its cache and root) so that it can store this state and
inherit it when computing isIgnored, despite being in a different AXObjectCache.

The above can happen with a direct call between caches for local frames. But, with site
isolation (and remote frames), this will need to happen via IPC. I have left comments in
the code where this needs to happen, and will follow up with a patch to implement those
messages.

This work is covered by the existing test, accessibility/mac/iframe-aria-hidden.html, which
passes after this PR with and without isolated tree mode enabled.

Since this patch doesn&apos;t implement support for inert and visibility propagation, tests
that involve those properties will become broken (accessibility/iframe-content-inert.html
and accessibility/iframe-content-visibility.html) only when the
ENABLE_ACCESSIBILITY_LOCAL_FRAME flag is set to 1. But, those will be resolved by follow-
up patches.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::contents):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isScrollArea const):
(WebCore::AXCoreObject::axScrollView const):
(WebCore::AXCoreObject::isScrollView const): Deleted.
* Source/WebCore/accessibility/AXLocalFrame.cpp:
(WebCore::AXLocalFrame::computeIsIgnored const):
* Source/WebCore/accessibility/AXLocalFrame.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::rootWebArea):
(WebCore::AXObjectCache::objectBecameIgnored):
(WebCore::AXObjectCache::objectBecameUnignored):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXObjectCacheInlines.h:
(WebCore::AXObjectCache::objectBecameIgnored): Deleted.
(WebCore::AXObjectCache::objectBecameUnignored): Deleted.
* Source/WebCore/accessibility/AXRemoteFrame.cpp:
(WebCore::AXRemoteFrame::computeIsIgnored const):
* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::language const):
(WebCore::AccessibilityObject::scrollToMakeVisible const):
(WebCore::AccessibilityObject::scrollToMakeVisibleWithSubFocus const):
(WebCore::AccessibilityObject::scrollToGlobalPoint const):
(WebCore::AccessibilityObject::isIgnoredWithoutCache const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::getScrollableAreaIfScrollable const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::isRoot const):
(WebCore::AccessibilityScrollView::updateScrollbars):
(WebCore::AccessibilityScrollView::determineAccessibilityRole):
(WebCore::AccessibilityScrollView::computeIsIgnored const):
(WebCore::AccessibilityScrollView::addLocalFrameChild):
(WebCore::AccessibilityScrollView::addRemoteFrameChild):
(WebCore::AccessibilityScrollView::addChildren):
(WebCore::AccessibilityScrollView::parentObject const):
(WebCore::AccessibilityScrollView::isAXHidden const):
(WebCore::AccessibilityScrollView::isARIAHidden const):
(WebCore::AccessibilityScrollView::updateHostedFrameInheritedState):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
(WebCore::InheritedFrameState::InheritedFrameState):
(isType):
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::platformPerformDeferredCacheUpdate):
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::scrollToMakeVisible const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityContainer]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::appendPlatformProperties):
(WebCore::AXIsolatedObject::remoteParent const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):
(children):
(scrollViewParent):
(-[WebAccessibilityObjectWrapper _accessibilityShowContextMenu]):
(-[WebAccessibilityObjectWrapper _accessibilityChildrenFromIndex:maxCount:returnPlatformElements:]):

Canonical link: <a href="https://commits.webkit.org/306210@main">https://commits.webkit.org/306210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/746d62a98f7f208398fe8fdf016a7cccb5f3a77f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93782 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7231c614-e83b-4e27-95f0-08fe79eba12d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107895 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/393a81c8-b40b-47c1-bc73-93305ae72bf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88796 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5630235e-c397-4e50-bffe-beb584d019a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7827 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9128 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151658 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116193 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116530 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29629 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12478 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67890 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12807 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12591 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->