### PR TITLE
Unreviewed, reverting 304975@main (7f525e50e298)

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -2022,14 +2022,13 @@ bool Graph::canDoFastSpread(Node* node, const AbstractValue& value)
 
     JSGlobalObject* globalObject = globalObjectFor(node->child1()->origin.semantic);
     ArrayPrototype* arrayPrototype = globalObject->arrayPrototype();
-
     bool allGood = true;
     value.m_structure.forEach([&] (RegisteredStructure structure) {
-        allGood &= structure->globalObject() == globalObject
+        allGood &= structure->globalObject() == globalObject 
             && structure->hasMonoProto()
             && structure->storedPrototype() == arrayPrototype
             && !structure->isDictionary()
-            && !structure->hasSpecialProperties()
+            && structure->getConcurrently(m_vm.propertyNames->iteratorSymbol.impl()) == invalidOffset
             && !structure->mayInterceptIndexedAccesses();
     });
 

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1980,6 +1980,7 @@ bool JSArray::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isArrayPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
+    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many arrays will be an original array.
     if (globalObject->isOriginalArrayStructure(structure))
@@ -1991,7 +1992,10 @@ bool JSArray::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->arrayPrototype())
         return false;
 
-    return !structure->hasSpecialProperties();
+    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
+        return false;
+
+    return true;
 }
 
 bool JSArray::isToPrimitiveFastAndNonObservable()

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -366,6 +366,7 @@ bool JSArrayBufferView::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(typedArrayType))
         return false;
 
+    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many TypedArrays will be an original typed array structure.
     if (globalObject->isOriginalTypedArrayStructure(structure, true) || globalObject->isOriginalTypedArrayStructure(structure, false))
@@ -374,7 +375,10 @@ bool JSArrayBufferView::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->typedArrayPrototype(typedArrayType))
         return false;
 
-    return !structure->hasSpecialProperties();
+    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
+        return false;
+
+    return true;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMapInlines.h
+++ b/Source/JavaScriptCore/runtime/JSMapInlines.h
@@ -45,6 +45,7 @@ ALWAYS_INLINE bool JSMap::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isMapPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
+    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many maps will be an original map.
     if (structure == globalObject->mapStructure())
@@ -53,7 +54,10 @@ ALWAYS_INLINE bool JSMap::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->mapPrototype())
         return false;
 
-    return !structure->hasSpecialProperties();
+    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
+        return false;
+
+    return true;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSSetInlines.h
+++ b/Source/JavaScriptCore/runtime/JSSetInlines.h
@@ -40,6 +40,7 @@ ALWAYS_INLINE bool JSSet::isIteratorProtocolFastAndNonObservable()
     if (!globalObject->isSetPrototypeIteratorProtocolFastAndNonObservable())
         return false;
 
+    VM& vm = globalObject->vm();
     Structure* structure = this->structure();
     // This is the fast case. Many sets will be an original set.
     if (structure == globalObject->setStructure())
@@ -48,7 +49,10 @@ ALWAYS_INLINE bool JSSet::isIteratorProtocolFastAndNonObservable()
     if (getPrototypeDirect() != globalObject->jsSetPrototype())
         return false;
 
-    return !structure->hasSpecialProperties();
+    if (getDirectOffset(vm, vm.propertyNames->iteratorSymbol) != invalidOffset)
+        return false;
+
+    return true;
 }
 
 }

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -525,7 +525,7 @@ inline PropertyOffset Structure::add(VM& vm, PropertyName propertyName, unsigned
     }
     if (propertyName == vm.propertyNames->underscoreProto)
         setHasUnderscoreProtoPropertyExcludingOriginalProto(true);
-    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol)
+    else if (propertyName == vm.propertyNames->then)
         setHasSpecialProperties(true);
 
     auto rep = propertyName.uid();
@@ -685,7 +685,7 @@ ALWAYS_INLINE auto Structure::addOrReplacePropertyWithoutTransition(VM& vm, Prop
     }
     if (propertyName == vm.propertyNames->underscoreProto)
         setHasUnderscoreProtoPropertyExcludingOriginalProto(true);
-    else if (propertyName == vm.propertyNames->then || propertyName == vm.propertyNames->iteratorSymbol)
+    else if (propertyName == vm.propertyNames->then)
         setHasSpecialProperties(true);
 
     PropertyOffset newOffset = table->nextOffset(m_inlineCapacity);


### PR DESCRIPTION
#### 4fb57beb23ac7f872f444945e549816ff0217ddf
<pre>
Unreviewed, reverting 304975@main (7f525e50e298)
<a href="https://bugs.webkit.org/show_bug.cgi?id=306168">https://bugs.webkit.org/show_bug.cgi?id=306168</a>
<a href="https://rdar.apple.com/168807954">rdar://168807954</a>

This is not a correct way to track own properties. This bit is for properties which should not exist in the chain

Reverted change:

    [JSC] Use `hasSpecialProperties` for checking iterable
    <a href="https://bugs.webkit.org/show_bug.cgi?id=304718">https://bugs.webkit.org/show_bug.cgi?id=304718</a>
    304975@main (7f525e50e298)

Canonical link: <a href="https://commits.webkit.org/306149@main">https://commits.webkit.org/306149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fb57beb23ac7f872f444945e549816ff0217ddf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21684 "Built successfully and passed tests") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->