### PR TITLE
AX: Add a test verifying AX thread hit testing returns table cell contents and not a column

### DIFF
--- a/LayoutTests/accessibility/table-cell-hit-test-not-column-expected.txt
+++ b/LayoutTests/accessibility/table-cell-hit-test-not-column-expected.txt
@@ -1,0 +1,14 @@
+This test ensures that hit testing a table cell returns the cell contents, not a table column.
+
+Hit test on cell 1: AXRole: AXStaticText
+PASS: hitTestResult.role.toLowerCase().includes('column') === false
+PASS: hitTestResult.role.toLowerCase().includes('statictext') === true
+Hit test on cell 4: AXRole: AXStaticText
+PASS: hitTestResult.role.toLowerCase().includes('column') === false
+PASS: hitTestResult.role.toLowerCase().includes('statictext') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Cell 1	Cell 2
+Cell 3	Cell 4

--- a/LayoutTests/accessibility/table-cell-hit-test-not-column.html
+++ b/LayoutTests/accessibility/table-cell-hit-test-not-column.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<table border="1">
+<tr>
+<td id="cell1">Cell 1</td>
+<td>Cell 2</td>
+</tr>
+<tr>
+<td>Cell 3</td>
+<td id="cell4">Cell 4</td>
+</tr>
+</table>
+
+<script>
+var output = "This test ensures that hit testing a table cell returns the cell contents, not a table column.\n\n";
+
+if (window.accessibilityController) {
+    var cell1 = document.getElementById("cell1");
+    var rect1 = cell1.getBoundingClientRect();
+    var hitTestResult = accessibilityController.elementAtPoint(rect1.x + rect1.width / 2, rect1.y + rect1.height / 2);
+
+    output += `Hit test on cell 1: ${hitTestResult.role}\n`;
+    output += expect("hitTestResult.role.toLowerCase().includes('column')", "false");
+    output += expect("hitTestResult.role.toLowerCase().includes('statictext')", "true");
+
+    var cell4 = document.getElementById("cell4");
+    var rect4 = cell4.getBoundingClientRect();
+    hitTestResult = accessibilityController.elementAtPoint(rect4.x + rect4.width / 2, rect4.y + rect4.height / 2);
+
+    output += `Hit test on cell 4: ${hitTestResult.role}\n`;
+    output += expect("hitTestResult.role.toLowerCase().includes('column')", "false");
+    output += expect("hitTestResult.role.toLowerCase().includes('statictext')", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -832,6 +832,7 @@ accessibility/aria-owns-id-change.html [ Skip ]
 accessibility/opacity-0-bounding-box.html [ Skip ]
 accessibility/clip-path-bounding-box.html [ Skip ]
 accessibility/first-letter-single-character.html [ Skip ]
+accessibility/table-cell-hit-test-not-column.html [ Skip ]
 
 accessibility/dynamic-expanded-text.html [ Failure ]
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -648,8 +648,6 @@ RefPtr<AXIsolatedObject> AXIsolatedObject::approximateHitTest(const IntPoint& po
             // Returning columns via hit testing is typically not what ATs expect as they are mock objects
             // and thus not backed by any real DOM node. Returning nullptr allows us to return the table
             // cell (or cell contents) instead, which is typically more useful for ATs like Hover Text.
-            //
-            // FIXME: This has been manually tested to behave correctly, but needs a layout test.
             continue;
         }
 


### PR DESCRIPTION
#### 38666a88f32629c4ff95a8a2a3a9fadfac74c1ca
<pre>
AX: Add a test verifying AX thread hit testing returns table cell contents and not a column
<a href="https://bugs.webkit.org/show_bug.cgi?id=306190">https://bugs.webkit.org/show_bug.cgi?id=306190</a>
<a href="https://rdar.apple.com/168842188">rdar://168842188</a>

Reviewed by Chris Fleizach.

* LayoutTests/accessibility/table-cell-hit-test-not-column-expected.txt: Added.
* LayoutTests/accessibility/table-cell-hit-test-not-column.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::approximateHitTest const):
Remove FIXME.

Canonical link: <a href="https://commits.webkit.org/306179@main">https://commits.webkit.org/306179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/711c80da49b7b748bb7f4e5cacae7d409570dcb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148847 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93597 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107730 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78212 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88630 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10101 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7659 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8943 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151472 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12580 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116035 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/11908 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12622 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1848 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12362 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76322 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->