### PR TITLE
[JSC] Account for user code to arguments in Array.from

### DIFF
--- a/JSTests/stress/array-from-arguments-overwritten-length.js
+++ b/JSTests/stress/array-from-arguments-overwritten-length.js
@@ -1,0 +1,41 @@
+function testArgumentsWriteLength(...xs) {
+    arguments.length = 65535;
+    let a = Array.from(arguments);
+    if (a.length !== 65535)
+        throw new Error("wrong array length");
+}
+
+function testArgumentsCursedIndexedGetter(...xs) {
+    let getterCalled = false;
+    // This test should come after all others because it modifies Object.prototype
+    Object.defineProperty(Object.prototype, 3, { get() {
+        getterCalled = true;
+        return -42;
+    }, enumerable: true });
+    arguments.length = 65535;
+    let a = Array.from(arguments);
+    if (a.length !== 65535)
+        throw new Error("wrong array length");
+    if (!getterCalled || a[3] !== -42)
+        throw new Error("wrong array value");
+}
+
+function testArgumentsCursedIndexedGetterThrows(...xs) {
+    Object.defineProperty(Object.prototype, 4, { get() {
+        throw -43;
+    }, enumerable: true });
+    arguments.length = 65535;
+    let caughtException;
+    try {
+        Array.from(arguments);
+    } catch (e) {
+        caughtException = e;
+    }
+    if (caughtException !== -43)
+        throw new Error("didn't throw");
+}
+
+
+testArgumentsWriteLength({});
+testArgumentsCursedIndexedGetter({});
+testArgumentsCursedIndexedGetterThrows({});


### PR DESCRIPTION
#### 877adec845ec625cc1a090f159e101dbea4c7144
<pre>
[JSC] Account for user code to arguments in Array.from
<a href="https://bugs.webkit.org/show_bug.cgi?id=306000">https://bugs.webkit.org/show_bug.cgi?id=306000</a>
<a href="https://rdar.apple.com/168635038">rdar://168635038</a>

Reviewed by Sosuke Suzuki and Yusuke Suzuki.

Arguments objects in JS are array-like, so there is no guarantee that .length
implies a backing store of that size, and that indexed getters won&apos;t be called,
even when the iterator protocol isn&apos;t user modified.

This PR makes the optimized version of Array.from for arguments robust to user
modification to fall back to generic get().

Test: JSTests/stress/array-from-arguments-overwritten-length.js
Canonical link: <a href="https://commits.webkit.org/306050@main">https://commits.webkit.org/306050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a21ef66a5ad24b76bc0530dbbf2751b56eb5f75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148346 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12722 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88219 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7392 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8620 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132160 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151125 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/983 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115754 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29494 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11073 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/121997 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12296 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171459 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/75994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12082 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->