### PR TITLE
[Linux] Stop caching memory footprint

### DIFF
--- a/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
+++ b/Source/WTF/wtf/linux/MemoryFootprintLinux.cpp
@@ -26,26 +26,14 @@
 #include "config.h"
 #include <wtf/MemoryFootprint.h>
 
-#include <stdio.h>
-#include <wtf/MonotonicTime.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/linux/CurrentProcessMemoryStatus.h>
-#include <wtf/text/StringView.h>
 
 namespace WTF {
 
-static const Seconds s_memoryFootprintUpdateInterval = 1_s;
-
 size_t memoryFootprint()
 {
-    static ProcessMemoryStatus memoryStatus;
-    static MonotonicTime previousUpdateTime = { };
-    Seconds elapsed = MonotonicTime::now() - previousUpdateTime;
-    if (elapsed >= s_memoryFootprintUpdateInterval) {
-        currentProcessMemoryStatus(memoryStatus);
-        previousUpdateTime = MonotonicTime::now();
-    }
-
+    ProcessMemoryStatus memoryStatus;
+    currentProcessMemoryStatus(memoryStatus);
     return memoryStatus.resident;
 }
 


### PR DESCRIPTION
#### 6083924154b53b7778aeb5dce797c4ac46b43810
<pre>
[Linux] Stop caching memory footprint
<a href="https://bugs.webkit.org/show_bug.cgi?id=306104">https://bugs.webkit.org/show_bug.cgi?id=306104</a>

Reviewed by Miguel Gomez.

Since 305569@main `memoryFootprint()` uses `/proc/self/statm` instead of
`/proc/self/smaps` which is significantly faster, eliminating the need
of caching. Removing cache will provide much more accurate value.

* Source/WTF/wtf/linux/MemoryFootprintLinux.cpp:
(WTF::memoryFootprint):

Canonical link: <a href="https://commits.webkit.org/306193@main">https://commits.webkit.org/306193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/095eac0789c6cc6b94573b3eb5b3d9493968564a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107553 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78131 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88425 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9953 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7489 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8746 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132297 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151257 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1109 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12382 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115852 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10601 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116188 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11276 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67395 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12424 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1554 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171586 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76121 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44525 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12358 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->