### PR TITLE
AX: Split InjectedBundle/AccessibilityUIElement into subclasses

### DIFF
--- a/Tools/TestRunnerShared/Bindings/JSWrapper.cpp
+++ b/Tools/TestRunnerShared/Bindings/JSWrapper.cpp
@@ -51,7 +51,8 @@ JSWrappable* JSWrapper::unwrap(JSContextRef context, JSValueRef value)
     ASSERT_ARG(value, value);
     if (!context || !value)
         return 0;
-    return static_cast<JSWrappable*>(JSObjectGetPrivate(JSValueToObject(context, value, 0)));
+    JSObjectRef object = JSValueToObject(context, value, 0);
+    return static_cast<JSWrappable*>(JSObjectGetPrivate(object));
 }
 
 static JSWrappable* unwrapObject(JSObjectRef object)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -28,17 +28,57 @@
 
 #include "JSAccessibilityUIElement.h"
 
+#if PLATFORM(MAC)
+#include "mac/AccessibilityUIElementMac.h"
+#elif PLATFORM(IOS_FAMILY)
+#include "ios/AccessibilityUIElementIOS.h"
+#elif USE(ATSPI)
+#include "atspi/AccessibilityUIElementAtspi.h"
+#elif PLATFORM(WIN)
+#include "win/AccessibilityUIElementWin.h"
+#elif PLATFORM(PLAYSTATION)
+#include "playstation/AccessibilityUIElementPlayStation.h"
+#endif
+
 namespace WTR {
 
+// Static controller reference used by subclasses
+RefPtr<AccessibilityController> AccessibilityUIElement::s_controller;
+
+// Factory method - dispatches to platform-specific create()
 Ref<AccessibilityUIElement> AccessibilityUIElement::create(PlatformUIElement uiElement)
 {
     RELEASE_ASSERT(uiElement);
+#if PLATFORM(MAC)
+    return AccessibilityUIElementMac::create(uiElement);
+#elif PLATFORM(IOS_FAMILY)
+    return AccessibilityUIElementIOS::create(uiElement);
+#elif USE(ATSPI)
+    return AccessibilityUIElementAtspi::create(uiElement);
+#elif PLATFORM(WIN)
+    return AccessibilityUIElementWin::create(uiElement);
+#elif PLATFORM(PLAYSTATION)
+    return AccessibilityUIElementPlayStation::create(uiElement);
+#else
     return adoptRef(*new AccessibilityUIElement(uiElement));
+#endif
 }
 
 Ref<AccessibilityUIElement> AccessibilityUIElement::create(const AccessibilityUIElement& uiElement)
 {
+#if PLATFORM(MAC)
+    return AccessibilityUIElementMac::create(static_cast<const AccessibilityUIElementMac&>(uiElement));
+#elif PLATFORM(IOS_FAMILY)
+    return AccessibilityUIElementIOS::create(static_cast<const AccessibilityUIElementIOS&>(uiElement));
+#elif USE(ATSPI)
+    return AccessibilityUIElementAtspi::create(static_cast<const AccessibilityUIElementAtspi&>(uiElement));
+#elif PLATFORM(WIN)
+    return AccessibilityUIElementWin::create(static_cast<const AccessibilityUIElementWin&>(uiElement));
+#elif PLATFORM(PLAYSTATION)
+    return AccessibilityUIElementPlayStation::create(static_cast<const AccessibilityUIElementPlayStation&>(uiElement));
+#else
     return adoptRef(*new AccessibilityUIElement(uiElement));
+#endif
 }
 
 JSClassRef AccessibilityUIElement::wrapperClass()
@@ -46,163 +86,1401 @@ JSClassRef AccessibilityUIElement::wrapperClass()
     return JSAccessibilityUIElement::accessibilityUIElementClass();
 }
 
-// Implementation
-
-bool AccessibilityUIElement::isValid() const
+// Base class constructors are empty - all platforms store m_element in their subclasses
+AccessibilityUIElement::AccessibilityUIElement(PlatformUIElement)
 {
-#if PLATFORM(COCOA)
-    return m_element.getAutoreleased();
-#else
-    return m_element;
-#endif
 }
 
-// iOS specific methods
-#if !PLATFORM(IOS_FAMILY)
-JSRetainPtr<JSStringRef> AccessibilityUIElement::identifier() { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::traits() { return nullptr; }
-int AccessibilityUIElement::elementTextPosition() { return 0; }
-int AccessibilityUIElement::elementTextLength() { return 0; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForSelection() { return nullptr; }
-void AccessibilityUIElement::increaseTextSelection() { }
-void AccessibilityUIElement::decreaseTextSelection() { }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedElement() { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::headerElementAtIndex(unsigned) { return nullptr; }
-void AccessibilityUIElement::assistiveTechnologySimulatedFocus() { return; }
-bool AccessibilityUIElement::scrollPageUp() { return false; }
-bool AccessibilityUIElement::scrollPageDown() { return false; }
-bool AccessibilityUIElement::scrollPageLeft() { return false; }
-bool AccessibilityUIElement::scrollPageRight() { return false; }
-bool AccessibilityUIElement::hasTextEntryTrait() { return false; }
-bool AccessibilityUIElement::hasTabBarTrait() { return false; }
-bool AccessibilityUIElement::hasMenuItemTrait() { return false; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::fieldsetAncestorElement() { return nullptr; }
-bool AccessibilityUIElement::isSearchField() const { return false; }
-bool AccessibilityUIElement::isSwitch() const { return false; }
-bool AccessibilityUIElement::isTextArea() const { return false; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeMatchesTextNearMarkers(JSStringRef, AccessibilityTextMarker*, AccessibilityTextMarker*) { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForElement() { return nullptr; }
-bool AccessibilityUIElement::isInLandmark() const { return false; }
-bool AccessibilityUIElement::isInList() const { return false; }
-bool AccessibilityUIElement::isMarkAnnotation() const { return false; }
-bool AccessibilityUIElement::supportsExpanded() const { return false; }
-#endif
+AccessibilityUIElement::AccessibilityUIElement(const AccessibilityUIElement&)
+{
+}
 
-// Unsupported methods on various platforms. As they're implemented on other platforms this list should be modified.
+AccessibilityUIElement::~AccessibilityUIElement() = default;
 
-#if PLATFORM(COCOA)
+// Stub implementations for methods that are virtual and may be overridden by platform-specific subclasses
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::accessibilityElementForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::characterAtOffset(int) { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::wordAtOffset(int) { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::lineAtOffset(int) { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sentenceAtOffset(int) { return nullptr; }
+JSRetainPtr<JSStringRef> AccessibilityUIElement::accessibilityValue() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::addNotificationListener(OpaqueJSContext const*, OpaqueJSValue const*)
+{
+    return false;
+}
+
+void AccessibilityUIElement::addSelection()
+{
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::allAttributes()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaControlsElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDescribedByElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDetailsElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::ariaDropEffects() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaErrorMessageElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaFlowToElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaOwnsElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+void AccessibilityUIElement::assistiveTechnologySimulatedFocus()
+{
+    return;
+}
+
+void AccessibilityUIElement::asyncDecrement()
+{
+}
+
+void AccessibilityUIElement::asyncIncrement()
+{
+}
+
+void AccessibilityUIElement::attributeValueAsync(OpaqueJSContext const*, OpaqueJSString*, OpaqueJSValue const*)
+{
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForElement()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsigned, unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRange(WTR::AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute(OpaqueJSString*, WTR::AccessibilityTextMarkerRange*)
+{
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(WTR::AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(WTR::AccessibilityTextMarkerRange*, bool)
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::attributedStringRangeIsMisspelled(unsigned, unsigned)
+{
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfChildren()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumns()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfDocumentLinks()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfHeader()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfLinkedUIElements()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfVisibleCells()
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::boolAttributeValue(OpaqueJSString*)
+{
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned, unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRangeWithPagePosition(unsigned, unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::brailleLabel() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::brailleRoleDescription() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::cellForColumnAndRow(unsigned, unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::characterAtOffset(int)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndexWithRemoteElement(unsigned)
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::children(OpaqueJSContext const*)
+{
+    return nullptr;
+}
 
 unsigned AccessibilityUIElement::childrenCount()
 {
-    return getChildren().size();
+    return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndex(unsigned index)
+JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
 {
-    auto children = getChildrenInRange(index, 1);
-    return children.size() == 1 ? children[0] : nullptr;
+    return nullptr;
 }
 
-#endif // PLATFORM(COCOA)
+void AccessibilityUIElement::clearSelectedChildren() const
+{
+}
 
-#if !PLATFORM(MAC)
-bool AccessibilityUIElement::isTextMarkerNull(AccessibilityTextMarker* marker) { return !isTextMarkerValid(marker); }
-bool AccessibilityUIElement::isTextMarkerRangeValid(AccessibilityTextMarkerRange*) { return false; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::rightLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::leftLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-int AccessibilityUIElement::lineIndexForTextMarker(AccessibilityTextMarker*) const { return -1; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::styleTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForRange(unsigned, unsigned) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::selectedTextMarkerRange() { return nullptr; }
-void AccessibilityUIElement::resetSelectedTextMarkerRange() { }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textInputMarkedTextMarkerRange() const { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerDebugDescription(AccessibilityTextMarker*) { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*) { return nullptr; }
-void AccessibilityUIElement::setBoolAttributeValue(JSStringRef, bool) { }
-void AccessibilityUIElement::setValue(JSStringRef) { }
-JSValueRef AccessibilityUIElement::searchTextWithCriteria(JSContextRef, JSValueRef, JSStringRef, JSStringRef) { return nullptr; }
-JSValueRef AccessibilityUIElement::performTextOperation(JSContextRef, JSStringRef, JSValueRef, JSValueRef, bool) { return nullptr; }
-bool AccessibilityUIElement::isOnScreen() const { return true; }
-JSValueRef AccessibilityUIElement::mathRootRadicand(JSContextRef) { return { }; }
-unsigned AccessibilityUIElement::numberOfCharacters() const { return 0; }
-JSValueRef AccessibilityUIElement::columns(JSContextRef) { return { }; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::dateValue() { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForLine(long) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPointWithRemoteElement(int x, int y) { return nullptr; }
-void AccessibilityUIElement::elementAtPointResolvingRemoteFrame(JSContextRef context, int x, int y, JSValueRef jsCallback) { }
-bool AccessibilityUIElement::isRemoteFrame() const { return false; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndexWithRemoteElement(unsigned) { return nullptr; }
-#endif // !PLATFORM(MAC)
+double AccessibilityUIElement::clickPointX()
+{
+    return 0;
+}
 
-#if !PLATFORM(COCOA)
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusedElement() const { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::customContent() const { return nullptr; }
+double AccessibilityUIElement::clickPointY()
+{
+    return 0;
+}
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::brailleLabel() const { return nullptr; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::brailleRoleDescription() const { return nullptr; }
+int AccessibilityUIElement::columnCount()
+{
+    return 0;
+}
 
-bool AccessibilityUIElement::isInDescriptionListDetail() const { return false; }
-bool AccessibilityUIElement::isInDescriptionListTerm() const { return false; }
-bool AccessibilityUIElement::isInCell() const { return false; }
-bool AccessibilityUIElement::isInTable() const { return false; }
+JSValueRef AccessibilityUIElement::columnHeaders(OpaqueJSContext const*)
+{
+    return nullptr;
+}
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::lineRectsAndText() const { return { }; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::leftWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::rightWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousWordStartTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextWordEndTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::paragraphTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextParagraphEndTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousParagraphStartTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::sentenceTextMarkerRangeForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange*, bool, JSValueRef, JSStringRef, bool, bool) { return nullptr; }
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::misspellingTextMarkerRange(AccessibilityTextMarkerRange*, bool) { return nullptr; }
-bool AccessibilityUIElement::dismiss() { return false; }
-JSValueRef AccessibilityUIElement::children(JSContextRef) { return { }; }
-JSValueRef AccessibilityUIElement::imageOverlayElements(JSContextRef) { return { }; }
-JSRetainPtr<JSStringRef> AccessibilityUIElement::embeddedImageDescription() const { return nullptr; }
-#endif // !PLATFORM(COCOA)
+JSRetainPtr<JSStringRef> AccessibilityUIElement::columnIndexRange()
+{
+    return nullptr;
+}
 
-#if PLATFORM(IOS_FAMILY)
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::controllerElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDescribedByElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::descriptionForElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::detailsForElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::errorMessageForElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::flowFromElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const { return nullptr; }
-JSValueRef AccessibilityUIElement::selectedChildren(JSContextRef) { return { }; }
-#endif // PLATFORM(IOS_FAMILY)
+JSValueRef AccessibilityUIElement::columns(OpaqueJSContext const*)
+{
+    return nullptr;
+}
 
-#if PLATFORM(WIN) || PLATFORM(PLAYSTATION)
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::controllerElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDescribedByElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::descriptionForElementAtIndex(unsigned) { return nullptr; }
-JSValueRef AccessibilityUIElement::detailsElements(JSContextRef) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDetailsElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::detailsForElementAtIndex(unsigned) { return nullptr; }
-JSValueRef AccessibilityUIElement::errorMessageElements(JSContextRef) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaErrorMessageElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::errorMessageForElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::flowFromElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned) { return nullptr; }
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const { return nullptr; }
-JSValueRef AccessibilityUIElement::selectedChildren(JSContextRef) { return { }; }
-#endif // PLATFORM(WIN) || PLATFORM(PLAYSTATION)
+JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::controllerElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::customContent() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::dateTimeValue() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::dateValue()
+{
+    return nullptr;
+}
+
+void AccessibilityUIElement::decreaseTextSelection()
+{
+}
+
+void AccessibilityUIElement::decrement()
+{
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::description()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::descriptionForElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::detailsElements(OpaqueJSContext const*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::detailsForElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedByRow()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedRowAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::dismiss()
+{
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::editableAncestor()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPoint(int, int)
+{
+    return nullptr;
+}
+
+void AccessibilityUIElement::elementAtPointResolvingRemoteFrame(OpaqueJSContext const*, int, int, OpaqueJSValue const*)
+{
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPointWithRemoteElement(int, int)
+{
+    return nullptr;
+}
+
+int AccessibilityUIElement::elementTextLength()
+{
+    return 0;
+}
+
+int AccessibilityUIElement::elementTextPosition()
+{
+    return 0;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::embeddedImageDescription() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarker()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForBounds(int, int, int, int)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForTextMarkerRange(WTR::AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::errorMessageElements(OpaqueJSContext const*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::errorMessageForElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::fieldsetAncestorElement()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::flowFromElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusableAncestor()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::focusedElement() const
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::hasMenuItemTrait()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::hasPopup() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::hasTabBarTrait()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::hasTextEntryTrait()
+{
+    return false;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::headerElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+double AccessibilityUIElement::height()
+{
+    return 0;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
+{
+    return nullptr;
+}
+
+int AccessibilityUIElement::hierarchicalLevel() const
+{
+    return 0;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::highestEditableAncestor()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::horizontalScrollbar() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::identifier()
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::imageOverlayElements(OpaqueJSContext const*)
+{
+    return nullptr;
+}
+
+void AccessibilityUIElement::increaseTextSelection()
+{
+}
+
+void AccessibilityUIElement::increment()
+{
+}
+
+int AccessibilityUIElement::indexForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return 0;
+}
+
+int AccessibilityUIElement::indexInTable()
+{
+    return 0;
+}
+
+unsigned AccessibilityUIElement::indexOfChild(WTR::AccessibilityUIElement*)
+{
+    return 0;
+}
+
+bool AccessibilityUIElement::insertText(OpaqueJSString*)
+{
+    return false;
+}
+
+int AccessibilityUIElement::insertionPointLineNumber()
+{
+    return 0;
+}
+
+double AccessibilityUIElement::intValue() const
+{
+    return 0;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::intersectionWithSelectionRange()
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::isAtomicLiveRegion() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isAttributeSettable(OpaqueJSString*)
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isAttributeSupported(OpaqueJSString*)
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isBusy() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isChecked() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isCollapsed() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isDecrementActionSupported()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isDeletion() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isEnabled()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isEqual(WTR::AccessibilityUIElement*)
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isExpanded() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isFirstItemInSuggestion() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isFocusable() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isFocused() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isGrabbed() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isIgnored() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isInCell() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isInDescriptionListDetail() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isInDescriptionListTerm() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isInLandmark() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isInList() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isInTable() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isIncrementActionSupported()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isIndeterminate() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isInsertion() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isLastItemInSuggestion() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isMarkAnnotation() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isMultiLine() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isMultiSelectable() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isOffScreen() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isOnScreen() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isPressActionSupported()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isRemoteFrame() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isRequired() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isSearchField() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isSelectable() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isSelected() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isSelectedOptionActive() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isSingleLine() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isSwitch() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isTextArea() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isTextMarkerNull(WTR::AccessibilityTextMarker*)
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isTextMarkerRangeValid(WTR::AccessibilityTextMarkerRange*)
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isTextMarkerValid(WTR::AccessibilityTextMarker*)
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isValid() const
+{
+    return false;
+}
+
+bool AccessibilityUIElement::isVisible() const
+{
+    return false;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::language()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::leftLineTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::leftWordTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::lineAtOffset(int)
+{
+    return nullptr;
+}
+
+int AccessibilityUIElement::lineForIndex(int)
+{
+    return 0;
+}
+
+int AccessibilityUIElement::lineIndexForTextMarker(WTR::AccessibilityTextMarker*) const
+{
+    return 0;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::lineRectsAndText() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::lineTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedElement()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedUIElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionRelevant() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionStatus() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPostscriptsDescription() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPrescriptsDescription() const
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::mathRootRadicand(OpaqueJSContext const*)
+{
+    return nullptr;
+}
+
+double AccessibilityUIElement::maxValue()
+{
+    return 0;
+}
+
+double AccessibilityUIElement::minValue()
+{
+    return 0;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::misspellingTextMarkerRange(WTR::AccessibilityTextMarkerRange*, bool)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextLineEndTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextParagraphEndTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextSentenceEndTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextWordEndTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+double AccessibilityUIElement::numberAttributeValue(OpaqueJSString*)
+{
+    return 0;
+}
+
+unsigned AccessibilityUIElement::numberOfCharacters() const
+{
+    return 0;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+double AccessibilityUIElement::pageX()
+{
+    return 0;
+}
+
+double AccessibilityUIElement::pageY()
+{
+    return 0;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::paragraphTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::parameterizedAttributeNames()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::parentElement()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::pathDescription() const
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::performTextOperation(OpaqueJSContext const*, OpaqueJSString*, OpaqueJSValue const*, OpaqueJSValue const*, bool)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
+{
+    return nullptr;
+}
+
+void AccessibilityUIElement::press()
+{
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousLineStartTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousParagraphStartTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousSentenceStartTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousWordStartTextMarkerForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForLine(int)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForPosition(int, int)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::rectsForTextMarkerRange(WTR::AccessibilityTextMarkerRange*, OpaqueJSString*)
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::removeNotificationListener()
+{
+    return false;
+}
+
+void AccessibilityUIElement::removeSelection()
+{
+}
+
+void AccessibilityUIElement::removeSelectionAtIndex(unsigned) const
+{
+}
+
+bool AccessibilityUIElement::replaceTextInRange(OpaqueJSString*, int, int)
+{
+    return false;
+}
+
+void AccessibilityUIElement::resetSelectedTextMarkerRange()
+{
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::rightLineTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::rightWordTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::roleDescription()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::rowAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+int AccessibilityUIElement::rowCount()
+{
+    return 0;
+}
+
+JSValueRef AccessibilityUIElement::rowHeaders(OpaqueJSContext const*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::rowIndexRange()
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::scrollPageDown()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::scrollPageLeft()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::scrollPageRight()
+{
+    return false;
+}
+
+bool AccessibilityUIElement::scrollPageUp()
+{
+    return false;
+}
+
+void AccessibilityUIElement::scrollToGlobalPoint(int, int)
+{
+}
+
+void AccessibilityUIElement::scrollToMakeVisible()
+{
+}
+
+void AccessibilityUIElement::scrollToMakeVisibleWithSubFocus(int, int, int, int)
+{
+}
+
+JSValueRef AccessibilityUIElement::searchTextWithCriteria(OpaqueJSContext const*, OpaqueJSValue const*, OpaqueJSString*, OpaqueJSString*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(OpaqueJSContext const*, OpaqueJSString*, OpaqueJSValue const*, OpaqueJSString*, OpaqueJSString*)
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::selectedCells(OpaqueJSContext const*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedChildAtIndex(unsigned) const
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::selectedChildren(OpaqueJSContext const*)
+{
+    return nullptr;
+}
+
+unsigned AccessibilityUIElement::selectedChildrenCount() const
+{
+    return 0;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedRowAtIndex(unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedText()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::selectedTextMarkerRange()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedTextRange()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::sentenceAtOffset(int)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::sentenceTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+void AccessibilityUIElement::setBoolAttributeValue(OpaqueJSString*, bool)
+{
+}
+
+void AccessibilityUIElement::setSelectedChild(WTR::AccessibilityUIElement*) const
+{
+}
+
+void AccessibilityUIElement::setSelectedChildAtIndex(unsigned) const
+{
+}
+
+bool AccessibilityUIElement::setSelectedTextMarkerRange(WTR::AccessibilityTextMarkerRange*)
+{
+    return false;
+}
+
+bool AccessibilityUIElement::setSelectedTextRange(unsigned, unsigned)
+{
+    return false;
+}
+
+void AccessibilityUIElement::setValue(OpaqueJSString*)
+{
+}
+
+void AccessibilityUIElement::showMenu()
+{
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarker()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForBounds(int, int, int, int)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForTextMarkerRange(WTR::AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(OpaqueJSString*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::stringDescriptionOfAttributeValue(OpaqueJSString*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned, unsigned)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForSelection()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForTextMarkerRange(WTR::AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::styleTextMarkerRangeForTextMarker(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::subrole()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::supportedActions() const
+{
+    return nullptr;
+}
+
+bool AccessibilityUIElement::supportsExpanded() const
+{
+    return false;
+}
+
+void AccessibilityUIElement::syncPress()
+{
+}
+
+void AccessibilityUIElement::takeFocus()
+{
+}
+
+void AccessibilityUIElement::takeSelection()
+{
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textInputMarkedTextMarkerRange() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerDebugDescription(WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForIndex(int)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForPoint(int, int)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::textMarkerRangeDebugDescription(WTR::AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForElement(WTR::AccessibilityUIElement*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForLine(long)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForMarkers(WTR::AccessibilityTextMarker*, WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForRange(unsigned, unsigned)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForSearchPredicate(OpaqueJSContext const*, WTR::AccessibilityTextMarkerRange*, bool, OpaqueJSValue const*, OpaqueJSString*, bool, bool)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForUnorderedMarkers(WTR::AccessibilityTextMarker*, WTR::AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+int AccessibilityUIElement::textMarkerRangeLength(WTR::AccessibilityTextMarkerRange*)
+{
+    return 0;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeMatchesTextNearMarkers(JSStringRef, AccessibilityTextMarker*, AccessibilityTextMarker*)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::title()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::titleUIElement()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::traits()
+{
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(OpaqueJSContext const*, OpaqueJSString*)
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementAttributeValue(OpaqueJSString*) const
+{
+    return nullptr;
+}
+
+unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(OpaqueJSContext const*, WTR::AccessibilityUIElement*, bool, OpaqueJSValue const*, OpaqueJSString*, bool, bool)
+{
+    return 0;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredicate(OpaqueJSContext const*, WTR::AccessibilityUIElement*, bool, OpaqueJSValue const*, OpaqueJSString*, bool, bool)
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::valueDescription()
+{
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
+{
+    return nullptr;
+}
+
+double AccessibilityUIElement::width()
+{
+    return 0;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElement::wordAtOffset(int)
+{
+    return nullptr;
+}
+
+double AccessibilityUIElement::x()
+{
+    return 0;
+}
+
+double AccessibilityUIElement::y()
+{
+    return 0;
+}
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -56,9 +56,6 @@ typedef void* PlatformUIElement;
 namespace WTR {
 
 class AccessibilityController;
-#if USE(ATSPI)
-class AccessibilityNotificationHandler;
-#endif
 
 class AccessibilityUIElement : public JSWrappable {
 #if PLATFORM(COCOA)
@@ -71,416 +68,350 @@ public:
     static Ref<AccessibilityUIElement> create(PlatformUIElement);
     static Ref<AccessibilityUIElement> create(const AccessibilityUIElement&);
 
-    ~AccessibilityUIElement();
+    virtual ~AccessibilityUIElement();
 
-#if PLATFORM(COCOA)
-    id platformUIElement() { return m_element.getAutoreleased(); }
-#elif USE(ATSPI)
-    PlatformUIElement platformUIElement() { return m_element.get(); }
-#else
-    PlatformUIElement platformUIElement() { return m_element; }
-#endif
+    virtual PlatformUIElement platformUIElement() = 0;
 
     virtual JSClassRef wrapperClass();
 
     static JSObjectRef makeJSAccessibilityUIElement(JSContextRef, const AccessibilityUIElement&);
 
-    bool isEqual(AccessibilityUIElement* otherElement);
-    JSRetainPtr<JSStringRef> domIdentifier() const;
+    virtual bool isEqual(AccessibilityUIElement* otherElement);
+    virtual JSRetainPtr<JSStringRef> domIdentifier() const;
 
-    RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y);
-    RefPtr<AccessibilityUIElement> elementAtPointWithRemoteElement(int x, int y);
-    void elementAtPointResolvingRemoteFrame(JSContextRef, int x, int y, JSValueRef callback);
+    virtual RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y);
+    virtual RefPtr<AccessibilityUIElement> elementAtPointWithRemoteElement(int x, int y);
+    virtual void elementAtPointResolvingRemoteFrame(JSContextRef, int x, int y, JSValueRef callback);
 
-    JSValueRef children(JSContextRef);
-    RefPtr<AccessibilityUIElement> childAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> childAtIndexWithRemoteElement(unsigned);
-    unsigned indexOfChild(AccessibilityUIElement*);
-    unsigned childrenCount();
-    RefPtr<AccessibilityUIElement> titleUIElement();
-    RefPtr<AccessibilityUIElement> parentElement();
+    virtual JSValueRef children(JSContextRef);
+    virtual RefPtr<AccessibilityUIElement> childAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> childAtIndexWithRemoteElement(unsigned);
+    virtual unsigned indexOfChild(AccessibilityUIElement*);
+    virtual unsigned childrenCount();
+    virtual RefPtr<AccessibilityUIElement> titleUIElement();
+    virtual RefPtr<AccessibilityUIElement> parentElement();
 
-    void takeFocus();
-    void takeSelection();
-    void addSelection();
-    void removeSelection();
+    virtual void takeFocus();
+    virtual void takeSelection();
+    virtual void addSelection();
+    virtual void removeSelection();
 
     // Methods - platform-independent implementations
-    JSRetainPtr<JSStringRef> allAttributes();
-    JSRetainPtr<JSStringRef> attributesOfLinkedUIElements();
-    RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned);
+    virtual JSRetainPtr<JSStringRef> allAttributes();
+    virtual JSRetainPtr<JSStringRef> attributesOfLinkedUIElements();
+    virtual RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned);
 
-    JSRetainPtr<JSStringRef> attributesOfDocumentLinks();
-    JSRetainPtr<JSStringRef> attributesOfChildren();
-    JSRetainPtr<JSStringRef> parameterizedAttributeNames();
-    void increment();
-    void decrement();
-    void showMenu();
-    void press();
-    bool dismiss();
-#if PLATFORM(MAC)
-    void syncPress();
-    void asyncIncrement();
-    void asyncDecrement();
-    RefPtr<AccessibilityUIElement> focusableAncestor();
-    RefPtr<AccessibilityUIElement> editableAncestor();
-    RefPtr<AccessibilityUIElement> highestEditableAncestor();
-    JSRetainPtr<JSStringRef> selectedText();
-#else
-    void syncPress() { press(); }
-    void asyncIncrement() { }
-    void asyncDecrement() { };
-    RefPtr<AccessibilityUIElement> focusableAncestor() { return nullptr; }
-    RefPtr<AccessibilityUIElement> editableAncestor() { return nullptr; }
-    RefPtr<AccessibilityUIElement> highestEditableAncestor() { return nullptr; }
-    JSRetainPtr<JSStringRef> selectedText() { return nullptr; }
-#endif // PLATFORM(MAC)
+    virtual JSRetainPtr<JSStringRef> attributesOfDocumentLinks();
+    virtual JSRetainPtr<JSStringRef> attributesOfChildren();
+    virtual JSRetainPtr<JSStringRef> parameterizedAttributeNames();
+    virtual void increment();
+    virtual void decrement();
+    virtual void showMenu();
+    virtual void press();
+    virtual bool dismiss();
+    virtual void syncPress();
+    virtual void asyncIncrement();
+    virtual void asyncDecrement();
+    virtual RefPtr<AccessibilityUIElement> focusableAncestor();
+    virtual RefPtr<AccessibilityUIElement> editableAncestor();
+    virtual RefPtr<AccessibilityUIElement> highestEditableAncestor();
+    virtual JSRetainPtr<JSStringRef> selectedText();
 
-#if PLATFORM(COCOA)
-    JSRetainPtr<JSStringRef> dateTimeValue() const;
-#else
-    JSRetainPtr<JSStringRef> dateTimeValue() const { return nullptr; }
-#endif // PLATFORM(COCOA)
+    virtual JSRetainPtr<JSStringRef> dateTimeValue() const;
 
     // Attributes - platform-independent implementations
-    JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute);
-    JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute);
-    double numberAttributeValue(JSStringRef attribute);
-    JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute);
-    RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const;
-    bool boolAttributeValue(JSStringRef attribute);
-#if PLATFORM(MAC)
-    RetainPtr<id> attributeValue(NSString *) const;
-    void attributeValueAsync(JSContextRef, JSStringRef attribute, JSValueRef callback);
-    NSArray *actionNames() const;
-    bool performAction(NSString *) const;
-#else
-    void attributeValueAsync(JSContextRef, JSStringRef attribute, JSValueRef callback) { }
-#endif
-    void setBoolAttributeValue(JSStringRef attribute, bool value);
-    bool isAttributeSupported(JSStringRef attribute);
-    bool isAttributeSettable(JSStringRef attribute);
-    bool isPressActionSupported();
-    bool isIncrementActionSupported();
-    bool isDecrementActionSupported();
-    void setValue(JSStringRef);
-    JSRetainPtr<JSStringRef> role();
-    JSRetainPtr<JSStringRef> subrole();
-    JSRetainPtr<JSStringRef> roleDescription();
-    JSRetainPtr<JSStringRef> computedRoleString();
-    JSRetainPtr<JSStringRef> title();
-    JSRetainPtr<JSStringRef> description();
-    JSRetainPtr<JSStringRef> language();
-    JSRetainPtr<JSStringRef> stringValue();
-    JSRetainPtr<JSStringRef> dateValue();
-    JSRetainPtr<JSStringRef> accessibilityValue() const;
-    JSRetainPtr<JSStringRef> helpText() const;
-    JSRetainPtr<JSStringRef> orientation() const;
-    JSRetainPtr<JSStringRef> liveRegionRelevant() const;
-    JSRetainPtr<JSStringRef> liveRegionStatus() const;
-    double pageX();
-    double pageY();
-    double x();
-    double y();
-    double width();
-    double height();
-    JSRetainPtr<JSStringRef> lineRectsAndText() const;
-    JSRetainPtr<JSStringRef> brailleLabel() const;
-    JSRetainPtr<JSStringRef> brailleRoleDescription() const;
+    virtual JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute);
+    virtual JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute);
+    virtual double numberAttributeValue(JSStringRef attribute);
+    virtual JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute);
+    virtual RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const;
+    virtual bool boolAttributeValue(JSStringRef attribute);
+    virtual void attributeValueAsync(JSContextRef, JSStringRef attribute, JSValueRef callback);
+    virtual void setBoolAttributeValue(JSStringRef attribute, bool value);
+    virtual bool isAttributeSupported(JSStringRef attribute);
+    virtual bool isAttributeSettable(JSStringRef attribute);
+    virtual bool isPressActionSupported();
+    virtual bool isIncrementActionSupported();
+    virtual bool isDecrementActionSupported();
+    virtual void setValue(JSStringRef);
+    virtual JSRetainPtr<JSStringRef> role();
+    virtual JSRetainPtr<JSStringRef> subrole();
+    virtual JSRetainPtr<JSStringRef> roleDescription();
+    virtual JSRetainPtr<JSStringRef> computedRoleString();
+    virtual JSRetainPtr<JSStringRef> title();
+    virtual JSRetainPtr<JSStringRef> description();
+    virtual JSRetainPtr<JSStringRef> language();
+    virtual JSRetainPtr<JSStringRef> stringValue();
+    virtual JSRetainPtr<JSStringRef> dateValue();
+    virtual JSRetainPtr<JSStringRef> accessibilityValue() const;
+    virtual JSRetainPtr<JSStringRef> helpText() const;
+    virtual JSRetainPtr<JSStringRef> orientation() const;
+    virtual JSRetainPtr<JSStringRef> liveRegionRelevant() const;
+    virtual JSRetainPtr<JSStringRef> liveRegionStatus() const;
+    virtual double pageX();
+    virtual double pageY();
+    virtual double x();
+    virtual double y();
+    virtual double width();
+    virtual double height();
+    virtual JSRetainPtr<JSStringRef> lineRectsAndText() const;
+    virtual JSRetainPtr<JSStringRef> brailleLabel() const;
+    virtual JSRetainPtr<JSStringRef> brailleRoleDescription() const;
 
-    double intValue() const;
-    double minValue();
-    double maxValue();
-    JSRetainPtr<JSStringRef> valueDescription();
-    unsigned numberOfCharacters() const;
-    int insertionPointLineNumber();
-    JSRetainPtr<JSStringRef> selectedTextRange();
-    JSRetainPtr<JSStringRef> intersectionWithSelectionRange();
-    JSRetainPtr<JSStringRef> textInputMarkedRange() const;
-    bool isAtomicLiveRegion() const;
-    bool isBusy() const;
-    bool isEnabled();
-    bool isRequired() const;
+    virtual double intValue() const;
+    virtual double minValue();
+    virtual double maxValue();
+    virtual JSRetainPtr<JSStringRef> valueDescription();
+    virtual unsigned numberOfCharacters() const;
+    virtual int insertionPointLineNumber();
+    virtual JSRetainPtr<JSStringRef> selectedTextRange();
+    virtual JSRetainPtr<JSStringRef> intersectionWithSelectionRange();
+    virtual JSRetainPtr<JSStringRef> textInputMarkedRange() const;
+    virtual bool isAtomicLiveRegion() const;
+    virtual bool isBusy() const;
+    virtual bool isEnabled();
+    virtual bool isRequired() const;
 
-    RefPtr<AccessibilityUIElement> focusedElement() const;
-    bool isFocused() const;
-    bool isFocusable() const;
-    bool isSelected() const;
-    bool isSelectedOptionActive() const;
-    bool isSelectable() const;
-    bool isMultiSelectable() const;
-    void setSelectedChild(AccessibilityUIElement*) const;
-    void setSelectedChildAtIndex(unsigned) const;
-    void removeSelectionAtIndex(unsigned) const;
-    void clearSelectedChildren() const;
-    RefPtr<AccessibilityUIElement> activeElement() const;
-    JSValueRef selectedChildren(JSContextRef);
-    unsigned selectedChildrenCount() const;
-    RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const;
+    virtual RefPtr<AccessibilityUIElement> focusedElement() const;
+    virtual bool isFocused() const;
+    virtual bool isFocusable() const;
+    virtual bool isSelected() const;
+    virtual bool isSelectedOptionActive() const;
+    virtual bool isSelectable() const;
+    virtual bool isMultiSelectable() const;
+    virtual void setSelectedChild(AccessibilityUIElement*) const;
+    virtual void setSelectedChildAtIndex(unsigned) const;
+    virtual void removeSelectionAtIndex(unsigned) const;
+    virtual void clearSelectedChildren() const;
+    virtual RefPtr<AccessibilityUIElement> activeElement() const;
+    virtual JSValueRef selectedChildren(JSContextRef);
+    virtual unsigned selectedChildrenCount() const;
+    virtual RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const;
 
-    bool isValid() const;
-    bool isExpanded() const;
-    bool supportsExpanded() const;
-    bool isChecked() const;
-    JSRetainPtr<JSStringRef> currentStateValue() const;
-    JSRetainPtr<JSStringRef> sortDirection() const;
-    bool isIndeterminate() const;
-    bool isVisible() const;
-    bool isOnScreen() const;
-    bool isOffScreen() const;
-    bool isCollapsed() const;
-    bool isIgnored() const;
-    bool isSingleLine() const;
-    bool isMultiLine() const;
-    bool hasPopup() const;
-    JSRetainPtr<JSStringRef> popupValue() const;
-    int hierarchicalLevel() const;
-    double clickPointX();
-    double clickPointY();
-    JSRetainPtr<JSStringRef> url();
-    JSRetainPtr<JSStringRef> classList() const;
-    JSRetainPtr<JSStringRef> embeddedImageDescription() const;
-    JSValueRef imageOverlayElements(JSContextRef);
+    virtual bool isValid() const;
+    virtual bool isExpanded() const;
+    virtual bool supportsExpanded() const;
+    virtual bool isChecked() const;
+    virtual JSRetainPtr<JSStringRef> currentStateValue() const;
+    virtual JSRetainPtr<JSStringRef> sortDirection() const;
+    virtual bool isIndeterminate() const;
+    virtual bool isVisible() const;
+    virtual bool isOnScreen() const;
+    virtual bool isOffScreen() const;
+    virtual bool isCollapsed() const;
+    virtual bool isIgnored() const;
+    virtual bool isSingleLine() const;
+    virtual bool isMultiLine() const;
+    virtual bool hasPopup() const;
+    virtual JSRetainPtr<JSStringRef> popupValue() const;
+    virtual int hierarchicalLevel() const;
+    virtual double clickPointX();
+    virtual double clickPointY();
+    virtual JSRetainPtr<JSStringRef> url();
+    virtual JSRetainPtr<JSStringRef> classList() const;
+    virtual JSRetainPtr<JSStringRef> embeddedImageDescription() const;
+    virtual JSValueRef imageOverlayElements(JSContextRef);
 
     // CSS3-speech properties.
-    JSRetainPtr<JSStringRef> speakAs();
+    virtual JSRetainPtr<JSStringRef> speakAs();
 
     // Table-specific attributes
-    JSRetainPtr<JSStringRef> attributesOfColumnHeaders();
-    JSRetainPtr<JSStringRef> attributesOfRowHeaders();
-    JSRetainPtr<JSStringRef> attributesOfColumns();
-    JSValueRef columns(JSContextRef);
-    JSRetainPtr<JSStringRef> attributesOfRows();
-    JSRetainPtr<JSStringRef> attributesOfVisibleCells();
-    JSRetainPtr<JSStringRef> attributesOfHeader();
-    bool isInCell() const;
-    bool isInTable() const;
-    bool isInList() const;
-    bool isInLandmark() const;
-    int indexInTable();
-    JSRetainPtr<JSStringRef> rowIndexRange();
-    JSRetainPtr<JSStringRef> columnIndexRange();
-    int rowCount();
-    int columnCount();
-    JSValueRef rowHeaders(JSContextRef);
-    JSValueRef columnHeaders(JSContextRef);
-    JSRetainPtr<JSStringRef> customContent() const;
-    JSValueRef selectedCells(JSContextRef);
+    virtual JSRetainPtr<JSStringRef> attributesOfColumnHeaders();
+    virtual JSRetainPtr<JSStringRef> attributesOfRowHeaders();
+    virtual JSRetainPtr<JSStringRef> attributesOfColumns();
+    virtual JSValueRef columns(JSContextRef);
+    virtual JSRetainPtr<JSStringRef> attributesOfRows();
+    virtual JSRetainPtr<JSStringRef> attributesOfVisibleCells();
+    virtual JSRetainPtr<JSStringRef> attributesOfHeader();
+    virtual bool isInCell() const;
+    virtual bool isInTable() const;
+    virtual bool isInList() const;
+    virtual bool isInLandmark() const;
+    virtual int indexInTable();
+    virtual JSRetainPtr<JSStringRef> rowIndexRange();
+    virtual JSRetainPtr<JSStringRef> columnIndexRange();
+    virtual int rowCount();
+    virtual int columnCount();
+    virtual JSValueRef rowHeaders(JSContextRef);
+    virtual JSValueRef columnHeaders(JSContextRef);
+    virtual JSRetainPtr<JSStringRef> customContent() const;
+    virtual JSValueRef selectedCells(JSContextRef);
 
     // Tree/Outline specific attributes
-    RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> disclosedByRow();
-    RefPtr<AccessibilityUIElement> disclosedRowAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> rowAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> disclosedByRow();
+    virtual RefPtr<AccessibilityUIElement> disclosedRowAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> rowAtIndex(unsigned);
 
     // Relationships.
     // FIXME: replace all ***AtIndex methods with ones that return an array and make the naming consistent.
-    RefPtr<AccessibilityUIElement> controllerElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> ariaDescribedByElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> descriptionForElementAtIndex(unsigned);
-    JSValueRef detailsElements(JSContextRef);
-    RefPtr<AccessibilityUIElement> ariaDetailsElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> detailsForElementAtIndex(unsigned);
-    JSValueRef errorMessageElements(JSContextRef);
-    RefPtr<AccessibilityUIElement> ariaErrorMessageElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> errorMessageForElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> flowFromElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> ariaFlowToElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> ariaLabelledByElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> labelForElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> ownerElementAtIndex(unsigned);
-    RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> controllerElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> ariaDescribedByElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> descriptionForElementAtIndex(unsigned);
+    virtual JSValueRef detailsElements(JSContextRef);
+    virtual RefPtr<AccessibilityUIElement> ariaDetailsElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> detailsForElementAtIndex(unsigned);
+    virtual JSValueRef errorMessageElements(JSContextRef);
+    virtual RefPtr<AccessibilityUIElement> ariaErrorMessageElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> errorMessageForElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> flowFromElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> ariaFlowToElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> ariaLabelledByElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> labelForElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> ownerElementAtIndex(unsigned);
+    virtual RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned);
 
     // Drag and drop
-    bool isGrabbed() const;
+    virtual bool isGrabbed() const;
     // A space concatentated string of all the drop effects.
-    JSRetainPtr<JSStringRef> ariaDropEffects() const;
+    virtual JSRetainPtr<JSStringRef> ariaDropEffects() const;
 
     // Parameterized attributes
-    int lineForIndex(int);
-    JSRetainPtr<JSStringRef> rangeForLine(int);
-    JSRetainPtr<JSStringRef> rangeForPosition(int x, int y);
-    JSRetainPtr<JSStringRef> boundsForRange(unsigned location, unsigned length);
-#if PLATFORM(MAC)
-    JSRetainPtr<JSStringRef> boundsForRangeWithPagePosition(unsigned location, unsigned length);
-#else
-    JSRetainPtr<JSStringRef> boundsForRangeWithPagePosition(unsigned location, unsigned length) { return createJSString(); };
-#endif
-    bool setSelectedTextRange(unsigned location, unsigned length);
-    JSRetainPtr<JSStringRef> stringForRange(unsigned location, unsigned length);
-    JSRetainPtr<JSStringRef> attributedStringForRange(unsigned location, unsigned length);
-    JSRetainPtr<JSStringRef> attributedStringForElement();
+    virtual int lineForIndex(int);
+    virtual JSRetainPtr<JSStringRef> rangeForLine(int);
+    virtual JSRetainPtr<JSStringRef> rangeForPosition(int x, int y);
+    virtual JSRetainPtr<JSStringRef> boundsForRange(unsigned location, unsigned length);
+    virtual JSRetainPtr<JSStringRef> boundsForRangeWithPagePosition(unsigned location, unsigned length);
+    virtual bool setSelectedTextRange(unsigned location, unsigned length);
+    virtual JSRetainPtr<JSStringRef> stringForRange(unsigned location, unsigned length);
+    virtual JSRetainPtr<JSStringRef> attributedStringForRange(unsigned location, unsigned length);
+    virtual JSRetainPtr<JSStringRef> attributedStringForElement();
 
-    bool attributedStringRangeIsMisspelled(unsigned location, unsigned length);
-    unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
-    RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
-    JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity);
-    JSValueRef searchTextWithCriteria(JSContextRef, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction);
-    JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSValueRef replacementStrings, bool shouldSmartReplace);
+    virtual bool attributedStringRangeIsMisspelled(unsigned location, unsigned length);
+    virtual unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
+    virtual RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
+    virtual JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity);
+    virtual JSValueRef searchTextWithCriteria(JSContextRef, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction);
+    virtual JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSValueRef replacementStrings, bool shouldSmartReplace);
 
     // Text-specific
-    JSRetainPtr<JSStringRef> characterAtOffset(int offset);
-    JSRetainPtr<JSStringRef> wordAtOffset(int offset);
-    JSRetainPtr<JSStringRef> lineAtOffset(int offset);
-    JSRetainPtr<JSStringRef> sentenceAtOffset(int offset);
+    virtual JSRetainPtr<JSStringRef> characterAtOffset(int offset);
+    virtual JSRetainPtr<JSStringRef> wordAtOffset(int offset);
+    virtual JSRetainPtr<JSStringRef> lineAtOffset(int offset);
+    virtual JSRetainPtr<JSStringRef> sentenceAtOffset(int offset);
 
     // Table-specific
-    RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row);
+    virtual RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row);
 
     // Scrollarea-specific
-    RefPtr<AccessibilityUIElement> horizontalScrollbar() const;
-    RefPtr<AccessibilityUIElement> verticalScrollbar() const;
+    virtual RefPtr<AccessibilityUIElement> horizontalScrollbar() const;
+    virtual RefPtr<AccessibilityUIElement> verticalScrollbar() const;
 
-    void scrollToMakeVisible();
-    void scrollToGlobalPoint(int x, int y);
-    void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height);
+    virtual void scrollToMakeVisible();
+    virtual void scrollToGlobalPoint(int x, int y);
+    virtual void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height);
 
     // Text markers.
-    RefPtr<AccessibilityTextMarkerRange> lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> rightLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> leftLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker*);
-    int lineIndexForTextMarker(AccessibilityTextMarker*) const;
-    RefPtr<AccessibilityTextMarkerRange> styleTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange* startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
-    RefPtr<AccessibilityTextMarkerRange> misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward);
-    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*);
-    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForRange(unsigned location, unsigned length);
-    RefPtr<AccessibilityTextMarkerRange> selectedTextMarkerRange();
-    void resetSelectedTextMarkerRange();
-    bool replaceTextInRange(JSStringRef, int position, int length);
-    bool insertText(JSStringRef);
-    RefPtr<AccessibilityTextMarkerRange> textInputMarkedTextMarkerRange() const;
-    RefPtr<AccessibilityTextMarker> startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*);
-    RefPtr<AccessibilityTextMarker> endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*);
-    RefPtr<AccessibilityTextMarker> endTextMarkerForBounds(int x, int y, int width, int height);
-    RefPtr<AccessibilityTextMarker> startTextMarkerForBounds(int x, int y, int width, int height);
-    RefPtr<AccessibilityTextMarker> textMarkerForPoint(int x, int y);
-    RefPtr<AccessibilityTextMarker> previousTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> nextTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForLine(long);
-    JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*);
-    JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef);
-    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*);
-    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*);
-    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool);
-    int textMarkerRangeLength(AccessibilityTextMarkerRange*);
-    bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*);
-    int indexForTextMarker(AccessibilityTextMarker*);
-    bool isTextMarkerValid(AccessibilityTextMarker*);
-    bool isTextMarkerRangeValid(AccessibilityTextMarkerRange*);
-    bool isTextMarkerNull(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> textMarkerForIndex(int);
-    RefPtr<AccessibilityTextMarker> startTextMarker();
-    RefPtr<AccessibilityTextMarker> endTextMarker();
-    bool setSelectedTextMarkerRange(AccessibilityTextMarkerRange*);
-    RefPtr<AccessibilityTextMarkerRange> leftWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> rightWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> previousWordStartTextMarkerForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> nextWordEndTextMarkerForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> paragraphTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> nextParagraphEndTextMarkerForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> previousParagraphStartTextMarkerForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> sentenceTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarker> previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*);
-    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeMatchesTextNearMarkers(JSStringRef, AccessibilityTextMarker*, AccessibilityTextMarker*);
-    JSRetainPtr<JSStringRef> textMarkerDebugDescription(AccessibilityTextMarker*);
-    JSRetainPtr<JSStringRef> textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*);
+    virtual RefPtr<AccessibilityTextMarkerRange> lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> rightLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> leftLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual int lineIndexForTextMarker(AccessibilityTextMarker*) const;
+    virtual RefPtr<AccessibilityTextMarkerRange> styleTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange* startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
+    virtual RefPtr<AccessibilityTextMarkerRange> misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward);
+    virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*);
+    virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForRange(unsigned location, unsigned length);
+    virtual RefPtr<AccessibilityTextMarkerRange> selectedTextMarkerRange();
+    virtual void resetSelectedTextMarkerRange();
+    virtual bool replaceTextInRange(JSStringRef, int position, int length);
+    virtual bool insertText(JSStringRef);
+    virtual RefPtr<AccessibilityTextMarkerRange> textInputMarkedTextMarkerRange() const;
+    virtual RefPtr<AccessibilityTextMarker> startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*);
+    virtual RefPtr<AccessibilityTextMarker> endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*);
+    virtual RefPtr<AccessibilityTextMarker> endTextMarkerForBounds(int x, int y, int width, int height);
+    virtual RefPtr<AccessibilityTextMarker> startTextMarkerForBounds(int x, int y, int width, int height);
+    virtual RefPtr<AccessibilityTextMarker> textMarkerForPoint(int x, int y);
+    virtual RefPtr<AccessibilityTextMarker> previousTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> nextTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForLine(long);
+    virtual JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*);
+    virtual JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef);
+    virtual JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*);
+    virtual JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*);
+    virtual JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool);
+    virtual int textMarkerRangeLength(AccessibilityTextMarkerRange*);
+    virtual bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*);
+    virtual int indexForTextMarker(AccessibilityTextMarker*);
+    virtual bool isTextMarkerValid(AccessibilityTextMarker*);
+    virtual bool isTextMarkerRangeValid(AccessibilityTextMarkerRange*);
+    virtual bool isTextMarkerNull(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> textMarkerForIndex(int);
+    virtual RefPtr<AccessibilityTextMarker> startTextMarker();
+    virtual RefPtr<AccessibilityTextMarker> endTextMarker();
+    virtual bool setSelectedTextMarkerRange(AccessibilityTextMarkerRange*);
+    virtual RefPtr<AccessibilityTextMarkerRange> leftWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> rightWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> previousWordStartTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> nextWordEndTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> paragraphTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> nextParagraphEndTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> previousParagraphStartTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> sentenceTextMarkerRangeForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarker> previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeMatchesTextNearMarkers(JSStringRef, AccessibilityTextMarker*, AccessibilityTextMarker*);
+    virtual JSRetainPtr<JSStringRef> textMarkerDebugDescription(AccessibilityTextMarker*);
+    virtual JSRetainPtr<JSStringRef> textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*);
 
     // Returns an ordered list of supported actions for an element.
-    JSRetainPtr<JSStringRef> supportedActions() const;
-    JSRetainPtr<JSStringRef> mathPostscriptsDescription() const;
-    JSRetainPtr<JSStringRef> mathPrescriptsDescription() const;
-    JSValueRef mathRootRadicand(JSContextRef);
+    virtual JSRetainPtr<JSStringRef> supportedActions() const;
+    virtual JSRetainPtr<JSStringRef> mathPostscriptsDescription() const;
+    virtual JSRetainPtr<JSStringRef> mathPrescriptsDescription() const;
+    virtual JSValueRef mathRootRadicand(JSContextRef);
 
-    JSRetainPtr<JSStringRef> pathDescription() const;
+    virtual JSRetainPtr<JSStringRef> pathDescription() const;
 
     // Notifications
     // Function callback should take one argument, the name of the notification.
-    bool addNotificationListener(JSContextRef, JSValueRef functionCallback);
+    virtual bool addNotificationListener(JSContextRef, JSValueRef functionCallback);
     // Make sure you call remove, because you can't rely on objects being deallocated in a timely fashion.
-    bool removeNotificationListener();
+    virtual bool removeNotificationListener();
 
-    JSRetainPtr<JSStringRef> identifier();
-    JSRetainPtr<JSStringRef> traits();
-    int elementTextPosition();
-    int elementTextLength();
-    JSRetainPtr<JSStringRef> stringForSelection();
-    void increaseTextSelection();
-    void decreaseTextSelection();
-    RefPtr<AccessibilityUIElement> linkedElement();
-    RefPtr<AccessibilityUIElement> headerElementAtIndex(unsigned index);
-    void assistiveTechnologySimulatedFocus();
-    bool isSearchField() const;
-    bool isSwitch() const;
-    bool isTextArea() const;
+    virtual JSRetainPtr<JSStringRef> identifier();
+    virtual JSRetainPtr<JSStringRef> traits();
+    virtual int elementTextPosition();
+    virtual int elementTextLength();
+    virtual JSRetainPtr<JSStringRef> stringForSelection();
+    virtual void increaseTextSelection();
+    virtual void decreaseTextSelection();
+    virtual RefPtr<AccessibilityUIElement> linkedElement();
+    virtual RefPtr<AccessibilityUIElement> headerElementAtIndex(unsigned index);
+    virtual void assistiveTechnologySimulatedFocus();
+    virtual bool isSearchField() const;
+    virtual bool isSwitch() const;
+    virtual bool isTextArea() const;
 
-    bool scrollPageUp();
-    bool scrollPageDown();
-    bool scrollPageLeft();
-    bool scrollPageRight();
+    virtual bool scrollPageUp();
+    virtual bool scrollPageDown();
+    virtual bool scrollPageLeft();
+    virtual bool scrollPageRight();
 
-    bool isInDescriptionListDetail() const;
-    bool isInDescriptionListTerm() const;
+    virtual bool isInDescriptionListDetail() const;
+    virtual bool isInDescriptionListTerm() const;
 
-    bool hasTextEntryTrait();
-    bool hasTabBarTrait();
-    bool hasMenuItemTrait();
-    RefPtr<AccessibilityUIElement> fieldsetAncestorElement();
+    virtual bool hasTextEntryTrait();
+    virtual bool hasTabBarTrait();
+    virtual bool hasMenuItemTrait();
+    virtual RefPtr<AccessibilityUIElement> fieldsetAncestorElement();
 
-    bool isInsertion() const;
-    bool isDeletion() const;
-    bool isFirstItemInSuggestion() const;
-    bool isLastItemInSuggestion() const;
-    bool isRemoteFrame() const;
+    virtual bool isInsertion() const;
+    virtual bool isDeletion() const;
+    virtual bool isFirstItemInSuggestion() const;
+    virtual bool isLastItemInSuggestion() const;
+    virtual bool isRemoteFrame() const;
 
-    bool isMarkAnnotation() const;
-private:
+    virtual bool isMarkAnnotation() const;
+protected:
     AccessibilityUIElement(PlatformUIElement);
     AccessibilityUIElement(const AccessibilityUIElement&);
 
-#if PLATFORM(MAC)
-    RetainPtr<id> attributeValueForParameter(NSString *, id) const;
-    unsigned arrayAttributeCount(NSString *) const;
-    RetainPtr<NSString> descriptionOfValue(id valueObject) const;
-    bool boolAttributeValueNS(NSString *attribute) const;
-    JSRetainPtr<JSStringRef> stringAttributeValueNS(NSString *attribute) const;
-    double numberAttributeValueNS(NSString *attribute) const;
-    bool isAttributeSettableNS(NSString *) const;
-#endif
-
-#if !PLATFORM(COCOA) && !USE(ATSPI)
-    PlatformUIElement m_element;
-#endif
-
-    // A retained, platform specific object used to help manage notifications for this object.
-#if PLATFORM(COCOA)
-    WeakObjCPtr<id> m_element;
-    RetainPtr<id> m_notificationHandler;
     static RefPtr<AccessibilityController> s_controller;
-
-    void getLinkedUIElements(Vector<RefPtr<AccessibilityUIElement> >&);
-    void getDocumentLinks(Vector<RefPtr<AccessibilityUIElement> >&);
-    RefPtr<AccessibilityUIElement> elementForAttribute(NSString*) const;
-    RefPtr<AccessibilityUIElement> elementForAttributeAtIndex(NSString*, unsigned) const;
-
-    void getUIElementsWithAttribute(JSStringRef, Vector<RefPtr<AccessibilityUIElement> >&) const;
-#endif
-
-    Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
-    Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
-
-#if USE(ATSPI)
-    static RefPtr<AccessibilityController> s_controller;
-    RefPtr<WebCore::AccessibilityObjectAtspi> m_element;
-    std::unique_ptr<AccessibilityNotificationHandler> m_notificationHandler;
-#endif
 };
 
 #ifdef __OBJC__

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "AccessibilityUIElement.h"
+#include "AccessibilityUIElementAtspi.h"
 
 #if USE(ATSPI)
 #include "AccessibilityNotificationHandler.h"
@@ -46,61 +46,75 @@
 
 namespace WTR {
 
-RefPtr<AccessibilityController> AccessibilityUIElement::s_controller;
+Ref<AccessibilityUIElementAtspi> AccessibilityUIElementAtspi::create(PlatformUIElement element)
+{
+    return adoptRef(*new AccessibilityUIElementAtspi(element));
+}
 
-AccessibilityUIElement::AccessibilityUIElement(PlatformUIElement element)
-    : m_element(element)
+Ref<AccessibilityUIElementAtspi> AccessibilityUIElementAtspi::create(const AccessibilityUIElementAtspi& other)
+{
+    return adoptRef(*new AccessibilityUIElementAtspi(other));
+}
+
+AccessibilityUIElementAtspi::AccessibilityUIElementAtspi(PlatformUIElement element)
+    : AccessibilityUIElement(element)
+    , m_element(element)
 {
     if (!s_controller)
         s_controller = InjectedBundle::singleton().accessibilityController();
 }
 
-AccessibilityUIElement::AccessibilityUIElement(const AccessibilityUIElement& other)
-    : JSWrappable()
+AccessibilityUIElementAtspi::AccessibilityUIElementAtspi(const AccessibilityUIElementAtspi& other)
+    : AccessibilityUIElement(other)
     , m_element(other.m_element)
 {
 }
 
-AccessibilityUIElement::~AccessibilityUIElement() = default;
+AccessibilityUIElementAtspi::~AccessibilityUIElementAtspi() = default;
 
-bool AccessibilityUIElement::isEqual(AccessibilityUIElement* otherElement)
+bool AccessibilityUIElementAtspi::isValid() const
+{
+    return m_element;
+}
+
+bool AccessibilityUIElementAtspi::isEqual(AccessibilityUIElement* otherElement)
 {
     return otherElement && m_element.get() == otherElement->platformUIElement();
 }
 
-Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElement::getChildren() const
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementAtspi::getChildren() const
 {
     return { };
 }
 
-Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElement::getChildrenInRange(unsigned location, unsigned length) const
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementAtspi::getChildrenInRange(unsigned location, unsigned length) const
 {
     return { };
 }
 
-unsigned AccessibilityUIElement::childrenCount()
+unsigned AccessibilityUIElementAtspi::childrenCount()
 {
     m_element->updateBackingStore();
     return m_element->childCount();
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPoint(int x, int y)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::elementAtPoint(int x, int y)
 {
     m_element->updateBackingStore();
     auto* element = m_element->hitTest({ x, y }, WebCore::Atspi::CoordinateType::WindowCoordinates);
-    return AccessibilityUIElement::create(element ? element : m_element.get());
+    return AccessibilityUIElementAtspi::create(element ? element : m_element.get());
 }
 
-unsigned AccessibilityUIElement::indexOfChild(AccessibilityUIElement* element)
+unsigned AccessibilityUIElementAtspi::indexOfChild(AccessibilityUIElement* element)
 {
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::childAtIndex(unsigned index)
 {
     m_element->updateBackingStore();
     if (auto* child = m_element->childAt(index))
-        return AccessibilityUIElement::create(child);
+        return AccessibilityUIElementAtspi::create(child);
     return nullptr;
 }
 
@@ -113,90 +127,90 @@ static RefPtr<AccessibilityUIElement> elementForRelationAtIndex(WebCore::Accessi
         return nullptr;
 
     Ref target = targets[index];
-    return AccessibilityUIElement::create(target.ptr());
+    return AccessibilityUIElementAtspi::create(target.ptr());
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedUIElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::linkedUIElementAtIndex(unsigned index)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaOwnsElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ariaOwnsElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::NodeParentOf, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ownerElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ownerElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::NodeChildOf, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaFlowToElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ariaFlowToElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::FlowsTo, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::flowFromElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::flowFromElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::FlowsFrom, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaControlsElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ariaControlsElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::ControllerFor, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::controllerElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::controllerElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::ControlledBy, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaLabelledByElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ariaLabelledByElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::LabelledBy, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::labelForElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::labelForElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::LabelFor, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDescribedByElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ariaDescribedByElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::DescribedBy, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::descriptionForElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::descriptionForElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::DescriptionFor, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaDetailsElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ariaDetailsElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::Details, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::detailsForElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::detailsForElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::DetailsFor, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaErrorMessageElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::ariaErrorMessageElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::ErrorMessage, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::errorMessageForElementAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::errorMessageForElementAtIndex(unsigned index)
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::ErrorFor, index);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedRowAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::disclosedRowAtIndex(unsigned index)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::rowAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::rowAtIndex(unsigned index)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return nullptr;
@@ -206,21 +220,21 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::rowAtIndex(unsigned index
     if (index >= rows.size())
         return nullptr;
 
-    return AccessibilityUIElement::create(rows[index].ptr());
+    return AccessibilityUIElementAtspi::create(rows[index].ptr());
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedChildAtIndex(unsigned index) const
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::selectedChildAtIndex(unsigned index) const
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
         return nullptr;
 
     m_element->updateBackingStore();
     if (auto* selectedChild = m_element->selectedChild(index))
-        return AccessibilityUIElement::create(selectedChild);
+        return AccessibilityUIElementAtspi::create(selectedChild);
     return nullptr;
 }
 
-unsigned AccessibilityUIElement::selectedChildrenCount() const
+unsigned AccessibilityUIElementAtspi::selectedChildrenCount() const
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
         return 0;
@@ -229,35 +243,35 @@ unsigned AccessibilityUIElement::selectedChildrenCount() const
     return m_element->selectionCount();
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedRowAtIndex(unsigned index)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::selectedRowAtIndex(unsigned index)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::titleUIElement()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::titleUIElement()
 {
     return elementForRelationAtIndex(m_element.get(), WebCore::Atspi::Relation::LabelledBy, 0);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::parentElement()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::parentElement()
 {
     m_element->updateBackingStore();
     if (auto* parent = m_element->parent().value_or(nullptr))
-        return AccessibilityUIElement::create(parent);
+        return AccessibilityUIElementAtspi::create(parent);
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedByRow()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::disclosedByRow()
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfLinkedUIElements()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfLinkedUIElements()
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfDocumentLinks()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfDocumentLinks()
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
@@ -349,7 +363,7 @@ static Vector<Ref<AccessibilityUIElement>> elementsVector(const Vector<Ref<WebCo
     Vector<Ref<AccessibilityUIElement>> elements;
     elements.reserveInitialCapacity(wrappers.size());
     for (auto& wrapper : wrappers)
-        elements.append(AccessibilityUIElement::create(wrapper.ptr()));
+        elements.append(AccessibilityUIElementAtspi::create(wrapper.ptr()));
     return elements;
 }
 
@@ -359,18 +373,18 @@ static String attributesOfElements(const Vector<Ref<WebCore::AccessibilityObject
     return attributesOfElements(elements);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfChildren()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfChildren()
 {
     m_element->updateBackingStore();
     return OpaqueJSString::tryCreate(attributesOfElements(m_element->children())).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::allAttributes()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::allAttributes()
 {
     return OpaqueJSString::tryCreate(attributesOfElement(*this)).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringDescriptionOfAttributeValue(JSStringRef attribute)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::stringDescriptionOfAttributeValue(JSStringRef attribute)
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
@@ -380,7 +394,7 @@ static bool checkElementState(WebCore::AccessibilityObjectAtspi* element, WebCor
     return element->states().contains(state);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(JSStringRef attribute)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::stringAttributeValue(JSStringRef attribute)
 {
     String attributeName = toWTFString(attribute);
     if (attributeName == "AXSelectedText"_s) {
@@ -422,7 +436,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(JSStringRe
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
+double AccessibilityUIElementAtspi::numberAttributeValue(JSStringRef attribute)
 {
     String attributeName = toWTFString(attribute);
     m_element->updateBackingStore();
@@ -447,14 +461,14 @@ double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::currentStateValue() const
 {
     m_element->updateBackingStore();
     auto value = m_element->attributes().get("current"_s);
     return OpaqueJSString::tryCreate(!value.isNull() ? value : "false"_s).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::sortDirection() const
 {
     m_element->updateBackingStore();
     auto sort = m_element->attributes().get("sort"_s);
@@ -469,13 +483,13 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::domIdentifier() const
 {
     m_element->updateBackingStore();
     return OpaqueJSString::tryCreate(m_element->attributes().get("id"_s)).leakRef();
 }
 
-JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
+JSValueRef AccessibilityUIElementAtspi::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
 {
     return nullptr;
 }
@@ -490,7 +504,7 @@ static JSValueRef makeJSArray(JSContextRef context, const Vector<Ref<Accessibili
     return JSObjectMakeArray(context, elementCount, valueElements.get(), nullptr);
 }
 
-JSValueRef AccessibilityUIElement::rowHeaders(JSContextRef context)
+JSValueRef AccessibilityUIElementAtspi::rowHeaders(JSContextRef context)
 {
     if (m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table)) {
         m_element->updateBackingStore();
@@ -505,7 +519,7 @@ JSValueRef AccessibilityUIElement::rowHeaders(JSContextRef context)
     return makeJSArray(context, { });
 }
 
-JSValueRef AccessibilityUIElement::columnHeaders(JSContextRef context)
+JSValueRef AccessibilityUIElementAtspi::columnHeaders(JSContextRef context)
 {
     if (m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table)) {
         m_element->updateBackingStore();
@@ -520,7 +534,7 @@ JSValueRef AccessibilityUIElement::columnHeaders(JSContextRef context)
     return makeJSArray(context, { });
 }
 
-JSValueRef AccessibilityUIElement::selectedCells(JSContextRef context)
+JSValueRef AccessibilityUIElementAtspi::selectedCells(JSContextRef context)
 {
     return makeJSArray(context, { });
 }
@@ -536,22 +550,22 @@ static JSValueRef elementsForRelation(JSContextRef context, WebCore::Accessibili
     return makeJSArray(context, elementsVector(targets));
 }
 
-JSValueRef AccessibilityUIElement::detailsElements(JSContextRef context)
+JSValueRef AccessibilityUIElementAtspi::detailsElements(JSContextRef context)
 {
     return elementsForRelation(context, m_element.get(), WebCore::Atspi::Relation::Details);
 }
 
-JSValueRef AccessibilityUIElement::errorMessageElements(JSContextRef context)
+JSValueRef AccessibilityUIElementAtspi::errorMessageElements(JSContextRef context)
 {
     return elementsForRelation(context, m_element.get(), WebCore::Atspi::Relation::ErrorMessage);
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementAttributeValue(JSStringRef attribute) const
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::uiElementAttributeValue(JSStringRef attribute) const
 {
     return nullptr;
 }
 
-bool AccessibilityUIElement::boolAttributeValue(JSStringRef attribute)
+bool AccessibilityUIElementAtspi::boolAttributeValue(JSStringRef attribute)
 {
     String attributeName = toWTFString(attribute);
     m_element->updateBackingStore();
@@ -573,7 +587,7 @@ bool AccessibilityUIElement::boolAttributeValue(JSStringRef attribute)
     return false;
 }
 
-bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
+bool AccessibilityUIElementAtspi::isAttributeSettable(JSStringRef attribute)
 {
     String attributeName = toWTFString(attribute);
     if (attributeName != "AXValue"_s)
@@ -606,7 +620,7 @@ bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
             }
 
             if (child)
-                return checkElementState(child->m_element.get(), WebCore::Atspi::State::Selectable);
+                return checkElementState(static_cast<AccessibilityUIElementAtspi*>(child.get())->m_element.get(), WebCore::Atspi::State::Selectable);
         }
         break;
     default:
@@ -621,7 +635,7 @@ bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
     return false;
 }
 
-bool AccessibilityUIElement::isAttributeSupported(JSStringRef attribute)
+bool AccessibilityUIElementAtspi::isAttributeSupported(JSStringRef attribute)
 {
     String attributeName = toWTFString(attribute);
     m_element->updateBackingStore();
@@ -644,7 +658,7 @@ bool AccessibilityUIElement::isAttributeSupported(JSStringRef attribute)
     return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::parameterizedAttributeNames()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::parameterizedAttributeNames()
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
@@ -867,7 +881,7 @@ static String roleValueToString(WebCore::Atspi::Role roleValue)
     return { };
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::role()
 {
     m_element->updateBackingStore();
     auto roleValue = m_element->role();
@@ -878,19 +892,19 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
     return OpaqueJSString::tryCreate(makeString("AXRole: "_s, roleValueString)).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::subrole()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::subrole()
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::roleDescription()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::roleDescription()
 {
     m_element->updateBackingStore();
     auto roleDescription = m_element->attributes().get("roledescription"_s);
     return OpaqueJSString::tryCreate(makeString("AXRoleDescription: "_s, roleDescription)).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::computedRoleString()
 {
     m_element->updateBackingStore();
     auto computedRole = m_element->attributes().get("computed-role"_s);
@@ -900,21 +914,21 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
     return OpaqueJSString::tryCreate(computedRole).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::title()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::title()
 {
     m_element->updateBackingStore();
     auto titleValue = makeString("AXTitle: "_s, m_element->name().span());
     return OpaqueJSString::tryCreate(titleValue).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::description()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::description()
 {
     m_element->updateBackingStore();
     auto descriptionValue = makeString("AXDescription: "_s, m_element->description().span());
     return OpaqueJSString::tryCreate(descriptionValue).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::orientation() const
 {
     m_element->updateBackingStore();
     ASCIILiteral orientation;
@@ -929,28 +943,28 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
     return OpaqueJSString::tryCreate(orientationValue).leakRef();
 }
 
-bool AccessibilityUIElement::isAtomicLiveRegion() const
+bool AccessibilityUIElementAtspi::isAtomicLiveRegion() const
 {
     return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionRelevant() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::liveRegionRelevant() const
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionStatus() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::liveRegionStatus() const
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::stringValue()
 {
     m_element->updateBackingStore();
     if (m_element->role() == WebCore::Atspi::Role::ComboBox) {
         // Tests expect the combo box to expose the selected element name as the string value.
         if (auto menu = childAtIndex(0)) {
-            if (auto* selectedChild = menu->m_element->selectedChild(0))
+            if (auto* selectedChild = static_cast<AccessibilityUIElementAtspi*>(menu.get())->m_element->selectedChild(0))
                 return OpaqueJSString::tryCreate(makeString("AXValue: "_s, selectedChild->name().span())).leakRef();
         }
     }
@@ -962,7 +976,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
     return OpaqueJSString::tryCreate(value).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::language()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::language()
 {
     m_element->updateBackingStore();
     auto locale = m_element->locale();
@@ -972,7 +986,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::language()
     return OpaqueJSString::tryCreate(makeString("AXLanguage: "_s, locale)).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::helpText() const
 {
     m_element->updateBackingStore();
     auto relationMap = m_element->relationMap();
@@ -995,55 +1009,55 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
     return OpaqueJSString::tryCreate(builder.toString()).leakRef();
 }
 
-double AccessibilityUIElement::pageX()
+double AccessibilityUIElementAtspi::pageX()
 {
     return 0;
 }
 
-double AccessibilityUIElement::pageY()
+double AccessibilityUIElementAtspi::pageY()
 {
     return 0;
 }
 
-double AccessibilityUIElement::x()
+double AccessibilityUIElementAtspi::x()
 {
     m_element->updateBackingStore();
     return m_element->elementRect(WebCore::Atspi::CoordinateType::ScreenCoordinates).x();
 }
 
-double AccessibilityUIElement::y()
+double AccessibilityUIElementAtspi::y()
 {
     m_element->updateBackingStore();
     return m_element->elementRect(WebCore::Atspi::CoordinateType::ScreenCoordinates).y();
 }
 
-double AccessibilityUIElement::width()
+double AccessibilityUIElementAtspi::width()
 {
     m_element->updateBackingStore();
     return m_element->elementRect(WebCore::Atspi::CoordinateType::ScreenCoordinates).width();
 }
 
-double AccessibilityUIElement::height()
+double AccessibilityUIElementAtspi::height()
 {
     m_element->updateBackingStore();
     return m_element->elementRect(WebCore::Atspi::CoordinateType::ScreenCoordinates).height();
 }
 
-double AccessibilityUIElement::clickPointX()
+double AccessibilityUIElementAtspi::clickPointX()
 {
     m_element->updateBackingStore();
     auto rect = m_element->elementRect(WebCore::Atspi::CoordinateType::WindowCoordinates);
     return rect.center().x();
 }
 
-double AccessibilityUIElement::clickPointY()
+double AccessibilityUIElementAtspi::clickPointY()
 {
     m_element->updateBackingStore();
     auto rect = m_element->elementRect(WebCore::Atspi::CoordinateType::WindowCoordinates);
     return rect.center().y();
 }
 
-double AccessibilityUIElement::intValue() const
+double AccessibilityUIElementAtspi::intValue() const
 {
     m_element->updateBackingStore();
     if (m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Value))
@@ -1056,7 +1070,7 @@ double AccessibilityUIElement::intValue() const
     return 0;
 }
 
-double AccessibilityUIElement::minValue()
+double AccessibilityUIElementAtspi::minValue()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Value))
         return 0;
@@ -1065,7 +1079,7 @@ double AccessibilityUIElement::minValue()
     return m_element->minimumValue();
 }
 
-double AccessibilityUIElement::maxValue()
+double AccessibilityUIElementAtspi::maxValue()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Value))
         return 0;
@@ -1074,7 +1088,7 @@ double AccessibilityUIElement::maxValue()
     return m_element->maximumValue();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::valueDescription()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::valueDescription()
 {
     m_element->updateBackingStore();
     auto attributes = m_element->attributes();
@@ -1082,83 +1096,83 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::valueDescription()
     return OpaqueJSString::tryCreate(value).leakRef();
 }
 
-int AccessibilityUIElement::insertionPointLineNumber()
+int AccessibilityUIElementAtspi::insertionPointLineNumber()
 {
     return -1;
 }
 
-bool AccessibilityUIElement::isPressActionSupported()
+bool AccessibilityUIElementAtspi::isPressActionSupported()
 {
     m_element->updateBackingStore();
     auto name = m_element->actionName();
     return name == "press"_s || name == "jump"_s;
 }
 
-bool AccessibilityUIElement::isIncrementActionSupported()
+bool AccessibilityUIElementAtspi::isIncrementActionSupported()
 {
     return false;
 }
 
-bool AccessibilityUIElement::isDecrementActionSupported()
+bool AccessibilityUIElementAtspi::isDecrementActionSupported()
 {
     return false;
 }
 
-bool AccessibilityUIElement::isBusy() const
+bool AccessibilityUIElementAtspi::isBusy() const
 {
     // FIXME: Implement.
     return false;
 }
 
-bool AccessibilityUIElement::isEnabled()
+bool AccessibilityUIElementAtspi::isEnabled()
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Enabled);
 }
 
-bool AccessibilityUIElement::isRequired() const
+bool AccessibilityUIElementAtspi::isRequired() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Required);
 }
 
-bool AccessibilityUIElement::isFocused() const
+bool AccessibilityUIElementAtspi::isFocused() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Focused);
 }
 
-bool AccessibilityUIElement::isSelected() const
+bool AccessibilityUIElementAtspi::isSelected() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Selected);
 }
 
-bool AccessibilityUIElement::isSelectedOptionActive() const
+bool AccessibilityUIElementAtspi::isSelectedOptionActive() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Active);
 }
 
-bool AccessibilityUIElement::isExpanded() const
+bool AccessibilityUIElementAtspi::isExpanded() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Expanded);
 }
 
-bool AccessibilityUIElement::isChecked() const
+bool AccessibilityUIElementAtspi::isChecked() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Checked);
 }
 
-bool AccessibilityUIElement::isIndeterminate() const
+bool AccessibilityUIElementAtspi::isIndeterminate() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Indeterminate);
 }
 
-int AccessibilityUIElement::hierarchicalLevel() const
+int AccessibilityUIElementAtspi::hierarchicalLevel() const
 {
     m_element->updateBackingStore();
     auto level = m_element->attributes().get("level"_s);
@@ -1168,18 +1182,18 @@ int AccessibilityUIElement::hierarchicalLevel() const
     return parseIntegerAllowingTrailingJunk<int>(level).value_or(0);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::speakAs()
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-bool AccessibilityUIElement::isGrabbed() const
+bool AccessibilityUIElementAtspi::isGrabbed() const
 {
     m_element->updateBackingStore();
     return m_element->attributes().get("grabbed"_s) == "true"_s;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::ariaDropEffects() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::ariaDropEffects() const
 {
     m_element->updateBackingStore();
     auto dropEffects = m_element->attributes().get("dropeffect"_s);
@@ -1188,7 +1202,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::ariaDropEffects() const
     return OpaqueJSString::tryCreate(dropEffects).leakRef();
 }
 
-int AccessibilityUIElement::lineForIndex(int index)
+int AccessibilityUIElementAtspi::lineForIndex(int index)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return -1;
@@ -1207,7 +1221,7 @@ int AccessibilityUIElement::lineForIndex(int index)
     return lineNumber;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForLine(int line)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::rangeForLine(int line)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1221,12 +1235,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForLine(int line)
     return OpaqueJSString::tryCreate(range).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForPosition(int x, int y)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::rangeForPosition(int x, int y)
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned location, unsigned length)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::boundsForRange(unsigned location, unsigned length)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1237,7 +1251,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned locatio
     return OpaqueJSString::tryCreate(bounds).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned location, unsigned length)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::stringForRange(unsigned location, unsigned length)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1246,7 +1260,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned locatio
     return OpaqueJSString::tryCreate(m_element->text().substring(location, length)).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsigned location, unsigned length)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributedStringForRange(unsigned location, unsigned length)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1284,27 +1298,27 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsign
     return OpaqueJSString::tryCreate(builder.toString()).leakRef();
 }
 
-bool AccessibilityUIElement::attributedStringRangeIsMisspelled(unsigned location, unsigned length)
+bool AccessibilityUIElementAtspi::attributedStringRangeIsMisspelled(unsigned location, unsigned length)
 {
     return false;
 }
 
-unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
+unsigned AccessibilityUIElementAtspi::uiElementCountForSearchPredicate(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredicate(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::uiElementForSearchPredicate(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly)
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContextRef context, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::selectTextWithCriteria(JSContextRef context, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfColumnHeaders()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1313,7 +1327,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
     return OpaqueJSString::tryCreate(attributesOfElements(m_element->columnHeaders())).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfRowHeaders()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1322,12 +1336,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
     return OpaqueJSString::tryCreate(attributesOfElements(m_element->rowHeaders())).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumns()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfColumns()
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfRows()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1336,7 +1350,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
     return OpaqueJSString::tryCreate(attributesOfElements(m_element->rows())).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfVisibleCells()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfVisibleCells()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1345,12 +1359,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfVisibleCells()
     return OpaqueJSString::tryCreate(attributesOfElements(m_element->cells())).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfHeader()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributesOfHeader()
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-int AccessibilityUIElement::rowCount()
+int AccessibilityUIElementAtspi::rowCount()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return 0;
@@ -1359,7 +1373,7 @@ int AccessibilityUIElement::rowCount()
     return m_element->rowCount();
 }
 
-int AccessibilityUIElement::columnCount()
+int AccessibilityUIElementAtspi::columnCount()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return 0;
@@ -1368,12 +1382,12 @@ int AccessibilityUIElement::columnCount()
     return m_element->columnCount();
 }
 
-int AccessibilityUIElement::indexInTable()
+int AccessibilityUIElementAtspi::indexInTable()
 {
     return -1;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rowIndexRange()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::rowIndexRange()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::TableCell))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1387,7 +1401,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::rowIndexRange()
     return OpaqueJSString::tryCreate(makeString('{', *position, ", "_s, span, '}')).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::columnIndexRange()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::columnIndexRange()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::TableCell))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1401,28 +1415,28 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::columnIndexRange()
     return OpaqueJSString::tryCreate(makeString('{', *position, ", "_s, span, '}')).leakRef();
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::cellForColumnAndRow(unsigned column, unsigned row)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::cellForColumnAndRow(unsigned column, unsigned row)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Table))
         return nullptr;
 
     m_element->updateBackingStore();
     if (auto* cell = m_element->cell(row, column))
-        return AccessibilityUIElement::create(cell);
+        return AccessibilityUIElementAtspi::create(cell);
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::horizontalScrollbar() const
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::horizontalScrollbar() const
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::verticalScrollbar() const
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedTextRange()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::selectedTextRange()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1433,12 +1447,12 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedTextRange()
     return OpaqueJSString::tryCreate(range).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::intersectionWithSelectionRange()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::intersectionWithSelectionRange()
 {
     return nullptr;
 }
 
-bool AccessibilityUIElement::setSelectedTextRange(unsigned location, unsigned length)
+bool AccessibilityUIElementAtspi::setSelectedTextRange(unsigned location, unsigned length)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return false;
@@ -1449,12 +1463,12 @@ bool AccessibilityUIElement::setSelectedTextRange(unsigned location, unsigned le
     return true;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::textInputMarkedRange() const
 {
     return nullptr;
 }
 
-void AccessibilityUIElement::increment()
+void AccessibilityUIElementAtspi::increment()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Value))
         return;
@@ -1463,7 +1477,7 @@ void AccessibilityUIElement::increment()
     m_element->setCurrentValue(intValue() + m_element->minimumIncrement());
 }
 
-void AccessibilityUIElement::decrement()
+void AccessibilityUIElementAtspi::decrement()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Value))
         return;
@@ -1472,39 +1486,39 @@ void AccessibilityUIElement::decrement()
     m_element->setCurrentValue(intValue() - m_element->minimumIncrement());
 }
 
-void AccessibilityUIElement::showMenu()
+void AccessibilityUIElementAtspi::showMenu()
 {
 }
 
-void AccessibilityUIElement::press()
+void AccessibilityUIElementAtspi::press()
 {
     m_element->updateBackingStore();
     m_element->doAction();
 }
 
-void AccessibilityUIElement::setSelectedChild(AccessibilityUIElement* element) const
+void AccessibilityUIElementAtspi::setSelectedChild(AccessibilityUIElement* element) const
 {
 }
 
-void AccessibilityUIElement::setSelectedChildAtIndex(unsigned index) const
-{
-    if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
-        return;
-
-    m_element->updateBackingStore();
-    m_element->setChildSelected(index, true);
-}
-
-void AccessibilityUIElement::removeSelectionAtIndex(unsigned index) const
+void AccessibilityUIElementAtspi::setSelectedChildAtIndex(unsigned index) const
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
         return;
 
     m_element->updateBackingStore();
-    m_element->setChildSelected(index, false);
+    m_element->setChildSelected(index, /* selected */ true);
 }
 
-void AccessibilityUIElement::clearSelectedChildren() const
+void AccessibilityUIElementAtspi::removeSelectionAtIndex(unsigned index) const
+{
+    if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
+        return;
+
+    m_element->updateBackingStore();
+    m_element->setChildSelected(index, /* selected */ false);
+}
+
+void AccessibilityUIElementAtspi::clearSelectedChildren() const
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
         return;
@@ -1513,15 +1527,15 @@ void AccessibilityUIElement::clearSelectedChildren() const
     m_element->clearSelection();
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::activeElement() const
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::activeElement() const
 {
     m_element->updateBackingStore();
     if (auto* activeDescendant = m_element->activeDescendant())
-        return AccessibilityUIElement::create(activeDescendant);
+        return AccessibilityUIElementAtspi::create(activeDescendant);
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::selectedChildren(JSContextRef context)
+JSValueRef AccessibilityUIElementAtspi::selectedChildren(JSContextRef context)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Selection))
         return makeJSArray(context, { });
@@ -1530,12 +1544,12 @@ JSValueRef AccessibilityUIElement::selectedChildren(JSContextRef context)
     return makeJSArray(context, elementsVector(m_element->selectedChildren()));
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::accessibilityValue() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::accessibilityValue() const
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::url()
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Hyperlink))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1555,7 +1569,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
     return OpaqueJSString::tryCreate(makeString("AXURL: "_s, stringURL)).leakRef();
 }
 
-bool AccessibilityUIElement::addNotificationListener(JSContextRef, JSValueRef functionCallback)
+bool AccessibilityUIElementAtspi::addNotificationListener(JSContextRef, JSValueRef functionCallback)
 {
     if (!functionCallback)
         return false;
@@ -1567,247 +1581,247 @@ bool AccessibilityUIElement::addNotificationListener(JSContextRef, JSValueRef fu
     return true;
 }
 
-bool AccessibilityUIElement::removeNotificationListener()
+bool AccessibilityUIElementAtspi::removeNotificationListener()
 {
     ASSERT(m_notificationHandler);
     m_notificationHandler = nullptr;
     return true;
 }
 
-bool AccessibilityUIElement::isFocusable() const
+bool AccessibilityUIElementAtspi::isFocusable() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Focusable);
 }
 
-bool AccessibilityUIElement::isSelectable() const
+bool AccessibilityUIElementAtspi::isSelectable() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Selectable);
 }
 
-bool AccessibilityUIElement::isMultiSelectable() const
+bool AccessibilityUIElementAtspi::isMultiSelectable() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Multiselectable);
 }
 
-bool AccessibilityUIElement::isVisible() const
+bool AccessibilityUIElementAtspi::isVisible() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Visible);
 }
 
-bool AccessibilityUIElement::isOffScreen() const
+bool AccessibilityUIElementAtspi::isOffScreen() const
 {
     m_element->updateBackingStore();
     return !checkElementState(m_element.get(), WebCore::Atspi::State::Showing);
 }
 
-bool AccessibilityUIElement::isCollapsed() const
+bool AccessibilityUIElementAtspi::isCollapsed() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::Collapsed);
 }
 
-bool AccessibilityUIElement::isIgnored() const
+bool AccessibilityUIElementAtspi::isIgnored() const
 {
     m_element->updateBackingStore();
     return m_element->isIgnored();
 }
 
-bool AccessibilityUIElement::isSingleLine() const
+bool AccessibilityUIElementAtspi::isSingleLine() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::SingleLine);
 }
 
-bool AccessibilityUIElement::isMultiLine() const
+bool AccessibilityUIElementAtspi::isMultiLine() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::MultiLine);
 }
 
-bool AccessibilityUIElement::hasPopup() const
+bool AccessibilityUIElementAtspi::hasPopup() const
 {
     m_element->updateBackingStore();
     return checkElementState(m_element.get(), WebCore::Atspi::State::HasPopup);
 }
 
-void AccessibilityUIElement::takeFocus()
+void AccessibilityUIElementAtspi::takeFocus()
 {
 }
 
-void AccessibilityUIElement::takeSelection()
+void AccessibilityUIElementAtspi::takeSelection()
 {
 }
 
-void AccessibilityUIElement::addSelection()
+void AccessibilityUIElementAtspi::addSelection()
 {
 }
 
-void AccessibilityUIElement::removeSelection()
+void AccessibilityUIElementAtspi::removeSelection()
 {
 }
 
 // Text markers
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::lineTextMarkerRangeForTextMarker(AccessibilityTextMarker* textMarker)
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementAtspi::lineTextMarkerRangeForTextMarker(AccessibilityTextMarker* textMarker)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForElement(AccessibilityUIElement* element)
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementAtspi::textMarkerRangeForElement(AccessibilityUIElement* element)
 {
     return nullptr;
 }
 
-int AccessibilityUIElement::textMarkerRangeLength(AccessibilityTextMarkerRange* range)
+int AccessibilityUIElementAtspi::textMarkerRangeLength(AccessibilityTextMarkerRange* range)
 {
     return 0;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousTextMarker(AccessibilityTextMarker* textMarker)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::previousTextMarker(AccessibilityTextMarker* textMarker)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextTextMarker(AccessibilityTextMarker* textMarker)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::nextTextMarker(AccessibilityTextMarker* textMarker)
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForTextMarkerRange(AccessibilityTextMarkerRange* markerRange)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::stringForTextMarkerRange(AccessibilityTextMarkerRange* markerRange)
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rectsForTextMarkerRange(AccessibilityTextMarkerRange* markerRange, JSStringRef searchText)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::rectsForTextMarkerRange(AccessibilityTextMarkerRange* markerRange, JSStringRef searchText)
 {
     return JSStringCreateWithCharacters(nullptr, 0);
 }
 
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForMarkers(AccessibilityTextMarker* startMarker, AccessibilityTextMarker* endMarker)
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementAtspi::textMarkerRangeForMarkers(AccessibilityTextMarker* startMarker, AccessibilityTextMarker* endMarker)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange* range)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange* range)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange* range)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange* range)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForBounds(int x, int y, int width, int height)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::endTextMarkerForBounds(int x, int y, int width, int height)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForBounds(int x, int y, int width, int height)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::startTextMarkerForBounds(int x, int y, int width, int height)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForPoint(int x, int y)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::textMarkerForPoint(int x, int y)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::accessibilityElementForTextMarker(AccessibilityTextMarker* marker)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::accessibilityElementForTextMarker(AccessibilityTextMarker* marker)
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*)
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
 {
     return nullptr;
 }
 
-bool AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute(JSStringRef attribute, AccessibilityTextMarkerRange* range)
+bool AccessibilityUIElementAtspi::attributedStringForTextMarkerRangeContainsAttribute(JSStringRef attribute, AccessibilityTextMarkerRange* range)
 {
     return false;
 }
 
-int AccessibilityUIElement::indexForTextMarker(AccessibilityTextMarker* marker)
+int AccessibilityUIElementAtspi::indexForTextMarker(AccessibilityTextMarker* marker)
 {
     return -1;
 }
 
-bool AccessibilityUIElement::isTextMarkerValid(AccessibilityTextMarker* textMarker)
+bool AccessibilityUIElementAtspi::isTextMarkerValid(AccessibilityTextMarker* textMarker)
 {
     return false;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForIndex(int textIndex)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::textMarkerForIndex(int textIndex)
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarker()
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::startTextMarker()
 {
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarker()
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementAtspi::endTextMarker()
 {
     return nullptr;
 }
 
-bool AccessibilityUIElement::setSelectedTextMarkerRange(AccessibilityTextMarkerRange*)
+bool AccessibilityUIElementAtspi::setSelectedTextMarkerRange(AccessibilityTextMarkerRange*)
 {
     return false;
 }
 
-void AccessibilityUIElement::scrollToMakeVisible()
+void AccessibilityUIElementAtspi::scrollToMakeVisible()
 {
     m_element->updateBackingStore();
     m_element->scrollToMakeVisible(WebCore::Atspi::ScrollType::Anywhere);
 }
 
-void AccessibilityUIElement::scrollToGlobalPoint(int x, int y)
+void AccessibilityUIElementAtspi::scrollToGlobalPoint(int x, int y)
 {
     m_element->updateBackingStore();
     m_element->scrollToPoint({ x, y }, WebCore::Atspi::CoordinateType::WindowCoordinates);
 }
 
-void AccessibilityUIElement::scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height)
+void AccessibilityUIElementAtspi::scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height)
 {
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::supportedActions() const
-{
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::pathDescription() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::supportedActions() const
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPostscriptsDescription() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::pathDescription() const
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPrescriptsDescription() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::mathPostscriptsDescription() const
 {
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::mathPrescriptsDescription() const
+{
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::classList() const
 {
     return nullptr;
 }
@@ -1828,7 +1842,7 @@ static String stringAtOffset(WebCore::AccessibilityObjectAtspi* element, int off
     return makeString(text.substring(startOffset, endOffset - startOffset), ", "_s, startOffset, ", "_s, endOffset);
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::characterAtOffset(int offset)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::characterAtOffset(int offset)
 {
     if (!m_element->interfaces().contains(WebCore::AccessibilityObjectAtspi::Interface::Text))
         return JSStringCreateWithCharacters(nullptr, 0);
@@ -1842,52 +1856,52 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::characterAtOffset(int offset)
     return OpaqueJSString::tryCreate(string).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::wordAtOffset(int offset)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::wordAtOffset(int offset)
 {
     return OpaqueJSString::tryCreate(stringAtOffset(m_element.get(), offset, WebCore::AccessibilityObjectAtspi::TextGranularity::WordStart)).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::lineAtOffset(int offset)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::lineAtOffset(int offset)
 {
     return OpaqueJSString::tryCreate(stringAtOffset(m_element.get(), offset, WebCore::AccessibilityObjectAtspi::TextGranularity::LineStart)).leakRef();
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sentenceAtOffset(int offset)
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::sentenceAtOffset(int offset)
 {
     return OpaqueJSString::tryCreate(stringAtOffset(m_element.get(), offset, WebCore::AccessibilityObjectAtspi::TextGranularity::SentenceStart)).leakRef();
 }
 
-bool AccessibilityUIElement::replaceTextInRange(JSStringRef, int, int)
+bool AccessibilityUIElementAtspi::replaceTextInRange(JSStringRef, int, int)
 {
     return false;
 }
 
-bool AccessibilityUIElement::insertText(JSStringRef)
+bool AccessibilityUIElementAtspi::insertText(JSStringRef)
 {
     return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::popupValue() const
 {
     return nullptr;
 }
 
-bool AccessibilityUIElement::isInsertion() const
+bool AccessibilityUIElementAtspi::isInsertion() const
 {
     return false;
 }
 
-bool AccessibilityUIElement::isDeletion() const
+bool AccessibilityUIElementAtspi::isDeletion() const
 {
     return false;
 }
 
-bool AccessibilityUIElement::isFirstItemInSuggestion() const
+bool AccessibilityUIElementAtspi::isFirstItemInSuggestion() const
 {
     return false;
 }
 
-bool AccessibilityUIElement::isLastItemInSuggestion() const
+bool AccessibilityUIElementAtspi::isLastItemInSuggestion() const
 {
     return false;
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(ATSPI)
+
+#include "AccessibilityUIElement.h"
+#include <wtf/RefPtr.h>
+
+namespace WebCore {
+class AccessibilityObjectAtspi;
+}
+
+namespace WTR {
+
+class AccessibilityNotificationHandler;
+
+// ATSPI implementation of AccessibilityUIElement
+class AccessibilityUIElementAtspi final : public AccessibilityUIElement {
+public:
+    static Ref<AccessibilityUIElementAtspi> create(PlatformUIElement);
+    static Ref<AccessibilityUIElementAtspi> create(const AccessibilityUIElementAtspi&);
+
+    virtual ~AccessibilityUIElementAtspi();
+
+    PlatformUIElement platformUIElement() override { return m_element.get(); }
+
+    bool isEqual(AccessibilityUIElement* otherElement) override;
+    JSRetainPtr<JSStringRef> domIdentifier() const override;
+
+    RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y) override;
+    unsigned indexOfChild(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+    unsigned childrenCount() override;
+    RefPtr<AccessibilityUIElement> titleUIElement() override;
+    RefPtr<AccessibilityUIElement> parentElement() override;
+
+    void takeFocus() override;
+    void takeSelection() override;
+    void addSelection() override;
+    void removeSelection() override;
+
+    JSRetainPtr<JSStringRef> allAttributes() override;
+    JSRetainPtr<JSStringRef> attributesOfLinkedUIElements() override;
+    RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned) override;
+
+    JSRetainPtr<JSStringRef> attributesOfDocumentLinks() override;
+    JSRetainPtr<JSStringRef> attributesOfChildren() override;
+    JSRetainPtr<JSStringRef> parameterizedAttributeNames() override;
+    void increment() override;
+    void decrement() override;
+    void showMenu() override;
+    void press() override;
+
+    JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute) override;
+    JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute) override;
+    double numberAttributeValue(JSStringRef attribute) override;
+    JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute) override;
+    RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const override;
+    bool boolAttributeValue(JSStringRef attribute) override;
+    bool isAttributeSupported(JSStringRef attribute) override;
+    bool isAttributeSettable(JSStringRef attribute) override;
+    bool isPressActionSupported() override;
+    bool isIncrementActionSupported() override;
+    bool isDecrementActionSupported() override;
+    JSRetainPtr<JSStringRef> role() override;
+    JSRetainPtr<JSStringRef> subrole() override;
+    JSRetainPtr<JSStringRef> roleDescription() override;
+    JSRetainPtr<JSStringRef> computedRoleString() override;
+    JSRetainPtr<JSStringRef> title() override;
+    JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> language() override;
+    JSRetainPtr<JSStringRef> stringValue() override;
+    JSRetainPtr<JSStringRef> accessibilityValue() const override;
+    JSRetainPtr<JSStringRef> helpText() const override;
+    JSRetainPtr<JSStringRef> orientation() const override;
+    JSRetainPtr<JSStringRef> liveRegionRelevant() const override;
+    JSRetainPtr<JSStringRef> liveRegionStatus() const override;
+    double x() override;
+    double y() override;
+    double width() override;
+    double height() override;
+    double pageX() override;
+    double pageY() override;
+    double clickPointX() override;
+    double clickPointY() override;
+
+    double intValue() const override;
+    double minValue() override;
+    double maxValue() override;
+    JSRetainPtr<JSStringRef> valueDescription() override;
+    int insertionPointLineNumber() override;
+    JSRetainPtr<JSStringRef> selectedTextRange() override;
+    JSRetainPtr<JSStringRef> intersectionWithSelectionRange() override;
+    JSRetainPtr<JSStringRef> textInputMarkedRange() const override;
+    bool isAtomicLiveRegion() const override;
+    bool isBusy() const override;
+    bool isEnabled() override;
+    bool isRequired() const override;
+
+    bool isFocused() const override;
+    bool isFocusable() const override;
+    bool isSelected() const override;
+    bool isSelectedOptionActive() const override;
+    bool isSelectable() const override;
+    bool isMultiSelectable() const override;
+    void setSelectedChild(AccessibilityUIElement*) const override;
+    void setSelectedChildAtIndex(unsigned) const override;
+    void removeSelectionAtIndex(unsigned) const override;
+    void clearSelectedChildren() const override;
+    RefPtr<AccessibilityUIElement> activeElement() const override;
+    JSValueRef selectedChildren(JSContextRef) override;
+    unsigned selectedChildrenCount() const override;
+    RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const override;
+
+    bool isValid() const override;
+    bool isExpanded() const override;
+    bool isChecked() const override;
+    JSRetainPtr<JSStringRef> currentStateValue() const override;
+    JSRetainPtr<JSStringRef> sortDirection() const override;
+    bool isIndeterminate() const override;
+    bool isVisible() const override;
+    bool isCollapsed() const override;
+    bool isIgnored() const override;
+    bool isSingleLine() const override;
+    bool isMultiLine() const override;
+    bool isOffScreen() const override;
+    bool hasPopup() const override;
+    JSRetainPtr<JSStringRef> popupValue() const override;
+    int hierarchicalLevel() const override;
+    JSRetainPtr<JSStringRef> url() override;
+    JSRetainPtr<JSStringRef> classList() const override;
+
+    JSRetainPtr<JSStringRef> speakAs() override;
+
+    JSRetainPtr<JSStringRef> attributesOfColumnHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfRowHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfColumns() override;
+    JSRetainPtr<JSStringRef> attributesOfRows() override;
+    JSRetainPtr<JSStringRef> attributesOfVisibleCells() override;
+    JSRetainPtr<JSStringRef> attributesOfHeader() override;
+    int indexInTable() override;
+    JSRetainPtr<JSStringRef> rowIndexRange() override;
+    JSRetainPtr<JSStringRef> columnIndexRange() override;
+    int rowCount() override;
+    int columnCount() override;
+    JSValueRef rowHeaders(JSContextRef) override;
+    JSValueRef columnHeaders(JSContextRef) override;
+    JSValueRef selectedCells(JSContextRef) override;
+
+    RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> disclosedByRow() override;
+    RefPtr<AccessibilityUIElement> disclosedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> rowAtIndex(unsigned) override;
+
+    RefPtr<AccessibilityUIElement> controllerElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaDescribedByElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> descriptionForElementAtIndex(unsigned) override;
+    JSValueRef detailsElements(JSContextRef) override;
+    RefPtr<AccessibilityUIElement> ariaDetailsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> detailsForElementAtIndex(unsigned) override;
+    JSValueRef errorMessageElements(JSContextRef) override;
+    RefPtr<AccessibilityUIElement> ariaErrorMessageElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> errorMessageForElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> flowFromElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaFlowToElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaLabelledByElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> labelForElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ownerElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned) override;
+
+    bool isGrabbed() const override;
+    JSRetainPtr<JSStringRef> ariaDropEffects() const override;
+
+    int lineForIndex(int) override;
+    JSRetainPtr<JSStringRef> rangeForLine(int) override;
+    JSRetainPtr<JSStringRef> rangeForPosition(int x, int y) override;
+    JSRetainPtr<JSStringRef> boundsForRange(unsigned location, unsigned length) override;
+    bool setSelectedTextRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> stringForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> attributedStringForRange(unsigned location, unsigned length) override;
+    bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
+    unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
+
+    RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row) override;
+
+    RefPtr<AccessibilityUIElement> horizontalScrollbar() const override;
+    RefPtr<AccessibilityUIElement> verticalScrollbar() const override;
+
+    void scrollToMakeVisible() override;
+    void scrollToGlobalPoint(int x, int y) override;
+    void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height) override;
+
+    RefPtr<AccessibilityTextMarker> textMarkerForPoint(int x, int y) override;
+    RefPtr<AccessibilityTextMarker> textMarkerForIndex(int) override;
+    RefPtr<AccessibilityTextMarker> startTextMarker() override;
+    RefPtr<AccessibilityTextMarker> endTextMarker() override;
+    bool setSelectedTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> previousTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextTextMarker(AccessibilityTextMarker*) override;
+    JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*) override;
+    int textMarkerRangeLength(AccessibilityTextMarkerRange*) override;
+    bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*) override;
+    int indexForTextMarker(AccessibilityTextMarker*) override;
+    bool isTextMarkerValid(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*) override;
+
+    JSRetainPtr<JSStringRef> supportedActions() const override;
+    JSRetainPtr<JSStringRef> mathPostscriptsDescription() const override;
+    JSRetainPtr<JSStringRef> mathPrescriptsDescription() const override;
+
+    JSRetainPtr<JSStringRef> pathDescription() const override;
+
+    bool addNotificationListener(JSContextRef, JSValueRef functionCallback) override;
+    bool removeNotificationListener() override;
+
+    bool isInsertion() const override;
+    bool isDeletion() const override;
+    bool isFirstItemInSuggestion() const override;
+    bool isLastItemInSuggestion() const override;
+
+    bool replaceTextInRange(JSStringRef, int position, int length) override;
+    bool insertText(JSStringRef) override;
+
+    JSRetainPtr<JSStringRef> characterAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> wordAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> lineAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> sentenceAtOffset(int offset) override;
+
+private:
+    AccessibilityUIElementAtspi(PlatformUIElement);
+    AccessibilityUIElementAtspi(const AccessibilityUIElementAtspi&);
+
+    Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
+    Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
+
+    RefPtr<WebCore::AccessibilityObjectAtspi> m_element;
+    std::unique_ptr<AccessibilityNotificationHandler> m_notificationHandler;
+};
+
+} // namespace WTR
+
+#endif // USE(ATSPI)

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -39,6 +39,10 @@
 #import <objc/runtime.h>
 #import <wtf/ObjCRuntimeExtras.h>
 
+#if PLATFORM(MAC)
+#import "../mac/AccessibilityUIElementMac.h"
+#endif
+
 @implementation NSString (JSStringRefAdditions)
 
 + (NSString *)stringWithJSStringRef:(JSStringRef)jsStringRef
@@ -116,8 +120,13 @@ NSDictionary *searchPredicateForSearchCriteria(JSContextRef context, Accessibili
 {
     NSMutableDictionary *parameterizedAttribute = [NSMutableDictionary dictionary];
 
+#if PLATFORM(MAC)
+    if (startElement && static_cast<AccessibilityUIElementMac*>(startElement)->platformUIElement())
+        [parameterizedAttribute setObject:static_cast<AccessibilityUIElementMac*>(startElement)->platformUIElement() forKey:@"AXStartElement"];
+#else
     if (startElement && startElement->platformUIElement())
         [parameterizedAttribute setObject:startElement->platformUIElement() forKey:@"AXStartElement"];
+#endif
 
     if (startRange)
         [parameterizedAttribute setObject:startRange->platformTextMarkerRange() forKey:@"AXStartRange"];

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
@@ -1,0 +1,360 @@
+/*
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(IOS_FAMILY)
+
+#include "AccessibilityUIElement.h"
+#include <wtf/RetainPtr.h>
+#include <wtf/WeakObjCPtr.h>
+
+namespace WTR {
+
+class AccessibilityUIElementIOS final : public AccessibilityUIElement {
+public:
+    static Ref<AccessibilityUIElementIOS> create(PlatformUIElement);
+    static Ref<AccessibilityUIElementIOS> create(const AccessibilityUIElementIOS&);
+
+    ~AccessibilityUIElementIOS();
+
+    PlatformUIElement platformUIElement() override { return m_element.getAutoreleased(); }
+
+    // AccessibilityUIElement overrides
+    bool isValid() const override;
+    bool isEqual(AccessibilityUIElement* otherElement) override;
+
+    JSRetainPtr<JSStringRef> domIdentifier() const override;
+    RefPtr<AccessibilityUIElement> headerElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> linkedElement() override;
+    void getLinkedUIElements(Vector<RefPtr<AccessibilityUIElement>>&);
+    void getDocumentLinks(Vector<RefPtr<AccessibilityUIElement>>&);
+    JSValueRef children(JSContextRef) override;
+    unsigned childrenCount() override;
+    RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+    Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
+    Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
+    RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y) override;
+    unsigned indexOfChild(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned) override;
+    JSValueRef detailsElements(JSContextRef) override;
+    JSValueRef errorMessageElements(JSContextRef) override;
+    RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaFlowToElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaDetailsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaErrorMessageElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> disclosedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> rowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const override;
+    unsigned selectedChildrenCount() const override;
+
+    JSRetainPtr<JSStringRef> allAttributes() override;
+    JSRetainPtr<JSStringRef> attributesOfLinkedUIElements() override;
+    RefPtr<AccessibilityUIElement> titleUIElement() override;
+    RefPtr<AccessibilityUIElement> parentElement() override;
+
+    JSRetainPtr<JSStringRef> attributesOfChildren() override;
+    JSRetainPtr<JSStringRef> parameterizedAttributeNames() override;
+
+    JSRetainPtr<JSStringRef> role() override;
+    JSRetainPtr<JSStringRef> subrole() override;
+    JSRetainPtr<JSStringRef> roleDescription() override;
+    JSRetainPtr<JSStringRef> computedRoleString() override;
+    JSRetainPtr<JSStringRef> title() override;
+    JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> language() override;
+    JSRetainPtr<JSStringRef> stringValue() override;
+    JSRetainPtr<JSStringRef> accessibilityValue() const override;
+    JSRetainPtr<JSStringRef> helpText() const override;
+    JSRetainPtr<JSStringRef> orientation() const override;
+    double x() override;
+    double y() override;
+    double width() override;
+    double height() override;
+    double intValue() const override;
+    double minValue() override;
+    double maxValue() override;
+    JSRetainPtr<JSStringRef> valueDescription() override;
+    int insertionPointLineNumber() override;
+    JSRetainPtr<JSStringRef> selectedTextRange() override;
+    bool isEnabled() override;
+    bool isRequired() const override;
+
+    bool isFocused() const override;
+    bool isFocusable() const override;
+    bool isSelected() const override;
+    bool isSelectable() const override;
+    bool isMultiSelectable() const override;
+    void setSelectedChild(AccessibilityUIElement*) const override;
+    void setSelectedChildAtIndex(unsigned) const override;
+    void removeSelectionAtIndex(unsigned) const override;
+    void clearSelectedChildren() const override;
+
+    bool isExpanded() const override;
+    bool isChecked() const override;
+    bool isIndeterminate() const override;
+    bool isVisible() const override;
+    bool isOffScreen() const override;
+    bool isCollapsed() const override;
+    bool isIgnored() const override;
+    bool isSingleLine() const override;
+    bool isMultiLine() const override;
+    bool hasPopup() const override;
+    JSRetainPtr<JSStringRef> popupValue() const override;
+    int hierarchicalLevel() const override;
+    double clickPointX() override;
+    double clickPointY() override;
+    JSRetainPtr<JSStringRef> documentEncoding();
+    JSRetainPtr<JSStringRef> documentURI();
+    JSRetainPtr<JSStringRef> url() override;
+
+    JSRetainPtr<JSStringRef> classList() const override;
+
+    // Additional platform-specific methods
+    JSRetainPtr<JSStringRef> identifier() override;
+    JSRetainPtr<JSStringRef> traits() override;
+    int elementTextPosition() override;
+    int elementTextLength() override;
+    JSRetainPtr<JSStringRef> stringForSelection() override;
+    void increaseTextSelection() override;
+    void decreaseTextSelection() override;
+    RefPtr<AccessibilityUIElement> fieldsetAncestorElement() override;
+
+    bool scrollPageUp() override;
+    bool scrollPageDown() override;
+    bool scrollPageLeft() override;
+    bool scrollPageRight() override;
+
+    bool hasTextEntryTrait() override;
+    bool hasTabBarTrait() override;
+    bool hasMenuItemTrait() override;
+
+    bool isSearchField() const override;
+    bool isSwitch() const override;
+    bool isTextArea() const override;
+
+    void assistiveTechnologySimulatedFocus() override;
+
+    JSRetainPtr<JSStringRef> customContent() const override;
+    JSRetainPtr<JSStringRef> brailleLabel() const override;
+    JSRetainPtr<JSStringRef> brailleRoleDescription() const override;
+
+    JSRetainPtr<JSStringRef> embeddedImageDescription() const override;
+    JSValueRef imageOverlayElements(JSContextRef) override;
+
+    bool hasDocumentRoleAncestor() const;
+    bool hasWebApplicationAncestor() const;
+    bool isInDescriptionListDetail() const override;
+    bool isInDescriptionListTerm() const override;
+    bool isInCell() const override;
+    bool isInTable() const override;
+    bool isInLandmark() const override;
+    bool isInList() const override;
+
+    JSValueRef selectedChildren(JSContextRef) override;
+
+    // Attribute methods
+    JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute) override;
+    JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute) override;
+    double numberAttributeValue(JSStringRef attribute) override;
+    JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute) override;
+    RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const override;
+    bool boolAttributeValue(JSStringRef attribute) override;
+    bool isAttributeSettable(JSStringRef attribute) override;
+    bool isAttributeSupported(JSStringRef attribute) override;
+
+    // Table methods
+    JSValueRef rowHeaders(JSContextRef) override;
+    JSValueRef columnHeaders(JSContextRef) override;
+    JSValueRef selectedCells(JSContextRef) override;
+    RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> disclosedByRow() override;
+
+    // Other methods
+    JSRetainPtr<JSStringRef> attributesOfDocumentLinks() override;
+    JSRetainPtr<JSStringRef> liveRegionRelevant() const override;
+    JSRetainPtr<JSStringRef> liveRegionStatus() const override;
+    double pageX() override;
+    double pageY() override;
+
+    // Action support
+    bool isPressActionSupported() override;
+    bool isIncrementActionSupported() override;
+    bool isDecrementActionSupported() override;
+
+    // State methods
+    bool isAtomicLiveRegion() const override;
+    bool isBusy() const override;
+    bool isSelectedOptionActive() const override;
+    bool supportsExpanded() const override;
+    bool isGrabbed() const override;
+
+    // Focus
+    RefPtr<AccessibilityUIElement> focusedElement() const override;
+
+    // ARIA
+    JSRetainPtr<JSStringRef> currentStateValue() const override;
+    JSRetainPtr<JSStringRef> sortDirection() const override;
+    JSRetainPtr<JSStringRef> speakAs() override;
+    JSRetainPtr<JSStringRef> ariaDropEffects() const override;
+
+    // Text/Range methods
+    JSRetainPtr<JSStringRef> lineRectsAndText() const override;
+    int lineForIndex(int) override;
+    JSRetainPtr<JSStringRef> rangeForLine(int) override;
+    JSRetainPtr<JSStringRef> rangeForPosition(int x, int y) override;
+    JSRetainPtr<JSStringRef> boundsForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> stringForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> attributedStringForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> attributedStringForElement() override;
+    bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
+
+    // Search methods
+    unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
+
+    // Table attribute methods
+    JSRetainPtr<JSStringRef> attributesOfColumnHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfRowHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfColumns() override;
+    JSRetainPtr<JSStringRef> attributesOfRows() override;
+    JSRetainPtr<JSStringRef> attributesOfVisibleCells() override;
+    JSRetainPtr<JSStringRef> attributesOfHeader() override;
+
+    // Table cell methods
+    int rowCount() override;
+    int columnCount() override;
+    int indexInTable() override;
+    JSRetainPtr<JSStringRef> rowIndexRange() override;
+    JSRetainPtr<JSStringRef> columnIndexRange() override;
+    RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned col, unsigned row) override;
+
+    // Scrollbar methods
+    RefPtr<AccessibilityUIElement> horizontalScrollbar() const override;
+    RefPtr<AccessibilityUIElement> verticalScrollbar() const override;
+
+    // Scrolling methods
+    void scrollToMakeVisible() override;
+    void scrollToGlobalPoint(int x, int y) override;
+    void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height) override;
+
+    // Selection methods
+    JSRetainPtr<JSStringRef> intersectionWithSelectionRange() override;
+    bool setSelectedTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    bool setSelectedTextRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> textInputMarkedRange() const override;
+
+    // Action methods
+    void increment() override;
+    void decrement() override;
+    void showMenu() override;
+    void press() override;
+    bool dismiss() override;
+
+    // Focus and selection actions
+    void takeFocus() override;
+    void takeSelection() override;
+    void addSelection() override;
+    void removeSelection() override;
+
+    // Notification methods
+    bool addNotificationListener(JSContextRef, JSValueRef functionCallback) override;
+    bool removeNotificationListener() override;
+
+    // Date/time
+    JSRetainPtr<JSStringRef> dateTimeValue() const override;
+
+    // Math
+    JSRetainPtr<JSStringRef> mathPostscriptsDescription() const override;
+    JSRetainPtr<JSStringRef> mathPrescriptsDescription() const override;
+
+    // Path
+    JSRetainPtr<JSStringRef> pathDescription() const override;
+
+    // Supported actions
+    JSRetainPtr<JSStringRef> supportedActions() const override;
+
+    // Insertion/deletion
+    bool isInsertion() const override;
+    bool isDeletion() const override;
+    bool isFirstItemInSuggestion() const override;
+    bool isLastItemInSuggestion() const override;
+    bool isMarkAnnotation() const override;
+
+    // Text input
+    bool insertText(JSStringRef) override;
+    bool replaceTextInRange(JSStringRef, int position, int length) override;
+
+    // Text marker methods
+    RefPtr<AccessibilityTextMarker> textMarkerForPoint(int x, int y) override;
+    RefPtr<AccessibilityTextMarker> textMarkerForIndex(int) override;
+    RefPtr<AccessibilityTextMarker> startTextMarker() override;
+    RefPtr<AccessibilityTextMarker> endTextMarker() override;
+    bool isTextMarkerValid(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextTextMarker(AccessibilityTextMarker*) override;
+    JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    int textMarkerRangeLength(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    int indexForTextMarker(AccessibilityTextMarker*) override;
+    JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool) override;
+    bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarkerRange> lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> leftWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> rightWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousWordStartTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextWordEndTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> paragraphTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousParagraphStartTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextParagraphEndTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> sentenceTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange* startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    RefPtr<AccessibilityTextMarkerRange> misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeMatchesTextNearMarkers(JSStringRef, AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+
+private:
+    AccessibilityUIElementIOS(PlatformUIElement);
+    AccessibilityUIElementIOS(const AccessibilityUIElementIOS&);
+
+    WeakObjCPtr<id> m_element;
+    RetainPtr<id> m_notificationHandler;
+};
+
+} // namespace WTR
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2011 Apple Inc. All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#include "AccessibilityUIElement.h"
+#include <wtf/RetainPtr.h>
+#include <wtf/WeakObjCPtr.h>
+
+OBJC_CLASS NSArray;
+OBJC_CLASS NSString;
+
+namespace WTR {
+
+// Mac implementation of AccessibilityUIElement using in-process accessibility wrappers
+class AccessibilityUIElementMac final : public AccessibilityUIElement {
+    // Helper functions that dispatch to AX secondary thread
+    friend RetainPtr<NSArray> supportedAttributes(id);
+    friend void setAttributeValue(id, NSString *, id, bool synchronous);
+
+public:
+    static Ref<AccessibilityUIElementMac> create(PlatformUIElement);
+    static Ref<AccessibilityUIElementMac> create(const AccessibilityUIElementMac&);
+
+    virtual ~AccessibilityUIElementMac();
+
+    PlatformUIElement platformUIElement() override { return m_element.getAutoreleased(); }
+
+    bool isEqual(AccessibilityUIElement* otherElement) override;
+    JSRetainPtr<JSStringRef> domIdentifier() const override;
+
+    RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y) override;
+    RefPtr<AccessibilityUIElement> elementAtPointWithRemoteElement(int x, int y) override;
+    void elementAtPointResolvingRemoteFrame(JSContextRef, int x, int y, JSValueRef callback) override;
+
+    JSValueRef children(JSContextRef) override;
+    unsigned childrenCount() override;
+    RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> childAtIndexWithRemoteElement(unsigned) override;
+    unsigned indexOfChild(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityUIElement> titleUIElement() override;
+    RefPtr<AccessibilityUIElement> parentElement() override;
+
+    void takeFocus() override;
+    void takeSelection() override;
+    void addSelection() override;
+    void removeSelection() override;
+
+    JSRetainPtr<JSStringRef> allAttributes() override;
+    JSRetainPtr<JSStringRef> attributesOfLinkedUIElements() override;
+    RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned) override;
+
+    JSRetainPtr<JSStringRef> attributesOfDocumentLinks() override;
+    JSRetainPtr<JSStringRef> attributesOfChildren() override;
+    JSRetainPtr<JSStringRef> parameterizedAttributeNames() override;
+    void increment() override;
+    void decrement() override;
+    void showMenu() override;
+    void press() override;
+    bool dismiss() override;
+    void syncPress() override;
+    void asyncIncrement() override;
+    void asyncDecrement() override;
+    RefPtr<AccessibilityUIElement> focusableAncestor() override;
+    RefPtr<AccessibilityUIElement> editableAncestor() override;
+    RefPtr<AccessibilityUIElement> highestEditableAncestor() override;
+    JSRetainPtr<JSStringRef> selectedText() override;
+
+    JSRetainPtr<JSStringRef> dateTimeValue() const override;
+
+    JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute) override;
+    JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute) override;
+    double numberAttributeValue(JSStringRef attribute) override;
+    JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute) override;
+    RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const override;
+    bool boolAttributeValue(JSStringRef attribute) override;
+    RetainPtr<id> attributeValue(NSString *) const;
+    void attributeValueAsync(JSContextRef, JSStringRef attribute, JSValueRef callback) override;
+    void setBoolAttributeValue(JSStringRef attribute, bool value) override;
+    bool isAttributeSupported(JSStringRef attribute) override;
+    bool isAttributeSettable(JSStringRef attribute) override;
+    bool isPressActionSupported() override;
+    bool isIncrementActionSupported() override;
+    bool isDecrementActionSupported() override;
+    void setValue(JSStringRef) override;
+    JSRetainPtr<JSStringRef> role() override;
+    JSRetainPtr<JSStringRef> subrole() override;
+    JSRetainPtr<JSStringRef> roleDescription() override;
+    JSRetainPtr<JSStringRef> computedRoleString() override;
+    JSRetainPtr<JSStringRef> title() override;
+    JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> language() override;
+    JSRetainPtr<JSStringRef> stringValue() override;
+    JSRetainPtr<JSStringRef> dateValue() override;
+    JSRetainPtr<JSStringRef> accessibilityValue() const override;
+    JSRetainPtr<JSStringRef> helpText() const override;
+    JSRetainPtr<JSStringRef> orientation() const override;
+    JSRetainPtr<JSStringRef> liveRegionRelevant() const override;
+    JSRetainPtr<JSStringRef> liveRegionStatus() const override;
+    double pageX() override;
+    double pageY() override;
+    double x() override;
+    double y() override;
+    double width() override;
+    double height() override;
+    JSRetainPtr<JSStringRef> lineRectsAndText() const override;
+    JSRetainPtr<JSStringRef> brailleLabel() const override;
+    JSRetainPtr<JSStringRef> brailleRoleDescription() const override;
+
+    double intValue() const override;
+    double minValue() override;
+    double maxValue() override;
+    JSRetainPtr<JSStringRef> valueDescription() override;
+    unsigned numberOfCharacters() const override;
+    int insertionPointLineNumber() override;
+    JSRetainPtr<JSStringRef> selectedTextRange() override;
+    JSRetainPtr<JSStringRef> intersectionWithSelectionRange() override;
+    JSRetainPtr<JSStringRef> textInputMarkedRange() const override;
+    bool isAtomicLiveRegion() const override;
+    bool isBusy() const override;
+    bool isEnabled() override;
+    bool isRequired() const override;
+
+    RefPtr<AccessibilityUIElement> focusedElement() const override;
+    bool isFocused() const override;
+    bool isFocusable() const override;
+    bool isSelected() const override;
+    bool isSelectedOptionActive() const override;
+    bool isSelectable() const override;
+    bool isMultiSelectable() const override;
+    void setSelectedChild(AccessibilityUIElement*) const override;
+    void setSelectedChildAtIndex(unsigned) const override;
+    void removeSelectionAtIndex(unsigned) const override;
+    void clearSelectedChildren() const override;
+    RefPtr<AccessibilityUIElement> activeElement() const override;
+    JSValueRef selectedChildren(JSContextRef) override;
+    unsigned selectedChildrenCount() const override;
+    RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const override;
+
+    bool isValid() const override;
+    bool isExpanded() const override;
+    bool isChecked() const override;
+    JSRetainPtr<JSStringRef> currentStateValue() const override;
+    JSRetainPtr<JSStringRef> sortDirection() const override;
+    bool isIndeterminate() const override;
+    bool isVisible() const override;
+    bool isOnScreen() const override;
+    bool isOffScreen() const override;
+    bool isCollapsed() const override;
+    bool isIgnored() const override;
+    bool isSingleLine() const override;
+    bool isMultiLine() const override;
+    bool hasPopup() const override;
+    JSRetainPtr<JSStringRef> popupValue() const override;
+    int hierarchicalLevel() const override;
+    double clickPointX() override;
+    double clickPointY() override;
+    JSRetainPtr<JSStringRef> url() override;
+    JSRetainPtr<JSStringRef> classList() const override;
+    JSRetainPtr<JSStringRef> embeddedImageDescription() const override;
+    JSValueRef imageOverlayElements(JSContextRef) override;
+
+    JSRetainPtr<JSStringRef> speakAs() override;
+
+    JSRetainPtr<JSStringRef> attributesOfColumnHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfRowHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfColumns() override;
+    JSValueRef columns(JSContextRef) override;
+    JSRetainPtr<JSStringRef> attributesOfRows() override;
+    JSRetainPtr<JSStringRef> attributesOfVisibleCells() override;
+    JSRetainPtr<JSStringRef> attributesOfHeader() override;
+    bool isInCell() const override;
+    bool isInTable() const override;
+    int indexInTable() override;
+    JSRetainPtr<JSStringRef> rowIndexRange() override;
+    JSRetainPtr<JSStringRef> columnIndexRange() override;
+    int rowCount() override;
+    int columnCount() override;
+    JSValueRef rowHeaders(JSContextRef) override;
+    JSValueRef columnHeaders(JSContextRef) override;
+    JSRetainPtr<JSStringRef> customContent() const override;
+    JSValueRef selectedCells(JSContextRef) override;
+
+    RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> disclosedByRow() override;
+    RefPtr<AccessibilityUIElement> disclosedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> rowAtIndex(unsigned) override;
+
+    RefPtr<AccessibilityUIElement> controllerElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaDescribedByElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> descriptionForElementAtIndex(unsigned) override;
+    JSValueRef detailsElements(JSContextRef) override;
+    RefPtr<AccessibilityUIElement> ariaDetailsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> detailsForElementAtIndex(unsigned) override;
+    JSValueRef errorMessageElements(JSContextRef) override;
+    RefPtr<AccessibilityUIElement> ariaErrorMessageElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> errorMessageForElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> flowFromElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaFlowToElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaLabelledByElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> labelForElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ownerElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned) override;
+
+    bool isGrabbed() const override;
+    JSRetainPtr<JSStringRef> ariaDropEffects() const override;
+
+    int lineForIndex(int) override;
+    JSRetainPtr<JSStringRef> rangeForLine(int) override;
+    JSRetainPtr<JSStringRef> rangeForPosition(int x, int y) override;
+    JSRetainPtr<JSStringRef> boundsForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> boundsForRangeWithPagePosition(unsigned location, unsigned length) override;
+    bool setSelectedTextRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> stringForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> attributedStringForRange(unsigned location, unsigned length) override;
+
+    bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
+    unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
+    JSValueRef searchTextWithCriteria(JSContextRef, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction) override;
+    JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSValueRef replacementStrings, bool shouldSmartReplace) override;
+
+    RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row) override;
+
+    RefPtr<AccessibilityUIElement> horizontalScrollbar() const override;
+    RefPtr<AccessibilityUIElement> verticalScrollbar() const override;
+
+    void scrollToMakeVisible() override;
+    void scrollToGlobalPoint(int x, int y) override;
+    void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height) override;
+
+    RefPtr<AccessibilityTextMarkerRange> lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> rightLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> leftLineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousLineStartTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextLineEndTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    int lineIndexForTextMarker(AccessibilityTextMarker*) const override;
+    RefPtr<AccessibilityTextMarkerRange> styleTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForSearchPredicate(JSContextRef, AccessibilityTextMarkerRange* startRange, bool forward, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    RefPtr<AccessibilityTextMarkerRange> misspellingTextMarkerRange(AccessibilityTextMarkerRange* start, bool forward) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForRange(unsigned location, unsigned length) override;
+    RefPtr<AccessibilityTextMarkerRange> selectedTextMarkerRange() override;
+    void resetSelectedTextMarkerRange() override;
+    bool replaceTextInRange(JSStringRef, int position, int length) override;
+    bool insertText(JSStringRef) override;
+    RefPtr<AccessibilityTextMarkerRange> textInputMarkedTextMarkerRange() const override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> textMarkerForPoint(int x, int y) override;
+    RefPtr<AccessibilityTextMarker> previousTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForLine(long) override;
+    JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool) override;
+    int textMarkerRangeLength(AccessibilityTextMarkerRange*) override;
+    bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*) override;
+    int indexForTextMarker(AccessibilityTextMarker*) override;
+    bool isTextMarkerValid(AccessibilityTextMarker*) override;
+    bool isTextMarkerRangeValid(AccessibilityTextMarkerRange*) override;
+    bool isTextMarkerNull(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> textMarkerForIndex(int) override;
+    RefPtr<AccessibilityTextMarker> startTextMarker() override;
+    RefPtr<AccessibilityTextMarker> endTextMarker() override;
+    bool setSelectedTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarkerRange> leftWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> rightWordTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousWordStartTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextWordEndTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> paragraphTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextParagraphEndTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousParagraphStartTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> sentenceTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextSentenceEndTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> previousSentenceStartTextMarkerForTextMarker(AccessibilityTextMarker*) override;
+    JSRetainPtr<JSStringRef> textMarkerDebugDescription(AccessibilityTextMarker*) override;
+    JSRetainPtr<JSStringRef> textMarkerRangeDebugDescription(AccessibilityTextMarkerRange*) override;
+
+    JSRetainPtr<JSStringRef> supportedActions() const override;
+    JSRetainPtr<JSStringRef> mathPostscriptsDescription() const override;
+    JSRetainPtr<JSStringRef> mathPrescriptsDescription() const override;
+    JSValueRef mathRootRadicand(JSContextRef) override;
+
+    JSRetainPtr<JSStringRef> pathDescription() const override;
+
+    bool addNotificationListener(JSContextRef, JSValueRef functionCallback) override;
+    bool removeNotificationListener() override;
+
+    bool isInDescriptionListDetail() const override;
+    bool isInDescriptionListTerm() const override;
+
+    bool isInsertion() const override;
+    bool isDeletion() const override;
+    bool isFirstItemInSuggestion() const override;
+    bool isLastItemInSuggestion() const override;
+    bool isRemoteFrame() const override;
+
+private:
+    AccessibilityUIElementMac(PlatformUIElement);
+    AccessibilityUIElementMac(const AccessibilityUIElementMac&);
+
+    NSArray *actionNames() const;
+    bool performAction(NSString *) const;
+    RetainPtr<id> attributeValueForParameter(NSString *, id) const;
+    unsigned arrayAttributeCount(NSString *) const;
+    RetainPtr<NSString> descriptionOfValue(id valueObject) const;
+    bool boolAttributeValueNS(NSString *attribute) const;
+    JSRetainPtr<JSStringRef> stringAttributeValueNS(NSString *attribute) const;
+    double numberAttributeValueNS(NSString *attribute) const;
+    bool isAttributeSettableNS(NSString *) const;
+
+    WeakObjCPtr<id> m_element;
+    RetainPtr<id> m_notificationHandler;
+
+    void getLinkedUIElements(Vector<RefPtr<AccessibilityUIElement> >&);
+    void getDocumentLinks(Vector<RefPtr<AccessibilityUIElement> >&);
+    RefPtr<AccessibilityUIElement> elementForAttribute(NSString*) const;
+    RefPtr<AccessibilityUIElement> elementForAttributeAtIndex(NSString*, unsigned) const;
+
+    void getUIElementsWithAttribute(JSStringRef, Vector<RefPtr<AccessibilityUIElement> >&) const;
+
+    Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
+    Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
+};
+
+} // namespace WTR
+
+#endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
@@ -24,1078 +24,1092 @@
  */
 
 #include "config.h"
-#include "AccessibilityUIElement.h"
+#include "AccessibilityUIElementPlayStation.h"
 
 #include <WebCore/NotImplemented.h>
 
 namespace WTR {
 
-AccessibilityUIElement::AccessibilityUIElement(PlatformUIElement)
+Ref<AccessibilityUIElementPlayStation> AccessibilityUIElementPlayStation::create(PlatformUIElement element)
+{
+    return adoptRef(*new AccessibilityUIElementPlayStation(element));
+}
+
+Ref<AccessibilityUIElementPlayStation> AccessibilityUIElementPlayStation::create(const AccessibilityUIElementPlayStation& other)
+{
+    return adoptRef(*new AccessibilityUIElementPlayStation(other));
+}
+
+AccessibilityUIElementPlayStation::AccessibilityUIElementPlayStation(PlatformUIElement element)
+    : AccessibilityUIElement(element)
+    , m_element(element)
 {
     notImplemented();
 }
 
-AccessibilityUIElement::AccessibilityUIElement(const AccessibilityUIElement&)
+AccessibilityUIElementPlayStation::AccessibilityUIElementPlayStation(const AccessibilityUIElementPlayStation& other)
+    : AccessibilityUIElement(other)
+    , m_element(other.m_element)
 {
     notImplemented();
 }
 
-AccessibilityUIElement::~AccessibilityUIElement()
+AccessibilityUIElementPlayStation::~AccessibilityUIElementPlayStation()
 {
     notImplemented();
 }
 
-bool AccessibilityUIElement::isEqual(AccessibilityUIElement*)
+bool AccessibilityUIElementPlayStation::isEqual(AccessibilityUIElement*)
 {
     notImplemented();
     return false;
 }
 
-Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElement::getChildren() const
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementPlayStation::getChildren() const
 {
     notImplemented();
     return { };
 }
 
-Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElement::getChildrenInRange(unsigned, unsigned) const
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementPlayStation::getChildrenInRange(unsigned, unsigned) const
 {
     notImplemented();
     return { };
 }
 
-unsigned AccessibilityUIElement::childrenCount()
+unsigned AccessibilityUIElementPlayStation::childrenCount()
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPoint(int, int)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::elementAtPoint(int, int)
 {
     notImplemented();
     return nullptr;
 }
 
-unsigned AccessibilityUIElement::indexOfChild(AccessibilityUIElement*)
-{
-    notImplemented();
-    return 0;
-}
-
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedUIElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaOwnsElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaFlowToElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaControlsElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedRowAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::rowAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedChildAtIndex(unsigned) const
-{
-    notImplemented();
-    return nullptr;
-}
-
-unsigned AccessibilityUIElement::selectedChildrenCount() const
+unsigned AccessibilityUIElementPlayStation::indexOfChild(AccessibilityUIElement*)
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedRowAtIndex(unsigned)
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::childAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::titleUIElement()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::linkedUIElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::parentElement()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::ariaOwnsElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedByRow()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::ariaFlowToElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfLinkedUIElements()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::ariaControlsElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfDocumentLinks()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::disclosedRowAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfChildren()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::rowAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::allAttributes()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::selectedChildAtIndex(unsigned) const
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(JSStringRef)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringDescriptionOfAttributeValue(JSStringRef)
-{
-    notImplemented();
-    return nullptr;
-}
-
-double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
+unsigned AccessibilityUIElementPlayStation::selectedChildrenCount() const
 {
     notImplemented();
     return 0;
 }
 
-JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::selectedRowAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::rowHeaders(JSContextRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::titleUIElement()
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::columnHeaders(JSContextRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::parentElement()
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::selectedCells(JSContextRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::disclosedByRow()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementAttributeValue(JSStringRef attribute) const
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfLinkedUIElements()
 {
     notImplemented();
     return nullptr;
 }
 
-bool AccessibilityUIElement::boolAttributeValue(JSStringRef attribute)
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isAttributeSupported(JSStringRef attribute)
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::parameterizedAttributeNames()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfDocumentLinks()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfChildren()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::subrole()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::allAttributes()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::roleDescription()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::stringAttributeValue(JSStringRef)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::currentStateValue() const
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::title()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::sortDirection() const
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::description()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::stringDescriptionOfAttributeValue(JSStringRef)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::isAtomicLiveRegion() const
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionRelevant() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionStatus() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::language()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-double AccessibilityUIElement::pageX()
+double AccessibilityUIElementPlayStation::numberAttributeValue(JSStringRef attribute)
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::pageY()
+JSValueRef AccessibilityUIElementPlayStation::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElementPlayStation::rowHeaders(JSContextRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElementPlayStation::columnHeaders(JSContextRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElementPlayStation::selectedCells(JSContextRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::uiElementAttributeValue(JSStringRef attribute) const
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementPlayStation::boolAttributeValue(JSStringRef attribute)
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isAttributeSettable(JSStringRef attribute)
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isAttributeSupported(JSStringRef attribute)
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::parameterizedAttributeNames()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::role()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::subrole()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::roleDescription()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::computedRoleString()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::title()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::description()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::orientation() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementPlayStation::isAtomicLiveRegion() const
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::liveRegionRelevant() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::liveRegionStatus() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::stringValue()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::language()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::helpText() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+double AccessibilityUIElementPlayStation::pageX()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::x()
+double AccessibilityUIElementPlayStation::pageY()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::y()
+double AccessibilityUIElementPlayStation::x()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::width()
+double AccessibilityUIElementPlayStation::y()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::height()
+double AccessibilityUIElementPlayStation::width()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::clickPointX()
+double AccessibilityUIElementPlayStation::height()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::clickPointY()
+double AccessibilityUIElementPlayStation::clickPointX()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::intValue() const
+double AccessibilityUIElementPlayStation::clickPointY()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::minValue()
+double AccessibilityUIElementPlayStation::intValue() const
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::maxValue()
+double AccessibilityUIElementPlayStation::minValue()
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::valueDescription()
-{
-    notImplemented();
-    return nullptr;
-}
-
-int AccessibilityUIElement::insertionPointLineNumber()
+double AccessibilityUIElementPlayStation::maxValue()
 {
     notImplemented();
     return 0;
 }
 
-bool AccessibilityUIElement::isPressActionSupported()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::valueDescription()
 {
     notImplemented();
-    return false;
+    return nullptr;
 }
 
-bool AccessibilityUIElement::isIncrementActionSupported()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isDecrementActionSupported()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isBusy() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isEnabled()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isRequired() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isFocused() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSelected() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSelectedOptionActive() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isExpanded() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isChecked() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isIndeterminate() const
-{
-    notImplemented();
-    return false;
-}
-
-int AccessibilityUIElement::hierarchicalLevel() const
+int AccessibilityUIElementPlayStation::insertionPointLineNumber()
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::isGrabbed() const
+bool AccessibilityUIElementPlayStation::isPressActionSupported()
 {
     notImplemented();
     return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::ariaDropEffects() const
+bool AccessibilityUIElementPlayStation::isIncrementActionSupported()
 {
     notImplemented();
-    return nullptr;
+    return false;
 }
 
-int AccessibilityUIElement::lineForIndex(int)
+bool AccessibilityUIElementPlayStation::isDecrementActionSupported()
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isBusy() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isEnabled()
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isRequired() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isFocused() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isSelected() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isSelectedOptionActive() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isExpanded() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isChecked() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isIndeterminate() const
+{
+    notImplemented();
+    return false;
+}
+
+int AccessibilityUIElementPlayStation::hierarchicalLevel() const
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForLine(int)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::speakAs()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForPosition(int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::attributedStringRangeIsMisspelled(unsigned, unsigned)
+bool AccessibilityUIElementPlayStation::isGrabbed() const
 {
     notImplemented();
     return false;
 }
 
-unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::ariaDropEffects() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+int AccessibilityUIElementPlayStation::lineForIndex(int)
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::rangeForLine(int)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContextRef, JSStringRef, JSValueRef, JSStringRef, JSStringRef)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::rangeForPosition(int, int)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::boundsForRange(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::stringForRange(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumns()
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributedStringForRange(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
+bool AccessibilityUIElementPlayStation::attributedStringRangeIsMisspelled(unsigned, unsigned)
 {
     notImplemented();
-    return nullptr;
+    return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfVisibleCells()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfHeader()
-{
-    notImplemented();
-    return nullptr;
-}
-
-int AccessibilityUIElement::rowCount()
+unsigned AccessibilityUIElementPlayStation::uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
 {
     notImplemented();
     return 0;
 }
 
-int AccessibilityUIElement::columnCount()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::selectTextWithCriteria(JSContextRef, JSStringRef, JSValueRef, JSStringRef, JSStringRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfColumnHeaders()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfRowHeaders()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfColumns()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfRows()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfVisibleCells()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributesOfHeader()
+{
+    notImplemented();
+    return nullptr;
+}
+
+int AccessibilityUIElementPlayStation::rowCount()
 {
     notImplemented();
     return 0;
 }
 
-int AccessibilityUIElement::indexInTable()
+int AccessibilityUIElementPlayStation::columnCount()
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rowIndexRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::columnIndexRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::cellForColumnAndRow(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::horizontalScrollbar() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedTextRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::intersectionWithSelectionRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::setSelectedTextRange(unsigned, unsigned)
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-void AccessibilityUIElement::increment()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::decrement()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::showMenu()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::press()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::setSelectedChild(AccessibilityUIElement* element) const
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::setSelectedChildAtIndex(unsigned index) const
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::removeSelectionAtIndex(unsigned index) const
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::clearSelectedChildren() const
-{
-    notImplemented();
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::accessibilityValue() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::addNotificationListener(JSContextRef, JSValueRef functionCallback)
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::removeNotificationListener()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isFocusable() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSelectable() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isMultiSelectable() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isVisible() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isOffScreen() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isCollapsed() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isIgnored() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSingleLine() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isMultiLine() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::hasPopup() const
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-void AccessibilityUIElement::takeFocus()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::takeSelection()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::addSelection()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::removeSelection()
-{
-    notImplemented();
-}
-
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForElement(AccessibilityUIElement*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-int AccessibilityUIElement::textMarkerRangeLength(AccessibilityTextMarkerRange*)
+int AccessibilityUIElementPlayStation::indexInTable()
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousTextMarker(AccessibilityTextMarker*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::rowIndexRange()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextTextMarker(AccessibilityTextMarker*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::columnIndexRange()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::cellForColumnAndRow(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForTextMarkerRange(AccessibilityTextMarkerRange*)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::horizontalScrollbar() const
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::verticalScrollbar() const
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::selectedTextRange()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::intersectionWithSelectionRange()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForBounds(int, int, int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForBounds(int, int, int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForPoint(int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::accessibilityElementForTextMarker(AccessibilityTextMarker*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*)
+bool AccessibilityUIElementPlayStation::setSelectedTextRange(unsigned, unsigned)
 {
     notImplemented();
     return false;
 }
 
-int AccessibilityUIElement::indexForTextMarker(AccessibilityTextMarker*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::textInputMarkedRange() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+void AccessibilityUIElementPlayStation::increment()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::decrement()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::showMenu()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::press()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::setSelectedChild(AccessibilityUIElement* element) const
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::setSelectedChildAtIndex(unsigned index) const
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::removeSelectionAtIndex(unsigned index) const
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::clearSelectedChildren() const
+{
+    notImplemented();
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::accessibilityValue() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::url()
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementPlayStation::addNotificationListener(JSContextRef, JSValueRef functionCallback)
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::removeNotificationListener()
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isFocusable() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isSelectable() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isMultiSelectable() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isVisible() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isOffScreen() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isCollapsed() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isIgnored() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isSingleLine() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isMultiLine() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::hasPopup() const
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::popupValue() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+void AccessibilityUIElementPlayStation::takeFocus()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::takeSelection()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::addSelection()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::removeSelection()
+{
+    notImplemented();
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementPlayStation::lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementPlayStation::textMarkerRangeForElement(AccessibilityUIElement*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+int AccessibilityUIElementPlayStation::textMarkerRangeLength(AccessibilityTextMarkerRange*)
 {
     notImplemented();
     return 0;
 }
 
-bool AccessibilityUIElement::isTextMarkerValid(AccessibilityTextMarker*)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::previousTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::nextTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::stringForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementPlayStation::textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::endTextMarkerForBounds(int, int, int, int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::startTextMarkerForBounds(int, int, int, int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::textMarkerForPoint(int, int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::accessibilityElementForTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementPlayStation::attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*)
 {
     notImplemented();
     return false;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForIndex(int)
+int AccessibilityUIElementPlayStation::indexForTextMarker(AccessibilityTextMarker*)
 {
     notImplemented();
-    return nullptr;
+    return 0;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarker()
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarker()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::setSelectedTextMarkerRange(AccessibilityTextMarkerRange*)
+bool AccessibilityUIElementPlayStation::isTextMarkerValid(AccessibilityTextMarker*)
 {
     notImplemented();
     return false;
 }
 
-void AccessibilityUIElement::scrollToMakeVisible()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::scrollToGlobalPoint(int, int)
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::scrollToMakeVisibleWithSubFocus(int, int, int, int)
-{
-    notImplemented();
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::supportedActions() const
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::textMarkerForIndex(int)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::pathDescription() const
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::startTextMarker()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPostscriptsDescription() const
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementPlayStation::endTextMarker()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPrescriptsDescription() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::characterAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::wordAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::lineAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sentenceAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::replaceTextInRange(JSStringRef, int, int)
+bool AccessibilityUIElementPlayStation::setSelectedTextMarkerRange(AccessibilityTextMarkerRange*)
 {
     notImplemented();
     return false;
 }
 
-bool AccessibilityUIElement::insertText(JSStringRef)
+void AccessibilityUIElementPlayStation::scrollToMakeVisible()
 {
     notImplemented();
-    return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
+void AccessibilityUIElementPlayStation::scrollToGlobalPoint(int, int)
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementPlayStation::scrollToMakeVisibleWithSubFocus(int, int, int, int)
+{
+    notImplemented();
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::supportedActions() const
 {
     notImplemented();
     return nullptr;
 }
 
-bool AccessibilityUIElement::isInsertion() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::pathDescription() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::mathPostscriptsDescription() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::mathPrescriptsDescription() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::classList() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::characterAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::wordAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::lineAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::sentenceAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementPlayStation::replaceTextInRange(JSStringRef, int, int)
 {
     notImplemented();
     return false;
 }
 
-bool AccessibilityUIElement::isDeletion() const
+bool AccessibilityUIElementPlayStation::insertText(JSStringRef)
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::domIdentifier() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementPlayStation::isInsertion() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementPlayStation::isDeletion() const
 {
     notImplemented();
     return false;
 }
 
 
-bool AccessibilityUIElement::isFirstItemInSuggestion() const
+bool AccessibilityUIElementPlayStation::isFirstItemInSuggestion() const
 {
     notImplemented();
     return false;
 }
 
 
-bool AccessibilityUIElement::isLastItemInSuggestion() const
+bool AccessibilityUIElementPlayStation::isLastItemInSuggestion() const
 {
     notImplemented();
     return false;
 }
 
-bool AccessibilityUIElement::isInNonNativeTextControl() const
+bool AccessibilityUIElementPlayStation::isInNonNativeTextControl() const
 {
     notImplemented();
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2024 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(PLAYSTATION)
+
+#include "AccessibilityUIElement.h"
+
+namespace WTR {
+
+// PlayStation implementation of AccessibilityUIElement
+class AccessibilityUIElementPlayStation final : public AccessibilityUIElement {
+public:
+    static Ref<AccessibilityUIElementPlayStation> create(PlatformUIElement);
+    static Ref<AccessibilityUIElementPlayStation> create(const AccessibilityUIElementPlayStation&);
+
+    virtual ~AccessibilityUIElementPlayStation();
+
+    PlatformUIElement platformUIElement() override { return m_element; }
+
+    bool isEqual(AccessibilityUIElement* otherElement) override;
+    JSRetainPtr<JSStringRef> domIdentifier() const override;
+
+    RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y) override;
+    unsigned indexOfChild(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+    unsigned childrenCount() override;
+    RefPtr<AccessibilityUIElement> titleUIElement() override;
+    RefPtr<AccessibilityUIElement> parentElement() override;
+
+    void takeFocus() override;
+    void takeSelection() override;
+    void addSelection() override;
+    void removeSelection() override;
+
+    JSRetainPtr<JSStringRef> allAttributes() override;
+    JSRetainPtr<JSStringRef> attributesOfLinkedUIElements() override;
+    RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned) override;
+
+    JSRetainPtr<JSStringRef> attributesOfDocumentLinks() override;
+    JSRetainPtr<JSStringRef> attributesOfChildren() override;
+    JSRetainPtr<JSStringRef> parameterizedAttributeNames() override;
+    void increment() override;
+    void decrement() override;
+    void showMenu() override;
+    void press() override;
+
+    JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute) override;
+    JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute) override;
+    double numberAttributeValue(JSStringRef attribute) override;
+    JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute) override;
+    RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const override;
+    bool boolAttributeValue(JSStringRef attribute) override;
+    bool isAttributeSupported(JSStringRef attribute) override;
+    bool isAttributeSettable(JSStringRef attribute) override;
+    bool isPressActionSupported() override;
+    bool isIncrementActionSupported() override;
+    bool isDecrementActionSupported() override;
+    JSRetainPtr<JSStringRef> role() override;
+    JSRetainPtr<JSStringRef> subrole() override;
+    JSRetainPtr<JSStringRef> roleDescription() override;
+    JSRetainPtr<JSStringRef> computedRoleString() override;
+    JSRetainPtr<JSStringRef> title() override;
+    JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> language() override;
+    JSRetainPtr<JSStringRef> stringValue() override;
+    JSRetainPtr<JSStringRef> accessibilityValue() const override;
+    JSRetainPtr<JSStringRef> helpText() const override;
+    JSRetainPtr<JSStringRef> orientation() const override;
+    JSRetainPtr<JSStringRef> liveRegionRelevant() const override;
+    JSRetainPtr<JSStringRef> liveRegionStatus() const override;
+    double x() override;
+    double y() override;
+    double width() override;
+    double height() override;
+    double pageX() override;
+    double pageY() override;
+    double clickPointX() override;
+    double clickPointY() override;
+
+    double intValue() const override;
+    double minValue() override;
+    double maxValue() override;
+    JSRetainPtr<JSStringRef> valueDescription() override;
+    int insertionPointLineNumber() override;
+    JSRetainPtr<JSStringRef> selectedTextRange() override;
+    JSRetainPtr<JSStringRef> intersectionWithSelectionRange() override;
+    JSRetainPtr<JSStringRef> textInputMarkedRange() const override;
+    bool isAtomicLiveRegion() const override;
+    bool isBusy() const override;
+    bool isEnabled() override;
+    bool isRequired() const override;
+
+    bool isFocused() const override;
+    bool isFocusable() const override;
+    bool isSelected() const override;
+    bool isSelectedOptionActive() const override;
+    bool isSelectable() const override;
+    bool isMultiSelectable() const override;
+    void setSelectedChild(AccessibilityUIElement*) const override;
+    void setSelectedChildAtIndex(unsigned) const override;
+    void removeSelectionAtIndex(unsigned) const override;
+    void clearSelectedChildren() const override;
+    unsigned selectedChildrenCount() const override;
+    RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const override;
+
+    bool isValid() const override;
+    bool isExpanded() const override;
+    bool isChecked() const override;
+    JSRetainPtr<JSStringRef> currentStateValue() const override;
+    JSRetainPtr<JSStringRef> sortDirection() const override;
+    bool isIndeterminate() const override;
+    bool isVisible() const override;
+    bool isOffScreen() const override;
+    bool isCollapsed() const override;
+    bool isIgnored() const override;
+    bool isSingleLine() const override;
+    bool isMultiLine() const override;
+    bool hasPopup() const override;
+    JSRetainPtr<JSStringRef> popupValue() const override;
+    int hierarchicalLevel() const override;
+    JSRetainPtr<JSStringRef> url() override;
+    JSRetainPtr<JSStringRef> classList() const override;
+
+    JSRetainPtr<JSStringRef> speakAs() override;
+
+    JSRetainPtr<JSStringRef> attributesOfColumnHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfRowHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfColumns() override;
+    JSRetainPtr<JSStringRef> attributesOfRows() override;
+    JSRetainPtr<JSStringRef> attributesOfVisibleCells() override;
+    JSRetainPtr<JSStringRef> attributesOfHeader() override;
+    int indexInTable() override;
+    JSRetainPtr<JSStringRef> rowIndexRange() override;
+    JSRetainPtr<JSStringRef> columnIndexRange() override;
+    int rowCount() override;
+    int columnCount() override;
+    JSValueRef rowHeaders(JSContextRef) override;
+    JSValueRef columnHeaders(JSContextRef) override;
+    JSValueRef selectedCells(JSContextRef) override;
+
+    RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> disclosedByRow() override;
+    RefPtr<AccessibilityUIElement> disclosedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> rowAtIndex(unsigned) override;
+
+    RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaFlowToElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned) override;
+
+    bool isGrabbed() const override;
+    JSRetainPtr<JSStringRef> ariaDropEffects() const override;
+
+    int lineForIndex(int) override;
+    JSRetainPtr<JSStringRef> rangeForLine(int) override;
+    JSRetainPtr<JSStringRef> rangeForPosition(int x, int y) override;
+    JSRetainPtr<JSStringRef> boundsForRange(unsigned location, unsigned length) override;
+    bool setSelectedTextRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> stringForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> attributedStringForRange(unsigned location, unsigned length) override;
+    bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
+    unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
+
+    RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row) override;
+
+    RefPtr<AccessibilityUIElement> horizontalScrollbar() const override;
+    RefPtr<AccessibilityUIElement> verticalScrollbar() const override;
+
+    void scrollToMakeVisible() override;
+    void scrollToGlobalPoint(int x, int y) override;
+    void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height) override;
+
+    RefPtr<AccessibilityTextMarker> textMarkerForPoint(int x, int y) override;
+    RefPtr<AccessibilityTextMarker> textMarkerForIndex(int) override;
+    RefPtr<AccessibilityTextMarker> startTextMarker() override;
+    RefPtr<AccessibilityTextMarker> endTextMarker() override;
+    bool setSelectedTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> previousTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextTextMarker(AccessibilityTextMarker*) override;
+    JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*) override;
+    int textMarkerRangeLength(AccessibilityTextMarkerRange*) override;
+    bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*) override;
+    int indexForTextMarker(AccessibilityTextMarker*) override;
+    bool isTextMarkerValid(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*) override;
+
+    JSRetainPtr<JSStringRef> supportedActions() const override;
+    JSRetainPtr<JSStringRef> mathPostscriptsDescription() const override;
+    JSRetainPtr<JSStringRef> mathPrescriptsDescription() const override;
+
+    JSRetainPtr<JSStringRef> pathDescription() const override;
+
+    bool addNotificationListener(JSContextRef, JSValueRef functionCallback) override;
+    bool removeNotificationListener() override;
+
+    bool isInsertion() const override;
+    bool isDeletion() const override;
+    bool isFirstItemInSuggestion() const override;
+    bool isLastItemInSuggestion() const override;
+
+    bool replaceTextInRange(JSStringRef, int position, int length) override;
+    bool insertText(JSStringRef) override;
+
+    JSRetainPtr<JSStringRef> characterAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> wordAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> lineAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> sentenceAtOffset(int offset) override;
+
+    bool isInNonNativeTextControl() override;
+
+private:
+    AccessibilityUIElementPlayStation(PlatformUIElement);
+    AccessibilityUIElementPlayStation(const AccessibilityUIElementPlayStation&);
+
+    Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
+    Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
+
+    PlatformUIElement m_element;
+};
+
+} // namespace WTR
+
+#endif // PLATFORM(PLAYSTATION)

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -24,1072 +24,1091 @@
  */
 
 #include "config.h"
-#include "AccessibilityUIElement.h"
+#include "AccessibilityUIElementWin.h"
 
 #include <WebCore/NotImplemented.h>
 
 namespace WTR {
 
-AccessibilityUIElement::AccessibilityUIElement(PlatformUIElement)
+Ref<AccessibilityUIElementWin> AccessibilityUIElementWin::create(PlatformUIElement element)
+{
+    return adoptRef(*new AccessibilityUIElementWin(element));
+}
+
+Ref<AccessibilityUIElementWin> AccessibilityUIElementWin::create(const AccessibilityUIElementWin& other)
+{
+    return adoptRef(*new AccessibilityUIElementWin(other));
+}
+
+AccessibilityUIElementWin::AccessibilityUIElementWin(PlatformUIElement element)
+    : AccessibilityUIElement(element)
+    , m_element(element)
 {
     notImplemented();
 }
 
-AccessibilityUIElement::AccessibilityUIElement(const AccessibilityUIElement&)
+AccessibilityUIElementWin::AccessibilityUIElementWin(const AccessibilityUIElementWin& other)
+    : AccessibilityUIElement(other)
+    , m_element(other.m_element)
 {
     notImplemented();
 }
 
-AccessibilityUIElement::~AccessibilityUIElement()
+AccessibilityUIElementWin::~AccessibilityUIElementWin()
 {
     notImplemented();
 }
 
-bool AccessibilityUIElement::isEqual(AccessibilityUIElement*)
+bool AccessibilityUIElementWin::isValid() const
+{
+    return m_element;
+}
+
+bool AccessibilityUIElementWin::isEqual(AccessibilityUIElement*)
 {
     notImplemented();
     return false;
 }
 
-Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElement::getChildren() const
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementWin::getChildren() const
 {
     notImplemented();
     return { };
 }
 
-Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElement::getChildrenInRange(unsigned, unsigned) const
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementWin::getChildrenInRange(unsigned, unsigned) const
 {
     notImplemented();
     return { };
 }
 
-unsigned AccessibilityUIElement::childrenCount()
+unsigned AccessibilityUIElementWin::childrenCount()
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::elementAtPoint(int, int)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::elementAtPoint(int, int)
 {
     notImplemented();
     return nullptr;
 }
 
-unsigned AccessibilityUIElement::indexOfChild(AccessibilityUIElement*)
-{
-    notImplemented();
-    return 0;
-}
-
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::childAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::linkedUIElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaOwnsElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaFlowToElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::ariaControlsElementAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedRowAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::rowAtIndex(unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedChildAtIndex(unsigned) const
-{
-    notImplemented();
-    return nullptr;
-}
-
-unsigned AccessibilityUIElement::selectedChildrenCount() const
+unsigned AccessibilityUIElementWin::indexOfChild(AccessibilityUIElement*)
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::selectedRowAtIndex(unsigned)
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::childAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::titleUIElement()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::linkedUIElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::parentElement()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::ariaOwnsElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::disclosedByRow()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::ariaFlowToElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfLinkedUIElements()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::ariaControlsElementAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfDocumentLinks()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::disclosedRowAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfChildren()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::rowAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::allAttributes()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::selectedChildAtIndex(unsigned) const
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringAttributeValue(JSStringRef)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::currentStateValue() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sortDirection() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringDescriptionOfAttributeValue(JSStringRef)
-{
-    notImplemented();
-    return nullptr;
-}
-
-double AccessibilityUIElement::numberAttributeValue(JSStringRef attribute)
+unsigned AccessibilityUIElementWin::selectedChildrenCount() const
 {
     notImplemented();
     return 0;
 }
 
-JSValueRef AccessibilityUIElement::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::selectedRowAtIndex(unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::rowHeaders(JSContextRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::titleUIElement()
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::columnHeaders(JSContextRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::parentElement()
 {
     notImplemented();
     return nullptr;
 }
 
-JSValueRef AccessibilityUIElement::selectedCells(JSContextRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::disclosedByRow()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementAttributeValue(JSStringRef attribute) const
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfLinkedUIElements()
 {
     notImplemented();
     return nullptr;
 }
 
-bool AccessibilityUIElement::boolAttributeValue(JSStringRef attribute)
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isAttributeSupported(JSStringRef attribute)
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::parameterizedAttributeNames()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfDocumentLinks()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::role()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfChildren()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::subrole()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::allAttributes()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::roleDescription()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::stringAttributeValue(JSStringRef)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::currentStateValue() const
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::title()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::sortDirection() const
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::description()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::stringDescriptionOfAttributeValue(JSStringRef)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::orientation() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::isAtomicLiveRegion() const
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionRelevant() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::liveRegionStatus() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::language()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::helpText() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-double AccessibilityUIElement::pageX()
+double AccessibilityUIElementWin::numberAttributeValue(JSStringRef attribute)
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::pageY()
+JSValueRef AccessibilityUIElementWin::uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElementWin::rowHeaders(JSContextRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElementWin::columnHeaders(JSContextRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSValueRef AccessibilityUIElementWin::selectedCells(JSContextRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::uiElementAttributeValue(JSStringRef attribute) const
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementWin::boolAttributeValue(JSStringRef attribute)
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isAttributeSettable(JSStringRef attribute)
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isAttributeSupported(JSStringRef attribute)
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::parameterizedAttributeNames()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::role()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::subrole()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::roleDescription()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::computedRoleString()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::title()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::description()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::orientation() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementWin::isAtomicLiveRegion() const
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::liveRegionRelevant() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::liveRegionStatus() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::stringValue()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::language()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::helpText() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+double AccessibilityUIElementWin::pageX()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::x()
+double AccessibilityUIElementWin::pageY()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::y()
+double AccessibilityUIElementWin::x()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::width()
+double AccessibilityUIElementWin::y()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::height()
+double AccessibilityUIElementWin::width()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::clickPointX()
+double AccessibilityUIElementWin::height()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::clickPointY()
+double AccessibilityUIElementWin::clickPointX()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::intValue() const
+double AccessibilityUIElementWin::clickPointY()
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::minValue()
+double AccessibilityUIElementWin::intValue() const
 {
     notImplemented();
     return 0;
 }
 
-double AccessibilityUIElement::maxValue()
+double AccessibilityUIElementWin::minValue()
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::valueDescription()
-{
-    notImplemented();
-    return nullptr;
-}
-
-int AccessibilityUIElement::insertionPointLineNumber()
+double AccessibilityUIElementWin::maxValue()
 {
     notImplemented();
     return 0;
 }
 
-bool AccessibilityUIElement::isPressActionSupported()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::valueDescription()
 {
     notImplemented();
-    return false;
+    return nullptr;
 }
 
-bool AccessibilityUIElement::isIncrementActionSupported()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isDecrementActionSupported()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isBusy() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isEnabled()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isRequired() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isFocused() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSelected() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSelectedOptionActive() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isExpanded() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isChecked() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isIndeterminate() const
-{
-    notImplemented();
-    return false;
-}
-
-int AccessibilityUIElement::hierarchicalLevel() const
+int AccessibilityUIElementWin::insertionPointLineNumber()
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::speakAs()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::isGrabbed() const
+bool AccessibilityUIElementWin::isPressActionSupported()
 {
     notImplemented();
     return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::ariaDropEffects() const
+bool AccessibilityUIElementWin::isIncrementActionSupported()
 {
     notImplemented();
-    return nullptr;
+    return false;
 }
 
-int AccessibilityUIElement::lineForIndex(int)
+bool AccessibilityUIElementWin::isDecrementActionSupported()
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isBusy() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isEnabled()
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isRequired() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isFocused() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isSelected() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isSelectedOptionActive() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isExpanded() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isChecked() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isIndeterminate() const
+{
+    notImplemented();
+    return false;
+}
+
+int AccessibilityUIElementWin::hierarchicalLevel() const
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForLine(int)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::speakAs()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rangeForPosition(int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::boundsForRange(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForRange(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForRange(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::attributedStringRangeIsMisspelled(unsigned, unsigned)
+bool AccessibilityUIElementWin::isGrabbed() const
 {
     notImplemented();
     return false;
 }
 
-unsigned AccessibilityUIElement::uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::ariaDropEffects() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+int AccessibilityUIElementWin::lineForIndex(int)
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::rangeForLine(int)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::selectTextWithCriteria(JSContextRef, JSStringRef, JSValueRef, JSStringRef, JSStringRef)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::rangeForPosition(int, int)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumnHeaders()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::boundsForRange(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRowHeaders()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::stringForRange(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfColumns()
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributedStringForRange(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfRows()
+bool AccessibilityUIElementWin::attributedStringRangeIsMisspelled(unsigned, unsigned)
 {
     notImplemented();
-    return nullptr;
+    return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfVisibleCells()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributesOfHeader()
-{
-    notImplemented();
-    return nullptr;
-}
-
-int AccessibilityUIElement::rowCount()
+unsigned AccessibilityUIElementWin::uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
 {
     notImplemented();
     return 0;
 }
 
-int AccessibilityUIElement::columnCount()
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::selectTextWithCriteria(JSContextRef, JSStringRef, JSValueRef, JSStringRef, JSStringRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfColumnHeaders()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfRowHeaders()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfColumns()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfRows()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfVisibleCells()
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributesOfHeader()
+{
+    notImplemented();
+    return nullptr;
+}
+
+int AccessibilityUIElementWin::rowCount()
 {
     notImplemented();
     return 0;
 }
 
-int AccessibilityUIElement::indexInTable()
+int AccessibilityUIElementWin::columnCount()
 {
     notImplemented();
     return 0;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rowIndexRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::columnIndexRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::cellForColumnAndRow(unsigned, unsigned)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::horizontalScrollbar() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::verticalScrollbar() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::selectedTextRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::intersectionWithSelectionRange()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::setSelectedTextRange(unsigned, unsigned)
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::textInputMarkedRange() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-void AccessibilityUIElement::increment()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::decrement()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::showMenu()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::press()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::setSelectedChild(AccessibilityUIElement* element) const
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::setSelectedChildAtIndex(unsigned index) const
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::removeSelectionAtIndex(unsigned index) const
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::clearSelectedChildren() const
-{
-    notImplemented();
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::accessibilityValue() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::addNotificationListener(JSContextRef, JSValueRef functionCallback)
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::removeNotificationListener()
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isFocusable() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSelectable() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isMultiSelectable() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isVisible() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isOffScreen() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isCollapsed() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isIgnored() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isSingleLine() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::isMultiLine() const
-{
-    notImplemented();
-    return false;
-}
-
-bool AccessibilityUIElement::hasPopup() const
-{
-    notImplemented();
-    return false;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::popupValue() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-void AccessibilityUIElement::takeFocus()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::takeSelection()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::addSelection()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::removeSelection()
-{
-    notImplemented();
-}
-
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForElement(AccessibilityUIElement*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-int AccessibilityUIElement::textMarkerRangeLength(AccessibilityTextMarkerRange*)
+int AccessibilityUIElementWin::indexInTable()
 {
     notImplemented();
     return 0;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::previousTextMarker(AccessibilityTextMarker*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::rowIndexRange()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::nextTextMarker(AccessibilityTextMarker*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::columnIndexRange()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::cellForColumnAndRow(unsigned, unsigned)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::stringForTextMarkerRange(AccessibilityTextMarkerRange*)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::horizontalScrollbar() const
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*)
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::verticalScrollbar() const
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::selectedTextRange()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::intersectionWithSelectionRange()
 {
     notImplemented();
     return nullptr;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarkerForBounds(int, int, int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarkerForBounds(int, int, int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForPoint(int, int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityUIElement> AccessibilityUIElement::accessibilityElementForTextMarker(AccessibilityTextMarker*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*)
+bool AccessibilityUIElementWin::setSelectedTextRange(unsigned, unsigned)
 {
     notImplemented();
     return false;
 }
 
-int AccessibilityUIElement::indexForTextMarker(AccessibilityTextMarker*)
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::textInputMarkedRange() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+void AccessibilityUIElementWin::increment()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::decrement()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::showMenu()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::press()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::setSelectedChild(AccessibilityUIElement* element) const
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::setSelectedChildAtIndex(unsigned index) const
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::removeSelectionAtIndex(unsigned index) const
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::clearSelectedChildren() const
+{
+    notImplemented();
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::accessibilityValue() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::url()
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementWin::addNotificationListener(JSContextRef, JSValueRef functionCallback)
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::removeNotificationListener()
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isFocusable() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isSelectable() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isMultiSelectable() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isVisible() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isOffScreen() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isCollapsed() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isIgnored() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isSingleLine() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isMultiLine() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::hasPopup() const
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::popupValue() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+void AccessibilityUIElementWin::takeFocus()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::takeSelection()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::addSelection()
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::removeSelection()
+{
+    notImplemented();
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementWin::lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementWin::textMarkerRangeForElement(AccessibilityUIElement*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+int AccessibilityUIElementWin::textMarkerRangeLength(AccessibilityTextMarkerRange*)
 {
     notImplemented();
     return 0;
 }
 
-bool AccessibilityUIElement::isTextMarkerValid(AccessibilityTextMarker*)
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::previousTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::nextTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::stringForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementWin::textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::endTextMarkerForBounds(int, int, int, int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::startTextMarkerForBounds(int, int, int, int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::textMarkerForPoint(int, int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::accessibilityElementForTextMarker(AccessibilityTextMarker*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool)
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementWin::attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*)
 {
     notImplemented();
     return false;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::textMarkerForIndex(int)
+int AccessibilityUIElementWin::indexForTextMarker(AccessibilityTextMarker*)
 {
     notImplemented();
-    return nullptr;
+    return 0;
 }
 
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::startTextMarker()
-{
-    notImplemented();
-    return nullptr;
-}
-
-RefPtr<AccessibilityTextMarker> AccessibilityUIElement::endTextMarker()
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::setSelectedTextMarkerRange(AccessibilityTextMarkerRange*)
+bool AccessibilityUIElementWin::isTextMarkerValid(AccessibilityTextMarker*)
 {
     notImplemented();
     return false;
 }
 
-void AccessibilityUIElement::scrollToMakeVisible()
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::scrollToGlobalPoint(int, int)
-{
-    notImplemented();
-}
-
-void AccessibilityUIElement::scrollToMakeVisibleWithSubFocus(int, int, int, int)
-{
-    notImplemented();
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::supportedActions() const
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::textMarkerForIndex(int)
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::pathDescription() const
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::startTextMarker()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPostscriptsDescription() const
+RefPtr<AccessibilityTextMarker> AccessibilityUIElementWin::endTextMarker()
 {
     notImplemented();
     return nullptr;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::mathPrescriptsDescription() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::classList() const
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::characterAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::wordAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::lineAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-JSRetainPtr<JSStringRef> AccessibilityUIElement::sentenceAtOffset(int)
-{
-    notImplemented();
-    return nullptr;
-}
-
-bool AccessibilityUIElement::replaceTextInRange(JSStringRef, int, int)
+bool AccessibilityUIElementWin::setSelectedTextMarkerRange(AccessibilityTextMarkerRange*)
 {
     notImplemented();
     return false;
 }
 
-bool AccessibilityUIElement::insertText(JSStringRef)
+void AccessibilityUIElementWin::scrollToMakeVisible()
 {
     notImplemented();
-    return false;
 }
 
-JSRetainPtr<JSStringRef> AccessibilityUIElement::domIdentifier() const
+void AccessibilityUIElementWin::scrollToGlobalPoint(int, int)
+{
+    notImplemented();
+}
+
+void AccessibilityUIElementWin::scrollToMakeVisibleWithSubFocus(int, int, int, int)
+{
+    notImplemented();
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::supportedActions() const
 {
     notImplemented();
     return nullptr;
 }
 
-bool AccessibilityUIElement::isInsertion() const
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::pathDescription() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::mathPostscriptsDescription() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::mathPrescriptsDescription() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::classList() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::characterAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::wordAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::lineAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::sentenceAtOffset(int)
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementWin::replaceTextInRange(JSStringRef, int, int)
 {
     notImplemented();
     return false;
 }
 
-bool AccessibilityUIElement::isDeletion() const
+bool AccessibilityUIElementWin::insertText(JSStringRef)
+{
+    notImplemented();
+    return false;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementWin::domIdentifier() const
+{
+    notImplemented();
+    return nullptr;
+}
+
+bool AccessibilityUIElementWin::isInsertion() const
+{
+    notImplemented();
+    return false;
+}
+
+bool AccessibilityUIElementWin::isDeletion() const
 {
     notImplemented();
     return false;
 }
 
 
-bool AccessibilityUIElement::isFirstItemInSuggestion() const
+bool AccessibilityUIElementWin::isFirstItemInSuggestion() const
 {
     notImplemented();
     return false;
 }
 
 
-bool AccessibilityUIElement::isLastItemInSuggestion() const
+bool AccessibilityUIElementWin::isLastItemInSuggestion() const
 {
     notImplemented();
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.h
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2018 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(WIN)
+
+#include "AccessibilityUIElement.h"
+
+namespace WTR {
+
+// Windows implementation of AccessibilityUIElement
+class AccessibilityUIElementWin final : public AccessibilityUIElement {
+public:
+    static Ref<AccessibilityUIElementWin> create(PlatformUIElement);
+    static Ref<AccessibilityUIElementWin> create(const AccessibilityUIElementWin&);
+
+    virtual ~AccessibilityUIElementWin();
+
+    PlatformUIElement platformUIElement() override { return m_element; }
+
+    bool isEqual(AccessibilityUIElement* otherElement) override;
+    JSRetainPtr<JSStringRef> domIdentifier() const override;
+
+    RefPtr<AccessibilityUIElement> elementAtPoint(int x, int y) override;
+    unsigned indexOfChild(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+    unsigned childrenCount() override;
+    RefPtr<AccessibilityUIElement> titleUIElement() override;
+    RefPtr<AccessibilityUIElement> parentElement() override;
+
+    void takeFocus() override;
+    void takeSelection() override;
+    void addSelection() override;
+    void removeSelection() override;
+
+    JSRetainPtr<JSStringRef> allAttributes() override;
+    JSRetainPtr<JSStringRef> attributesOfLinkedUIElements() override;
+    RefPtr<AccessibilityUIElement> linkedUIElementAtIndex(unsigned) override;
+
+    JSRetainPtr<JSStringRef> attributesOfDocumentLinks() override;
+    JSRetainPtr<JSStringRef> attributesOfChildren() override;
+    JSRetainPtr<JSStringRef> parameterizedAttributeNames() override;
+    void increment() override;
+    void decrement() override;
+    void showMenu() override;
+    void press() override;
+
+    JSRetainPtr<JSStringRef> stringDescriptionOfAttributeValue(JSStringRef attribute) override;
+    JSRetainPtr<JSStringRef> stringAttributeValue(JSStringRef attribute) override;
+    double numberAttributeValue(JSStringRef attribute) override;
+    JSValueRef uiElementArrayAttributeValue(JSContextRef, JSStringRef attribute) override;
+    RefPtr<AccessibilityUIElement> uiElementAttributeValue(JSStringRef attribute) const override;
+    bool boolAttributeValue(JSStringRef attribute) override;
+    bool isAttributeSupported(JSStringRef attribute) override;
+    bool isAttributeSettable(JSStringRef attribute) override;
+    bool isPressActionSupported() override;
+    bool isIncrementActionSupported() override;
+    bool isDecrementActionSupported() override;
+    JSRetainPtr<JSStringRef> role() override;
+    JSRetainPtr<JSStringRef> subrole() override;
+    JSRetainPtr<JSStringRef> roleDescription() override;
+    JSRetainPtr<JSStringRef> computedRoleString() override;
+    JSRetainPtr<JSStringRef> title() override;
+    JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> language() override;
+    JSRetainPtr<JSStringRef> stringValue() override;
+    JSRetainPtr<JSStringRef> accessibilityValue() const override;
+    JSRetainPtr<JSStringRef> helpText() const override;
+    JSRetainPtr<JSStringRef> orientation() const override;
+    JSRetainPtr<JSStringRef> liveRegionRelevant() const override;
+    JSRetainPtr<JSStringRef> liveRegionStatus() const override;
+    double x() override;
+    double y() override;
+    double width() override;
+    double height() override;
+    double pageX() override;
+    double pageY() override;
+    double clickPointX() override;
+    double clickPointY() override;
+
+    double intValue() const override;
+    double minValue() override;
+    double maxValue() override;
+    JSRetainPtr<JSStringRef> valueDescription() override;
+    int insertionPointLineNumber() override;
+    JSRetainPtr<JSStringRef> selectedTextRange() override;
+    JSRetainPtr<JSStringRef> intersectionWithSelectionRange() override;
+    JSRetainPtr<JSStringRef> textInputMarkedRange() const override;
+    bool isAtomicLiveRegion() const override;
+    bool isBusy() const override;
+    bool isEnabled() override;
+    bool isRequired() const override;
+
+    bool isFocused() const override;
+    bool isFocusable() const override;
+    bool isSelected() const override;
+    bool isSelectedOptionActive() const override;
+    bool isSelectable() const override;
+    bool isMultiSelectable() const override;
+    void setSelectedChild(AccessibilityUIElement*) const override;
+    void setSelectedChildAtIndex(unsigned) const override;
+    void removeSelectionAtIndex(unsigned) const override;
+    void clearSelectedChildren() const override;
+    unsigned selectedChildrenCount() const override;
+    RefPtr<AccessibilityUIElement> selectedChildAtIndex(unsigned) const override;
+
+    bool isValid() const override;
+    bool isExpanded() const override;
+    bool isChecked() const override;
+    JSRetainPtr<JSStringRef> currentStateValue() const override;
+    JSRetainPtr<JSStringRef> sortDirection() const override;
+    bool isIndeterminate() const override;
+    bool isVisible() const override;
+    bool isOffScreen() const override;
+    bool isCollapsed() const override;
+    bool isIgnored() const override;
+    bool isSingleLine() const override;
+    bool isMultiLine() const override;
+    bool hasPopup() const override;
+    JSRetainPtr<JSStringRef> popupValue() const override;
+    int hierarchicalLevel() const override;
+    JSRetainPtr<JSStringRef> url() override;
+    JSRetainPtr<JSStringRef> classList() const override;
+
+    JSRetainPtr<JSStringRef> speakAs() override;
+
+    JSRetainPtr<JSStringRef> attributesOfColumnHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfRowHeaders() override;
+    JSRetainPtr<JSStringRef> attributesOfColumns() override;
+    JSRetainPtr<JSStringRef> attributesOfRows() override;
+    JSRetainPtr<JSStringRef> attributesOfVisibleCells() override;
+    JSRetainPtr<JSStringRef> attributesOfHeader() override;
+    int indexInTable() override;
+    JSRetainPtr<JSStringRef> rowIndexRange() override;
+    JSRetainPtr<JSStringRef> columnIndexRange() override;
+    int rowCount() override;
+    int columnCount() override;
+    JSValueRef rowHeaders(JSContextRef) override;
+    JSValueRef columnHeaders(JSContextRef) override;
+    JSValueRef selectedCells(JSContextRef) override;
+
+    RefPtr<AccessibilityUIElement> selectedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> disclosedByRow() override;
+    RefPtr<AccessibilityUIElement> disclosedRowAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> rowAtIndex(unsigned) override;
+
+    RefPtr<AccessibilityUIElement> ariaControlsElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaFlowToElementAtIndex(unsigned) override;
+    RefPtr<AccessibilityUIElement> ariaOwnsElementAtIndex(unsigned) override;
+
+    bool isGrabbed() const override;
+    JSRetainPtr<JSStringRef> ariaDropEffects() const override;
+
+    int lineForIndex(int) override;
+    JSRetainPtr<JSStringRef> rangeForLine(int) override;
+    JSRetainPtr<JSStringRef> rangeForPosition(int x, int y) override;
+    JSRetainPtr<JSStringRef> boundsForRange(unsigned location, unsigned length) override;
+    bool setSelectedTextRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> stringForRange(unsigned location, unsigned length) override;
+    JSRetainPtr<JSStringRef> attributedStringForRange(unsigned location, unsigned length) override;
+    bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
+    unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
+
+    RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row) override;
+
+    RefPtr<AccessibilityUIElement> horizontalScrollbar() const override;
+    RefPtr<AccessibilityUIElement> verticalScrollbar() const override;
+
+    void scrollToMakeVisible() override;
+    void scrollToGlobalPoint(int x, int y) override;
+    void scrollToMakeVisibleWithSubFocus(int x, int y, int width, int height) override;
+
+    RefPtr<AccessibilityTextMarker> textMarkerForPoint(int x, int y) override;
+    RefPtr<AccessibilityTextMarker> textMarkerForIndex(int) override;
+    RefPtr<AccessibilityTextMarker> startTextMarker() override;
+    RefPtr<AccessibilityTextMarker> endTextMarker() override;
+    bool setSelectedTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*) override;
+    RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    RefPtr<AccessibilityTextMarker> endTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> startTextMarkerForBounds(int x, int y, int width, int height) override;
+    RefPtr<AccessibilityTextMarker> previousTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarker> nextTextMarker(AccessibilityTextMarker*) override;
+    JSRetainPtr<JSStringRef> stringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithOptions(AccessibilityTextMarkerRange*, bool) override;
+    JSRetainPtr<JSStringRef> attributedStringForTextMarkerRangeWithDidSpellCheck(AccessibilityTextMarkerRange*) override;
+    int textMarkerRangeLength(AccessibilityTextMarkerRange*) override;
+    bool attributedStringForTextMarkerRangeContainsAttribute(JSStringRef, AccessibilityTextMarkerRange*) override;
+    int indexForTextMarker(AccessibilityTextMarker*) override;
+    bool isTextMarkerValid(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> lineTextMarkerRangeForTextMarker(AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*) override;
+
+    JSRetainPtr<JSStringRef> supportedActions() const override;
+    JSRetainPtr<JSStringRef> mathPostscriptsDescription() const override;
+    JSRetainPtr<JSStringRef> mathPrescriptsDescription() const override;
+
+    JSRetainPtr<JSStringRef> pathDescription() const override;
+
+    bool addNotificationListener(JSContextRef, JSValueRef functionCallback) override;
+    bool removeNotificationListener() override;
+
+    bool isInsertion() const override;
+    bool isDeletion() const override;
+    bool isFirstItemInSuggestion() const override;
+    bool isLastItemInSuggestion() const override;
+
+    bool replaceTextInRange(JSStringRef, int position, int length) override;
+    bool insertText(JSStringRef) override;
+
+    JSRetainPtr<JSStringRef> characterAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> wordAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> lineAtOffset(int offset) override;
+    JSRetainPtr<JSStringRef> sentenceAtOffset(int offset) override;
+
+private:
+    AccessibilityUIElementWin(PlatformUIElement);
+    AccessibilityUIElementWin(const AccessibilityUIElementWin&);
+
+    Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
+    Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
+
+    PlatformUIElement m_element;
+};
+
+} // namespace WTR
+
+#endif // PLATFORM(WIN)


### PR DESCRIPTION
#### 000c765e2e26a086d729bf2d6842ee5d8161e579
<pre>
AX: Split InjectedBundle/AccessibilityUIElement into subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=306085">https://bugs.webkit.org/show_bug.cgi?id=306085</a>
<a href="https://rdar.apple.com/168724525">rdar://168724525</a>

Reviewed by Tyler Wilcock.

I&apos;d like to experiment with the idea of letting some layout tests opt
into a different subclass of InjectedBundle/AccessibilityUIElement,
for better site isolation tests.

To do this cleanly, this change first refactors the different platform
implementations of AccessibilityUIElement into subclasses rather than
different implementations of the same header.

It also reduces the number of platform-specific guards, which I think helps readability.

* Tools/TestRunnerShared/Bindings/JSWrapper.cpp:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h: Added.
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h: Added.
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h: Copied from Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp:
* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.h: Added.
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp:
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.h: Added.

Canonical link: <a href="https://commits.webkit.org/306205@main">https://commits.webkit.org/306205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c865e59b4ef90eea117f82e53587941b25494c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148966 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107826 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78286 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10212 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7763 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9059 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151589 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29626 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12326 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67793 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12738 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1955 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->