### PR TITLE
[MacOS release] inspector/canvas/setRecordingAutoCaptureFrameCount.html is a flakey text failure

### DIFF
--- a/LayoutTests/inspector/canvas/setRecordingAutoCaptureFrameCount.html
+++ b/LayoutTests/inspector/canvas/setRecordingAutoCaptureFrameCount.html
@@ -21,9 +21,11 @@ function performActions(frames) {
         if (index < frames.length)
             requestAnimationFrameId = requestAnimationFrame(executeFrameFunction);
         else {
-            setTimeout(() => {
-                TestPage.dispatchEventToFrontend("LastFrame");
-            }, 0);
+            requestAnimationFrame(() => {
+                setTimeout(() => {
+                    TestPage.dispatchEventToFrontend("LastFrame");
+                }, 50);
+            });
         }
     };
     executeFrameFunction();
@@ -87,6 +89,11 @@ function test() {
 
                 InspectorTest.awaitEvent("LastFrame")
                 .then((event) => {
+                    return new Promise((resolveAfterDispatches) => {
+                        InspectorBackend.runAfterPendingDispatches(resolveAfterDispatches);
+                    });
+                })
+                .then(() => {
                     canvas.removeEventListener(WI.Canvas.Event.RecordingStarted, handleRecordingStartedWrapper);
                     canvas.removeEventListener(WI.Canvas.Event.RecordingStopped, handleRecordingStoppedWrapper);
 


### PR DESCRIPTION
#### 327e3ead94d53a33da280c3f8788e2fd938cd0a2
<pre>
[MacOS release] inspector/canvas/setRecordingAutoCaptureFrameCount.html is a flakey text failure
<a href="https://rdar.apple.com/168693902">rdar://168693902</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306053">https://bugs.webkit.org/show_bug.cgi?id=306053</a>

Reviewed by BJ Burg.

Addresses test failure by fixing potential timing issue in test case with the following changes:

  1. Ensuring a full animation frame completes before dispatching the &quot;LastFrame&quot; event (with a 50ms buffer)
  2. Using InspectorBackend.runAfterPendingDispatches() to guarantee all backend messages are processed before checking canvas state

  Both fixes work together to eliminate the race condition that was causing intermittent failures in both the 2D and WebGL test cases.

* LayoutTests/inspector/canvas/setRecordingAutoCaptureFrameCount.html:

Canonical link: <a href="https://commits.webkit.org/307521@main">https://commits.webkit.org/307521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4f90f69e00325618914c06319e06a79a0833c1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93253 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107465 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7386 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151115 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12245 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115745 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116073 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30661 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11083 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121988 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67253 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12286 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1460 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12028 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->