### PR TITLE
Changing flow-tolerance in Web Inspector doesn't trigger relayout for display: grid-lanes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-expected.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: flow-tolerance dynamic update triggers relayout (reference)</title>
+  <style>
+    html, body {
+      color: black;
+      background-color: white;
+      padding: 0;
+      margin: 0;
+    }
+
+    .grid {
+      display: inline-grid-lanes;
+      grid-template-rows: repeat(2, 100px);
+      gap: 10px;
+      border: 1px solid;
+      padding: 2px;
+    }
+
+    .item {
+      background-color: #444;
+      color: #fff;
+      padding: 10px;
+      margin: 3px;
+      border: 2px solid blue;
+    }
+  </style>
+</head>
+<body>
+
+<p>Test passes if the grid items are arranged in round-robin order (blue/green in first row, orange/red in second row).</p>
+
+<!--
+  With flow-tolerance: infinite, items are placed in strict round-robin
+  order across rows:
+  Item 1 (blue) -> Row 1 Col 1
+  Item 2 (orange) -> Row 2 Col 1
+  Item 3 (green) -> Row 1 Col 2
+  Item 4 (red) -> Row 2 Col 2
+-->
+<div class="grid">
+  <div class="item" style="width: 100px; background: blue; grid-row: 1; grid-column: 1;"></div>
+  <div class="item" style="width: 50px; background: orange; grid-row: 2; grid-column: 1;"></div>
+  <div class="item" style="width: 50px; background: green; grid-row: 1; grid-column: 2;"></div>
+  <div class="item" style="width: 100px; background: red; grid-row: 2; grid-column: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: flow-tolerance dynamic update triggers relayout (reference)</title>
+  <style>
+    html, body {
+      color: black;
+      background-color: white;
+      padding: 0;
+      margin: 0;
+    }
+
+    .grid {
+      display: inline-grid-lanes;
+      grid-template-rows: repeat(2, 100px);
+      gap: 10px;
+      border: 1px solid;
+      padding: 2px;
+    }
+
+    .item {
+      background-color: #444;
+      color: #fff;
+      padding: 10px;
+      margin: 3px;
+      border: 2px solid blue;
+    }
+  </style>
+</head>
+<body>
+
+<p>Test passes if the grid items are arranged in round-robin order (blue/green in first row, orange/red in second row).</p>
+
+<!--
+  With flow-tolerance: infinite, items are placed in strict round-robin
+  order across rows:
+  Item 1 (blue) -> Row 1 Col 1
+  Item 2 (orange) -> Row 2 Col 1
+  Item 3 (green) -> Row 1 Col 2
+  Item 4 (red) -> Row 2 Col 2
+-->
+<div class="grid">
+  <div class="item" style="width: 100px; background: blue; grid-row: 1; grid-column: 1;"></div>
+  <div class="item" style="width: 50px; background: orange; grid-row: 2; grid-column: 1;"></div>
+  <div class="item" style="width: 50px; background: green; grid-row: 1; grid-column: 2;"></div>
+  <div class="item" style="width: 100px; background: red; grid-row: 2; grid-column: 2;"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html
@@ -1,0 +1,57 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Grid Test: flow-tolerance dynamic update triggers relayout</title>
+  <link rel="author" title="Apple Inc.">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#placement-tolerance">
+  <link rel="match" href="flow-tolerance-dynamic-update-ref.html">
+  <style>
+    html, body {
+      color: black;
+      background-color: white;
+      padding: 0;
+      margin: 0;
+    }
+
+    .grid-lanes {
+      display: inline-grid-lanes;
+      grid-template-rows: repeat(2, 100px);
+      gap: 10px;
+      flow-tolerance: normal;
+      border: 1px solid;
+      padding: 2px;
+    }
+
+    .item {
+      background-color: #444;
+      color: #fff;
+      padding: 10px;
+      margin: 3px;
+      border: 2px solid blue;
+    }
+  </style>
+</head>
+<body>
+
+<p>Test passes if the grid items are arranged in round-robin order (blue/green in first row, orange/red in second row).</p>
+
+<div class="grid-lanes" id="grid">
+  <div class="item" style="width: 100px; background: blue;"></div>
+  <div class="item" style="width: 50px; background: orange;"></div>
+  <div class="item" style="width: 50px; background: green;"></div>
+  <div class="item" style="width: 100px; background: red;"></div>
+</div>
+
+<script>
+  window.onload = function() {
+    // Start with normal tolerance, then change to infinite.
+    // With infinite tolerance, items are placed strictly in round-robin order.
+    // If layout is properly invalidated, items will reflow to match the reference.
+    const grid = document.getElementById("grid");
+    grid.style.flowTolerance = "infinite";
+  };
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -5225,7 +5225,7 @@
                 "infinite"
             ],
             "codegen-properties": {
-                "computed-style-storage-path": ["m_nonInheritedData", "rareData"],
+                "computed-style-storage-path": ["m_nonInheritedData", "rareData", "grid"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::FlowTolerance",
                 "parser-grammar": "normal | <length-percentage> | infinite"

--- a/Source/WebCore/style/computed/data/StyleGridData.cpp
+++ b/Source/WebCore/style/computed/data/StyleGridData.cpp
@@ -44,6 +44,7 @@ GridData::GridData()
     , gridTemplateAreas(ComputedStyle::initialGridTemplateAreas())
     , gridTemplateColumns(ComputedStyle::initialGridTemplateColumns())
     , gridTemplateRows(ComputedStyle::initialGridTemplateRows())
+    , flowTolerance(ComputedStyle::initialFlowTolerance())
 {
 }
 
@@ -55,6 +56,7 @@ inline GridData::GridData(const GridData& o)
     , gridTemplateAreas(o.gridTemplateAreas)
     , gridTemplateColumns(o.gridTemplateColumns)
     , gridTemplateRows(o.gridTemplateRows)
+    , flowTolerance(o.flowTolerance)
 {
 }
 
@@ -65,7 +67,8 @@ bool GridData::operator==(const GridData& o) const
         && gridAutoRows == o.gridAutoRows
         && gridTemplateAreas == o.gridTemplateAreas
         && gridTemplateColumns == o.gridTemplateColumns
-        && gridTemplateRows == o.gridTemplateRows;
+        && gridTemplateRows == o.gridTemplateRows
+        && flowTolerance == o.flowTolerance;
 }
 
 Ref<GridData> GridData::copy() const
@@ -82,6 +85,7 @@ void GridData::dumpDifferences(TextStream& ts, const GridData& other) const
     LOG_IF_DIFFERENT(gridTemplateAreas);
     LOG_IF_DIFFERENT(gridTemplateColumns);
     LOG_IF_DIFFERENT(gridTemplateRows);
+    LOG_IF_DIFFERENT(flowTolerance);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/style/computed/data/StyleGridData.h
+++ b/Source/WebCore/style/computed/data/StyleGridData.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <WebCore/StyleFlowTolerance.h>
 #include <WebCore/StyleGridAutoFlow.h>
 #include <WebCore/StyleGridTemplateAreas.h>
 #include <WebCore/StyleGridTemplateList.h>
@@ -55,6 +56,7 @@ public:
     GridTemplateAreas gridTemplateAreas;
     GridTemplateList gridTemplateColumns;
     GridTemplateList gridTemplateRows;
+    FlowTolerance flowTolerance;
 
 private:
     GridData();

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -73,7 +73,6 @@ NonInheritedRareData::NonInheritedRareData()
     , viewTransitionName(ComputedStyle::initialViewTransitionName())
     , columnGap(ComputedStyle::initialColumnGap())
     , rowGap(ComputedStyle::initialRowGap())
-    , flowTolerance(ComputedStyle::initialFlowTolerance())
     , offsetPath(ComputedStyle::initialOffsetPath())
     , offsetDistance(ComputedStyle::initialOffsetDistance())
     , offsetPosition(ComputedStyle::initialOffsetPosition())
@@ -184,7 +183,6 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , viewTransitionName(o.viewTransitionName)
     , columnGap(o.columnGap)
     , rowGap(o.rowGap)
-    , flowTolerance(o.flowTolerance)
     , offsetPath(o.offsetPath)
     , offsetDistance(o.offsetDistance)
     , offsetPosition(o.offsetPosition)
@@ -301,7 +299,6 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && containerNames == o.containerNames
         && columnGap == o.columnGap
         && rowGap == o.rowGap
-        && flowTolerance == o.flowTolerance
         && offsetPath == o.offsetPath
         && offsetDistance == o.offsetDistance
         && offsetPosition == o.offsetPosition
@@ -451,7 +448,6 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
 
     LOG_IF_DIFFERENT(columnGap);
     LOG_IF_DIFFERENT(rowGap);
-    LOG_IF_DIFFERENT(flowTolerance);
 
     LOG_IF_DIFFERENT(offsetPath);
     LOG_IF_DIFFERENT(offsetDistance);

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -38,7 +38,6 @@
 #include <WebCore/StyleCounterIncrement.h>
 #include <WebCore/StyleCounterReset.h>
 #include <WebCore/StyleCounterSet.h>
-#include <WebCore/StyleFlowTolerance.h>
 #include <WebCore/StyleGapGutter.h>
 #include <WebCore/StyleMarginTrim.h>
 #include <WebCore/StyleMaskBorder.h>
@@ -175,8 +174,6 @@ public:
 
     GapGutter columnGap;
     GapGutter rowGap;
-
-    FlowTolerance flowTolerance;
 
     OffsetPath offsetPath;
     OffsetDistance offsetDistance;


### PR DESCRIPTION
#### 4b7904bbcb5825b6cfeb802a48d52728d74df5c0
<pre>
Changing flow-tolerance in Web Inspector doesn&apos;t trigger relayout for display: grid-lanes
<a href="https://bugs.webkit.org/show_bug.cgi?id=306068">https://bugs.webkit.org/show_bug.cgi?id=306068</a>
<a href="https://rdar.apple.com/problem/168711707">rdar://problem/168711707</a>

Reviewed by Sammy Gill and Tim Nguyen.

The flow-tolerance CSS property was stored directly in NonInheritedRareData,
but rareDataChangeRequiresLayout only checked for changes to the grid and
gridItem DataRefs. This meant changes to flow-tolerance weren&apos;t detected as
requiring layout.

Move flow-tolerance into GridData alongside the other grid container properties.
This ensures changes to flow-tolerance are detected by the existing
`a.grid != b.grid` check in rareDataChangeRequiresLayout.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/computed/data/StyleGridData.cpp:
(WebCore::Style::GridData::GridData):
(WebCore::Style::GridData::operator== const):
(WebCore::Style::GridData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleGridData.h:
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp:
(WebCore::Style::NonInheritedRareData::NonInheritedRareData):
(WebCore::Style::NonInheritedRareData::operator== const):
(WebCore::Style::NonInheritedRareData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:

Canonical link: <a href="https://commits.webkit.org/306093@main">https://commits.webkit.org/306093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920ba9da68703fa6898569d4829463f73b1987bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148646 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12861 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10337 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88460 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9959 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8759 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119197 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151272 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12395 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116202 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29530 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/11328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12438 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12178 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12376 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->