### PR TITLE
[GFC] Add some initial logic to support track sizing with max-content track sizing functions

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -161,6 +161,12 @@ static Vector<LayoutUnit> minContentContributions(const PlacedGridItems&, const 
     return { { } };
 }
 
+static Vector<LayoutUnit> maxContentContributions(const PlacedGridItems&, const GridItemIndexes&, const IntegrationUtils&)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { { } };
+}
+
 static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList,
     const IntegrationUtils& integrationUtils)
 {
@@ -181,8 +187,13 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
                 return std::max({ }, std::ranges::max(itemContributions));
             },
             [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
-                ASSERT_NOT_IMPLEMENTED_YET();
-                return { };
+                // If the track has a max-content min track sizing function, set its base
+                // size to the maximum of the items’ max-content contributions, floored at zero.
+                auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, integrationUtils);
+                ASSERT(itemContributions.size() == singleSpanningItemsIndexes.size());
+                if (itemContributions.isEmpty())
+                    return { };
+                return std::max({ }, std::ranges::max(itemContributions));
             },
             [&](const CSS::Keyword::Auto&) -> LayoutUnit {
                 ASSERT_NOT_IMPLEMENTED_YET();
@@ -206,8 +217,22 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
                 return std::ranges::max(itemContributions);
             },
             [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
-                ASSERT_NOT_IMPLEMENTED_YET();
-                return { };
+                // If the track has a max-content max track sizing function, set its growth
+                // limit to the maximum of the items’ max-content contributions.
+                auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, integrationUtils);
+                auto maximumMaxContentContribution = itemContributions.isEmpty() ? 0_lu : std::ranges::max(itemContributions);
+
+                auto hasFitContentMaximum = [] {
+                    ASSERT_NOT_IMPLEMENTED_YET();
+                    return false;
+                };
+                // For fit-content() maximums, furthermore clamp this growth limit by the
+                // fit-content() argument.
+                if (hasFitContentMaximum())  {
+                    ASSERT_NOT_IMPLEMENTED_YET();
+                    return { };
+                }
+                return maximumMaxContentContribution;
             },
             [&](const CSS::Keyword::Auto&) -> LayoutUnit {
                 ASSERT_NOT_IMPLEMENTED_YET();


### PR DESCRIPTION
#### e5a6e7611a0804d051452d07ee67f2b60c19889b
<pre>
[GFC] Add some initial logic to support track sizing with max-content track sizing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306135">https://bugs.webkit.org/show_bug.cgi?id=306135</a>
<a href="https://rdar.apple.com/168773221">rdar://168773221</a>

Reviewed by Alan Baradlay.

We build upon 306091@main which added a decent amount of track sizing
skeleton code by adding in some initial logic for max-content as the
track sizing function. Specifically, we build upon the case where we are
sizing tracks to fit non-spanning items (step 11.5.2).
<a href="https://drafts.csswg.org/css-grid-1/#algo-single-span-items">https://drafts.csswg.org/css-grid-1/#algo-single-span-items</a>

Most of this should just be the spec verbatim where we get the
max-content contributions of the items in the case where max-content is
the min track sizing functions and max track sizing functions. Right now
the function to get these size contributions is an empty stub but will
be filled in with some logic to return a Vector of all max-content
contributions of the items.

The one slightly tricky case is the scenario in which the max track
sizing function may have been max-content. In this case, we treat that
function as max-content for the purposes of this step, but after we get
the maximum max-content contribution we also need to clamp it by the
argument to the fit-content function. The problem is that GridLayout
would have transformed this fit-content function into max-content so
that we arrive at this &quot;max-content maximums,&quot; but we lost the fact that
this was originally a fit-content sizing function. We will likely need
to store some extra information or do something else entirely to support
this properly, but I defer that for now and just leave some skeleton
code with a notImplemented() to figure out in a future patch.

Canonical link: <a href="https://commits.webkit.org/306239@main">https://commits.webkit.org/306239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5a84a76a63c192fa690e8dde6d9660ee6e872a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149121 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13275 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125995 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88849 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7858 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9172 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119545 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151702 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12809 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2173 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116561 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29643 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12556 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67949 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12851 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12591 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76551 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12635 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->