### PR TITLE
JSC_CF_ENUM macro triggers -Welaborated-enum-base warnings with upstream clang

### DIFF
--- a/Source/JavaScriptCore/API/JSBase.h
+++ b/Source/JavaScriptCore/API/JSBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -153,10 +153,20 @@ JS_EXPORT void JSGarbageCollect(JSContextRef ctx);
 #endif
 
 #if JSC_OBJC_API_ENABLED
+#if defined(__cplusplus)
+// In C++, avoid the forward declaration pattern from CF_ENUM
+// that triggers -Welaborated-enum-base warnings.
+#define JSC_CF_ENUM(enumName, ...) \
+    enum enumName : uint32_t { \
+        __VA_ARGS__                \
+    }
+#else
+// In Objective-C, use CF_ENUM for full Swift interop support.
 #define JSC_CF_ENUM(enumName, ...)       \
     typedef CF_ENUM(uint32_t, enumName) { \
         __VA_ARGS__                       \
     }
+#endif
 #else
 #define JSC_CF_ENUM(enumName, ...) \
     typedef enum {                  \


### PR DESCRIPTION
#### b769e2ee79c861136dcae71c693a626ceece9179
<pre>
JSC_CF_ENUM macro triggers -Welaborated-enum-base warnings with upstream clang
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306197">https://bugs.webkit.org/show_bug.cgi?id=306197</a>&gt;
&lt;<a href="https://rdar.apple.com/168848718">rdar://168848718</a>&gt;

Reviewed by Darin Adler.

The JSC_CF_ENUM macro triggers -Welaborated-enum-base warnings when
compiling with upstream clang compilers. The warning fires because
CF_ENUM expands to a forward declaration of an enum with fixed
underlying type embedded in a typedef context, which violates C++11
[dcl.type.elab] requirements.

The fix modifies JSC_CF_ENUM to use different macro expansions for C++
vs. Objective-C compilation:
- C++: Use plain enum definition without forward declaration
- Objective-C: Keep CF_ENUM for Swift interoperability
- Swift imports headers in Objective-C mode, so the paths remain separate

This eliminates all -Welaborated-enum-base errors while maintaining full
backward compatibility and Swift interoperability.

No tests since no change in behavior.

* Source/JavaScriptCore/API/JSBase.h:
- Modified JSC_CF_ENUM macro to avoid forward declaration pattern in C++
  compilation.

Canonical link: <a href="https://commits.webkit.org/306242@main">https://commits.webkit.org/306242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1c1a51c9d4f9b23835baae46f5fdc73f02cd38c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93610 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ab62ad1-b3ff-414e-a3a8-cce01e4f0aba) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107743 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78220 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61a669ab-0590-44c3-a54a-377a7c095263) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88642 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e29c63f-c363-459c-814f-17df26bf4966) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10113 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7670 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8956 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132501 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151486 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1321 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12593 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116385 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12003 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122347 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67645 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21723 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12635 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1863 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171796 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76335 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44588 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12573 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->