### PR TITLE
[GStreamer] Add a quirk for platforms shipping the Qualcomm video decoder

### DIFF
--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -112,6 +112,7 @@ platform/gstreamer/GStreamerQuirkBcmNexus.cpp
 platform/gstreamer/GStreamerQuirkBroadcom.cpp
 platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
 platform/gstreamer/GStreamerQuirkOpenMAX.cpp
+platform/gstreamer/GStreamerQuirkQualcomm.cpp
 platform/gstreamer/GStreamerQuirkRealtek.cpp
 platform/gstreamer/GStreamerQuirkRialto.cpp
 platform/gstreamer/GStreamerQuirkWesteros.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -283,7 +283,7 @@ enum class AsynchronousPipelineDumping : bool { No, Yes };
 void connectSimpleBusMessageCallback(GstElement*, Function<void(GstMessage*)>&& = [](GstMessage*) { }, AsynchronousPipelineDumping = AsynchronousPipelineDumping::No);
 void disconnectSimpleBusMessageCallback(GstElement*);
 
-enum class GstVideoDecoderPlatform { ImxVPU, Video4Linux, OpenMAX };
+enum class GstVideoDecoderPlatform { ImxVPU, Video4Linux, OpenMAX, Qualcomm };
 
 bool isGStreamerPluginAvailable(ASCIILiteral name);
 bool gstElementFactoryEquals(GstElement*, ASCIILiteral name);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3595,6 +3595,8 @@ void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)
         m_videoDecoderPlatform = GstVideoDecoderPlatform::ImxVPU;
     else if (startsWith(name.span(), "omx"_s))
         m_videoDecoderPlatform = GstVideoDecoderPlatform::OpenMAX;
+    else if (startsWith(name.span(), "c2vdec"_s))
+        m_videoDecoderPlatform = GstVideoDecoderPlatform::Qualcomm;
     else if (gstElementMatchesFactoryAndHasProperty(decoder, "avdec*"_s, "max-threads"_s)) {
         // Set the decoder maximum number of threads to a low, fixed value, not depending on the
         // platform. This also helps with processing metrics gathering. When using the default value

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "GStreamerQuirkQualcomm.h"
+
+#if USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+
+namespace WebCore {
+
+GST_DEBUG_CATEGORY_STATIC(webkit_qualcomm_quirks_debug);
+#define GST_CAT_DEFAULT webkit_qualcomm_quirks_debug
+
+GStreamerQuirkQualcomm::GStreamerQuirkQualcomm()
+{
+    GST_DEBUG_CATEGORY_INIT(webkit_qualcomm_quirks_debug, "webkitquirksqualcomm", 0, "WebKit Qualcomm Quirks");
+}
+
+bool GStreamerQuirkQualcomm::isPlatformSupported() const
+{
+    auto factory = adoptGRef(gst_element_factory_find("qtic2vdec"));
+    if (!factory)
+        return false;
+
+    // Make sure decodebin will not auto-plug any of these elements. The Qualcomm decoder already
+    // has primary rank.
+    static const std::array<ASCIILiteral, 5> s_disabledDecoders {
+        "avdec_h264"_s,
+        "avdec_h265"_s,
+        "v4l2h264dec"_s,
+        "v4l2h265dec"_s,
+        "v4l2vp9dec"_s,
+    };
+    for (const auto& factoryName : s_disabledDecoders) {
+        if (auto factory = adoptGRef(gst_element_factory_find(factoryName.characters())))
+            gst_plugin_feature_set_rank(GST_PLUGIN_FEATURE_CAST(factory.get()), GST_RANK_NONE);
+    }
+
+    // Non-standard caps format of the video decoder src pad. glupload and glcolorconvert don't
+    // accept this, so we need to avoid them in our GL sink.
+    m_glCaps = adoptGRef(gst_caps_from_string("video/x-raw(memory:GBM), format=(string){NV12, NV12_10LE32, P010_10LE}"));
+
+    GST_DEBUG("Qualcomm quirk configured and enabled");
+    return true;
+}
+
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Igalia S.L
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+#include "GStreamerQuirks.h"
+
+namespace WebCore {
+
+class GStreamerQuirkQualcomm final : public GStreamerQuirk {
+public:
+    GStreamerQuirkQualcomm();
+    bool isPlatformSupported() const final;
+    const ASCIILiteral identifier() const final { return "Qualcomm"_s; }
+    [[nodiscard]] GRefPtr<GstCaps> videoSinkGLCapsFormat() const final { return m_glCaps; }
+
+private:
+    mutable GRefPtr<GstCaps> m_glCaps;
+};
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -32,6 +32,7 @@
 #include "GStreamerQuirkBcmNexus.h"
 #include "GStreamerQuirkBroadcom.h"
 #include "GStreamerQuirkOpenMAX.h"
+#include "GStreamerQuirkQualcomm.h"
 #include "GStreamerQuirkRealtek.h"
 #include "GStreamerQuirkRialto.h"
 #include "GStreamerQuirkWesteros.h"
@@ -87,7 +88,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     GST_DEBUG("Attempting to parse requested quirks: %s", GST_STR_NULL(quirksString.utf8()));
     if (quirksString) {
         if (WTF::equalLettersIgnoringASCIICase(quirksString.span(), "help"_s)) {
-            gst_printerrln("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, openmax, realtek, rialto, westeros");
+            gst_printerrln("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, openmax, qualcomm, realtek, rialto, westeros");
             return;
         }
 
@@ -101,6 +102,8 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
                 quirk = WTF::makeUnique<GStreamerQuirkBcmNexus>();
             else if (WTF::equalLettersIgnoringASCIICase(identifier, "openmax"_s))
                 quirk = WTF::makeUnique<GStreamerQuirkOpenMAX>();
+            else if (WTF::equalLettersIgnoringASCIICase(identifier, "qualcomm"_s))
+                quirk = WTF::makeUnique<GStreamerQuirkQualcomm>();
             else if (WTF::equalLettersIgnoringASCIICase(identifier, "realtek"_s))
                 quirk = WTF::makeUnique<GStreamerQuirkRealtek>();
             else if (WTF::equalLettersIgnoringASCIICase(identifier, "rialto"_s))
@@ -125,6 +128,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
         ADD_QUIRK(Broadcom);
         ADD_QUIRK(BcmNexus);
         ADD_QUIRK(OpenMAX);
+        ADD_QUIRK(Qualcomm);
         ADD_QUIRK(Realtek);
         ADD_QUIRK(Rialto);
         ADD_QUIRK(Westeros);
@@ -310,6 +314,15 @@ bool GStreamerQuirksManager::shouldParseIncomingLibWebRTCBitStream() const
             return false;
     }
     return true;
+}
+
+GRefPtr<GstCaps> GStreamerQuirksManager::videoSinkGLCapsFormat() const
+{
+    for (auto& quirk : m_quirks) {
+        if (auto caps = quirk->videoSinkGLCapsFormat())
+            return caps;
+    }
+    return nullptr;
 }
 
 bool GStreamerQuirksManager::needsBufferingPercentageCorrection() const

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -105,6 +105,8 @@ public:
         GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_DROPPABLE);
         return false;
     }
+
+    [[nodiscard]] virtual GRefPtr<GstCaps> videoSinkGLCapsFormat() const { return nullptr;  }
 };
 
 class GStreamerHolePunchQuirk : public GStreamerQuirkBase {
@@ -138,6 +140,8 @@ public:
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) const;
     GstElementFactoryListType audioVideoDecoderFactoryListType() const;
     Vector<String> disallowedWebAudioDecoders() const;
+
+    [[nodiscard]] GRefPtr<GstCaps> videoSinkGLCapsFormat() const;
 
     bool supportsVideoHolePunchRendering() const;
     GstElement* createHolePunchVideoSink(bool isLegacyPlaybin, const MediaPlayer*);


### PR DESCRIPTION
#### 4ab703e2cf8828efa29817f38e2de68608566f0f
<pre>
[GStreamer] Add a quirk for platforms shipping the Qualcomm video decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=306099">https://bugs.webkit.org/show_bug.cgi?id=306099</a>

Reviewed by Xabier Rodriguez-Calvar.

This new quirk enables support for the qticv2dec Qualcomm video decoder which uses a non-standard
caps format. Rendering support for the TextureMapper will be added as a follow-up.

* Source/WebCore/platform/SourcesGStreamer.txt:
* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(webKitGLVideoSinkConstructed):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
* Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp: Added.
(WebCore::GStreamerQuirkQualcomm::GStreamerQuirkQualcomm):
(WebCore::GStreamerQuirkQualcomm::isPlatformSupported const):
* Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h: Added.
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::GStreamerQuirksManager):
(WebCore::GStreamerQuirksManager::videoSinkGLCapsFormat const):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::videoSinkGLCapsFormat const):

Canonical link: <a href="https://commits.webkit.org/306198@main">https://commits.webkit.org/306198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/163449fb8cf6d8016141edfb11f526029292cbe0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149004 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107861 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88761 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10242 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7795 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9096 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151626 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12733 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2087 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29620 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12406 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122541 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67833 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12775 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76475 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->