### PR TITLE
[JSC] Embed RTT* into WasmGC object and use it instead of Structure

### DIFF
--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -139,7 +139,6 @@ namespace JSC::B3 {
     macro(JSWebAssemblyInstance_cachedTable0Length, JSWebAssemblyInstance::offsetOfCachedTable0Length(), Mutability::Mutable) \
     macro(JSWebAssemblyInstance_moduleRecord, JSWebAssemblyInstance::offsetOfModuleRecord(), Mutability::Mutable) \
     macro(JSWebAssemblyInstance_vm, JSWebAssemblyInstance::offsetOfVM(), Mutability::Immutable) \
-    macro(JSWebAssemblyStruct_size, JSWebAssemblyStruct::offsetOfSize(), Mutability::Immutable) \
     macro(NativeExecutable_asString, NativeExecutable::offsetOfAsString(), Mutability::Mutable) \
     macro(RegExpObject_regExpAndFlags, RegExpObject::offsetOfRegExpAndFlags(), Mutability::Mutable) \
     macro(RegExpObject_lastIndex, RegExpObject::offsetOfLastIndex(), Mutability::Mutable) \
@@ -204,6 +203,7 @@ namespace JSC::B3 {
     macro(WebAssemblyFunctionBase_entrypointLoadLocation, WebAssemblyFunctionBase::offsetOfEntrypointLoadLocation(), Mutability::Immutable) \
     macro(WebAssemblyFunctionBase_rtt, WebAssemblyFunctionBase::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyFunctionBase_targetInstance, WebAssemblyFunctionBase::offsetOfTargetInstance(), Mutability::Immutable) \
+    macro(WebAssemblyGCObjectBase_rtt, WebAssemblyGCObjectBase::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyGCStructure_rtt, WebAssemblyGCStructure::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject(), Mutability::Mutable) \
     macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl(), Mutability::Immutable) \
@@ -229,7 +229,6 @@ namespace JSC::B3 {
     macro(HasOwnPropertyCache, 0, sizeof(HasOwnPropertyCache::Entry)) \
     macro(SmallIntCache, 0, sizeof(NumericStrings::StringWithJSString)) \
     macro(WasmRTT_data, Wasm::RTT::offsetOfData(), sizeof(RefPtr<const Wasm::RTT>)) \
-    macro(WebAssemblyGCStructure_inlinedTypeDisplays, WebAssemblyGCStructure::offsetOfInlinedTypeDisplay(), sizeof(RefPtr<const Wasm::RTT>)) \
 
 #define FOR_EACH_NUMBERED_ABSTRACT_HEAP(macro) \
     macro(properties) \

--- a/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.cpp
@@ -28,9 +28,28 @@
 
 #if ENABLE(B3_JIT)
 
+#include "B3ValueInlines.h"
+
 namespace JSC::B3 {
 
 WasmRefTypeCheckValue::~WasmRefTypeCheckValue() = default;
+
+void WasmRefTypeCheckValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
+{
+    out.print(comma, "targetHeapType = ", m_targetHeapType);
+    if (m_targetRTT)
+        out.print(comma, "targetRTT = ", RawPointer(m_targetRTT.get()));
+    if (allowNull())
+        out.print(comma, "allowNull");
+    if (shouldNegate())
+        out.print(comma, "shouldNegate");
+    if (referenceIsNullable())
+        out.print(comma, "referenceIsNullable");
+    if (definitelyIsCellOrNull())
+        out.print(comma, "definitelyIsCellOrNull");
+    if (definitelyIsWasmGCObjectOrNull())
+        out.print(comma, "definitelyIsWasmGCObjectOrNull");
+}
 
 } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
+++ b/Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h
@@ -64,6 +64,9 @@ public:
     B3_SPECIALIZE_VALUE_FOR_FIXED_CHILDREN(1)
     B3_SPECIALIZE_VALUE_FOR_FINAL_SIZE_FIXED_CHILDREN
 
+private:
+    void dumpMeta(CommaPrinter&, PrintStream&) const final;
+
 protected:
     friend class Procedure;
     friend class Value;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -5671,11 +5671,9 @@ void BBQJIT::emitArrayGetPayload(StorageType type, GPRReg arrayGPR, GPRReg paylo
         return;
     }
 
-    // FIXME: This could probably use a moveConditionally but we don't have enough scratches and this case is unlikely to exist in practice.
-    m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::offsetOfData()), arrayGPR, payloadGPR);
-    auto precise = m_jit.branchTestPtr(MacroAssembler::NonZero, arrayGPR, MacroAssembler::TrustedImm32(PreciseAllocation::halfAlignment));
-    m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::v128AlignmentShift), payloadGPR, payloadGPR);
-    precise.link(m_jit);
+    // Round-up to 16x for PreciseAllocation + V128 array data handling.
+    m_jit.addPtr(MacroAssembler::TrustedImm32(JSWebAssemblyArray::offsetOfData() + 15), arrayGPR, payloadGPR);
+    m_jit.andPtr(MacroAssembler::TrustedImm32(-16), payloadGPR);
 }
 
 } // namespace JSC::Wasm::BBQJITImpl

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -840,6 +840,7 @@ class alignas(16) RTT final : public ThreadSafeRefCounted<RTT>, private Trailing
     friend TrailingArrayType;
 public:
     static_assert(sizeof(const RTT*) == sizeof(RefPtr<const RTT>));
+    static constexpr unsigned inlinedDisplaySize = 6;
     RTT() = delete;
 
     static RefPtr<RTT> tryCreate(RTTKind, bool isFinalType, StructFieldCount fieldCount);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -127,20 +127,13 @@ private:
 
 #if ASSERT_ENABLED
     bool m_isUnpopulated { false };
-#else
-    // FIXME: We shouldn't need this padding but otherwise all the calculations about v128AlignmentShifts are wrong.
-    // (With ASSERT_ENABLED, the necessary padding is added implicitly after 'm_isUnpopulated').
-#if USE(JSVALUE32_64)
-    unsigned m_padding;
 #endif
-#endif
-
 };
 
 static_assert(std::is_final_v<JSWebAssemblyArray>, "JSWebAssemblyArray is a TrailingArray-like object so must know about all members");
 // We still have to check for PreciseAllocations since those are correctly aligned for v128 but this asserts our shifted offset will be correct.
 // FIXME: Fix this check for 32-bit.
-static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData() + JSWebAssemblyArray::v128AlignmentShift) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
+static_assert(isAddress32Bit() || !((JSWebAssemblyArray::offsetOfData()) % 16), "JSWebAssemblyArray storage needs to be aligned for v128_t");
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h
@@ -54,7 +54,7 @@ std::span<T> JSWebAssemblyArray::span() LIFETIME_BOUND
     ASSERT(sizeof(T) == elementType().type.elementSize());
     uint8_t* data = this->data();
     if constexpr (std::is_same_v<T, v128_t>)
-        data += isPreciseAllocation() ? 0 : v128AlignmentShift;
+        data = WTF::roundUpToMultipleOf<16>(data);
     else
         ASSERT(!needsAlignmentCheck(elementType().type));
     ASSERT(data == this->bytes().data());
@@ -69,9 +69,9 @@ std::span<uint64_t> JSWebAssemblyArray::refTypeSpan() LIFETIME_BOUND
 
 std::span<uint8_t> JSWebAssemblyArray::bytes()
 {
-    if (!needsAlignmentCheck(elementType().type) || isPreciseAllocation())
+    if (!needsAlignmentCheck(elementType().type))
         return { data(), sizeInBytes() };
-    return { data() + v128AlignmentShift, sizeInBytes() };
+    return { WTF::roundUpToMultipleOf<16>(data()), sizeInBytes() };
 }
 
 auto JSWebAssemblyArray::visitSpan(auto functor)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp
@@ -38,7 +38,9 @@ const ClassInfo WebAssemblyGCObjectBase::s_info = { "WebAssemblyGCObjectBase"_s,
 
 WebAssemblyGCObjectBase::WebAssemblyGCObjectBase(VM& vm, WebAssemblyGCStructure* structure)
     : Base(vm, structure)
-{ }
+    , m_rtt(&gcStructure()->rtt())
+{
+}
 
 template<typename Visitor>
 void WebAssemblyGCObjectBase::visitChildrenImpl(JSCell* cell, Visitor& visitor)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h
@@ -44,7 +44,9 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     const WebAssemblyGCStructure* gcStructure() const { return uncheckedDowncast<WebAssemblyGCStructure>(structure()); }
-    Ref<const Wasm::RTT> rtt() const { return gcStructure()->rtt(); }
+    Ref<const Wasm::RTT> rtt() const { return *m_rtt; }
+
+    static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCObjectBase, m_rtt); }
 
 protected:
     WebAssemblyGCObjectBase(VM&, WebAssemblyGCStructure*);
@@ -63,6 +65,9 @@ protected:
     JS_EXPORT_PRIVATE static bool setPrototype(JSObject*, JSGlobalObject*, JSValue, bool shouldThrowIfCantSet);
     JS_EXPORT_PRIVATE static bool isExtensible(JSObject*, JSGlobalObject*);
     JS_EXPORT_PRIVATE static bool preventExtensions(JSObject*, JSGlobalObject*);
+
+    // It is held by structure. Keeping Wasm GC object trivially destructible is critical for performance.
+    SUPPRESS_UNCOUNTED_MEMBER const Wasm::RTT* m_rtt;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp
@@ -77,15 +77,12 @@ WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, JSGlobalObject* globalObj
     , m_type(WTF::move(type))
     , m_typeDependencies(WebAssemblyGCStructureTypeDependencies { WTF::move(unexpandedType) })
 {
-    for (unsigned i = 0; i < std::min((m_rtt->displaySizeExcludingThis() + 1), inlinedTypeDisplaySize); ++i)
-        m_inlinedTypeDisplay[i] = m_rtt->displayEntry(i);
 }
 
 WebAssemblyGCStructure::WebAssemblyGCStructure(VM& vm, WebAssemblyGCStructure* previous)
     : Structure(vm, StructureVariant::WebAssemblyGC, previous)
     , m_rtt(previous->m_rtt)
     , m_type(previous->m_type)
-    , m_inlinedTypeDisplay(previous->m_inlinedTypeDisplay)
     , m_typeDependencies(previous->m_typeDependencies)
 {
 }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h
@@ -67,8 +67,6 @@ class WebAssemblyGCStructure final : public Structure {
 public:
     friend class Structure;
 
-    static constexpr unsigned inlinedTypeDisplaySize = 6;
-
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
@@ -81,7 +79,6 @@ public:
     static WebAssemblyGCStructure* create(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&& unexpandedType, Ref<const Wasm::TypeDefinition>&& expandedType, Ref<const Wasm::RTT>&&);
 
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WebAssemblyGCStructure, m_rtt); }
-    static constexpr ptrdiff_t offsetOfInlinedTypeDisplay() { return OBJECT_OFFSETOF(WebAssemblyGCStructure, m_inlinedTypeDisplay); }
 
 private:
     WebAssemblyGCStructure(VM&, JSGlobalObject*, const TypeInfo&, const ClassInfo*, Ref<const Wasm::TypeDefinition>&& unexpandedType, Ref<const Wasm::TypeDefinition>&& expandedType, Ref<const Wasm::RTT>&&);
@@ -89,7 +86,6 @@ private:
 
     Ref<const Wasm::RTT> m_rtt;
     Ref<const Wasm::TypeDefinition> m_type;
-    std::array<RefPtr<const Wasm::RTT>, inlinedTypeDisplaySize> m_inlinedTypeDisplay { };
     WebAssemblyGCStructureTypeDependencies m_typeDependencies;
 };
 


### PR DESCRIPTION
#### cf081af6f520988721d37786cf2b93fb7c719d1e
<pre>
[JSC] Embed RTT* into WasmGC object and use it instead of Structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=306142">https://bugs.webkit.org/show_bug.cgi?id=306142</a>
<a href="https://rdar.apple.com/168781508">rdar://168781508</a>

Reviewed by Dan Hecht.

Still, loading RTT from structure for type check is costly. But
structure is not sharable between multiple VMs, and structures can be
different for each JSWebAssemblyInstance with different realm for the
same RTT types. Thus, let&apos;s just add const RTT* field to Wasm GC object
field to make type check faster.

This patch improves several things.

1. We stop using TrailingArray for JSWebAssemblyStruct since it adds
   size, which is not used, but taking much space. This allows 8 byte
   space for us, which can be used for `const RTT*`.
2. Add `const RTT*` field to WebAssemblyGCObjectBase and use it for type
   checking. We no longer need to load structure for type checks.
3. We stop having inlined RTT display list in WebAssemblyGCStructure.
   And instead, having it in RTT. So we can continue using this
   optimization. Since it now becomes per-RTT, it is more memory efficient
   than the previuos approach.

* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.cpp:
(JSC::B3::WasmRefTypeCheckValue::dumpMeta const):
* Source/JavaScriptCore/b3/B3WasmRefTypeCheckValue.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArrayGetPayload):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCArrayUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAllocateGCStructUninitialized):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitRefTestOrCast):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitGetArrayPayloadBase):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCObject):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
(JSC::Wasm::OMGIRGenerator::decodeNonNullStructure): Deleted.
(JSC::Wasm::OMGIRGenerator::emitLoadRTTFromObject): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::emitGetArrayPayloadBase):
(JSC::Wasm::OMGIRGenerator::emitRefTestOrCast):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCObject):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCArrayUninitialized):
(JSC::Wasm::OMGIRGenerator::allocateWasmGCStructUninitialized):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::RTT::RTT):
(JSC::Wasm::RTT::tryCreate):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArrayInlines.h:
(JSC::JSWebAssemblyArray::bytes):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::JSWebAssemblyStruct):
(JSC::JSWebAssemblyStruct::tryCreate):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.cpp:
(JSC::WebAssemblyGCObjectBase::WebAssemblyGCObjectBase):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCObjectBase.h:
(JSC::WebAssemblyGCObjectBase::rtt const):
(JSC::WebAssemblyGCObjectBase::offsetOfRTT):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.cpp:
(JSC::WebAssemblyGCStructure::WebAssemblyGCStructure):
* Source/JavaScriptCore/wasm/js/WebAssemblyGCStructure.h:

Canonical link: <a href="https://commits.webkit.org/306226@main">https://commits.webkit.org/306226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb8a43545c48c7c100cb2dc54ab641989bcb5604

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140432 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93519 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a1d0384-494a-4b7f-8116-3c866e97c180) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107659 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78165 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a01fe0c8-1075-458c-848d-82eec0ba85c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88559 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/412c00ea-53df-4158-acad-70b010054887) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7587 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8865 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132410 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151382 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1230 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12502 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115956 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116294 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11483 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67520 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21714 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12544 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1654 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12284 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76244 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44546 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12328 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->