### PR TITLE
[appearance: base] Move the pseudoElementType and pseudoBits to NonInheritedRareData

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -214,7 +214,7 @@ void ElementRuleCollector::collectMatchingRules(DeclarationOrigin origin)
 
 void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest)
 {
-    ASSERT_WITH_MESSAGE(!(m_mode == SelectorChecker::Mode::StyleInvalidation && m_pseudoElementRequest), "When in StyleInvalidation or SharingRules, SelectorChecker does not try to match the pseudo ID. While ElementRuleCollector supports matching a particular pseudoId in this case, this would indicate a error at the call site since matching a particular element should be unnecessary.");
+    ASSERT_WITH_MESSAGE(!(m_mode == SelectorChecker::Mode::StyleInvalidation && pseudoElementRequest()), "When in StyleInvalidation or SharingRules, SelectorChecker does not try to match the pseudo ID. While ElementRuleCollector supports matching a particular pseudoId in this case, this would indicate a error at the call site since matching a particular element should be unnecessary.");
 
     auto& element = this->element();
     auto* shadowRoot = element.containingShadowRoot();
@@ -241,8 +241,8 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
         for (auto* rules : ruleVectors)
             collectMatchingRulesForList(rules, matchRequest);
     }
-    if (m_pseudoElementRequest && m_pseudoElementRequest->nameArgument() != nullAtom())
-        collectMatchingRulesForList(matchRequest.ruleSet.namedPseudoElementRules(m_pseudoElementRequest->nameArgument()), matchRequest);
+    if (pseudoElementRequest() && pseudoElementRequest()->nameArgument() != nullAtom())
+        collectMatchingRulesForList(matchRequest.ruleSet.namedPseudoElementRules(pseudoElementRequest()->nameArgument()), matchRequest);
     if (element.isLink())
         collectMatchingRulesForList(matchRequest.ruleSet.linkPseudoClassRules(), matchRequest);
     if (matchesFocusPseudoClass(element))
@@ -497,7 +497,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
     // This is limited to HTML only so we don't need to check the namespace (because of tag name match).
     auto matchBasedOnRuleHash = ruleData.matchBasedOnRuleHash();
     if (matchBasedOnRuleHash != MatchBasedOnRuleHash::None && element().isHTMLElement()) {
-        ASSERT_WITH_MESSAGE(!m_pseudoElementRequest, "If we match based on the rule hash while collecting for a particular pseudo element ID, we would add incorrect rules for that pseudo element ID. We should never end in ruleMatches() with a pseudo element if the ruleData cannot match any pseudo element.");
+        ASSERT_WITH_MESSAGE(!pseudoElementRequest(), "If we match based on the rule hash while collecting for a particular pseudo element ID, we would add incorrect rules for that pseudo element ID. We should never end in ruleMatches() with a pseudo element if the ruleData cannot match any pseudo element.");
 
         switch (matchBasedOnRuleHash) {
         case MatchBasedOnRuleHash::None:
@@ -532,7 +532,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 
 #if !ASSERT_MSG_DISABLED
             unsigned ignoreSpecificity;
-            ASSERT_WITH_MESSAGE(!SelectorCompiler::ruleCollectorSimpleSelectorChecker(compiledSelector, &element(), &ignoreSpecificity) || !m_pseudoElementRequest, "When matching pseudo elements, we should never compile a selector checker without context unless it cannot match anything.");
+            ASSERT_WITH_MESSAGE(!SelectorCompiler::ruleCollectorSimpleSelectorChecker(compiledSelector, &element(), &ignoreSpecificity) || !pseudoElementRequest(), "When matching pseudo elements, we should never compile a selector checker without context unless it cannot match anything.");
 #endif
             bool selectorMatches = SelectorCompiler::ruleCollectorSimpleSelectorChecker(compiledSelector, &element(), &specificity);
 
@@ -542,10 +542,10 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
 #endif // ENABLE(CSS_SELECTOR_JIT)
 
     SelectorChecker::CheckingContext context(m_mode);
-    if (m_pseudoElementRequest) {
-        auto pseudoElementIdentifier = m_pseudoElementRequest->identifier();
+    if (pseudoElementRequest()) {
+        auto pseudoElementIdentifier = pseudoElementRequest()->identifier();
         context.setRequestedPseudoElement(pseudoElementIdentifier);
-        context.scrollbarState = m_pseudoElementRequest->scrollbarState();
+        context.scrollbarState = pseudoElementRequest()->scrollbarState();
         if (isNamedViewTransitionPseudoElement(pseudoElementIdentifier))
             context.classList = classListForNamedViewTransitionPseudoElement(element().document(), pseudoElementIdentifier.nameArgument);
     }
@@ -572,7 +572,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
             specificity = selector.computeSpecificity();
     }
 
-    m_matchedPseudoElements.add(context.publicPseudoElements);
+    m_result->matchedPseudoElements.add(context.publicPseudoElements);
     m_styleRelations.appendVector(context.styleRelations);
 
     return selectorMatches;
@@ -584,7 +584,7 @@ void ElementRuleCollector::collectMatchingRulesForListSlow(const RuleSet::RuleDa
         if (!ruleData.isEnabled()) [[unlikely]]
             continue;
 
-        if (!ruleData.canMatchPseudoElement() && m_pseudoElementRequest)
+        if (!ruleData.canMatchPseudoElement() && pseudoElementRequest())
             continue;
 
         if (m_selectorMatchingState && m_selectorMatchingState->selectorFilter.fastRejectSelector(ruleData.descendantSelectorIdentifierHashes()))
@@ -931,7 +931,7 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
 void ElementRuleCollector::addAuthorKeyframeRules(const StyleRuleKeyframe& keyframe)
 {
     ASSERT(m_result->authorDeclarations.isEmpty());
-    auto propertyAllowlist = m_pseudoElementRequest ? propertyAllowlistForPseudoElement(m_pseudoElementRequest->type()) : PropertyAllowlist::None;
+    auto propertyAllowlist = pseudoElementRequest() ? propertyAllowlistForPseudoElement(pseudoElementRequest()->type()) : PropertyAllowlist::None;
     m_result->authorDeclarations.append({ keyframe.properties(), SelectorChecker::MatchAll, propertyAllowlist });
 }
 

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -24,7 +24,6 @@
 #include "MatchResult.h"
 #include "MediaQueryEvaluator.h"
 #include "PropertyAllowlist.h"
-#include "PseudoElementRequest.h"
 #include "RuleSet.h"
 #include "SelectorChecker.h"
 #include "StyleScopeOrdinal.h"
@@ -61,7 +60,7 @@ public:
 
     bool matchesAnyAuthorRules();
 
-    void setPseudoElementRequest(const std::optional<PseudoElementRequest>& request) { m_pseudoElementRequest = request; }
+    void setPseudoElementRequest(const std::optional<PseudoElementRequest>& request) { m_result->pseudoElementRequest = request; }
     void setMedium(const MQ::MediaQueryEvaluator& medium) { m_isPrintStyle = medium.isPrintMedia(); }
 
 
@@ -72,7 +71,8 @@ public:
 
     void clearMatchedRules();
 
-    EnumSet<PseudoElementType> matchedPseudoElements() const { return m_matchedPseudoElements; }
+    std::optional<PseudoElementRequest> pseudoElementRequest() const { return m_result->pseudoElementRequest; }
+    EnumSet<PseudoElementType> matchedPseudoElements() const { return m_result->matchedPseudoElements; }
     const Relations& styleRelations() const { return m_styleRelations; }
 
     void addAuthorKeyframeRules(const StyleRuleKeyframe&);
@@ -126,7 +126,6 @@ private:
 
     bool m_shouldIncludeEmptyRules { false };
     bool m_isPrintStyle { false };
-    std::optional<PseudoElementRequest> m_pseudoElementRequest { };
     const SelectorChecker::Mode m_mode { SelectorChecker::Mode::ResolvingStyle };
 
     Vector<MatchedRule, 64> m_matchedRules;
@@ -136,7 +135,6 @@ private:
     Vector<Ref<const StyleRule>> m_matchedRuleList;
     Ref<MatchResult> m_result;
     Relations m_styleRelations;
-    EnumSet<PseudoElementType> m_matchedPseudoElements;
 };
 
 ALWAYS_INLINE void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVector* rules, const MatchRequest& matchRequest)

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "PropertyAllowlist.h"
+#include "PseudoElementRequest.h"
 #include "RuleSet.h"
 #include "SelectorChecker.h"
 #include "StylePropertiesInlines.h"
@@ -53,6 +54,8 @@ struct MatchResult : RefCounted<MatchResult> {
     bool isForLink { false };
     bool isCompletelyNonCacheable { false };
     bool hasStartingStyle { false };
+    std::optional<PseudoElementRequest> pseudoElementRequest { };
+    EnumSet<PseudoElementType> matchedPseudoElements;
     Vector<MatchedProperties> userAgentDeclarations;
     Vector<MatchedProperties> userDeclarations;
     Vector<MatchedProperties> authorDeclarations;
@@ -82,7 +85,13 @@ inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
 
 inline bool MatchResult::cacheablePropertiesEqual(const MatchResult& other) const
 {
-    if (isForLink != other.isForLink || hasStartingStyle != other.hasStartingStyle)
+    if (isForLink != other.isForLink || hasStartingStyle != other.hasStartingStyle || matchedPseudoElements != other.matchedPseudoElements)
+        return false;
+
+    if (pseudoElementRequest.has_value() != other.pseudoElementRequest.has_value())
+        return false;
+
+    if (pseudoElementRequest && pseudoElementRequest->type() != other.pseudoElementRequest->type())
         return false;
 
     // Only author style can be non-cacheable.
@@ -131,7 +140,14 @@ inline void add(Hasher& hasher, const MatchedProperties& matchedProperties)
 inline void add(Hasher& hasher, const MatchResult& matchResult)
 {
     ASSERT(!matchResult.isCompletelyNonCacheable);
-    add(hasher, matchResult.isForLink, matchResult.nonCacheablePropertyIds, matchResult.userAgentDeclarations, matchResult.userDeclarations, matchResult.authorDeclarations);
+    add(hasher,
+        matchResult.isForLink,
+        matchResult.nonCacheablePropertyIds,
+        matchResult.pseudoElementRequest ? static_cast<unsigned>(enumToUnderlyingType(matchResult.pseudoElementRequest->type()) + 1) : 0u,
+        matchResult.matchedPseudoElements,
+        matchResult.userAgentDeclarations,
+        matchResult.userDeclarations,
+        matchResult.authorDeclarations);
 }
 
 }

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -128,7 +128,7 @@ void ComputedStyle::copyContentFrom(const ComputedStyle& other)
 
 void ComputedStyle::copyPseudoElementBitsFrom(const ComputedStyle& other)
 {
-    m_nonInheritedFlags.pseudoBits = other.m_nonInheritedFlags.pseudoBits;
+    m_nonInheritedData.access().rareData.access().pseudoBits = other.m_nonInheritedData->rareData->pseudoBits;
 }
 
 bool ComputedStyle::operator==(const ComputedStyle& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -40,7 +40,6 @@ public:
     void fastPathInheritFrom(const ComputedStyle&);
     void copyNonInheritedFrom(const ComputedStyle&);
     void copyContentFrom(const ComputedStyle&);
-    void copyPseudoElementsFrom(const ComputedStyle&);
     void copyPseudoElementBitsFrom(const ComputedStyle&);
 
     // MARK: - Comparisons

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -85,8 +85,6 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.firstChildState = false;
     m_nonInheritedFlags.lastChildState = false;
     m_nonInheritedFlags.isLink = false;
-    m_nonInheritedFlags.pseudoElementType = 0;
-    m_nonInheritedFlags.pseudoBits = 0;
 
     static_assert((sizeof(InheritedFlags) <= 8), "InheritedFlags does not grow");
     static_assert((sizeof(NonInheritedFlags) <= 8), "NonInheritedFlags does not grow");

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -83,19 +83,6 @@
 namespace WebCore {
 namespace Style {
 
-// MARK: - ComputedStyleBase::NonInheritedFlags
-
-inline bool ComputedStyleBase::NonInheritedFlags::hasPseudoStyle(PseudoElementType pseudo) const
-{
-    ASSERT(allPublicPseudoElementTypes.contains(pseudo));
-    return EnumSet<PseudoElementType>::fromRaw(pseudoBits).contains(pseudo);
-}
-
-inline bool ComputedStyleBase::NonInheritedFlags::hasAnyPublicPseudoStyles() const
-{
-    return !!pseudoBits;
-}
-
 // MARK: - Non-property getters
 
 inline bool ComputedStyleBase::usesViewportUnits() const
@@ -269,7 +256,7 @@ inline AppleVisualEffect ComputedStyleBase::usedAppleVisualEffectForSubtree() co
 
 inline std::optional<PseudoElementType> ComputedStyleBase::pseudoElementType() const
 {
-    return m_nonInheritedFlags.pseudoElementType ? std::make_optional(static_cast<PseudoElementType>(m_nonInheritedFlags.pseudoElementType - 1)) : std::nullopt;
+    return m_nonInheritedData->rareData->pseudoElementType ? std::make_optional(static_cast<PseudoElementType>(m_nonInheritedData->rareData->pseudoElementType - 1)) : std::nullopt;
 }
 
 inline const AtomString& ComputedStyleBase::pseudoElementNameArgument() const
@@ -279,12 +266,13 @@ inline const AtomString& ComputedStyleBase::pseudoElementNameArgument() const
 
 inline bool ComputedStyleBase::hasPseudoStyle(PseudoElementType pseudo) const
 {
-    return m_nonInheritedFlags.hasPseudoStyle(pseudo);
+    ASSERT(allPublicPseudoElementTypes.contains(pseudo));
+    return EnumSet<PseudoElementType>::fromRaw(m_nonInheritedData->rareData->pseudoBits).contains(pseudo);
 }
 
 inline bool ComputedStyleBase::hasAnyPublicPseudoStyles() const
 {
-    return m_nonInheritedFlags.hasAnyPublicPseudoStyles();
+    return !!m_nonInheritedData->rareData->pseudoBits;
 }
 
 // MARK: - Custom properties

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -47,15 +47,6 @@ template<typename T, typename U> inline bool compareEqual(const T& a, const U& b
      return a == b;
 }
 
-// MARK: - ComputedStyleBase::NonInheritedFlags
-
-inline void ComputedStyleBase::NonInheritedFlags::setHasPseudoStyles(EnumSet<PseudoElementType> pseudoElementSet)
-{
-    ASSERT(pseudoElementSet);
-    ASSERT(pseudoElementSet.containsOnly(allPublicPseudoElementTypes));
-    pseudoBits = pseudoElementSet.toRaw();
-}
-
 // MARK: - Non-property setters
 
 inline void ComputedStyleBase::setUsesViewportUnits()
@@ -221,16 +212,18 @@ inline void ComputedStyleBase::setUsedAppleVisualEffectForSubtree(AppleVisualEff
 
 inline void ComputedStyleBase::setHasPseudoStyles(EnumSet<PseudoElementType> set)
 {
-    m_nonInheritedFlags.setHasPseudoStyles(set);
+    ASSERT(set);
+    ASSERT(set.containsOnly(allPublicPseudoElementTypes));
+    SET_NESTED(m_nonInheritedData, rareData, pseudoBits, set.toRaw());
 }
 
 inline void ComputedStyleBase::setPseudoElementIdentifier(std::optional<PseudoElementIdentifier>&& identifier)
 {
     if (identifier) {
-        m_nonInheritedFlags.pseudoElementType = enumToUnderlyingType(identifier->type) + 1;
+        SET_NESTED(m_nonInheritedData, rareData, pseudoElementType, static_cast<unsigned>(enumToUnderlyingType(identifier->type) + 1));
         SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, WTF::move(identifier->nameArgument));
     } else {
-        m_nonInheritedFlags.pseudoElementType = 0;
+        SET_NESTED(m_nonInheritedData, rareData, pseudoElementType, 0u);
         SET_NESTED(m_nonInheritedData, rareData, pseudoElementNameArgument, nullAtom());
     }
 }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -59,7 +59,6 @@
 namespace WebCore {
 namespace Style {
 
-static_assert(PublicPseudoIDBits == allPublicPseudoElementTypes.size());
 static_assert(!(static_cast<unsigned>(maxTextTransformValue) >> TextTransformBits));
 
 // Value zero is used to indicate no pseudo-element.
@@ -442,9 +441,6 @@ void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const
     LOG_IF_DIFFERENT(firstChildState);
     LOG_IF_DIFFERENT(lastChildState);
     LOG_IF_DIFFERENT(isLink);
-
-    LOG_IF_DIFFERENT_WITH_CAST(PseudoId, pseudoElementType);
-    LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoBits);
 }
 
 void ComputedStyleBase::InheritedFlags::dumpDifferences(TextStream& ts, const InheritedFlags& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -439,10 +439,8 @@ using WebkitBoxFlex = Number<CSS::All, float>;
 using WebkitBoxFlexGroup = Integer<CSS::Nonnegative>;
 using WebkitBoxOrdinalGroup = Integer<CSS::Positive>;
 
-constexpr auto PublicPseudoIDBits = 17;
 constexpr auto TextDecorationLineBits = 5;
 constexpr auto TextTransformBits = 6;
-constexpr auto PseudoElementTypeBits = 5;
 
 using PseudoStyleCache = HashMap<PseudoElementIdentifier, std::unique_ptr<RenderStyle>>;
 
@@ -764,8 +762,6 @@ public:
         PREFERRED_TYPE(bool) unsigned firstChildState : 1;
         PREFERRED_TYPE(bool) unsigned lastChildState : 1;
         PREFERRED_TYPE(bool) unsigned isLink : 1;
-        PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
-        unsigned pseudoBits : PublicPseudoIDBits;
         unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element. PREFERRED_TYPE elided to avoid header inclusion.
 
         // If you add more style bits here, you will also need to update ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom().

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp
@@ -32,6 +32,9 @@ namespace Style {
 
 using namespace CSS::Literals;
 
+static_assert(PublicPseudoIDBits == allPublicPseudoElementTypes.size());
+static_assert(PublicPseudoIDBits < 1 << PseudoElementTypeBits);
+
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(NonInheritedRareData);
 
 NonInheritedRareData::NonInheritedRareData()
@@ -252,6 +255,8 @@ inline NonInheritedRareData::NonInheritedRareData(const NonInheritedRareData& o)
     , contain(o.contain)
     , overflowContinue(o.overflowContinue)
     , scrollSnapStop(o.scrollSnapStop)
+    , pseudoElementType(o.pseudoElementType)
+    , pseudoBits(o.pseudoBits)
 {
 }
 
@@ -369,7 +374,9 @@ bool NonInheritedRareData::operator==(const NonInheritedRareData& o) const
         && marginTrim == o.marginTrim
         && contain == o.contain
         && overflowContinue == o.overflowContinue
-        && scrollSnapStop == o.scrollSnapStop;
+        && scrollSnapStop == o.scrollSnapStop
+        && pseudoElementType == o.pseudoElementType
+        && pseudoBits == o.pseudoBits;
 }
 
 Contain NonInheritedRareData::usedContain() const
@@ -544,6 +551,9 @@ void NonInheritedRareData::dumpDifferences(TextStream& ts, const NonInheritedRar
 
     LOG_IF_DIFFERENT_WITH_CAST(OverflowContinue, overflowContinue);
     LOG_IF_DIFFERENT_WITH_CAST(ScrollSnapStop, scrollSnapStop);
+
+    LOG_IF_DIFFERENT_WITH_CAST(PseudoId, pseudoElementType);
+    LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoBits);
 }
 #endif // !LOG_DISABLED
 

--- a/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedRareData.h
@@ -98,6 +98,9 @@ class GridItemData;
 class MarqueeData;
 class MaskBorderData;
 
+constexpr auto PublicPseudoIDBits = 17;
+constexpr auto PseudoElementTypeBits = 5;
+
 // This class is for rarely used non-inherited property data. By grouping them
 // together, we save space, and only allocate this object when someone actually
 // uses one of these properties.
@@ -258,6 +261,8 @@ public:
     PREFERRED_TYPE(Contain) unsigned contain : 5;
     PREFERRED_TYPE(OverflowContinue) unsigned overflowContinue : 1;
     PREFERRED_TYPE(ScrollSnapStop) unsigned scrollSnapStop : 1;
+    PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits { 0 };
+    unsigned pseudoBits : PublicPseudoIDBits { 0 };
 
 private:
     NonInheritedRareData();


### PR DESCRIPTION
#### 131ed9c836c6f9f5e8ca1ef52a0e203cdcee4ae5
<pre>
[appearance: base] Move the pseudoElementType and pseudoBits to NonInheritedRareData
<a href="https://bugs.webkit.org/show_bug.cgi?id=306081">https://bugs.webkit.org/show_bug.cgi?id=306081</a>
<a href="https://rdar.apple.com/168722225">rdar://168722225</a>

Reviewed by NOBODY (OOPS!).

Move NonInheritedFlags::pseudoElementType and pseudoBits to NonInheritedRareData.
This will allow adding bits pseudo elements without increasing the size of
RenderStyle. Increasing the size of RenderStyle can cause performance regression.

ComputedStyle::copyNonInheritedFrom() used to preserve matchedPseudoElements and
pseudoElementType of its nonInheritedFlags. This can not be done with
NonInheritedRareData since ComputedStyle::copyNonInheritedFrom() replaces a pointer
with another pointer.

To fix this siisue, move ElementRuleCollector::m_pseudoElementRequest and
m_matchedPseudoElements to MatchResult and include the matchedPseudoElements and
pseudoElementType in calculating the hash key of MatchedDeclarationsCache entries.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
(WebCore::Style::ElementRuleCollector::ruleMatches):
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForListSlow):
(WebCore::Style::ElementRuleCollector::addAuthorKeyframeRules):
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::setPseudoElementRequest):
(WebCore::Style::ElementRuleCollector::pseudoElementRequest const):
(WebCore::Style::ElementRuleCollector::matchedPseudoElements const):
* Source/WebCore/style/MatchResult.h:
(WebCore::Style::MatchResult::cacheablePropertiesEqual const):
(WebCore::Style::add):
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::copyPseudoElementBitsFrom):
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
(WebCore::Style::ComputedStyleBase::ComputedStyleBase):
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::pseudoElementType const):
(WebCore::Style::ComputedStyleBase::hasPseudoStyle const):
(WebCore::Style::ComputedStyleBase::hasAnyPublicPseudoStyles const):
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::hasPseudoStyle const): Deleted.
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::hasAnyPublicPseudoStyles const): Deleted.
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setHasPseudoStyles):
(WebCore::Style::ComputedStyleBase::setPseudoElementIdentifier):
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::setHasPseudoStyles): Deleted.
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::dumpDifferences const):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.cpp:
(WebCore::Style::NonInheritedRareData::NonInheritedRareData):
(WebCore::Style::NonInheritedRareData::operator== const):
(WebCore::Style::NonInheritedRareData::dumpDifferences const):
* Source/WebCore/style/computed/data/StyleNonInheritedRareData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/131ed9c836c6f9f5e8ca1ef52a0e203cdcee4ae5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140506 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148842 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93593 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107725 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78206 "2 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88625 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7653 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151467 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116368 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11904 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67620 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12618 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1828 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12402 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->