### PR TITLE
ThreadSafeRefCounted should support relaxed ref/derefs

### DIFF
--- a/Source/JavaScriptCore/API/OpaqueJSString.h
+++ b/Source/JavaScriptCore/API/OpaqueJSString.h
@@ -69,8 +69,6 @@ struct OpaqueJSString : public ThreadSafeRefCounted<OpaqueJSString> {
     static bool equal(const OpaqueJSString*, const OpaqueJSString*);
 
 private:
-    friend class WTF::ThreadSafeRefCounted<OpaqueJSString>;
-
     OpaqueJSString()
         : m_characters(nullptr)
     {

--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
@@ -50,7 +50,7 @@ class RemoteControllableTarget;
 typedef Vector<Function<void ()>> RemoteTargetQueue;
 #endif
 
-class RemoteConnectionToTarget final : public ThreadSafeRefCounted<RemoteConnectionToTarget>, public FrontendChannel {
+class RemoteConnectionToTarget final : public DeprecatedThreadSafeRefCountedSeqCst<RemoteConnectionToTarget>, public FrontendChannel {
 public:
 #if PLATFORM(COCOA)
     RemoteConnectionToTarget(RemoteControllableTarget*, NSString* connectionIdentifier, NSString* destination);

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
@@ -40,7 +40,7 @@ OBJC_CLASS NSString;
 
 namespace Inspector {
 
-class RemoteInspectorXPCConnection : public ThreadSafeRefCounted<RemoteInspectorXPCConnection> {
+class RemoteInspectorXPCConnection : public DeprecatedThreadSafeRefCountedSeqCst<RemoteInspectorXPCConnection> {
 public:
     class Client {
     public:

--- a/Source/JavaScriptCore/runtime/Watchdog.h
+++ b/Source/JavaScriptCore/runtime/Watchdog.h
@@ -37,7 +37,7 @@ class CallFrame;
 class JSGlobalObject;
 class VM;
 
-class Watchdog : public ThreadSafeRefCounted<Watchdog> {
+class Watchdog : public DeprecatedThreadSafeRefCountedSeqCst<Watchdog> {
     WTF_MAKE_TZONE_ALLOCATED(Watchdog);
 public:
     class Scope;

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -69,7 +69,7 @@ namespace WTF {
 
 class AutomaticThread;
 
-class AutomaticThreadCondition : public ThreadSafeRefCounted<AutomaticThreadCondition> {
+class AutomaticThreadCondition : public DeprecatedThreadSafeRefCountedSeqCst<AutomaticThreadCondition> {
 public:
     static WTF_EXPORT_PRIVATE Ref<AutomaticThreadCondition> create();
     
@@ -99,7 +99,7 @@ private:
     Vector<CheckedPtr<AutomaticThread>> m_threads;
 };
 
-class WTF_EXPORT_PRIVATE AutomaticThread : public ThreadSafeRefCounted<AutomaticThread>, public CanMakeThreadSafeCheckedPtr<AutomaticThread> {
+class WTF_EXPORT_PRIVATE AutomaticThread : public DeprecatedThreadSafeRefCountedSeqCst<AutomaticThread>, public CanMakeThreadSafeCheckedPtr<AutomaticThread> {
     WTF_MAKE_TZONE_ALLOCATED(AutomaticThread);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AutomaticThread);
 public:

--- a/Source/WTF/wtf/CallbackAggregator.h
+++ b/Source/WTF/wtf/CallbackAggregator.h
@@ -34,7 +34,7 @@
 namespace WTF {
 
 template <DestructionThread destructionThread>
-class CallbackAggregatorOnThread : public ThreadSafeRefCounted<CallbackAggregatorOnThread<destructionThread>, destructionThread> {
+class CallbackAggregatorOnThread : public DeprecatedThreadSafeRefCountedSeqCst<CallbackAggregatorOnThread<destructionThread>, destructionThread> {
 public:
     static auto create(CompletionHandler<void()>&& callback) { return adoptRef(*new CallbackAggregatorOnThread(WTF::move(callback))); }
 
@@ -70,7 +70,7 @@ using MainRunLoopCallbackAggregator = CallbackAggregatorOnThread<DestructionThre
 
 template<typename> class EagerCallbackAggregator;
 template <typename Out, typename... In>
-class EagerCallbackAggregator<Out(In...)> : public ThreadSafeRefCounted<EagerCallbackAggregator<Out(In...)>> {
+class EagerCallbackAggregator<Out(In...)> : public DeprecatedThreadSafeRefCountedSeqCst<EagerCallbackAggregator<Out(In...)>> {
 public:
     template<typename CallableType>
         requires (std::is_rvalue_reference_v<CallableType&&>)
@@ -106,7 +106,7 @@ private:
 
 // Waits for all bool completions and resolves to true only if all succeed.
 template <DestructionThread destructionThread>
-class SuccessCallbackAggregatorOnThread : public ThreadSafeRefCounted<SuccessCallbackAggregatorOnThread<destructionThread>, destructionThread> {
+class SuccessCallbackAggregatorOnThread : public DeprecatedThreadSafeRefCountedSeqCst<SuccessCallbackAggregatorOnThread<destructionThread>, destructionThread> {
 public:
     static auto create(CompletionHandler<void(bool)>&& callback) { return adoptRef(*new SuccessCallbackAggregatorOnThread(WTF::move(callback))); }
 

--- a/Source/WTF/wtf/CrossThreadCopier.cpp
+++ b/Source/WTF/wtf/CrossThreadCopier.cpp
@@ -37,7 +37,7 @@ namespace WTF {
 // Test CrossThreadCopier using static_assert.
 
 // Verify that ThreadSafeRefCounted objects get handled correctly.
-class CopierThreadSafeRefCountedTest : public ThreadSafeRefCounted<CopierThreadSafeRefCountedTest> {
+class CopierThreadSafeRefCountedTest : public DeprecatedThreadSafeRefCountedSeqCst<CopierThreadSafeRefCountedTest> {
 };
 
 static_assert((std::is_same<RefPtr<CopierThreadSafeRefCountedTest>, CrossThreadCopier<RefPtr<CopierThreadSafeRefCountedTest>>::Type>::value), "RefPtrTest");

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -131,7 +131,7 @@ struct ConsoleLogValue<Argument, false> {
 WTF_EXPORT_PRIVATE extern Lock loggerObserverLock;
 WTF_EXPORT_PRIVATE extern Lock messageHandlerLoggerObserverLock;
 
-class Logger : public ThreadSafeRefCounted<Logger> {
+class Logger : public DeprecatedThreadSafeRefCountedSeqCst<Logger> {
     WTF_MAKE_NONCOPYABLE(Logger);
 public:
     virtual ~Logger() { }

--- a/Source/WTF/wtf/MetaAllocatorHandle.h
+++ b/Source/WTF/wtf/MetaAllocatorHandle.h
@@ -39,7 +39,7 @@ namespace WTF {
 class MetaAllocator;
 class PrintStream;
 
-class MetaAllocatorHandle final : public ThreadSafeRefCounted<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::ThreadSafeNode {
+class MetaAllocatorHandle final : public DeprecatedThreadSafeRefCountedSeqCst<MetaAllocatorHandle>, public RedBlackTree<MetaAllocatorHandle, void*>::ThreadSafeNode {
     WTF_MAKE_COMPACT_TZONE_ALLOCATED(MetaAllocatorHandle);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MetaAllocatorHandle);
 public:

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -198,7 +198,7 @@ namespace WTF {
  *
  * struct PhotoSettings { };
  *
- * class PhotoProducer : public ThreadSafeRefCounted<PhotoProducer> {
+ * class PhotoProducer : public DeprecatedThreadSafeRefCountedSeqCst<PhotoProducer> {
  * public:
  *    using PhotoPromise = NativePromise<std::pair<Vector<uint8_t>, String>, int>;
  *    static Ref<PhotoProducer> create(const PhotoSettings& settings) { return adoptRef(*new PhotoProducer(settings)); }
@@ -250,7 +250,7 @@ namespace WTF {
  * For additional examples on how to use NativePromise, refer to NativePromise.cpp API tests.
  */
 
-class NativePromiseBase : public ThreadSafeRefCounted<NativePromiseBase>  {
+class NativePromiseBase : public DeprecatedThreadSafeRefCountedSeqCst<NativePromiseBase>  {
 public:
     virtual void assertIsDead() = 0;
     virtual ~NativePromiseBase() = default;
@@ -290,7 +290,7 @@ public:
         ASSERT(!m_callback, "complete() or disconnect() wasn't called");
     }
 
-    class Callback : public ThreadSafeRefCounted<Callback> {
+    class Callback : public DeprecatedThreadSafeRefCountedSeqCst<Callback> {
     public:
         virtual ~Callback() = default;
         virtual void disconnect() = 0;
@@ -546,7 +546,7 @@ private:
     // We can't move the Result object with non-exclusive promise.
     using ResultParam = std::conditional_t<IsExclusive, Result&&, const Result&>;
 
-    class AllPromiseProducer : public ThreadSafeRefCounted<AllPromiseProducer> {
+    class AllPromiseProducer : public DeprecatedThreadSafeRefCountedSeqCst<AllPromiseProducer> {
     public:
         explicit AllPromiseProducer(size_t dependentPromisesCount)
             : m_producer(makeUnique<typename AllPromiseType::Producer>())
@@ -610,7 +610,7 @@ private:
         size_t m_outstandingPromises WTF_GUARDED_BY_LOCK(m_lock);
     };
 
-    class AllSettledPromiseProducer : public ThreadSafeRefCounted<AllSettledPromiseProducer> {
+    class AllSettledPromiseProducer : public DeprecatedThreadSafeRefCountedSeqCst<AllSettledPromiseProducer> {
     public:
         explicit AllSettledPromiseProducer(size_t dependentPromisesCount)
             : m_producer(makeUnique<typename AllSettledPromiseType::Producer>())
@@ -1232,7 +1232,7 @@ private:
         struct NoResult { };
 
         using StorageType = Variant<NoResult, Result, ResultRunnable>;
-        struct RefCountedResult : ThreadSafeRefCounted<RefCountedResult> {
+        struct RefCountedResult : DeprecatedThreadSafeRefCountedSeqCst<RefCountedResult> {
             StorageType result = NoResult { };
         };
         using ResultType = std::conditional_t<IsExclusive, StorageType, Ref<RefCountedResult>>;

--- a/Source/WTF/wtf/ParallelHelperPool.h
+++ b/Source/WTF/wtf/ParallelHelperPool.h
@@ -66,7 +66,7 @@ class AutomaticThreadCondition;
 
 class ParallelHelperClient;
 
-class ParallelHelperPool final : public ThreadSafeRefCounted<ParallelHelperPool>, public CanMakeThreadSafeCheckedPtr<ParallelHelperPool> {
+class ParallelHelperPool final : public DeprecatedThreadSafeRefCountedSeqCst<ParallelHelperPool>, public CanMakeThreadSafeCheckedPtr<ParallelHelperPool> {
     WTF_MAKE_TZONE_ALLOCATED(ParallelHelperPool);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ParallelHelperPool);
 public:

--- a/Source/WTF/wtf/RefCountable.h
+++ b/Source/WTF/wtf/RefCountable.h
@@ -37,7 +37,7 @@ namespace WTF {
 // FIXME: becomes largely unnecessary once rdar://162361370 is fixed in Swift/C++
 // interop.
 template<typename T>
-class RefCountable : public ThreadSafeRefCounted<RefCountable<T>> {
+class RefCountable : public DeprecatedThreadSafeRefCountedSeqCst<RefCountable<T>> {
 public:
     template<typename... Arguments>
     static Ref<RefCountable> create(Arguments&&... arguments)
@@ -56,12 +56,12 @@ public:
     // type hierarchy.
     void ref() const
     {
-        ThreadSafeRefCounted<RefCountable<T>>::ref();
+        DeprecatedThreadSafeRefCountedSeqCst<RefCountable<T>>::ref();
     }
 
     void deref() const
     {
-        ThreadSafeRefCounted<RefCountable<T>>::deref();
+        DeprecatedThreadSafeRefCountedSeqCst<RefCountable<T>>::deref();
     }
 #endif
 

--- a/Source/WTF/wtf/RefCountedFixedVector.h
+++ b/Source/WTF/wtf/RefCountedFixedVector.h
@@ -34,7 +34,7 @@
 namespace WTF {
 
 template<typename T, bool isThreadSafe>
-class RefCountedFixedVectorBase final : public std::conditional<isThreadSafe, ThreadSafeRefCounted<RefCountedFixedVectorBase<T, isThreadSafe>>, RefCounted<RefCountedFixedVectorBase<T, isThreadSafe>>>::type, public TrailingArray<RefCountedFixedVectorBase<T, isThreadSafe>, T> {
+class RefCountedFixedVectorBase final : public std::conditional<isThreadSafe, DeprecatedThreadSafeRefCountedSeqCst<RefCountedFixedVectorBase<T, isThreadSafe>>, RefCounted<RefCountedFixedVectorBase<T, isThreadSafe>>>::type, public TrailingArray<RefCountedFixedVectorBase<T, isThreadSafe>, T> {
 public:
     using Base = TrailingArray<RefCountedFixedVectorBase<T, isThreadSafe>, T>;
 

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -264,7 +264,7 @@ public:
         Function<void()> m_function;
     };
 
-    class DispatchTimer final : public TimerBase, public ThreadSafeRefCounted<DispatchTimer> {
+    class DispatchTimer final : public TimerBase, public DeprecatedThreadSafeRefCountedSeqCst<DispatchTimer> {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DispatchTimer);
     public:
         DispatchTimer(RunLoop& runLoop)

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -40,7 +40,7 @@ OBJC_CLASS NSRunLoop;
 
 namespace WTF {
 
-class SchedulePair : public ThreadSafeRefCounted<SchedulePair> {
+class SchedulePair : public DeprecatedThreadSafeRefCountedSeqCst<SchedulePair> {
 public:
     static Ref<SchedulePair> create(CFRunLoopRef runLoop, CFStringRef mode) { return adoptRef(*new SchedulePair(runLoop, mode)); }
 

--- a/Source/WTF/wtf/SharedTask.h
+++ b/Source/WTF/wtf/SharedTask.h
@@ -59,7 +59,7 @@ namespace WTF {
 // state is shared between instances of the task.
 template<typename FunctionType> class SharedTask;
 template<typename PassedResultType, typename... ArgumentTypes>
-class SharedTask<PassedResultType (ArgumentTypes...)> : public ThreadSafeRefCounted<SharedTask<PassedResultType (ArgumentTypes...)>> {
+class SharedTask<PassedResultType(ArgumentTypes...)> : public DeprecatedThreadSafeRefCountedSeqCst<SharedTask<PassedResultType(ArgumentTypes...)>> {
 public:
     typedef PassedResultType ResultType;
     

--- a/Source/WTF/wtf/SynchronizedFixedQueue.h
+++ b/Source/WTF/wtf/SynchronizedFixedQueue.h
@@ -33,7 +33,7 @@
 namespace WTF {
 
 template<typename T, size_t BufferSize>
-class SynchronizedFixedQueue final : public ThreadSafeRefCounted<SynchronizedFixedQueue<T, BufferSize>> {
+class SynchronizedFixedQueue final : public DeprecatedThreadSafeRefCountedSeqCst<SynchronizedFixedQueue<T, BufferSize>> {
 public:
     static Ref<SynchronizedFixedQueue> create()
     {

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -147,7 +147,7 @@ uint32_t ThreadLike::currentSequence()
     return Thread::currentSingleton().uid();
 }
 
-struct Thread::NewThreadContext : public ThreadSafeRefCounted<NewThreadContext> {
+struct Thread::NewThreadContext : public DeprecatedThreadSafeRefCountedSeqCst<NewThreadContext> {
 public:
     NewThreadContext(ASCIILiteral name, Function<void()>&& entryPoint, Ref<Thread>&& thread)
         : name(name)

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -111,7 +111,7 @@ public:
     friend class ThreadGroup;
     friend WTF_EXPORT_PRIVATE void initialize();
 
-    class ClientData : public ThreadSafeRefCounted<ClientData> {
+    class ClientData : public DeprecatedThreadSafeRefCountedSeqCst<ClientData> {
     public:
         virtual ~ClientData() = default;
 

--- a/Source/WTF/wtf/WeakPtrImpl.h
+++ b/Source/WTF/wtf/WeakPtrImpl.h
@@ -37,7 +37,7 @@ namespace WTF {
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(WeakPtrImplBase);
 
 template<typename Derived>
-class WeakPtrImplBase : public ThreadSafeRefCounted<Derived> {
+class WeakPtrImplBase : public DeprecatedThreadSafeRefCountedSeqCst<Derived> {
     WTF_MAKE_NONCOPYABLE(WeakPtrImplBase);
     WTF_DEPRECATED_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(WeakPtrImplBase, WeakPtrImplBase);
 public:

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -118,7 +118,7 @@ private:
  * A ConcurrentWorkQueue unlike a WorkQueue doesn't guarantee the order in which the dispatched runnable will run
  * and each can run concurrently on different threads.
  */
-class WTF_EXPORT_PRIVATE ConcurrentWorkQueue final : public WorkQueueBase, public FunctionDispatcher, public ThreadSafeRefCounted<ConcurrentWorkQueue> {
+class WTF_EXPORT_PRIVATE ConcurrentWorkQueue final : public WorkQueueBase, public FunctionDispatcher, public DeprecatedThreadSafeRefCountedSeqCst<ConcurrentWorkQueue> {
 public:
     static Ref<ConcurrentWorkQueue> create(ASCIILiteral name, QOS = QOS::Default);
     static void apply(size_t iterations, WTF::Function<void(size_t index)>&&);
@@ -133,12 +133,12 @@ private:
 
 inline void ConcurrentWorkQueue::ref() const
 {
-    ThreadSafeRefCounted<ConcurrentWorkQueue>::ref();
+    DeprecatedThreadSafeRefCountedSeqCst<ConcurrentWorkQueue>::ref();
 }
 
 inline void ConcurrentWorkQueue::deref() const
 {
-    ThreadSafeRefCounted<ConcurrentWorkQueue>::deref();
+    DeprecatedThreadSafeRefCountedSeqCst<ConcurrentWorkQueue>::deref();
 }
 
 }

--- a/Source/WTF/wtf/WorkerPool.h
+++ b/Source/WTF/wtf/WorkerPool.h
@@ -36,7 +36,7 @@
 
 namespace WTF {
 
-class WorkerPool final : public ThreadSafeRefCounted<WorkerPool>, public CanMakeThreadSafeCheckedPtr<WorkerPool> {
+class WorkerPool final : public DeprecatedThreadSafeRefCountedSeqCst<WorkerPool>, public CanMakeThreadSafeCheckedPtr<WorkerPool> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerPool);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerPool);
 public:

--- a/Source/WTF/wtf/generic/RunLoopGeneric.cpp
+++ b/Source/WTF/wtf/generic/RunLoopGeneric.cpp
@@ -36,7 +36,7 @@ namespace WTF {
 
 static constexpr bool report = false;
 
-class RunLoop::TimerBase::ScheduledTask final : public ThreadSafeRefCounted<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::ThreadSafeNode {
+class RunLoop::TimerBase::ScheduledTask final : public DeprecatedThreadSafeRefCountedSeqCst<ScheduledTask>, public RedBlackTree<ScheduledTask, MonotonicTime>::ThreadSafeNode {
     WTF_MAKE_TZONE_ALLOCATED(ScheduledTask);
     WTF_MAKE_NONCOPYABLE(ScheduledTask);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScheduledTask);

--- a/Source/WTF/wtf/glib/ActivityObserver.h
+++ b/Source/WTF/wtf/glib/ActivityObserver.h
@@ -28,7 +28,7 @@
 namespace WTF {
 
 // Activity observers (used to implement WebCore::RunLoopObserver)
-class ActivityObserver : public ThreadSafeRefCounted<ActivityObserver> {
+class ActivityObserver : public DeprecatedThreadSafeRefCountedSeqCst<ActivityObserver> {
     WTF_MAKE_TZONE_ALLOCATED(ActivityObserver);
 public:
     using Callback = Function<void()>;

--- a/Source/WebCore/Modules/cache/CacheStorageConnection.h
+++ b/Source/WebCore/Modules/cache/CacheStorageConnection.h
@@ -38,7 +38,7 @@ namespace WebCore {
 struct ClientOrigin;
 class FetchResponse;
 
-class CacheStorageConnection : public ThreadSafeRefCounted<CacheStorageConnection> {
+class CacheStorageConnection : public DeprecatedThreadSafeRefCountedSeqCst<CacheStorageConnection> {
 public:
     virtual ~CacheStorageConnection() = default;
 

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -70,7 +70,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CookieStore);
 
-class CookieStore::MainThreadBridge : public ThreadSafeRefCounted<MainThreadBridge, WTF::DestructionThread::Main> {
+class CookieStore::MainThreadBridge : public DeprecatedThreadSafeRefCountedSeqCst<MainThreadBridge, WTF::DestructionThread::Main> {
 public:
     static Ref<MainThreadBridge> create(CookieStore& cookieStore)
     {

--- a/Source/WebCore/Modules/filesystem/FileSystemHandleCloseScope.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandleCloseScope.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class FileSystemHandleCloseScope : public ThreadSafeRefCounted<FileSystemHandleCloseScope, WTF::DestructionThread::MainRunLoop> {
+class FileSystemHandleCloseScope : public DeprecatedThreadSafeRefCountedSeqCst<FileSystemHandleCloseScope, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<FileSystemHandleCloseScope> create(FileSystemHandleIdentifier identifier, bool isDirectory, FileSystemStorageConnection& connection)
     {

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
@@ -46,7 +46,7 @@ class FileSystemSyncAccessHandle;
 class FileSystemWritableFileStream;
 template<typename> class ExceptionOr;
 
-class FileSystemStorageConnection : public ThreadSafeRefCounted<FileSystemStorageConnection> {
+class FileSystemStorageConnection : public DeprecatedThreadSafeRefCountedSeqCst<FileSystemStorageConnection> {
 public:
     virtual ~FileSystemStorageConnection() { }
 

--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
@@ -42,7 +42,7 @@ namespace IDBClient {
 class IDBConnectionProxy;
 }
 
-class IDBDatabaseNameAndVersionRequest final : public ThreadSafeRefCounted<IDBDatabaseNameAndVersionRequest>, public IDBActiveDOMObject {
+class IDBDatabaseNameAndVersionRequest final : public DeprecatedThreadSafeRefCountedSeqCst<IDBDatabaseNameAndVersionRequest>, public IDBActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IDBDatabaseNameAndVersionRequest, WEBCORE_EXPORT);
 public:
     using InfoCallback = Function<void(std::optional<Vector<IDBDatabaseNameAndVersion>>&&)>;

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.h
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.h
@@ -50,7 +50,7 @@ namespace IDBClient {
 class IDBConnectionProxy;
 }
 
-class IDBFactory : public ThreadSafeRefCounted<IDBFactory> {
+class IDBFactory : public DeprecatedThreadSafeRefCountedSeqCst<IDBFactory> {
     WTF_MAKE_TZONE_ALLOCATED(IDBFactory);
 public:
     static Ref<IDBFactory> create(IDBClient::IDBConnectionProxy&);

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -65,7 +65,7 @@ class IDBConnectionProxy;
 class IDBConnectionToServer;
 }
 
-class IDBRequest : public EventTarget, public IDBActiveDOMObject, public ThreadSafeRefCounted<IDBRequest> {
+class IDBRequest : public EventTarget, public IDBActiveDOMObject, public DeprecatedThreadSafeRefCountedSeqCst<IDBRequest> {
     WTF_MAKE_TZONE_ALLOCATED(IDBRequest);
 public:
     enum class NullResultType {

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -67,7 +67,7 @@ class IDBConnectionProxy;
 class TransactionOperation;
 }
 
-class IDBTransaction final : public ThreadSafeRefCounted<IDBTransaction>, public EventTarget, public IDBActiveDOMObject {
+class IDBTransaction final : public DeprecatedThreadSafeRefCountedSeqCst<IDBTransaction>, public EventTarget, public IDBActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IDBTransaction, WEBCORE_EXPORT);
 public:
     static Ref<IDBTransaction> create(IDBDatabase&, const IDBTransactionInfo&);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -59,7 +59,7 @@ struct IDBIterateCursorData;
 
 namespace IDBClient {
 
-class IDBConnectionToServer final : public ThreadSafeRefCounted<IDBConnectionToServer>, public CanMakeThreadSafeCheckedPtr<IDBConnectionToServer> {
+class IDBConnectionToServer final : public DeprecatedThreadSafeRefCountedSeqCst<IDBConnectionToServer>, public CanMakeThreadSafeCheckedPtr<IDBConnectionToServer> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IDBConnectionToServer, WEBCORE_EXPORT);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBConnectionToServer);
 public:

--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
@@ -49,7 +49,7 @@ enum class IndexRecordType : bool;
 
 namespace IDBClient {
 
-class TransactionOperation : public ThreadSafeRefCounted<TransactionOperation> {
+class TransactionOperation : public DeprecatedThreadSafeRefCountedSeqCst<TransactionOperation> {
     WTF_MAKE_TZONE_ALLOCATED(TransactionOperation);
     friend IDBRequestData::IDBRequestData(TransactionOperation&);
 public:

--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaSourceHandle);
 
-class MediaSourceHandle::SharedPrivate final : public ThreadSafeRefCounted<SharedPrivate> {
+class MediaSourceHandle::SharedPrivate final : public DeprecatedThreadSafeRefCountedSeqCst<SharedPrivate> {
 public:
     static Ref<SharedPrivate> create(MediaSource& mediaSource, MediaSourceHandle::DispatcherType&& dispatcher) { return adoptRef(*new SharedPrivate(mediaSource, WTF::move(dispatcher))); }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -140,7 +140,7 @@ private:
         const unsigned short m_maxVideoFramesCount { 1 };
     };
 
-    class VideoFrameObserverWrapper : public ThreadSafeRefCounted<VideoFrameObserverWrapper, WTF::DestructionThread::Main> {
+    class VideoFrameObserverWrapper : public DeprecatedThreadSafeRefCountedSeqCst<VideoFrameObserverWrapper, WTF::DestructionThread::Main> {
     public:
         static Ref<VideoFrameObserverWrapper> create(ScriptExecutionContextIdentifier, MediaStreamTrackProcessor&, Ref<RealtimeMediaSource>&&, unsigned short maxVideoFramesCount);
 

--- a/Source/WebCore/Modules/mediastream/RTCNetworkManager.h
+++ b/Source/WebCore/Modules/mediastream/RTCNetworkManager.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class RTCNetworkManager : public ThreadSafeRefCounted<RTCNetworkManager, WTF::DestructionThread::MainRunLoop> {
+class RTCNetworkManager : public DeprecatedThreadSafeRefCountedSeqCst<RTCNetworkManager, WTF::DestructionThread::MainRunLoop> {
 public:
     virtual ~RTCNetworkManager() = default;
     virtual void close() = 0;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
@@ -39,7 +39,7 @@ class CryptoKey;
 
 template<typename> class ExceptionOr;
 
-class RTCRtpSFrameTransformer : public ThreadSafeRefCounted<RTCRtpSFrameTransformer, WTF::DestructionThread::Main> {
+class RTCRtpSFrameTransformer : public DeprecatedThreadSafeRefCountedSeqCst<RTCRtpSFrameTransformer, WTF::DestructionThread::Main> {
 public:
     enum class CompatibilityMode : uint8_t { None, H264, VP8 };
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.h
@@ -43,7 +43,7 @@ class RTCRtpTransformBackend;
 class Worker;
 
 class RTCRtpScriptTransform final
-    : public ThreadSafeRefCounted<RTCRtpScriptTransform, WTF::DestructionThread::Main>
+    : public DeprecatedThreadSafeRefCountedSeqCst<RTCRtpScriptTransform, WTF::DestructionThread::Main>
     , public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(RTCRtpScriptTransform);
 public:

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransformBackend.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class Exception;
 class RTCRtpTransformableFrame;
 
-class RTCRtpTransformBackend : public ThreadSafeRefCounted<RTCRtpTransformBackend, WTF::DestructionThread::Main> {
+class RTCRtpTransformBackend : public DeprecatedThreadSafeRefCountedSeqCst<RTCRtpTransformBackend, WTF::DestructionThread::Main> {
 public:
     virtual ~RTCRtpTransformBackend() = default;
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransformableFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransformableFrame.h
@@ -59,7 +59,7 @@ struct RTCEncodedVideoFrameMetadata {
 };
 
 class RTCRtpScriptTransformer;
-class RTCRtpTransformableFrame : public ThreadSafeRefCounted<RTCRtpTransformableFrame> {
+class RTCRtpTransformableFrame : public DeprecatedThreadSafeRefCountedSeqCst<RTCRtpTransformableFrame> {
 public:
     virtual ~RTCRtpTransformableFrame() = default;
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 GST_DEBUG_CATEGORY(webkit_webrtc_dtls_transport_debug);
 #define GST_CAT_DEFAULT webkit_webrtc_dtls_transport_debug
 
-class GStreamerDtlsTransportBackendObserver final : public ThreadSafeRefCounted<GStreamerDtlsTransportBackendObserver> {
+class GStreamerDtlsTransportBackendObserver final : public DeprecatedThreadSafeRefCountedSeqCst<GStreamerDtlsTransportBackendObserver> {
     WTF_MAKE_NONCOPYABLE(GStreamerDtlsTransportBackendObserver);
 public:
     static Ref<GStreamerDtlsTransportBackendObserver> create(RTCDtlsTransportBackendClient& client, GRefPtr<GstWebRTCDTLSTransport>&& backend) { return adoptRef(*new GStreamerDtlsTransportBackendObserver(client, WTF::move(backend))); }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -351,7 +351,7 @@ RTCStatsReport::VideoSourceStats::VideoSourceStats(const GstStructure* structure
 {
 }
 
-struct ReportHolder : public ThreadSafeRefCounted<ReportHolder> {
+struct ReportHolder : public DeprecatedThreadSafeRefCountedSeqCst<ReportHolder> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(ReportHolder);
     WTF_MAKE_NONCOPYABLE(ReportHolder);
 public:

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class RTCStatsReport;
 
-class GStreamerStatsCollector : public ThreadSafeRefCounted<GStreamerStatsCollector, WTF::DestructionThread::Main> {
+class GStreamerStatsCollector : public DeprecatedThreadSafeRefCountedSeqCst<GStreamerStatsCollector, WTF::DestructionThread::Main> {
 public:
     static Ref<GStreamerStatsCollector> create() { return adoptRef(*new GStreamerStatsCollector()); }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -316,7 +316,7 @@ std::optional<Ref<RTCCertificate>> generateCertificate(Ref<SecurityOrigin>&&, co
 
 bool sdpMediaHasAttributeKey(const GstSDPMedia*, ASCIILiteral key);
 
-class UniqueSSRCGenerator : public ThreadSafeRefCounted<UniqueSSRCGenerator> {
+class UniqueSSRCGenerator : public DeprecatedThreadSafeRefCountedSeqCst<UniqueSSRCGenerator> {
     WTF_MAKE_TZONE_ALLOCATED(UniqueSSRCGenerator);
 public:
     static Ref<UniqueSSRCGenerator> create() { return adoptRef(*new UniqueSSRCGenerator()); }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
@@ -46,7 +46,7 @@ namespace WebCore {
 
 namespace LibWebRTCCertificateGenerator {
 
-class RTCCertificateGeneratorCallbackWrapper : public ThreadSafeRefCounted<RTCCertificateGeneratorCallbackWrapper, WTF::DestructionThread::Main> {
+class RTCCertificateGeneratorCallbackWrapper : public DeprecatedThreadSafeRefCountedSeqCst<RTCCertificateGeneratorCallbackWrapper, WTF::DestructionThread::Main> {
 public:
     static Ref<RTCCertificateGeneratorCallbackWrapper> create(Ref<SecurityOrigin>&& origin, Function<void(ExceptionOr<Ref<RTCCertificate>>&&)>&& resultCallback)
     {

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDtlsTransportBackend.cpp
@@ -55,7 +55,7 @@ static inline RTCDtlsTransportState toRTCDtlsTransportState(webrtc::DtlsTranspor
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-class LibWebRTCDtlsTransportBackendObserver final : public ThreadSafeRefCounted<LibWebRTCDtlsTransportBackendObserver>, public webrtc::DtlsTransportObserverInterface {
+class LibWebRTCDtlsTransportBackendObserver final : public DeprecatedThreadSafeRefCountedSeqCst<LibWebRTCDtlsTransportBackendObserver>, public webrtc::DtlsTransportObserverInterface {
 public:
     static Ref<LibWebRTCDtlsTransportBackendObserver> create(RTCDtlsTransportBackendClient& client, Ref<webrtc::DtlsTransportInterface>&& backend) { return adoptRef(*new LibWebRTCDtlsTransportBackendObserver(client, WTF::move(backend))); }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCSctpTransportBackend.cpp
@@ -51,7 +51,7 @@ static inline RTCSctpTransportState toRTCSctpTransportState(webrtc::SctpTranspor
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-class LibWebRTCSctpTransportBackendObserver final : public ThreadSafeRefCounted<LibWebRTCSctpTransportBackendObserver>, public webrtc::SctpTransportObserverInterface {
+class LibWebRTCSctpTransportBackendObserver final : public DeprecatedThreadSafeRefCountedSeqCst<LibWebRTCSctpTransportBackendObserver>, public webrtc::SctpTransportObserverInterface {
 public:
     static Ref<LibWebRTCSctpTransportBackendObserver> create(RTCSctpTransportBackendClient& client, Ref<webrtc::SctpTransportInterface>&& backend) { return adoptRef(*new LibWebRTCSctpTransportBackendObserver(client, WTF::move(backend))); }
 

--- a/Source/WebCore/Modules/notifications/NotificationResources.h
+++ b/Source/WebCore/Modules/notifications/NotificationResources.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class NotificationResources : public ThreadSafeRefCounted<NotificationResources> {
+class NotificationResources : public DeprecatedThreadSafeRefCountedSeqCst<NotificationResources> {
 public:
     static Ref<NotificationResources> create()
     {

--- a/Source/WebCore/Modules/permissions/PermissionController.h
+++ b/Source/WebCore/Modules/permissions/PermissionController.h
@@ -42,7 +42,7 @@ class RegistrableDomain;
 class SecurityOriginData;
 struct ClientOrigin;
 
-class PermissionController : public ThreadSafeRefCounted<PermissionController> {
+class PermissionController : public DeprecatedThreadSafeRefCountedSeqCst<PermissionController> {
 public:
     WEBCORE_EXPORT static PermissionController& singleton();
     WEBCORE_EXPORT static void setSharedController(Ref<PermissionController>&&);

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -68,7 +68,7 @@ struct WebLockManager::LockRequest {
     bool isValid() const { return !!lockIdentifier; }
 };
 
-class WebLockManager::MainThreadBridge : public ThreadSafeRefCounted<MainThreadBridge, WTF::DestructionThread::Main> {
+class WebLockManager::MainThreadBridge : public DeprecatedThreadSafeRefCountedSeqCst<MainThreadBridge, WTF::DestructionThread::Main> {
 public:
     static RefPtr<MainThreadBridge> create(ScriptExecutionContext* context)
     {

--- a/Source/WebCore/Modules/webaudio/AudioNodeInput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeInput.h
@@ -41,7 +41,7 @@ class AudioNodeOutput;
 // In the case of multiple connections, the input will act as a unity-gain summing junction, mixing all the outputs.
 // The number of channels of the input's bus is the maximum of the number of channels of all its connections.
 
-class AudioNodeInput final : public AudioSummingJunction, public ThreadSafeRefCounted<AudioNodeInput> {
+class AudioNodeInput final : public AudioSummingJunction, public DeprecatedThreadSafeRefCountedSeqCst<AudioNodeInput> {
     WTF_MAKE_NONCOPYABLE(AudioNodeInput);
     WTF_MAKE_TZONE_ALLOCATED(AudioNodeInput);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioNodeInput);

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -90,7 +90,7 @@ struct AudioParamDescriptor;
 
 class BaseAudioContext
     : public ActiveDOMObject
-    , public ThreadSafeRefCounted<BaseAudioContext>
+    , public DeprecatedThreadSafeRefCountedSeqCst<BaseAudioContext>
     , public EventTarget
 #if !RELEASE_LOG_DISABLED
     , public LoggerHelper

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 template<typename> class ExceptionOr;
 
-class WebCodecsEncodedAudioChunkStorage : public ThreadSafeRefCounted<WebCodecsEncodedAudioChunkStorage> {
+class WebCodecsEncodedAudioChunkStorage : public DeprecatedThreadSafeRefCountedSeqCst<WebCodecsEncodedAudioChunkStorage> {
 public:
     static Ref<WebCodecsEncodedAudioChunkStorage> create(WebCodecsEncodedAudioChunkType type, int64_t timestamp, std::optional<uint64_t> duration, Vector<uint8_t>&& buffer) { return create(WebCodecsEncodedAudioChunkData { type, timestamp, duration, WTF::move(buffer) }); }
     static Ref<WebCodecsEncodedAudioChunkStorage> create(WebCodecsEncodedAudioChunkData&& data) { return adoptRef(* new WebCodecsEncodedAudioChunkStorage(WTF::move(data))); }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 template<typename> class ExceptionOr;
 
-class WebCodecsEncodedVideoChunkStorage : public ThreadSafeRefCounted<WebCodecsEncodedVideoChunkStorage> {
+class WebCodecsEncodedVideoChunkStorage : public DeprecatedThreadSafeRefCountedSeqCst<WebCodecsEncodedVideoChunkStorage> {
 public:
     static Ref<WebCodecsEncodedVideoChunkStorage> create(WebCodecsEncodedVideoChunkType type, int64_t timestamp, std::optional<uint64_t> duration, Vector<uint8_t>&& buffer) { return create(WebCodecsEncodedVideoChunkData { type, timestamp, duration, WTF::move(buffer) }); }
     static Ref<WebCodecsEncodedVideoChunkStorage> create(WebCodecsEncodedVideoChunkData&& data) { return adoptRef(* new WebCodecsEncodedVideoChunkStorage(WTF::move(data))); }

--- a/Source/WebCore/Modules/webdatabase/DatabaseAuthorizer.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseAuthorizer.h
@@ -40,7 +40,7 @@ extern const int SQLAuthAllow;
 extern const int SQLAuthIgnore;
 extern const int SQLAuthDeny;
 
-class DatabaseAuthorizer : public ThreadSafeRefCounted<DatabaseAuthorizer> {
+class DatabaseAuthorizer : public DeprecatedThreadSafeRefCountedSeqCst<DatabaseAuthorizer> {
 public:
 
     enum Permissions {

--- a/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseCallback.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 class Database;
 
-class DatabaseCallback : public ThreadSafeRefCounted<DatabaseCallback>, public ActiveDOMCallback {
+class DatabaseCallback : public DeprecatedThreadSafeRefCountedSeqCst<DatabaseCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.h
@@ -46,7 +46,7 @@ class DatabaseThread;
 class SecurityOrigin;
 class SecurityOriginData;
 
-class DatabaseContext final : public ThreadSafeRefCounted<DatabaseContext>, private ActiveDOMObject {
+class DatabaseContext final : public DeprecatedThreadSafeRefCountedSeqCst<DatabaseContext>, private ActiveDOMObject {
 public:
     // ActiveDOMObject.
     void ref() const final { ThreadSafeRefCounted::ref(); }

--- a/Source/WebCore/Modules/webdatabase/OriginLock.h
+++ b/Source/WebCore/Modules/webdatabase/OriginLock.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class OriginLock : public ThreadSafeRefCounted<OriginLock> {
+class OriginLock : public DeprecatedThreadSafeRefCountedSeqCst<OriginLock> {
 public:
     static Ref<OriginLock> create(const String& originPath)
     {

--- a/Source/WebCore/Modules/webdatabase/SQLError.h
+++ b/Source/WebCore/Modules/webdatabase/SQLError.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-class SQLError : public ThreadSafeRefCounted<SQLError> {
+class SQLError : public DeprecatedThreadSafeRefCountedSeqCst<SQLError> {
 public:
     static Ref<SQLError> create(unsigned code, String&& message) { return adoptRef(*new SQLError(code, WTF::move(message))); }
     static Ref<SQLError> create(unsigned code, ASCIILiteral message, int sqliteCode)

--- a/Source/WebCore/Modules/webdatabase/SQLResultSet.h
+++ b/Source/WebCore/Modules/webdatabase/SQLResultSet.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 template<typename> class ExceptionOr;
 
-class SQLResultSet : public ThreadSafeRefCounted<SQLResultSet> {
+class SQLResultSet : public DeprecatedThreadSafeRefCountedSeqCst<SQLResultSet> {
 public:
     static Ref<SQLResultSet> create() { return adoptRef(*new SQLResultSet); }
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementCallback.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class SQLTransaction;
 class SQLResultSet;
 
-class SQLStatementCallback : public ThreadSafeRefCounted<SQLStatementCallback>, public ActiveDOMCallback {
+class SQLStatementCallback : public DeprecatedThreadSafeRefCountedSeqCst<SQLStatementCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatementErrorCallback.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class SQLTransaction;
 class SQLError;
 
-class SQLStatementErrorCallback : public ThreadSafeRefCounted<SQLStatementErrorCallback>, public ActiveDOMCallback {
+class SQLStatementErrorCallback : public DeprecatedThreadSafeRefCountedSeqCst<SQLStatementErrorCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.h
@@ -47,7 +47,7 @@ class SQLTransactionErrorCallback;
 class VoidCallback;
 template<typename> class ExceptionOr;
 
-class SQLTransactionWrapper : public ThreadSafeRefCounted<SQLTransactionWrapper> {
+class SQLTransactionWrapper : public DeprecatedThreadSafeRefCountedSeqCst<SQLTransactionWrapper> {
 public:
     virtual ~SQLTransactionWrapper() = default;
     virtual bool performPreflight(SQLTransaction&) = 0;

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionCallback.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class SQLTransaction;
 
-class SQLTransactionCallback : public ThreadSafeRefCounted<SQLTransactionCallback>, public ActiveDOMCallback {
+class SQLTransactionCallback : public DeprecatedThreadSafeRefCountedSeqCst<SQLTransactionCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionErrorCallback.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class SQLError;
 
-class SQLTransactionErrorCallback : public ThreadSafeRefCounted<SQLTransactionErrorCallback>, public ActiveDOMCallback {
+class SQLTransactionErrorCallback : public DeprecatedThreadSafeRefCountedSeqCst<SQLTransactionErrorCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -108,7 +108,7 @@ struct ErrorInformation {
 std::optional<ErrorInformation> extractErrorInformationFromErrorInstance(JSC::JSGlobalObject*, JSC::ErrorInstance&);
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
-class SerializedScriptValue : public ThreadSafeRefCounted<SerializedScriptValue> {
+class SerializedScriptValue : public DeprecatedThreadSafeRefCountedSeqCst<SerializedScriptValue> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SerializedScriptValue, SerializedScriptValue);
 public:
     WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default);

--- a/Source/WebCore/contentextensions/CompiledContentExtension.h
+++ b/Source/WebCore/contentextensions/CompiledContentExtension.h
@@ -34,7 +34,7 @@
 
 namespace WebCore::ContentExtensions {
 
-class WEBCORE_EXPORT CompiledContentExtension : public ThreadSafeRefCounted<CompiledContentExtension> {
+class WEBCORE_EXPORT CompiledContentExtension : public DeprecatedThreadSafeRefCountedSeqCst<CompiledContentExtension> {
 public:
     virtual ~CompiledContentExtension();
 

--- a/Source/WebCore/crypto/CryptoAlgorithm.h
+++ b/Source/WebCore/crypto/CryptoAlgorithm.h
@@ -49,7 +49,7 @@ enum class ExceptionCode : uint8_t;
 using KeyData = Variant<Vector<uint8_t>, JsonWebKey>;
 using KeyOrKeyPair = Variant<RefPtr<CryptoKey>, CryptoKeyPair>;
 
-class CryptoAlgorithm : public ThreadSafeRefCounted<CryptoAlgorithm> {
+class CryptoAlgorithm : public DeprecatedThreadSafeRefCountedSeqCst<CryptoAlgorithm> {
 public:
     virtual ~CryptoAlgorithm() = default;
 

--- a/Source/WebCore/crypto/CryptoKey.h
+++ b/Source/WebCore/crypto/CryptoKey.h
@@ -42,7 +42,7 @@ namespace WebCore {
 
 class WebCoreOpaqueRoot;
 
-class CryptoKey : public ThreadSafeRefCounted<CryptoKey> {
+class CryptoKey : public DeprecatedThreadSafeRefCountedSeqCst<CryptoKey> {
 public:
     using Type = CryptoKeyType;
     using Data = CryptoKeyData;

--- a/Source/WebCore/dom/AbortAlgorithm.h
+++ b/Source/WebCore/dom/AbortAlgorithm.h
@@ -35,7 +35,7 @@ class JSValue;
 
 namespace WebCore {
 
-class AbortAlgorithm : public ThreadSafeRefCounted<AbortAlgorithm>, public ActiveDOMCallback {
+class AbortAlgorithm : public DeprecatedThreadSafeRefCountedSeqCst<AbortAlgorithm>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -69,7 +69,7 @@ static PartitionedSecurityOrigin partitionedSecurityOriginFromContext(ScriptExec
     return { context.topOrigin(), context.protectedSecurityOrigin().releaseNonNull() };
 }
 
-class BroadcastChannel::MainThreadBridge : public ThreadSafeRefCounted<MainThreadBridge, WTF::DestructionThread::Main>, public Identified<BroadcastChannelIdentifier> {
+class BroadcastChannel::MainThreadBridge : public DeprecatedThreadSafeRefCountedSeqCst<MainThreadBridge, WTF::DestructionThread::Main>, public Identified<BroadcastChannelIdentifier> {
 public:
     static Ref<MainThreadBridge> create(BroadcastChannel& channel, const String& name)
     {

--- a/Source/WebCore/dom/CreateHTMLCallback.h
+++ b/Source/WebCore/dom/CreateHTMLCallback.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class CreateHTMLCallback : public ThreadSafeRefCounted<CreateHTMLCallback>, public ActiveDOMCallback {
+class CreateHTMLCallback : public DeprecatedThreadSafeRefCountedSeqCst<CreateHTMLCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/dom/CreateScriptCallback.h
+++ b/Source/WebCore/dom/CreateScriptCallback.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class CreateScriptCallback : public ThreadSafeRefCounted<CreateScriptCallback>, public ActiveDOMCallback {
+class CreateScriptCallback : public DeprecatedThreadSafeRefCountedSeqCst<CreateScriptCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/dom/CreateScriptURLCallback.h
+++ b/Source/WebCore/dom/CreateScriptURLCallback.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class CreateScriptURLCallback : public ThreadSafeRefCounted<CreateScriptURLCallback>, public ActiveDOMCallback {
+class CreateScriptURLCallback : public DeprecatedThreadSafeRefCountedSeqCst<CreateScriptURLCallback>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/html/DirectoryFileListCreator.h
+++ b/Source/WebCore/html/DirectoryFileListCreator.h
@@ -38,7 +38,7 @@ class FileList;
 
 struct FileChooserFileInfo;
 
-class DirectoryFileListCreator : public ThreadSafeRefCounted<DirectoryFileListCreator> {
+class DirectoryFileListCreator : public DeprecatedThreadSafeRefCountedSeqCst<DirectoryFileListCreator> {
 public:
     using CompletionHandler = Function<void(Ref<FileList>&&)>;
 

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class PlaceholderRenderingContext;
 
 // Thread-safe interface to submit frames from worker to the placeholder rendering context.
-class PlaceholderRenderingContextSource : public ThreadSafeRefCounted<PlaceholderRenderingContextSource> {
+class PlaceholderRenderingContextSource : public DeprecatedThreadSafeRefCountedSeqCst<PlaceholderRenderingContextSource> {
     WTF_MAKE_TZONE_ALLOCATED(PlaceholderRenderingContextSource);
     WTF_MAKE_NONCOPYABLE(PlaceholderRenderingContextSource);
 public:

--- a/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
+++ b/Source/WebCore/inspector/InspectorThreadableLoaderClient.h
@@ -42,7 +42,7 @@ namespace Inspector {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(InspectorThreadableLoaderClient);
 
-class InspectorThreadableLoaderClient final : public ThreadSafeRefCounted<InspectorThreadableLoaderClient, WTF::DestructionThread::Main>, public WebCore::ThreadableLoaderClient {
+class InspectorThreadableLoaderClient final : public DeprecatedThreadSafeRefCountedSeqCst<InspectorThreadableLoaderClient, WTF::DestructionThread::Main>, public WebCore::ThreadableLoaderClient {
     WTF_MAKE_NONCOPYABLE(InspectorThreadableLoaderClient);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(InspectorThreadableLoaderClient, InspectorThreadableLoaderClient);
 public:

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
@@ -74,7 +74,7 @@ protected:
     void connectToWorkerInspectorProxy(WorkerInspectorProxy&);
 
 private:
-    class PageChannel final : public WorkerInspectorProxy::PageChannel, public ThreadSafeRefCounted<PageChannel> {
+    class PageChannel final : public WorkerInspectorProxy::PageChannel, public DeprecatedThreadSafeRefCountedSeqCst<PageChannel> {
         WTF_MAKE_TZONE_ALLOCATED_INLINE(PageChannel);
         WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageChannel);
 

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -93,7 +93,7 @@ public:
 private:
     using State = PlatformContentFilter::State;
 
-    class ContentFilterCallbackAggregator : public ThreadSafeRefCounted<ContentFilterCallbackAggregator> {
+    class ContentFilterCallbackAggregator : public DeprecatedThreadSafeRefCountedSeqCst<ContentFilterCallbackAggregator> {
     public:
         static auto create(ContentFilter& contentFilter, const ResourceRequest& request, CompletionHandler<void(ResourceRequest&&)>&& callback) { return adoptRef(*new ContentFilterCallbackAggregator(contentFilter, request, WTF::move(callback))); }
 

--- a/Source/WebCore/loader/ThreadableLoaderClientWrapper.h
+++ b/Source/WebCore/loader/ThreadableLoaderClientWrapper.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-class ThreadableLoaderClientWrapper : public ThreadSafeRefCounted<ThreadableLoaderClientWrapper> {
+class ThreadableLoaderClientWrapper : public DeprecatedThreadSafeRefCountedSeqCst<ThreadableLoaderClientWrapper> {
 public:
     static Ref<ThreadableLoaderClientWrapper> create(ThreadableLoaderClient& client, const String& initiator)
     {

--- a/Source/WebCore/loader/WorkerThreadableLoader.h
+++ b/Source/WebCore/loader/WorkerThreadableLoader.h
@@ -87,7 +87,7 @@ private:
     //    go through it. All tasks posted from the worker object's thread to the worker context's
     //    thread contain the RefPtr<ThreadableLoaderClientWrapper> object, so the
     //    ThreadableLoaderClientWrapper instance is there until all tasks are executed.
-    class MainThreadBridge final : public ThreadableLoaderClient, public ThreadSafeRefCounted<MainThreadBridge, WTF::DestructionThread::Main> {
+    class MainThreadBridge final : public ThreadableLoaderClient, public DeprecatedThreadSafeRefCountedSeqCst<MainThreadBridge, WTF::DestructionThread::Main> {
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(MainThreadBridge, Loader);
     public:
         // All executed on the worker context's thread.

--- a/Source/WebCore/page/NavigationInterceptHandler.h
+++ b/Source/WebCore/page/NavigationInterceptHandler.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class NavigationInterceptHandler : public ThreadSafeRefCounted<NavigationInterceptHandler>, public ActiveDOMCallback {
+class NavigationInterceptHandler : public DeprecatedThreadSafeRefCountedSeqCst<NavigationInterceptHandler>, public ActiveDOMCallback {
 public:
     using ActiveDOMCallback::ActiveDOMCallback;
 

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 class OriginAccessPatterns;
 
-class SecurityOrigin : public ThreadSafeRefCounted<SecurityOrigin> {
+class SecurityOrigin : public DeprecatedThreadSafeRefCountedSeqCst<SecurityOrigin> {
 public:
     enum class Policy : uint8_t {
         AlwaysDeny = 0,

--- a/Source/WebCore/page/SocketProvider.h
+++ b/Source/WebCore/page/SocketProvider.h
@@ -48,7 +48,7 @@ class RiceBackend;
 class RiceBackendClient;
 #endif
 
-class WEBCORE_EXPORT SocketProvider : public ThreadSafeRefCounted<SocketProvider> {
+class WEBCORE_EXPORT SocketProvider : public DeprecatedThreadSafeRefCountedSeqCst<SocketProvider> {
 public:
     virtual RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&) = 0;
     virtual std::pair<RefPtr<WebTransportSession>, Ref<WebTransportSessionPromise>> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&, const WebTransportOptions&) = 0;

--- a/Source/WebCore/platform/AbortableTaskQueue.h
+++ b/Source/WebCore/platform/AbortableTaskQueue.h
@@ -172,7 +172,7 @@ private:
     // Protected state:
     //   Main thread: read-write. Writes must be made with the lock.
     //   Background threads: read only. Reads must be made with the lock.
-    class Task : public ThreadSafeRefCounted<Task> {
+    class Task : public DeprecatedThreadSafeRefCountedSeqCst<Task> {
         WTF_MAKE_NONCOPYABLE(Task);
         WTF_DEPRECATED_MAKE_FAST_ALLOCATED(Task);
     public:

--- a/Source/WebCore/platform/AudioDecoder.h
+++ b/Source/WebCore/platform/AudioDecoder.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class PlatformRawAudioData;
 
-class AudioDecoder : public ThreadSafeRefCounted<AudioDecoder> {
+class AudioDecoder : public DeprecatedThreadSafeRefCountedSeqCst<AudioDecoder> {
 public:
     WEBCORE_EXPORT AudioDecoder();
     WEBCORE_EXPORT virtual ~AudioDecoder();

--- a/Source/WebCore/platform/AudioEncoder.h
+++ b/Source/WebCore/platform/AudioEncoder.h
@@ -39,7 +39,7 @@
 
 namespace WebCore {
 
-class AudioEncoder : public ThreadSafeRefCounted<AudioEncoder> {
+class AudioEncoder : public DeprecatedThreadSafeRefCountedSeqCst<AudioEncoder> {
 public:
     virtual ~AudioEncoder() = default;
 

--- a/Source/WebCore/platform/MediaDescription.h
+++ b/Source/WebCore/platform/MediaDescription.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class MediaDescription : public ThreadSafeRefCounted<MediaDescription> {
+class MediaDescription : public DeprecatedThreadSafeRefCountedSeqCst<MediaDescription> {
 public:
     explicit MediaDescription(String&& codec)
         : m_codec(WTF::move(codec))

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -74,7 +74,7 @@ private:
     VariantType m_sample;
 };
 
-class MediaSample : public ThreadSafeRefCounted<MediaSample> {
+class MediaSample : public DeprecatedThreadSafeRefCountedSeqCst<MediaSample> {
 public:
     virtual ~MediaSample() = default;
 

--- a/Source/WebCore/platform/ShareableResource.h
+++ b/Source/WebCore/platform/ShareableResource.h
@@ -57,7 +57,7 @@ private:
     unsigned m_size { 0 };
 };
 
-class ShareableResource : public ThreadSafeRefCounted<ShareableResource> {
+class ShareableResource : public DeprecatedThreadSafeRefCountedSeqCst<ShareableResource> {
 public:
     using Handle = ShareableResourceHandle;
 

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -81,7 +81,7 @@ class SharedMemoryHandle;
 
 // Data wrapped by a DataSegment should be immutable because it can be referenced by other objects.
 // To modify or combine the data, allocate a new DataSegment.
-class DataSegment : public ThreadSafeRefCounted<DataSegment> {
+class DataSegment : public DeprecatedThreadSafeRefCountedSeqCst<DataSegment> {
 public:
     size_t size() const { return span().size(); }
     WEBCORE_EXPORT std::span<const uint8_t> span() const LIFETIME_BOUND;
@@ -162,7 +162,7 @@ private:
     friend class SharedBuffer; // For createCFData
 };
 
-class FragmentedSharedBuffer : public ThreadSafeRefCounted<FragmentedSharedBuffer> {
+class FragmentedSharedBuffer : public DeprecatedThreadSafeRefCountedSeqCst<FragmentedSharedBuffer> {
 public:
     using IPCData = Variant<std::optional<WebCore::SharedMemoryHandle>, Vector<std::span<const uint8_t>>>;
 

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -109,7 +109,7 @@ private:
     uint64_t m_size { 0 };
 };
 
-class SharedMemory : public ThreadSafeRefCounted<SharedMemory> {
+class SharedMemory : public DeprecatedThreadSafeRefCountedSeqCst<SharedMemory> {
 public:
     using Handle = SharedMemoryHandle;
     using Protection = SharedMemoryProtection;

--- a/Source/WebCore/platform/ThreadSafeDataBuffer.h
+++ b/Source/WebCore/platform/ThreadSafeDataBuffer.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class ThreadSafeDataBuffer;
 
-class ThreadSafeDataBufferImpl : public ThreadSafeRefCounted<ThreadSafeDataBufferImpl> {
+class ThreadSafeDataBufferImpl : public DeprecatedThreadSafeRefCountedSeqCst<ThreadSafeDataBufferImpl> {
 private:
     friend class ThreadSafeDataBuffer;
     friend struct IPC::ArgumentCoder<ThreadSafeDataBufferImpl>;

--- a/Source/WebCore/platform/ThreadTimers.h
+++ b/Source/WebCore/platform/ThreadTimers.h
@@ -79,7 +79,7 @@ private:
     MonotonicTime m_pendingSharedTimerFireTime;
 };
 
-struct ThreadTimerHeapItem : ThreadSafeRefCounted<ThreadTimerHeapItem> {
+struct ThreadTimerHeapItem : DeprecatedThreadSafeRefCountedSeqCst<ThreadTimerHeapItem> {
     WTF_MAKE_COMPACT_TZONE_ALLOCATED(ThreadTimerHeapItem);
 
 public:

--- a/Source/WebCore/platform/TrackInfo.h
+++ b/Source/WebCore/platform/TrackInfo.h
@@ -86,7 +86,7 @@ struct TrackInfoData {
     bool operator==(const TrackInfoData&) const = default;
 };
 
-class TrackInfo : public ThreadSafeRefCounted<TrackInfo> {
+class TrackInfo : public DeprecatedThreadSafeRefCountedSeqCst<TrackInfo> {
 public:
     virtual ~TrackInfo() = default;
     using TrackType = TrackInfoTrackType;

--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class VideoFrame;
 
-class VideoDecoder : public ThreadSafeRefCounted<VideoDecoder> {
+class VideoDecoder : public DeprecatedThreadSafeRefCountedSeqCst<VideoDecoder> {
 public:
     WEBCORE_EXPORT virtual ~VideoDecoder();
 

--- a/Source/WebCore/platform/VideoEncoder.h
+++ b/Source/WebCore/platform/VideoEncoder.h
@@ -36,7 +36,7 @@
 
 namespace WebCore {
 
-class VideoEncoder : public ThreadSafeRefCounted<VideoEncoder> {
+class VideoEncoder : public DeprecatedThreadSafeRefCountedSeqCst<VideoEncoder> {
 public:
     virtual ~VideoEncoder() = default;
 

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -72,7 +72,7 @@ enum class VideoFrameRotation : uint16_t {
 };
 
 // A class representing a video frame from a decoder, capture source, or similar.
-class VideoFrame : public ThreadSafeRefCounted<VideoFrame> {
+class VideoFrame : public DeprecatedThreadSafeRefCountedSeqCst<VideoFrame> {
 public:
     virtual ~VideoFrame() = default;
 

--- a/Source/WebCore/platform/audio/AudioBus.h
+++ b/Source/WebCore/platform/audio/AudioBus.h
@@ -46,7 +46,7 @@ enum class ChannelInterpretation {
     Discrete,
 };
 
-class AudioBus final : public ThreadSafeRefCounted<AudioBus> {
+class AudioBus final : public DeprecatedThreadSafeRefCountedSeqCst<AudioBus> {
     WTF_MAKE_NONCOPYABLE(AudioBus);
 public:
     enum {

--- a/Source/WebCore/platform/audio/PlatformRawAudioData.h
+++ b/Source/WebCore/platform/audio/PlatformRawAudioData.h
@@ -30,7 +30,7 @@ namespace WebCore {
 enum class AudioSampleFormat;
 class MediaSample;
 
-class PlatformRawAudioData : public ThreadSafeRefCounted<PlatformRawAudioData> {
+class PlatformRawAudioData : public DeprecatedThreadSafeRefCountedSeqCst<PlatformRawAudioData> {
 public:
     virtual ~PlatformRawAudioData() = default;
     static RefPtr<PlatformRawAudioData> create(std::span<const uint8_t>, AudioSampleFormat, float sampleRate, int64_t timestamp, size_t numberOfFrames, size_t numberOfChannels);

--- a/Source/WebCore/platform/audio/SharedAudioDestination.h
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class SharedAudioDestinationAdapter;
 
-class SharedAudioDestination final : public AudioDestination, public ThreadSafeRefCounted<SharedAudioDestination, WTF::DestructionThread::Main> {
+class SharedAudioDestination final : public AudioDestination, public DeprecatedThreadSafeRefCountedSeqCst<SharedAudioDestination, WTF::DestructionThread::Main> {
 public:
     using AudioDestinationCreationFunction = Function<Ref<AudioDestination>(const CreationOptions&)>;
     WEBCORE_EXPORT static Ref<SharedAudioDestination> create(const CreationOptions&, AudioDestinationCreationFunction&&);

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
@@ -44,12 +44,12 @@ class PushPullFIFO;
 using CreateAudioDestinationCocoaOverride = Ref<AudioDestination>(*)(const AudioDestinationCreationOptions&);
 
 // An AudioDestination using CoreAudio's default output AudioUnit
-class AudioDestinationCocoa : public AudioDestinationResampler, public AudioUnitRenderer, public ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main> {
+class AudioDestinationCocoa : public AudioDestinationResampler, public AudioUnitRenderer, public DeprecatedThreadSafeRefCountedSeqCst<AudioDestinationCocoa, WTF::DestructionThread::Main> {
 public:
     WEBCORE_EXPORT AudioDestinationCocoa(const CreationOptions&);
     WEBCORE_EXPORT virtual ~AudioDestinationCocoa();
-    void ref() const final { return ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main>::ref(); }
-    void deref() const final { return ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main>::deref(); }
+    void ref() const final { return DeprecatedThreadSafeRefCountedSeqCst<AudioDestinationCocoa, WTF::DestructionThread::Main>::ref(); }
+    void deref() const final { return DeprecatedThreadSafeRefCountedSeqCst<AudioDestinationCocoa, WTF::DestructionThread::Main>::deref(); }
 
     WEBCORE_EXPORT static CreateAudioDestinationCocoaOverride createOverride;
 

--- a/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h
@@ -43,7 +43,7 @@ namespace WebCore {
 class AudioSampleBufferList;
 class PlatformAudioData;
 
-class AudioSampleDataSource : public ThreadSafeRefCounted<AudioSampleDataSource, WTF::DestructionThread::MainRunLoop>
+class AudioSampleDataSource : public DeprecatedThreadSafeRefCountedSeqCst<AudioSampleDataSource, WTF::DestructionThread::MainRunLoop>
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -40,7 +40,7 @@ namespace WebCore {
 struct ParentalControlsURLFilterParameters;
 class ParentalControlsContentFilter;
 
-class ParentalControlsURLFilter : public ThreadSafeRefCounted<ParentalControlsURLFilter, WTF::DestructionThread::Main> {
+class ParentalControlsURLFilter : public DeprecatedThreadSafeRefCountedSeqCst<ParentalControlsURLFilter, WTF::DestructionThread::Main> {
 public:
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     WEBCORE_EXPORT static ParentalControlsURLFilter& filterWithConfigurationPath(const String&);

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -60,7 +60,7 @@ using KeyHandleValueVariant = Variant<
 #endif
 >;
 
-class KeyHandle : public ThreadSafeRefCounted<KeyHandle> {
+class KeyHandle : public DeprecatedThreadSafeRefCountedSeqCst<KeyHandle> {
 public:
     using KeyStatus = CDMInstanceSession::KeyStatus;
 
@@ -239,7 +239,7 @@ class CDMProxyDecryptionClient;
 
 // Handle to a "real" CDM, not the JavaScript facade. This can be used
 // from background threads (i.e. decryptors).
-class CDMProxy : public ThreadSafeRefCounted<CDMProxy> {
+class CDMProxy : public DeprecatedThreadSafeRefCountedSeqCst<CDMProxy> {
 public:
     static constexpr Seconds MaxKeyWaitTimeSeconds = 7_s;
 

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -215,7 +215,7 @@ public:
 private:
     friend void add(Hasher&, const Color&);
 
-    class OutOfLineComponents : public ThreadSafeRefCounted<OutOfLineComponents> {
+    class OutOfLineComponents : public DeprecatedThreadSafeRefCountedSeqCst<OutOfLineComponents> {
         WTF_DEPRECATED_MAKE_FAST_COMPACT_ALLOCATED(OutOfLineComponents);
     public:
         static Ref<OutOfLineComponents> create(ColorComponents<float, 4>&& components)

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitor.h
@@ -40,7 +40,7 @@ class DisplayAnimationClient;
 class DisplayRefreshMonitorClient;
 class DisplayRefreshMonitorFactory;
 
-class DisplayRefreshMonitor : public ThreadSafeRefCounted<DisplayRefreshMonitor> {
+class DisplayRefreshMonitor : public DeprecatedThreadSafeRefCountedSeqCst<DisplayRefreshMonitor> {
     friend class DisplayRefreshMonitorManager;
 public:
     static RefPtr<DisplayRefreshMonitor> create(DisplayRefreshMonitorFactory*, PlatformDisplayID);

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -65,7 +65,7 @@ class FloatRect;
 class GraphicsContext;
 
 // Note: currently this class is not usable from multiple threads due to mutating interface.
-class Gradient final : public ThreadSafeRefCounted<Gradient>, public CanMakeThreadSafeCheckedPtr<NativeImage> {
+class Gradient final : public DeprecatedThreadSafeRefCountedSeqCst<Gradient>, public CanMakeThreadSafeCheckedPtr<NativeImage> {
     WTF_MAKE_TZONE_ALLOCATED(Gradient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Gradient);
 public:

--- a/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
+++ b/Source/WebCore/platform/graphics/ImageFrameWorkQueue.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class BitmapImageSource;
 
-class ImageFrameWorkQueue : public ThreadSafeRefCounted<ImageFrameWorkQueue> {
+class ImageFrameWorkQueue : public DeprecatedThreadSafeRefCountedSeqCst<ImageFrameWorkQueue> {
 public:
     struct Request {
         unsigned index;

--- a/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTarget.h
@@ -40,7 +40,7 @@ enum class MediaPlaybackTargetType : uint8_t {
     Serialized = 1 << 3,
 };
 
-class MediaPlaybackTarget : public ThreadSafeRefCounted<MediaPlaybackTarget> {
+class MediaPlaybackTarget : public DeprecatedThreadSafeRefCountedSeqCst<MediaPlaybackTarget> {
 public:
     using Type = MediaPlaybackTargetType;
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -118,7 +118,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaPlayerFactory);
 
 // a null player to make MediaPlayer logic simpler
 
-class NullMediaPlayerPrivate final : public MediaPlayerPrivateInterface, public ThreadSafeRefCounted<NullMediaPlayerPrivate, WTF::DestructionThread::Main> {
+class NullMediaPlayerPrivate final : public MediaPlayerPrivateInterface, public DeprecatedThreadSafeRefCountedSeqCst<NullMediaPlayerPrivate, WTF::DestructionThread::Main> {
 public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -49,7 +49,7 @@ class IntSize;
 class NativeImageBackend;
 struct ImagePaintingOptions;
 
-class NativeImage : public ThreadSafeRefCounted<NativeImage>, public CanMakeThreadSafeCheckedPtr<NativeImage> {
+class NativeImage : public DeprecatedThreadSafeRefCountedSeqCst<NativeImage>, public CanMakeThreadSafeCheckedPtr<NativeImage> {
     WTF_MAKE_TZONE_ALLOCATED(NativeImage);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NativeImage);
 public:

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-class PathImpl : public ThreadSafeRefCounted<PathImpl> {
+class PathImpl : public DeprecatedThreadSafeRefCountedSeqCst<PathImpl> {
     WTF_MAKE_TZONE_ALLOCATED(PathImpl);
 public:
     virtual ~PathImpl() = default;

--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -62,7 +62,7 @@ struct PatternParameters {
     AffineTransform patternSpaceTransform;
 };
 
-class Pattern final : public ThreadSafeRefCounted<Pattern> {
+class Pattern final : public DeprecatedThreadSafeRefCountedSeqCst<Pattern> {
 public:
     using Parameters = PatternParameters;
     WEBCORE_EXPORT static Ref<Pattern> create(SourceImage&& tileImage, const Parameters& = { });

--- a/Source/WebCore/platform/graphics/PlatformMediaResourceLoader.h
+++ b/Source/WebCore/platform/graphics/PlatformMediaResourceLoader.h
@@ -46,7 +46,7 @@ class ResourceError;
 class ResourceRequest;
 class ResourceResponse;
 
-class PlatformMediaResourceClient : public ThreadSafeRefCounted<PlatformMediaResourceClient> {
+class PlatformMediaResourceClient : public DeprecatedThreadSafeRefCountedSeqCst<PlatformMediaResourceClient> {
 public:
     virtual ~PlatformMediaResourceClient() = default;
 
@@ -63,7 +63,7 @@ public:
     virtual bool isWebCoreNSURLSessionDataTaskClient() const { return false; }
 };
 
-class PlatformMediaResourceLoader : public ThreadSafeRefCounted<PlatformMediaResourceLoader, WTF::DestructionThread::Main> {
+class PlatformMediaResourceLoader : public DeprecatedThreadSafeRefCountedSeqCst<PlatformMediaResourceLoader, WTF::DestructionThread::Main> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PlatformMediaResourceLoader);
     WTF_MAKE_NONCOPYABLE(PlatformMediaResourceLoader);
 public:

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -139,7 +139,7 @@ private:
     ShareableBitmapConfiguration m_configuration;
 };
 
-class ShareableBitmap : public ThreadSafeRefCounted<ShareableBitmap> {
+class ShareableBitmap : public DeprecatedThreadSafeRefCountedSeqCst<ShareableBitmap> {
 public:
     using Handle = ShareableBitmapHandle;
 

--- a/Source/WebCore/platform/graphics/SystemImage.h
+++ b/Source/WebCore/platform/graphics/SystemImage.h
@@ -45,7 +45,7 @@ enum class SystemImageType : uint8_t {
 #endif
 };
 
-class WEBCORE_EXPORT SystemImage : public ThreadSafeRefCounted<SystemImage> {
+class WEBCORE_EXPORT SystemImage : public DeprecatedThreadSafeRefCountedSeqCst<SystemImage> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SystemImage);
 public:
     virtual ~SystemImage() = default;

--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -95,7 +95,7 @@ protected:
     TrackPrivateBase() = default;
 
     template <typename T>
-    class Shared final : public ThreadSafeRefCounted<Shared<T>> {
+    class Shared final : public DeprecatedThreadSafeRefCountedSeqCst<Shared<T>> {
     public:
         static Ref<Shared> create(T&& obj) { return adoptRef(*new Shared(WTF::move(obj))); }
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -58,7 +58,7 @@ namespace WebCore {
 
 static const double kRingBufferDuration = 1;
 
-class AudioSourceProviderAVFObjC::TapStorage : public ThreadSafeRefCounted<AudioSourceProviderAVFObjC::TapStorage> {
+class AudioSourceProviderAVFObjC::TapStorage : public DeprecatedThreadSafeRefCountedSeqCst<AudioSourceProviderAVFObjC::TapStorage> {
 public:
     TapStorage(AudioSourceProviderAVFObjC* _this) : _this(_this) { }
     ThreadSafeWeakPtr<AudioSourceProviderAVFObjC> _this;

--- a/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h
+++ b/Source/WebCore/platform/graphics/avfoundation/WebAVSampleBufferListener.h
@@ -49,7 +49,7 @@ public:
     virtual void outputObscuredDueToInsufficientExternalProtectionChanged(bool) { }
 };
 
-class WebAVSampleBufferListener final : public ThreadSafeRefCounted<WebAVSampleBufferListener> {
+class WebAVSampleBufferListener final : public DeprecatedThreadSafeRefCountedSeqCst<WebAVSampleBufferListener> {
 public:
     static Ref<WebAVSampleBufferListener> create(WebAVSampleBufferListenerClient& client) { return adoptRef(*new WebAVSampleBufferListener(client)); }
     void invalidate();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1243,7 +1243,7 @@ void CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequests(Vector<Retai
         appIdentifier = certificate->makeContiguous()->createNSData();
 
     using RequestsData = Vector<std::pair<RefPtr<SharedBuffer>, RetainPtr<NSData>>>;
-    struct CallbackAggregator final : public ThreadSafeRefCounted<CallbackAggregator> {
+    struct CallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<CallbackAggregator> {
         using CallbackFunction = Function<void(RequestsData&&)>;
         static RefPtr<CallbackAggregator> create(CallbackFunction&& completionHandler)
         {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -54,7 +54,7 @@ enum class VideoFrameRotation : uint16_t;
 
 class MediaPlayerPrivateMediaStreamAVFObjC final
     : public MediaPlayerPrivateInterface
-    , public ThreadSafeRefCounted<MediaPlayerPrivateMediaStreamAVFObjC, WTF::DestructionThread::Main>
+    , public DeprecatedThreadSafeRefCountedSeqCst<MediaPlayerPrivateMediaStreamAVFObjC, WTF::DestructionThread::Main>
     , private MediaStreamPrivateObserver
     , public MediaStreamTrackPrivateObserver
     , public RealtimeMediaSource::VideoFrameObserver

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerDelegatedContents.h
@@ -35,7 +35,7 @@ class IOSurface;
 
 constexpr inline Seconds delegatedContentsFinishedTimeout = 5_s;
 
-class WEBCORE_EXPORT PlatformCALayerDelegatedContentsFence : public ThreadSafeRefCounted<PlatformCALayerDelegatedContentsFence> {
+class WEBCORE_EXPORT PlatformCALayerDelegatedContentsFence : public DeprecatedThreadSafeRefCountedSeqCst<PlatformCALayerDelegatedContentsFence> {
     WTF_MAKE_NONCOPYABLE(PlatformCALayerDelegatedContentsFence);
 public:
     PlatformCALayerDelegatedContentsFence();

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerContentsDelayedReleaser.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerContentsDelayedReleaser.h
@@ -36,7 +36,7 @@ class PlatformCALayer;
 
 // This class exists to work around rdar://85892959, where CABackingStore objects would get released on the ScrollingThread
 // during scrolling commits, which can take long enough to cause scrolling frame drops.
-class PlatformCALayerContentsDelayedReleaser : ThreadSafeRefCounted<PlatformCALayerContentsDelayedReleaser> {
+class PlatformCALayerContentsDelayedReleaser : DeprecatedThreadSafeRefCountedSeqCst<PlatformCALayerContentsDelayedReleaser> {
     WTF_MAKE_NONCOPYABLE(PlatformCALayerContentsDelayedReleaser);
 public:
     static PlatformCALayerContentsDelayedReleaser& singleton();

--- a/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
+++ b/Source/WebCore/platform/graphics/cg/GradientRendererCG.h
@@ -61,7 +61,7 @@ private:
     struct Shading {
         template<typename InterpolationSpace, AlphaPremultiplication> static void shadingFunction(void*, const CGFloat*, CGFloat*);
 
-        class Data : public ThreadSafeRefCounted<Data> {
+        class Data : public DeprecatedThreadSafeRefCountedSeqCst<Data> {
         public:
             static Ref<Data> create(ColorInterpolationMethod colorInterpolationMethod, Vector<ColorConvertedToInterpolationColorSpaceStop> stops, bool firstStopIsSynthetic, bool lastStopIsSynthetic)
             {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -42,7 +42,7 @@ namespace DisplayList {
 
 // Note: currently this class is not usable from multiple threads due to the underlying objects, such
 // Font instances, not being thread-safe.
-class DisplayList final : public ThreadSafeRefCounted<DisplayList>, public CanMakeThreadSafeCheckedPtr<DisplayList> {
+class DisplayList final : public DeprecatedThreadSafeRefCountedSeqCst<DisplayList>, public CanMakeThreadSafeCheckedPtr<DisplayList> {
     WTF_MAKE_TZONE_ALLOCATED(DisplayList);
     WTF_MAKE_NONCOPYABLE(DisplayList);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DisplayList);

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.h
@@ -39,7 +39,7 @@ namespace WebCore {
 struct BlendingContext;
 using IntOutsets = IntBoxExtent;
 
-class FilterOperation : public ThreadSafeRefCounted<FilterOperation> {
+class FilterOperation : public DeprecatedThreadSafeRefCountedSeqCst<FilterOperation> {
 public:
     enum class Type : uint8_t {
         Grayscale,

--- a/Source/WebCore/platform/graphics/gbm/DMABufBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufBuffer.h
@@ -45,7 +45,7 @@ struct DMABufBufferAttributes {
     uint64_t modifier { 0 };
 };
 
-class DMABufBuffer final : public ThreadSafeRefCounted<DMABufBuffer> {
+class DMABufBuffer final : public DeprecatedThreadSafeRefCountedSeqCst<DMABufBuffer> {
 public:
     using Attributes = DMABufBufferAttributes;
 

--- a/Source/WebCore/platform/graphics/gbm/GBMDevice.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMDevice.h
@@ -34,7 +34,7 @@ struct gbm_device;
 
 namespace WebCore {
 
-class GBMDevice final : public ThreadSafeRefCounted<GBMDevice, WTF::DestructionThread::Main> {
+class GBMDevice final : public DeprecatedThreadSafeRefCountedSeqCst<GBMDevice, WTF::DestructionThread::Main> {
 public:
     static RefPtr<GBMDevice> create(const CString&);
     ~GBMDevice();

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -199,7 +199,7 @@ using GstMappedBuffer = GstBufferMapper<GstMapInfo, gst_buffer_map, gst_buffer_u
 // This class maps only buffers in GST_MAP_READ mode to be able to
 // bump the reference count and keep it alive during the life of this
 // object.
-class GstMappedOwnedBuffer : public GstMappedBuffer, public ThreadSafeRefCounted<GstMappedOwnedBuffer> {
+class GstMappedOwnedBuffer : public GstMappedBuffer, public DeprecatedThreadSafeRefCountedSeqCst<GstMappedOwnedBuffer> {
 
 public:
     static RefPtr<GstMappedOwnedBuffer> create(GRefPtr<GstBuffer>&&);

--- a/Source/WebCore/platform/graphics/gstreamer/MainThreadNotifier.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MainThreadNotifier.h
@@ -28,7 +28,7 @@
 namespace WebCore {
 
 template <typename T>
-class MainThreadNotifier final : public ThreadSafeRefCounted<MainThreadNotifier<T>> {
+class MainThreadNotifier final : public DeprecatedThreadSafeRefCountedSeqCst<MainThreadNotifier<T>> {
 public:
     static Ref<MainThreadNotifier> create()
     {

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
@@ -39,7 +39,7 @@
 
 namespace WebCore {
 
-class MediaSourceTrackGStreamer final: public ThreadSafeRefCounted<MediaSourceTrackGStreamer> {
+class MediaSourceTrackGStreamer final: public DeprecatedThreadSafeRefCountedSeqCst<MediaSourceTrackGStreamer> {
 public:
     static Ref<MediaSourceTrackGStreamer> create(TrackPrivateBaseGStreamer::TrackType, TrackID, GRefPtr<GstCaps>&& initialCaps);
     ~MediaSourceTrackGStreamer();

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -39,7 +39,7 @@ class SkImage;
 
 namespace WebCore {
 
-class SkiaRecordingResult final : public ThreadSafeRefCounted<SkiaRecordingResult, WTF::DestructionThread::Main> {
+class SkiaRecordingResult final : public DeprecatedThreadSafeRefCountedSeqCst<SkiaRecordingResult, WTF::DestructionThread::Main> {
 public:
     ~SkiaRecordingResult();
     static Ref<SkiaRecordingResult> create(sk_sp<SkPicture>&&, SkiaImageToFenceMap&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale);

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -50,7 +50,7 @@ class NativeImage;
 class TextureMapper;
 enum class TextureMapperFlags : uint16_t;
 
-class BitmapTexture final : public ThreadSafeRefCounted<BitmapTexture> {
+class BitmapTexture final : public DeprecatedThreadSafeRefCountedSeqCst<BitmapTexture> {
 public:
     enum class Flags : uint8_t {
         SupportsAlpha = 1 << 0,

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGPUBuffer.h
@@ -33,7 +33,7 @@
 
 namespace WebCore {
 
-class TextureMapperGPUBuffer final : public ThreadSafeRefCounted<TextureMapperGPUBuffer> {
+class TextureMapperGPUBuffer final : public DeprecatedThreadSafeRefCountedSeqCst<TextureMapperGPUBuffer> {
     WTF_MAKE_NONCOPYABLE(TextureMapperGPUBuffer);
 public:
     enum class Type : uint8_t {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedAnimatedBackingStoreClient.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class GraphicsLayer;
 class TransformationMatrix;
 
-class CoordinatedAnimatedBackingStoreClient final : public ThreadSafeRefCounted<CoordinatedAnimatedBackingStoreClient> {
+class CoordinatedAnimatedBackingStoreClient final : public DeprecatedThreadSafeRefCountedSeqCst<CoordinatedAnimatedBackingStoreClient> {
 public:
     static Ref<CoordinatedAnimatedBackingStoreClient> create(GraphicsLayer&);
     ~CoordinatedAnimatedBackingStoreClient() = default;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -35,7 +35,7 @@ class CoordinatedPlatformLayer;
 class CoordinatedTileBuffer;
 class GraphicsLayer;
 
-class CoordinatedBackingStoreProxy final : public ThreadSafeRefCounted<CoordinatedBackingStoreProxy> {
+class CoordinatedBackingStoreProxy final : public DeprecatedThreadSafeRefCountedSeqCst<CoordinatedBackingStoreProxy> {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedBackingStoreProxy);
 public:
     static Ref<CoordinatedBackingStoreProxy> create();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedImageBackingStore.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class CoordinatedPlatformLayerBuffer;
 class NativeImage;
 
-class CoordinatedImageBackingStore final : public ThreadSafeRefCounted<CoordinatedImageBackingStore> {
+class CoordinatedImageBackingStore final : public DeprecatedThreadSafeRefCountedSeqCst<CoordinatedImageBackingStore> {
 public:
     static Ref<CoordinatedImageBackingStore> create(Ref<NativeImage>&&);
     ~CoordinatedImageBackingStore();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -60,7 +60,7 @@ class PaintingEngine;
 }
 #endif
 
-class CoordinatedPlatformLayer : public ThreadSafeRefCounted<CoordinatedPlatformLayer> {
+class CoordinatedPlatformLayer : public DeprecatedThreadSafeRefCountedSeqCst<CoordinatedPlatformLayer> {
 public:
     // FIXME: remove this client when a subclass is added for the WebProcess.
     class Client {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferProxy.h
@@ -37,7 +37,7 @@ class CoordinatedPlatformLayerBuffer;
 class IntSize;
 class TextureMapperLayer;
 
-class CoordinatedPlatformLayerBufferProxy final : public ThreadSafeRefCounted<CoordinatedPlatformLayerBufferProxy> {
+class CoordinatedPlatformLayerBufferProxy final : public DeprecatedThreadSafeRefCountedSeqCst<CoordinatedPlatformLayerBufferProxy> {
 public:
     static Ref<CoordinatedPlatformLayerBufferProxy> create();
     ~CoordinatedPlatformLayerBufferProxy();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -49,7 +49,7 @@ namespace WebCore {
 class BitmapTexture;
 class GLFence;
 
-class CoordinatedTileBuffer : public ThreadSafeRefCounted<CoordinatedTileBuffer> {
+class CoordinatedTileBuffer : public DeprecatedThreadSafeRefCountedSeqCst<CoordinatedTileBuffer> {
 public:
     enum Flag {
         NoFlags = 0,

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -31,11 +31,11 @@
 
 namespace WebCore {
 
-class GStreamerElementHarness : public ThreadSafeRefCounted<GStreamerElementHarness> {
+class GStreamerElementHarness : public DeprecatedThreadSafeRefCountedSeqCst<GStreamerElementHarness> {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerElementHarness);
 
 public:
-    class Stream : public ThreadSafeRefCounted<Stream> {
+    class Stream : public DeprecatedThreadSafeRefCountedSeqCst<Stream> {
         WTF_MAKE_TZONE_ALLOCATED(Stream);
 
     public:

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp
@@ -70,7 +70,7 @@ static WorkQueue& vpxDecoderQueueSingleton()
     return queue.get();
 }
 
-class LibWebRTCVPXInternalVideoDecoder : public ThreadSafeRefCounted<LibWebRTCVPXInternalVideoDecoder> , public webrtc::DecodedImageCallback {
+class LibWebRTCVPXInternalVideoDecoder : public DeprecatedThreadSafeRefCountedSeqCst<LibWebRTCVPXInternalVideoDecoder> , public webrtc::DecodedImageCallback {
 public:
     static Ref<LibWebRTCVPXInternalVideoDecoder> create(LibWebRTCVPXVideoDecoder::Type type, const VideoDecoder::Config& config, VideoDecoder::OutputCallback&& outputCallback) { return adoptRef(*new LibWebRTCVPXInternalVideoDecoder(type, config, WTF::move(outputCallback))); }
     ~LibWebRTCVPXInternalVideoDecoder() = default;

--- a/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
+++ b/Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoEncoder.cpp
@@ -63,7 +63,7 @@ static WorkQueue& vpxEncoderQueueSingleton()
     return queue.get();
 }
 
-class LibWebRTCVPXInternalVideoEncoder : public ThreadSafeRefCounted<LibWebRTCVPXInternalVideoEncoder> , public webrtc::EncodedImageCallback {
+class LibWebRTCVPXInternalVideoEncoder : public DeprecatedThreadSafeRefCountedSeqCst<LibWebRTCVPXInternalVideoEncoder> , public webrtc::EncodedImageCallback {
 public:
     static Ref<LibWebRTCVPXInternalVideoEncoder> create(LibWebRTCVPXVideoEncoder::Type type, VideoEncoder::OutputCallback&& outputCallback) { return adoptRef(*new LibWebRTCVPXInternalVideoEncoder(type, WTF::move(outputCallback))); }
     ~LibWebRTCVPXInternalVideoEncoder() = default;

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class PreventSourceFromEndingObserverWrapper : public ThreadSafeRefCounted<PreventSourceFromEndingObserverWrapper, WTF::DestructionThread::Main> {
+class PreventSourceFromEndingObserverWrapper : public DeprecatedThreadSafeRefCountedSeqCst<PreventSourceFromEndingObserverWrapper, WTF::DestructionThread::Main> {
 public:
     static Ref<PreventSourceFromEndingObserverWrapper> create(Ref<RealtimeMediaSource>&& source)
     {

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -221,7 +221,7 @@ private:
     bool m_isStarted { false };
 };
 
-class MediaStreamTrackPrivateSourceObserver : public ThreadSafeRefCounted<MediaStreamTrackPrivateSourceObserver, WTF::DestructionThread::Main> {
+class MediaStreamTrackPrivateSourceObserver : public DeprecatedThreadSafeRefCountedSeqCst<MediaStreamTrackPrivateSourceObserver, WTF::DestructionThread::Main> {
 public:
     static Ref<MediaStreamTrackPrivateSourceObserver> create(Ref<RealtimeMediaSource>&& source, std::function<void(Function<void()>&&)>&& postTask) { return adoptRef(*new MediaStreamTrackPrivateSourceObserver(WTF::move(source), WTF::move(postTask))); }
 

--- a/Source/WebCore/platform/mediastream/RTCDataChannelRemoteHandlerConnection.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelRemoteHandlerConnection.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class RTCDataChannelRemoteHandler;
 
-class RTCDataChannelRemoteHandlerConnection : public ThreadSafeRefCounted<RTCDataChannelRemoteHandlerConnection, WTF::DestructionThread::Main> {
+class RTCDataChannelRemoteHandlerConnection : public DeprecatedThreadSafeRefCountedSeqCst<RTCDataChannelRemoteHandlerConnection, WTF::DestructionThread::Main> {
 public:
     virtual ~RTCDataChannelRemoteHandlerConnection() = default;
 

--- a/Source/WebCore/platform/mediastream/RTCDataChannelRemoteSourceConnection.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelRemoteSourceConnection.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-class RTCDataChannelRemoteSourceConnection : public ThreadSafeRefCounted<RTCDataChannelRemoteSourceConnection, WTF::DestructionThread::Main> {
+class RTCDataChannelRemoteSourceConnection : public DeprecatedThreadSafeRefCountedSeqCst<RTCDataChannelRemoteSourceConnection, WTF::DestructionThread::Main> {
 public:
     virtual ~RTCDataChannelRemoteSourceConnection() = default;
 

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingAudioSource.h
@@ -57,7 +57,7 @@ class AudioTrackSinkInterface;
 namespace WebCore {
 
 class RealtimeOutgoingAudioSource
-    : public ThreadSafeRefCounted<RealtimeOutgoingAudioSource, WTF::DestructionThread::Main>
+    : public DeprecatedThreadSafeRefCountedSeqCst<RealtimeOutgoingAudioSource, WTF::DestructionThread::Main>
     , public webrtc::AudioSourceInterface
     , private MediaStreamTrackPrivateObserver
     , private RealtimeMediaSource::AudioSampleObserver

--- a/Source/WebCore/platform/mediastream/WebAudioSourceProvider.h
+++ b/Source/WebCore/platform/mediastream/WebAudioSourceProvider.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class WebAudioSourceProvider : public ThreadSafeRefCounted<WebAudioSourceProvider, WTF::DestructionThread::Main>, public AudioSourceProvider {
+class WebAudioSourceProvider : public DeprecatedThreadSafeRefCountedSeqCst<WebAudioSourceProvider, WTF::DestructionThread::Main>, public AudioSourceProvider {
 };
 
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerRTPPacketizer.h
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-class GStreamerRTPPacketizer : public ThreadSafeRefCounted<GStreamerRTPPacketizer> {
+class GStreamerRTPPacketizer : public DeprecatedThreadSafeRefCountedSeqCst<GStreamerRTPPacketizer> {
     WTF_MAKE_NONCOPYABLE(GStreamerRTPPacketizer);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(GStreamerRTPPacketizer);
 public:

--- a/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockAudioCaptureUnit.mm
@@ -93,7 +93,7 @@ CaptureSourceOrError MockRealtimeAudioSource::create(String&& deviceID, AtomStri
     return CoreAudioCaptureSource::createForTesting(WTF::move(deviceID), std::get<MockMicrophoneProperties>(device->properties).deviceID, WTF::move(name), WTF::move(hashSalts), constraints, pageIdentifier, std::get<MockMicrophoneProperties>(device->properties).echoCancellation);
 }
 
-class MockAudioCaptureInternalUnitState : public ThreadSafeRefCounted<MockAudioCaptureInternalUnitState> {
+class MockAudioCaptureInternalUnitState : public DeprecatedThreadSafeRefCountedSeqCst<MockAudioCaptureInternalUnitState> {
 public:
     static Ref<MockAudioCaptureInternalUnitState> create() { return adoptRef(*new MockAudioCaptureInternalUnitState()); }
 

--- a/Source/WebCore/platform/network/BlobData.h
+++ b/Source/WebCore/platform/network/BlobData.h
@@ -106,7 +106,7 @@ private:
 
 typedef Vector<BlobDataItem> BlobDataItemList;
 
-class BlobData : public ThreadSafeRefCounted<BlobData> {
+class BlobData : public DeprecatedThreadSafeRefCountedSeqCst<BlobData> {
 public:
     static Ref<BlobData> create(const String& contentType)
     {

--- a/Source/WebCore/platform/network/StorageSessionProvider.h
+++ b/Source/WebCore/platform/network/StorageSessionProvider.h
@@ -31,7 +31,7 @@ namespace WebCore {
 
 class NetworkStorageSession;
 
-class StorageSessionProvider : public ThreadSafeRefCounted<StorageSessionProvider> {
+class StorageSessionProvider : public DeprecatedThreadSafeRefCountedSeqCst<StorageSessionProvider> {
 public:
     virtual NetworkStorageSession* storageSession() const = 0;
 

--- a/Source/WebCore/platform/network/SynchronousLoaderClient.h
+++ b/Source/WebCore/platform/network/SynchronousLoaderClient.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 class SharedBuffer;
 
-class SynchronousLoaderMessageQueue : public ThreadSafeRefCounted<SynchronousLoaderMessageQueue> {
+class SynchronousLoaderMessageQueue : public DeprecatedThreadSafeRefCountedSeqCst<SynchronousLoaderMessageQueue> {
 public:
     static Ref<SynchronousLoaderMessageQueue> create() { return adoptRef(*new SynchronousLoaderMessageQueue); }
 

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -43,7 +43,7 @@ class NetworkLoadMetrics;
 class ResourceError;
 class FragmentedSharedBuffer;
 
-class CurlRequest final : public ThreadSafeRefCounted<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient, public CanMakeThreadSafeCheckedPtr<CurlRequest> {
+class CurlRequest final : public DeprecatedThreadSafeRefCountedSeqCst<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient, public CanMakeThreadSafeCheckedPtr<CurlRequest> {
     WTF_MAKE_TZONE_ALLOCATED(CurlRequest);
     WTF_MAKE_NONCOPYABLE(CurlRequest);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CurlRequest);

--- a/Source/WebCore/platform/text/BidiContext.cpp
+++ b/Source/WebCore/platform/text/BidiContext.cpp
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-struct SameSizeAsBidiContext : public ThreadSafeRefCounted<SameSizeAsBidiContext> {
+struct SameSizeAsBidiContext : public DeprecatedThreadSafeRefCountedSeqCst<SameSizeAsBidiContext> {
     uint32_t bitfields : 16;
     void* parent;
 };

--- a/Source/WebCore/platform/text/BidiContext.h
+++ b/Source/WebCore/platform/text/BidiContext.h
@@ -30,7 +30,7 @@ namespace WebCore {
 enum BidiEmbeddingSource { FromStyleOrDOM, FromUnicode };
 
 // Used to keep track of explicit embeddings.
-class BidiContext : public ThreadSafeRefCounted<BidiContext> {
+class BidiContext : public DeprecatedThreadSafeRefCountedSeqCst<BidiContext> {
 public:
     WEBCORE_EXPORT static Ref<BidiContext> create(unsigned char level, UCharDirection, bool override = false, BidiEmbeddingSource = FromStyleOrDOM, BidiContext* parent = nullptr);
 

--- a/Source/WebCore/svg/properties/SVGAnimatedProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedProperty.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class SVGElement;
 class WeakPtrImplWithEventTargetData;
 
-class SVGAnimatedProperty : public ThreadSafeRefCounted<SVGAnimatedProperty>, public SVGPropertyOwner {
+class SVGAnimatedProperty : public DeprecatedThreadSafeRefCountedSeqCst<SVGAnimatedProperty>, public SVGPropertyOwner {
 public:
     virtual ~SVGAnimatedProperty() = default;
     

--- a/Source/WebCore/svg/properties/SVGProperty.h
+++ b/Source/WebCore/svg/properties/SVGProperty.h
@@ -29,7 +29,7 @@ namespace WebCore {
 enum class SVGPropertyAccess : uint8_t { ReadWrite, ReadOnly };
 enum class SVGPropertyState : uint8_t { Clean, Dirty };
 
-class SVGProperty : public ThreadSafeRefCounted<SVGProperty> {
+class SVGProperty : public DeprecatedThreadSafeRefCountedSeqCst<SVGProperty> {
 public:
     virtual ~SVGProperty() = default;
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -70,7 +70,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WorkerMessagingProxy);
 // The WorkerUserGestureForwarder, on the other hand, can be ref'd and deref'd from
 // non-main thread contexts, allowing it to be passed from main to Worker scopes and
 // vice versa.
-class WorkerUserGestureForwarder : public ThreadSafeRefCounted<WorkerUserGestureForwarder, WTF::DestructionThread::Main> {
+class WorkerUserGestureForwarder : public DeprecatedThreadSafeRefCountedSeqCst<WorkerUserGestureForwarder, WTF::DestructionThread::Main> {
 public:
     static Ref<WorkerUserGestureForwarder> create(RefPtr<UserGestureToken>&& token) { return *new WorkerUserGestureForwarder(WTF::move(token)); }
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -43,7 +43,7 @@ class WeakPtrImplWithEventTargetData;
 class WorkerInspectorProxy;
 class WorkerUserGestureForwarder;
 
-class WorkerMessagingProxy final : public ThreadSafeRefCounted<WorkerMessagingProxy>, public WorkerGlobalScopeProxy, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy, public CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy> {
+class WorkerMessagingProxy final : public DeprecatedThreadSafeRefCountedSeqCst<WorkerMessagingProxy>, public WorkerGlobalScopeProxy, public WorkerObjectProxy, public WorkerLoaderProxy, public WorkerDebuggerProxy, public WorkerBadgeProxy, public CanMakeThreadSafeCheckedPtr<WorkerMessagingProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WorkerMessagingProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerMessagingProxy);
 public:

--- a/Source/WebCore/workers/WorkerNotificationClient.h
+++ b/Source/WebCore/workers/WorkerNotificationClient.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class WeakPtrImplWithEventTargetData;
 class WorkerGlobalScope;
 
-class WorkerNotificationClient : public NotificationClient, public ThreadSafeRefCounted<WorkerNotificationClient> {
+class WorkerNotificationClient : public NotificationClient, public DeprecatedThreadSafeRefCountedSeqCst<WorkerNotificationClient> {
 public:
     static Ref<WorkerNotificationClient> create(WorkerGlobalScope&);
 

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -105,7 +105,7 @@ public:
 
     WEBCORE_EXPORT static ResourceError validateWorkerResponse(const ResourceResponse&, Source, FetchOptions::Destination);
 
-    class ServiceWorkerDataManager : public ThreadSafeRefCounted<ServiceWorkerDataManager, WTF::DestructionThread::Main> {
+    class ServiceWorkerDataManager : public DeprecatedThreadSafeRefCountedSeqCst<ServiceWorkerDataManager, WTF::DestructionThread::Main> {
     public:
         static Ref<ServiceWorkerDataManager> create(ScriptExecutionContextIdentifier identifier) { return adoptRef(*new ServiceWorkerDataManager(identifier)); }
         WEBCORE_EXPORT ~ServiceWorkerDataManager();

--- a/Source/WebCore/worklets/WorkletGlobalScopeProxy.h
+++ b/Source/WebCore/worklets/WorkletGlobalScopeProxy.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class WorkletPendingTasks;
 
-class WorkletGlobalScopeProxy : public ThreadSafeRefCounted<WorkletGlobalScopeProxy> {
+class WorkletGlobalScopeProxy : public DeprecatedThreadSafeRefCountedSeqCst<WorkletGlobalScopeProxy> {
 public:
     virtual ~WorkletGlobalScopeProxy() = default;
 

--- a/Source/WebCore/worklets/WorkletPendingTasks.h
+++ b/Source/WebCore/worklets/WorkletPendingTasks.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class Worklet;
 
 // https://drafts.css-houdini.org/worklets/#pending-tasks-struct
-class WorkletPendingTasks : public ThreadSafeRefCounted<WorkletPendingTasks> {
+class WorkletPendingTasks : public DeprecatedThreadSafeRefCountedSeqCst<WorkletPendingTasks> {
 public:
     static Ref<WorkletPendingTasks> create(Worklet& worklet, DOMPromiseDeferred<void>&& promise, int counter)
     {

--- a/Source/WebGPU/WebGPU/DDMesh.h
+++ b/Source/WebGPU/WebGPU/DDMesh.h
@@ -45,7 +45,7 @@ namespace WebGPU {
 
 class Instance;
 
-class DDMesh : public ThreadSafeRefCounted<DDMesh>, public WGPUDDMeshImpl {
+class DDMesh : public DeprecatedThreadSafeRefCountedSeqCst<DDMesh>, public WGPUDDMeshImpl {
     WTF_MAKE_TZONE_ALLOCATED(DDMesh);
 public:
     static Ref<DDMesh> create(const WGPUDDCreateMeshDescriptor& descriptor, Instance& instance)

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -53,7 +53,7 @@ class TextureView;
 
 // https://gpuweb.github.io/gpuweb/#gpuqueue
 // A device owns its default queue, not the other way around.
-class Queue : public WGPUQueueImpl, public ThreadSafeRefCounted<Queue> {
+class Queue : public WGPUQueueImpl, public DeprecatedThreadSafeRefCountedSeqCst<Queue> {
     WTF_MAKE_TZONE_ALLOCATED(Queue);
 public:
     static Ref<Queue> create(id<MTLCommandQueue> commandQueue, Adapter& adapter, Device& device)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -91,7 +91,7 @@ struct GPUProcessCreationParameters;
 struct GPUProcessSessionParameters;
 struct SharedPreferencesForWebProcess;
 
-class GPUProcess final : public AuxiliaryProcess, public ThreadSafeRefCounted<GPUProcess> {
+class GPUProcess final : public AuxiliaryProcess, public DeprecatedThreadSafeRefCountedSeqCst<GPUProcess> {
     WTF_MAKE_NONCOPYABLE(GPUProcess);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(GPUProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GPUProcess);

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -48,7 +48,7 @@ namespace WebKit {
 class GPUConnectionToWebProcess;
 // Class holding GPU process resources per Web Content process.
 // Thread-safe.
-class RemoteSharedResourceCache final : public ThreadSafeRefCounted<RemoteSharedResourceCache>, IPC::MessageReceiver {
+class RemoteSharedResourceCache final : public DeprecatedThreadSafeRefCountedSeqCst<RemoteSharedResourceCache>, IPC::MessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteSharedResourceCache);
 public:
     static Ref<RemoteSharedResourceCache> create(GPUConnectionToWebProcess&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteSnapshot.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteSnapshot.h
@@ -44,7 +44,7 @@ namespace WebKit {
 // should not have any access to data of each other.
 // Each display list receives a placeholder for their subframe display lists. The placeholders are resolved through applyFrame().
 // The snapshot starts with the root frame pending as if the frame reference was added with it.
-class RemoteSnapshot final : public ThreadSafeRefCounted<RemoteSnapshot> {
+class RemoteSnapshot final : public DeprecatedThreadSafeRefCountedSeqCst<RemoteSnapshot> {
     WTF_MAKE_NONCOPYABLE(RemoteSnapshot);
     WTF_MAKE_TZONE_ALLOCATED(RemoteSnapshot);
 public:

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -41,7 +41,7 @@ class CARingBuffer;
 
 namespace WebKit {
 
-class RemoteAudioSourceProviderProxy : public ThreadSafeRefCounted<RemoteAudioSourceProviderProxy>
+class RemoteAudioSourceProviderProxy : public DeprecatedThreadSafeRefCountedSeqCst<RemoteAudioSourceProviderProxy>
     , public WebCore::AudioSourceProviderClient {
 public:
     static Ref<RemoteAudioSourceProviderProxy> create(WebCore::MediaPlayerIdentifier, Ref<IPC::Connection>&&, WebCore::AudioSourceProviderAVFObjC&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioTrackProxy.h
@@ -48,7 +48,7 @@ class GPUConnectionToWebProcess;
 struct AudioTrackPrivateRemoteConfiguration;
 
 class RemoteAudioTrackProxy final
-    : public ThreadSafeRefCounted<RemoteAudioTrackProxy, WTF::DestructionThread::Main>
+    : public DeprecatedThreadSafeRefCountedSeqCst<RemoteAudioTrackProxy, WTF::DestructionThread::Main>
     , public WebCore::AudioTrackPrivateClient {
     WTF_MAKE_TZONE_ALLOCATED(RemoteAudioTrackProxy);
 public:

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -48,7 +48,7 @@ class GPUConnectionToWebProcess;
 struct TextTrackPrivateRemoteConfiguration;
 
 class RemoteTextTrackProxy final
-    : public ThreadSafeRefCounted<RemoteTextTrackProxy, WTF::DestructionThread::Main>
+    : public DeprecatedThreadSafeRefCountedSeqCst<RemoteTextTrackProxy, WTF::DestructionThread::Main>
     , private WebCore::InbandTextTrackPrivateClient {
     WTF_MAKE_TZONE_ALLOCATED(RemoteTextTrackProxy);
 public:

--- a/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoTrackProxy.h
@@ -48,7 +48,7 @@ class GPUConnectionToWebProcess;
 struct VideoTrackPrivateRemoteConfiguration;
 
 class RemoteVideoTrackProxy final
-    : public ThreadSafeRefCounted<RemoteVideoTrackProxy, WTF::DestructionThread::Main>
+    : public DeprecatedThreadSafeRefCountedSeqCst<RemoteVideoTrackProxy, WTF::DestructionThread::Main>
     , private WebCore::VideoTrackPrivateClient {
     WTF_MAKE_TZONE_ALLOCATED(RemoteVideoTrackProxy);
 public:

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -51,7 +51,7 @@ namespace WebKit {
 class GPUConnectionToWebProcess;
 struct SharedPreferencesForWebProcess;
 
-class RemoteSampleBufferDisplayLayer : public ThreadSafeRefCounted<RemoteSampleBufferDisplayLayer, WTF::DestructionThread::MainRunLoop>, public WebCore::SampleBufferDisplayLayerClient, public IPC::MessageReceiver, private IPC::MessageSender {
+class RemoteSampleBufferDisplayLayer : public DeprecatedThreadSafeRefCountedSeqCst<RemoteSampleBufferDisplayLayer, WTF::DestructionThread::MainRunLoop>, public WebCore::SampleBufferDisplayLayerClient, public IPC::MessageReceiver, private IPC::MessageSender {
     WTF_MAKE_TZONE_ALLOCATED(RemoteSampleBufferDisplayLayer);
 public:
     void ref() const final { ThreadSafeRefCounted::ref(); }

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -65,7 +65,7 @@ class ModelProcessModelPlayerManagerProxy;
 struct ModelProcessConnectionParameters;
 
 class ModelConnectionToWebProcess
-    : public ThreadSafeRefCounted<ModelConnectionToWebProcess, WTF::DestructionThread::Main>
+    : public DeprecatedThreadSafeRefCountedSeqCst<ModelConnectionToWebProcess, WTF::DestructionThread::Main>
     , public CanMakeWeakPtr<ModelConnectionToWebProcess>
     , IPC::Connection::Client {
     WTF_MAKE_NONCOPYABLE(ModelConnectionToWebProcess);

--- a/Source/WebKit/ModelProcess/ModelProcess.h
+++ b/Source/WebKit/ModelProcess/ModelProcess.h
@@ -51,7 +51,7 @@ class ModelConnectionToWebProcess;
 struct ModelProcessConnectionParameters;
 struct ModelProcessCreationParameters;
 
-class ModelProcess final : public AuxiliaryProcess, public ThreadSafeRefCounted<ModelProcess> {
+class ModelProcess final : public AuxiliaryProcess, public DeprecatedThreadSafeRefCountedSeqCst<ModelProcess> {
     WTF_MAKE_NONCOPYABLE(ModelProcess);
     WTF_MAKE_TZONE_ALLOCATED(ModelProcess);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ModelProcess);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1675,7 +1675,7 @@ void NetworkProcess::fetchWebsitesWithUserInteractions(PAL::SessionID sessionID,
 void NetworkProcess::fetchWebsiteData(PAL::SessionID sessionID, OptionSet<WebsiteDataType> websiteDataTypes, OptionSet<WebsiteDataFetchOption> fetchOptions, CompletionHandler<void(WebsiteData&&)>&& completionHandler)
 {
     RELEASE_LOG(Storage, "NetworkProcess::fetchWebsiteData started to fetch data for session %" PRIu64, sessionID.toUInt64());
-    struct CallbackAggregator final : public ThreadSafeRefCounted<CallbackAggregator> {
+    struct CallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<CallbackAggregator> {
         explicit CallbackAggregator(CompletionHandler<void(WebsiteData&&)>&& completionHandler)
             : m_completionHandler(WTF::move(completionHandler))
         {
@@ -2044,7 +2044,7 @@ void NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains(PAL::Sess
 
     OptionSet<WebsiteDataFetchOption> fetchOptions = WebsiteDataFetchOption::DoNotCreateProcesses;
 
-    struct CallbackAggregator final : public ThreadSafeRefCounted<CallbackAggregator> {
+    struct CallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<CallbackAggregator> {
         explicit CallbackAggregator(CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
             : m_completionHandler(WTF::move(completionHandler))
         {
@@ -2201,7 +2201,7 @@ void NetworkProcess::deleteCookiesForTesting(PAL::SessionID sessionID, Registrab
 void NetworkProcess::registrableDomainsWithWebsiteData(PAL::SessionID sessionID, OptionSet<WebsiteDataType> websiteDataTypes, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
 {
     CheckedPtr session = networkSession(sessionID);
-    struct CallbackAggregator final : public ThreadSafeRefCounted<CallbackAggregator> {
+    struct CallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<CallbackAggregator> {
         explicit CallbackAggregator(CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)
             : m_completionHandler(WTF::move(completionHandler))
         {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -139,7 +139,7 @@ class Cache;
 enum class CacheOption : uint8_t;
 }
 
-class NetworkProcess final : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>
+class NetworkProcess final : public AuxiliaryProcess, private DownloadManager::Client, public DeprecatedThreadSafeRefCountedSeqCst<NetworkProcess>
 {
     WTF_MAKE_NONCOPYABLE(NetworkProcess);
     WTF_MAKE_TZONE_ALLOCATED(NetworkProcess);
@@ -377,8 +377,8 @@ public:
 
     const String& uiProcessBundleIdentifier() const;
 
-    void ref() const final { ThreadSafeRefCounted<NetworkProcess>::ref(); }
-    void deref() const final { ThreadSafeRefCounted<NetworkProcess>::deref(); }
+    void ref() const final { DeprecatedThreadSafeRefCountedSeqCst<NetworkProcess>::ref(); }
+    void deref() const final { DeprecatedThreadSafeRefCountedSeqCst<NetworkProcess>::deref(); }
 
     void storePrivateClickMeasurement(PAL::SessionID, WebCore::PrivateClickMeasurement&&);
     void simulatePrivateClickMeasurementConversion(PAL::SessionID, int priority, int triggerData, const URL& sourceURL, const URL& destinationURL);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementStore.h
@@ -36,7 +36,7 @@ namespace PCM {
 class Database;
 struct DebugInfo;
 
-class Store : public ThreadSafeRefCounted<Store> {
+class Store : public DeprecatedThreadSafeRefCountedSeqCst<Store> {
 public:
     virtual ~Store() = default;
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannel.h
@@ -41,7 +41,7 @@ typedef struct _GOutputStream GOutputStream;
 namespace WebKit {
 namespace NetworkCache {
 
-class IOChannel : public ThreadSafeRefCounted<IOChannel> {
+class IOChannel : public DeprecatedThreadSafeRefCountedSeqCst<IOChannel> {
 public:
     enum class Type { Read, Write, Create };
     static Ref<IOChannel> open(const String& filePath, Type type, std::optional<WorkQueue::QOS> qos = { }) { return adoptRef(*new IOChannel(filePath, type, qos)); }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -240,7 +240,7 @@ void Storage::WriteOperation::invokeMappedBodyHandler(const Data& data)
         m_mappedBodyHandler(data);
 }
 
-class TraverseOperation final : public ThreadSafeRefCounted<TraverseOperation, WTF::DestructionThread::MainRunLoop> {
+class TraverseOperation final : public DeprecatedThreadSafeRefCountedSeqCst<TraverseOperation, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<TraverseOperation> create(Storage::TraverseHandler&& handler)
     {

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
@@ -35,7 +35,7 @@ namespace WebKit {
 
 class CacheStorageCache;
 
-class CacheStorageRegistry : public ThreadSafeRefCounted<CacheStorageRegistry> {
+class CacheStorageRegistry : public DeprecatedThreadSafeRefCountedSeqCst<CacheStorageRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(CacheStorageRegistry);
 public:
     static Ref<CacheStorageRegistry> create();

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageStore.h
@@ -33,7 +33,7 @@ namespace WebKit {
 class CacheStorageRecordInformation;
 struct CacheStorageRecord;
 
-class CacheStorageStore : public ThreadSafeRefCounted<CacheStorageStore> {
+class CacheStorageStore : public DeprecatedThreadSafeRefCountedSeqCst<CacheStorageStore> {
 public:
     virtual ~CacheStorageStore() = default;
     using ReadAllRecordInfosCallback = CompletionHandler<void(Vector<CacheStorageRecordInformation>&&)>;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -85,7 +85,7 @@ private:
 #endif
 };
 
-class IPAddressCallbackAggregator final : public ThreadSafeRefCounted<IPAddressCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
+class IPAddressCallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<IPAddressCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
 public:
     using Callback = CompletionHandler<void(RTCNetwork::IPAddress&&, RTCNetwork::IPAddress&&, HashMap<String, RTCNetwork>&&)>;
     static Ref<IPAddressCallbackAggregator> create(Callback&& callback) { return adoptRef(*new IPAddressCallbackAggregator(WTF::move(callback))); }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -78,7 +78,7 @@ struct SocketComparator {
     }
 };
 
-class NetworkRTCProvider : private FunctionDispatcher, private IPC::MessageReceiver, public ThreadSafeRefCounted<NetworkRTCProvider, WTF::DestructionThread::MainRunLoop>, public CanMakeThreadSafeCheckedPtr<NetworkRTCProvider> {
+class NetworkRTCProvider : private FunctionDispatcher, private IPC::MessageReceiver, public DeprecatedThreadSafeRefCountedSeqCst<NetworkRTCProvider, WTF::DestructionThread::MainRunLoop>, public CanMakeThreadSafeCheckedPtr<NetworkRTCProvider> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(NetworkRTCProvider);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkRTCProvider);
 public:

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -63,7 +63,7 @@ public:
     void setOption(int option, int value);
     void sendTo(std::span<const uint8_t>, const webrtc::SocketAddress&, const webrtc::AsyncSocketPacketOptions&);
 
-    class ConnectionStateTracker : public ThreadSafeRefCounted<ConnectionStateTracker> {
+    class ConnectionStateTracker : public DeprecatedThreadSafeRefCountedSeqCst<ConnectionStateTracker> {
     public:
         static Ref<ConnectionStateTracker> create() { return adoptRef(*new ConnectionStateTracker()); }
         void markAsStopped() { m_isStopped = true; }

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -57,7 +57,7 @@ namespace IPC {
 // The whole IPC::Connection message order is not preserved.
 //
 // The StreamClientConnection trusts the StreamServerConnection.
-class StreamClientConnection final : public ThreadSafeRefCounted<StreamClientConnection>, public CanMakeThreadSafeCheckedPtr<StreamClientConnection> {
+class StreamClientConnection final : public DeprecatedThreadSafeRefCountedSeqCst<StreamClientConnection>, public CanMakeThreadSafeCheckedPtr<StreamClientConnection> {
     WTF_MAKE_TZONE_ALLOCATED(StreamClientConnection);
     WTF_MAKE_NONCOPYABLE(StreamClientConnection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StreamClientConnection);

--- a/Source/WebKit/Platform/IPC/StreamMessageReceiver.h
+++ b/Source/WebKit/Platform/IPC/StreamMessageReceiver.h
@@ -32,7 +32,7 @@ namespace IPC {
 class StreamServerConnection;
 class Decoder;
 
-class StreamMessageReceiver : public ThreadSafeRefCounted<StreamMessageReceiver> {
+class StreamMessageReceiver : public DeprecatedThreadSafeRefCountedSeqCst<StreamMessageReceiver> {
 public:
     virtual ~StreamMessageReceiver() { }
 

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -78,7 +78,7 @@ protected:
 //   void didReceiveStreamMessage(StreamServerConnection&, Decoder&);
 //
 // The StreamServerConnection does not trust the StreamClientConnection.
-class StreamServerConnection final : public ThreadSafeRefCounted<StreamServerConnection>, private MessageReceiveQueue, private Connection::Client {
+class StreamServerConnection final : public DeprecatedThreadSafeRefCountedSeqCst<StreamServerConnection>, private MessageReceiveQueue, private Connection::Client {
     WTF_MAKE_NONCOPYABLE(StreamServerConnection);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StreamServerConnection);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StreamServerConnection);

--- a/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.h
+++ b/Source/WebKit/Platform/classifier/cocoa/TextExtractionFilter.h
@@ -41,7 +41,7 @@ OBJC_CLASS MLModel;
 
 namespace WebKit {
 
-class TextExtractionFilter : public ThreadSafeRefCounted<TextExtractionFilter> {
+class TextExtractionFilter : public DeprecatedThreadSafeRefCountedSeqCst<TextExtractionFilter> {
     WTF_MAKE_TZONE_ALLOCATED(TextExtractionFilter);
     WTF_MAKE_NONCOPYABLE(TextExtractionFilter);
 public:

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -48,7 +48,7 @@ namespace API {
 
 class Object
 #if !DELEGATE_REF_COUNTING_TO_COCOA
-    : public ThreadSafeRefCounted<Object>
+    : public DeprecatedThreadSafeRefCountedSeqCst<Object>
 #endif
 {
     WTF_MAKE_NONCOPYABLE(Object);

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -264,7 +264,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
         RetainPtr<_WKRemoteObjectRegistry> remoteObjectRegistry = self;
         uint64_t replyID = replyInfo->replyID;
 
-        class ReplyBlockCallChecker : public WTF::ThreadSafeRefCounted<ReplyBlockCallChecker, WTF::DestructionThread::MainRunLoop> {
+        class ReplyBlockCallChecker : public WTF::DeprecatedThreadSafeRefCountedSeqCst<ReplyBlockCallChecker, WTF::DestructionThread::MainRunLoop> {
         public:
             static Ref<ReplyBlockCallChecker> create(_WKRemoteObjectRegistry *registry, uint64_t replyID) { return adoptRef(*new ReplyBlockCallChecker(registry, replyID)); }
 

--- a/Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h
+++ b/Source/WebKit/Shared/Cocoa/CompletionHandlerCallChecker.h
@@ -30,7 +30,7 @@
 
 namespace WebKit {
 
-class CompletionHandlerCallChecker : public WTF::ThreadSafeRefCounted<CompletionHandlerCallChecker> {
+class CompletionHandlerCallChecker : public WTF::DeprecatedThreadSafeRefCountedSeqCst<CompletionHandlerCallChecker> {
 public:
     static Ref<CompletionHandlerCallChecker> create(id delegate, SEL delegateMethodSelector);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
@@ -30,7 +30,7 @@
 
 namespace WebKit {
 
-class PageLoadStateObserver : public ThreadSafeRefCounted<PageLoadStateObserver>, public PageLoadState::Observer {
+class PageLoadStateObserver : public DeprecatedThreadSafeRefCountedSeqCst<PageLoadStateObserver>, public PageLoadState::Observer {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PageLoadStateObserver);
 public:
     static Ref<PageLoadStateObserver> create(id object, NSString *activeURLKey = @"activeURL")

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -66,7 +66,7 @@ enum class AlwaysRunsAtBackgroundPriority : bool { No, Yes };
 using ExtensionCapabilityGrantMap = HashMap<String, ExtensionCapabilityGrant>;
 
 class AuxiliaryProcessProxy
-    : public ThreadSafeRefCounted<AuxiliaryProcessProxy, WTF::DestructionThread::MainRunLoop>
+    : public DeprecatedThreadSafeRefCountedSeqCst<AuxiliaryProcessProxy, WTF::DestructionThread::MainRunLoop>
     , public ResponsivenessTimer::Client
     , private ProcessLauncher::Client
     , public IPC::Connection::Client {

--- a/Source/WebKit/UIProcess/Cocoa/LegacyWebArchiveCallbackAggregator.h
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyWebArchiveCallbackAggregator.h
@@ -31,7 +31,7 @@
 
 namespace WebKit {
 
-class LegacyWebArchiveCallbackAggregator final : public ThreadSafeRefCounted<LegacyWebArchiveCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
+class LegacyWebArchiveCallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<LegacyWebArchiveCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<LegacyWebArchiveCallbackAggregator> create(WebCore::FrameIdentifier rootFrameIdentifier, HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>>&& frameArchives, CompletionHandler<void(RefPtr<WebCore::LegacyWebArchive>&&)>&& callback)
     {

--- a/Source/WebKit/UIProcess/Cocoa/XPCEventHandler.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCEventHandler.h
@@ -29,7 +29,7 @@
 
 namespace WebKit {
 
-class XPCEventHandler : public ThreadSafeRefCounted<XPCEventHandler> {
+class XPCEventHandler : public DeprecatedThreadSafeRefCountedSeqCst<XPCEventHandler> {
 public:
     virtual ~XPCEventHandler() { }
 

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -105,7 +105,7 @@ struct ProcessLaunchOptions {
 };
 
 #if USE(EXTENSIONKIT)
-class LaunchGrant : public ThreadSafeRefCounted<LaunchGrant> {
+class LaunchGrant : public DeprecatedThreadSafeRefCountedSeqCst<LaunchGrant> {
 public:
     static Ref<LaunchGrant> create(ExtensionProcess&);
     ~LaunchGrant();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16027,7 +16027,7 @@ void WebPageProxy::didFindTextManipulationItems(const Vector<WebCore::TextManipu
 
 void WebPageProxy::completeTextManipulation(const Vector<TextManipulationItem>& items, CompletionHandler<void(Vector<TextManipulationControllerManipulationFailure>&&)>&& completionHandler)
 {
-    class TextManipulationCallbackAggregator final : public ThreadSafeRefCounted<TextManipulationCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
+    class TextManipulationCallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<TextManipulationCallbackAggregator, WTF::DestructionThread::MainRunLoop> {
     public:
         struct ItemInfo {
             Markable<FrameIdentifier> frameID;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -612,7 +612,7 @@ void WebsiteDataStore::fetchData(OptionSet<WebsiteDataType> dataTypes, OptionSet
 void WebsiteDataStore::fetchDataAndApply(OptionSet<WebsiteDataType> dataTypes, OptionSet<WebsiteDataFetchOption> fetchOptions, Ref<WorkQueue>&& queue, Function<void(Vector<WebsiteDataRecord>)>&& apply)
 {
     RELEASE_LOG(Storage, "WebsiteDataStore::fetchDataAndApply started to fetch data for session %" PRIu64, m_sessionID.toUInt64());
-    class CallbackAggregator final : public ThreadSafeRefCounted<CallbackAggregator, WTF::DestructionThread::MainRunLoop> {
+    class CallbackAggregator final : public DeprecatedThreadSafeRefCountedSeqCst<CallbackAggregator, WTF::DestructionThread::MainRunLoop> {
     public:
         static Ref<CallbackAggregator> create(OptionSet<WebsiteDataFetchOption> fetchOptions, Ref<WorkQueue>&& queue, Function<void(Vector<WebsiteDataRecord>)>&& apply, WebsiteDataStore& dataStore)
         {

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.h
@@ -59,7 +59,7 @@ class WebAutomationSessionProxy : public IPC::MessageReceiver
 #if ENABLE(WEBDRIVER_BIDI)
     , public WebCore::AutomationInstrumentationClient
 #endif
-    , public ThreadSafeRefCounted<WebAutomationSessionProxy> {
+    , public DeprecatedThreadSafeRefCountedSeqCst<WebAutomationSessionProxy> {
     WTF_MAKE_TZONE_ALLOCATED(WebAutomationSessionProxy);
 public:
     static Ref<WebAutomationSessionProxy> create(const String& sessionIdentifier);

--- a/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/RemoteSharedResourceCacheProxy.h
@@ -35,7 +35,7 @@ namespace WebKit {
 
 // Class for maintaining view of GPU process RemoteSharedResourceCache state in Web process.
 // Thread-safe.
-class RemoteSharedResourceCacheProxy : public ThreadSafeRefCounted<RemoteSharedResourceCacheProxy> {
+class RemoteSharedResourceCacheProxy : public DeprecatedThreadSafeRefCountedSeqCst<RemoteSharedResourceCacheProxy> {
     WTF_MAKE_TZONE_ALLOCATED(RemoteSharedResourceCacheProxy);
 public:
     static Ref<RemoteSharedResourceCacheProxy> create();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -62,7 +62,7 @@ constexpr uint64_t putPixelBufferBatchedAreaLimit = 60 * 60;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteImageBufferProxy);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteSerializedImageBufferProxy);
 
-class RemoteImageBufferProxyFlushFence : public ThreadSafeRefCounted<RemoteImageBufferProxyFlushFence> {
+class RemoteImageBufferProxyFlushFence : public DeprecatedThreadSafeRefCountedSeqCst<RemoteImageBufferProxyFlushFence> {
     WTF_MAKE_NONCOPYABLE(RemoteImageBufferProxyFlushFence);
     WTF_MAKE_TZONE_ALLOCATED(RemoteImageBufferProxyFlushFence);
 public:

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -38,7 +38,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-class RemoteImageBufferSetProxyFlushFence : public ThreadSafeRefCounted<RemoteImageBufferSetProxyFlushFence> {
+class RemoteImageBufferSetProxyFlushFence : public DeprecatedThreadSafeRefCountedSeqCst<RemoteImageBufferSetProxyFlushFence> {
     WTF_MAKE_NONCOPYABLE(RemoteImageBufferSetProxyFlushFence);
     WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteImageBufferSetProxyFlushFence);
 public:

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -59,7 +59,7 @@ class ConvertToBackingContext;
 class DowncastConvertToBackingContext;
 }
 
-class RemoteGPUProxy final : public WebCore::WebGPU::GPU, private IPC::Connection::Client, public ThreadSafeRefCounted<RemoteGPUProxy>, SerialFunctionDispatcher {
+class RemoteGPUProxy final : public WebCore::WebGPU::GPU, private IPC::Connection::Client, public DeprecatedThreadSafeRefCountedSeqCst<RemoteGPUProxy>, SerialFunctionDispatcher {
     WTF_MAKE_TZONE_ALLOCATED(RemoteGPUProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteGPUProxy);
 public:
@@ -73,8 +73,8 @@ public:
     IPC::StreamClientConnection& streamClientConnection() { return *m_streamConnection; }
     Ref<IPC::StreamClientConnection> protectedStreamClientConnection() { return *m_streamConnection; }
 
-    void ref() const final { return ThreadSafeRefCounted<RemoteGPUProxy>::ref(); }
-    void deref() const final { return ThreadSafeRefCounted<RemoteGPUProxy>::deref(); }
+    void ref() const final { return DeprecatedThreadSafeRefCountedSeqCst<RemoteGPUProxy>::ref(); }
+    void deref() const final { return DeprecatedThreadSafeRefCountedSeqCst<RemoteGPUProxy>::deref(); }
 
     void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) final;
     WebGPUIdentifier backing() const { return m_backing; }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp
@@ -35,7 +35,7 @@
 
 namespace WebKit {
 
-class RemoteVideoDecoderCallbacks : public ThreadSafeRefCounted<RemoteVideoDecoderCallbacks> {
+class RemoteVideoDecoderCallbacks : public DeprecatedThreadSafeRefCountedSeqCst<RemoteVideoDecoderCallbacks> {
 public:
     static Ref<RemoteVideoDecoderCallbacks> create(WebCore::VideoDecoder::OutputCallback&& outputCallback) { return adoptRef(*new RemoteVideoDecoderCallbacks(WTF::move(outputCallback))); }
 
@@ -70,7 +70,7 @@ private:
     const Ref<RemoteVideoDecoderCallbacks> m_callbacks;
 };
 
-class RemoteVideoEncoderCallbacks : public ThreadSafeRefCounted<RemoteVideoEncoderCallbacks> {
+class RemoteVideoEncoderCallbacks : public DeprecatedThreadSafeRefCountedSeqCst<RemoteVideoEncoderCallbacks> {
 public:
     static Ref<RemoteVideoEncoderCallbacks> create(WebCore::VideoEncoder::DescriptionCallback&& descriptionCallback, WebCore::VideoEncoder::OutputCallback&& outputCallback) { return adoptRef(*new RemoteVideoEncoderCallbacks(WTF::move(descriptionCallback), WTF::move(outputCallback))); }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxy.h
@@ -44,7 +44,7 @@ class RemoteVideoFrameProxy;
 #endif
 
 // Wrapper around RemoteVideoFrameObjectHeapProxyProcessor that will always be destroyed on main thread.
-class RemoteVideoFrameObjectHeapProxy : public ThreadSafeRefCounted<RemoteVideoFrameObjectHeapProxy, WTF::DestructionThread::MainRunLoop> {
+class RemoteVideoFrameObjectHeapProxy : public DeprecatedThreadSafeRefCountedSeqCst<RemoteVideoFrameObjectHeapProxy, WTF::DestructionThread::MainRunLoop> {
 public:
     static Ref<RemoteVideoFrameObjectHeapProxy> create(GPUProcessConnection& connection) { return adoptRef(*new RemoteVideoFrameObjectHeapProxy(connection)); }
 

--- a/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableFrontendChannel.h
+++ b/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableFrontendChannel.h
@@ -35,7 +35,7 @@
 
 namespace WebKit {
 
-class ServiceWorkerDebuggableFrontendChannel final : public ThreadSafeRefCounted<ServiceWorkerDebuggableFrontendChannel>, public Inspector::FrontendChannel {
+class ServiceWorkerDebuggableFrontendChannel final : public DeprecatedThreadSafeRefCountedSeqCst<ServiceWorkerDebuggableFrontendChannel>, public Inspector::FrontendChannel {
     WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerDebuggableFrontendChannel);
     WTF_MAKE_NONCOPYABLE(ServiceWorkerDebuggableFrontendChannel);
 public:

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -37,7 +37,7 @@ namespace WebKit {
 
 class WebPage;
 
-class WebInspectorBackend : public ThreadSafeRefCounted<WebInspectorBackend>, private IPC::Connection::Client {
+class WebInspectorBackend : public DeprecatedThreadSafeRefCountedSeqCst<WebInspectorBackend>, private IPC::Connection::Client {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WebInspectorBackend);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebInspectorBackend);
 public:

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -149,7 +149,7 @@ void ByteRangeRequest::completeUnconditionally(PDFIncrementalLoader& loader)
 
 #pragma mark -
 
-class PDFPluginStreamLoaderClient final : public ThreadSafeRefCounted<PDFPluginStreamLoaderClient>,
+class PDFPluginStreamLoaderClient final : public DeprecatedThreadSafeRefCountedSeqCst<PDFPluginStreamLoaderClient>,
     public NetscapePlugInStreamLoaderClient {
 public:
     static Ref<PDFPluginStreamLoaderClient> create(PDFIncrementalLoader& loader)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -37,7 +37,7 @@ class CoordinatedPlatformLayer;
 
 namespace WebKit {
 
-class CoordinatedSceneState final : public ThreadSafeRefCounted<CoordinatedSceneState> {
+class CoordinatedSceneState final : public DeprecatedThreadSafeRefCountedSeqCst<CoordinatedSceneState> {
     WTF_MAKE_TZONE_ALLOCATED(CoordinatedSceneState);
 public:
     static Ref<CoordinatedSceneState> create()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.h
@@ -55,7 +55,7 @@ class AcceleratedSurface;
 class CoordinatedSceneState;
 class LayerTreeHost;
 
-class ThreadedCompositor : public ThreadSafeRefCounted<ThreadedCompositor>, public CanMakeThreadSafeCheckedPtr<ThreadedCompositor> {
+class ThreadedCompositor : public DeprecatedThreadSafeRefCountedSeqCst<ThreadedCompositor>, public CanMakeThreadSafeCheckedPtr<ThreadedCompositor> {
     WTF_MAKE_TZONE_ALLOCATED(ThreadedCompositor);
     WTF_MAKE_NONCOPYABLE(ThreadedCompositor);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThreadedCompositor);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -144,7 +144,7 @@ private:
 
     void scheduleRenderingUpdateTimerFired();
 
-    class BackingStoreFlusher : public ThreadSafeRefCounted<BackingStoreFlusher> {
+    class BackingStoreFlusher : public DeprecatedThreadSafeRefCountedSeqCst<BackingStoreFlusher> {
     public:
         static Ref<BackingStoreFlusher> create(Ref<IPC::Connection>&&);
 

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -55,7 +55,7 @@ class IDBServer;
 }
 } // namespace WebCore
 
-class InProcessIDBServer final : public WebCore::IDBClient::IDBConnectionToServerDelegate, public WebCore::IDBServer::IDBConnectionToClientDelegate, public ThreadSafeRefCounted<InProcessIDBServer> {
+class InProcessIDBServer final : public WebCore::IDBClient::IDBConnectionToServerDelegate, public WebCore::IDBServer::IDBConnectionToClientDelegate, public DeprecatedThreadSafeRefCountedSeqCst<InProcessIDBServer> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(InProcessIDBServer);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InProcessIDBServer);
 public:

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h
@@ -47,7 +47,7 @@ struct SourceApplicationAuditToken {
 #endif
 };
 
-class SocketStreamHandle : public ThreadSafeRefCounted<SocketStreamHandle, WTF::DestructionThread::Main> {
+class SocketStreamHandle : public DeprecatedThreadSafeRefCountedSeqCst<SocketStreamHandle, WTF::DestructionThread::Main> {
 public:
     enum SocketStreamState { Connecting, Open, Closing, Closed };
     virtual ~SocketStreamHandle() = default;


### PR DESCRIPTION
#### 5d8cb3a085ff53073d602c26692b370e49e787e6
<pre>
ThreadSafeRefCounted should support relaxed ref/derefs
<a href="https://bugs.webkit.org/show_bug.cgi?id=306072">https://bugs.webkit.org/show_bug.cgi?id=306072</a>
<a href="https://rdar.apple.com/168715394">rdar://168715394</a>

Reviewed by NOBODY (OOPS!).

ThreadSafeRefCounted should be able to use relaxed increment and release
decrement instructions when modifying the reference count. Right now all
operations on ThreadSafeRefCounted&apos;s ref count are sequentially
consistent. This is almost certainly unnecessary for any use case as the
barriers don&apos;t provide any mutual exclusion.

That said, I didn&apos;t change many users of the existing API because the
barriers could hide existing bugs. For example, if you had:

```
class Foo : ThreadSafeRefCounted&lt;Foo&gt; {
    int m_member;
};
...

Ref&lt;Foo&gt; f = sharedObject-&gt;m_foo;
f-&gt;m_member += 42;
return;
```

Nearly all the time the above code would appear atomic because the
ref/deref create memory barriers but there is still a race. With this
change that race window becomes much larger. There&apos;s also a chance that
code today is doing something like:

```
Ref&lt;Foo&gt; f = Foo::create();
f-&gt;m_member = 42;
sharedObject-&gt;m_foo = f;
return;
```

Which would be valid because we ref Foo before assigning it to m_foo so
there would be a store barrier before publication. (This obviously
assumes some non-mutex synchronization for m_foo e.g. single creator
multi-consumer). I expect that code is rare but I don&apos;t know enough
about WebCore&apos;s internals to do that validation there. Thus, I only
applied this change to JSC data structures that I can fairly confidently
say don&apos;t do that. Every other reference is now converted to
`DeprecatedThreadSafeRefCountedSeqCst` to indicate it should be avoided.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d8cb3a085ff53073d602c26692b370e49e787e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140933 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13317 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2572 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149371 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94021 "Failed to checkout and rebase branch from PR 57088") | ⏳ 🛠 ios-apple 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142806 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14027 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13469 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/149371 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/94021 "Failed to checkout and rebase branch from PR 57088") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143884 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/14027 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/2572 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/149371 "Failed to checkout and rebase branch from PR 57088") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/14027 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/2572 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9367 "Failed to checkout and rebase branch from PR 57088") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132911 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/14027 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/2572 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151897 "Failed to checkout and rebase branch from PR 57088") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1732 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13003 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/2572 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/151897 "Failed to checkout and rebase branch from PR 57088") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13018 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/13469 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/151897 "Failed to checkout and rebase branch from PR 57088") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/2572 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68164 "Failed to checkout and rebase branch from PR 57088") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13046 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/2572 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172225 "Failed to checkout and rebase branch from PR 57088") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12785 "Failed to checkout and rebase branch from PR 57088") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76747 "Failed to checkout and rebase branch from PR 57088") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/172225 "Failed to checkout and rebase branch from PR 57088") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12984 "Failed to checkout and rebase branch from PR 57088") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12829 "Failed to checkout and rebase branch from PR 57088") | | | | 
<!--EWS-Status-Bubble-End-->