### PR TITLE
AX: Change most non-PDF usage of retrieveValueFromMainThread to retrieveValueFromMainThreadWithTimeout

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -14,7 +14,6 @@ Modules/webcodecs/WebCodecsBase.cpp
 Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webdatabase/DatabaseThread.cpp
-[ Mac ] accessibility/isolatedtree/AXIsolatedObject.cpp
 animation/KeyframeEffect.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp


### PR DESCRIPTION
#### f115a7fb37438d37f49c80fea306ebc10c3272e6
<pre>
AX: Change most non-PDF usage of retrieveValueFromMainThread to retrieveValueFromMainThreadWithTimeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=306170">https://bugs.webkit.org/show_bug.cgi?id=306170</a>
<a href="https://rdar.apple.com/168812301">rdar://168812301</a>

Reviewed by Joshua Hoffman.

The main-thread can be busy, sometimes forever. We shouldn&apos;t wait an unbounded amount of time for any API.
Some usage of retrieveValueFromMainThread is removed outright in contexts where we know we&apos;re on the main-thread
(i.e. because we fell past an !isMainThread()) branch.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::intersectionWith const):
(WebCore::operator&lt;=&gt;):
(WebCore::AXTextMarkerRange::toString const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::performDismissAction):
(WebCore::AXIsolatedObject::setValue):
(WebCore::AXIsolatedObject::selectedText const):
(WebCore::AXIsolatedObject::findTextRanges const):
(WebCore::AXIsolatedObject::performTextOperation):
(WebCore::AXIsolatedObject::elementRect const):
(WebCore::AXIsolatedObject::convertFrameToSpace const):
(WebCore::AXIsolatedObject::replaceTextInRange):
(WebCore::AXIsolatedObject::insertionPointLineNumber const):
(WebCore::AXIsolatedObject::identifierAttribute const):
(WebCore::AXIsolatedObject::doAXRangeForLine const):
(WebCore::AXIsolatedObject::doAXStringForRange const):
(WebCore::AXIsolatedObject::characterRangeForPoint const):
(WebCore::AXIsolatedObject::doAXRangeForIndex const):
(WebCore::AXIsolatedObject::doAXStyleRangeForIndex const):
(WebCore::AXIsolatedObject::doAXBoundsForRange const):
(WebCore::AXIsolatedObject::doAXBoundsForRangeUsingCharacterOffset const):
(WebCore::AXIsolatedObject::doAXLineForIndex):
(WebCore::AXIsolatedObject::modelElementChildren):
(WebCore::AXIsolatedObject::isOnScreen const):
(WebCore::AXIsolatedObject::misspellingRanges const):
(WebCore::AXIsolatedObject::hasSameFont):
(WebCore::AXIsolatedObject::hasSameFontColor):
(WebCore::AXIsolatedObject::hasSameStyle):
(WebCore::AXIsolatedObject::linkRelValue const):
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::convertRectToPlatformSpace const):
(WebCore::AXIsolatedObject::textContent const):
(WebCore::AXIsolatedObject::textMarkerRange const):
(WebCore::AXIsolatedObject::textMarkerRangeForNSRange const):
(WebCore::AXIsolatedObject::platformStringValue const):
(WebCore::AXIsolatedObject::textLength const):
(WebCore::AXIsolatedObject::attributedStringForTextMarkerRange const):
(WebCore::AXIsolatedObject::clickPoint):
(WebCore::AXIsolatedObject::pressedIsPresent const):
(WebCore::AXIsolatedObject::determineDropEffects const):
(WebCore::AXIsolatedObject::layoutCount const):
(WebCore::AXIsolatedObject::classList const):
(WebCore::AXIsolatedObject::computedRoleString const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase accessibilityVisibleCharacterRange]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper computeTextBoundsForRange:backingObject:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
(-[WebAccessibilityObjectWrapper _indexForTextMarker:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/306949@main">https://commits.webkit.org/306949@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f65ab3ff8acc95736e152a40c6a86cb538f8162

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151410 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95925 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5100da76-3478-4ff1-9af5-f983efade638) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15864 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109768 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95925 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/717902c2-24fe-451b-93f0-812d7153ef1d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eac581d4-6a20-457a-a031-ff9fd938ecbc) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9413 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1409 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153723 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14834 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117782 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118113 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30224 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14117 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70531 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14877 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3949 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14612 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78586 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14674 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->