### PR TITLE
AX: A Grid with the child row in a shadow root does not work in safari+VO

### DIFF
--- a/LayoutTests/accessibility/shadow-dom-aria-grid-expected.txt
+++ b/LayoutTests/accessibility/shadow-dom-aria-grid-expected.txt
@@ -1,0 +1,22 @@
+This tests that ARIA grids correctly recognize rows in shadow DOM, including after dynamic changes.
+
+Initial shadow DOM grid state:
+PASS: shadowGrid.rowCount === 2
+PASS: shadowGrid.columnCount === 2
+PASS: shadowGrid.width >= 2 === true
+PASS: shadowGrid.height >= 2 === true
+PASS: shadowGrid.cellForColumnAndRow(0, 0).role.toLowerCase().includes('cell') === true
+
+Adding a third row dynamically to shadow DOM...
+PASS: shadowGrid.rowCount === 3
+PASS: shadowGrid.columnCount === 2
+PASS: cell.role.toLowerCase().includes('cell') === true
+
+Removing the first row from shadow DOM...
+PASS: shadowGrid.rowCount === 2
+PASS: shadowGrid.columnCount === 2
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/shadow-dom-aria-grid.html
+++ b/LayoutTests/accessibility/shadow-dom-aria-grid.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="grid-with-shadow-rows" role="grid" aria-label="Shadow DOM grid"></div>
+
+<script>
+var output = "This tests that ARIA grids correctly recognize rows in shadow DOM, including after dynamic changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var shadowHost = document.getElementById("grid-with-shadow-rows");
+    var shadowRoot = shadowHost.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = `
+        <div role="row" id="shadow-row-1">
+            <div role="gridcell">Shadow Row 1 Cell 1</div>
+            <div role="gridcell">Shadow Row 1 Cell 2</div>
+        </div>
+        <div role="row" id="shadow-row-2">
+            <div role="gridcell">Shadow Row 2 Cell 1</div>
+            <div role="gridcell">Shadow Row 2 Cell 2</div>
+        </div>
+    `;
+
+    var shadowGrid = accessibilityController.accessibleElementById("grid-with-shadow-rows");
+
+    output += "Initial shadow DOM grid state:\n";
+    output += expect("shadowGrid.rowCount", "2");
+    output += expect("shadowGrid.columnCount", "2");
+    output += expect("shadowGrid.width >= 2", "true");
+    output += expect("shadowGrid.height >= 2", "true");
+    output += expect("shadowGrid.cellForColumnAndRow(0, 0).role.toLowerCase().includes('cell')", "true");
+
+    output += "\nAdding a third row dynamically to shadow DOM...\n";
+    var newRow = document.createElement("div");
+    newRow.setAttribute("role", "row");
+    newRow.innerHTML = `
+        <div role="gridcell">Shadow Row 3 Cell 1</div>
+        <div role="gridcell">Shadow Row 3 Cell 2</div>
+    `;
+    shadowRoot.appendChild(newRow);
+
+    setTimeout(async function() {
+        output += await expectAsync("shadowGrid.rowCount", "3");
+        output += expect("shadowGrid.columnCount", "2");
+        cell = shadowGrid.cellForColumnAndRow(0, 2);
+        output += expect("cell.role.toLowerCase().includes('cell')", "true");
+
+        output += "\nRemoving the first row from shadow DOM...\n";
+        shadowRoot.querySelector("[role='row']").remove();
+        output += await expectAsync("shadowGrid.rowCount", "2");
+        output += expect("shadowGrid.columnCount", "2");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2505,7 +2505,7 @@ unsigned AccessibilityNodeObject::computeCellSlots()
     };
 
     // Step 4: Let the table be the table represented by the table element.
-    RefPtr tableElement = this->node();
+    RefPtr tableElement = element();
     // `isAriaTable()` will return true for table-like ARIA structures (grid, treegrid, table).
     if (!is<HTMLTableElement>(tableElement.get()) && !isAriaTable())
         return 0;
@@ -2579,8 +2579,9 @@ unsigned AccessibilityNodeObject::computeCellSlots()
             processRowGroup(*element);
     };
     // Step 7: Let the current element be the first element child of the table element.
-    for (RefPtr currentElement = tableElement->firstChild(); currentElement; currentElement = currentElement->nextSibling()) {
-        processTableDescendant(currentElement.get());
+    // Use composedTreeChildren to traverse shadow DOM children too.
+    for (Ref child : composedTreeChildren<0>(*tableElement)) {
+        processTableDescendant(&child.get());
         // Step 17 + 18: Advance the current element to the next child of the table.
     }
 


### PR DESCRIPTION
#### 717acb6d9ec5c5f8b0bdcffccf335d4b6b60e264
<pre>
AX: A Grid with the child row in a shadow root does not work in safari+VO
<a href="https://bugs.webkit.org/show_bug.cgi?id=294357">https://bugs.webkit.org/show_bug.cgi?id=294357</a>
<a href="https://rdar.apple.com/153134654">rdar://153134654</a>

Reviewed by Chris Fleizach.

Prior to this commit, grids and tables whose child rows were in the
shadow DOM were not properly accounted for when building the
accessibility table cell slots, making them inaccessible to ATs. Fix
this by walking the composed tree when looking through table descendant
in computeCellSlots.

* LayoutTests/accessibility/shadow-dom-aria-grid-expected.txt: Added.
* LayoutTests/accessibility/shadow-dom-aria-grid.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::computeCellSlots):

Canonical link: <a href="https://commits.webkit.org/306159@main">https://commits.webkit.org/306159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc994228cb9254f32f9fd21c9dcfdccf3dde0d94

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | | ⏳ 🛠 vision-apple 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac-debug ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-Cairo-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-26-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-26-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-26-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | | | 
<!--EWS-Status-Bubble-End-->