### PR TITLE
Add MotionMark1.4 patch files.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.4.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.4.patch
@@ -1,0 +1,52 @@
+diff --git a/MotionMark/resources/runner/benchmark-runner.js b/MotionMark/resources/runner/benchmark-runner.js
+index 82ffcf0efe809f6901fd27413a2bdf279fae634e..39f079d5cf22832938522633034e27280506884c 100644
+--- a/MotionMark/resources/runner/benchmark-runner.js
++++ b/MotionMark/resources/runner/benchmark-runner.js
+@@ -115,12 +115,18 @@ class BenchmarkRunner {
+         const options = { complexity: test.complexity };
+         Utilities.extendObject(options, this._client.options);
+         Utilities.extendObject(options, Utilities.parseParameters(contentWindow.location));
++        Utilities.extendObject(options, { "suite": suite, "test": test });
+ 
+         const benchmark = new contentWindow.benchmarkClass(options);
+         document.body.style.backgroundColor = benchmark.backgroundColor(); // FIXME: Do this via a selector.
+         
+         await benchmark.initialize(options);
++
++        __signpostStart(`${suite.name}.${test.name}`);
+         const testData = await benchmark.run();
++        __signpostStop(`${suite.name}.${test.name}`);
++
++
+         const suiteResults = this._suitesResults[suite.name] || {};
+         suiteResults[test.name] = testData;
+         this._suitesResults[suite.name] = suiteResults;
+diff --git a/MotionMark/tests/resources/benchmark.js b/MotionMark/tests/resources/benchmark.js
+index 0d0bd8ea62f02a2a3750cc728d1409ca5ef42d18..b24a4b4de9a66967853953027291beeca7e18102 100644
+--- a/MotionMark/tests/resources/benchmark.js
++++ b/MotionMark/tests/resources/benchmark.js
+@@ -31,6 +31,8 @@ class Benchmark {
+         this._frameCount = 0;
+         this._warmupFrameCount = options["warmup-frame-count"];
+         this._firstFrameMinimumLength = options["first-frame-minimum-length"];
++        this._suite = options["suite"]
++        this._test = options["test"]
+ 
+         this._stage = stage;
+ 
+@@ -93,6 +95,7 @@ class Benchmark {
+             this._completionFunction = resolve;
+             this._previousTimestamp = undefined;
+             this._didWarmUp = false;
++            __signpostStart(`${this._suite.name}.${this._test.name}: warmup`);
+             this._stage.tune(this._controller.initialComplexity - this._stage.complexity());
+             this._animateLoop();
+         });
+@@ -114,6 +117,7 @@ class Benchmark {
+                 this._benchmarkStartTimestamp = timestamp;
+             } else if (timestamp - this._previousTimestamp >= this._warmupLength && this._frameCount >= this._warmupFrameCount) {
+                 this._didWarmUp = true;
++                __signpostStop(`${this._suite.name}.${this._test.name}: warmup`);
+                 this._benchmarkStartTimestamp = timestamp;
+                 this._controller.start(timestamp, this._stage);
+                 this._previousTimestamp = timestamp;

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.4.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.4.patch
@@ -1,0 +1,152 @@
+diff --git a/MotionMark/resources/debug-runner/debug-runner.js b/MotionMark/resources/debug-runner/debug-runner.js
+index 085f4d3eb3f0fd6d8fec0bee914f2f3c3789ff15..fd63cabff133a821ab797df00eee62038556484b 100644
+--- a/MotionMark/resources/debug-runner/debug-runner.js
++++ b/MotionMark/resources/debug-runner/debug-runner.js
+@@ -510,6 +510,37 @@ window.suitesManager = new class SuitesManager {
+         return suites;
+     }
+ 
++    constructSuitesFromURLParameters: function(urlParameterString) {
++        var urlParams = new URLSearchParams(urlParameterString);
++        var suiteNames = urlParams.getAll("suite-name");
++        var testNames = urlParams.getAll("test-name");
++        var suites = [];
++        for (var i = 0; i < suiteNames.length; i++) {
++            var suiteName = decodeURIComponent(suiteNames[i]);
++            var testName = decodeURIComponent(testNames[i]);
++            var suiteRegExp = new RegExp(suiteName.toLowerCase(), "i");
++            var testRegExp = new RegExp(testName.toLowerCase(), "i");
++            var test = [];
++            for (var j = 0; j < Suites.length; ++j) {
++                var suite = Suites[j];
++                if (!Utilities.stripUnwantedCharactersForURL(suite.name.toLowerCase()).match(suiteRegExp))
++                    continue;
++                var test;
++                for (var k = 0; k < suite.tests.length; ++k) {
++                    suiteTest = suite.tests[k];
++                    if (Utilities.stripUnwantedCharactersForURL(suiteTest.name.toLowerCase()).match(testRegExp)) {
++                        test = suiteTest;
++                        break;
++                    }
++                }
++                if (!test)
++                    continue;
++                suites.push(new Suite(suiteName, [test]));
++            };
++        }
++        return suites;
++    },
++
+     updateLocalStorageFromJSON(results)
+     {
+         for (var suiteName in results[Strings.json.results.tests]) {
+@@ -665,16 +696,13 @@ class DebugBenchmarkController extends BenchmarkController {
+     startBenchmarkImmediatelyIfEncoded()
+     {
+         benchmarkController.determineCanvasSize();
+-        benchmarkController.options = Utilities.convertQueryStringToObject(location.search);
+-        if (!benchmarkController.options)
+-            return false;
+ 
+-        benchmarkController.suites = suitesManager.suitesFromQueryString(benchmarkController.options["suite-name"], benchmarkController.options["test-name"]);
++        benchmarkController.suites = suitesManager.constructSuitesFromURLParameters(location.search)
+         if (!benchmarkController.suites.length)
+             return false;
+ 
+         setTimeout(function() {
+-            this._startBenchmark(benchmarkController.suites, benchmarkController.options, "running-test");
++            this._startBenchmark(benchmarkController.suites, this.benchmarkDefaultParameters, "running-test");
+         }.bind(this), 0);
+         return true;
+     }
+diff --git a/MotionMark/resources/runner/motionmark.js b/MotionMark/resources/runner/motionmark.js
+index 193e212edcecc7a66d2e50eb46db0a4ddbe7ee0b..4bb8ea799e9a92fbe9b47bb9ea17e8b17908bd6f 100644
+--- a/MotionMark/resources/runner/motionmark.js
++++ b/MotionMark/resources/runner/motionmark.js
+@@ -58,9 +58,60 @@ class BenchmarkRunnerClient {
+         this._scoreCalculator.calculateScore(testData);
+     }
+ 
++    _computeTestReport(testName, testResults)
++    {
++        return [testResults[Strings.json.score]];
++    }
++ 
++    _computeSuiteReports(suiteName, suiteResults)
++    {
++        const testsReports = {};
++        for (let testName in suiteResults) {
++            const testReports = this._computeTestReport(testName, suiteResults[testName]);
++            testsReports[testName] = { "metrics": { "Score": { "current": testReports } } };
++        }
++        return testsReports;
++    }
++ 
++    _computeIterationReports(iterationResults)
++    {
++        const suitesReports = {};
++        const suffix = Strings.version ? '-' + Strings.version : '';
++        for (let suiteName in iterationResults[Strings.json.results.tests]) {
++            const testsReports = this._computeSuiteReports(suiteName, iterationResults[Strings.json.results.tests][suiteName]);
++            suitesReports[suiteName + suffix] = { "metrics": { "Score": ["Geometric"] }, "tests": testsReports };
++        }
++        return suitesReports;
++    }
++ 
++    _computeResultsReports()
++    {
++        const results = this._scoreCalculator.results[0];
++        const iterationReports = this._computeIterationReports(results);
++        iterationReports['debugOutput'] = {
++            options: this._scoreCalculator.options,
++            data: this._scoreCalculator.data,
++        }
++        return iterationReports;
++    }
++
+     didFinishLastIteration()
+     {
+-        benchmarkController.showResults();
++       // Submit result to server
++       const results = JSON.stringify(this._computeResultsReports());
++       const xhr = new XMLHttpRequest();
++       xhr.open("POST", "/report");
++       xhr.setRequestHeader("Content-type", "application/json");
++       xhr.setRequestHeader("Content-length", results.length);
++       xhr.setRequestHeader("Connection", "close");
++       xhr.onreadystatechange = function() {
++           if (xhr.readyState == XMLHttpRequest.DONE && xhr.status == 200) {
++               closeRequest = new XMLHttpRequest();
++               closeRequest.open("GET", "/shutdown");
++               closeRequest.send()
++           }
++       }
++       xhr.send(results);
+     }
+ }
+ 
+@@ -417,10 +468,17 @@ window.benchmarkControllerClass = BenchmarkController;
+ window.benchmarkRunnerClientClass = BenchmarkRunnerClient;
+ window.sectionsManagerClass = SectionsManager;
+ 
+-window.addEventListener("load", () => {
+-
+-    window.sectionsManager = new sectionsManagerClass();
+-    window.benchmarkController = new benchmarkControllerClass();
+-
+-    benchmarkController.initialize();
+-});
++if (window.location.href.includes("developer.html")) {
++    window.addEventListener("load", () => {
++        window.sectionsManager = new sectionsManagerClass();
++        window.benchmarkController = new benchmarkControllerClass();
++        benchmarkController.initialize();
++    });
++} else {
++    window.addEventListener("load", async function() {
++        window.sectionsManager = new sectionsManagerClass();
++        window.benchmarkController = new benchmarkControllerClass();
++        await benchmarkController.initialize();
++        setTimeout(async () => { benchmarkController.startBenchmark() }, 3000);
++    });
++}


### PR DESCRIPTION
#### 2d155639c991a4649a26f8c1d2683a8ff2557368
<pre>
Add MotionMark1.4 patch files.
<a href="https://rdar.apple.com/168078090">rdar://168078090</a>

Reviewed by Dewei Zhu.

Add MotionMark1.4 patch files.

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/signposts/MotionMark1.4.patch: Added.
* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/MotionMark1.4.patch: Added.

Canonical link: <a href="https://commits.webkit.org/306301@main">https://commits.webkit.org/306301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c10a6819c992e57aa111cf5df312511988599a06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149390 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13480 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10839 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89071 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/140289 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8017 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9378 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151908 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13014 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13029 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116721 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12789 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122825 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21752 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13057 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12796 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->