### PR TITLE
[Results DB] GTK results markers missing when grouping configurations

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -74,44 +74,53 @@ function commitsForResults(results, limit, allCommits = true) {
     let commits = [];
     let repositories = new Set();
     let currentCommitIndex = CommitBank.commits.length - 1;
+
+    let uuids = new Set();
     Object.keys(results).forEach((key) => {
         results[key].forEach(pair => {
             pair.results.forEach(result => {
                 if (result.uuid < minDisplayedUuid)
                     return;
-                let candidateCommits = [];
-
-                if (!allCommits)
-                    currentCommitIndex = CommitBank.commits.length - 1;
-                while (currentCommitIndex >= 0) {
-                    if (CommitBank.commits[currentCommitIndex].uuid < result.uuid)
-                        break;
-                    if (allCommits || CommitBank.commits[currentCommitIndex].uuid === result.uuid)
-                        candidateCommits.push(CommitBank.commits[currentCommitIndex]);
-                    --currentCommitIndex;
-                }
-                if (candidateCommits.length === 0 || candidateCommits[candidateCommits.length - 1].uuid !== result.uuid)
-                    candidateCommits.push({
-                        id: '?',
-                        uuid: result.uuid,
-                    });
-
-                let index = 0;
-                candidateCommits.forEach(commit => {
-                    if (commit.repository_id)
-                        repositories.add(commit.repository_id);
-                    while (index < commits.length) {
-                        if (commit.uuid === commits[index].uuid)
-                            return;
-                        if (commit.uuid > commits[index].uuid) {
-                            commits.splice(index, 0, commit);
-                            return;
-                        }
-                        ++index;
-                    }
-                    commits.push(commit);
-                });
+                uuids.add(result.uuid);
             });
+        });
+    });
+
+    let sortedUuids = [...uuids].sort((a, b) => b - a);
+
+    sortedUuids.forEach(uuid => {
+        let candidateCommits = [];
+
+        if (!allCommits)
+            currentCommitIndex = CommitBank.commits.length - 1;
+        while (currentCommitIndex >= 0) {
+            if (CommitBank.commits[currentCommitIndex].uuid < uuid)
+                break;
+            if (allCommits || CommitBank.commits[currentCommitIndex].uuid === uuid)
+                candidateCommits.push(CommitBank.commits[currentCommitIndex]);
+            --currentCommitIndex;
+        }
+
+        if (candidateCommits.length === 0 || candidateCommits[candidateCommits.length - 1].uuid !== uuid)
+            candidateCommits.push({
+                id: '?',
+                uuid: uuid,
+            });
+
+        let index = 0;
+        candidateCommits.forEach(commit => {
+            if (commit.repository_id)
+                repositories.add(commit.repository_id);
+            while (index < commits.length) {
+                if (commit.uuid === commits[index].uuid)
+                    return;
+                if (commit.uuid > commits[index].uuid) {
+                    commits.splice(index, 0, commit);
+                    return;
+                }
+                ++index;
+            }
+            commits.push(commit);
         });
     });
     if (currentCommitIndex >= 0 && commits.length) {
@@ -1119,7 +1128,9 @@ class TimelineFromEndpoint {
             let resultsByKey = {};
             this.results[configuration.toKey()].forEach(pair => {
                 const strippedConfig = new Configuration(pair.configuration);
-                resultsByKey[strippedConfig.toKey()] = combineResults([], [...pair.results].sort(function(a, b) {return b.uuid - a.uuid;}));
+                const key = strippedConfig.toKey();
+                const sortedPairResults = [...pair.results].sort(function(a, b) {return b.uuid - a.uuid;});
+                resultsByKey[key] = combineResults(resultsByKey[key] || [], sortedPairResults);
                 strippedConfig.sdk = null;
                 mappedChildrenConfigs[strippedConfig.toKey()] = strippedConfig;
                 if (!childrenConfigsBySDK[strippedConfig.toKey()])
@@ -1138,9 +1149,16 @@ class TimelineFromEndpoint {
             childrenConfigs.forEach(config => {
                 childrenConfigsBySDK[config.toKey()].sort(function(a, b) {return a.compareSDKs(b);});
 
+                // If all configs map to the same key in resultsByKey,
+                // there's no point showing expandable SDK rows.
+                const uniqueResultKeys = [...new Set(
+                    childrenConfigsBySDK[config.toKey()].map(c => c.toKey())
+                )];
+                const hasMultipleResultSets = uniqueResultKeys.length > 1;
+
                 let resultsForConfig = [];
-                childrenConfigsBySDK[config.toKey()].forEach(sdkConfig => {
-                    resultsForConfig = combineResults(resultsForConfig, resultsByKey[sdkConfig.toKey()]);
+                uniqueResultKeys.forEach(key => {
+                    resultsForConfig = combineResults(resultsForConfig, resultsByKey[key] || []);
                 });
                 allResults = combineResults(allResults, resultsForConfig);
 
@@ -1150,7 +1168,7 @@ class TimelineFromEndpoint {
                     queueParams['branch'] = branch;
                 const uuidsInThisSeries = new Set(resultsForConfig.map(r => r.uuid));
                 let myTimeline = Timeline.SeriesWithHeaderComponent(
-                    `${childrenConfigsBySDK[config.toKey()].length > 1 ? ' | ' : ''}<a href="/urls/queue?${paramsToQuery(queueParams)}" target="_blank">${config}</a>`,
+                    `${hasMultipleResultSets ? ' | ' : ''}<a href="/urls/queue?${paramsToQuery(queueParams)}" target="_blank">${config}</a>`,
                     Timeline.CanvasSeriesComponent(resultsForConfig, this.scale, {
                         getScaleFunc: options.getScaleFunc,
                         compareFunc: options.compareFunc,
@@ -1171,10 +1189,13 @@ class TimelineFromEndpoint {
                         exporter: exporterFactory(resultsForConfig),
                     }));
 
-                if (childrenConfigsBySDK[config.toKey()].length > 1) {
+                if (hasMultipleResultSets) {
                     let timelinesBySDK = [];
-                    childrenConfigsBySDK[config.toKey()].forEach(sdkConfig => {
-                        const seriesResults = resultsByKey[sdkConfig.toKey()];
+                    uniqueResultKeys.forEach(resultKey => {
+                        const sdkConfig = childrenConfigsBySDK[config.toKey()].find(c => c.toKey() === resultKey);
+                        if (sdkConfig === undefined)
+                            return;
+                        const seriesResults = resultsByKey[resultKey] || [];
                         const uuidsInThisSDKRow = new Set(seriesResults.map(r => r.uuid));
                         timelinesBySDK.push(
                             Timeline.SeriesWithHeaderComponent(`${Configuration.integerToVersion(sdkConfig.version)} (${sdkConfig.sdk})`,


### PR DESCRIPTION
#### 606834adbdc94c9b1a59a2fb6d793529e2ecd089
<pre>
[Results DB] GTK results markers missing when grouping configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=306091">https://bugs.webkit.org/show_bug.cgi?id=306091</a>

Reviewed by NOBODY (OOPS!).

tl;dr:

- Only changes resultsdbpy&apos;s timeline.js.
- Ensures the uuid from all retrieved results are accounted for when
  finding the matching commits.
- Ensures the results from all nested timelines are combined to create
  the parent expandable timeline markers.
- Only create the expandable timelines if the nested timelines are
  represented by a different configuration key.

Now, the details:

When processing the retrieved test results, the frontend might
receive multiple configurations, each one with their own set of results.
Currently, the configurations are iterated separately, with the
assumption that the results will be ordered by uuid, so we can match the
proper commit ids sequentially.

While this works most of the time as the configurations are versioned in
a way that favors this, in some scenarios we might get out of order
configurations. For example, this happened with GTK after <a href="https://commits.webkit.org/305707@main">305707@main</a>,
which rolled back the version number while keeping the placeholder
xvfb version name.

For some tests, this led to the newer configuration being processed
after the older ones. Given that the older ones already had their
commit ids matched and commitsForResults did not reset the commit
cursor, these newer results ended up having an unknown commit id and not
being rendered.

This commit fixes this by getting a sorted list of all unique uuids
before matching the commits, so every result has a chance to find the
commit it belongs to before the commit cursor advances past it. While
we could have worked around this by removing the &quot;version_name&quot; from
GTK results (which we, in fact, already did in commit <a href="https://commits.webkit.org/306101@main">306101@main</a>),
the current code would still be subject to this problem depending on
the order of the grouped configurations.

This commit also ensures we combine the results for all grouped
configurations in the parent expandable timeline instead of using just
the last of the grouped configuration&apos;s results. That way we can draw
the information across all commits covered by the group.

The current criteria to create an expandable timeline is the presence of
multiple configurations with the same key after stripping the SDK
information. Under this expandable timeline, we keep the individual
timeline for each configuration. This is used mainly for grouping the Mac
configurations that only differ on the SDK version.

And given we&apos;re already combining all results that share the same
&quot;visible&quot; configuration key, we don&apos;t need to show the nested items
for these cases. This happens, for example, for GTK
results until <a href="https://commits.webkit.org/306101@main">306101@main</a>, where the presence of `version_name` and no
SDK info caused different configurations to be grouped together.

Despite losing the information about the actual configurations when
they&apos;re grouped under a given key (as they won&apos;t be listed individually
anymore), the relevant information already lives in the key itself,
and we can deduce the actual configuration from a given test result if
needed.

Another open issue is that, currently, the last configuration in an
expandable list is the one that defines the parameters linked by the
configuration link. This should be fixed in a follow up commit.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(commitsForResults): Collect all unique uuids from all results before
matching commits.
(TimelineFromEndpoint.prototype.render):
Combine the results from all configurations, not just the last one, and
only draw expandable timelines if the nested timelines have different
configuration keys.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/606834adbdc94c9b1a59a2fb6d793529e2ecd089

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107672 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78177 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88572 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/139796 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10047 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7602 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8884 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12521 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115975 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/139874 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116313 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11525 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67539 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1683 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12303 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->