### PR TITLE
[Build] Pass -target flag to preprocessor invocation in IDL parser

### DIFF
--- a/Source/WebCore/bindings/scripts/preprocessor.pm
+++ b/Source/WebCore/bindings/scripts/preprocessor.pm
@@ -59,6 +59,10 @@ sub applyPreprocessor
     }
 
     if ($Config::Config{"osname"} eq "darwin") {
+        (my $arch, @_) = split(" ", $ENV{ARCHS});
+        my $vendor = $ENV{LLVM_TARGET_TRIPLE_VENDOR};
+        my $os = $ENV{LLVM_TARGET_TRIPLE_OS_VERSION} . ($ENV{LLVM_TARGET_TRIPLE_SUFFIX} // "");
+        push(@args, "-target", "$arch-$vendor-$os");
         push(@args, "-I" . $ENV{BUILT_PRODUCTS_DIR} . "/usr/local/include") if $ENV{BUILT_PRODUCTS_DIR};
         push(@args, "-isysroot", $ENV{SDKROOT}) if $ENV{SDKROOT};
     }

--- a/Tools/Scripts/webkitpy/bindings/main.py
+++ b/Tools/Scripts/webkitpy/bindings/main.py
@@ -37,6 +37,10 @@ from webkitpy.common.system.executive import ScriptError
 
 
 class BindingsTests:
+    generator_env = dict(os.environ,
+                         ARCHS='arm64',
+                         LLVM_TARGET_TRIPLE_VENDOR='apple',
+                         LLVM_TARGET_TRIPLE_OS_VERSION='macos26.0')
 
     def __init__(self, reset_results, generators, executive, verbose, patterns, json_file_name):
         self.reset_results = reset_results
@@ -63,7 +67,7 @@ class BindingsTests:
 
         exit_code = 0
         try:
-            output = self.executive.run_command(cmd)
+            output = self.executive.run_command(cmd, env=self.generator_env)
             if output:
                 print(output)
         except ScriptError as e:
@@ -110,7 +114,7 @@ class BindingsTests:
 
         exit_code = 0
         try:
-            output = self.executive.run_command(cmd)
+            output = self.executive.run_command(cmd, env=self.generator_env)
             if output:
                 print(output)
         except ScriptError as e:


### PR DESCRIPTION
#### 6e9d9a44e3dbd920095dbed0096c23b482dae1d1
<pre>
[Build] Pass -target flag to preprocessor invocation in IDL parser
<a href="https://bugs.webkit.org/show_bug.cgi?id=306159">https://bugs.webkit.org/show_bug.cgi?id=306159</a>
<a href="https://rdar.apple.com/168798872">rdar://168798872</a>

Reviewed by Ryosuke Niwa.

On Xcode-based builds, it&apos;s ambiguous which platform to use when
invoking clang as a preprocessor. All the necessary information is in
the environment, we just need to wire up the -target specifier.

This is important to ensure that &lt;wtf/Platform.h&gt; preprocessor guards
work correctly in IDLs, and to work around some errors seen when testing
the nightly toolchain.

* Source/WebCore/bindings/scripts/preprocessor.pm:
(applyPreprocessor):
* Tools/Scripts/webkitpy/bindings/main.py:
(BindingsTests):
(BindingsTests.generate_from_idl):
(BindingsTests.generate_supplemental_dependency):

Canonical link: <a href="https://commits.webkit.org/306209@main">https://commits.webkit.org/306209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3f922c7783167fba053224c18e6de46ae8f9809

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93527 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fd6d4a6-fdeb-4099-8a79-b845f07ecb63) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142313 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107657 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78168 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51b9d675-8860-4735-accf-c272a71984ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10417 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88557 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7440bed-4072-494e-9264-e8f364dc4036) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/139785 "Passed tests") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7592 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8873 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1732 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151391 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29628 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11497 "Passed tests") | [⏳ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/macOS-Release-WK2-Stress-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67528 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12552 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76252 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12490 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->