### PR TITLE
Unreviewed, reverting 303003@main.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -164,6 +164,12 @@ static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPol
 
 } // namespace WebKit
 
+// EnhancedSecurityFeatureEnabled is a temporary NSUserDefault, See: rdar://163369863
+static BOOL isEnhancedSecurityFeatureEnabled()
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"EnhancedSecurityFeatureEnabled"];
+}
+
 static Ref<API::WebsitePolicies> protectedWebsitePolicies(WKWebpagePreferences *preferences)
 {
     return *preferences->_websitePolicies;
@@ -512,11 +518,16 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)_setEnhancedSecurityEnabled:(BOOL)isEnhancedSecurityEnabled
 {
+    if (!isEnhancedSecurityFeatureEnabled())
+        return;
+
     _websitePolicies->setIsEnhancedSecurityEnabled(isEnhancedSecurityEnabled);
 }
 
 - (BOOL)_enhancedSecurityEnabled
 {
+    if (!isEnhancedSecurityFeatureEnabled())
+        return NO;
     return _websitePolicies->isEnhancedSecurityEnabled();
 }
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
@@ -842,6 +853,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)setSecurityRestrictionMode:(WKSecurityRestrictionMode)mode
 {
+    if (!isEnhancedSecurityFeatureEnabled())
+        return;
+
     switch (mode) {
     case WKSecurityRestrictionModeNone:
         _websitePolicies->setIsEnhancedSecurityEnabled(false);
@@ -860,6 +874,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (WKSecurityRestrictionMode)securityRestrictionMode
 {
+    if (!isEnhancedSecurityFeatureEnabled())
+        return WKSecurityRestrictionModeNone;
     if (Ref { *_websitePolicies }->lockdownModeEnabled())
         return WKSecurityRestrictionModeLockdown;
     if (_websitePolicies->isEnhancedSecurityEnabled())

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -41,6 +41,19 @@ namespace TestWebKitAPI {
 
 #if !PLATFORM(IOS)
 
+class EnhancedSecurityTest : public testing::Test {
+public:
+    virtual void SetUp()
+    {
+        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"EnhancedSecurityFeatureEnabled"];
+    }
+
+    virtual void TearDown()
+    {
+        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"EnhancedSecurityFeatureEnabled"];
+    }
+};
+
 static bool isEnhancedSecurityEnabled(WKWebView *webView)
 {
     __block bool gotResponse = false;
@@ -67,7 +80,7 @@ static bool isJITEnabled(WKWebView *webView)
     return isJITEnabledResult;
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -80,7 +93,7 @@ TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
     EXPECT_STREQ("security", processVariant.UTF8String);
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -93,7 +106,7 @@ TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
     EXPECT_STREQ("standard", processVariant.UTF8String);
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -104,7 +117,7 @@ TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
     EXPECT_EQ(false, isJITEnabled(webView.get()));
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -130,7 +143,7 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecurity)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -168,7 +181,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySamePage)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -216,7 +229,7 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
     return processPoolConfiguration;
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -262,7 +275,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
+TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -308,7 +321,7 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
+TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)
 {
     auto webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration1.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -331,7 +344,7 @@ TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
     EXPECT_STREQ("standard", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
 }
 
-TEST(EnhancedSecurity, ProcessCanLaunch)
+TEST_F(EnhancedSecurityTest, ProcessCanLaunch)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
@@ -365,7 +378,7 @@ TEST(EnhancedSecurity, ProcessCanLaunch)
 
 }
 
-TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)
+TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
@@ -401,7 +414,7 @@ TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)
     [WKProcessPool _clearCaptivePortalModeEnabledGloballyForTesting];
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)
 {
     HTTPServer server({
         { "/example"_s, { "<iframe id='webkit_frame' src='https://example.com/webkit'></iframe>"_s } },
@@ -446,7 +459,7 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
 
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)
 {
 
     HTTPServer server({
@@ -492,7 +505,7 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
 
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)
 {
 
     HTTPServer server({
@@ -538,7 +551,7 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
 
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)
 {
 
     HTTPServer server({
@@ -583,7 +596,7 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
 }
 
-TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
+TEST_F(EnhancedSecurityTest, WindowOpenWithNoopenerFromEnhancedSecurityPage)
 {
     HTTPServer server({
         { "/example"_s, { "<script>w = window.open('https://webkit.org/webkit', '_blank', 'noopener')</script>"_s } },
@@ -623,7 +636,7 @@ TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
     EXPECT_FALSE(hasOpener);
 }
 
-TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
+TEST_F(EnhancedSecurityTest, WindowOpenWithOpenerFromEnhancedSecurityPage)
 {
     HTTPServer server({
         { "/example"_s, { "<script>w = window.open('https://webkit.org/webkit')</script>"_s } },
@@ -661,7 +674,7 @@ TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
     EXPECT_EQ([openerWebView _webProcessIdentifier], [openedWebView _webProcessIdentifier]);
 }
 
-TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
+TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
 {
     HTTPServer server({
         { "/target"_s, { "target page"_s } },
@@ -725,7 +738,7 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSec
     EXPECT_FALSE(hasOpener);
 }
 
-TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)
+TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)
 {
     HTTPServer server({
         { "/opener"_s, { "<script>function openwithnoopener() {w = window.open('https://webkit.org/opened', '_blank', 'noopener')}</script>"_s } },
@@ -791,7 +804,7 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDele
     EXPECT_FALSE(hasOpener);
 }
 
-TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)
+TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)
 {
     HTTPServer server({
         { "/opener"_s, { "<script>function openwithnoopener() {w = window.open('https://webkit.org/opened', '_blank', 'noopener')}</script>"_s } },
@@ -851,7 +864,7 @@ TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDele
     EXPECT_FALSE(hasOpener);
 }
 
-TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
+TEST_F(EnhancedSecurityTest, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
@@ -867,7 +880,7 @@ TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
     EXPECT_STREQ("lockdown", [webView _webContentProcessVariantForFrame:nil].UTF8String);
 }
 
-TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
+TEST_F(EnhancedSecurityTest, EnhancedSecurityRequestedWhenLockdownModeActive)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;


### PR DESCRIPTION
#### be4717b56b5f807e90addb584d30edaa520fe8b6
<pre>
Unreviewed, reverting 303003@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306138">https://bugs.webkit.org/show_bug.cgi?id=306138</a>
<a href="https://rdar.apple.com/166794459">rdar://166794459</a>

Change caused a regression in an adopter of the EnhancedSecurity API

Reverted changeset:
    Remove EnhancedSecurityFeatureEnabled UserDefault
    <a href="https://bugs.webkit.org/show_bug.cgi?id=302475">https://bugs.webkit.org/show_bug.cgi?id=302475</a>
    <a href="https://rdar.apple.com/163369863">rdar://163369863</a>

Canonical link: <a href="https://commits.webkit.org/306130@main">https://commits.webkit.org/306130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b65eec98f650d2c20a30b10c472daac4bda44da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148711 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107618 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88514 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/9999 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7553 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8821 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151337 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12458 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115919 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116255 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29555 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11406 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122155 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12500 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1609 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76200 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12438 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12284 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->