### PR TITLE
AX: Children-changed events are not issued when direct children of a canvas are added or removed, breaking accessibility/dynamically-ignored-canvas.html in ITM

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -4,7 +4,6 @@ accessibility/isolated-tree [ Pass ]
 #
 # Potentially caused by: https://github.com/WebKit/WebKit/commit/2517a540e6f5a2037c6843102f3a9cb753f2f9f0
 accessibility/content-editable-set-inner-text-generates-axvalue-notification.html [ Failure Pass ]
-accessibility/dynamically-ignored-canvas.html [ Failure ]
 accessibility/keyevents-for-actions-mimic-real-key-events.html [ Failure ]
 accessibility/keyevents-posted-for-increment-actions.html [ Failure ]
 accessibility/mac/focus-setting-selection-syncronizing-not-clearing.html [ Failure ]

--- a/LayoutTests/accessibility/dynamically-ignored-canvas.html
+++ b/LayoutTests/accessibility/dynamically-ignored-canvas.html
@@ -6,82 +6,72 @@
 </head>
 <body>
 
-<!--
-  This test fails on ITM because we have a bug where the AXObjectCache never receives a children changed notification
-  for the <canvas> element, despite the fact all of its children are removed. One place we could start sending those
-  notifications is in ContainerNode::childrenChanged. I briefly experimented with this and it did fix this test in ITM,
-  but to confidently make that change we need to investigate more.
-
-  For example, that function is very hot, so we need to make sure hooking into it doesn't kill performance.
-  There may also be better candidates for getting these updates.
--->
-
 <div id="group" role="group">
     <canvas id="canvas"><div>I am some text inside a div, which is inside a canvas</div></canvas>
 </div>
 
 <script>
-    // This test uses a <canvas> to dynamically change ignored status, but the goal is to ensure that any element
-    // that changes ignored status dynamically results in that element's parent getting a childrenChanged call. Then the
-    // AX tree should be updated appropriately, either removing or adding the ignored or un-ignored element respectively.
-    var testOutput = "This test ensures that we properly change an object's ignored status after dynamically changing the page.\n\n";
+// This test uses a <canvas> to dynamically change ignored status, but the goal is to ensure that any element
+// that changes ignored status dynamically results in that element's parent getting a childrenChanged call. Then the
+// AX tree should be updated appropriately, either removing or adding the ignored or un-ignored element respectively.
+var testOutput = "This test ensures that we properly change an object's ignored status after dynamically changing the page.\n\n";
 
-    function isIgnored(id) {
-        const axElement = accessibilityController.accessibleElementById(id);
-        if (!axElement)
-            return true;
-        return axElement.isIgnored;
-    }
+function isIgnored(id) {
+    const axElement = accessibilityController.accessibleElementById(id);
+    if (!axElement)
+        return true;
+    return axElement.isIgnored;
+}
 
-    function addTreeToOutput(axElement, indent = 0) {
-        if (!axElement)
-            return;
+function addTreeToOutput(axElement, indent = 0) {
+    if (!axElement)
+        return;
 
-        let indentStr = "";
-        for (let i = 0; i < indent; i++)
-            indentStr += "  ";
+    let indentStr = "";
+    for (let i = 0; i < indent; i++)
+        indentStr += "  ";
 
-        for (let i = 0; i < axElement.childrenCount; i++) {
-            const child = axElement.childAtIndex(i);
-            testOutput += `${indentStr}${child.role}`;
-            if (child.role && child.role.includes("StaticText"))
-                testOutput += ` ${accessibilityController.platformName === "ios" ? child.description : child.stringValue}`;
-            testOutput += "\n";
-            addTreeToOutput(child, indent + 1);
-        }
-    }
-
-    function addGroupTreeToOutput() {
-        const group = accessibilityController.accessibleElementById("group");
-        addTreeToOutput(group);
+    for (let i = 0; i < axElement.childrenCount; i++) {
+        const child = axElement.childAtIndex(i);
+        testOutput += `${indentStr}${child.role}`;
+        if (child.role && child.role.includes("StaticText"))
+            testOutput += ` ${accessibilityController.platformName === "ios" ? child.description : child.stringValue}`;
         testOutput += "\n";
+        addTreeToOutput(child, indent + 1);
     }
+}
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+function addGroupTreeToOutput() {
+    const group = accessibilityController.accessibleElementById("group");
+    addTreeToOutput(group);
+    testOutput += "\n";
+}
 
-        testOutput += `#canvas is initially ignored: ${isIgnored("canvas")}\n`;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    testOutput += `#canvas is initially ignored: ${isIgnored("canvas")}\n`;
+    testOutput += "Dumping AX tree starting at #group.\n";
+    addGroupTreeToOutput();
+
+    testOutput += `Removing all children of #canvas.\n`;
+    const canvasElement = document.getElementById("canvas");
+    while (canvasElement.firstChild) { canvasElement.removeChild(canvasElement.firstChild); }
+    setTimeout(async function() {
+        await waitFor(() => {
+            const axCanvas = accessibilityController.accessibleElementById("canvas");
+            return !axCanvas || !axCanvas.childrenCount;
+        });
+        testOutput += `#canvas is ignored: ${isIgnored("canvas")}\n`;
+        // Removing the <canvas> fallback content makes it ignored, so the canvas should send a notification to its parent
+        // that it needs to update its children.
         testOutput += "Dumping AX tree starting at #group.\n";
         addGroupTreeToOutput();
 
-        testOutput += `Removing all children of #canvas.\n`;
-        const canvasElement = document.getElementById("canvas");
-        while (canvasElement.firstChild) { canvasElement.removeChild(canvasElement.firstChild); }
-        setTimeout(async function() {
-            await waitFor(() => {
-                const axCanvas = accessibilityController.accessibleElementById("canvas");
-                return !axCanvas || !axCanvas.childrenCount;
-            });
-            testOutput += `#canvas is ignored: ${isIgnored("canvas")}\n`;
-            // Removing the <canvas> fallback content makes it ignored, so the canvas should send a notification to its parent
-            // that it needs to update its children.
-            testOutput += "Dumping AX tree starting at #group.\n";
-            addGroupTreeToOutput();
-
-            debug(testOutput);
-            finishJSTest();
-        }, 0);
-    }
+        debug(testOutput);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/ios/accessibility/dynamically-ignored-canvas-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/dynamically-ignored-canvas-expected.txt
@@ -9,7 +9,6 @@ Canvas
 Removing all children of #canvas.
 #canvas is ignored: true
 Dumping AX tree starting at #group.
-Canvas
 
 
 PASS successfullyParsed is true

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -450,6 +450,10 @@ public:
             // If something does have a renderer, we would already get children-changed notifications
             // from the render tree.
             childrenChanged(RefPtr { get(node) }.get());
+        } else if (node.renderer()->isRenderHTMLCanvas()) {
+            // Canvas fallback content (its DOM children) is not rendered, so we won't receive
+            // children-changed notifications from the render tree when those children change.
+            childrenChanged(RefPtr { get(node) }.get());
         }
     }
     void childrenChanged(RenderObject&, RenderObject* newChild = nullptr);


### PR DESCRIPTION
#### 47c6fa59fffbe41e0e105e4035638c1ccd14632e
<pre>
AX: Children-changed events are not issued when direct children of a canvas are added or removed, breaking accessibility/dynamically-ignored-canvas.html in ITM
<a href="https://bugs.webkit.org/show_bug.cgi?id=306198">https://bugs.webkit.org/show_bug.cgi?id=306198</a>
<a href="https://rdar.apple.com/168851684">rdar://168851684</a>

Reviewed by Joshua Hoffman.

AXObjectCache::childrenChanged(Node&amp;) exited early for anything that had a renderer under the assumption that we would
get notifications from the render tree for rendered things. But canvas descendants are not rendered, so that assumption
isn&apos;t true in that case. Allow RenderCanvas as an exception in this method, fixing the test in ITM.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/dynamically-ignored-canvas.html:
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/307920@main">https://commits.webkit.org/307920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4827770d6883c7cf83f521e01b79da50c3b119ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93617 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142403 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107748 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78222 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88647 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10119 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7676 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119360 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151493 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116055 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30911 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122358 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67654 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12034 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1867 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76342 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12382 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->