### PR TITLE
Add TextStream operator<< for ViewportConstraints for ease of debugging

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.cpp
@@ -153,6 +153,16 @@ TextStream& operator<<(TextStream& ts, const AbsolutePositionConstraints& constr
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, const ViewportConstraints& constraints)
+{
+    if (auto fixedConstraints = dynamicDowncast<FixedPositionViewportConstraints>(constraints))
+        return ts << *fixedConstraints;
+    if (auto stickyConstraints = dynamicDowncast<StickyPositionViewportConstraints>(constraints))
+        return ts << *stickyConstraints;
+    ASSERT_NOT_REACHED();
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, const FixedPositionViewportConstraints& constraints)
 {
     ts.dumpProperty("viewport-rect-at-last-layout"_s, constraints.viewportRectAtLastLayout());

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -202,6 +202,7 @@ private:
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollPositioningBehavior);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const AbsolutePositionConstraints&);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const ViewportConstraints&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FixedPositionViewportConstraints&);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const StickyPositionViewportConstraints&);
 


### PR DESCRIPTION
#### 58cec1846b46f1be6203bc0084a0eb74c2886cb3
<pre>
Add TextStream operator&lt;&lt; for ViewportConstraints for ease of debugging
<a href="https://bugs.webkit.org/show_bug.cgi?id=306145">https://bugs.webkit.org/show_bug.cgi?id=306145</a>
<a href="https://rdar.apple.com/168783509">rdar://168783509</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebCore/page/scrolling/ScrollingConstraints.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingConstraints.h:
I recently had reason to need this, and figured it might help someone else someday.

Canonical link: <a href="https://commits.webkit.org/306133@main">https://commits.webkit.org/306133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1164e13972babb3737afd70ee98de8f374fc7fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148730 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142280 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13501 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107631 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88528 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8840 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151356 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12477 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115933 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116270 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29558 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11426 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122168 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12519 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1621 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12259 "Failed to checkout and rebase branch from PR 57147") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76219 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->