### PR TITLE
Fix transform attribute reappearing after explicit removal

### DIFF
--- a/LayoutTests/svg/transforms/empty-transform-list-attribute-removal-expected.txt
+++ b/LayoutTests/svg/transforms/empty-transform-list-attribute-removal-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Transform attribute should remain removed after emptying list via removeItem()
+PASS Transform attribute should remain removed after emptying list iteratively
+PASS Transform attribute should serialize to empty string when list is emptied without removal
+PASS Transform attribute removal should work on dynamically created elements
+

--- a/LayoutTests/svg/transforms/empty-transform-list-attribute-removal.html
+++ b/LayoutTests/svg/transforms/empty-transform-list-attribute-removal.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>SVG transform attribute synchronization with empty lists</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<svg>
+  <rect id="rect1" transform="matrix(1,0,0,1,0,0)"/>
+  <rect id="rect2" transform="translate(10, 20)"/>
+  <rect id="rect3" transform="rotate(45)"/>
+</svg>
+<script>
+test(function() {
+  var elem = document.getElementById('rect1');
+  
+  // Empty the transform list by removing its only item
+  elem.transform.baseVal.removeItem(0);
+  
+  // Explicitly delete the transform attribute
+  elem.removeAttribute('transform');
+  
+  // The attribute should not exist
+  assert_equals(elem.getAttribute('transform'), null, 
+    'Transform attribute should be null after removal');
+  
+}, 'Transform attribute should remain removed after emptying list via removeItem()');
+
+test(function() {
+  var elem = document.getElementById('rect2');
+  
+  // Empty the transform list completely
+  while (elem.transform.baseVal.numberOfItems > 0) {
+    elem.transform.baseVal.removeItem(0);
+  }
+  
+  // Explicitly delete the transform attribute
+  elem.removeAttribute('transform');
+  
+  // The attribute should not exist
+  assert_equals(elem.getAttribute('transform'), null,
+    'Transform attribute should be null after removal');
+    
+}, 'Transform attribute should remain removed after emptying list iteratively');
+
+test(function() {
+  var elem = document.getElementById('rect3');
+  
+  // Empty the transform list WITHOUT removing the attribute
+  elem.transform.baseVal.removeItem(0);
+  
+  // The attribute should still exist but be empty
+  assert_equals(elem.getAttribute('transform'), '',
+    'Transform attribute should be empty string when list is emptied but attribute not removed');
+    
+}, 'Transform attribute should serialize to empty string when list is emptied without removal');
+
+test(function() {
+  var elem = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  elem.setAttribute('transform', 'scale(2)');
+  document.querySelector('svg').appendChild(elem);
+  
+  // Remove the only transform
+  elem.transform.baseVal.removeItem(0);
+  
+  // Delete the attribute
+  elem.removeAttribute('transform');
+  
+  // Verify attribute is gone
+  assert_equals(elem.getAttribute('transform'), null,
+    'Transform attribute should be null after removal on dynamically created element');
+    
+}, 'Transform attribute removal should work on dynamically created elements');
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -562,8 +562,15 @@ void SVGElement::attributeChanged(const QualifiedName& name, const AtomString& o
 void SVGElement::synchronizeAttribute(const QualifiedName& name)
 {
     // If the value of the property has changed, serialize the new value to the attribute.
-    if (auto value = propertyRegistry().synchronize(name))
+    if (auto value = propertyRegistry().synchronize(name)) {
+        // If the serialized value is empty and the attribute doesn't exist,
+        // don't recreate it. This handles the case where the attribute was
+        // explicitly removed after the list was emptied.
+        if (value->isEmpty() && !hasAttribute(name))
+            return;
+
         setSynchronizedLazyAttribute(name, AtomString { *value });
+    }
 }
 
 void SVGElement::synchronizeAllAttributes()


### PR DESCRIPTION
#### 2867fa859ff6be800a78a5db2a63c4cce8d38d20
<pre>
Fix transform attribute reappearing after explicit removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=263712">https://bugs.webkit.org/show_bug.cgi?id=263712</a>
<a href="https://rdar.apple.com/117840533">rdar://117840533</a>

Reviewed by Nikolas Zimmermann.

When an SVGTransformList is emptied via removeItem() and then the transform
attribute is explicitly removed, the attribute would incorrectly reappear
when queried in WebKit.

The bug occurred because synchronizeAttribute() would re-serialize the empty
transform list as an empty string attribute, recreating the attribute that
was just removed.

Fix by checking if the attribute exists before serializing an empty value.
If the list is empty and the attribute was explicitly removed, don&apos;t recreate
it. If the list is empty but the attribute still exists, serialize it to an
empty string to maintain proper synchronization.

Test: svg/transforms/empty-transform-list-attribute-removal.html

* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::synchronizeAttribute):
* LayoutTests/svg/transforms/empty-transform-list-attribute-removal.html: Added.
* LayoutTests/svg/transforms/empty-transform-list-attribute-removal-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/306162@main">https://commits.webkit.org/306162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216209bf14cf780243b99ff48ff4cd5a82550200

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29599 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->