### PR TITLE
[libpas] Use futex-based locking in Windows / FreeBSD

### DIFF
--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -25,6 +25,7 @@ if (WIN32)
     list(APPEND WTF_LIBRARIES
         DbgHelp
         shlwapi
+        synchronization
         winmm
     )
     list(APPEND WTF_PUBLIC_HEADERS

--- a/Source/WTF/wtf/PlatformWin.cmake
+++ b/Source/WTF/wtf/PlatformWin.cmake
@@ -37,5 +37,6 @@ list(APPEND WTF_PUBLIC_HEADERS
 list(APPEND WTF_LIBRARIES
     DbgHelp
     shlwapi
+    synchronization
     winmm
 )

--- a/Source/bmalloc/libpas/src/libpas/pas_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_config.h
@@ -138,11 +138,5 @@
 
 #define PAS_ALLOCATOR_INDEX_BYTES        4
 
-#if PAS_OS(DARWIN) || PAS_OS(LINUX) || PAS_PLATFORM(PLAYSTATION)
-#define PAS_USE_SPINLOCKS                0
-#else
-#define PAS_USE_SPINLOCKS                1
-#endif
-
 #endif /* PAS_CONFIG_H */
 

--- a/Source/bmalloc/libpas/src/libpas/pas_lock.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_lock.h
@@ -52,72 +52,7 @@ typedef enum pas_lock_lock_mode pas_lock_lock_mode;
 
 PAS_END_EXTERN_C;
 
-#if PAS_USE_SPINLOCKS
-
-PAS_BEGIN_EXTERN_C;
-
-struct pas_lock;
-typedef struct pas_lock pas_lock;
-
-struct pas_lock {
-    bool lock;
-    bool is_spinning;
-};
-
-#define PAS_LOCK_INITIALIZER ((pas_lock){ .lock = false, .is_spinning = false })
-
-static inline void pas_lock_construct(pas_lock* lock)
-{
-    *lock = PAS_LOCK_INITIALIZER;
-}
-
-static inline void pas_lock_construct_disabled(pas_lock* lock)
-{
-    *lock = PAS_LOCK_INITIALIZER;
-    lock->lock = true; /* This isn't great; it'll just mean that if we use the lock wrong then
-                          we'll infinite loop. But we test in a mode where we don't use this
-                          code path. */
-}
-
-PAS_API PAS_NEVER_INLINE void pas_lock_lock_slow(pas_lock* lock);
-
-static inline void pas_lock_lock(pas_lock* lock)
-{
-    pas_race_test_will_lock(lock);
-    if (!pas_compare_and_swap_bool_weak(&lock->lock, false, true))
-        pas_lock_lock_slow(lock);
-    pas_race_test_did_lock(lock);
-}
-
-static inline bool pas_lock_try_lock(pas_lock* lock)
-{
-    bool result;
-    result = !pas_compare_and_swap_bool_strong(&lock->lock, false, true);
-    if (result)
-        pas_race_test_did_try_lock(lock);
-    return result;
-}
-
-static inline void pas_lock_unlock(pas_lock* lock)
-{
-    pas_race_test_will_unlock(lock);
-    pas_atomic_store_bool((bool*)&lock->lock, false);
-}
-
-static inline void pas_lock_assert_held(pas_lock* lock)
-{
-    PAS_ASSERT(lock->lock);
-}
-
-static inline void pas_lock_testing_assert_held(pas_lock* lock)
-{
-    PAS_TESTING_ASSERT(lock->lock);
-}
-
-PAS_END_EXTERN_C;
-
-#elif PAS_OS(DARWIN) /* !PAS_USE_SPINLOCKS */
-
+#if PAS_OS(DARWIN)
 
 #if defined(__has_include) && __has_include(<os/lock_private.h>) && (defined(LIBPAS) || defined(PAS_BMALLOC))
 #define PAS_USE_ULOCK_SPI 1
@@ -235,127 +170,7 @@ static inline void pas_lock_testing_assert_held(pas_lock* lock)
 
 PAS_END_EXTERN_C;
 
-#elif PAS_OS(LINUX)
-
-#include <linux/futex.h>
-#include <sys/syscall.h>
-#include <unistd.h>
-
-PAS_BEGIN_EXTERN_C;
-
-struct pas_lock;
-typedef struct pas_lock pas_lock;
-
-struct pas_lock {
-    unsigned futex;
-};
-
-#define PAS_LOCK_INITIALIZER ((pas_lock){ .futex = 0 })
-
-static inline void pas_lock_construct(pas_lock* lock)
-{
-    *lock = PAS_LOCK_INITIALIZER;
-}
-
-static inline void pas_lock_construct_disabled(pas_lock* lock)
-{
-    pas_zero_memory(lock, sizeof(pas_lock));
-}
-
-static inline long pas_lock_futex_wait(unsigned* addr, unsigned val)
-{
-    return syscall(SYS_futex, addr, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, val, NULL, NULL, 0);
-}
-
-static inline long pas_lock_futex_wake(unsigned* addr)
-{
-    return syscall(SYS_futex, addr, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 1, NULL, NULL, 0);
-}
-
-static inline void pas_lock_lock(pas_lock* lock)
-{
-    unsigned expected = 0;
-
-    if (PAS_LOCK_VERBOSE)
-        pas_log("Thread %p Locking lock %p\n", (void*)pthread_self(), lock);
-
-    pas_race_test_will_lock(lock);
-
-    /* Fast path: Try to acquire 0 -> 1 */
-    if (__atomic_compare_exchange_n(&lock->futex, &expected, 1, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
-        pas_race_test_did_lock(lock);
-        return;
-    }
-
-    /* Slow path: lock is contended */
-    do {
-        /* If lock is currently 1 (locked, no waiters), mark it as 2 (locked with waiters) */
-        if (expected == 1) {
-            expected = __atomic_exchange_n(&lock->futex, 2, __ATOMIC_ACQUIRE);
-            // If we swapped 0 -> 2, we actually acquired the lock.
-            if (expected == 0) {
-                pas_race_test_did_lock(lock);
-                return;
-            }
-        }
-
-        /* If still not free, wait for wakeup */
-        if (expected != 0)
-            pas_lock_futex_wait(&lock->futex, 2);
-
-        /* Try to acquire the lock: 0 -> 2 (since we know there's contention) */
-        expected = 0;
-    } while (!__atomic_compare_exchange_n(&lock->futex, &expected, 2, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED));
-
-    pas_race_test_did_lock(lock);
-}
-
-static inline bool pas_lock_try_lock(pas_lock* lock)
-{
-    unsigned expected = 0;
-    bool result;
-
-    if (PAS_LOCK_VERBOSE)
-        pas_log("Thread %p Trylocking lock %p\n", (void*)pthread_self(), lock);
-
-    result = __atomic_compare_exchange_n(&lock->futex, &expected, 1, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
-
-    if (result)
-        pas_race_test_did_try_lock(lock);
-
-    return result;
-}
-
-static inline void pas_lock_unlock(pas_lock* lock)
-{
-    if (PAS_LOCK_VERBOSE)
-        pas_log("Thread %p Unlocking lock %p\n", (void*)pthread_self(), lock);
-
-    pas_race_test_will_unlock(lock);
-
-    /* If we had no waiters (state was 1), just unlock to 0 */
-    if (__atomic_fetch_sub(&lock->futex, 1, __ATOMIC_RELEASE) == 1)
-        return; /* No waiters, we're done */
-
-    /* We had waiters (state was 2), so we need to wake them up */
-    __atomic_store_n(&lock->futex, 0, __ATOMIC_RELEASE);
-    pas_lock_futex_wake(&lock->futex);
-}
-
-static inline void pas_lock_assert_held(pas_lock* lock)
-{
-    PAS_ASSERT(__atomic_load_n(&lock->futex, __ATOMIC_RELAXED) != 0);
-}
-
-static inline void pas_lock_testing_assert_held(pas_lock* lock)
-{
-    if (PAS_ENABLE_TESTING)
-        PAS_TESTING_ASSERT(__atomic_load_n(&lock->futex, __ATOMIC_RELAXED) != 0);
-}
-
-PAS_END_EXTERN_C;
-
-#elif PAS_PLATFORM(PLAYSTATION) /* !PAS_USE_SPINLOCKS */
+#elif PAS_PLATFORM(PLAYSTATION)
 
 #include <errno.h>
 #include <pthread_np.h>
@@ -439,9 +254,92 @@ static inline void pas_lock_testing_assert_held(pas_lock* lock)
 
 PAS_END_EXTERN_C;
 
-#else /* !PAS_USE_SPINLOCKS */
+#elif PAS_OS(LINUX) || PAS_OS(WINDOWS) || PAS_OS(FREEBSD)
+
+PAS_BEGIN_EXTERN_C;
+
+struct pas_lock;
+typedef struct pas_lock pas_lock;
+
+struct pas_lock {
+    unsigned futex;
+};
+
+#define PAS_LOCK_INITIALIZER ((pas_lock){ .futex = 0 })
+
+static inline void pas_lock_construct(pas_lock* lock)
+{
+    *lock = PAS_LOCK_INITIALIZER;
+}
+
+static inline void pas_lock_construct_disabled(pas_lock* lock)
+{
+    pas_zero_memory(lock, sizeof(pas_lock));
+}
+
+PAS_API PAS_NEVER_INLINE void pas_lock_lock_slow(pas_lock* lock, unsigned expected);
+PAS_API PAS_NEVER_INLINE void pas_lock_unlock_slow(pas_lock* lock);
+
+static inline void pas_lock_lock(pas_lock* lock)
+{
+    unsigned expected = 0;
+
+    if (PAS_LOCK_VERBOSE)
+        pas_log("Thread %p Locking lock %p\n", (void*)pthread_self(), lock);
+
+    pas_race_test_will_lock(lock);
+
+    /* Fast path: Try to acquire 0 -> 1 */
+    if (PAS_UNLIKELY(!__atomic_compare_exchange_n(&lock->futex, &expected, 1, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)))
+        pas_lock_lock_slow(lock, expected);
+
+    pas_race_test_did_lock(lock);
+}
+
+static inline bool pas_lock_try_lock(pas_lock* lock)
+{
+    unsigned expected = 0;
+    bool result;
+
+    if (PAS_LOCK_VERBOSE)
+        pas_log("Thread %p Trylocking lock %p\n", (void*)pthread_self(), lock);
+
+    result = __atomic_compare_exchange_n(&lock->futex, &expected, 1, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+
+    if (result)
+        pas_race_test_did_try_lock(lock);
+
+    return result;
+}
+
+static inline void pas_lock_unlock(pas_lock* lock)
+{
+    if (PAS_LOCK_VERBOSE)
+        pas_log("Thread %p Unlocking lock %p\n", (void*)pthread_self(), lock);
+
+    pas_race_test_will_unlock(lock);
+
+    /* If we had no waiters (state was 1), just unlock to 0 */
+    if (PAS_UNLIKELY(__atomic_fetch_sub(&lock->futex, 1, __ATOMIC_RELEASE) != 1))
+        pas_lock_unlock_slow(lock);
+}
+
+static inline void pas_lock_assert_held(pas_lock* lock)
+{
+    PAS_ASSERT(__atomic_load_n(&lock->futex, __ATOMIC_RELAXED) != 0);
+}
+
+static inline void pas_lock_testing_assert_held(pas_lock* lock)
+{
+    if (PAS_ENABLE_TESTING)
+        PAS_TESTING_ASSERT(__atomic_load_n(&lock->futex, __ATOMIC_RELAXED) != 0);
+}
+
+PAS_END_EXTERN_C;
+
+#else
 #error "No pas_lock implementation found"
-#endif /* !PAS_USE_SPINLOCKS */
+#endif
 
 PAS_BEGIN_EXTERN_C;
 


### PR DESCRIPTION
#### b933ba61804bdad9b40c5e8d3f55c4da93824dd6
<pre>
[libpas] Use futex-based locking in Windows / FreeBSD
<a href="https://bugs.webkit.org/show_bug.cgi?id=306203">https://bugs.webkit.org/show_bug.cgi?id=306203</a>
<a href="https://rdar.apple.com/168860161">rdar://168860161</a>

Reviewed by Justin Michaud and Sosuke Suzuki.

This patch adds futex locking in Windows / FreeBSD as well.
Also remove spinlock, as all libpas-suppoting platforms support
this new locking. Also move slow path code to C side to avoid bloating
code for locking.

* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformWin.cmake:
* Source/bmalloc/libpas/src/libpas/pas_config.h:
* Source/bmalloc/libpas/src/libpas/pas_lock.c:
(pas_lock_futex_wait):
(pas_lock_futex_wake):
(pas_lock_lock_slow):
(pas_lock_unlock_slow):
* Source/bmalloc/libpas/src/libpas/pas_lock.h:
(pas_lock_construct_disabled):
(pas_lock_mutex_setname):
(pas_lock_lock):
(pas_lock_try_lock):
(pas_lock_unlock):
(pas_lock_test_held):
(pas_lock_assert_held):
(pas_lock_testing_assert_held):
(pas_lock_futex_wait):
(pas_lock_futex_wake):

Canonical link: <a href="https://commits.webkit.org/306197@main">https://commits.webkit.org/306197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5ebfddc7e4ccc82919b1cbef42c86fd0dd3262f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140614 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93701 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b510bac6-4a80-46a3-b41d-6283daa7e3d0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107817 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78280 "3 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc4a5a43-4181-41e2-b8b7-e96dcb8e7aea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125889 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88717 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a22c5ec-5395-4a7f-bee1-ff7716649002) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7756 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9047 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132592 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151577 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1412 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12684 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2042 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116460 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12312 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122488 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67781 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12726 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1943 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171887 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12466 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76426 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44613 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->