### PR TITLE
[CMake] Change FindATSPI.cmake to use an imported target

### DIFF
--- a/Source/cmake/FindATSPI.cmake
+++ b/Source/cmake/FindATSPI.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Igalia S.L.
+# Copyright (c) 2013, 2026 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -23,29 +23,46 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-#
-# Try to find AT-SPI include and library directories.
-#
-# After successful discovery, this will set for inclusion where needed:
-# ATSPI_INCLUDE_DIRS - containg the AT-SPI headers
-# ATSPI_LIBRARIES - containg the AT-SPI library
+
+#[=======================================================================[.rst:
+FindATSPI
+---------
+
+Find the AT-SPI headers and library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``ATSPI::ATSPI``
+The AT-SPI library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``ATSPI_FOUND``
+  true if (the requested version of) the AT-SPI library is available.
+``ATSPI_VERSION``
+  the version of the AT-SPI library.
+
+#]=======================================================================]
+
+if (DEFINED ATSPI_FIND_VERSION)
+    set(ATSPI_PKG_CONFIG_SPEC "atspi-2>=${ATSPI_FIND_VERSION}")
+else ()
+    set(ATSPI_PKG_CONFIG_SPEC "atspi-2")
+endif ()
 
 find_package(PkgConfig QUIET)
+pkg_check_modules(ATSPI QUIET IMPORTED_TARGET "${ATSPI_PKG_CONFIG_SPEC}")
 
-pkg_check_modules(ATSPI atspi-2)
-
-set(VERSION_OK TRUE)
-if (ATSPI_VERSION)
-    if (ATSPI_FIND_VERSION_EXACT)
-        if (NOT("${ATSPI_FIND_VERSION}" VERSION_EQUAL "${ATSPI_VERSION}"))
-            set(VERSION_OK FALSE)
-        endif ()
-    else ()
-        if ("${ATSPI_VERSION}" VERSION_LESS "${ATSPI_FIND_VERSION}")
-            set(VERSION_OK FALSE)
-        endif ()
-    endif ()
+if (TARGET PkgConfig::ATSPI AND NOT TARGET ATSPI::ATSPI)
+    add_library(ATSPI::ATSPI INTERFACE IMPORTED GLOBAL)
+    set_property(TARGET ATSPI::ATSPI PROPERTY
+        INTERFACE_LINK_LIBRARIES PkgConfig::ATSPI
+    )
 endif ()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(ATSPI DEFAULT_MSG ATSPI_INCLUDE_DIRS ATSPI_LIBRARIES VERSION_OK)
+find_package_handle_standard_args(ATSPI
+    REQUIRED_VARS ATSPI_VERSION
+)

--- a/Tools/TestWebKitAPI/glib/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/glib/PlatformGTK.cmake
@@ -19,12 +19,8 @@ list(APPEND WebKitGLibAPITests_INCLUDE_DIRECTORIES
     ${WebKitGTK_FRAMEWORK_HEADERS_DIR}/webkitgtk-web-process-extension
 )
 
-list(APPEND WebKitGLibAPITests_SYSTEM_INCLUDE_DIRECTORIES
-    ${ATSPI_INCLUDE_DIRS}
-)
-
 list(APPEND WebKitGLibAPITest_LIBRARIES
-    ${ATSPI_LIBRARIES}
+    ATSPI::ATSPI
     GTK::GTK
 )
 


### PR DESCRIPTION
#### 04932911e423bbcaa5d9e067f0c9964d073bb16d
<pre>
[CMake] Change FindATSPI.cmake to use an imported target
<a href="https://bugs.webkit.org/show_bug.cgi?id=306097">https://bugs.webkit.org/show_bug.cgi?id=306097</a>

Reviewed by Carlos Alberto Lopez Perez.

Change the FindATSPI.cmake module to define an ATSPI::ATSPI imported
target, and make use of it. Provided this is used only by the GTK port
and therefore pkg-config is assumed to be available, use the simpler
approach that requests an imported target from pkg_check_modules() and
chain into it.

* Source/cmake/FindATSPI.cmake:
* Tools/TestWebKitAPI/glib/PlatformGTK.cmake:

Canonical link: <a href="https://commits.webkit.org/306144@main">https://commits.webkit.org/306144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b24e9e66a0e8788861e8cf6e215e3d5e343949aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142162 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107551 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78124 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88429 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9925 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7465 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8722 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132262 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151233 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1085 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12358 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115836 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10576 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116173 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11215 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122074 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67371 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21677 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12399 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1534 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171562 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12140 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44520 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12184 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->