### PR TITLE
[Site Isolation] Fix WebLocks.LockRequestWaitingOnAnotherPageInSameProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -248,6 +248,19 @@ WebPageProxy* PageConfiguration::relatedPage() const
     return m_data.relatedPage.get();
 }
 
+BrowsingContextGroup* PageConfiguration::preferredBrowsingContextGroup() const
+{
+    if (auto opener = openerInfo())
+        return opener->browsingContextGroup.ptr();
+
+    if (auto relatedPage = this->relatedPage()) {
+        if (!relatedPage->isClosed())
+            return &relatedPage->browsingContextGroup();
+    }
+
+    return nullptr;
+}
+
 WebPageProxy* PageConfiguration::pageToCloneSessionStorageFrom() const
 {
     return m_data.pageToCloneSessionStorageFrom.get();

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -469,6 +469,8 @@ public:
     void setBackgroundTextExtractionEnabled(bool enabled) { m_data.backgroundTextExtractionEnabled = enabled; }
     bool backgroundTextExtractionEnabled() const { return m_data.backgroundTextExtractionEnabled; }
 
+    WebKit::BrowsingContextGroup* preferredBrowsingContextGroup() const;
+
 #if PLATFORM(VISION)
 
 #if ENABLE(GAMEPAD)


### PR DESCRIPTION
#### b5c988402057fdfe3e319fff027bb18dce94baae
<pre>
[Site Isolation] Fix WebLocks.LockRequestWaitingOnAnotherPageInSameProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=306201">https://bugs.webkit.org/show_bug.cgi?id=306201</a>
<a href="https://rdar.apple.com/168857642">rdar://168857642</a>

Reviewed by Alex Christensen.

The test fails because it uses `_relatedWebView` and expects two WebViews (one related to another) use the same process
to load the same site. The current `_relatedWebView` implementation is kind of broken under Site Isolation: it would
select the process from related page (see `WebProcessPool::createWebPage`) and associate the process with a site that is
different from the related page&apos;s site when adding it to new browsing context group (`WebPageProxy::initializeWebPage`).

The purpose of `_relatedWebView` is to make sure two WebViews share the same process for every load request. Under Site
Isolation, one load might involve multiple processes, so there is no way to implement it correctly, and we decided to
deprecated the SPI. However, there are still existing clients and it might be important for them that the process is
still shared when two WebViews are loading the same site (as in the test). So, this patch keeps that working by making
page uses related page&apos;s browsing context group.

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::preferredBrowsingContextGroup const):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::getOrCreateBrowsingContextGroup):
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::launchProcess):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):

Canonical link: <a href="https://commits.webkit.org/306438@main">https://commits.webkit.org/306438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d92dc722e3720aaed548d58857ccbaf813e3f15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13719 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/3117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94434 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4fbc9fdd-5080-4216-b8ce-e681b0fc0016) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108590 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8732b43-3073-45cf-8f22-0795a6da0b6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11143 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/3117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/311df44c-dd4e-4e75-886e-f2f82113b97a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10717 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8340 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119983 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/3117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152303 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13410 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/3117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116696 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13088 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/3117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68607 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13453 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/3117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13389 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13235 "Failed to checkout and rebase branch from PR 57195") | | | | 
<!--EWS-Status-Bubble-End-->