### PR TITLE
[Rice] Build issues due to API break in version 0.3.0

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -260,7 +260,13 @@ static void webkitGstWebRTCIceAgentAddRiceTurnServer(WebKitGstIceAgent* agent, c
 
     auto family = rice_address_get_family(riceAddress.get());
     for (unsigned i = 0; i < nRelay; i++) {
-        auto config = adoptGRef(rice_turn_config_new(relays[i], riceAddress.get(), credentials.get(), 1, &family, tlsConfig.get()));
+        // FIXME: Hardcoding UDP as allocation transport type for now. Our TURN support needs further work anyway.
+        // https://bugs.webkit.org/show_bug.cgi?id=310005
+        auto config = adoptGRef(rice_turn_config_new(relays[i], riceAddress.get(), credentials.get(),
+#if RICE_CHECK_VERSION(0, 3, 0)
+            RICE_TRANSPORT_TYPE_UDP,
+#endif
+            1, &family, tlsConfig.get()));
         agent->priv->turnConfigs.append(WTF::move(config));
     }
 }


### PR DESCRIPTION
#### 1298b68972d99f8aeb6ba194d0d5c4f34e7358d0
<pre>
[Rice] Build issues due to API break in version 0.3.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=306098">https://bugs.webkit.org/show_bug.cgi?id=306098</a>
&lt;<a href="https://rdar.apple.com/problem/169254926">rdar://problem/169254926</a>&gt;

Reviewed by Xabier Rodriguez-Calvar.

Use UDP as allocation transport, this is a new parameter for rice_turn_config_new() added in librice
0.3.0.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(webkitGstWebRTCIceAgentAddRiceTurnServer):

Canonical link: <a href="https://commits.webkit.org/309311@main">https://commits.webkit.org/309311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8add29b665b97d5e5fdd7bee58395a1ac88f2e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152173 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23489 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115956 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96688 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15111 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161488 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4616 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14305 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124161 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33703 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134547 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79214 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11304 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22460 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86260 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22228 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->