### PR TITLE
AX: Remove accessibilityBusAddress from GTK display

### DIFF
--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -371,14 +371,6 @@ const String& WebProcessPool::accessibilityBusAddress() const
         return m_accessibilityBusAddress.value();
     }
 
-#if PLATFORM(GTK)
-    auto address = Display::singleton().accessibilityBusAddress();
-    if (!address.isEmpty()) {
-        m_accessibilityBusAddress = WTF::move(address);
-        return m_accessibilityBusAddress.value();
-    }
-#endif
-
     m_accessibilityBusAddress = queryAccessibilityBusAddress();
     return m_accessibilityBusAddress.value();
 }

--- a/Source/WebKit/UIProcess/gtk/Display.cpp
+++ b/Source/WebKit/UIProcess/gtk/Display.cpp
@@ -96,24 +96,6 @@ GLDisplay* Display::glDisplay() const
     return nullptr;
 }
 
-String Display::accessibilityBusAddress() const
-{
-    if (!m_gdkDisplay)
-        return { };
-
-#if USE(GTK4)
-    if (const char* atspiBusAddress = static_cast<const char*>(g_object_get_data(G_OBJECT(m_gdkDisplay.get()), "-gtk-atspi-bus-address")))
-        return String::fromUTF8(atspiBusAddress);
-#endif
-
-#if PLATFORM(X11)
-    if (isX11())
-        return accessibilityBusAddressX11();
-#endif
-
-    return { };
-}
-
 #if !PLATFORM(X11)
 bool Display::isX11() const
 {

--- a/Source/WebKit/UIProcess/gtk/Display.h
+++ b/Source/WebKit/UIProcess/gtk/Display.h
@@ -51,13 +51,10 @@ public:
     bool isX11() const;
     bool isWayland() const;
 
-    String accessibilityBusAddress() const;
-
 private:
     Display();
 #if PLATFORM(X11)
     bool initializeGLDisplayX11() const;
-    String accessibilityBusAddressX11() const;
 #endif
 #if PLATFORM(WAYLAND)
     bool initializeGLDisplayWayland() const;

--- a/Source/WebKit/UIProcess/gtk/DisplayX11.cpp
+++ b/Source/WebKit/UIProcess/gtk/DisplayX11.cpp
@@ -77,26 +77,6 @@ bool Display::initializeGLDisplayX11() const
     return false;
 }
 
-String Display::accessibilityBusAddressX11() const
-{
-    auto* xDisplay = GDK_DISPLAY_XDISPLAY(m_gdkDisplay.get());
-    Atom atspiBusAtom = XInternAtom(xDisplay, "AT_SPI_BUS", False);
-    Atom type;
-    int format;
-    unsigned long itemCount, bytesAfter;
-    unsigned char* data = nullptr;
-    XErrorTrapper trapper(xDisplay, XErrorTrapper::Policy::Ignore);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK port.
-    XGetWindowProperty(xDisplay, RootWindowOfScreen(DefaultScreenOfDisplay(xDisplay)), atspiBusAtom, 0L, 8192, False, XA_STRING, &type, &format, &itemCount, &bytesAfter, &data);
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-    auto atspiBusAddress = String::fromUTF8(reinterpret_cast<char*>(data));
-    if (data)
-        XFree(data);
-
-    return atspiBusAddress;
-}
-
 } // namespace WebKit
 
 #endif // PLATFORM(X11)


### PR DESCRIPTION
#### b89408b1091f63f3832b2086510a675a04d5f404
<pre>
AX: Remove accessibilityBusAddress from GTK display
<a href="https://bugs.webkit.org/show_bug.cgi?id=306148">https://bugs.webkit.org/show_bug.cgi?id=306148</a>

Reviewed by Michael Catanzaro.

We have code to check AT_SPI_BUS_ADDRESS from the environment or query
at-spi-bus-launcher via DBus. This should suffice for finding the
accessibility bus. Historically, the address has also been stored as an
atom on the X display in order to allow applications running as the
super-user to be able to connect with accessibility clients running as a
normal user, but this is not common nowadays, and a WebKit application
running as root is going to crash anyhow when trying to execute bubblewrap.
We are sometimes obtaining an accessibility bus address that we don&apos;t have
permission to connect to, causing the process to abort later (see
<a href="https://gitlab.gnome.org/GNOME/at-spi2-core/core/-/issues/180)">https://gitlab.gnome.org/GNOME/at-spi2-core/core/-/issues/180)</a>, and this
change may help and should not do any harm.

* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::accessibilityBusAddress const):
* Source/WebKit/UIProcess/gtk/Display.cpp:
(WebKit::Display::accessibilityBusAddress const): Deleted.
* Source/WebKit/UIProcess/gtk/Display.h:
* Source/WebKit/UIProcess/gtk/DisplayX11.cpp:
(WebKit::Display::accessibilityBusAddressX11 const): Deleted.

Canonical link: <a href="https://commits.webkit.org/306124@main">https://commits.webkit.org/306124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8bdc931a315a3fa8c57a2b19787d044450bed76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148735 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12948 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143363 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88534 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8845 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151361 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1770 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/115939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12497 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116276 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11442 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12524 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/76224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->