### PR TITLE
[Navigation API] Fix order of setting interception state in NavigateEvent::intercept()

### DIFF
--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -103,6 +103,8 @@ ExceptionOr<void> NavigateEvent::intercept(Document& document, NavigationInterce
 
     ASSERT(!m_interceptionState || m_interceptionState == InterceptionState::Intercepted);
 
+    m_interceptionState = InterceptionState::Intercepted;
+
     if (options.handler)
         m_handlers.append(options.handler.releaseNonNull());
 
@@ -115,8 +117,6 @@ ExceptionOr<void> NavigateEvent::intercept(Document& document, NavigationInterce
         // FIXME: Print warning to console if it was already set.
         m_scrollBehavior = options.scroll;
     }
-
-    m_interceptionState = InterceptionState::Intercepted;
 
     return { };
 }


### PR DESCRIPTION
#### 8a90f367b487b2c8f5c20448a96331742cf00a81
<pre>
[Navigation API] Fix order of setting interception state in NavigateEvent::intercept()
<a href="https://bugs.webkit.org/show_bug.cgi?id=306073">https://bugs.webkit.org/show_bug.cgi?id=306073</a>
<a href="https://rdar.apple.com/168715747">rdar://168715747</a>

Reviewed by Basuke Suzuki.

According to the spec, setting the interception state to &quot;intercepted&quot; is
step 6. Right now it&apos;s happening much later. So we fix this ordering.
(<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept).">https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept).</a>

This change is tested by existing WPT Navigation API layout tests.

* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::intercept):

Canonical link: <a href="https://commits.webkit.org/306111@main">https://commits.webkit.org/306111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fddce2f1f507dede6447ce654c7e35b2d5b02efb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93290 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d6b4d0e-db33-49b3-a860-09ae235735c1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13307 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107512 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78091 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88405 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb8a7e89-17f5-4b05-bb6c-d9f297bd89f3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9876 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7416 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151153 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12283 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115770 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116101 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11104 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122007 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67290 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21662 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12323 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1479 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12065 "Hash fddce2f1 for PR 57085 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12259 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->