### PR TITLE
Remove IDLObject special case in JSDOMConvertOptional

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -83,15 +83,15 @@ static ExceptionOr<bool> isReadableByteSource(JSC::ThrowScope& throwScope, JSDOM
     return true;
 }
 
-ExceptionOr<Ref<ReadableStream>> ReadableStream::create(JSDOMGlobalObject& globalObject, std::optional<JSC::Strong<JSC::JSObject>>&& underlyingSourceValue, std::optional<JSC::Strong<JSC::JSObject>>&& strategyValue)
+ExceptionOr<Ref<ReadableStream>> ReadableStream::create(JSDOMGlobalObject& globalObject, JSC::Strong<JSC::JSObject>&& underlyingSourceValue, JSC::Strong<JSC::JSObject>&& strategyValue)
 {
     JSC::JSValue underlyingSource = JSC::jsUndefined();
     if (underlyingSourceValue)
-        underlyingSource = underlyingSourceValue->get();
+        underlyingSource = underlyingSourceValue.get();
 
     JSC::JSValue strategy = JSC::jsUndefined();
     if (strategyValue)
-        strategy = strategyValue->get();
+        strategy = strategyValue.get();
 
     Ref vm = globalObject.vm();
     auto throwScope = DECLARE_THROW_SCOPE(vm);

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -71,7 +71,7 @@ public:
         bool preventCancel { false };
     };
 
-    static ExceptionOr<Ref<ReadableStream>> create(JSDOMGlobalObject&, std::optional<JSC::Strong<JSC::JSObject>>&&, std::optional<JSC::Strong<JSC::JSObject>>&&);
+    static ExceptionOr<Ref<ReadableStream>> create(JSDOMGlobalObject&, JSC::Strong<JSC::JSObject>&&, JSC::Strong<JSC::JSObject>&&);
     static ExceptionOr<Ref<ReadableStream>> create(JSDOMGlobalObject&, Ref<ReadableStreamSource>&&);
     static ExceptionOr<Ref<ReadableStream>> createFromByteUnderlyingSource(JSDOMGlobalObject&, JSC::JSValue underlyingSource, UnderlyingSource&&, double highWaterMark);
     static Ref<ReadableStream> create(Ref<InternalReadableStream>&&);

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -44,19 +44,19 @@ struct CreateInternalTransformStreamResult {
 
 static ExceptionOr<CreateInternalTransformStreamResult> createInternalTransformStream(JSDOMGlobalObject&, JSC::JSValue transformer, JSC::JSValue writableStrategy, JSC::JSValue readableStrategy);
 
-ExceptionOr<Ref<TransformStream>> TransformStream::create(JSC::JSGlobalObject& globalObject, std::optional<JSC::Strong<JSC::JSObject>>&& transformer, std::optional<JSC::Strong<JSC::JSObject>>&& writableStrategy, std::optional<JSC::Strong<JSC::JSObject>>&& readableStrategy)
+ExceptionOr<Ref<TransformStream>> TransformStream::create(JSC::JSGlobalObject& globalObject, JSC::Strong<JSC::JSObject>&& transformer, JSC::Strong<JSC::JSObject>&& writableStrategy, JSC::Strong<JSC::JSObject>&& readableStrategy)
 {
     JSC::JSValue transformerValue = JSC::jsUndefined();
     if (transformer)
-        transformerValue = transformer->get();
+        transformerValue = transformer.get();
 
     JSC::JSValue writableStrategyValue = JSC::jsUndefined();
     if (writableStrategy)
-        writableStrategyValue = writableStrategy->get();
+        writableStrategyValue = writableStrategy.get();
 
     JSC::JSValue readableStrategyValue = JSC::jsUndefined();
     if (readableStrategy)
-        readableStrategyValue = readableStrategy->get();
+        readableStrategyValue = readableStrategy.get();
 
     auto result = createInternalTransformStream(*JSC::jsCast<JSDOMGlobalObject*>(&globalObject), transformerValue, writableStrategyValue, readableStrategyValue);
     if (result.hasException())

--- a/Source/WebCore/Modules/streams/TransformStream.h
+++ b/Source/WebCore/Modules/streams/TransformStream.h
@@ -42,7 +42,7 @@ template<typename> class ExceptionOr;
 
 class TransformStream : public RefCounted<TransformStream> {
 public:
-    static ExceptionOr<Ref<TransformStream>> create(JSC::JSGlobalObject&, std::optional<JSC::Strong<JSC::JSObject>>&&, std::optional<JSC::Strong<JSC::JSObject>>&&, std::optional<JSC::Strong<JSC::JSObject>>&&);
+    static ExceptionOr<Ref<TransformStream>> create(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>&&, JSC::Strong<JSC::JSObject>&&, JSC::Strong<JSC::JSObject>&&);
 
     ~TransformStream();
 

--- a/Source/WebCore/Modules/streams/WritableStream.cpp
+++ b/Source/WebCore/Modules/streams/WritableStream.cpp
@@ -33,15 +33,15 @@
 
 namespace WebCore {
 
-ExceptionOr<Ref<WritableStream>> WritableStream::create(JSC::JSGlobalObject& globalObject, std::optional<JSC::Strong<JSC::JSObject>>&& underlyingSink, std::optional<JSC::Strong<JSC::JSObject>>&& strategy)
+ExceptionOr<Ref<WritableStream>> WritableStream::create(JSC::JSGlobalObject& globalObject, JSC::Strong<JSC::JSObject>&& underlyingSink, JSC::Strong<JSC::JSObject>&& strategy)
 {
     JSC::JSValue underlyingSinkValue = JSC::jsUndefined();
     if (underlyingSink)
-        underlyingSinkValue = underlyingSink->get();
+        underlyingSinkValue = underlyingSink.get();
 
     JSC::JSValue strategyValue = JSC::jsUndefined();
     if (strategy)
-        strategyValue = strategy->get();
+        strategyValue = strategy.get();
 
     return create(globalObject, underlyingSinkValue, strategyValue);
 }

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -41,7 +41,7 @@ template<typename> class ExceptionOr;
 
 class WritableStream : public RefCountedAndCanMakeWeakPtr<WritableStream> {
 public:
-    static ExceptionOr<Ref<WritableStream>> create(JSC::JSGlobalObject&, std::optional<JSC::Strong<JSC::JSObject>>&&, std::optional<JSC::Strong<JSC::JSObject>>&&);
+    static ExceptionOr<Ref<WritableStream>> create(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>&&, JSC::Strong<JSC::JSObject>&&);
     static ExceptionOr<Ref<WritableStream>> create(JSDOMGlobalObject&, Ref<WritableStreamSink>&&);
     static Ref<WritableStream> create(Ref<InternalWritableStream>&&);
 

--- a/Source/WebCore/bindings/js/JSDOMConvertOptional.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertOptional.h
@@ -25,30 +25,11 @@
 
 #pragma once
 
-#include "JSDOMConvertDictionary.h"
-#include "JSDOMConvertNullable.h"
+#include "IDLTypes.h"
+#include "JSDOMConvertBase.h"
+#include "JSDOMGlobalObject.h"
 
 namespace WebCore {
-
-namespace Detail {
-
-template<typename IDL>
-struct OptionalConversionType;
-
-template<typename IDL>
-struct OptionalConversionType {
-    using Type = typename IDLOptional<IDL>::ConversionResultType;
-    static constexpr Type nullValue() { return IDL::nullValue(); }
-};
-
-template<>
-struct OptionalConversionType<IDLObject> {
-    // FIXME: Switch all nullable IDLObjects to using std::optional<JSC::Strong<JSC::JSObject>> and remove this.
-    using Type = std::optional<JSC::Strong<JSC::JSObject>>;
-    static constexpr Type nullValue() { return std::nullopt; }
-};
-
-}
 
 // `IDLOptional` is just like `IDLNullable`, but used in places that where the type is implicitly optional,
 // like optional arguments to functions without default values, or non-required members of dictionaries
@@ -58,47 +39,45 @@ struct OptionalConversionType<IDLObject> {
 // is needed in those cases.
 
 template<typename IDL> struct Converter<IDLOptional<IDL>> : DefaultConverter<IDLOptional<IDL>> {
-    using OptionalConversionType = typename Detail::OptionalConversionType<IDL>;
-    using ReturnType = typename OptionalConversionType::Type;
     using Result = ConversionResult<IDLOptional<IDL>>;
 
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
     {
         if (value.isUndefined())
-            return { OptionalConversionType::nullValue() };
+            return { IDL::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value);
     }
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject)
     {
         if (value.isUndefined())
-            return { OptionalConversionType::nullValue() };
+            return { IDL::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, thisObject);
     }
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject)
     {
         if (value.isUndefined())
-            return { OptionalConversionType::nullValue() };
+            return { IDL::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, globalObject);
     }
     template<ExceptionThrowerFunctor ExceptionThrower = DefaultExceptionThrower>
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ExceptionThrower&& exceptionThrower)
     {
         if (value.isUndefined())
-            return { OptionalConversionType::nullValue() };
+            return { IDL::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, std::forward<ExceptionThrower>(exceptionThrower));
     }
     template<ExceptionThrowerFunctor ExceptionThrower = DefaultExceptionThrower>
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSC::JSObject& thisObject, ExceptionThrower&& exceptionThrower)
     {
         if (value.isUndefined())
-            return { OptionalConversionType::nullValue() };
+            return { IDL::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, thisObject, std::forward<ExceptionThrower>(exceptionThrower));
     }
     template<ExceptionThrowerFunctor ExceptionThrower = DefaultExceptionThrower>
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, ExceptionThrower&& exceptionThrower)
     {
         if (value.isUndefined())
-            return { OptionalConversionType::nullValue() };
+            return { IDL::nullValue() };
         return WebCore::convert<IDL>(lexicalGlobalObject, value, globalObject, std::forward<ExceptionThrower>(exceptionThrower));
     }
 };

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -34,6 +34,7 @@
 #include <WebCore/JSDOMConvertBufferSource.h>
 #include <WebCore/JSDOMConvertInterface.h>
 #include <WebCore/JSDOMConvertNull.h>
+#include <WebCore/JSDOMConvertNullable.h>
 #include <WebCore/JSDOMConvertUndefined.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### 474a2f8f8422dba6683fd94c959b8dd8a49caf46
<pre>
Remove IDLObject special case in JSDOMConvertOptional
<a href="https://bugs.webkit.org/show_bug.cgi?id=306126">https://bugs.webkit.org/show_bug.cgi?id=306126</a>

Reviewed by Darin Adler.

Treat IDL `optional object` and `object?` the same, using
`JSC::Strong&lt;JSC::Object&gt;&gt;`, utilizing its cleared state.

* Source/WebCore/Modules/streams/ReadableStream.cpp:
* Source/WebCore/Modules/streams/ReadableStream.h:
* Source/WebCore/Modules/streams/TransformStream.cpp:
* Source/WebCore/Modules/streams/TransformStream.h:
* Source/WebCore/Modules/streams/WritableStream.cpp:
* Source/WebCore/Modules/streams/WritableStream.h:
* Source/WebCore/bindings/js/JSDOMConvertOptional.h:
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:

Canonical link: <a href="https://commits.webkit.org/306131@main">https://commits.webkit.org/306131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de98d829d6f59ec41f0a4ab3d6fe55a3e380c098

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148679 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13453 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107600 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9991 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7533 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119230 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151307 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115901 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116236 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29556 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11388 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122140 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67441 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12471 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1596 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76171 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->