### PR TITLE
[ macOS wk2 Release ] 3 imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-00*.html are flaky failures.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html
@@ -24,6 +24,11 @@
   requestAnimationFrame(()=> {
     requestAnimationFrame(()=> {
       target.focus();
+      requestAnimationFrame(()=> {
+        requestAnimationFrame(()=> {
+          takeScreenshot();
+        });
+      });
     });
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html
@@ -25,6 +25,11 @@
   requestAnimationFrame(()=> {
     requestAnimationFrame(()=> {
       target.focus();
+      requestAnimationFrame(()=> {
+        requestAnimationFrame(()=> {
+          takeScreenshot();
+        })
+      })
     });
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html
@@ -27,6 +27,11 @@
   requestAnimationFrame(()=> {
     requestAnimationFrame(()=> {
       target.focus();
+      requestAnimationFrame(()=> {
+        requestAnimationFrame(()=> {
+          takeScreenshot();
+        })
+      })
     });
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html
@@ -28,6 +28,11 @@
   requestAnimationFrame(()=> {
     requestAnimationFrame(()=> {
       target.focus();
+      requestAnimationFrame(()=> {
+        requestAnimationFrame(()=> {
+          takeScreenshot();
+        })
+      })
     });
   });
 </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2047,11 +2047,6 @@ webkit.org/b/289211 [ Sequoia Release x86_64 ] imported/w3c/web-platform-tests/m
 
 webkit.org/b/289284 fast/canvas/image-buffer-resource-limits.html [ Pass Timeout Crash ]
 
-# webkit.org/b/289298 [ macOS wk2 Release ] 3x imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-00*.html are flaky failures.
-[ Release ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html [ Pass Failure ]
-[ Release ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html [ Pass Failure ]
-[ Release ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html [ Pass Failure ]
-
 webkit.org/b/289370 [ Debug arm64 ] media/video-webm-seek-singlekeyframe.html [ Pass Failure ]
 
 webkit.org/b/289487 [ Sequoia Release x86_64 ] fast/webgpu/nocrash/RenderBundle_WRITE.html [ Pass Timeout ]
@@ -2165,8 +2160,6 @@ webkit.org/b/295938 scrollingcoordinator/mac/latching/horizontal-overflow-back-s
 webkit.org/b/296017 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-021.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/296066 [ Sequoia Debug arm64 ] accessibility/mac/scrolling-in-pdf-crash.html [ Pass Timeout ]
-
-webkit.org/b/295929 [ Release ] imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/296101 [ Release ] imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-012.html [ Pass ImageOnlyFailure ]
 


### PR DESCRIPTION
#### 47e0139d9c335adca00d7f1ad51e97f0637515dd
<pre>
[ macOS wk2 Release ] 3 imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-00*.html are flaky failures.
<a href="https://rdar.apple.com/146433875">rdar://146433875</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289298">https://bugs.webkit.org/show_bug.cgi?id=289298</a>

Reviewed by NOBODY (OOPS!).

This is a test issue caused by timing. Added &quot;reftest-wait&quot; to the &lt;html&gt; tag and
added an additional requestAnimationFrame after target.focus() to ensure style recalculation completion
and called takeScreenshot() to signal when the test harness should capture an image.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-004.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47e0139d9c335adca00d7f1ad51e97f0637515dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101872 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114435 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81519 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95205 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15769 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13596 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159459 "Built successfully") | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12693 "Exiting early after 10 failures. 17 tests run. 4 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122478 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122700 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20935 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132987 "Exiting early after 10 failures. 16 tests run. 4 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77087 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18076 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9737 "Exiting early after 10 failures. 10 tests run. 1 flakes 3 failures") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20543 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20420 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->