### PR TITLE
Repaint issue with Material UI modal dialog

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1434,6 +1434,8 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
             for (auto* childLayer : layer.negativeZOrderLayers()) {
                 computeCompositingRequirements(&layer, *childLayer, overlapMap, currentState, backingSharingState);
 
+                if (currentState.subtreeIsCompositing && willBeComposited)
+                    layer.setNeedsCompositingConfigurationUpdate();
                 // If we have to make a layer for this child, make one now so we can have a contents layer
                 // (since we need to ensure that the -ve z-order child renders underneath our contents).
                 if (!willBeComposited && currentState.subtreeIsCompositing) {


### PR DESCRIPTION
#### 4d91a87f66260e4ee857d2f3c7f28acc0fd63950
<pre>
Repaint issue with Material UI modal dialog
<a href="https://rdar.apple.com/166585575">rdar://166585575</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304133">https://bugs.webkit.org/show_bug.cgi?id=304133</a>

WIP. This is to correctness test. This is needs a layout test as well.

When a parent layer with composited negative z-index children does not split
into separate background and foreground GraphicsLayers, incorrect visual
stacking order occurs.

The bug shows when:
1. A parent element creates a stacking context and is composited
2. A child element has z-index: -1 and becomes composited
3. The parent&apos;s foreground content is not composited

In this scenario, the parent creates only one GraphicsLayer with
paintingPhases [background, foreground]. The negative z-index child becomes
a child GraphicsLayer. Because GPU compositing orders children after their
parent, the negative z-index child composites on top of the parent&apos;s texture,
even though CSS z-index: -1 requires it to appear beneath the parent&apos;s
foreground content.

The correct behavior requires splitting the parent into two sibling
GraphicsLayers: one with paintingPhases [background] (containing the negative
z-index child), and another with paintingPhases [foreground] (containing the
parent&apos;s foreground content). This allows GPU tree-order compositing to
produce the correct z-index visual result: parent background (bottom), negative
z-index child (above), then parent foreground (top).

The fix calls setNeedsCompositingConfigurationUpdate() on the parent layer
when processing negative z-order children that will be composited. This forces
the parent to re-evaluate needsContentsCompositingLayer(), ensuring it splits
to accommodate the composited negative z-index child.

No new tests (OOPS!).

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d91a87f66260e4ee857d2f3c7f28acc0fd63950

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93510 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6cfb4619-4df9-45cd-aed9-6328a75b0343) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12959 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78159 "layout-tests (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fab01507-ab17-47f8-a269-9f452ecb893c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10409 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e695d7f5-22bb-4d98-999a-ee91ab3fbd37) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10028 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8856 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151373 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12493 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1786 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12508 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11467 "Passed tests") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67511 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12535 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->