### PR TITLE
Fix intrinsic sizing for absolutely positioned replaced elements with both insets specified

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax-expected.txt
@@ -35,8 +35,8 @@ PASS minmax replaced IMG svg 32
 PASS minmax replaced IMG svg 33
 PASS minmax replaced IMG 34
 PASS minmax replaced IMG 35
-FAIL minmax replaced IMG 36 assert_equals: incorrect offsetWidth expected "188" but got "388"
-FAIL minmax replaced IMG 37 assert_equals: incorrect offsetWidth expected "188" but got "138"
+PASS minmax replaced IMG 36
+PASS minmax replaced IMG 37
 PASS minmax replaced IMG 38
 PASS minmax replaced IMG 39
 PASS minmax replaced IMG 40


### PR DESCRIPTION
#### 69c6a0c0233b97fe8025cb675921ece2272c070e
<pre>
Fix intrinsic sizing for absolutely positioned replaced elements with both insets specified
<a href="https://bugs.webkit.org/show_bug.cgi?id=306171">https://bugs.webkit.org/show_bug.cgi?id=306171</a>
<a href="https://rdar.apple.com/168815514">rdar://168815514</a>

Reviewed by Alan Baradlay.

When an absolutely positioned replaced element has an aspect ratio but no
intrinsic size, and both inline-axis insets (left/right in horizontal
writing mode) are specified, the element&apos;s size should be determined by
the available space between the insets, not by intrinsic sizing keywords
like fit-content, min-content, or max-content.

Per CSS Positioned Layout Level 3 §3.8.2 [1] and CSS 2.2 §10.3.8 [2],
intrinsic sizing keywords on min-width and max-width should be treated
as their initial values when an absolutely positioned replaced element
with aspect ratio but no intrinsic size has both inline-axis insets
specified.

This particularly affects SVG images with only a viewBox attribute (no
width/height) when used as absolutely positioned &lt;img&gt; elements with both
left and right specified, along with max-width: fit-content.

[1] <a href="https://www.w3.org/TR/css-position-3/#abs-replaced-width">https://www.w3.org/TR/css-position-3/#abs-replaced-width</a>
[2] <a href="https://www.w3.org/TR/CSS22/visudet.html#abs-replaced-width">https://www.w3.org/TR/CSS22/visudet.html#abs-replaced-width</a>

* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeConstrainedLogicalWidth): For absolutely
positioned elements with both left and right specified, compute the
constrained width by subtracting the offset values from the container
width, rather than using the full container width.
(WebCore::RenderReplaced::computeReplacedLogicalWidth): When computing
width for absolutely positioned replaced elements with aspect ratio but
no intrinsic size, where both inline insets are specified, treat
intrinsic sizing keywords in min-width/max-width as their initial values
to avoid incorrect clamping based on non-existent intrinsic dimensions.
* LayoutTests/imported/w3c/web-platform-tests/css/css-position/position-absolute-replaced-minmax-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/306309@main">https://commits.webkit.org/306309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9be69f0b94304d5fa1f595a62baf03c9a52e6b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149425 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108196 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143921 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89099 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8038 "Passed tests") | [⏳ wpe-libwebrtc ](None "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151934 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/13040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2438 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116400 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13055 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116740 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29688 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/12808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122849 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13083 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76784 "Failed to build and analyze WebKit") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->