### PR TITLE
[GTK][resultsdb] Remove version_name from the uploaded results

### DIFF
--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -169,7 +169,10 @@ class GtkPort(GLibPort):
     def configuration_for_upload(self, host=None):
         configuration = super(GtkPort, self).configuration_for_upload(host=host)
         configuration['platform'] = 'GTK'
-        configuration['version_name'] = self._display_server.capitalize() if self._display_server else 'Xvfb'
+        # resultsdbpy frontend tends to group multiple versions in a single timeline
+        # when they share a version name. As we are using stable versions since 305707@main,
+        # let's avoid this grouping for now due to issues like https://webkit.org/b/306091.
+        configuration.pop('version_name', None)
         return configuration
 
     def get_browser_path(self, browser_name):

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -99,7 +99,7 @@ class GtkPortTest(port_testcase.PortTestCase):
         self.assertEqual(configuration['is_simulator'], False)
         self.assertEqual(configuration['platform'], 'GTK')
         self.assertEqual(configuration['style'], 'release')
-        self.assertEqual(configuration['version_name'], 'Xvfb')
+        self.assertNotIn('version_name', configuration)
         self.assertEqual(configuration['version'], '2.51')
 
     def test_gtk4_expectations_binary_only(self):

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -126,6 +126,10 @@ class WPEPort(GLibPort):
     def configuration_for_upload(self, host=None):
         configuration = super(WPEPort, self).configuration_for_upload(host=host)
         configuration['platform'] = 'WPE'
+        # resultsdbpy frontend tends to group multiple versions in a single timeline
+        # when they share a version name. As we are using stable versions since 305707@main,
+        # let's avoid this grouping for now due to issues like https://webkit.org/b/306091.
+        configuration.pop('version_name', None)
         return configuration
 
     def cog_path_to(self, *components):

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -95,6 +95,7 @@ class WPEPortTest(port_testcase.PortTestCase):
         self.assertEqual(configuration['platform'], 'WPE')
         self.assertEqual(configuration['style'], 'release')
         self.assertEqual(configuration['version'], '2.51')
+        self.assertNotIn('version_name', configuration)
 
     def test_browser_name_default_wihout_cog_built(self):
         port = self.make_port()


### PR DESCRIPTION
#### 6a1eadfc3e3e354664f95761f341766f8a75a312
<pre>
[GTK][resultsdb] Remove version_name from the uploaded results
<a href="https://bugs.webkit.org/show_bug.cgi?id=214511">https://bugs.webkit.org/show_bug.cgi?id=214511</a>

Reviewed by Carlos Alberto Lopez Perez.

305707@main changed WPE and GTK to use the project version as the result
upload version instead of the kernel version, resulting in more stable
versioning.

Meanwhile, GTK still uses the display server name as the version_name.
This causes the frontend code to group different configurations with
different versions together in a single timeline, also dropping the
platform name and version, as it&apos;s implied from the version_name. Thus
for GTK we had rows with the cryptic title `Xvfb wk2 Debug...`.

On top of that, we have bugs like bug306091, where markers are not
rendered when configurations are grouped out of order. As the default
GTK timelines were grouped by version_name, it was more prone to be
affected by this problem than WPE.

This commit ensures we send an empty version_name field for both WPE and
GTK, aligning their behavior.

In fact, if we need the display server name in the future, we can add it
back as a different flavor.

Note that with the current resultsdbpy frontend code, this will create a
new result series for GTK on front page (i.e. decoupled from the
&apos;Xvfb&apos; group). But over time, the old configurations will be archived
out of the front page. And for long term history of GTK/WPE, we can use
tools like webkit-testhunter.

* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.configuration_for_upload):
* Tools/Scripts/webkitpy/port/gtk_unittest.py:
(GtkPortTest.test_default_upload_configuration):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.configuration_for_upload):
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_default_upload_configuration):

Canonical link: <a href="https://commits.webkit.org/306101@main">https://commits.webkit.org/306101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca6634a0656efc87321e2eb6b1966ee39417ef46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148664 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12879 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88478 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/139689 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7519 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8777 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12413 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115883 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116218 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11345 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122125 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12456 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1581 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12394 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12240 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->