### PR TITLE
Update IDL files and IDL parser for spelling change from "async iterable" to "async_iterable"

### DIFF
--- a/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl
+++ b/Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl
@@ -40,7 +40,7 @@ dictionary FileSystemRemoveOptions {
     Exposed=(Window,Worker),
     SecureContext
 ] interface FileSystemDirectoryHandle : FileSystemHandle {
-    async iterable<USVString, FileSystemHandle>;
+    async_iterable<USVString, FileSystemHandle>;
 
     Promise<FileSystemFileHandle> getFileHandle(USVString name, optional FileSystemGetFileOptions options = {});
     Promise<FileSystemDirectoryHandle> getDirectoryHandle(USVString name, optional FileSystemGetDirectoryOptions options = {});

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -63,5 +63,5 @@ typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStream
     [CallWith=CurrentGlobalObject] ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
     [CallWith=CurrentGlobalObject] sequence<ReadableStream> tee();
 
-    [EnabledBySetting=ReadableStreamIterableEnabled] async iterable<any>(optional ReadableStreamIteratorOptions options = {});
+    [EnabledBySetting=ReadableStreamIterableEnabled] async_iterable<any>(optional ReadableStreamIteratorOptions options = {});
 };

--- a/Source/WebCore/bindings/scripts/IDLParser.pm
+++ b/Source/WebCore/bindings/scripts/IDLParser.pm
@@ -70,7 +70,7 @@ struct( IDLInterface => {
     isMixin => '$', # Used for mixin interfaces
     isPartial => '$', # Used for partial interfaces
     iterable => '$', # Used for iterable interfaces, of type 'IDLIterable'
-    asyncIterable => '$', # Used for async iterable interfaces, of type 'IDLAsyncIterable'
+    asyncIterable => '$', # Used for async_iterable interfaces, of type 'IDLAsyncIterable'
     mapLike => '$', # Used for mapLike interfaces, of type 'IDLMapLike'
     setLike => '$', # Used for setLike interfaces, of type 'IDLSetLike'
     extendedAttributes => '%',
@@ -630,7 +630,7 @@ my $nextMixinMembers_1 = '^(\(|attribute|ByteString|DOMString|USVString|any|bool
 my $nextNamespaceMembers_1 = '^(\(|ByteString|DOMString|USVString|any|boolean|byte|const|double|float|long|object|octet|readonly|sequence|short|symbol|undefined|unrestricted|unsigned)$';
 my $nextPartialInterfaceMember_1 = '^(\(|ByteString|DOMString|USVString|any|attribute|boolean|byte|const|deleter|double|float|getter|inherit|long|object|octet|readonly|sequence|setter|short|static|stringifier|symbol|undefined|unrestricted|unsigned)$';
 my $nextSingleType_1 = '^(ByteString|DOMString|USVString|boolean|byte|double|float|long|object|octet|sequence|short|symbol|undefined|unrestricted|unsigned)$';
-my $nextArgumentName_1 = '^(async|attribute|callback|const|constructor|deleter|dictionary|enum|getter|includes|inherit|interface|iterable|maplike|mixin|namespace|partial|readonly|required|setlike|setter|static|stringifier|typedef|unrestricted)$';
+my $nextArgumentName_1 = '^(async_iterable|attribute|callback|const|constructor|deleter|dictionary|enum|getter|includes|inherit|interface|iterable|maplike|mixin|namespace|partial|readonly|required|setlike|setter|static|stringifier|typedef|unrestricted)$';
 my $nextConstValue_1 = '^(false|true)$';
 my $nextConstValue_2 = '^(-|Infinity|NaN)$';
 my $nextCallbackOrInterface = '^(callback|interface)$';
@@ -1273,7 +1273,7 @@ sub parsePartialInterfaceMember
     if ($next->value() eq "iterable") {
         return $self->parseIterableRest($extendedAttributeList);
     }
-    if ($next->value() eq "async") {
+    if ($next->value() eq "async_iterable") {
         return $self->parseAsyncIterable($extendedAttributeList);
     }
     if ($next->value() eq "readonly") {
@@ -2025,9 +2025,8 @@ sub parseAsyncIterable
     my $extendedAttributeList = shift;
 
     my $next = $self->nextToken();
-    if ($next->value() eq "async") {
-        $self->assertTokenValue($self->getToken(), "async", __LINE__);
-        $self->assertTokenValue($self->getToken(), "iterable", __LINE__);
+    if ($next->value() eq "async_iterable") {
+        $self->assertTokenValue($self->getToken(), "async_iterable", __LINE__);
 
         my $asyncIterable = IDLAsyncIterable->new();
 

--- a/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
+++ b/Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl
@@ -26,6 +26,6 @@
 [
     Exposed=TestGlobalObject
 ] interface TestAsyncIterable {
-    async iterable<TestNode>(optional TestNode option);
+    async_iterable<TestNode>(optional TestNode option);
 };
 

--- a/Source/WebCore/bindings/scripts/test/TestAsyncIterableWithoutFlags.idl
+++ b/Source/WebCore/bindings/scripts/test/TestAsyncIterableWithoutFlags.idl
@@ -26,6 +26,6 @@
 [
     Exposed=TestGlobalObject
 ] interface TestAsyncIterableWithoutFlags {
-    async iterable<TestNode>;
+    async_iterable<TestNode>;
 };
 

--- a/Source/WebCore/bindings/scripts/test/TestAsyncKeyValueIterable.idl
+++ b/Source/WebCore/bindings/scripts/test/TestAsyncKeyValueIterable.idl
@@ -26,6 +26,6 @@
 [
     Exposed=TestGlobalObject
 ] interface TestAsyncKeyValueIterable {
-    async iterable<USVString, TestNode>;
+    async_iterable<USVString, TestNode>;
 };
 


### PR DESCRIPTION
#### 5019b03742575a0fbfcdf646fe3857298ea1ad40
<pre>
Update IDL files and IDL parser for spelling change from &quot;async iterable&quot; to &quot;async_iterable&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=306115">https://bugs.webkit.org/show_bug.cgi?id=306115</a>

Reviewed by Darin Adler.

The WebIDL spec updated the spelling of &quot;async iterable&quot; to be
&quot;async_interable&quot; in <a href="https://github.com/whatwg/webidl/commit/a8b10f5380e157144679e239380f54315b5f912a.">https://github.com/whatwg/webidl/commit/a8b10f5380e157144679e239380f54315b5f912a.</a>

This updates the IDL files and IDL parser for the new spelling.

* Source/WebCore/Modules/filesystem/FileSystemDirectoryHandle.idl:
* Source/WebCore/Modules/streams/ReadableStream.idl:
* Source/WebCore/bindings/scripts/IDLParser.pm:
* Source/WebCore/bindings/scripts/test/TestAsyncIterable.idl:
* Source/WebCore/bindings/scripts/test/TestAsyncIterableWithoutFlags.idl:
* Source/WebCore/bindings/scripts/test/TestAsyncKeyValueIterable.idl:

Canonical link: <a href="https://commits.webkit.org/306116@main">https://commits.webkit.org/306116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa6753cc2367738079afe94ae13a6803290b870

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1873 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/148707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12895 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107596 "3 flakes") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143311 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88492 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/9992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7532 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8793 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115896 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11391 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122141 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12472 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1597 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12212 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76172 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->