### PR TITLE
[JSC] Optimize `Set#size` and `Map#size` in DFG/FTL and IC

### DIFF
--- a/JSTests/microbenchmarks/map-size.js
+++ b/JSTests/microbenchmarks/map-size.js
@@ -1,0 +1,12 @@
+function mapSize(m) {
+    return m.size;
+}
+noInline(mapSize);
+
+var m = new Map();
+for (var i = 0; i < 100; ++i)
+    m.set(i, i);
+
+var sum = 0;
+for (var i = 0; i < 1e6; ++i)
+    sum += mapSize(m);

--- a/JSTests/microbenchmarks/set-size.js
+++ b/JSTests/microbenchmarks/set-size.js
@@ -1,0 +1,12 @@
+function setSize(s) {
+    return s.size;
+}
+noInline(setSize);
+
+var s = new Set();
+for (var i = 0; i < 100; ++i)
+    s.add(i);
+
+var sum = 0;
+for (var i = 0; i < 1e6; ++i)
+    sum += setSize(s);

--- a/JSTests/stress/map-size-dfg.js
+++ b/JSTests/stress/map-size-dfg.js
@@ -1,0 +1,29 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function mapSize(m) {
+    return m.size;
+}
+noInline(mapSize);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var m = new Map();
+    shouldBe(mapSize(m), 0);
+
+    m.set(1, 'a');
+    m.set(2, 'b');
+    m.set(3, 'c');
+    shouldBe(mapSize(m), 3);
+
+    m.delete(2);
+    shouldBe(mapSize(m), 2);
+
+    m.set(2, 'x');
+    m.set(4, 'd');
+    shouldBe(mapSize(m), 4);
+
+    m.clear();
+    shouldBe(mapSize(m), 0);
+}

--- a/JSTests/stress/set-size-cse.js
+++ b/JSTests/stress/set-size-cse.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function testSizeCSE(s, f) {
+    let first = s.size;
+    f();
+    let second = s.size;
+    return { first, second };
+}
+noInline(testSizeCSE);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var s = new Set([1, 2, 3]);
+
+    // add changes size
+    var result = testSizeCSE(s, () => s.add(4));
+    shouldBe(result.first, 3);
+    shouldBe(result.second, 4);
+
+    // delete changes size
+    result = testSizeCSE(s, () => s.delete(1));
+    shouldBe(result.first, 4);
+    shouldBe(result.second, 3);
+
+    // no side effect (CSE is valid)
+    result = testSizeCSE(s, () => {});
+    shouldBe(result.first, 3);
+    shouldBe(result.second, 3);
+}

--- a/JSTests/stress/set-size-dfg.js
+++ b/JSTests/stress/set-size-dfg.js
@@ -1,0 +1,29 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function setSize(s) {
+    return s.size;
+}
+noInline(setSize);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var s = new Set();
+    shouldBe(setSize(s), 0);
+
+    s.add(1);
+    s.add(2);
+    s.add(3);
+    shouldBe(setSize(s), 3);
+
+    s.delete(2);
+    shouldBe(setSize(s), 2);
+
+    s.add(2);
+    s.add(4);
+    shouldBe(setSize(s), 4);
+
+    s.clear();
+    shouldBe(setSize(s), 0);
+}

--- a/JSTests/stress/set-size-type-check.js
+++ b/JSTests/stress/set-size-type-check.js
@@ -1,0 +1,30 @@
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        if (String(e) !== errorMessage)
+            throw new Error('bad error: ' + String(e));
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+}
+
+var sizeGetter = Object.getOwnPropertyDescriptor(Set.prototype, 'size').get;
+
+function getSize(obj) {
+    return sizeGetter.call(obj);
+}
+noInline(getSize);
+
+// Compile with Set objects
+for (var i = 0; i < testLoopCount; ++i) {
+    var s = new Set([1, 2, 3]);
+    if (getSize(s) !== 3)
+        throw new Error('bad size');
+}
+
+// Type check failure (OSR exit)
+shouldThrow(() => { getSize(new Map()); }, "TypeError: Set operation called on non-Set object");
+shouldThrow(() => { getSize({}); }, "TypeError: Set operation called on non-Set object");

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1656,6 +1656,10 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case MapSet:
         break;
 
+    case MapOrSetSize:
+        setTypeForNode(node, SpecInt32Only);
+        break;
+
     case MapGet:
         clearForNode(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -5019,6 +5019,18 @@ bool ByteCodeParser::handleIntrinsicGetter(Operand result, SpeculatedType predic
     }
 #endif
 
+    case JSSetSizeIntrinsic: {
+        insertChecks();
+        set(result, addToGraph(MapOrSetSize, Edge(thisNode, SetObjectUse)));
+        return true;
+    }
+
+    case JSMapSizeIntrinsic: {
+        insertChecks();
+        set(result, addToGraph(MapOrSetSize, Edge(thisNode, MapObjectUse)));
+        return true;
+    }
+
     default:
         return false;
     }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2416,6 +2416,14 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
     }
 
+    case MapOrSetSize: {
+        Edge& mapOrSetEdge = node->child1();
+        AbstractHeapKind heap = (mapOrSetEdge.useKind() == MapObjectUse) ? JSMapFields : JSSetFields;
+        read(heap);
+        def(HeapLocation(MapOrSetSizeLoc, heap, mapOrSetEdge), LazyNode(node));
+        return;
+    }
+
     case SetAdd: {
         Edge& mapEdge = node->child1();
         Edge& keyEdge = node->child2();

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -276,6 +276,7 @@ bool doesGC(Graph& graph, Node* node)
     case DataViewSet:
     case PutByOffset:
     case WeakMapGet:
+    case MapOrSetSize:
     case NumberIsNaN:
     case NumberIsFinite:
     case NumberIsSafeInteger:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3082,6 +3082,16 @@ private:
             break;
         }
 
+        case MapOrSetSize: {
+            if (node->child1().useKind() == MapObjectUse)
+                fixEdge<MapObjectUse>(node->child1());
+            else {
+                ASSERT(node->child1().useKind() == SetObjectUse);
+                fixEdge<SetObjectUse>(node->child1());
+            }
+            break;
+        }
+
         case SetAdd: {
             fixEdge<SetObjectUse>(node->child1());
             fixEdge<Int32Use>(node->child3());

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -94,6 +94,7 @@ enum LocationKind {
     MapIterationEntryLoc,
     MapIterationEntryKeyLoc,
     MapIterationEntryValueLoc,
+    MapOrSetSizeLoc,
     MapEntryKeyLoc,
     MapEntryValueLoc,
     LoadMapValueLoc,

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -596,6 +596,7 @@ namespace JSC { namespace DFG {
     macro(MapIterationEntry, NodeResultJS) \
     macro(MapIterationEntryKey, NodeResultInt32) \
     macro(MapIterationEntryValue, NodeResultJS) \
+    macro(MapOrSetSize, NodeResultInt32) \
     macro(SetAdd, NodeMustGenerate) \
     macro(MapSet, NodeMustGenerate | NodeHasVarArgs) \
     macro(MapOrSetDelete, NodeMustGenerate | NodeResultBoolean) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1132,6 +1132,7 @@ private:
 
         case MapHash:
         case MapIterationEntry:
+        case MapOrSetSize:
             setPrediction(SpecInt32Only);
             break;
 

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -323,6 +323,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ToLowerCase:
     case MapGet:
     case LoadMapValue:
+    case MapOrSetSize:
     case MapStorage:
     case MapStorageOrSentinel:
     case MapIterationNext:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1498,6 +1498,7 @@ public:
     void compileMapIterationEntry(Node*);
     void compileMapIterationEntryKey(Node*);
     void compileMapIterationEntryValue(Node*);
+    void compileMapOrSetSize(Node*);
     void compileSetAdd(Node*);
     void compileMapSet(Node*);
     void compileMapOrSetDelete(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3963,6 +3963,10 @@ void SpeculativeJIT::compile(Node* node)
         compileExtractValueFromWeakMapGet(node);
         break;
 
+    case MapOrSetSize:
+        compileMapOrSetSize(node);
+        break;
+
     case SetAdd:
         compileSetAdd(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5532,6 +5532,10 @@ void SpeculativeJIT::compile(Node* node)
         compileExtractValueFromWeakMapGet(node);
         break;
 
+    case MapOrSetSize:
+        compileMapOrSetSize(node);
+        break;
+
     case SetAdd:
         compileSetAdd(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -290,6 +290,7 @@ inline CapabilityLevel canCompile(Node* node)
     case MapIterationEntry:
     case MapIterationEntryKey:
     case MapIterationEntryValue:
+    case MapOrSetSize:
     case MapStorage:
     case MapStorageOrSentinel:
     case MapIteratorNext:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -219,6 +219,8 @@ namespace JSC {
     macro(UnderscoreProtoIntrinsic) \
     macro(SpeciesGetterIntrinsic) \
     macro(WebAssemblyInstanceExportsIntrinsic) \
+    macro(JSSetSizeIntrinsic) \
+    macro(JSMapSizeIntrinsic) \
     \
     /* Debugging intrinsics. These are meant to be used as testing hacks within jsc.cpp and should never be exposed to users.*/ \
     macro(DFGTrueIntrinsic) \

--- a/Source/JavaScriptCore/runtime/MapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/MapPrototype.cpp
@@ -92,7 +92,7 @@ void MapPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("getOrInsert"_s, mapProtoFuncGetOrInsert, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("getOrInsertComputed"_s, mapProtoFuncGetOrInsertComputed, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
 
-    JSFunction* sizeGetter = JSFunction::create(vm, globalObject, 0, "get size"_s, mapProtoFuncSize, ImplementationVisibility::Public);
+    JSFunction* sizeGetter = JSFunction::create(vm, globalObject, 0, "get size"_s, mapProtoFuncSize, ImplementationVisibility::Public, JSMapSizeIntrinsic);
     GetterSetter* sizeAccessor = GetterSetter::create(vm, globalObject, sizeGetter, nullptr);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->size, sizeAccessor, PropertyAttribute::DontEnum | PropertyAttribute::Accessor);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->builtinNames().sizePrivateName(), sizeAccessor, PropertyAttribute::DontEnum | PropertyAttribute::Accessor);

--- a/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTableHelper.h
@@ -153,6 +153,9 @@ public:
     ALWAYS_INLINE static constexpr TableIndex capacityIndex() { return deletedEntryCountIndex() + 1; }
     ALWAYS_INLINE static constexpr TableIndex iterationEntryIndex() { return capacityIndex() + 1; }
 
+    ALWAYS_INLINE static constexpr size_t offsetInStorageForIndex(TableIndex index) { return JSCellButterfly::offsetOfData() + index * sizeof(uint64_t); }
+    ALWAYS_INLINE static constexpr size_t offsetOfAliveEntryCount() { return offsetInStorageForIndex(aliveEntryCountIndex()); }
+
     ALWAYS_INLINE static constexpr TableSize aliveEntryCount(Storage& storage) { return asNumber(storage, aliveEntryCountIndex()); }
     ALWAYS_INLINE static constexpr TableSize deletedEntryCount(Storage& storage) { return asNumber(storage, deletedEntryCountIndex()); }
     ALWAYS_INLINE static constexpr TableSize usedCapacity(Storage& storage) { return aliveEntryCount(storage) + deletedEntryCount(storage); }

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -90,7 +90,7 @@ void SetPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().keysPublicName(), values, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectWithoutTransition(vm, vm.propertyNames->builtinNames().keysPrivateName(), values, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    JSFunction* sizeGetter = JSFunction::create(vm, globalObject, 0, "get size"_s, setProtoFuncSize, ImplementationVisibility::Public);
+    JSFunction* sizeGetter = JSFunction::create(vm, globalObject, 0, "get size"_s, setProtoFuncSize, ImplementationVisibility::Public, JSSetSizeIntrinsic);
     GetterSetter* sizeAccessor = GetterSetter::create(vm, globalObject, sizeGetter, nullptr);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->size, sizeAccessor, PropertyAttribute::DontEnum | PropertyAttribute::Accessor);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->builtinNames().sizePrivateName(), sizeAccessor, PropertyAttribute::DontEnum | PropertyAttribute::Accessor);


### PR DESCRIPTION
#### 2e2c23521a24a39d687eefd77fab36d962078af2
<pre>
[JSC] Optimize `Set#size` and `Map#size` in DFG/FTL and IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=306080">https://bugs.webkit.org/show_bug.cgi?id=306080</a>

Reviewed by Yusuke Suzuki.

This patch changes to optimize `Set#size` and `Map#size` getter
in DFG/FTL and IC.

                                TipOfTree                  Patched

set-size                      7.6794+-0.1954     ^      3.4315+-1.1951        ^ definitely 2.2379x faster
map-size                      9.8016+-1.8670     ^      3.5752+-0.9468        ^ definitely 2.7416x faster

Tests: JSTests/microbenchmarks/map-size.js
       JSTests/microbenchmarks/set-size.js
       JSTests/stress/map-size-dfg.js
       JSTests/stress/set-size-cse.js
       JSTests/stress/set-size-dfg.js
       JSTests/stress/set-size-type-check.js

* JSTests/microbenchmarks/map-size.js: Added.
(mapSize):
* JSTests/microbenchmarks/set-size.js: Added.
(setSize):
* JSTests/stress/map-size-dfg.js: Added.
(shouldBe):
(mapSize):
* JSTests/stress/set-size-cse.js: Added.
(shouldBe):
(testSizeCSE):
* JSTests/stress/set-size-dfg.js: Added.
(shouldBe):
(setSize):
* JSTests/stress/set-size-type-check.js: Added.
(shouldThrow):
(getSize):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::canEmitIntrinsicGetter):
(JSC::InlineCacheCompiler::emitIntrinsicGetter):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicGetter):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGHeapLocation.h:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/MapPrototype.cpp:
(JSC::MapPrototype::finishCreation):
* Source/JavaScriptCore/runtime/OrderedHashTableHelper.h:
(JSC::OrderedHashTableHelper::offsetInStorageForIndex):
(JSC::OrderedHashTableHelper::offsetOfAliveEntryCount):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::SetPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/306337@main">https://commits.webkit.org/306337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0e9cf0afcb0999da20ac6b241ee4dfbc9aebcf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149578 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14164 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108321 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126245 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89228 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10520 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8106 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133050 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152046 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1871 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13140 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116480 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116823 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29708 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12873 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122920 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13183 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172363 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76886 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->