### PR TITLE
[Swift in WebKit] Improve RefPtr ergonomics when used from Swift

### DIFF
--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2025 Apple Inc. All rights reserved.
+ *  Copyright (C) 2005-2026 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -18,12 +18,11 @@
  *
  */
 
-// RefPtr is documented at http://webkit.org/coding/RefPtr.html
-
 #pragma once
 
 #include <algorithm>
 #include <utility>
+#include <wtf/Compiler.h>
 #include <wtf/RawPtrTraits.h>
 #include <wtf/Ref.h>
 #include <wtf/SwiftBridging.h>
@@ -31,11 +30,17 @@
 namespace WTF {
 
 template<typename T, typename PtrTraits, typename RefDerefTraits> class RefPtr;
-template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>> RefPtr<T, PtrTraits, RefDerefTraits> adoptRef(T*);
+template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>> RefPtr<T, PtrTraits, RefDerefTraits> adoptRef(T* WTF_NULLABLE);
 
+/// ``WTF::RefPtr`` is a smart pointer class template that calls ``ref`` on incoming values and ``deref`` on outgoing values
+/// to implement intrusive reference counting.
+///
+/// RefPtr works on any object with both a ``ref`` and a ``deref`` member function. For more information, see [RefPtr Basics](http://webkit.org/coding/RefPtr.html).
 template<typename T, typename _PtrTraits, typename _RefDerefTraits>
 class RefPtr {
+    IGNORE_CLANG_WARNINGS_BEGIN("nullability-completeness")
     WTF_FORBID_HEAP_ALLOCATION_ALLOWING_PLACEMENT_NEW;
+    IGNORE_CLANG_WARNINGS_END
 public:
     using PtrTraits = _PtrTraits;
     using RefDerefTraits = _RefDerefTraits;
@@ -46,7 +51,7 @@ public:
 
     ALWAYS_INLINE constexpr RefPtr() : m_ptr(nullptr) { }
     ALWAYS_INLINE constexpr RefPtr(std::nullptr_t) : m_ptr(nullptr) { }
-    ALWAYS_INLINE RefPtr(T* ptr) : m_ptr(RefDerefTraits::refIfNotNull(ptr)) { }
+    ALWAYS_INLINE RefPtr(T* WTF_NULLABLE ptr) : m_ptr(RefDerefTraits::refIfNotNull(ptr)) { }
     ALWAYS_INLINE RefPtr(T& ptr) : m_ptr(&RefDerefTraits::ref(ptr)) { }
     ALWAYS_INLINE RefPtr(const RefPtr& o) : m_ptr(RefDerefTraits::refIfNotNull(PtrTraits::unwrap(o.m_ptr))) { }
     template<typename X, typename Y, typename Z> RefPtr(const RefPtr<X, Y, Z>& o) : m_ptr(RefDerefTraits::refIfNotNull(PtrTraits::unwrap(o.get()))) { }
@@ -64,26 +69,26 @@ public:
 
     RefPtr(HashTableEmptyValueType) : m_ptr(hashTableEmptyValue()) { }
     bool isHashTableEmptyValue() const { return m_ptr == hashTableEmptyValue(); }
-    static T* hashTableEmptyValue() { return nullptr; }
+    static T* WTF_NULLABLE hashTableEmptyValue() { return nullptr; }
 
     ALWAYS_INLINE ~RefPtr() { RefDerefTraits::derefIfNotNull(PtrTraits::exchange(m_ptr, nullptr)); }
 
-    T* get() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
-    T* unsafeGet() const { return PtrTraits::unwrap(m_ptr); } // FIXME: Replace with get() then remove.
-    operator T*() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
+    SWIFT_RETURNS_UNRETAINED T* WTF_NULLABLE get() const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
+    T* WTF_NULLABLE unsafeGet() const { return PtrTraits::unwrap(m_ptr); } // FIXME: Replace with get() then remove.
+    SWIFT_RETURNS_UNRETAINED operator T* WTF_NULLABLE () const LIFETIME_BOUND { return PtrTraits::unwrap(m_ptr); }
 
     Ref<T> releaseNonNull() { ASSERT(m_ptr); Ref<T> tmp(adoptRef(*m_ptr)); m_ptr = nullptr; return tmp; }
 
-    [[nodiscard]] T* leakRef();
+    [[nodiscard]] T* WTF_NULLABLE leakRef();
 
     ALWAYS_INLINE T& operator*() const LIFETIME_BOUND { ASSERT(m_ptr); return *PtrTraits::unwrap(m_ptr); }
-    ALWAYS_INLINE T* operator->() const LIFETIME_BOUND { return &**this; }
+    ALWAYS_INLINE SWIFT_RETURNS_UNRETAINED T* WTF_NULLABLE operator->() const LIFETIME_BOUND { return &**this; }
 
     bool operator!() const { return !m_ptr; }
     explicit operator bool() const { return !!m_ptr; }
-    
+
     RefPtr& operator=(const RefPtr&);
-    RefPtr& operator=(T*);
+    RefPtr& operator=(T* WTF_NULLABLE);
     RefPtr& operator=(std::nullptr_t);
     template<typename X, typename Y, typename Z> RefPtr& operator=(const RefPtr<X, Y, Z>&);
     RefPtr& operator=(RefPtr&&);
@@ -96,16 +101,16 @@ public:
     [[nodiscard]] RefPtr copyRef() const & { return RefPtr(m_ptr); }
 
 private:
-    friend RefPtr adoptRef<T, PtrTraits, RefDerefTraits>(T*);
+    friend RefPtr adoptRef<T, PtrTraits, RefDerefTraits>(T* WTF_NULLABLE);
     template<typename X, typename Y, typename Z> friend class RefPtr;
 
     template<typename T1, typename U, typename V, typename X, typename Y, typename Z>
     friend bool operator==(const RefPtr<T1, U, V>&, const RefPtr<X, Y, Z>&);
     template<typename T1, typename U, typename V, typename X>
-    friend bool operator==(const RefPtr<T1, U, V>&, X*);
+    friend bool operator==(const RefPtr<T1, U, V>&, X* WTF_NULLABLE);
 
     enum AdoptTag { Adopt };
-    RefPtr(T* ptr, AdoptTag) : m_ptr(ptr) { }
+    RefPtr(T* WTF_NULLABLE ptr, AdoptTag) : m_ptr(ptr) { }
 
     typename PtrTraits::StorageType m_ptr;
 } SWIFT_ESCAPABLE;
@@ -127,7 +132,7 @@ inline RefPtr<T, U, V>::RefPtr(Ref<X, Y>&& reference)
 }
 
 template<typename T, typename U, typename V>
-inline T* RefPtr<T, U, V>::leakRef()
+inline T* WTF_NULLABLE RefPtr<T, U, V>::leakRef()
 {
     return U::exchange(m_ptr, nullptr);
 }
@@ -150,7 +155,7 @@ inline RefPtr<T, U, V>& RefPtr<T, U, V>::operator=(const RefPtr<X, Y, Z>& o)
 }
 
 template<typename T, typename U, typename V>
-inline RefPtr<T, U, V>& RefPtr<T, U, V>::operator=(T* optr)
+inline RefPtr<T, U, V>& RefPtr<T, U, V>::operator=(T* WTF_NULLABLE optr)
 {
     RefPtr ptr = optr;
     swap(ptr);
@@ -210,13 +215,13 @@ inline bool operator==(const RefPtr<T, U, V>& a, const RefPtr<X, Y, Z>& b)
 }
 
 template<typename T, typename U, typename V, typename X>
-inline bool operator==(const RefPtr<T, U, V>& a, X* b)
+inline bool operator==(const RefPtr<T, U, V>& a, X* WTF_NULLABLE b)
 {
     return a.m_ptr == b;
 }
 
 template<typename T, typename U, typename V>
-inline RefPtr<T, U, V> adoptRef(T* p)
+inline RefPtr<T, U, V> adoptRef(T* WTF_NULLABLE p)
 {
     adopted(p);
     return RefPtr<T, U, V>(p, RefPtr<T, U, V>::Adopt);
@@ -224,7 +229,7 @@ inline RefPtr<T, U, V> adoptRef(T* p)
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
     requires HasRefPtrMemberFunctions<T>::value
-ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, PtrTraits, RefDerefTraits> protect(T* ptr)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, PtrTraits, RefDerefTraits> protect(T* WTF_NULLABLE ptr)
 {
     return RefPtr<T, PtrTraits, RefDerefTraits>(ptr);
 }


### PR DESCRIPTION
#### fcdadb0e9266216a37c84a0d9dcde0b832b6ab9a
<pre>
[Swift in WebKit] Improve RefPtr ergonomics when used from Swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=306193">https://bugs.webkit.org/show_bug.cgi?id=306193</a>
<a href="https://rdar.apple.com/168844387">rdar://168844387</a>

Reviewed by NOBODY (OOPS!).

- Add a minimal header documentation comment to RefPtr to make it easier for newcomers to quickly tell what it
does at a glance, and also makes the help viewer when viewing the symbol in an IDE more informative.

- Add nullability annotations throughout the `RefPtr.h` file. This allows the Swift compiler to know if
a symbol is nullable or non-nullable, in contrast to the current state where symbols are imported to Swift
as implicitly unwrapped optionals.

- Add `SWIFT_RETURNS_UNRETAINED` where applicable so the Swift compiler can know that a function returns an
unretained value and can therefore be considered a &quot;borrowing&quot; function in Swift.

* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::RefPtr):
(WTF::RefPtr::hashTableEmptyValue):
(WTF::RefPtr::unsafeGet const):
(WTF::V&gt;::leakRef):
(WTF::=):
(WTF::operator==):
(WTF::adoptRef):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcdadb0e9266216a37c84a0d9dcde0b832b6ab9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140603 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93690 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13139 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78273 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125876 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10188 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7744 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9036 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132581 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151566 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1401 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12673 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116116 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116451 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12284 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122470 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67770 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12715 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1929 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171876 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76415 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44607 "Found 1 new JSC binary failure: testb3 (failure)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12653 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->