### PR TITLE
[CoordinatedGraphics] ASSERTION FAILED: !m_isUpdatingRendering in WebKit::LayerTreeHost::updateRendering() for inspector/debugger tests

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -164,6 +164,9 @@ void LayerTreeHost::scheduleRenderingUpdateRunLoopObserver()
     if (m_renderingUpdateRunLoopObserver->isScheduled())
         return;
 
+    if (m_isUpdatingRendering)
+        return;
+
     tracePoint(RenderingUpdateRunLoopObserverStart);
     m_renderingUpdateRunLoopObserver->schedule();
 


### PR DESCRIPTION
#### dc0b72ef27a7877bd0a5ba1b012a6bab729aa0ff
<pre>
[CoordinatedGraphics] ASSERTION FAILED: !m_isUpdatingRendering in WebKit::LayerTreeHost::updateRendering() for inspector/debugger tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=303375">https://bugs.webkit.org/show_bug.cgi?id=303375</a>

Reviewed by Carlos Garcia Campos.

LayerTreeHost::updateRendering() has an assertion ensuring no reentrant
happens. Even after 305838@main, the assertion was still randomly failing for
some inspector/debugger tests.
LayerTreeHost::scheduleRenderingUpdateRunLoopObserver() is called during
LayerTreeHost::updateRendering().
PageDebugger::platformShouldContinueRunningEventLoopWhilePaused calls
RunLoop::cycle() to iterate the run loop.
LayerTreeHost::scheduleRenderingUpdateRunLoopObserver() should return early
duing the rendering update.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::scheduleRenderingUpdateRunLoopObserver):

Canonical link: <a href="https://commits.webkit.org/306341@main">https://commits.webkit.org/306341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b4b61c5c0cfb0e0781f11567bbcba6a407bfb3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94103 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13543 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108281 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78464 "5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89171 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10495 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8066 "Found 1 new API test failure: TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure (failure)") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119746 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151971 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13077 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2473 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116428 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116772 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12838 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68250 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21766 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13120 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76821 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->