### PR TITLE
Address unsafe cast warning in NodeRareData.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,4 +1,3 @@
-dom/NodeRareData.h
 [ iOS ] platform/cocoa/WebAVPlayerLayerView.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
 [ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm

--- a/Source/WebCore/dom/AllDescendantsCollection.h
+++ b/Source/WebCore/dom/AllDescendantsCollection.h
@@ -25,11 +25,24 @@
 
 #pragma once
 
-#include "CachedHTMLCollection.h"
+#include <WebCore/CollectionType.h>
 
 namespace WebCore {
 
-class AllDescendantsCollection : public CachedHTMLCollection<AllDescendantsCollection, CollectionTypeTraits<CollectionType::AllDescendants>::traversalType> {
+class AllDescendantsCollection;
+
+template<>
+struct CollectionClassTraits<AllDescendantsCollection> {
+    static constexpr CollectionType collectionType = CollectionType::AllDescendants;
+};
+
+} // namespace WebCore
+
+#include <WebCore/CachedHTMLCollection.h>
+
+namespace WebCore {
+
+class AllDescendantsCollection : public CachedHTMLCollection<AllDescendantsCollection> {
     WTF_MAKE_TZONE_ALLOCATED(AllDescendantsCollection);
 public:
     static Ref<AllDescendantsCollection> create(ContainerNode& rootNode, CollectionType type)
@@ -44,4 +57,6 @@ protected:
     AllDescendantsCollection(ContainerNode&, CollectionType);
 };
 
-}
+} // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(AllDescendantsCollection)

--- a/Source/WebCore/dom/ClassCollection.h
+++ b/Source/WebCore/dom/ClassCollection.h
@@ -29,6 +29,19 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class ClassCollection;
+
+template<>
+struct CollectionClassTraits<ClassCollection> {
+    static constexpr CollectionType collectionType = CollectionType::ByClass;
+};
+
+} // namespace WebCore
+
 #include "CachedHTMLCollection.h"
 #include "Document.h"
 #include "Element.h"
@@ -36,7 +49,7 @@
 
 namespace WebCore {
 
-class ClassCollection final : public CachedHTMLCollection<ClassCollection, CollectionTypeTraits<CollectionType::ByClass>::traversalType> {
+class ClassCollection final : public CachedHTMLCollection<ClassCollection> {
     WTF_MAKE_TZONE_ALLOCATED(ClassCollection);
 public:
     static Ref<ClassCollection> create(ContainerNode&, CollectionType, const AtomString& classNames);
@@ -70,4 +83,4 @@ inline bool ClassCollection::elementMatches(Element& element) const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(ClassCollection, CollectionType::ByClass)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(ClassCollection)

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1222,11 +1222,11 @@ Ref<HTMLCollection> ContainerNode::getElementsByTagName(const AtomString& qualif
     ASSERT(!qualifiedName.isNull());
 
     if (qualifiedName == starAtom())
-        return ensureRareData().ensureNodeLists().addCachedCollection<AllDescendantsCollection>(*this, CollectionType::AllDescendants);
+        return ensureRareData().ensureNodeLists().addCachedCollection<AllDescendantsCollection>(*this);
 
     if (document().isHTMLDocument())
-        return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTagCollection>(*this, CollectionType::ByHTMLTag, qualifiedName);
-    return ensureRareData().ensureNodeLists().addCachedCollection<TagCollection>(*this, CollectionType::ByTag, qualifiedName);
+        return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTagCollection>(*this, qualifiedName);
+    return ensureRareData().ensureNodeLists().addCachedCollection<TagCollection>(*this, qualifiedName);
 }
 
 Ref<HTMLCollection> ContainerNode::getElementsByTagNameNS(const AtomString& namespaceURI, const AtomString& localName)
@@ -1237,7 +1237,7 @@ Ref<HTMLCollection> ContainerNode::getElementsByTagNameNS(const AtomString& name
 
 Ref<HTMLCollection> ContainerNode::getElementsByClassName(const AtomString& classNames)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<ClassCollection>(*this, CollectionType::ByClass, classNames);
+    return ensureRareData().ensureNodeLists().addCachedCollection<ClassCollection>(*this, classNames);
 }
 
 Ref<RadioNodeList> ContainerNode::radioNodeList(const AtomString& name)
@@ -1248,7 +1248,7 @@ Ref<RadioNodeList> ContainerNode::radioNodeList(const AtomString& name)
 
 Ref<HTMLCollection> ContainerNode::children()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::NodeChildren>::traversalType>>(*this, CollectionType::NodeChildren);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLNodeChildrenCollection>(*this);
 }
 
 Element* ContainerNode::firstElementChild() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8288,7 +8288,7 @@ bool Document::drawsHDRContent() const
 template <CollectionType collectionType>
 Ref<HTMLCollection> Document::ensureCachedCollection()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<collectionType>::traversalType>>(*this, collectionType);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<collectionType>>(*this);
 }
 
 Ref<HTMLCollection> Document::images()
@@ -8298,7 +8298,7 @@ Ref<HTMLCollection> Document::images()
 
 Ref<HTMLCollection> Document::applets()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<EmptyHTMLCollection>(*this, CollectionType::DocEmpty);
+    return ensureRareData().ensureNodeLists().addCachedCollection<EmptyHTMLCollection>(*this);
 }
 
 Ref<HTMLCollection> Document::embeds()
@@ -8328,22 +8328,22 @@ Ref<HTMLCollection> Document::anchors()
 
 Ref<HTMLAllCollection> Document::all()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllCollection>(*this, CollectionType::DocAll);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllCollection>(*this);
 }
 
 Ref<HTMLCollection> Document::allFilteredByName(const AtomString& name)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllNamedSubCollection>(*this, CollectionType::DocumentAllNamedItems, name);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllNamedSubCollection>(*this, name);
 }
 
 Ref<HTMLCollection> Document::windowNamedItems(const AtomString& name)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<WindowNameCollection>(*this, CollectionType::WindowNamedItems, name);
+    return ensureRareData().ensureNodeLists().addCachedCollection<WindowNameCollection>(*this, name);
 }
 
 Ref<HTMLCollection> Document::documentNamedItems(const AtomString& name)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<DocumentNameCollection>(*this, CollectionType::DocumentNamedItems, name);
+    return ensureRareData().ensureNodeLists().addCachedCollection<DocumentNameCollection>(*this, name);
 }
 
 Ref<NodeList> Document::getElementsByName(const AtomString& elementName)

--- a/Source/WebCore/dom/LiveNodeList.cpp
+++ b/Source/WebCore/dom/LiveNodeList.cpp
@@ -27,8 +27,9 @@
 
 namespace WebCore {
 
-LiveNodeList::LiveNodeList(ContainerNode& ownerNode, NodeListInvalidationType invalidationType)
+LiveNodeList::LiveNodeList(ContainerNode& ownerNode, LiveNodeListType type, NodeListInvalidationType invalidationType)
     : m_ownerNode(ownerNode)
+    , m_type(type)
     , m_invalidationType(invalidationType)
 {
 }

--- a/Source/WebCore/dom/LiveNodeListInlines.h
+++ b/Source/WebCore/dom/LiveNodeListInlines.h
@@ -85,8 +85,8 @@ inline ContainerNode& LiveNodeList::rootNode() const
 }
 
 template <class NodeListType, CollectionTraversalType traversalType>
-CachedLiveNodeList<NodeListType, traversalType>::CachedLiveNodeList(ContainerNode& ownerNode, NodeListInvalidationType invalidationType)
-    : LiveNodeList(ownerNode, invalidationType)
+CachedLiveNodeList<NodeListType, traversalType>::CachedLiveNodeList(ContainerNode& ownerNode, LiveNodeListType type, NodeListInvalidationType invalidationType)
+    : LiveNodeList(ownerNode, type, invalidationType)
 {
 }
 

--- a/Source/WebCore/dom/NameNodeList.cpp
+++ b/Source/WebCore/dom/NameNodeList.cpp
@@ -35,7 +35,7 @@ using namespace HTMLNames;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NameNodeList);
 
 NameNodeList::NameNodeList(ContainerNode& rootNode, const AtomString& name)
-    : CachedLiveNodeList(rootNode, NodeListInvalidationType::InvalidateOnNameAttrChange)
+    : CachedLiveNodeList(rootNode, LiveNodeListType::NameNodeList, NodeListInvalidationType::InvalidateOnNameAttrChange)
     , m_name(name)
 {
 }

--- a/Source/WebCore/dom/NameNodeList.h
+++ b/Source/WebCore/dom/NameNodeList.h
@@ -43,3 +43,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_LIVENODELIST(NameNodeList)

--- a/Source/WebCore/dom/TagCollection.h
+++ b/Source/WebCore/dom/TagCollection.h
@@ -23,6 +23,31 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class TagCollection;
+class TagCollectionNS;
+class HTMLTagCollection;
+
+template<>
+struct CollectionClassTraits<TagCollection> {
+    static constexpr CollectionType collectionType = CollectionType::ByTag;
+};
+
+template<>
+struct CollectionClassTraits<TagCollectionNS> {
+    static constexpr CollectionType collectionType = CollectionType::ByTag;
+};
+
+template<>
+struct CollectionClassTraits<HTMLTagCollection> {
+    static constexpr CollectionType collectionType = CollectionType::ByHTMLTag;
+};
+
+} // namespace WebCore
+
 #include "CachedHTMLCollection.h"
 #include "CommonAtomStrings.h"
 #include <wtf/text/AtomString.h>
@@ -30,7 +55,7 @@
 namespace WebCore {
 
 // HTMLCollection that limits to a particular tag.
-class TagCollection final : public CachedHTMLCollection<TagCollection, CollectionTypeTraits<CollectionType::ByTag>::traversalType> {
+class TagCollection final : public CachedHTMLCollection<TagCollection> {
     WTF_MAKE_TZONE_ALLOCATED(TagCollection);
 public:
     static Ref<TagCollection> create(ContainerNode& rootNode, CollectionType type, const AtomString& qualifiedName)
@@ -48,7 +73,7 @@ private:
     AtomString m_qualifiedName;
 };
 
-class TagCollectionNS final : public CachedHTMLCollection<TagCollectionNS, CollectionTypeTraits<CollectionType::ByTag>::traversalType> {
+class TagCollectionNS final : public CachedHTMLCollection<TagCollectionNS> {
     WTF_MAKE_TZONE_ALLOCATED(TagCollectionNS);
 public:
     static Ref<TagCollectionNS> create(ContainerNode& rootNode, const AtomString& namespaceURI, const AtomString& localName)
@@ -66,7 +91,7 @@ private:
     AtomString m_localName;
 };
 
-class HTMLTagCollection final : public CachedHTMLCollection<HTMLTagCollection, CollectionTypeTraits<CollectionType::ByHTMLTag>::traversalType> {
+class HTMLTagCollection final : public CachedHTMLCollection<HTMLTagCollection> {
     WTF_MAKE_TZONE_ALLOCATED(HTMLTagCollection);
 public:
     static Ref<HTMLTagCollection> create(ContainerNode& rootNode, CollectionType type, const AtomString& qualifiedName)
@@ -105,3 +130,6 @@ inline bool HTMLTagCollection::elementMatches(Element& element) const
 }
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(TagCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTagCollection)

--- a/Source/WebCore/html/CachedHTMLCollection.h
+++ b/Source/WebCore/html/CachedHTMLCollection.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/CollectionTraversal.h>
+#include <WebCore/CollectionType.h>
 #include <WebCore/Document.h>
 #include <WebCore/HTMLCollection.h>
 #include <WebCore/HTMLElement.h>
@@ -33,10 +34,12 @@
 
 namespace WebCore {
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
+template <typename HTMLCollectionClass>
 class CachedHTMLCollection : public HTMLCollection {
     WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(CachedHTMLCollection);
 public:
+    static constexpr auto traversalType = CollectionTypeTraits<CollectionClassTraits<HTMLCollectionClass>::collectionType>::traversalType;
+
     CachedHTMLCollection(ContainerNode& base, CollectionType);
     
     virtual ~CachedHTMLCollection();
@@ -67,14 +70,14 @@ private:
     mutable CollectionIndexCache<HTMLCollectionClass, Iterator> m_indexCache;
 };
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-CachedHTMLCollection<HTMLCollectionClass, traversalType>::CachedHTMLCollection(ContainerNode& base, CollectionType collectionType)
+template <typename HTMLCollectionClass>
+CachedHTMLCollection<HTMLCollectionClass>::CachedHTMLCollection(ContainerNode& base, CollectionType collectionType)
     : HTMLCollection(base, collectionType)
 {
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-bool CachedHTMLCollection<HTMLCollectionClass, traversalType>::elementMatches(Element&) const
+template <typename HTMLCollectionClass>
+bool CachedHTMLCollection<HTMLCollectionClass>::elementMatches(Element&) const
 {
     // We call the elementMatches() method directly on the subclass instead for performance.
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/html/CachedHTMLCollectionInlines.h
+++ b/Source/WebCore/html/CachedHTMLCollectionInlines.h
@@ -33,27 +33,27 @@
 
 namespace WebCore {
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-CachedHTMLCollection<HTMLCollectionClass, traversalType>::~CachedHTMLCollection()
+template <typename HTMLCollectionClass>
+CachedHTMLCollection<HTMLCollectionClass>::~CachedHTMLCollection()
 {
     if (m_indexCache.hasValidCache())
         document().unregisterCollection(*this);
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-unsigned CachedHTMLCollection<HTMLCollectionClass, traversalType>::length() const
+template <typename HTMLCollectionClass>
+unsigned CachedHTMLCollection<HTMLCollectionClass>::length() const
 {
     return m_indexCache.nodeCount(collection());
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::item(unsigned offset) const
+template <typename HTMLCollectionClass>
+Element* CachedHTMLCollection<HTMLCollectionClass>::item(unsigned offset) const
 {
     return m_indexCache.nodeAt(collection(), offset);
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-size_t CachedHTMLCollection<HTMLCollectionClass, traversalType>::memoryCost() const
+template <typename HTMLCollectionClass>
+size_t CachedHTMLCollection<HTMLCollectionClass>::memoryCost() const
 {
     // memoryCost() may be invoked concurrently from a GC thread, and we need to be careful about what data we access here and how.
     // Accessing m_indexCache.memoryCost() is safe because because it doesn't involve any pointer chasing.
@@ -61,8 +61,8 @@ size_t CachedHTMLCollection<HTMLCollectionClass, traversalType>::memoryCost() co
     return m_indexCache.memoryCost() + HTMLCollection::memoryCost();
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-void CachedHTMLCollection<HTMLCollectionClass, traversalType>::invalidateCacheForDocument(Document& document)
+template <typename HTMLCollectionClass>
+void CachedHTMLCollection<HTMLCollectionClass>::invalidateCacheForDocument(Document& document)
 {
     HTMLCollection::invalidateCacheForDocument(document);
     if (m_indexCache.hasValidCache()) {
@@ -96,8 +96,8 @@ static inline bool nameShouldBeVisibleInDocumentAll(Element& element)
     return htmlElement && nameShouldBeVisibleInDocumentAll(*htmlElement);
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(const AtomString& name) const
+template <typename HTMLCollectionClass>
+Element* CachedHTMLCollection<HTMLCollectionClass>::namedItem(const AtomString& name) const
 {
     // http://msdn.microsoft.com/workshop/author/dhtml/reference/methods/nameditem.asp
     // This method first searches for an object with a matching id
@@ -137,32 +137,32 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
     return namedItemSlow(name);
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-auto CachedHTMLCollection<HTMLCollectionClass, traversalType>::collectionBegin() const -> Iterator
+template <typename HTMLCollectionClass>
+auto CachedHTMLCollection<HTMLCollectionClass>::collectionBegin() const -> Iterator
 {
     return Traversal::begin(collection(), rootNode());
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-auto CachedHTMLCollection<HTMLCollectionClass, traversalType>::collectionLast() const -> Iterator
+template <typename HTMLCollectionClass>
+auto CachedHTMLCollection<HTMLCollectionClass>::collectionLast() const -> Iterator
 {
     return Traversal::last(collection(), rootNode());
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-void CachedHTMLCollection<HTMLCollectionClass, traversalType>::collectionTraverseForward(Iterator& current, unsigned count, unsigned& traversedCount) const
+template <typename HTMLCollectionClass>
+void CachedHTMLCollection<HTMLCollectionClass>::collectionTraverseForward(Iterator& current, unsigned count, unsigned& traversedCount) const
 {
     Traversal::traverseForward(collection(), current, count, traversedCount);
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-void CachedHTMLCollection<HTMLCollectionClass, traversalType>::collectionTraverseBackward(Iterator& current, unsigned count) const
+template <typename HTMLCollectionClass>
+void CachedHTMLCollection<HTMLCollectionClass>::collectionTraverseBackward(Iterator& current, unsigned count) const
 {
     Traversal::traverseBackward(collection(), current, count);
 }
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-bool CachedHTMLCollection<HTMLCollectionClass, traversalType>::collectionCanTraverseBackward() const
+template <typename HTMLCollectionClass>
+bool CachedHTMLCollection<HTMLCollectionClass>::collectionCanTraverseBackward() const
 {
     return traversalType != CollectionTraversalType::CustomForwardOnly;
 }

--- a/Source/WebCore/html/CollectionType.h
+++ b/Source/WebCore/html/CollectionType.h
@@ -95,4 +95,7 @@ struct CollectionTypeTraits<CollectionType::FormControls> {
     static const CollectionTraversalType traversalType = CollectionTraversalType::CustomForwardOnly;
 };
 
+template<typename CollectionClass>
+struct CollectionClassTraits;
+
 } // namespace WebCore

--- a/Source/WebCore/html/EmptyHTMLCollection.h
+++ b/Source/WebCore/html/EmptyHTMLCollection.h
@@ -25,6 +25,19 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class EmptyHTMLCollection;
+
+template<>
+struct CollectionClassTraits<EmptyHTMLCollection> {
+    static constexpr CollectionType collectionType = CollectionType::DocEmpty;
+};
+
+} // namespace WebCore
+
 #include "HTMLCollection.h"
 
 namespace WebCore {
@@ -47,3 +60,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(EmptyHTMLCollection)

--- a/Source/WebCore/html/GenericCachedHTMLCollection.cpp
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.cpp
@@ -34,22 +34,47 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-template <CollectionTraversalType traversalType>
-GenericCachedHTMLCollection<traversalType>::GenericCachedHTMLCollection(ContainerNode& base, CollectionType collectionType)
-    : CachedHTMLCollection<GenericCachedHTMLCollection<traversalType>, traversalType>(base, collectionType)
+template <CollectionType type>
+GenericCachedHTMLCollection<type>::GenericCachedHTMLCollection(ContainerNode& base, CollectionType collectionType)
+    : CachedHTMLCollection<GenericCachedHTMLCollection<type>>(base, collectionType)
 { }
-template GenericCachedHTMLCollection<CollectionTraversalType::Descendants>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
-template GenericCachedHTMLCollection<CollectionTraversalType::ChildrenOnly>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+// Explicit template instantiations for each CollectionType.
+template GenericCachedHTMLCollection<CollectionType::NodeChildren>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::TRCells>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::TSectionRows>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::TableTBodies>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::SelectedOptions>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::MapAreas>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::DocImages>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::DocScripts>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::DocForms>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::DocEmbeds>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::DocLinks>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::DocAnchors>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::DataListOptions>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
+template GenericCachedHTMLCollection<CollectionType::FieldSetElements>::GenericCachedHTMLCollection(ContainerNode&, CollectionType);
 
-template <CollectionTraversalType traversalType>
-GenericCachedHTMLCollection<traversalType>::~GenericCachedHTMLCollection() = default;
-template GenericCachedHTMLCollection<CollectionTraversalType::Descendants>::~GenericCachedHTMLCollection();
-template GenericCachedHTMLCollection<CollectionTraversalType::ChildrenOnly>::~GenericCachedHTMLCollection();
+template <CollectionType type>
+GenericCachedHTMLCollection<type>::~GenericCachedHTMLCollection() = default;
+template GenericCachedHTMLCollection<CollectionType::NodeChildren>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::TRCells>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::TSectionRows>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::TableTBodies>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::SelectedOptions>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::MapAreas>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::DocImages>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::DocScripts>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::DocForms>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::DocEmbeds>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::DocLinks>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::DocAnchors>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::DataListOptions>::~GenericCachedHTMLCollection();
+template GenericCachedHTMLCollection<CollectionType::FieldSetElements>::~GenericCachedHTMLCollection();
 
-template <CollectionTraversalType traversalType>
-bool GenericCachedHTMLCollection<traversalType>::elementMatches(Element& element) const
+template <CollectionType type>
+bool GenericCachedHTMLCollection<type>::elementMatches(Element& element) const
 {
-    switch (this->type()) {
+    switch (type) {
     case CollectionType::NodeChildren:
         return true;
     case CollectionType::DocImages:
@@ -103,7 +128,19 @@ bool GenericCachedHTMLCollection<traversalType>::elementMatches(Element& element
     return false;
 }
 
-template bool GenericCachedHTMLCollection<CollectionTraversalType::Descendants>::elementMatches(Element&) const;
-template bool GenericCachedHTMLCollection<CollectionTraversalType::ChildrenOnly>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::NodeChildren>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::TRCells>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::TSectionRows>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::TableTBodies>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::SelectedOptions>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::MapAreas>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::DocImages>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::DocScripts>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::DocForms>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::DocEmbeds>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::DocLinks>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::DocAnchors>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::DataListOptions>::elementMatches(Element&) const;
+template bool GenericCachedHTMLCollection<CollectionType::FieldSetElements>::elementMatches(Element&) const;
 
 } // namespace WebCore

--- a/Source/WebCore/html/GenericCachedHTMLCollection.h
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.h
@@ -25,17 +25,32 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+template <CollectionType type>
+class GenericCachedHTMLCollection;
+
+template<CollectionType type>
+struct CollectionClassTraits<GenericCachedHTMLCollection<type>> {
+    static constexpr CollectionType collectionType = type;
+};
+
+} // namespace WebCore
+
 #include "CachedHTMLCollection.h"
 
 namespace WebCore {
 
-template <CollectionTraversalType traversalType>
-class GenericCachedHTMLCollection final : public CachedHTMLCollection<GenericCachedHTMLCollection<traversalType>, traversalType> {
+template <CollectionType type>
+class GenericCachedHTMLCollection final : public CachedHTMLCollection<GenericCachedHTMLCollection<type>> {
     WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(GenericCachedHTMLCollection);
-    static_assert(traversalType != CollectionTraversalType::CustomForwardOnly, "CustomForwardOnly should use non GenericCachedHTMLCollection.");
+    static_assert(CollectionTypeTraits<type>::traversalType != CollectionTraversalType::CustomForwardOnly, "CustomForwardOnly should use non GenericCachedHTMLCollection.");
 public:
     static Ref<GenericCachedHTMLCollection> create(ContainerNode& base, CollectionType collectionType)
     {
+        ASSERT(collectionType == CollectionClassTraits<GenericCachedHTMLCollection>::collectionType); // Verify correct instantiation.
         return adoptRef(*new GenericCachedHTMLCollection(base, collectionType));
     }
 
@@ -47,6 +62,37 @@ private:
     GenericCachedHTMLCollection(ContainerNode&, CollectionType);
 };
 
-WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<CollectionTraversalType traversalType>, GenericCachedHTMLCollection<traversalType>);
+WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<CollectionType type>, GenericCachedHTMLCollection<type>);
+
+// Type aliases for GenericCachedHTMLCollection instantiations.
+using HTMLNodeChildrenCollection = GenericCachedHTMLCollection<CollectionType::NodeChildren>;
+using HTMLTRCellsCollection = GenericCachedHTMLCollection<CollectionType::TRCells>;
+using HTMLTSectionRowsCollection = GenericCachedHTMLCollection<CollectionType::TSectionRows>;
+using HTMLTableTBodiesCollection = GenericCachedHTMLCollection<CollectionType::TableTBodies>;
+using HTMLSelectedOptionsCollection = GenericCachedHTMLCollection<CollectionType::SelectedOptions>;
+using HTMLMapAreasCollection = GenericCachedHTMLCollection<CollectionType::MapAreas>;
+using HTMLDocImagesCollection = GenericCachedHTMLCollection<CollectionType::DocImages>;
+using HTMLDocScriptsCollection = GenericCachedHTMLCollection<CollectionType::DocScripts>;
+using HTMLDocFormsCollection = GenericCachedHTMLCollection<CollectionType::DocForms>;
+using HTMLDocEmbedsCollection = GenericCachedHTMLCollection<CollectionType::DocEmbeds>;
+using HTMLDocLinksCollection = GenericCachedHTMLCollection<CollectionType::DocLinks>;
+using HTMLDocAnchorsCollection = GenericCachedHTMLCollection<CollectionType::DocAnchors>;
+using HTMLDataListOptionsCollection = GenericCachedHTMLCollection<CollectionType::DataListOptions>;
+using HTMLFieldSetElementsCollection = GenericCachedHTMLCollection<CollectionType::FieldSetElements>;
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLNodeChildrenCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTRCellsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTSectionRowsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTableTBodiesCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLSelectedOptionsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLMapAreasCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLDocImagesCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLDocScriptsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLDocFormsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLDocEmbedsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLDocLinksCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLDocAnchorsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLDataListOptionsCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLFieldSetElementsCollection)

--- a/Source/WebCore/html/HTMLAllCollection.h
+++ b/Source/WebCore/html/HTMLAllCollection.h
@@ -25,6 +25,25 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class HTMLAllCollection;
+class HTMLAllNamedSubCollection;
+
+template<>
+struct CollectionClassTraits<HTMLAllCollection> {
+    static constexpr CollectionType collectionType = CollectionType::DocAll;
+};
+
+template<>
+struct CollectionClassTraits<HTMLAllNamedSubCollection> {
+    static constexpr CollectionType collectionType = CollectionType::DocumentAllNamedItems;
+};
+
+} // namespace WebCore
+
 #include "AllDescendantsCollection.h"
 
 namespace WebCore {
@@ -41,7 +60,7 @@ private:
 };
 static_assert(sizeof(HTMLAllCollection) == sizeof(AllDescendantsCollection));
 
-class HTMLAllNamedSubCollection final : public CachedHTMLCollection<HTMLAllNamedSubCollection, CollectionTraversalType::Descendants> {
+class HTMLAllNamedSubCollection final : public CachedHTMLCollection<HTMLAllNamedSubCollection> {
     WTF_MAKE_TZONE_ALLOCATED(HTMLAllNamedSubCollection);
 public:
     static Ref<HTMLAllNamedSubCollection> create(Document& document, CollectionType type, const AtomString& name)
@@ -60,5 +79,5 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllCollection, CollectionType::DocAll)
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllNamedSubCollection, CollectionType::DocumentAllNamedItems)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllNamedSubCollection)

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -128,7 +128,7 @@ inline CollectionType HTMLCollection::type() const
 
 } // namespace WebCore
 
-#define SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(ClassName, Type) \
+#define SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(ClassName) \
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::ClassName) \
-    static bool isType(const WebCore::HTMLCollection& collection) { return collection.type() == WebCore::Type; } \
+    static bool isType(const WebCore::HTMLCollection& collection) { return collection.type() == WebCore::CollectionClassTraits<WebCore::ClassName>::collectionType; } \
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLDataListElement.cpp
+++ b/Source/WebCore/html/HTMLDataListElement.cpp
@@ -70,7 +70,7 @@ void HTMLDataListElement::didMoveToNewDocument(Document& oldDocument, Document& 
 
 Ref<HTMLCollection> HTMLDataListElement::options()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::DataListOptions>::traversalType>>(*this, CollectionType::DataListOptions);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLDataListOptionsCollection>(*this);
 }
 
 void HTMLDataListElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -193,7 +193,7 @@ HTMLLegendElement* HTMLFieldSetElement::legend() const
 
 Ref<HTMLCollection> HTMLFieldSetElement::elements()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::FieldSetElements>::traversalType>>(*this, CollectionType::FieldSetElements);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLFieldSetElementsCollection>(*this);
 }
 
 void HTMLFieldSetElement::addInvalidDescendant(const HTMLElement& invalidFormControlElement)

--- a/Source/WebCore/html/HTMLFormControlsCollection.h
+++ b/Source/WebCore/html/HTMLFormControlsCollection.h
@@ -22,6 +22,19 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class HTMLFormControlsCollection;
+
+template<>
+struct CollectionClassTraits<HTMLFormControlsCollection> {
+    static constexpr CollectionType collectionType = CollectionType::FormControls;
+};
+
+} // namespace WebCore
+
 #include "CachedHTMLCollection.h"
 #include "HTMLFormElement.h"
 #include "RadioNodeList.h"
@@ -34,7 +47,7 @@ class HTMLImageElement;
 // This class is just a big hack to find form elements even in malformed HTML elements.
 // The famous <table><tr><form><td> problem.
 
-class HTMLFormControlsCollection final : public CachedHTMLCollection<HTMLFormControlsCollection, CollectionTypeTraits<CollectionType::FormControls>::traversalType> {
+class HTMLFormControlsCollection final : public CachedHTMLCollection<HTMLFormControlsCollection> {
     WTF_MAKE_TZONE_ALLOCATED(HTMLFormControlsCollection);
 public:
     static Ref<HTMLFormControlsCollection> create(ContainerNode&, CollectionType);
@@ -60,4 +73,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLFormControlsCollection, CollectionType::FormControls)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLFormControlsCollection)

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -661,7 +661,7 @@ Ref<HTMLFormControlsCollection> HTMLFormElement::elements()
     // Ordinarily JS wrapper keeps the collection alive but this function is used by HTMLFormElement::namedElements internally without creating one.
     // This cache is cleared whenever this element is disconnected from a document.
     if (!m_controlsCollection) {
-        Ref controlsCollection = ensureRareData().ensureNodeLists().addCachedCollection<HTMLFormControlsCollection>(*this, CollectionType::FormControls);
+        Ref controlsCollection = ensureRareData().ensureNodeLists().addCachedCollection<HTMLFormControlsCollection>(*this);
         if (!isConnected())
             return controlsCollection;
         m_controlsCollection = WTF::move(controlsCollection);

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -111,7 +111,7 @@ void HTMLMapElement::attributeChanged(const QualifiedName& name, const AtomStrin
 
 Ref<HTMLCollection> HTMLMapElement::areas()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::MapAreas>::traversalType>>(*this, CollectionType::MapAreas);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLMapAreasCollection>(*this);
 }
 
 Node::InsertedIntoAncestorResult HTMLMapElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -39,8 +39,8 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-template HTMLNameCollection<WindowNameCollection, CollectionTraversalType::Descendants>::~HTMLNameCollection();
-template HTMLNameCollection<DocumentNameCollection, CollectionTraversalType::Descendants>::~HTMLNameCollection();
+template HTMLNameCollection<WindowNameCollection>::~HTMLNameCollection();
+template HTMLNameCollection<DocumentNameCollection>::~HTMLNameCollection();
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WindowNameCollection);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentNameCollection);

--- a/Source/WebCore/html/HTMLNameCollection.h
+++ b/Source/WebCore/html/HTMLNameCollection.h
@@ -22,6 +22,25 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class WindowNameCollection;
+class DocumentNameCollection;
+
+template<>
+struct CollectionClassTraits<WindowNameCollection> {
+    static constexpr CollectionType collectionType = CollectionType::WindowNamedItems;
+};
+
+template<>
+struct CollectionClassTraits<DocumentNameCollection> {
+    static constexpr CollectionType collectionType = CollectionType::DocumentNamedItems;
+};
+
+} // namespace WebCore
+
 #include "CachedHTMLCollection.h"
 #include "NodeRareData.h"
 #include <wtf/TZoneMalloc.h>
@@ -31,8 +50,8 @@ namespace WebCore {
 
 class Document;
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-class HTMLNameCollection : public CachedHTMLCollection<HTMLCollectionClass, traversalType> {
+template <typename HTMLCollectionClass>
+class HTMLNameCollection : public CachedHTMLCollection<HTMLCollectionClass> {
     WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(HTMLNameCollection);
 public:
     virtual ~HTMLNameCollection();
@@ -45,14 +64,14 @@ protected:
     AtomString m_name;
 };
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-HTMLNameCollection<HTMLCollectionClass, traversalType>::HTMLNameCollection(Document& document, CollectionType type, const AtomString& name)
-    : CachedHTMLCollection<HTMLCollectionClass, traversalType>(document, type)
+template <typename HTMLCollectionClass>
+HTMLNameCollection<HTMLCollectionClass>::HTMLNameCollection(Document& document, CollectionType type, const AtomString& name)
+    : CachedHTMLCollection<HTMLCollectionClass>(document, type)
     , m_name(name)
 {
 }
 
-class WindowNameCollection final : public HTMLNameCollection<WindowNameCollection, CollectionTraversalType::Descendants> {
+class WindowNameCollection final : public HTMLNameCollection<WindowNameCollection> {
     WTF_MAKE_TZONE_ALLOCATED(WindowNameCollection);
 public:
     static Ref<WindowNameCollection> create(Document& document, CollectionType type, const AtomString& name)
@@ -69,13 +88,13 @@ public:
 
 private:
     WindowNameCollection(Document& document, CollectionType type, const AtomString& name)
-        : HTMLNameCollection<WindowNameCollection, CollectionTraversalType::Descendants>(document, type, name)
+        : HTMLNameCollection<WindowNameCollection>(document, type, name)
     {
         ASSERT(type == CollectionType::WindowNamedItems);
     }
 };
 
-class DocumentNameCollection final : public HTMLNameCollection<DocumentNameCollection, CollectionTraversalType::Descendants> {
+class DocumentNameCollection final : public HTMLNameCollection<DocumentNameCollection> {
     WTF_MAKE_TZONE_ALLOCATED(DocumentNameCollection);
 public:
     static Ref<DocumentNameCollection> create(Document& document, CollectionType type, const AtomString& name)
@@ -93,7 +112,7 @@ public:
 
 private:
     DocumentNameCollection(Document& document, CollectionType type, const AtomString& name)
-        : HTMLNameCollection<DocumentNameCollection, CollectionTraversalType::Descendants>(document, type, name)
+        : HTMLNameCollection<DocumentNameCollection>(document, type, name)
     {
         ASSERT(type == CollectionType::DocumentNamedItems);
     }
@@ -101,5 +120,5 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(WindowNameCollection, CollectionType::WindowNamedItems)
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(DocumentNameCollection, CollectionType::DocumentNamedItems)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(WindowNameCollection)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(DocumentNameCollection)

--- a/Source/WebCore/html/HTMLNameCollectionInlines.h
+++ b/Source/WebCore/html/HTMLNameCollectionInlines.h
@@ -31,8 +31,8 @@
 
 namespace WebCore {
 
-template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
-HTMLNameCollection<HTMLCollectionClass, traversalType>::~HTMLNameCollection()
+template <typename HTMLCollectionClass>
+HTMLNameCollection<HTMLCollectionClass>::~HTMLNameCollection()
 {
     ASSERT(this->type() == CollectionType::WindowNamedItems || this->type() == CollectionType::DocumentNamedItems);
 

--- a/Source/WebCore/html/HTMLOptionsCollection.h
+++ b/Source/WebCore/html/HTMLOptionsCollection.h
@@ -23,16 +23,29 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class HTMLOptionsCollection;
+
+template<>
+struct CollectionClassTraits<HTMLOptionsCollection> {
+    static constexpr CollectionType collectionType = CollectionType::SelectOptions;
+};
+
+} // namespace WebCore
+
 #include <WebCore/CachedHTMLCollection.h>
 #include <WebCore/HTMLOptionElement.h>
 #include <WebCore/HTMLSelectElement.h>
 
 namespace WebCore {
 
-class HTMLOptionsCollection final : public CachedHTMLCollection<HTMLOptionsCollection, CollectionTypeTraits<CollectionType::SelectOptions>::traversalType> {
+class HTMLOptionsCollection final : public CachedHTMLCollection<HTMLOptionsCollection> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(HTMLOptionsCollection, WEBCORE_EXPORT);
 public:
-    using Base = CachedHTMLCollection<HTMLOptionsCollection, CollectionTypeTraits<CollectionType::SelectOptions>::traversalType>;
+    using Base = CachedHTMLCollection<HTMLOptionsCollection>;
 
     static Ref<HTMLOptionsCollection> create(HTMLSelectElement&, CollectionType);
 
@@ -64,4 +77,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLOptionsCollection, CollectionType::SelectOptions)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLOptionsCollection)

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -376,12 +376,12 @@ bool HTMLSelectElement::childShouldCreateRenderer(const Node& child) const
 
 Ref<HTMLCollection> HTMLSelectElement::selectedOptions()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::SelectedOptions>::traversalType>>(*this, CollectionType::SelectedOptions);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLSelectedOptionsCollection>(*this);
 }
 
 Ref<HTMLOptionsCollection> HTMLSelectElement::options()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLOptionsCollection>(*this, CollectionType::SelectOptions);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLOptionsCollection>(*this);
 }
 
 void HTMLSelectElement::updateListItemSelectedStates(AllowStyleInvalidation allowStyleInvalidation)

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -584,12 +584,12 @@ bool HTMLTableElement::isURLAttribute(const Attribute& attribute) const
 
 Ref<HTMLCollection> HTMLTableElement::rows()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTableRowsCollection>(*this, CollectionType::TableRows);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTableRowsCollection>(*this);
 }
 
 Ref<HTMLCollection> HTMLTableElement::tBodies()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::TableTBodies>::traversalType>>(*this, CollectionType::TableTBodies);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTableTBodiesCollection>(*this);
 }
 
 const AtomString& HTMLTableElement::rules() const

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -149,7 +149,7 @@ ExceptionOr<void> HTMLTableRowElement::deleteCell(int index)
 
 Ref<HTMLCollection> HTMLTableRowElement::cells()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::TRCells>::traversalType>>(*this, CollectionType::TRCells);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTRCellsCollection>(*this);
 }
 
 }

--- a/Source/WebCore/html/HTMLTableRowsCollection.h
+++ b/Source/WebCore/html/HTMLTableRowsCollection.h
@@ -28,6 +28,19 @@
 
 #pragma once
 
+#include <WebCore/CollectionType.h>
+
+namespace WebCore {
+
+class HTMLTableRowsCollection;
+
+template<>
+struct CollectionClassTraits<HTMLTableRowsCollection> {
+    static constexpr CollectionType collectionType = CollectionType::TableRows;
+};
+
+} // namespace WebCore
+
 #include "CachedHTMLCollection.h"
 #include "HTMLTableElement.h"
 
@@ -35,7 +48,7 @@ namespace WebCore {
 
 class HTMLTableRowElement;
 
-class HTMLTableRowsCollection final : public CachedHTMLCollection<HTMLTableRowsCollection, CollectionTypeTraits<CollectionType::TableRows>::traversalType> {
+class HTMLTableRowsCollection final : public CachedHTMLCollection<HTMLTableRowsCollection> {
     WTF_MAKE_TZONE_ALLOCATED(HTMLTableRowsCollection);
 public:
     static Ref<HTMLTableRowsCollection> create(HTMLTableElement&, CollectionType);
@@ -54,4 +67,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTableRowsCollection, CollectionType::TableRows)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTableRowsCollection)

--- a/Source/WebCore/html/HTMLTableSectionElement.cpp
+++ b/Source/WebCore/html/HTMLTableSectionElement.cpp
@@ -101,7 +101,7 @@ int HTMLTableSectionElement::numRows() const
 
 Ref<HTMLCollection> HTMLTableSectionElement::rows()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::TSectionRows>::traversalType>>(*this, CollectionType::TSectionRows);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTSectionRowsCollection>(*this);
 }
 
 }

--- a/Source/WebCore/html/LabelsNodeList.cpp
+++ b/Source/WebCore/html/LabelsNodeList.cpp
@@ -38,7 +38,7 @@ using namespace HTMLNames;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LabelsNodeList);
 
 LabelsNodeList::LabelsNodeList(HTMLElement& element)
-    : CachedLiveNodeList(element, NodeListInvalidationType::InvalidateOnForTypeAttrChange)
+    : CachedLiveNodeList(element, LiveNodeListType::LabelsNodeList, NodeListInvalidationType::InvalidateOnForTypeAttrChange)
 {
 }
 

--- a/Source/WebCore/html/LabelsNodeList.h
+++ b/Source/WebCore/html/LabelsNodeList.h
@@ -44,3 +44,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_LIVENODELIST(LabelsNodeList)

--- a/Source/WebCore/html/RadioNodeList.cpp
+++ b/Source/WebCore/html/RadioNodeList.cpp
@@ -41,7 +41,7 @@ using namespace HTMLNames;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RadioNodeList);
 
 RadioNodeList::RadioNodeList(ContainerNode& rootNode, const AtomString& name)
-    : CachedLiveNodeList(rootNode, NodeListInvalidationType::InvalidateForFormControls)
+    : CachedLiveNodeList(rootNode, LiveNodeListType::RadioNodeList, NodeListInvalidationType::InvalidateForFormControls)
     , m_name(name)
     , m_isRootedAtTreeScope(is<HTMLFormElement>(rootNode))
 {

--- a/Source/WebCore/html/RadioNodeList.h
+++ b/Source/WebCore/html/RadioNodeList.h
@@ -49,3 +49,5 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_LIVENODELIST(RadioNodeList)


### PR DESCRIPTION
#### 60fbe5d0016f065b547a979cf2da049f16d3afbd
<pre>
Address unsafe cast warning in NodeRareData.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=306175">https://bugs.webkit.org/show_bug.cgi?id=306175</a>

Reviewed by Ryosuke Niwa.

This tested as performance neutral on Speedometer and MotionMark.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/dom/AllDescendantsCollection.h:
* Source/WebCore/dom/ClassCollection.h:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::getElementsByTagName):
(WebCore::ContainerNode::getElementsByClassName):
(WebCore::ContainerNode::children):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::ensureCachedCollection):
(WebCore::Document::applets):
(WebCore::Document::all):
(WebCore::Document::allFilteredByName):
(WebCore::Document::windowNamedItems):
(WebCore::Document::documentNamedItems):
* Source/WebCore/dom/LiveNodeList.cpp:
(WebCore::LiveNodeList::LiveNodeList):
* Source/WebCore/dom/LiveNodeList.h:
(WebCore::LiveNodeList::type const):
* Source/WebCore/dom/LiveNodeListInlines.h:
(WebCore::traversalType&gt;::CachedLiveNodeList):
* Source/WebCore/dom/NameNodeList.cpp:
(WebCore::NameNodeList::NameNodeList):
* Source/WebCore/dom/NameNodeList.h:
* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeListsNodeData::addCacheWithAtomName):
(WebCore::NodeListsNodeData::addCachedCollection):
(WebCore::NodeListsNodeData::cachedCollection):
* Source/WebCore/dom/TagCollection.h:
* Source/WebCore/html/CachedHTMLCollection.h:
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::CachedHTMLCollection):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::elementMatches const):
(WebCore::traversalType&gt;::CachedHTMLCollection): Deleted.
(WebCore::traversalType&gt;::elementMatches const): Deleted.
* Source/WebCore/html/CachedHTMLCollectionInlines.h:
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::~CachedHTMLCollection):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::length const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::item const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::memoryCost const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::invalidateCacheForDocument):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::namedItem const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::collectionBegin const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::collectionLast const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::collectionTraverseForward const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::collectionTraverseBackward const):
(WebCore::CachedHTMLCollection&lt;HTMLCollectionClass&gt;::collectionCanTraverseBackward const):
(WebCore::traversalType&gt;::~CachedHTMLCollection): Deleted.
(WebCore::traversalType&gt;::length const): Deleted.
(WebCore::traversalType&gt;::item const): Deleted.
(WebCore::traversalType&gt;::memoryCost const): Deleted.
(WebCore::traversalType&gt;::invalidateCacheForDocument): Deleted.
(WebCore::traversalType&gt;::namedItem const): Deleted.
(WebCore::traversalType&gt;::collectionBegin const): Deleted.
(WebCore::traversalType&gt;::collectionLast const): Deleted.
(WebCore::traversalType&gt;::collectionTraverseForward const): Deleted.
(WebCore::traversalType&gt;::collectionTraverseBackward const): Deleted.
(WebCore::traversalType&gt;::collectionCanTraverseBackward const): Deleted.
* Source/WebCore/html/CollectionType.h:
* Source/WebCore/html/EmptyHTMLCollection.h:
* Source/WebCore/html/GenericCachedHTMLCollection.cpp:
(WebCore::GenericCachedHTMLCollection&lt;type&gt;::GenericCachedHTMLCollection):
(WebCore::GenericCachedHTMLCollection&lt;type&gt;::elementMatches const):
(WebCore::GenericCachedHTMLCollection&lt;traversalType&gt;::GenericCachedHTMLCollection): Deleted.
(WebCore::GenericCachedHTMLCollection&lt;traversalType&gt;::elementMatches const): Deleted.
* Source/WebCore/html/GenericCachedHTMLCollection.h:
* Source/WebCore/html/HTMLAllCollection.h:
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLDataListElement.cpp:
(WebCore::HTMLDataListElement::options):
* Source/WebCore/html/HTMLFieldSetElement.cpp:
(WebCore::HTMLFieldSetElement::elements):
* Source/WebCore/html/HTMLFormControlsCollection.h:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::elements):
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::areas):
* Source/WebCore/html/HTMLNameCollection.cpp:
* Source/WebCore/html/HTMLNameCollection.h:
(WebCore::HTMLNameCollection&lt;HTMLCollectionClass&gt;::HTMLNameCollection):
(WebCore::traversalType&gt;::HTMLNameCollection): Deleted.
* Source/WebCore/html/HTMLNameCollectionInlines.h:
(WebCore::HTMLNameCollection&lt;HTMLCollectionClass&gt;::~HTMLNameCollection):
(WebCore::traversalType&gt;::~HTMLNameCollection): Deleted.
* Source/WebCore/html/HTMLOptionsCollection.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::selectedOptions):
(WebCore::HTMLSelectElement::options):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::rows):
(WebCore::HTMLTableElement::tBodies):
* Source/WebCore/html/HTMLTableRowElement.cpp:
(WebCore::HTMLTableRowElement::cells):
* Source/WebCore/html/HTMLTableRowsCollection.h:
* Source/WebCore/html/HTMLTableSectionElement.cpp:
(WebCore::HTMLTableSectionElement::rows):
* Source/WebCore/html/LabelsNodeList.cpp:
(WebCore::LabelsNodeList::LabelsNodeList):
* Source/WebCore/html/LabelsNodeList.h:
* Source/WebCore/html/RadioNodeList.cpp:
(WebCore::RadioNodeList::RadioNodeList):
* Source/WebCore/html/RadioNodeList.h:

Canonical link: <a href="https://commits.webkit.org/306267@main">https://commits.webkit.org/306267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01ec8ba6675693334eb7c0de6461c1241a8bef6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140839 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149248 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13933 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108055 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88957 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7934 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9273 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151802 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12909 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116303 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12924 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11253 "Found 1 new test failure: webrtc/addTransceiver-then-addTrack.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116642 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29658 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12659 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12952 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76652 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12735 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->