### PR TITLE
[macOS] Scroll bars of root scroller may be cutoff due to corner radii of window

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1899,6 +1899,11 @@
 #define HAVE_IMMERSIVE_VIDEO_METADATA_SUPPORT 1
 #endif
 
+#if !defined(HAVE_NSVIEW_CORNER_CONFIGURATION) \
+    && (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260100)
+#define HAVE_NSVIEW_CORNER_CONFIGURATION 1
+#endif
+
 #if !defined(HAVE_LIBPROC) \
     && __has_include(<libproc.h>)
 #define HAVE_LIBPROC 1

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -23,6 +23,7 @@
 
 #include <WebCore/AutoplayEvent.h>
 #include <WebCore/ContactInfo.h>
+#include <WebCore/CornerRadii.h>
 #include <WebCore/DatabaseDetails.h>
 #include <WebCore/DeviceOrientationOrMotionPermissionState.h>
 #include <WebCore/DisabledAdaptations.h>
@@ -325,6 +326,8 @@ public:
 
     virtual void scrollContainingScrollViewsToRevealRect(const IntRect&) const { }; // Currently only Mac has a non empty implementation.
     virtual void scrollMainFrameToRevealRect(const IntRect&) const { };
+
+    virtual CornerRadii scrollbarAvoidanceCornerRadii() const { return { }; }
 
     virtual bool shouldUnavailablePluginMessageBeButton(PluginUnavailabilityReason) const { return false; }
     virtual void unavailablePluginButtonClicked(Element&, PluginUnavailabilityReason) const { }

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -79,6 +79,18 @@ FloatBoxExtent FrameView::obscuredContentInsets(InsetType type) const
     return { };
 }
 
+CornerRadii FrameView::scrollbarAvoidanceCornerRadii() const
+{
+    Ref frame = this->frame();
+    if (!frame->isMainFrame())
+        return { };
+
+    if (RefPtr page = frame->page())
+        return page->chrome().client().scrollbarAvoidanceCornerRadii();
+
+    return { };
+}
+
 float FrameView::visibleContentScaleFactor() const
 {
     Ref frame = this->frame();

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -47,6 +47,7 @@ public:
     WEBCORE_EXPORT int footerHeight() const final;
 
     WEBCORE_EXPORT FloatBoxExtent obscuredContentInsets(InsetType = InsetType::WebCoreInset) const final;
+    CornerRadii scrollbarAvoidanceCornerRadii() const override;
 
     float visibleContentScaleFactor() const final;
 

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -27,6 +27,7 @@
 #include "ScrollView.h"
 
 #include "AccessibilityRegionContext.h"
+#include "CornerRadii.h"
 #include "FloatQuad.h"
 #include "GraphicsContext.h"
 #include "GraphicsLayer.h"
@@ -341,6 +342,11 @@ IntRect ScrollView::frameRectShrunkByInset() const
     FloatRect rect = frameRect();
     rect.contract(obscuredContentInsets());
     return roundedIntRect(rect);
+}
+
+CornerRadii ScrollView::scrollbarAvoidanceCornerRadii() const
+{
+    return { };
 }
 
 IntSize ScrollView::layoutSize() const
@@ -744,18 +750,34 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
 
     SetForScope inUpdateScrollbarsScope(m_inUpdateScrollbars, true, false);
 
+    auto needsLayersRepositioned = false;
     auto contentInsets = this->obscuredContentInsets();
+    auto cornerRadii = this->scrollbarAvoidanceCornerRadii();
+
     if (m_horizontalScrollbar) {
         int clientWidth = visibleWidth();
         IntRect oldRect(m_horizontalScrollbar->frameRect());
+
+        auto scrollerHalfHeight = m_horizontalScrollbar->height() / 2.f;
+        auto leftOffset = std::max(0.f, cornerRadii.bottomLeft().width() - scrollerHalfHeight);
+        auto rightOffset = std::max(0.f, cornerRadii.bottomRight().width() - scrollerHalfHeight);
+
+        leftOffset = std::max(leftOffset, contentInsets.left());
+        rightOffset = std::max(rightOffset, contentInsets.right());
+
+        auto horizontalOffset = leftOffset + (shouldPlaceVerticalScrollbarOnLeft() && m_verticalScrollbar ? m_verticalScrollbar->occupiedWidth() : 0.f);
+        auto barWidth = width() - (m_verticalScrollbar ? m_verticalScrollbar->occupiedWidth() : 0.f) - leftOffset - rightOffset;
+
         m_horizontalScrollbar->setFrameRect(roundedIntRect({
-            contentInsets.left() + (shouldPlaceVerticalScrollbarOnLeft() && m_verticalScrollbar ? m_verticalScrollbar->occupiedWidth() : 0.f),
+            horizontalOffset,
             static_cast<float>(height() - m_horizontalScrollbar->height()),
-            width() - (m_verticalScrollbar ? m_verticalScrollbar->occupiedWidth() : 0.f) - contentInsets.left() - contentInsets.right(),
+            barWidth,
             static_cast<float>(m_horizontalScrollbar->height())
         }));
-        if (!m_scrollbarsSuppressed && oldRect != m_horizontalScrollbar->frameRect())
+        if (!m_scrollbarsSuppressed && oldRect != m_horizontalScrollbar->frameRect()) {
             m_horizontalScrollbar->invalidate();
+            needsLayersRepositioned = true;
+        }
 
         if (m_scrollbarsSuppressed)
             m_horizontalScrollbar->setSuppressInvalidation(true);
@@ -768,14 +790,31 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
     if (m_verticalScrollbar) {
         int clientHeight = visibleHeight();
         IntRect oldRect(m_verticalScrollbar->frameRect());
+
+        auto scrollerHalfWidth = m_verticalScrollbar->width() / 2.f;
+        bool isRTL = shouldPlaceVerticalScrollbarOnLeft();
+
+        auto upperCornerRadius = isRTL ? cornerRadii.topLeft().height() : cornerRadii.topRight().height();
+        auto lowerCornerRadius = isRTL ? cornerRadii.bottomLeft().height() : cornerRadii.bottomRight().height();
+
+        auto topOffset = std::max(0.f, upperCornerRadius - scrollerHalfWidth);
+        auto bottomOffset = std::max(0.f, lowerCornerRadius - scrollerHalfWidth);
+
+        topOffset = std::max(topOffset, contentInsets.top());
+        bottomOffset = std::max(bottomOffset, contentInsets.bottom());
+
+        auto barHeight = height() - (m_horizontalScrollbar ? m_horizontalScrollbar->occupiedHeight() : 0) - topOffset - bottomOffset;
+
         m_verticalScrollbar->setFrameRect(roundedIntRect({
             shouldPlaceVerticalScrollbarOnLeft() ? 0.f : width() - m_verticalScrollbar->width(),
-            contentInsets.top(),
+            topOffset,
             static_cast<float>(m_verticalScrollbar->width()),
-            height() - contentInsets.top() - contentInsets.bottom() - (m_horizontalScrollbar ? m_horizontalScrollbar->occupiedHeight() : 0)
+            barHeight
         }));
-        if (!m_scrollbarsSuppressed && oldRect != m_verticalScrollbar->frameRect())
+        if (!m_scrollbarsSuppressed && oldRect != m_verticalScrollbar->frameRect()) {
             m_verticalScrollbar->invalidate();
+            needsLayersRepositioned = true;
+        }
 
         if (m_scrollbarsSuppressed)
             m_verticalScrollbar->setSuppressInvalidation(true);
@@ -786,6 +825,8 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
     }
 
     updateScrollbarSteps();
+    if (needsLayersRepositioned)
+        positionScrollbarLayers();
 
     if (hasHorizontalScrollbar != newHasHorizontalScrollbar || hasVerticalScrollbar != newHasVerticalScrollbar) {
         // FIXME: Is frameRectsChanged really necessary here? Have any frame rects changed?

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -61,6 +61,7 @@ OBJC_CLASS NSView;
 
 namespace WebCore {
 
+class CornerRadii;
 class FloatQuad;
 class HostWindow;
 class LegacyTileCache;
@@ -191,6 +192,8 @@ public:
     enum class InsetType : bool { WebCoreInset, WebCoreOrPlatformInset };
     virtual FloatBoxExtent obscuredContentInsets(InsetType = InsetType::WebCoreInset) const { return 0; }
     IntRect frameRectShrunkByInset() const;
+
+    virtual CornerRadii scrollbarAvoidanceCornerRadii() const;
 
     // The visible content rect has a location that is the scrolled offset of the document. The width and height are the unobscured viewport
     // width and height. By default the scrollbars themselves are excluded from this rectangle, but an optional boolean argument allows them
@@ -420,7 +423,7 @@ public:
     virtual void updateScrollbarSteps();
 
     // Called to update the scrollbars to accurately reflect the state of the view.
-    void updateScrollbars(const ScrollPosition& desiredPosition);
+    WEBCORE_EXPORT void updateScrollbars(const ScrollPosition& desiredPosition);
 
 protected:
     ScrollView();

--- a/Source/WebCore/platform/graphics/CornerRadii.h
+++ b/Source/WebCore/platform/graphics/CornerRadii.h
@@ -48,6 +48,14 @@ public:
     {
     }
 
+    CornerRadii(float topLeft, float topRight, float bottomLeft, float bottomRight)
+        : m_topLeft(FloatSize { topLeft, topLeft })
+        , m_topRight(FloatSize { topRight, topRight })
+        , m_bottomLeft(FloatSize { bottomLeft, bottomLeft })
+        , m_bottomRight(FloatSize { bottomRight, bottomRight })
+    {
+    }
+
     CornerRadii(const LayoutRoundedRect::Radii& intRadii)
         : m_topLeft(intRadii.topLeft())
         , m_topRight(intRadii.topRight())

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3516,6 +3516,30 @@ ExceptionOr<uint64_t> Internals::verticalScrollbarLayerID(Node* node) const
     return getLayerID(areaOrException.returnValue()->layerForVerticalScrollbar());
 }
 
+ExceptionOr<Ref<DOMRect>> Internals::horizontalScrollbarFrameRect(Node* node) const
+{
+    auto areaOrException = scrollableAreaForNode(node);
+    if (areaOrException.hasException())
+        return areaOrException.releaseException();
+
+    if (auto* scrollbar = areaOrException.returnValue()->horizontalScrollbar())
+        return DOMRect::create(scrollbar->frameRect());
+
+    return DOMRect::create();
+}
+
+ExceptionOr<Ref<DOMRect>> Internals::verticalScrollbarFrameRect(Node* node) const
+{
+    auto areaOrException = scrollableAreaForNode(node);
+    if (areaOrException.hasException())
+        return areaOrException.releaseException();
+
+    if (auto* scrollbar = areaOrException.returnValue()->verticalScrollbar())
+        return DOMRect::create(scrollbar->frameRect());
+
+    return DOMRect::create();
+}
+
 ExceptionOr<Internals::ScrollingNodeID> Internals::scrollingNodeIDForNode(Node* node)
 {
     auto areaOrException = scrollableAreaForNode(node);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -571,6 +571,8 @@ public:
 
     ExceptionOr<uint64_t> horizontalScrollbarLayerID(Node*) const;
     ExceptionOr<uint64_t> verticalScrollbarLayerID(Node*) const;
+    ExceptionOr<Ref<DOMRect>> horizontalScrollbarFrameRect(Node*) const;
+    ExceptionOr<Ref<DOMRect>> verticalScrollbarFrameRect(Node*) const;
 
     ExceptionOr<String> scrollbarsControllerTypeForNode(Node*) const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -823,7 +823,9 @@ enum ContentsFormat {
     unsigned long long layerIDForElement(Element element);
     unsigned long long horizontalScrollbarLayerID(optional Node? node = null);
     unsigned long long verticalScrollbarLayerID(optional Node? node = null);
-    
+    DOMRect horizontalScrollbarFrameRect(optional Node? node = null);
+    DOMRect verticalScrollbarFrameRect(optional Node? node = null);
+
     ScrollingNodeID scrollingNodeIDForNode(optional Node? node = null);
 
     // Flags for platformLayerTreeAsText.

--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -50,6 +50,10 @@ DECLARE_SYSTEM_HEADER
 
 #import <AppKit/NSPanGestureRecognizer_Private.h>
 
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+#import <AppKit/NSViewCornerConfiguration_Private.h>
+#endif
+
 #else
 
 @interface NSInspectorBar : NSObject
@@ -132,6 +136,35 @@ typedef NS_ENUM(NSInteger, NSScrollPocketEdge) {
 @interface NSPanGestureRecognizer (SPI)
 @property (readonly) NSTimeInterval timestamp;
 @end
+
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+
+@interface _NSCornerRadius : NSObject
+@property (class, copy, readonly) _NSCornerRadius *containerConcentricRadius;
++ (_NSCornerRadius *)fixedRadius:(CGFloat)radius;
+@end
+
+@interface NSViewCornerRadii : NSObject
+@property CGFloat topLeft;
+@property CGFloat topRight;
+@property CGFloat bottomLeft;
+@property CGFloat bottomRight;
+@property (copy) CALayerCornerCurve cornerCurve;
+@end
+
+@interface NSViewCornerConfiguration : NSObject
++ (NSViewCornerConfiguration *)configurationWithRadius:(_NSCornerRadius *)radius;
++ (instancetype)configurationWithTopLeftRadius:(nullable _NSCornerRadius *)topLeftRadius topRightRadius:(nullable _NSCornerRadius *)topRightRadius bottomLeftRadius:(nullable _NSCornerRadius *)bottomLeftRadius bottomRightRadius:(nullable _NSCornerRadius *)bottomRightRadius;
+@end
+
+@interface NSView (NSViewCornerConfiguration)
+@property (nullable, readonly) NSViewCornerRadii *_effectiveCornerRadii;
+@property (readonly, nullable, copy) NSViewCornerConfiguration *_cornerConfiguration;
+- (void)_viewDidChangeEffectiveCornerRadii;
+- (void)_invalidateCornerConfiguration;
+@end
+
+#endif
 
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -870,6 +870,15 @@ header: <WebCore/RenderStyleConstants.h>
     WebCore::FloatSize radii().bottomRight();
 }
 
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+class WebCore::CornerRadii {
+    WebCore::FloatSize topLeft();
+    WebCore::FloatSize topRight();
+    WebCore::FloatSize bottomLeft();
+    WebCore::FloatSize bottomRight();
+};
+#endif
+
 webkit_platform_headers: <WebCore/IntRect.h>
 
 [AdditionalEncoder=StreamConnectionEncoder, WebKitPlatform] class WebCore::IntRect {

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -43,6 +43,7 @@
 #include <WebCore/ActivityState.h>
 #include <WebCore/Color.h>
 #include <WebCore/ContentSecurityPolicy.h>
+#include <WebCore/CornerRadii.h>
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/FrameIdentifier.h>
@@ -324,6 +325,9 @@ struct WebPageCreationParameters {
 
 #if PLATFORM(MAC)
     double overflowHeightForTopScrollEdgeEffect { 0 };
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    WebCore::CornerRadii scrollbarAvoidanceCornerRadii;
+#endif
 #endif
 
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -240,6 +240,9 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 
 #if PLATFORM(MAC)
     double overflowHeightForTopScrollEdgeEffect;
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    WebCore::CornerRadii scrollbarAvoidanceCornerRadii;
+#endif
 #endif
 
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -33,6 +33,7 @@
 #import <WebCore/CocoaView.h>
 #import <WebCore/CocoaWritingToolsTypes.h>
 #import <WebCore/ColorCocoa.h>
+#import <WebCore/CornerRadii.h>
 #import <WebCore/FixedContainerEdges.h>
 #import <WebCore/LayerHostingContextIdentifier.h>
 #import <WebCore/TextExtractionTypes.h>
@@ -346,6 +347,9 @@ struct PerWebProcessState {
     RetainPtr<WKTextFinderClient> _textFinderClient;
 #if HAVE(NSWINDOW_SNAPSHOT_READINESS_HANDLER)
     BlockPtr<void()> _windowSnapshotReadinessHandler;
+#endif
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    WebCore::CornerRadii _lastViewCornerRadii;
 #endif
 #endif // PLATFORM(MAC)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12437,6 +12437,9 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     if (m_viewWindowCoordinates)
         parameters.viewWindowCoordinates = *m_viewWindowCoordinates;
     parameters.overflowHeightForTopScrollEdgeEffect = m_overflowHeightForTopScrollEdgeEffect;
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    parameters.scrollbarAvoidanceCornerRadii = internals().scrollbarAvoidanceCornerRadii;
+#endif
 #endif
 
 #if ENABLE(META_VIEWPORT)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -110,6 +110,7 @@ class CaptureDevice;
 class CertificateInfo;
 class Color;
 class ContentFilterUnblockHandler;
+class CornerRadii;
 class Cursor;
 class DataSegment;
 class DestinationColorSpace;
@@ -1009,6 +1010,10 @@ public:
 
     double overflowHeightForTopScrollEdgeEffect() const { return m_overflowHeightForTopScrollEdgeEffect; }
     void setOverflowHeightForTopScrollEdgeEffect(double);
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    void setScrollbarAvoidanceCornerRadii(WebCore::CornerRadii&&);
+#endif
+
 #endif // PLATFORM(MAC)
 
     // Corresponds to the web content's `<meta name="theme-color">` or application manifest's `"theme_color"`.

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -45,6 +45,7 @@
 #include "WebPopupMenuProxy.h"
 #include "WebURLSchemeHandlerIdentifier.h"
 #include "WindowKind.h"
+#include <WebCore/CornerRadii.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <WebCore/RegistrableDomain.h>
@@ -444,6 +445,10 @@ public:
     std::optional<TextManipulationParameters> textManipulationParameters;
 
     EnhancedSecurityTracking enhancedSecurityTracker;
+
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    WebCore::CornerRadii scrollbarAvoidanceCornerRadii;
+#endif
 
     explicit Internals(WebPageProxy&, std::optional<WebCore::SecurityOriginData>);
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -57,6 +57,7 @@
 #import "WebProcessProxy.h"
 #import <WebCore/AXObjectCache.h>
 #import <WebCore/AttributedString.h>
+#import <WebCore/CornerRadii.h>
 #import <WebCore/DestinationColorSpace.h>
 #import <WebCore/DictionaryLookup.h>
 #import <WebCore/DragItem.h>
@@ -1119,6 +1120,18 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
 
     return WebContentMode::Recommended;
 }
+
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+void WebPageProxy::setScrollbarAvoidanceCornerRadii(CornerRadii&& cornerRadii)
+{
+    internals().scrollbarAvoidanceCornerRadii = WTF::move(cornerRadii);
+
+    if (!hasRunningProcess())
+        return;
+
+    protectedLegacyMainFrameProcess()->send(Messages::WebPage::SetScrollbarAvoidanceCornerRadii(cornerRadii), webPageIDInMainFrameProcess());
+}
+#endif
 
 #if ENABLE(POINTER_LOCK)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -883,6 +883,15 @@ void WebChromeClient::scrollContainingScrollViewsToRevealRect(const IntRect&) co
     notImplemented();
 }
 
+CornerRadii WebChromeClient::scrollbarAvoidanceCornerRadii() const
+{
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    if (RefPtr page = m_page.get())
+        return page->scrollbarAvoidanceCornerRadii();
+#endif
+    return { };
+}
+
 bool WebChromeClient::shouldUnavailablePluginMessageBeButton(PluginUnavailabilityReason pluginUnavailabilityReason) const
 {
     switch (pluginUnavailabilityReason) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -156,6 +156,8 @@ private:
     void scrollContainingScrollViewsToRevealRect(const WebCore::IntRect&) const final; // Currently only Mac has a non empty implementation.
     void scrollMainFrameToRevealRect(const WebCore::IntRect&) const final;
 
+    WebCore::CornerRadii scrollbarAvoidanceCornerRadii() const final;
+
     bool shouldUnavailablePluginMessageBeButton(WebCore::PluginUnavailabilityReason) const final;
     void unavailablePluginButtonClicked(WebCore::Element&, WebCore::PluginUnavailabilityReason) const final;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -615,6 +615,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     , m_shouldRenderWebGLInGPUProcess { parameters.shouldRenderWebGLInGPUProcess }
 #endif
     , m_shouldSendConsoleLogsToUIProcessForTesting(parameters.shouldSendConsoleLogsToUIProcessForTesting)
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    , m_scrollbarAvoidanceCornerRadii(parameters.scrollbarAvoidanceCornerRadii)
+#endif
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
     , m_textCheckingControllerProxy(makeUniqueRefWithoutRefCountedCheck<TextCheckingControllerProxy>(*this))
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -32,6 +32,7 @@
 #include "SandboxExtension.h"
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <WebCore/BoxExtents.h>
+#include <WebCore/CornerRadii.h>
 #include <WebCore/DictionaryPopupInfo.h>
 #include <WebCore/DisabledAdaptations.h>
 #include <WebCore/DragActions.h>
@@ -608,6 +609,10 @@ public:
 #if ENABLE(ASYNC_SCROLLING)
     WebCore::ScrollingCoordinator* scrollingCoordinator() const;
     RefPtr<WebCore::ScrollingCoordinator> protectedScrollingCoordinator() const;
+#endif
+
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    const WebCore::CornerRadii& scrollbarAvoidanceCornerRadii() const { return m_scrollbarAvoidanceCornerRadii; }
 #endif
 
     WebPageGroupProxy* pageGroup() const { return m_pageGroup.get(); }
@@ -2322,6 +2327,10 @@ private:
     void setObscuredContentInsetsFenced(const WebCore::FloatBoxExtent&, const WTF::MachSendRight&);
 #endif
 
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    void setScrollbarAvoidanceCornerRadii(WebCore::CornerRadii&&);
+#endif
+
     void viewWillStartLiveResize();
     void viewWillEndLiveResize();
 
@@ -2763,6 +2772,10 @@ private:
     WebCore::FloatPoint m_accessibilityPosition;
 
     RetainPtr<WKAccessibilityWebPageObject> m_mockAccessibilityElement;
+#endif
+
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    WebCore::CornerRadii m_scrollbarAvoidanceCornerRadii;
 #endif
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -51,6 +51,10 @@ messages -> WebPage WantsAsyncDispatchMessage {
     SetUnderlayColor(WebCore::Color color)
     SetUnderPageBackgroundColorOverride(WebCore::Color underPageBackgroundColorOverride)
 
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+    SetScrollbarAvoidanceCornerRadii(WebCore::CornerRadii cornerRadii)
+#endif
+
     SetNeedsFixedContainerEdgesUpdate()
 
     ViewWillStartLiveResize()

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -1017,6 +1017,18 @@ void WebPage::setAppUsesCustomAccentColor(bool appUsesCustomAccentColor)
 
 #endif // HAVE(APP_ACCENT_COLORS)
 
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+void WebPage::setScrollbarAvoidanceCornerRadii(CornerRadii&& cornerRadii)
+{
+    m_scrollbarAvoidanceCornerRadii = WTF::move(cornerRadii);
+
+    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
+        if (RefPtr frameView = localMainFrame->view())
+            frameView->updateScrollbars(frameView->scrollPosition());
+    }
+}
+#endif
+
 #if ENABLE(PDF_PLUGIN)
 
 void WebPage::zoomPDFIn(PDFPluginIdentifier identifier)

--- a/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
+++ b/Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h
@@ -122,6 +122,35 @@ NSString * const NSInspectorBarTextAlignmentItemIdentifier = @"NSInspectorBarTex
 @property (readonly) BOOL _wantsConstraintBasedLayout;
 @end
 
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+
+@interface _NSCornerRadius : NSObject
+@property (class, copy, readonly) _NSCornerRadius *containerConcentricRadius;
++ (_NSCornerRadius *)fixedRadius:(CGFloat)radius;
+@end
+
+@interface NSViewCornerRadii : NSObject
+@property CGFloat topLeft;
+@property CGFloat topRight;
+@property CGFloat bottomLeft;
+@property CGFloat bottomRight;
+@property (copy) CALayerCornerCurve cornerCurve;
+@end
+
+@interface NSViewCornerConfiguration : NSObject
++ (NSViewCornerConfiguration *)configurationWithRadius:(_NSCornerRadius *)radius;
++ (instancetype)configurationWithTopLeftRadius:(nullable _NSCornerRadius *)topLeftRadius topRightRadius:(nullable _NSCornerRadius *)topRightRadius bottomLeftRadius:(nullable _NSCornerRadius *)bottomLeftRadius bottomRightRadius:(nullable _NSCornerRadius *)bottomRightRadius;
+@end
+
+@interface NSView (NSViewCornerConfiguration)
+@property (nullable, readonly) NSViewCornerRadii *_effectiveCornerRadii;
+@property (readonly, nullable, copy) NSViewCornerConfiguration *_cornerConfiguration;
+- (void)_viewDidChangeEffectiveCornerRadii;
+- (void)_invalidateCornerConfiguration;
+@end
+
+#endif
+
 #endif
 
 @protocol NSTextInputClient_Async_Staging_44648564

--- a/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
@@ -27,16 +27,58 @@
 
 #if PLATFORM(MAC)
 
+#import "AppKitSPI.h"
 #import "CGImagePixelReader.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebCore/Color.h>
+#import <WebCore/CornerRadii.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+
+@interface ContainerView : NSView
+@property (nonatomic) CGFloat topLeftRadius;
+@property (nonatomic) CGFloat topRightRadius;
+@property (nonatomic) CGFloat bottomLeftRadius;
+@property (nonatomic) CGFloat bottomRightRadius;
+@end
+
+@implementation ContainerView
+
+- (void)setCustomCornerRadius:(WebCore::CornerRadii)cornerRadii
+{
+    _topLeftRadius = cornerRadii.topLeft().width();
+    _topRightRadius = cornerRadii.topRight().width();
+    _bottomLeftRadius = cornerRadii.bottomLeft().width();
+    _bottomRightRadius = cornerRadii.bottomRight().width();
+    [self _invalidateCornerConfiguration];
+}
+
+- (NSViewCornerConfiguration *)_cornerConfiguration
+{
+    return [NSViewCornerConfiguration
+        configurationWithTopLeftRadius:[_NSCornerRadius fixedRadius:self.topLeftRadius]
+        topRightRadius:[_NSCornerRadius fixedRadius:self.topRightRadius]
+        bottomLeftRadius:[_NSCornerRadius fixedRadius:self.bottomLeftRadius]
+        bottomRightRadius:[_NSCornerRadius fixedRadius:self.bottomRightRadius]];
+}
+
+@end
+
+#endif
+
 namespace TestWebKitAPI {
+
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+enum class ScrollbarType : uint8_t {
+    Horizontal,
+    Vertical
+};
+#endif
 
 static double scrollbarLuminanceForWebView(WKWebView *webView)
 {
@@ -67,6 +109,309 @@ TEST(ScrollbarTests, AppearanceChangeAfterSystemAppearanceChange)
 
     EXPECT_LT(scrollbarLuminanceForWebView(webView.get()), 0.5f);
 }
+
+#if HAVE(NSVIEW_CORNER_CONFIGURATION)
+
+static std::optional<CGRect> scrollbarFrameRect(TestWKWebView *webView, ScrollbarType scrollbarType)
+{
+    RetainPtr frameRect = scrollbarType == ScrollbarType::Vertical
+        ? @"internals.verticalScrollbarFrameRect()"
+        : @"internals.horizontalScrollbarFrameRect()";
+
+    RetainPtr script = [NSString stringWithFormat:@"(() => { "
+        "const rect = %@; "
+        "if (!rect) return null; "
+        "return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }; "
+        "})()", frameRect.get()];
+
+    id result = [webView objectByEvaluatingJavaScript:script.get()];
+    if (RetainPtr<NSDictionary> dictionary = result) {
+        return CGRectMake(
+            [[dictionary objectForKey:@"x"] doubleValue],
+            [[dictionary objectForKey:@"y"] doubleValue],
+            [[dictionary objectForKey:@"width"] doubleValue],
+            [[dictionary objectForKey:@"height"] doubleValue]
+        );
+    }
+
+    return std::nullopt;
+}
+
+static void verifyVerticalScrollbarFrameRectIsCorrect(RetainPtr<TestWKWebView> webView)
+{
+    auto topLeftRadius = [webView _effectiveCornerRadii].topLeft;
+    auto topRightRadius = [webView _effectiveCornerRadii].topRight;
+    auto bottomLeftRadius = [webView _effectiveCornerRadii].bottomLeft;
+    auto bottomRightRadius = [webView _effectiveCornerRadii].bottomRight;
+
+    auto topObscuredContentInset = [webView obscuredContentInsets].top;
+    auto bottomObscuredContentInset = [webView obscuredContentInsets].bottom;
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height: 2000px;'></body>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto verticalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    EXPECT_TRUE(verticalFrameRect.has_value());
+    if (!verticalFrameRect.has_value())
+        return;
+
+    auto scrollCapRadius = verticalFrameRect->size.width / 2;
+    auto topInset = std::max(std::max(0.0, topRightRadius - scrollCapRadius), topObscuredContentInset);
+    auto bottomInset = std::max(std::max(0.0, bottomRightRadius - scrollCapRadius), bottomObscuredContentInset);
+
+    auto frameHeight = [webView frame].size.height;
+
+    auto actualHeight = verticalFrameRect->size.height;
+    auto expectedHeight = frameHeight - topInset - bottomInset;
+    auto heightWithinHalfPixelOfExpectedValue = expectedHeight - actualHeight <= 0.5 && expectedHeight - actualHeight >= -0.5;
+
+    auto actualYPosition = verticalFrameRect->origin.y;
+    auto expectedYPosition = topInset;
+    auto yPositionWithinHalfPixelOfExpectedValue = expectedYPosition - actualYPosition <= 0.5 && expectedYPosition - actualYPosition >= -0.5;
+
+    EXPECT_TRUE(yPositionWithinHalfPixelOfExpectedValue);
+    EXPECT_TRUE(heightWithinHalfPixelOfExpectedValue);
+
+    [webView synchronouslyLoadHTMLString:@"<html dir='rtl'><body style='height: 2000px;'></body></html>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    verticalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    EXPECT_TRUE(verticalFrameRect.has_value());
+    if (!verticalFrameRect.has_value())
+        return;
+
+    topInset = std::max(std::max(0.0, topLeftRadius - scrollCapRadius), topObscuredContentInset);
+    bottomInset = std::max(std::max(0.0, bottomLeftRadius - scrollCapRadius), bottomObscuredContentInset);
+
+    actualHeight = verticalFrameRect->size.height;
+    expectedHeight = frameHeight - topInset - bottomInset;
+    heightWithinHalfPixelOfExpectedValue = expectedHeight - actualHeight <= 0.5 && expectedHeight - actualHeight >= -0.5;
+
+    actualYPosition = verticalFrameRect->origin.y;
+    expectedYPosition = topInset;
+    yPositionWithinHalfPixelOfExpectedValue = expectedYPosition - actualYPosition <= 0.5 && expectedYPosition - actualYPosition >= -0.5;
+
+    EXPECT_TRUE(yPositionWithinHalfPixelOfExpectedValue);
+    EXPECT_TRUE(heightWithinHalfPixelOfExpectedValue);
+}
+
+static void verifyHorizontalScrollbarFrameRectIsCorrect(RetainPtr<TestWKWebView> webView)
+{
+    auto bottomLeftRadius = [webView _effectiveCornerRadii].bottomLeft;
+    auto bottomRightRadius = [webView _effectiveCornerRadii].bottomRight;
+
+    auto leftObscuredContentInset = webView.get().obscuredContentInsets.left;
+    auto rightObscuredContentInset = webView.get().obscuredContentInsets.right;
+
+    [webView synchronouslyLoadHTMLString:@"<body style='width: 2000px;'></body>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto horizontalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    EXPECT_TRUE(horizontalFrameRect.has_value());
+    if (!horizontalFrameRect.has_value())
+        return;
+
+    auto scrollCapRadius = horizontalFrameRect->size.height / 2;
+    auto leftInset = std::max(std::max(0.0, bottomLeftRadius - scrollCapRadius), leftObscuredContentInset);
+    auto rightInset = std::max(std::max(0.0, bottomRightRadius - scrollCapRadius), rightObscuredContentInset);
+
+    auto frameWidth = [webView frame].size.width;
+    auto actualWidth = horizontalFrameRect->size.width;
+    auto expectedWidth = frameWidth - leftInset - rightInset;
+
+    auto actualXPosition = horizontalFrameRect->origin.x;
+    auto expectedXPosition = leftInset;
+    auto xPositionWithinHalfPixelOfExpectedValue = expectedXPosition - actualXPosition <= 0.5 && expectedXPosition - actualXPosition >= -0.5;
+
+    auto widthWithinHalfPixelOfExpectedValue = expectedWidth - actualWidth <= 0.5 && expectedWidth - actualWidth >= -0.5;
+
+    EXPECT_TRUE(xPositionWithinHalfPixelOfExpectedValue);
+    EXPECT_TRUE(widthWithinHalfPixelOfExpectedValue);
+}
+
+static void verifyScrollbarFrameRectsAreCorrect(RetainPtr<TestWKWebView> webView)
+{
+    verifyVerticalScrollbarFrameRectIsCorrect(webView);
+    verifyHorizontalScrollbarFrameRectIsCorrect(webView);
+}
+
+static void verifyWebViewHasExpectedCornerRadii(RetainPtr<TestWKWebView> webView, WebCore::CornerRadii cornerRadii)
+{
+    auto topLeftRadius = [webView _effectiveCornerRadii].topLeft;
+    auto topRightRadius = [webView _effectiveCornerRadii].topRight;
+    auto bottomLeftRadius = [webView _effectiveCornerRadii].bottomLeft;
+    auto bottomRightRadius = [webView _effectiveCornerRadii].bottomRight;
+
+    EXPECT_EQ(topLeftRadius, cornerRadii.topLeft().width());
+    EXPECT_EQ(topRightRadius, cornerRadii.topRight().width());
+    EXPECT_EQ(bottomLeftRadius, cornerRadii.bottomLeft().width());
+    EXPECT_EQ(bottomRightRadius, cornerRadii.bottomRight().width());
+}
+
+static RetainPtr<TestWKWebView> scrollbarAvoidanceTestWebView()
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    return adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 500, 400) configuration:configuration.get()]);
+}
+
+static RetainPtr<NSWindow> scrollbarAvoidanceTestWindow()
+{
+    return adoptNS([[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 500, 400)
+        styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable)
+        backing:NSBackingStoreBuffered
+        defer:NO]);
+}
+
+TEST(ScrollbarTests, ScrollbarAvoidanceForTitledWindow)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+    [[window contentView] addSubview:webView.get()];
+
+    EXPECT_TRUE([webView _effectiveCornerRadii].bottomRight);
+    verifyScrollbarFrameRectsAreCorrect(webView);
+}
+
+TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedCompactToolbar)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+    RetainPtr toolbar = adoptNS([[NSToolbar alloc] initWithIdentifier:@"TestToolbar"]);
+
+    [window setToolbar:toolbar.get()];
+    [window setToolbarStyle:NSWindowToolbarStyleUnifiedCompact];
+    [[window contentView] addSubview:webView.get()];
+
+    EXPECT_TRUE([webView _effectiveCornerRadii].bottomRight);
+    verifyScrollbarFrameRectsAreCorrect(webView);
+}
+
+TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedToolbar)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+
+    RetainPtr toolbar = adoptNS([[NSToolbar alloc] initWithIdentifier:@"TestToolbar"]);
+    [window setToolbar:toolbar.get()];
+    [window setToolbarStyle:NSWindowToolbarStyleUnified];
+    [[window contentView] addSubview:webView.get()];
+
+    EXPECT_TRUE([webView _effectiveCornerRadii].bottomRight);
+    verifyScrollbarFrameRectsAreCorrect(webView);
+}
+
+TEST(ScrollbarTests, ScrollbarAvoidanceNoCornerRadii)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+
+    [webView synchronouslyLoadHTMLString:@"<body style='width: 2000px;'></body>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto horizontalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    EXPECT_TRUE(horizontalFrameRect.has_value());
+    if (!horizontalFrameRect.has_value())
+        return;
+
+    auto expectedWidth = [webView frame].size.width;
+    auto actualWidth = horizontalFrameRect->size.width;
+
+    auto actualXPosition = horizontalFrameRect->origin.x;
+    auto expectedXPosition = 0;
+
+    EXPECT_EQ(actualWidth, expectedWidth);
+    EXPECT_EQ(actualXPosition, expectedXPosition);
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height: 2000px;'></body>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto verticalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    EXPECT_TRUE(verticalFrameRect.has_value());
+    if (!verticalFrameRect.has_value())
+        return;
+
+    auto actualHeight = verticalFrameRect->size.height;
+    auto expectedHeight = [webView frame].size.height;
+
+    auto actualYPosition = verticalFrameRect->origin.y;
+    auto expectedYPosition = 0;
+
+    EXPECT_EQ(actualHeight, expectedHeight);
+    EXPECT_EQ(actualYPosition, expectedYPosition);
+}
+
+static void runTestCaseWithCornerRadii(RetainPtr<ContainerView> container, RetainPtr<TestWKWebView> webView, WebCore::CornerRadii cornerRadii)
+{
+    verifyWebViewHasExpectedCornerRadii(webView, cornerRadii);
+    verifyScrollbarFrameRectsAreCorrect(webView);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(5, 5, 5, 5)];
+    verifyScrollbarFrameRectsAreCorrect(webView);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(5, 5, 0, 0)];
+    verifyScrollbarFrameRectsAreCorrect(webView);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(75, 75, 75, 75)];
+    verifyScrollbarFrameRectsAreCorrect(webView);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(5, 5, 0, 0)];
+    verifyScrollbarFrameRectsAreCorrect(webView);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+}
+
+TEST(ScrollbarTests, ScrollbarAvoidanceInConcentricContainerWithUniformCornerRadii)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+    RetainPtr container = adoptNS([[ContainerView alloc] initWithFrame:NSMakeRect(0, 0, 500, 400)]);
+
+    [[window contentView] addSubview:container.get()];
+
+    WebCore::CornerRadii caseOne { 50 };
+    WebCore::CornerRadii caseTwo { 10 };
+    WebCore::CornerRadii caseThree { 0 };
+
+    [container setCustomCornerRadius:caseOne];
+    [container addSubview:webView.get()];
+
+    runTestCaseWithCornerRadii(container, webView, caseOne);
+
+    [container setCustomCornerRadius:caseTwo];
+    [webView waitForNextPresentationUpdate];
+    runTestCaseWithCornerRadii(container, webView, caseTwo);
+
+    [container setCustomCornerRadius:caseThree];
+    [webView waitForNextPresentationUpdate];
+    runTestCaseWithCornerRadii(container, webView, caseThree);
+}
+
+TEST(ScrollbarTests, ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+    RetainPtr container = adoptNS([[ContainerView alloc] initWithFrame:NSMakeRect(0, 0, 500, 400)]);
+
+    [[window contentView] addSubview:container.get()];
+
+    WebCore::CornerRadii caseOne { 50, 0, 16, 4 };
+    WebCore::CornerRadii caseTwo { 20, 8, 2, 10 };
+
+    [container setCustomCornerRadius:caseOne];
+    [container addSubview:webView.get()];
+
+    runTestCaseWithCornerRadii(container, webView, caseOne);
+
+    [container setCustomCornerRadius:caseTwo];
+    [webView waitForNextPresentationUpdate];
+    runTestCaseWithCornerRadii(container, webView, caseTwo);
+}
+
+#endif // HAVE(NSVIEW_CORNER_CONFIGURATION)
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### 643493bea2f9824959ebb9824bfb011aedf7498c
<pre>
[macOS] Scroll bars of root scroller may be cutoff due to corner radii of window
<a href="https://bugs.webkit.org/show_bug.cgi?id=305426">https://bugs.webkit.org/show_bug.cgi?id=305426</a>
<a href="https://rdar.apple.com/156100532">rdar://156100532</a>

Reviewed by Abrar Rahman Protyasha.

Reland 306039@main with corrected `PlatformHave` defintion.

On Mac, WKWebView now participates in the container concentricity
system by implementing `_cornerConfiguration` and
`_viewDidChangeEffectiveCornerRadii`, allowing WKWebView to determine
the corner radii of windows when the view is the window&apos;s content view,
and allowing WKWebView to determine the corner radii of parents views
that have an `NSCornerConfiguration`.

When `_viewDidChangeEffectiveCornerRadii` is called, we check if the
corner radii actually changed. If they did, we notify the web process
of the new radii and update the scrollbars to reposition them in order
to avoid the obscured corners by insetting by the corner radius minus
the radius of the scrollbar&apos;s cap. We take `obscuredContentInsets` into
account here as well by using whichever inset is larger.

Note that this change does not yet fix the issue of custom CSS scroll
bars getting cutoff. A separate patch will be needed to address that
bug.

Tested by new API tests:
+ ScrollbarTests.ScrollbarAvoidanceForTitledWindow
+ ScrollbarTests.ScrollbarAvoidanceForWindowWithUnifiedCompactToolbar
+ ScrollbarTests.ScrollbarAvoidanceForWindowWithUnifiedToolbar
+ ScrollbarTests.ScrollbarAvoidanceNoCornerRadii
+ ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithUniformCornerRadii
+ ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::scrollbarAvoidanceCornerRadii const):
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::scrollbarAvoidanceCornerRadii const):
* Source/WebCore/page/FrameView.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::scrollbarAvoidanceCornerRadii const):
(WebCore::ScrollView::updateScrollbars):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/graphics/CornerRadii.h:
(WebCore::CornerRadii::CornerRadii):
(WebCore::CornerRadii::m_topRight):
(WebCore::CornerRadii::m_bottomLeft):
(WebCore::CornerRadii::m_bottomRight):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::horizontalScrollbarFrameRect const):
(WebCore::Internals::verticalScrollbarFrameRect const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _viewDidChangeEffectiveCornerRadii]):
(-[WKWebView _cornerConfiguration]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::setScrollbarAvoidanceCornerRadii):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::scrollbarAvoidanceCornerRadii const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::setScrollbarAvoidanceCornerRadii):
* Tools/TestWebKitAPI/Tests/TestWebKitAPI/mac/AppKitSPI.h:
* Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm:
(-[ContainerView setCustomCornerRadius:]):
(-[ContainerView _cornerConfiguration]):
(TestWebKitAPI::scrollbarFrameRect):
(TestWebKitAPI::verifyVerticalScrollbarFrameRectIsCorrect):
(TestWebKitAPI::verifyHorizontalScrollbarFrameRectIsCorrect):
(TestWebKitAPI::verifyScrollbarFrameRectsAreCorrect):
(TestWebKitAPI::verifyWebViewHasExpectedCornerRadii):
(TestWebKitAPI::scrollbarAvoidanceTestWebView):
(TestWebKitAPI::scrollbarAvoidanceTestWindow):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceForTitledWindow)):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedCompactToolbar)):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceForWindowWithUnifiedToolbar)):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceNoCornerRadii)):
(TestWebKitAPI::runTestCaseWithCornerRadii):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceInConcentricContainerWithUniformCornerRadii)):
(TestWebKitAPI::TEST(ScrollbarTests, ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii)):

Canonical link: <a href="https://commits.webkit.org/306100@main">https://commits.webkit.org/306100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c223480189ceca6ee09e2a8482823d5d775c6ffc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148639 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54fdca65-e8bb-464b-8b54-c82daaf3085c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107563 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d2f239c-f177-4e36-a744-ffc9a91b9edb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88452 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33197303-959d-40cf-ae47-a1f4ed31d1a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7471 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8726 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132266 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151237 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1089 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1671 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115840 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11240 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122077 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67375 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12403 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1537 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171566 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76101 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44521 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->