### PR TITLE
Address unsafe cast warnings under Source/WebCore/bindings

### DIFF
--- a/Source/JavaScriptCore/runtime/TypedArrayController.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayController.h
@@ -43,6 +43,8 @@ public:
     virtual JSArrayBuffer* toJS(JSGlobalObject*, JSGlobalObject*, ArrayBuffer*) = 0;
     virtual void registerWrapper(JSGlobalObject*, ArrayBuffer*, JSArrayBuffer*) = 0;
     virtual bool isAtomicsWaitAllowedOnCurrentThread() = 0;
+
+    virtual bool isWebCoreTypedArrayController() const { return false; }
 };
 
 } // namespace JSC

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,9 +1,3 @@
-bindings/js/JSDOMGlobalObject.cpp
-bindings/js/JSDOMWindowBase.cpp
-bindings/js/JSDOMWindowCustom.h
-bindings/js/JSDOMWrapperCache.h
-bindings/js/JSWindowProxy.h
-bindings/js/JSWorkerGlobalScopeBase.cpp
 dom/NodeRareData.h
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -423,7 +423,7 @@ bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, Compilat
     VM& vm = globalObject->vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    auto& thisObject = static_cast<JSDOMGlobalObject&>(*globalObject);
+    auto& thisObject = *jsCast<JSDOMGlobalObject*>(globalObject);
     CheckedPtr scriptExecutionContext = thisObject.scriptExecutionContext();
 
     auto result = canCompile(*scriptExecutionContext, compilationType, codeString, args);
@@ -441,7 +441,7 @@ bool JSDOMGlobalObject::canCompileStrings(JSGlobalObject* globalObject, Compilat
 
 Structure* JSDOMGlobalObject::trustedScriptStructure(JSGlobalObject* globalObject)
 {
-    auto& thisObject = static_cast<JSDOMGlobalObject&>(*globalObject);
+    auto& thisObject = *jsCast<JSDOMGlobalObject*>(globalObject);
 
     return getDOMStructure<JSTrustedScript>(globalObject->vm(), thisObject);
 }

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -190,7 +190,7 @@ void JSDOMWindowBase::printErrorMessage(const String& message) const
 
 bool JSDOMWindowBase::supportsRichSourceInfo(const JSGlobalObject* object)
 {
-    const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
+    auto* thisObject = jsCast<const JSDOMWindowBase*>(object);
     auto* frame = thisObject->wrapped().frame();
     if (!frame)
         return false;
@@ -218,7 +218,7 @@ static inline bool shouldInterruptScriptToPreventInfiniteRecursionWhenClosingPag
 
 bool JSDOMWindowBase::shouldInterruptScript(const JSGlobalObject* object)
 {
-    const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
+    auto* thisObject = jsCast<const JSDOMWindowBase*>(object);
     ASSERT(thisObject->wrapped().frame());
     Page* page = thisObject->wrapped().frame()->page();
     return shouldInterruptScriptToPreventInfiniteRecursionWhenClosingPage(page);
@@ -226,7 +226,7 @@ bool JSDOMWindowBase::shouldInterruptScript(const JSGlobalObject* object)
 
 bool JSDOMWindowBase::shouldInterruptScriptBeforeTimeout(const JSGlobalObject* object)
 {
-    const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
+    auto* thisObject = jsCast<const JSDOMWindowBase*>(object);
     ASSERT(thisObject->wrapped().frame());
     Page* page = thisObject->wrapped().frame()->page();
 
@@ -243,7 +243,7 @@ bool JSDOMWindowBase::shouldInterruptScriptBeforeTimeout(const JSGlobalObject* o
 
 RuntimeFlags JSDOMWindowBase::javaScriptRuntimeFlags(const JSGlobalObject* object)
 {
-    const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
+    auto* thisObject = jsCast<const JSDOMWindowBase*>(object);
     auto* frame = thisObject->wrapped().frame();
     if (!frame)
         return RuntimeFlags();
@@ -286,7 +286,7 @@ WTF_MAKE_COMPACT_TZONE_ALLOCATED_IMPL(UserGestureInitiatedMicrotaskDispatcher);
 
 void JSDOMWindowBase::queueMicrotaskToEventLoop(JSGlobalObject& object, QueuedTask&& task)
 {
-    JSDOMWindowBase& thisObject = static_cast<JSDOMWindowBase&>(object);
+    auto& thisObject = *jsCast<JSDOMWindowBase*>(&object);
 
     CheckedPtr objectScriptExecutionContext = thisObject.scriptExecutionContext();
     CheckedRef eventLoop = objectScriptExecutionContext->eventLoop();
@@ -305,7 +305,7 @@ void JSDOMWindowBase::queueMicrotaskToEventLoop(JSGlobalObject& object, QueuedTa
 
 JSC::JSObject* JSDOMWindowBase::currentScriptExecutionOwner(JSGlobalObject* object)
 {
-    auto* thisObject = static_cast<JSDOMWindowBase*>(object);
+    auto* thisObject = jsCast<JSDOMWindowBase*>(object);
     RefPtr document = thisObject->wrapped().documentIfLocal();
     return jsCast<JSObject*>(document ? toJS(thisObject, thisObject, document.releaseNonNull()) : jsNull());
 }
@@ -317,7 +317,7 @@ JSC::ScriptExecutionStatus JSDOMWindowBase::scriptExecutionStatus(JSC::JSGlobalO
 
 void JSDOMWindowBase::reportViolationForUnsafeEval(JSGlobalObject* object, const String& source)
 {
-    const JSDOMWindowBase* thisObject = static_cast<const JSDOMWindowBase*>(object);
+    auto* thisObject = jsCast<const JSDOMWindowBase*>(object);
     CheckedPtr<ContentSecurityPolicy> contentSecurityPolicy;
     RefPtr localWindow = dynamicDowncast<LocalDOMWindow>(thisObject->wrapped());
     if (CheckedPtr element = localWindow ? localWindow->frameElement() : nullptr)

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.h
@@ -46,7 +46,7 @@ inline JSDOMWindow* asJSDOMWindow(JSC::JSGlobalObject* globalObject)
 
 inline const JSDOMWindow* asJSDOMWindow(const JSC::JSGlobalObject* globalObject)
 {
-    return static_cast<const JSDOMWindow*>(globalObject);
+    return JSC::jsCast<const JSDOMWindow*>(globalObject);
 }
 
 inline JSDOMWindow* mainWorldGlobalObject(LocalFrame* frame)

--- a/Source/WebCore/bindings/js/JSDOMWrapperCache.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapperCache.h
@@ -99,7 +99,7 @@ template<typename WrapperClass> inline JSC::JSObject* getDOMPrototype(JSC::VM& v
 
 inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld& world, JSC::ArrayBuffer*)
 {
-    return static_cast<WebCoreTypedArrayController*>(world.vm().m_typedArrayController.get())->wrapperOwner();
+    return downcast<WebCoreTypedArrayController>(*world.vm().m_typedArrayController).wrapperOwner();
 }
 
 inline void* wrapperKey(JSC::ArrayBuffer* domObject)

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -53,7 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    JSDOMGlobalObject* window() const { return static_cast<JSDOMGlobalObject*>(target()); }
+    JSDOMGlobalObject* window() const { return JSC::jsCast<JSDOMGlobalObject*>(target()); }
 
     void setWindow(JSC::VM&, JSDOMGlobalObject&);
     void setWindow(DOMWindow&);

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp
@@ -153,7 +153,7 @@ void JSWorkerGlobalScopeBase::reportViolationForUnsafeEval(JSC::JSGlobalObject* 
 
 void JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop(JSGlobalObject& object, JSC::QueuedTask&& task)
 {
-    JSWorkerGlobalScopeBase& thisObject = static_cast<JSWorkerGlobalScopeBase&>(object);
+    auto& thisObject = *jsCast<JSWorkerGlobalScopeBase*>(&object);
     CheckedRef context = thisObject.wrapped();
     task.setDispatcher(context->eventLoop().jsMicrotaskDispatcher(task));
     context->eventLoop().queueMicrotask(WTF::move(task));

--- a/Source/WebCore/bindings/js/WebCoreTypedArrayController.h
+++ b/Source/WebCore/bindings/js/WebCoreTypedArrayController.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/TypedArrayController.h>
 #include <JavaScriptCore/WeakHandleOwner.h>
+#include <wtf/TypeCasts.h>
 
 namespace JSC {
 class WeakHandleOwner;
@@ -46,6 +47,8 @@ public:
     JSC::WeakHandleOwner* wrapperOwner() { return &m_owner; }
 
 private:
+    bool isWebCoreTypedArrayController() const final { return true; }
+
     class JSArrayBufferOwner : public JSC::WeakHandleOwner {
     public:
         bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) override;
@@ -57,3 +60,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebCoreTypedArrayController)
+    static bool isType(const JSC::TypedArrayController& controller) { return controller.isWebCoreTypedArrayController(); }
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### 2edd75b26b458ef22b7a18f36d48ad3c7fe13328
<pre>
Address unsafe cast warnings under Source/WebCore/bindings
<a href="https://bugs.webkit.org/show_bug.cgi?id=306078">https://bugs.webkit.org/show_bug.cgi?id=306078</a>

Reviewed by Anne van Kesteren.

* Source/JavaScriptCore/runtime/TypedArrayController.h:
(JSC::TypedArrayController::isWebCoreTypedArrayController const):
* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::canCompileStrings):
(WebCore::JSDOMGlobalObject::trustedScriptStructure):
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
(WebCore::JSDOMWindowBase::supportsRichSourceInfo):
(WebCore::JSDOMWindowBase::shouldInterruptScript):
(WebCore::JSDOMWindowBase::shouldInterruptScriptBeforeTimeout):
(WebCore::JSDOMWindowBase::javaScriptRuntimeFlags):
(WebCore::JSDOMWindowBase::queueMicrotaskToEventLoop):
(WebCore::JSDOMWindowBase::currentScriptExecutionOwner):
(WebCore::JSDOMWindowBase::reportViolationForUnsafeEval):
* Source/WebCore/bindings/js/JSDOMWindowCustom.h:
(WebCore::asJSDOMWindow):
* Source/WebCore/bindings/js/JSDOMWrapperCache.h:
(WebCore::wrapperOwner):
* Source/WebCore/bindings/js/JSWindowProxy.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.cpp:
(WebCore::JSWorkerGlobalScopeBase::queueMicrotaskToEventLoop):
* Source/WebCore/bindings/js/WebCoreTypedArrayController.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/306070@main">https://commits.webkit.org/306070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11acad56625ab866e703cf623969a979c23f1c17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140273 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148511 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12808 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88347 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7456 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8706 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132246 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151216 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1069 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12342 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115821 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116158 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29509 "Failed to push commit to Webkit repository") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11181 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122057 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12382 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1523 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171545 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12124 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76081 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12318 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->