### PR TITLE
[GStreamer][WebRTC][Rice] Sockets TOS configuration support

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp
@@ -68,21 +68,7 @@ GUniquePtr<GstStructure> GStreamerDataChannelHandler::fromRTCDataChannelInit(con
     if (options.id)
         gst_structure_set(init.get(), "id", G_TYPE_INT, *options.id, nullptr);
 
-    GstWebRTCPriorityType priorityType;
-    switch (options.priority) {
-    case RTCPriorityType::VeryLow:
-        priorityType = GST_WEBRTC_PRIORITY_TYPE_VERY_LOW;
-        break;
-    case RTCPriorityType::Low:
-        priorityType = GST_WEBRTC_PRIORITY_TYPE_LOW;
-        break;
-    case RTCPriorityType::Medium:
-        priorityType = GST_WEBRTC_PRIORITY_TYPE_MEDIUM;
-        break;
-    case RTCPriorityType::High:
-        priorityType = GST_WEBRTC_PRIORITY_TYPE_HIGH;
-        break;
-    }
+    auto priorityType = fromRTCPriorityType(options.priority);
     gst_structure_set(init.get(), "priority", GST_TYPE_WEBRTC_PRIORITY_TYPE, priorityType, nullptr);
 
     return init;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -532,9 +532,22 @@ static GstWebRTCICETransport* webkitGstWebRTCIceAgentFindTransport(GstWebRTCICE*
     return webkitGstWebRTCIceStreamFindTransport(stream, component);
 }
 
-static void webkitGstWebRTCIceAgentSetTos(GstWebRTCICE*, GstWebRTCICEStream*, guint)
+static void webkitGstWebRTCIceAgentSetTos(GstWebRTCICE* ice, GstWebRTCICEStream* stream, guint tos)
 {
-    GST_FIXME("Not implemented yet.");
+    auto self = WEBKIT_GST_WEBRTC_ICE_BACKEND(ice);
+    auto backend = self->priv->iceBackend;
+    if (!backend) [[unlikely]]
+        return;
+
+    for (auto& riceStream : self->priv->streams.values()) {
+        if (riceStream->stream->stream_id != stream->stream_id)
+            continue;
+
+        GST_DEBUG_OBJECT(ice, "Setting socket TOS to %u on stream %u", tos, riceStream->riceStreamId);
+        backend->setSocketTypeOfService(riceStream->riceStreamId, tos);
+        return;
+    }
+    GST_WARNING_OBJECT(ice, "Unable to find stream %u and apply TOS on its sockets", stream->stream_id);
 }
 
 static gboolean webkitGstWebRTCIceAgentSetLocalCredentials(GstWebRTCICE*, GstWebRTCICEStream* stream, const gchar* ufrag, const gchar* pwd)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
@@ -90,6 +90,7 @@ public:
     using Socket = std::pair<String, RTCIceProtocol>;
     virtual HashMap<Socket, String> gatherSocketAddresses(ScriptExecutionContextIdentifier, unsigned) = 0;
     virtual void finalizeStream(unsigned) = 0;
+    virtual void setSocketTypeOfService(unsigned, unsigned) = 0;
 
 protected:
     RiceBackend() = default;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -275,6 +275,11 @@ void GStreamerRtpSenderBackend::setParameters(const RTCRtpSendParameters& parame
     }, [](const std::nullptr_t&) {
     });
 
+    if (!parameters.encodings.isEmpty()) {
+        const auto& encoding = parameters.encodings.first();
+        auto priorityType = fromRTCPriorityType(encoding.priority);
+        g_object_set(m_rtcSender.get(), "priority", priorityType, nullptr);
+    }
     promise.resolve();
 }
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -305,6 +305,22 @@ static inline std::optional<RTCErrorDetailType> toRTCErrorDetailType(GstWebRTCEr
     };
 }
 
+static inline GstWebRTCPriorityType fromRTCPriorityType(RTCPriorityType priority)
+{
+    switch (priority) {
+    case RTCPriorityType::VeryLow:
+        return GST_WEBRTC_PRIORITY_TYPE_VERY_LOW;
+    case RTCPriorityType::Low:
+        return GST_WEBRTC_PRIORITY_TYPE_LOW;
+    case RTCPriorityType::Medium:
+        return GST_WEBRTC_PRIORITY_TYPE_MEDIUM;
+    case RTCPriorityType::High:
+        return GST_WEBRTC_PRIORITY_TYPE_HIGH;
+    }
+    ASSERT_NOT_REACHED();
+    return GST_WEBRTC_PRIORITY_TYPE_MEDIUM;
+}
+
 RefPtr<RTCError> toRTCError(GError*);
 
 ExceptionOr<GUniquePtr<GstStructure>> fromRTCEncodingParameters(const RTCRtpEncodingParameters&, const String& kind);

--- a/Source/WebCore/platform/rice/RiceUtilities.h
+++ b/Source/WebCore/platform/rice/RiceUtilities.h
@@ -29,6 +29,13 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
+#ifndef RICE_CHECK_VERSION
+#define RICE_CHECK_VERSION(major, minor, patch) \
+    (RICE_PROTO_MAJOR > (major) || \
+    (RICE_PROTO_MAJOR == (major) && RICE_PROTO_MINOR > (minor)) || \
+    (RICE_PROTO_MAJOR == (major) && RICE_PROTO_MINOR == (minor) && RICE_PROTO_PATCH >= (patch)))
+#endif
+
 namespace WebCore {
 
 static inline String riceAddressToString(const RiceAddress* address, bool includePort = true)

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
@@ -380,6 +380,20 @@ const RiceAddress* RiceBackend::ensureRiceAddressFromCache(const String& address
     return result.get();
 }
 
+void RiceBackend::setSocketTypeOfService(unsigned streamId, unsigned value)
+{
+#if RICE_CHECK_VERSION(0, 2, 2)
+    auto sockets = getSocketsForStream(streamId);
+    if (!sockets) [[unlikely]]
+        return;
+
+    rice_sockets_set_tos(sockets.get(), value);
+#else
+    UNUSED_PARAM(streamId);
+    UNUSED_PARAM(value);
+#endif
+}
+
 } // namespace WebKit
 
 #endif // USE(LIBRICE)

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
@@ -80,6 +80,7 @@ public:
 
     void sendData(unsigned, WebCore::RTCIceProtocol, String, String, WebCore::SharedMemory::Handle&&);
     void finalizeStream(unsigned);
+    void setSocketTypeOfService(unsigned, unsigned);
 
     using GatherSocketAddressesCallback = CompletionHandler<void(HashMap<std::pair<String, WebCore::RTCIceProtocol>, String>&&)>;
     void gatherSocketAddresses(WebCore::ScriptExecutionContextIdentifier, unsigned, GatherSocketAddressesCallback&&);

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.messages.in
@@ -27,6 +27,7 @@ messages -> RiceBackend {
     SendData(unsigned streamId, enum:uint8_t WebCore::RTCIceProtocol protocol, String from, String to, WebCore::SharedMemory::Handle data);
     FinalizeStream(unsigned streamId);
     ResolveAddress(String address) -> (Expected<String, WebCore::ExceptionData> result)
+    SetSocketTypeOfService(unsigned streamId, unsigned value);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp
@@ -113,6 +113,11 @@ void RiceBackendProxy::finalizeStream(unsigned streamId)
     MessageSender::send(Messages::RiceBackend::FinalizeStream { streamId });
 }
 
+void RiceBackendProxy::setSocketTypeOfService(unsigned streamId, unsigned value)
+{
+    MessageSender::send(Messages::RiceBackend::SetSocketTypeOfService { streamId, value });
+}
+
 } // namespace WebKit
 
 #endif // USE(LIBRICE)

--- a/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.h
@@ -64,6 +64,7 @@ private:
     HashMap<WebCore::RiceBackend::Socket, String> gatherSocketAddresses(WebCore::ScriptExecutionContextIdentifier, unsigned) final;
 
     void finalizeStream(unsigned) final;
+    void setSocketTypeOfService(unsigned, unsigned) final;
 
     void refRiceBackend() final { ref(); }
     void derefRiceBackend() final { deref(); }


### PR DESCRIPTION
#### e6516c9e365639225144aea62a864e29c2e53456
<pre>
[GStreamer][WebRTC][Rice] Sockets TOS configuration support
<a href="https://bugs.webkit.org/show_bug.cgi?id=306204">https://bugs.webkit.org/show_bug.cgi?id=306204</a>

Reviewed by Xabier Rodriguez-Calvar.

The ICE agent is now able to propagate WebRTC packets priority hints down to the Rice sockets
managed in the NetworkProcess.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::fromRTCDataChannelInit):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(webkitGstWebRTCIceAgentSetTos):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::GStreamerRtpSenderBackend::setParameters):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
(WebCore::fromRTCPriorityType):
* Source/WebCore/platform/rice/RiceUtilities.h:
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp:
(WebKit::RiceBackend::setSocketTypeOfService):
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h:
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.cpp:
(WebKit::RiceBackendProxy::setSocketTypeOfService):
* Source/WebKit/WebProcess/Network/webrtc/rice/RiceBackendProxy.h:

Canonical link: <a href="https://commits.webkit.org/306196@main">https://commits.webkit.org/306196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcfab3e6394422bab1d4a0eab10502785c415ef5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149007 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13202 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10628 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10240 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7797 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9099 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119483 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/1939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151629 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12736 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116503 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12412 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67836 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12778 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76478 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->