### PR TITLE
Update style checker to prevent addition of new `protected*()` / `checked*()` member functions

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2038,6 +2038,21 @@ def check_function_definition(filename, file_extension, clean_lines, line_number
                     error(line_number, 'security/missing_warn_unused_return', 5,
                           'decode() function returning a value is missing WARN_UNUSED_RETURN attribute')
 
+    # Check for new protected*() member functions that should use regular getters with protect() at call site.
+    if function_state.is_declaration:
+        # Extract the simple function name (without class qualifiers).
+        simple_function_name = function_name.split('::')[-1] if '::' in function_name else function_name
+        # Only check getter-style functions with no parameters.
+        parameter_list = function_state.parameter_list()
+        # Check if it starts with 'protected', has no parameters (getter-style).
+        if simple_function_name.startswith('protected') and len(simple_function_name) > len('protected') and not parameter_list:
+            error(line_number, 'readability/protected_getter', 4,
+                  'Do not add new protected*() getter functions. Call the regular getter and use protect() at the call site instead.')
+        # Check if it starts with 'checked', has no parameters (getter-style).
+        if simple_function_name.startswith('checked') and len(simple_function_name) > len('checked') and not parameter_list:
+            error(line_number, 'readability/checked_getter', 4,
+                  'Do not add new checked*() getter functions. Call the regular getter and use protect() at the call site instead.')
+
     attributes = function_state.attributes_after_definition(r'(\bWARN_[0-9A-Z_]+\b|__attribute__\(\(__[a-z_]+__\)\))')
     if len(attributes) > 0:
         attribute_text = ', '.join(attributes)
@@ -5117,6 +5132,8 @@ class CppChecker(object):
         'readability/naming/protected',
         'readability/naming/underscores',
         'readability/null',
+        'readability/checked_getter',
+        'readability/protected_getter',
         'readability/streams',
         'readability/todo',
         'readability/utf8',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6152,6 +6152,91 @@ class WebKitStyleTest(CppStyleTestBase):
             "  [runtime/wtf_move] [4]",
             'foo.mm')
 
+    def test_protected_getter(self):
+        # Regular getter is fine.
+        self.assert_lint(
+            'Foo* foo();',
+            '',
+            'foo.h')
+
+        # protectedFoo() getter with RefPtr should trigger error.
+        self.assert_lint(
+            'RefPtr<Foo> protectedFoo();',
+            "Do not add new protected*() getter functions. Call the regular getter and use protect() at the call site instead."
+            "  [readability/protected_getter] [4]",
+            'foo.h')
+
+        # protectedDocument() with Ref should trigger error.
+        self.assert_lint(
+            'Ref<Document> protectedDocument();',
+            "Do not add new protected*() getter functions. Call the regular getter and use protect() at the call site instead."
+            "  [readability/protected_getter] [4]",
+            'foo.h')
+
+        # protectedOwner() should trigger error.
+        self.assert_lint(
+            'RefPtr<Owner> protectedOwner() const;',
+            "Do not add new protected*() getter functions. Call the regular getter and use protect() at the call site instead."
+            "  [readability/protected_getter] [4]",
+            'foo.h')
+
+        # Function implementation should not trigger (only declarations).
+        self.assert_lint(
+            'Ref<Document> protectedDocument() { return m_document.get(); }',
+            '',
+            'foo.cpp')
+
+        # Functions with parameters should not trigger (not getter-style).
+        self.assert_lint(
+            'RefPtr<Node> protectedThis(this);',
+            '',
+            'foo.h')
+
+        self.assert_lint(
+            'RefPtr<Foo> protectedFoo(int arg);',
+            '',
+            'foo.h')
+
+    def test_checked_getter(self):
+        # Regular getter is fine.
+        self.assert_lint(
+            'Foo* foo();',
+            '',
+            'foo.h')
+
+        # checkedFoo() getter with CheckedPtr should trigger error.
+        self.assert_lint(
+            'CheckedPtr<Foo> checkedFoo();',
+            "Do not add new checked*() getter functions. Call the regular getter and use protect() at the call site instead."
+            "  [readability/checked_getter] [4]",
+            'foo.h')
+
+        # checkedDocument() with CheckedRef should trigger error.
+        self.assert_lint(
+            'CheckedRef<Document> checkedDocument();',
+            "Do not add new checked*() getter functions. Call the regular getter and use protect() at the call site instead."
+            "  [readability/checked_getter] [4]",
+            'foo.h')
+
+        # checkedOwner() should trigger error.
+        self.assert_lint(
+            'CheckedPtr<Owner> checkedOwner() const;',
+            "Do not add new checked*() getter functions. Call the regular getter and use protect() at the call site instead."
+            "  [readability/checked_getter] [4]",
+            'foo.h')
+
+        # Function implementation should not trigger (only declarations).
+        self.assert_lint(
+            'CheckedRef<Document> checkedDocument() { return m_document.get(); }',
+            '',
+            'foo.cpp')
+
+        # Functions with parameters should not trigger (not getter-style).
+        self.assert_lint(
+            'CheckedPtr<Foo> checkedFoo(int arg);',
+            '',
+            'foo.h')
+
     def test_unsafe_get(self):
         self.assert_lint(
             'auto ptr = obj.get();',
@@ -7004,9 +7089,15 @@ class WebKitStyleTest(CppStyleTestBase):
         self.assert_lint('RefPtr<Widget> create();', '')
         self.assert_lint('Ref<GeolocationPermissionRequestProxy> createRequest(GeolocationIdentifier);', '')
         self.assert_lint('Ref<TypeName> createSomething(OtherTypeName);', '')
-        self.assert_lint('Ref<Settings> protectedSettings() const;', '')
-        self.assert_lint('RefPtr<Settings> protectedSettings() const;', '')
-        self.assert_lint('RefPtr<Settings> protectedSettings();', '')
+        self.assert_lint('Ref<Settings> protectedSettings() const;',
+                         "Do not add new protected*() getter functions. Call the regular getter and use protect() at the call site instead."
+                         "  [readability/protected_getter] [4]")
+        self.assert_lint('RefPtr<Settings> protectedSettings() const;',
+                         "Do not add new protected*() getter functions. Call the regular getter and use protect() at the call site instead."
+                         "  [readability/protected_getter] [4]")
+        self.assert_lint('RefPtr<Settings> protectedSettings();',
+                         "Do not add new protected*() getter functions. Call the regular getter and use protect() at the call site instead."
+                         "  [readability/protected_getter] [4]")
         self.assert_lint('RefPtr<Settings> protectedSettings() { return m_settings.get(); }', '')
 
     def test_parameter_names(self):


### PR DESCRIPTION
#### 20fc18a555f2c2bee8aed9aae9e4256f467c4ab2
<pre>
Update style checker to prevent addition of new `protected*()` / `checked*()` member functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306200">https://bugs.webkit.org/show_bug.cgi?id=306200</a>

Reviewed by Ryosuke Niwa.

Update style checker to prevent addition of new `protected*()` / `checked*()`
member functions, and recommend using `protect()` at call sites instead.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_function_definition):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_protected_getter):
(WebKitStyleTest):
(WebKitStyleTest.test_checked_getter):
(WebKitStyleTest.test_names):

Canonical link: <a href="https://commits.webkit.org/306163@main">https://commits.webkit.org/306163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/123571dda5eb52ccee3f0eb941e66e5a4aea26e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148867 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107747 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88646 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/139874 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10115 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7673 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8962 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151492 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12599 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116054 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10870 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116390 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29602 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12029 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67653 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12641 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12381 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12579 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->