### PR TITLE
WebKitBot - failed during bug creation

### DIFF
--- a/Tools/Scripts/webkitpy/common/config/committers.py
+++ b/Tools/Scripts/webkitpy/common/config/committers.py
@@ -68,15 +68,63 @@ class Contributor(object):
         self.can_commit = False
         self.can_review = False
         self.is_bot = False
+        self._bugzilla_email = None  # Cached validated email
+
+    def _validate_bugzilla_email(self):
+        """Validates which email from emails list exists in Bugzilla."""
+        if len(self.emails) == 0:
+            return None
+
+        # If only one email, no need to validate
+        if len(self.emails) == 1:
+            return self.emails[0]
+
+        try:
+            import urllib.request
+            import urllib.parse
+            from webkitpy.common.config import urls
+
+            # Check each email one at a time (Bugzilla REST API requires this)
+            for email in self.emails:
+                try:
+                    url = f"{urls.bug_server_url}rest/user?names={urllib.parse.quote(email)}"
+                    req = urllib.request.Request(url)
+
+                    # Make the REST API call with a short timeout
+                    with urllib.request.urlopen(req, timeout=5) as response:
+                        data = json.loads(
+                            response.read().decode('utf-8'))
+
+                        # If the API returns a user, this email is valid
+                        if 'users' in data and len(data['users']) > 0:
+                            # Verify email matches what we're looking for
+                            for user in data['users']:
+                                if user.get('name', '').lower() == email:
+                                    return email
+                except Exception:
+                    # If this email fails, try the next one
+                    continue
+
+        except Exception as e:
+            # If validation fails for any reason (network error, timeout, etc.),
+            # fall back to the first email
+            pass
+
+        # Default to first email if validation fails or no match found
+        return self.emails[0]
 
     def bugzilla_email(self):
-        # FIXME: We're assuming the first email is a valid bugzilla email,
-        # which might not be right.
-        return self.emails[0]
+        # Return cached email if already validated
+        if self._bugzilla_email is not None:
+            return self._bugzilla_email
+
+        # Validate and cache the result
+        self._bugzilla_email = self._validate_bugzilla_email()
+        return self._bugzilla_email
 
     @property
     def email(self):
-        self.bugzilla_email()
+        return self.bugzilla_email()
 
     def __str__(self):
         return string_utils.encode(u'"{}" <{}>'.format(unicode(self.full_name), unicode(self.emails[0])), target_type=str)

--- a/Tools/Scripts/webkitpy/common/config/test_email_validation.py
+++ b/Tools/Scripts/webkitpy/common/config/test_email_validation.py
@@ -1,0 +1,347 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of Apple Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import json
+import sys
+import time
+import unittest
+import urllib.parse
+import urllib.request
+
+from webkitpy.common.config.committers import Contributor, CommitterList
+
+
+class ContributorEmailValidationTest(unittest.TestCase):
+    """Tests for Contributor bugzilla_email() validation."""
+
+    def test_single_email_no_validation(self):
+        """Test that contributors with a single email don't need validation."""
+        contributor = Contributor("Test User", "test@example.com")
+        email = contributor.bugzilla_email()
+        self.assertEqual(email, "test@example.com")
+
+    def test_email_property_returns_bugzilla_email(self):
+        """Test that the email property returns the bugzilla_email()."""
+        contributor = Contributor("Test User", "test@example.com")
+        self.assertEqual(contributor.email, contributor.bugzilla_email())
+
+    def test_caching_works(self):
+        """Test that bugzilla_email() caches the validated email."""
+        contributor = Contributor("Test User", ["first@example.com", "second@example.com"])
+
+        # First call
+        email1 = contributor.bugzilla_email()
+
+        # Second call should return cached value
+        email2 = contributor.bugzilla_email()
+
+        self.assertEqual(email1, email2)
+        # Verify it's the same object reference (cached)
+        self.assertIs(contributor._bugzilla_email, email1)
+
+    def test_multiple_emails_validation_with_real_data(self):
+        """Test email validation with real contributors.json data."""
+        committer_list = CommitterList()
+        multi_email_contributors = [c for c in committer_list.contributors() if len(c.emails) > 1]
+
+        if not multi_email_contributors:
+            self.skipTest("No contributors with multiple emails found")
+
+        # Test first contributor with multiple emails
+        contributor = multi_email_contributors[0]
+        validated_email = contributor.bugzilla_email()
+
+        # Should return one of the emails
+        self.assertIn(validated_email, contributor.emails)
+
+        # Should be cached
+        cached_email = contributor.bugzilla_email()
+        self.assertEqual(validated_email, cached_email)
+
+
+def _print_separator():
+    print("=" * 70)
+
+
+def _test_contributor_by_name(contributor_name, debug=False):
+    """Test email validation for a specific contributor by name."""
+    _print_separator()
+    print("Testing email validation for: {}".format(contributor_name))
+    _print_separator()
+
+    print("\nLoading contributors from contributors.json...")
+    committer_list = CommitterList()
+
+    # Try to find the contributor by name (case-insensitive)
+    contributor = committer_list.contributor_by_name(contributor_name)
+
+    if not contributor:
+        # Try searching by partial name match
+        all_contributors = committer_list.contributors()
+        matches = [c for c in all_contributors if contributor_name.lower() in c.full_name.lower()]
+
+        if not matches:
+            print("Contributor '{}' not found in contributors.json".format(contributor_name))
+            print("\nTip: Try a partial name match, e.g., 'Smith' to find 'John Smith'")
+            return False
+
+        if len(matches) > 1:
+            print("Multiple contributors found matching '{}':".format(contributor_name))
+            for match in matches:
+                print("   - {}".format(match.full_name))
+            print("\nPlease be more specific.")
+            return False
+
+        contributor = matches[0]
+
+    print("Found contributor: {}".format(contributor.full_name))
+    print("\nEmail addresses in contributors.json:")
+    for i, email in enumerate(contributor.emails):
+        print("  [{}] {}".format(i + 1, email))
+
+    if len(contributor.emails) == 1:
+        print("\nThis contributor only has one email address.")
+        print("  No validation needed, will use: {}".format(contributor.emails[0]))
+    else:
+        print("\nValidating {} email addresses against Bugzilla...".format(len(contributor.emails)))
+
+    # If debug mode, manually validate and show details
+    if debug and len(contributor.emails) > 1:
+        print("\n" + "=" * 70)
+        print("DEBUG: Manual validation to see what's happening")
+        print("=" * 70)
+
+        from webkitpy.common.config import urls
+
+        print("\nTesting each email address individually...")
+        print("(Bugzilla REST API only accepts one email at a time)")
+
+        for i, email in enumerate(contributor.emails):
+            print("\n[{}] Testing: {}".format(i + 1, email))
+            api_url = "{}rest/user?names={}".format(urls.bug_server_url, urllib.parse.quote(email))
+            print("    API URL: {}".format(api_url))
+
+            try:
+                req = urllib.request.Request(api_url)
+                with urllib.request.urlopen(req, timeout=5) as response:
+                    response_text = response.read().decode('utf-8')
+                    data = json.loads(response_text)
+
+                    print("    Response:")
+                    if 'users' in data and len(data['users']) > 0:
+                        print("      User found!")
+                        for user in data['users']:
+                            print("        - name: {}".format(user.get('name')))
+                            print("        - id: {}".format(user.get('id')))
+                            print("        - real_name: {}".format(user.get('real_name', 'N/A')))
+                            if user.get('name', '').lower() == email:
+                                print("      Email MATCH: This is the valid email!")
+                    else:
+                        print("      No user found for this email")
+                        print("      Raw response: {}".format(response_text[:200]))
+
+            except Exception as e:
+                print("      Error: {}: {}".format(type(e).__name__, e))
+
+        print("\n" + "=" * 70)
+
+    # Validate email (this will use the actual Contributor class method)
+    print("\nRunning actual validation via Contributor.bugzilla_email()...")
+    start = time.time()
+    validated_email = contributor.bugzilla_email()
+    elapsed = time.time() - start
+
+    print("\nValidated email: {}".format(validated_email))
+    print("  (Validation took {:.3f}s)".format(elapsed))
+
+    # Show if validation picked a different email
+    if validated_email != contributor.emails[0]:
+        print("\nVALIDATION WORKED!")
+        print("   Selected: {}".format(validated_email))
+        print("   Instead of first email: {}".format(contributor.emails[0]))
+    elif len(contributor.emails) > 1:
+        print("\n   First email was valid (or validation failed, using fallback)")
+
+    # Test caching
+    print("\nTesting cache...")
+    start = time.time()
+    cached_email = contributor.bugzilla_email()
+    elapsed = time.time() - start
+    print("Cached email: {} (took {:.6f}s - should be instant)".format(cached_email, elapsed))
+
+    # Test email property
+    property_email = contributor.email
+    print("Email property: {}".format(property_email))
+
+    assert validated_email == cached_email == property_email, "All methods should return the same email"
+
+    print("\n" + "=" * 70)
+    print("Email validation test completed successfully!")
+    print("=" * 70)
+    return True
+
+
+def _test_with_real_data():
+    """Test email validation with real contributors.json data."""
+    _print_separator()
+    print("Testing email validation with REAL contributors.json data")
+    _print_separator()
+
+    print("\nLoading contributors from contributors.json...")
+    committer_list = CommitterList()
+    all_contributors = committer_list.contributors()
+    print("Loaded {} contributors".format(len(all_contributors)))
+
+    # Find contributors with multiple emails
+    multi_email_contributors = [c for c in all_contributors if len(c.emails) > 1]
+    print("Found {} contributors with multiple emails".format(len(multi_email_contributors)))
+
+    if not multi_email_contributors:
+        print("No contributors with multiple emails found. Skipping real data tests.")
+        return
+
+    # Test the first few contributors with multiple emails
+    print("\n" + "=" * 70)
+    print("Testing email validation for contributors with multiple emails:")
+    print("=" * 70)
+
+    for i, contributor in enumerate(multi_email_contributors[:5]):  # Test first 5
+        print("\n[{}] {}".format(i + 1, contributor.full_name))
+        print("    All emails: {}".format(contributor.emails))
+
+        start = time.time()
+        validated_email = contributor.bugzilla_email()
+        elapsed = time.time() - start
+
+        print("    Validated email: {}".format(validated_email))
+        print("    (Validation took {:.3f}s)".format(elapsed))
+
+        # Test caching
+        start = time.time()
+        cached_email = contributor.bugzilla_email()
+        elapsed = time.time() - start
+        print("    Cached email: {} (took {:.6f}s)".format(cached_email, elapsed))
+
+        assert validated_email == cached_email, "Cached email should match validated email"
+
+        if validated_email != contributor.emails[0]:
+            print("    VALIDATION WORKED! Selected '{}' instead of '{}'".format(
+                validated_email, contributor.emails[0]))
+
+    print("\n" + "=" * 70)
+    print("All real data tests passed!")
+    print("=" * 70)
+
+
+def _test_basic_functionality():
+    """Test basic functionality with mock data."""
+    print("\n" + "=" * 70)
+    print("Testing basic functionality")
+    print("=" * 70)
+
+    # Test 1: Contributor with single email
+    print("\nTest 1: Single email (should not validate)")
+    contributor1 = Contributor("Test User", "test@example.com")
+    email1 = contributor1.bugzilla_email()
+    print("  Result: {}".format(email1))
+    assert email1 == "test@example.com", "Single email should be returned as-is"
+    print("  Passed")
+
+    # Test 2: email property works
+    print("\nTest 2: email property returns correct value")
+    email2 = contributor1.email
+    print("  Result: {}".format(email2))
+    assert email2 == "test@example.com", "email property should return bugzilla_email()"
+    print("  Passed")
+
+    print("\nAll basic tests passed!")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Test email validation for WebKit contributors',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  python3 -m webkitpy.common.config.test_email_validation "Foo Bar"
+  python3 -m webkitpy.common.config.test_email_validation "Foo Bar" --debug
+  python3 -m webkitpy.common.config.test_email_validation --all
+  python3 -m webkitpy.common.config.test_email_validation --unittest
+        '''
+    )
+    parser.add_argument(
+        'name',
+        nargs='?',
+        help='Contributor name to test (full or partial name)'
+    )
+    parser.add_argument(
+        '--all',
+        action='store_true',
+        help='Run tests on first 5 contributors with multiple emails'
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Show detailed debug information including API calls and responses'
+    )
+    parser.add_argument(
+        '--unittest',
+        action='store_true',
+        help='Run unit tests'
+    )
+
+    args = parser.parse_args()
+
+    if args.unittest:
+        # Run unit tests
+        suite = unittest.TestLoader().loadTestsFromTestCase(ContributorEmailValidationTest)
+        runner = unittest.TextTestRunner(verbosity=2)
+        result = runner.run(suite)
+        sys.exit(0 if result.wasSuccessful() else 1)
+    elif args.name:
+        # Test specific contributor
+        _test_contributor_by_name(args.name, debug=args.debug)
+    elif args.all:
+        # Run all tests
+        _test_basic_functionality()
+        _test_with_real_data()
+    else:
+        # No arguments, show help
+        parser.print_help()
+        print("\n" + "=" * 70)
+        print("Quick start:")
+        print("  python3 -m webkitpy.common.config.test_email_validation 'Your Name'")
+        print("  python3 -m webkitpy.common.config.test_email_validation 'Your Name' --debug")
+        print("  python3 -m webkitpy.common.config.test_email_validation --all")
+        print("  python3 -m webkitpy.common.config.test_email_validation --unittest")
+        print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### 0fd187f9ba819e33251bb2417e97822c98e0a349
<pre>
WebKitBot - failed during bug creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=306167">https://bugs.webkit.org/show_bug.cgi?id=306167</a>
<a href="https://rdar.apple.com/168807599">rdar://168807599</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug.
bugzilla_email() is used by webkit-patch to retrieve email address of a user from contributors.json. However it always returns the first email address if there are multiple, and the first one may not be the correct one used in Bugizlla. This patch will cause bugzilla_email() to try to validate all email addresses in the list until one is confirmed to match a user in Bugzilla. If none of them can be validate, it falls back to the first email address.

* Tools/Scripts/webkitpy/common/config/committers.py:
(Contributor.__init__):
(Contributor._validate_bugzilla_email):
(Contributor.bugzilla_email):
(Contributor.email):
* Tools/Scripts/webkitpy/common/config/test_email_validation.py: Added.
(ContributorEmailValidationTest):
(ContributorEmailValidationTest.test_single_email_no_validation):
(ContributorEmailValidationTest.test_email_property_returns_bugzilla_email):
(ContributorEmailValidationTest.test_caching_works):
(ContributorEmailValidationTest.test_multiple_emails_validation_with_real_data):
(_print_separator):
(_test_contributor_by_name):
(_test_with_real_data):
(_test_basic_functionality):
(main):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fd187f9ba819e33251bb2417e97822c98e0a349

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/1969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93543 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f887ece-52bf-4a1b-a98a-5570df45f2b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/12992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107677 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78180 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d28267b5-e4bd-4e73-b30b-b3f8de0ccebf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88577 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc9604c0-20d9-4ffe-831d-80182cb74a48) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/139801 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7607 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8889 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151410 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12526 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/115981 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116319 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11560 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67549 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12568 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1700 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12308 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12506 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->