### PR TITLE
AX: Refactor the text editing enums in AXTextStateChangeIntent.h to be enum classes and add debugDescription methods

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -594,6 +594,7 @@ accessibility/AXStitchUtilities.cpp
 accessibility/AXTableHelpers.cpp
 accessibility/AXTextMarker.cpp
 accessibility/AXTextRun.cpp
+accessibility/AXTextStateChangeIntent.cpp
 accessibility/AXTreeStore.cpp
 accessibility/AXUtilities.cpp
 accessibility/AXAttachmentHelpers.cpp

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -619,10 +619,6 @@ public:
     // Requests clients to announce to the user the given message in the way they deem appropriate.
     WEBCORE_EXPORT void announce(const String&);
 
-#ifndef NDEBUG
-    void showIntent(const AXTextStateChangeIntent&);
-#endif
-
     void setTextSelectionIntent(const AXTextStateChangeIntent&);
     void setIsSynchronizingSelection(bool);
 

--- a/Source/WebCore/accessibility/AXTextStateChangeIntent.cpp
+++ b/Source/WebCore/accessibility/AXTextStateChangeIntent.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXTextStateChangeIntent.h"
+
+#include <wtf/text/MakeString.h>
+
+namespace WebCore {
+
+String debugDescription(AXTextStateChangeType type)
+{
+    switch (type) {
+    case AXTextStateChangeType::Unknown:
+        return "Unknown"_s;
+    case AXTextStateChangeType::Edit:
+        return "Edit"_s;
+    case AXTextStateChangeType::SelectionMove:
+        return "SelectionMove"_s;
+    case AXTextStateChangeType::SelectionExtend:
+        return "SelectionExtend"_s;
+    case AXTextStateChangeType::SelectionBoundary:
+        return "SelectionBoundary"_s;
+    }
+    return "Unknown"_s;
+}
+
+String debugDescription(AXTextEditType type)
+{
+    switch (type) {
+    case AXTextEditType::Unknown:
+        return "Unknown"_s;
+    case AXTextEditType::Delete:
+        return "Delete"_s;
+    case AXTextEditType::Insert:
+        return "Insert"_s;
+    case AXTextEditType::Typing:
+        return "Typing"_s;
+    case AXTextEditType::Dictation:
+        return "Dictation"_s;
+    case AXTextEditType::Cut:
+        return "Cut"_s;
+    case AXTextEditType::Paste:
+        return "Paste"_s;
+    case AXTextEditType::Replace:
+        return "Replace"_s;
+    case AXTextEditType::AttributesChange:
+        return "AttributesChange"_s;
+    }
+    return "Unknown"_s;
+}
+
+String debugDescription(AXTextSelectionDirection direction)
+{
+    switch (direction) {
+    case AXTextSelectionDirection::Unknown:
+        return "Unknown"_s;
+    case AXTextSelectionDirection::Beginning:
+        return "Beginning"_s;
+    case AXTextSelectionDirection::End:
+        return "End"_s;
+    case AXTextSelectionDirection::Previous:
+        return "Previous"_s;
+    case AXTextSelectionDirection::Next:
+        return "Next"_s;
+    case AXTextSelectionDirection::Discontiguous:
+        return "Discontiguous"_s;
+    }
+    return "Unknown"_s;
+}
+
+String debugDescription(AXTextSelectionGranularity granularity)
+{
+    switch (granularity) {
+    case AXTextSelectionGranularity::Unknown:
+        return "Unknown"_s;
+    case AXTextSelectionGranularity::Character:
+        return "Character"_s;
+    case AXTextSelectionGranularity::Word:
+        return "Word"_s;
+    case AXTextSelectionGranularity::Line:
+        return "Line"_s;
+    case AXTextSelectionGranularity::Sentence:
+        return "Sentence"_s;
+    case AXTextSelectionGranularity::Paragraph:
+        return "Paragraph"_s;
+    case AXTextSelectionGranularity::Page:
+        return "Page"_s;
+    case AXTextSelectionGranularity::Document:
+        return "Document"_s;
+    case AXTextSelectionGranularity::All:
+        return "All"_s;
+    }
+    return "Unknown"_s;
+}
+
+String AXTextSelection::debugDescription() const
+{
+    return makeString("AXTextSelection {direction: "_s, WebCore::debugDescription(direction), ", granularity: "_s, WebCore::debugDescription(granularity), ", focusChange: "_s, focusChange ? "true"_s : "false"_s, '}');
+}
+
+String AXTextStateChangeIntent::debugDescription() const
+{
+    if (type == AXTextStateChangeType::Edit)
+        return makeString("AXTextStateChangeIntent {type: "_s, WebCore::debugDescription(type), ", editType: "_s, WebCore::debugDescription(editType), '}');
+    return makeString("AXTextStateChangeIntent {type: "_s, WebCore::debugDescription(type), ", selection: "_s, selection.debugDescription(), '}');
+}
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXTextStateChangeIntent.h
+++ b/Source/WebCore/accessibility/AXTextStateChangeIntent.h
@@ -25,71 +25,82 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+
 namespace WebCore {
 
-enum AXTextStateChangeType {
-    AXTextStateChangeTypeUnknown,
-    AXTextStateChangeTypeEdit,
-    AXTextStateChangeTypeSelectionMove,
-    AXTextStateChangeTypeSelectionExtend,
-    AXTextStateChangeTypeSelectionBoundary
+enum class AXTextStateChangeType : uint8_t {
+    Unknown,
+    Edit,
+    SelectionMove,
+    SelectionExtend,
+    SelectionBoundary
 };
 
-enum AXTextEditType {
-    AXTextEditTypeUnknown,
-    AXTextEditTypeDelete, // Generic text delete
-    AXTextEditTypeInsert, // Generic text insert
-    AXTextEditTypeTyping, // Insert via typing
-    AXTextEditTypeDictation, // Insert via dictation
-    AXTextEditTypeCut, // Delete via Cut
-    AXTextEditTypePaste, // Insert via Paste
-    AXTextEditTypeReplace, // A deletion + insertion that should be notified as an atomic operation.
-    AXTextEditTypeAttributesChange // Change font, style, alignment, color, etc.
+enum class AXTextEditType : uint8_t {
+    Unknown,
+    Delete, // Generic text delete
+    Insert, // Generic text insert
+    Typing, // Insert via typing
+    Dictation, // Insert via dictation
+    Cut, // Delete via Cut
+    Paste, // Insert via Paste
+    Replace, // A deletion + insertion that should be notified as an atomic operation.
+    AttributesChange // Change font, style, alignment, color, etc.
 };
 
-enum AXTextSelectionDirection {
-    AXTextSelectionDirectionUnknown,
-    AXTextSelectionDirectionBeginning,
-    AXTextSelectionDirectionEnd,
-    AXTextSelectionDirectionPrevious,
-    AXTextSelectionDirectionNext,
-    AXTextSelectionDirectionDiscontiguous
+enum class AXTextSelectionDirection : uint8_t {
+    Unknown,
+    Beginning,
+    End,
+    Previous,
+    Next,
+    Discontiguous
 };
 
-enum AXTextSelectionGranularity {
-    AXTextSelectionGranularityUnknown,
-    AXTextSelectionGranularityCharacter,
-    AXTextSelectionGranularityWord,
-    AXTextSelectionGranularityLine,
-    AXTextSelectionGranularitySentence,
-    AXTextSelectionGranularityParagraph,
-    AXTextSelectionGranularityPage,
-    AXTextSelectionGranularityDocument,
-    AXTextSelectionGranularityAll // All granularity represents the action of selecting the whole document as a single action. Extending selection by some other granularity until it encompasses the whole document will not result in a all granularity notification.
+enum class AXTextSelectionGranularity : uint8_t {
+    Unknown,
+    Character,
+    Word,
+    Line,
+    Sentence,
+    Paragraph,
+    Page,
+    Document,
+    All // All granularity represents the action of selecting the whole document as a single action. Extending selection by some other granularity until it encompasses the whole document will not result in a all granularity notification.
 };
+
+String debugDescription(AXTextStateChangeType);
+String debugDescription(AXTextEditType);
+String debugDescription(AXTextSelectionDirection);
+String debugDescription(AXTextSelectionGranularity);
 
 struct AXTextSelection {
-    AXTextSelectionDirection direction;
-    AXTextSelectionGranularity granularity;
-    bool focusChange;
+    AXTextSelectionDirection direction { AXTextSelectionDirection::Unknown };
+    AXTextSelectionGranularity granularity { AXTextSelectionGranularity::Unknown };
+    bool focusChange { false };
+
+    String debugDescription() const;
 };
 
 struct AXTextStateChangeIntent {
-    AXTextStateChangeType type;
+    AXTextStateChangeType type { AXTextStateChangeType::Unknown };
     union {
         AXTextSelection selection;
         AXTextEditType editType;
     };
 
-    AXTextStateChangeIntent(AXTextStateChangeType type = AXTextStateChangeTypeUnknown, AXTextSelection selection = AXTextSelection())
+    AXTextStateChangeIntent(AXTextStateChangeType type = AXTextStateChangeType::Unknown, AXTextSelection selection = AXTextSelection())
         : type(type)
         , selection(selection)
     { }
 
     AXTextStateChangeIntent(AXTextEditType editType)
-        : type(AXTextStateChangeTypeEdit)
+        : type(AXTextStateChangeType::Edit)
         , editType(editType)
     { }
+
+    String debugDescription() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1834,7 +1834,7 @@ static void setTextSelectionIntent(AXObjectCache* cache, AXTextStateChangeType t
 {
     if (!cache)
         return;
-    AXTextStateChangeIntent intent(type, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, false });
+    AXTextStateChangeIntent intent(type, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::Unknown, false });
     cache->setTextSelectionIntent(intent);
     cache->setIsSynchronizingSelection(true);
 }
@@ -1849,7 +1849,7 @@ static void clearTextSelectionIntent(AXObjectCache* cache)
 
 void AccessibilityRenderObject::setSelectedTextRange(CharacterRange&& range)
 {
-    setTextSelectionIntent(axObjectCache(), range.length ? AXTextStateChangeTypeSelectionExtend : AXTextStateChangeTypeSelectionMove);
+    setTextSelectionIntent(axObjectCache(), range.length ? AXTextStateChangeType::SelectionExtend : AXTextStateChangeType::SelectionMove);
 
     CheckedPtr client = m_renderer ? m_renderer->document().editor().client() : nullptr;
     if (client)
@@ -2117,13 +2117,13 @@ void AccessibilityRenderObject::setSelectedVisiblePositionRange(const VisiblePos
             }
         }
 
-        setTextSelectionIntent(axObjectCache(), start == end ? AXTextStateChangeTypeSelectionMove : AXTextStateChangeTypeSelectionExtend);
+        setTextSelectionIntent(axObjectCache(), start == end ? AXTextStateChangeType::SelectionMove : AXTextStateChangeType::SelectionExtend);
         textControl->focus();
         textControl->setSelectionRange(start, end);
     } else if (m_renderer) {
         // Make selection and tell the document to use it. If it's zero length, then move to that position.
         if (range.start == range.end) {
-            setTextSelectionIntent(axObjectCache(), AXTextStateChangeTypeSelectionMove);
+            setTextSelectionIntent(axObjectCache(), AXTextStateChangeType::SelectionMove);
 
             auto start = range.start;
             if (auto elementRange = simpleRange()) {
@@ -2133,7 +2133,7 @@ void AccessibilityRenderObject::setSelectedVisiblePositionRange(const VisiblePos
 
             m_renderer->frame().selection().moveTo(start, UserTriggered::Yes);
         } else {
-            setTextSelectionIntent(axObjectCache(), AXTextStateChangeTypeSelectionExtend);
+            setTextSelectionIntent(axObjectCache(), AXTextStateChangeType::SelectionExtend);
 
             VisibleSelection newSelection = VisibleSelection(range.start, range.end);
             m_renderer->frame().selection().setSelection(newSelection, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes));

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -173,24 +173,24 @@ void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject*
         return;
 
     switch (editType) {
-    case AXTextEditTypeDelete:
-    case AXTextEditTypeCut:
+    case AXTextEditType::Delete:
+    case AXTextEditType::Cut:
         wrapper->textDeleted(text, position);
         break;
-    case AXTextEditTypeInsert:
-    case AXTextEditTypeTyping:
-    case AXTextEditTypeDictation:
-    case AXTextEditTypePaste:
+    case AXTextEditType::Insert:
+    case AXTextEditType::Typing:
+    case AXTextEditType::Dictation:
+    case AXTextEditType::Paste:
         wrapper->textInserted(text, position);
         break;
-    case AXTextEditTypeAttributesChange:
+    case AXTextEditType::AttributesChange:
         wrapper->textAttributesChanged();
         break;
-    case AXTextEditTypeReplace:
+    case AXTextEditType::Replace:
         // Should call postTextReplacementPlatformNotification instead.
         ASSERT_NOT_REACHED();
         break;
-    case AXTextEditTypeUnknown:
+    case AXTextEditType::Unknown:
         break;
     }
 }

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -111,15 +111,15 @@ typedef CF_ENUM(UInt32, AXTextSelectionGranularity)
 static AXTextStateChangeType platformChangeTypeForWebCoreChangeType(WebCore::AXTextStateChangeType changeType)
 {
     switch (changeType) {
-    case WebCore::AXTextStateChangeTypeUnknown:
+    case WebCore::AXTextStateChangeType::Unknown:
         return kAXTextStateChangeTypeUnknown;
-    case WebCore::AXTextStateChangeTypeEdit:
+    case WebCore::AXTextStateChangeType::Edit:
         return kAXTextStateChangeTypeEdit;
-    case WebCore::AXTextStateChangeTypeSelectionMove:
+    case WebCore::AXTextStateChangeType::SelectionMove:
         return kAXTextStateChangeTypeSelectionMove;
-    case WebCore::AXTextStateChangeTypeSelectionExtend:
+    case WebCore::AXTextStateChangeType::SelectionExtend:
         return kAXTextStateChangeTypeSelectionExtend;
-    case WebCore::AXTextStateChangeTypeSelectionBoundary:
+    case WebCore::AXTextStateChangeType::SelectionBoundary:
         return kAXTextStateChangeTypeSelectionBoundary;
     }
 }
@@ -127,23 +127,23 @@ static AXTextStateChangeType platformChangeTypeForWebCoreChangeType(WebCore::AXT
 static AXTextEditType platformEditTypeForWebCoreEditType(WebCore::AXTextEditType changeType)
 {
     switch (changeType) {
-    case WebCore::AXTextEditTypeUnknown:
+    case WebCore::AXTextEditType::Unknown:
         return kAXTextEditTypeUnknown;
-    case WebCore::AXTextEditTypeDelete:
+    case WebCore::AXTextEditType::Delete:
         return kAXTextEditTypeDelete;
-    case WebCore::AXTextEditTypeInsert:
+    case WebCore::AXTextEditType::Insert:
         return kAXTextEditTypeInsert;
-    case WebCore::AXTextEditTypeTyping:
+    case WebCore::AXTextEditType::Typing:
         return kAXTextEditTypeTyping;
-    case WebCore::AXTextEditTypeDictation:
+    case WebCore::AXTextEditType::Dictation:
         return kAXTextEditTypeDictation;
-    case WebCore::AXTextEditTypeCut:
+    case WebCore::AXTextEditType::Cut:
         return kAXTextEditTypeCut;
-    case WebCore::AXTextEditTypePaste:
+    case WebCore::AXTextEditType::Paste:
         return kAXTextEditTypePaste;
-    case WebCore::AXTextEditTypeReplace:
+    case WebCore::AXTextEditType::Replace:
         return kAXTextEditTypeUnknown; // Does not exist in platform enum.
-    case WebCore::AXTextEditTypeAttributesChange:
+    case WebCore::AXTextEditType::AttributesChange:
         return kAXTextEditTypeAttributesChange;
     }
 }
@@ -151,17 +151,17 @@ static AXTextEditType platformEditTypeForWebCoreEditType(WebCore::AXTextEditType
 static AXTextSelectionDirection platformDirectionForWebCoreDirection(WebCore::AXTextSelectionDirection direction)
 {
     switch (direction) {
-    case WebCore::AXTextSelectionDirectionUnknown:
+    case WebCore::AXTextSelectionDirection::Unknown:
         return kAXTextSelectionDirectionUnknown;
-    case WebCore::AXTextSelectionDirectionBeginning:
+    case WebCore::AXTextSelectionDirection::Beginning:
         return kAXTextSelectionDirectionBeginning;
-    case WebCore::AXTextSelectionDirectionEnd:
+    case WebCore::AXTextSelectionDirection::End:
         return kAXTextSelectionDirectionEnd;
-    case WebCore::AXTextSelectionDirectionPrevious:
+    case WebCore::AXTextSelectionDirection::Previous:
         return kAXTextSelectionDirectionPrevious;
-    case WebCore::AXTextSelectionDirectionNext:
+    case WebCore::AXTextSelectionDirection::Next:
         return kAXTextSelectionDirectionNext;
-    case WebCore::AXTextSelectionDirectionDiscontiguous:
+    case WebCore::AXTextSelectionDirection::Discontiguous:
         return kAXTextSelectionDirectionDiscontiguous;
     }
 }
@@ -169,23 +169,23 @@ static AXTextSelectionDirection platformDirectionForWebCoreDirection(WebCore::AX
 static AXTextSelectionGranularity platformGranularityForWebCoreGranularity(WebCore::AXTextSelectionGranularity granularity)
 {
     switch (granularity) {
-    case WebCore::AXTextSelectionGranularityUnknown:
+    case WebCore::AXTextSelectionGranularity::Unknown:
         return kAXTextSelectionGranularityUnknown;
-    case WebCore::AXTextSelectionGranularityCharacter:
+    case WebCore::AXTextSelectionGranularity::Character:
         return kAXTextSelectionGranularityCharacter;
-    case WebCore::AXTextSelectionGranularityWord:
+    case WebCore::AXTextSelectionGranularity::Word:
         return kAXTextSelectionGranularityWord;
-    case WebCore::AXTextSelectionGranularityLine:
+    case WebCore::AXTextSelectionGranularity::Line:
         return kAXTextSelectionGranularityLine;
-    case WebCore::AXTextSelectionGranularitySentence:
+    case WebCore::AXTextSelectionGranularity::Sentence:
         return kAXTextSelectionGranularitySentence;
-    case WebCore::AXTextSelectionGranularityParagraph:
+    case WebCore::AXTextSelectionGranularity::Paragraph:
         return kAXTextSelectionGranularityParagraph;
-    case WebCore::AXTextSelectionGranularityPage:
+    case WebCore::AXTextSelectionGranularity::Page:
         return kAXTextSelectionGranularityPage;
-    case WebCore::AXTextSelectionGranularityDocument:
+    case WebCore::AXTextSelectionGranularity::Document:
         return kAXTextSelectionGranularityDocument;
-    case WebCore::AXTextSelectionGranularityAll:
+    case WebCore::AXTextSelectionGranularity::All:
         return kAXTextSelectionGranularityAll;
     }
 }
@@ -474,7 +474,7 @@ AXTextStateChangeIntent AXObjectCache::inferDirectionFromIntent(AccessibilityObj
     if (!object.isTextControl() && !object.editableAncestor())
         return originalIntent;
 
-    if (originalIntent.selection.direction != AXTextSelectionDirectionDiscontiguous || object.objectID() != m_lastTextFieldAXID || m_lastSelection == selection) {
+    if (originalIntent.selection.direction != AXTextSelectionDirection::Discontiguous || object.objectID() != m_lastTextFieldAXID || m_lastSelection == selection) {
         m_lastTextFieldAXID = object.objectID();
         m_lastSelection = selection;
         return originalIntent;
@@ -484,24 +484,24 @@ AXTextStateChangeIntent AXObjectCache::inferDirectionFromIntent(AccessibilityObj
     if (m_lastSelection.isCaret() && selection.isCaret()) {
         // Cursor movement
         if (selection.visibleStart() == m_lastSelection.visibleStart().next(CannotCrossEditingBoundary)) {
-            intent.type = AXTextStateChangeTypeSelectionMove;
-            intent.selection.direction = AXTextSelectionDirectionNext;
-            intent.selection.granularity = AXTextSelectionGranularityCharacter;
+            intent.type = AXTextStateChangeType::SelectionMove;
+            intent.selection.direction = AXTextSelectionDirection::Next;
+            intent.selection.granularity = AXTextSelectionGranularity::Character;
         } else if (selection.visibleStart() == m_lastSelection.visibleStart().previous(CannotCrossEditingBoundary)) {
-            intent.type = AXTextStateChangeTypeSelectionMove;
-            intent.selection.direction = AXTextSelectionDirectionPrevious;
-            intent.selection.granularity = AXTextSelectionGranularityCharacter;
+            intent.type = AXTextStateChangeType::SelectionMove;
+            intent.selection.direction = AXTextSelectionDirection::Previous;
+            intent.selection.granularity = AXTextSelectionGranularity::Character;
         }
     } else if (selection.visibleBase() == m_lastSelection.visibleBase()) {
         // Selection
         if (selection.visibleExtent() == m_lastSelection.visibleExtent().next(CannotCrossEditingBoundary)) {
-            intent.type = AXTextStateChangeTypeSelectionExtend;
-            intent.selection.direction = AXTextSelectionDirectionNext;
-            intent.selection.granularity = AXTextSelectionGranularityCharacter;
+            intent.type = AXTextStateChangeType::SelectionExtend;
+            intent.selection.direction = AXTextSelectionDirection::Next;
+            intent.selection.granularity = AXTextSelectionGranularity::Character;
         } else if (selection.visibleExtent() == m_lastSelection.visibleExtent().previous(CannotCrossEditingBoundary)) {
-            intent.type = AXTextStateChangeTypeSelectionExtend;
-            intent.selection.direction = AXTextSelectionDirectionPrevious;
-            intent.selection.granularity = AXTextSelectionGranularityCharacter;
+            intent.type = AXTextStateChangeType::SelectionExtend;
+            intent.selection.direction = AXTextSelectionDirection::Previous;
+            intent.selection.granularity = AXTextSelectionGranularity::Character;
         }
     }
 
@@ -527,30 +527,30 @@ void AXObjectCache::postTextSelectionChangePlatformNotification(AccessibilityObj
     auto userInfo = adoptNS([[NSMutableDictionary alloc] initWithCapacity:5]);
     if (m_isSynchronizingSelection)
         [userInfo setObject:@YES forKey:NSAccessibilityTextStateSyncKey];
-    if (intent.type != AXTextStateChangeTypeUnknown) {
+    if (intent.type != AXTextStateChangeType::Unknown) {
         [userInfo setObject:@(platformChangeTypeForWebCoreChangeType(intent.type)) forKey:NSAccessibilityTextStateChangeTypeKey];
         switch (intent.type) {
-        case AXTextStateChangeTypeSelectionMove:
-        case AXTextStateChangeTypeSelectionExtend:
-        case AXTextStateChangeTypeSelectionBoundary:
+        case AXTextStateChangeType::SelectionMove:
+        case AXTextStateChangeType::SelectionExtend:
+        case AXTextStateChangeType::SelectionBoundary:
             [userInfo setObject:@(platformDirectionForWebCoreDirection(intent.selection.direction)) forKey:NSAccessibilityTextSelectionDirection];
             switch (intent.selection.direction) {
-            case AXTextSelectionDirectionUnknown:
+            case AXTextSelectionDirection::Unknown:
                 break;
-            case AXTextSelectionDirectionBeginning:
-            case AXTextSelectionDirectionEnd:
-            case AXTextSelectionDirectionPrevious:
-            case AXTextSelectionDirectionNext:
+            case AXTextSelectionDirection::Beginning:
+            case AXTextSelectionDirection::End:
+            case AXTextSelectionDirection::Previous:
+            case AXTextSelectionDirection::Next:
                 [userInfo setObject:@(platformGranularityForWebCoreGranularity(intent.selection.granularity)) forKey:NSAccessibilityTextSelectionGranularity];
                 break;
-            case AXTextSelectionDirectionDiscontiguous:
+            case AXTextSelectionDirection::Discontiguous:
                 break;
             }
             if (intent.selection.focusChange)
                 [userInfo setObject:@(intent.selection.focusChange) forKey:NSAccessibilityTextSelectionChangedFocus];
             break;
-        case AXTextStateChangeTypeUnknown:
-        case AXTextStateChangeTypeEdit:
+        case AXTextStateChangeType::Unknown:
+        case AXTextStateChangeType::Edit:
             break;
         }
     }
@@ -613,13 +613,13 @@ void AXObjectCache::postTextStateChangePlatformNotification(AccessibilityObject*
     if (!text.length())
         return;
 
-    postTextReplacementPlatformNotification(object, AXTextEditTypeUnknown, emptyString(), type, text, position);
+    postTextReplacementPlatformNotification(object, AXTextEditType::Unknown, emptyString(), type, text, position);
 }
 
 void AXObjectCache::postUserInfoForChanges(AccessibilityObject& rootWebArea, AccessibilityObject& object, RetainPtr<NSMutableArray> changes)
 {
     auto userInfo = adoptNS([[NSMutableDictionary alloc] initWithCapacity:4]);
-    [userInfo setObject:@(platformChangeTypeForWebCoreChangeType(AXTextStateChangeTypeEdit)) forKey:NSAccessibilityTextStateChangeTypeKey];
+    [userInfo setObject:@(platformChangeTypeForWebCoreChangeType(AXTextStateChangeType::Edit)) forKey:NSAccessibilityTextStateChangeTypeKey];
     auto changesArray = changes.autorelease();
     if (changesArray.count)
         [userInfo setObject:changesArray forKey:NSAccessibilityTextChangeValues];
@@ -667,9 +667,9 @@ void AXObjectCache::postTextReplacementPlatformNotificationForTextControl(Access
     processQueuedIsolatedNodeUpdates();
 
     auto changes = adoptNS([[NSMutableArray alloc] initWithCapacity:2]);
-    if (NSDictionary *change = textReplacementChangeDictionary(*this, *axObject, AXTextEditTypeDelete, deletedText, { }))
+    if (NSDictionary *change = textReplacementChangeDictionary(*this, *axObject, AXTextEditType::Delete, deletedText, { }))
         [changes addObject:change];
-    if (NSDictionary *change = textReplacementChangeDictionary(*this, *axObject, AXTextEditTypeInsert, insertedText, { }))
+    if (NSDictionary *change = textReplacementChangeDictionary(*this, *axObject, AXTextEditType::Insert, insertedText, { }))
         [changes addObject:change];
 
     if (RefPtr root = rootWebArea())

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -594,7 +594,7 @@ public:
     RefPtr<Element> findFocusDelegate(FocusTrigger = FocusTrigger::Other);
     RefPtr<Element> findAutofocusDelegate(FocusTrigger = FocusTrigger::Other);
 
-    static AXTextStateChangeIntent defaultFocusTextStateChangeIntent() { return AXTextStateChangeIntent(AXTextStateChangeTypeSelectionMove, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, true }); }
+    static AXTextStateChangeIntent defaultFocusTextStateChangeIntent() { return AXTextStateChangeIntent(AXTextStateChangeType::SelectionMove, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::Unknown, true }); }
     virtual void focus(const FocusOptions& = { });
     virtual void focusForBindings(FocusOptions&&);
     void findTargetAndUpdateFocusAppearance(SelectionRestorationMode, SelectionRevealMode = SelectionRevealMode::Reveal);

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -166,11 +166,11 @@ static void postTextStateChangeNotification(AXObjectCache* cache, const VisibleP
     if (!node)
         return;
     if (insertedText.length() && deletedText.length())
-        cache->postTextReplacementNotification(node.get(), AXTextEditTypeDelete, insertedText, AXTextEditTypeInsert, deletedText, position);
+        cache->postTextReplacementNotification(node.get(), AXTextEditType::Delete, insertedText, AXTextEditType::Insert, deletedText, position);
     else if (deletedText.length())
-        cache->postTextStateChangeNotification(node.get(), AXTextEditTypeInsert, deletedText, position);
+        cache->postTextStateChangeNotification(node.get(), AXTextEditType::Insert, deletedText, position);
     else if (insertedText.length())
-        cache->postTextStateChangeNotification(node.get(), AXTextEditTypeDelete, insertedText, position);
+        cache->postTextStateChangeNotification(node.get(), AXTextEditType::Delete, insertedText, position);
 }
 
 void AccessibilityUndoReplacedText::postTextStateChangeNotificationForUnapply(AXObjectCache* cache)

--- a/Source/WebCore/editing/DictationCommand.cpp
+++ b/Source/WebCore/editing/DictationCommand.cpp
@@ -114,7 +114,7 @@ void DictationCommand::doApply()
 {
     DictationCommandLineOperation operation(*this);
     forEachLineInString(m_textToInsert, operation);
-    postTextStateChangeNotification(AXTextEditTypeDictation, m_textToInsert);
+    postTextStateChangeNotification(AXTextEditType::Dictation, m_textToInsert);
 }
 
 void DictationCommand::insertTextRunWithoutNewlines(size_t lineStart, size_t lineLength)

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -769,13 +769,13 @@ void Editor::replaceSelectionWithFragment(DocumentFragment& fragment, SelectRepl
 
     if (AXObjectCache::accessibilityEnabled() && editingAction == EditAction::Paste) {
         String text = AccessibilityObject::stringForVisiblePositionRange(command->visibleSelectionForInsertedText());
-        replacedText.postTextStateChangeNotification(document->existingAXObjectCache(), AXTextEditTypePaste, text, document->selection().selection());
+        replacedText.postTextStateChangeNotification(document->existingAXObjectCache(), AXTextEditType::Paste, text, document->selection().selection());
         command->composition()->setRangeDeletedByUnapply(replacedText.replacedRange());
     }
 
     if (AXObjectCache::accessibilityEnabled() && editingAction == EditAction::Insert) {
         String text = command->documentFragmentPlainText();
-        replacedText.postTextStateChangeNotification(document->existingAXObjectCache(), AXTextEditTypeInsert, text, document->selection().selection());
+        replacedText.postTextStateChangeNotification(document->existingAXObjectCache(), AXTextEditType::Insert, text, document->selection().selection());
         command->composition()->setRangeDeletedByUnapply(replacedText.replacedRange());
     }
 
@@ -1597,7 +1597,7 @@ void Editor::postTextStateChangeNotificationForCut(const String& text, const Vis
     CheckedPtr cache = document().existingAXObjectCache();
     if (!cache)
         return;
-    cache->postTextStateChangeNotification(selection.start().anchorNode(), AXTextEditTypeCut, text, selection.start());
+    cache->postTextStateChangeNotification(selection.start().anchorNode(), AXTextEditType::Cut, text, selection.start());
 }
 
 void Editor::performCutOrCopy(EditorActionSpecifier action)

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -266,7 +266,7 @@ void FrameSelection::moveWithoutValidationTo(const Position& base, const Positio
     VisibleSelection newSelection;
     newSelection.setWithoutValidation(base, extent);
     newSelection.setDirectionality(selectionHasDirection ? Directionality::Strong : Directionality::None);
-    AXTextStateChangeIntent newIntent = intent.type == AXTextStateChangeTypeUnknown ? AXTextStateChangeIntent(AXTextStateChangeTypeSelectionMove, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, false }) : intent;
+    AXTextStateChangeIntent newIntent = intent.type == AXTextStateChangeType::Unknown ? AXTextStateChangeIntent(AXTextStateChangeType::SelectionMove, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::Unknown, false }) : intent;
     setSelection(newSelection, options, newIntent, CursorAlignOnScroll::IfNeeded, TextGranularity::CharacterGranularity);
 }
 
@@ -355,7 +355,7 @@ void FrameSelection::setSelectionByMouseIfDifferent(const VisibleSelection& pass
     
     AXTextStateChangeIntent intent;
     if (AXObjectCache::accessibilityEnabled() && newSelection.isCaret())
-        intent = AXTextStateChangeIntent(AXTextStateChangeTypeSelectionMove, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, false });
+        intent = AXTextStateChangeIntent(AXTextStateChangeType::SelectionMove, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::Unknown, false });
     else
         intent = AXTextStateChangeIntent();
     setSelection(newSelection, defaultSetSelectionOptions() | SetSelectionOption::FireSelectEvent, intent, CursorAlignOnScroll::IfNeeded, granularity);
@@ -1381,32 +1381,32 @@ AXTextStateChangeIntent FrameSelection::textSelectionIntent(Alteration alter, Se
     AXTextStateChangeIntent intent = AXTextStateChangeIntent();
     bool flip = false;
     if (alter == FrameSelection::Alteration::Move) {
-        intent.type = AXTextStateChangeTypeSelectionMove;
+        intent.type = AXTextStateChangeType::SelectionMove;
         flip = isRange() && directionOfSelection() == TextDirection::RTL;
     } else
-        intent.type = AXTextStateChangeTypeSelectionExtend;
+        intent.type = AXTextStateChangeType::SelectionExtend;
     switch (granularity) {
     case TextGranularity::CharacterGranularity:
-        intent.selection.granularity = AXTextSelectionGranularityCharacter;
+        intent.selection.granularity = AXTextSelectionGranularity::Character;
         break;
     case TextGranularity::WordGranularity:
-        intent.selection.granularity = AXTextSelectionGranularityWord;
+        intent.selection.granularity = AXTextSelectionGranularity::Word;
         break;
     case TextGranularity::SentenceGranularity:
     case TextGranularity::SentenceBoundary:
-        intent.selection.granularity = AXTextSelectionGranularitySentence;
+        intent.selection.granularity = AXTextSelectionGranularity::Sentence;
         break;
     case TextGranularity::LineGranularity:
     case TextGranularity::LineBoundary:
-        intent.selection.granularity = AXTextSelectionGranularityLine;
+        intent.selection.granularity = AXTextSelectionGranularity::Line;
         break;
     case TextGranularity::ParagraphGranularity:
     case TextGranularity::ParagraphBoundary:
-        intent.selection.granularity = AXTextSelectionGranularityParagraph;
+        intent.selection.granularity = AXTextSelectionGranularity::Paragraph;
         break;
     case TextGranularity::DocumentGranularity:
     case TextGranularity::DocumentBoundary:
-        intent.selection.granularity = AXTextSelectionGranularityDocument;
+        intent.selection.granularity = AXTextSelectionGranularity::Document;
         break;
     }
     bool boundary = false;
@@ -1429,16 +1429,16 @@ AXTextStateChangeIntent FrameSelection::textSelectionIntent(Alteration alter, Se
     case SelectionDirection::Right:
     case SelectionDirection::Forward:
         if (boundary)
-            intent.selection.direction = flip ? AXTextSelectionDirectionBeginning : AXTextSelectionDirectionEnd;
+            intent.selection.direction = flip ? AXTextSelectionDirection::Beginning : AXTextSelectionDirection::End;
         else
-            intent.selection.direction = flip ? AXTextSelectionDirectionPrevious : AXTextSelectionDirectionNext;
+            intent.selection.direction = flip ? AXTextSelectionDirection::Previous : AXTextSelectionDirection::Next;
         break;
     case SelectionDirection::Left:
     case SelectionDirection::Backward:
         if (boundary)
-            intent.selection.direction = flip ? AXTextSelectionDirectionEnd : AXTextSelectionDirectionBeginning;
+            intent.selection.direction = flip ? AXTextSelectionDirection::End : AXTextSelectionDirection::Beginning;
         else
-            intent.selection.direction = flip ? AXTextSelectionDirectionNext : AXTextSelectionDirectionPrevious;
+            intent.selection.direction = flip ? AXTextSelectionDirection::Next : AXTextSelectionDirection::Previous;
         break;
     }
     return intent;
@@ -1447,58 +1447,58 @@ AXTextStateChangeIntent FrameSelection::textSelectionIntent(Alteration alter, Se
 static AXTextSelection textSelectionWithDirectionAndGranularity(SelectionDirection direction, TextGranularity granularity)
 {
     // FIXME: Account for BIDI in SelectionDirection::Right & SelectionDirection::Left. (In a RTL block, Right would map to Previous/Beginning and Left to Next/End.)
-    AXTextSelectionDirection intentDirection = AXTextSelectionDirectionUnknown;
+    AXTextSelectionDirection intentDirection = AXTextSelectionDirection::Unknown;
     switch (direction) {
     case SelectionDirection::Forward:
-        intentDirection = AXTextSelectionDirectionNext;
+        intentDirection = AXTextSelectionDirection::Next;
         break;
     case SelectionDirection::Right:
-        intentDirection = AXTextSelectionDirectionNext;
+        intentDirection = AXTextSelectionDirection::Next;
         break;
     case SelectionDirection::Backward:
-        intentDirection = AXTextSelectionDirectionPrevious;
+        intentDirection = AXTextSelectionDirection::Previous;
         break;
     case SelectionDirection::Left:
-        intentDirection = AXTextSelectionDirectionPrevious;
+        intentDirection = AXTextSelectionDirection::Previous;
         break;
     }
-    AXTextSelectionGranularity intentGranularity = AXTextSelectionGranularityUnknown;
+    AXTextSelectionGranularity intentGranularity = AXTextSelectionGranularity::Unknown;
     switch (granularity) {
     case TextGranularity::CharacterGranularity:
-        intentGranularity = AXTextSelectionGranularityCharacter;
+        intentGranularity = AXTextSelectionGranularity::Character;
         break;
     case TextGranularity::WordGranularity:
-        intentGranularity = AXTextSelectionGranularityWord;
+        intentGranularity = AXTextSelectionGranularity::Word;
         break;
     case TextGranularity::SentenceGranularity:
     case TextGranularity::SentenceBoundary: // FIXME: Boundary should affect direction.
-        intentGranularity = AXTextSelectionGranularitySentence;
+        intentGranularity = AXTextSelectionGranularity::Sentence;
         break;
     case TextGranularity::LineGranularity:
-        intentGranularity = AXTextSelectionGranularityLine;
+        intentGranularity = AXTextSelectionGranularity::Line;
         break;
     case TextGranularity::ParagraphGranularity:
     case TextGranularity::ParagraphBoundary: // FIXME: Boundary should affect direction.
-        intentGranularity = AXTextSelectionGranularityParagraph;
+        intentGranularity = AXTextSelectionGranularity::Paragraph;
         break;
     case TextGranularity::DocumentGranularity:
     case TextGranularity::DocumentBoundary: // FIXME: Boundary should affect direction.
-        intentGranularity = AXTextSelectionGranularityDocument;
+        intentGranularity = AXTextSelectionGranularity::Document;
         break;
     case TextGranularity::LineBoundary:
-        intentGranularity = AXTextSelectionGranularityLine;
+        intentGranularity = AXTextSelectionGranularity::Line;
         switch (direction) {
         case SelectionDirection::Forward:
-            intentDirection = AXTextSelectionDirectionEnd;
+            intentDirection = AXTextSelectionDirection::End;
             break;
         case SelectionDirection::Right:
-            intentDirection = AXTextSelectionDirectionEnd;
+            intentDirection = AXTextSelectionDirection::End;
             break;
         case SelectionDirection::Backward:
-            intentDirection = AXTextSelectionDirectionBeginning;
+            intentDirection = AXTextSelectionDirection::Beginning;
             break;
         case SelectionDirection::Left:
-            intentDirection = AXTextSelectionDirectionBeginning;
+            intentDirection = AXTextSelectionDirection::Beginning;
             break;
         }
         break;
@@ -1563,7 +1563,7 @@ bool FrameSelection::modify(Alteration alter, SelectionDirection direction, Text
     }
 
     if (reachedBoundary && !isRange() && userTriggered == UserTriggered::Yes && m_document && AXObjectCache::accessibilityEnabled()) {
-        notifyAccessibilityForSelectionChange({ AXTextStateChangeTypeSelectionBoundary, textSelectionWithDirectionAndGranularity(direction, granularity) });
+        notifyAccessibilityForSelectionChange({ AXTextStateChangeType::SelectionBoundary, textSelectionWithDirectionAndGranularity(direction, granularity) });
         return true;
     }
 
@@ -2242,7 +2242,7 @@ void FrameSelection::selectAll()
 
     VisibleSelection newSelection(VisibleSelection::selectionFromContentsOfNode(root.get()));
     if (!newSelection.isOrphan() && shouldChangeSelection(newSelection)) {
-        AXTextStateChangeIntent intent(AXTextStateChangeTypeSelectionExtend, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityAll, false });
+        AXTextStateChangeIntent intent(AXTextStateChangeType::SelectionExtend, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::All, false });
         setSelection(newSelection, defaultSetSelectionOptions() | SetSelectionOption::FireSelectEvent, intent);
     }
 }

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -345,7 +345,7 @@ void TypingCommand::postTextStateChangeNotificationForDeletion(const VisibleSele
 {
     if (!AXObjectCache::accessibilityEnabled())
         return;
-    postTextStateChangeNotification(AXTextEditTypeDelete, AccessibilityObject::stringForVisiblePositionRange(selection), selection.start());
+    postTextStateChangeNotification(AXTextEditType::Delete, AccessibilityObject::stringForVisiblePositionRange(selection), selection.start());
     VisiblePositionIndexRange range;
     range.startIndex.value = indexForVisiblePosition(selection.visibleStart(), range.startIndex.scope);
     range.endIndex.value = indexForVisiblePosition(selection.visibleEnd(), range.endIndex.scope);
@@ -546,7 +546,7 @@ void TypingCommand::insertTextAndNotifyAccessibility(const String& text, bool se
 
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertText(text, selectInsertedText);
-    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditTypeTyping, text, document().selection().selection());
+    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, text, document().selection().selection());
     protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 
@@ -579,7 +579,7 @@ void TypingCommand::insertLineBreakAndNotifyAccessibility()
 {
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertLineBreak();
-    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditTypeTyping, "\n"_s, document().selection().selection());
+    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, "\n"_s, document().selection().selection());
     protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 
@@ -599,7 +599,7 @@ void TypingCommand::insertParagraphSeparatorAndNotifyAccessibility()
 {
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertParagraphSeparator();
-    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditTypeTyping, "\n"_s, document().selection().selection());
+    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, "\n"_s, document().selection().selection());
     protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 
@@ -623,7 +623,7 @@ void TypingCommand::insertParagraphSeparatorInQuotedContentAndNotifyAccessibilit
 {
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertParagraphSeparatorInQuotedContent();
-    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditTypeTyping, "\n"_s, document().selection().selection());
+    replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, "\n"_s, document().selection().selection());
     protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4410,7 +4410,7 @@ static void setInitialKeyboardSelection(LocalFrame& frame, SelectionDirection di
         break;
     }
 
-    AXTextStateChangeIntent intent(AXTextStateChangeTypeSelectionMove, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, false });
+    AXTextStateChangeIntent intent(AXTextStateChangeType::SelectionMove, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::Unknown, false });
     selection.setSelection(visiblePosition, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes), intent);
 }
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -733,7 +733,7 @@ FocusableElementSearchResult FocusController::findAndFocusElementInDocumentOrder
     if (caretBrowsing) {
         VisibleSelection newSelection(firstPositionInOrBeforeNode(element.get()), Affinity::Downstream);
         if (frame->selection().shouldChangeSelection(newSelection)) {
-            AXTextStateChangeIntent intent(AXTextStateChangeTypeSelectionMove, AXTextSelection { AXTextSelectionDirectionDiscontiguous, AXTextSelectionGranularityUnknown, true });
+            AXTextStateChangeIntent intent(AXTextStateChangeType::SelectionMove, AXTextSelection { AXTextSelectionDirection::Discontiguous, AXTextSelectionGranularity::Unknown, true });
             frame->selection().setSelection(newSelection, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes), intent);
         }
     }


### PR DESCRIPTION
#### 79584197ef17af66bf9f300973111044b43c2d1d
<pre>
AX: Refactor the text editing enums in AXTextStateChangeIntent.h to be enum classes and add debugDescription methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=306144">https://bugs.webkit.org/show_bug.cgi?id=306144</a>
<a href="https://rdar.apple.com/168783304">rdar://168783304</a>

Reviewed by Ryosuke Niwa.

enum classes are more safe than plain enums because they don&apos;t accept implicit conversions. Also add some debugDescription()
implementations for easier debugging.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AccessibilityReplacedText::postTextStateChangeNotification):
(WebCore::AXObjectCache::postTextStateChangeNotification):
(WebCore::AXObjectCache::postTextReplacementNotification):
(WebCore::AXObjectCache::postTextReplacementNotificationForTextControl):
(WebCore::AXObjectCache::passwordNotificationTimerFired):
(WebCore::AXObjectCache::textChangeForEditType):
(WebCore::AXObjectCache::showIntent): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextStateChangeIntent.cpp: Added.
(WebCore::debugDescription):
(WebCore::AXTextSelection::debugDescription const):
(WebCore::AXTextStateChangeIntent::debugDescription const):
* Source/WebCore/accessibility/AXTextStateChangeIntent.h:
(WebCore::AXTextStateChangeIntent::AXTextStateChangeIntent):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::setTextSelectionIntent):
(WebCore::AccessibilityRenderObject::setSelectedTextRange):
(WebCore::AccessibilityRenderObject::setSelectedVisiblePositionRange const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(platformChangeTypeForWebCoreChangeType):
(platformEditTypeForWebCoreEditType):
(platformDirectionForWebCoreDirection):
(platformGranularityForWebCoreGranularity):
(WebCore::AXObjectCache::inferDirectionFromIntent):
(WebCore::AXObjectCache::postTextSelectionChangePlatformNotification):
(WebCore::AXObjectCache::postTextStateChangePlatformNotification):
(WebCore::AXObjectCache::postUserInfoForChanges):
(WebCore::AXObjectCache::postTextReplacementPlatformNotificationForTextControl):
* Source/WebCore/dom/Element.h:
(WebCore::Element::defaultFocusTextStateChangeIntent):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::postTextStateChangeNotification):
* Source/WebCore/editing/DictationCommand.cpp:
(WebCore::DictationCommand::doApply):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::replaceSelectionWithFragment):
(WebCore::Editor::postTextStateChangeNotificationForCut):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::moveWithoutValidationTo):
(WebCore::FrameSelection::setSelectionByMouseIfDifferent):
(WebCore::FrameSelection::textSelectionIntent):
(WebCore::textSelectionWithDirectionAndGranularity):
(WebCore::FrameSelection::modify):
(WebCore::FrameSelection::selectAll):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::postTextStateChangeNotificationForDeletion):
(WebCore::TypingCommand::insertTextAndNotifyAccessibility):
(WebCore::TypingCommand::insertLineBreakAndNotifyAccessibility):
(WebCore::TypingCommand::insertParagraphSeparatorAndNotifyAccessibility):
(WebCore::TypingCommand::insertParagraphSeparatorInQuotedContentAndNotifyAccessibility):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::setInitialKeyboardSelection):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findAndFocusElementInDocumentOrderStartingWithFrame):

Canonical link: <a href="https://commits.webkit.org/306160@main">https://commits.webkit.org/306160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bb9104e924c8146a2bb697f44ddbbe6f85915cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->