### PR TITLE
Drop more `protected*()` getters in Source/WebKit/UIProcess

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -372,6 +372,20 @@ template<typename T, typename U, typename WeakPtrImpl, typename PtrTraits> inlin
     return a.get() == b;
 }
 
+template<typename T, typename WeakPtrImpl, typename PtrTraits, typename RefPtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
+    requires HasRefPtrMemberFunctions<T>::value
+ALWAYS_INLINE RefPtr<T, RefPtrTraits, RefDerefTraits> protect(const WeakPtr<T, WeakPtrImpl, PtrTraits>& weakPtr)
+{
+    return RefPtr<T, RefPtrTraits, RefDerefTraits>(weakPtr.get());
+}
+
+template<typename T, typename WeakPtrImpl, typename WeakPtrPtrTraits, typename CheckedPtrTraits = RawPtrTraits<T>>
+    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+ALWAYS_INLINE CheckedPtr<T, CheckedPtrTraits> protect(const WeakPtr<T, WeakPtrImpl, WeakPtrPtrTraits>& weakPtr)
+{
+    return CheckedPtr<T, CheckedPtrTraits>(weakPtr.get());
+}
+
 template<class T, typename = std::enable_if_t<!IsSmartPtr<T>::value>>
 WeakPtr(const T* value, EnableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) -> WeakPtr<T, typename T::WeakPtrImplType>;
 

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -217,6 +217,20 @@ inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> dynamicDowncast(W
     return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> { unsafeRefDowncast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 
+template<typename T, typename WeakPtrImpl, typename PtrTraits = RawPtrTraits<T>>
+    requires HasRefPtrMemberFunctions<T>::value
+ALWAYS_INLINE Ref<T, PtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
+{
+    return Ref<T, PtrTraits>(*weakRef.ptr());
+}
+
+template<typename T, typename WeakPtrImpl, typename CheckedPtrTraits = RawPtrTraits<T>>
+    requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
+ALWAYS_INLINE CheckedRef<T, CheckedPtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
+{
+    return CheckedRef<T, CheckedPtrTraits>(*weakRef.ptr());
+}
+
 } // namespace WTF
 
 using WTF::EnableWeakPtrThreadingAssertions;

--- a/Source/WebKit/UIProcess/API/APIDataTask.cpp
+++ b/Source/WebKit/UIProcess/API/APIDataTask.cpp
@@ -64,8 +64,8 @@ DataTask::DataTask(std::optional<WebKit::DataTaskIdentifier> identifier, WeakPtr
     : m_identifier(identifier)
     , m_page(WTF::move(page))
     , m_originalURL(WTF::move(originalURL))
-    , m_networkProcess(m_page ? WeakPtr { protect(protectedPage()->websiteDataStore())->networkProcess() } : nullptr)
-    , m_sessionID(m_page ? std::optional<PAL::SessionID> { protectedPage()->sessionID() } : std::nullopt)
+    , m_networkProcess(m_page ? WeakPtr { protect(protect(this->page())->websiteDataStore())->networkProcess() } : nullptr)
+    , m_sessionID(m_page ? std::optional<PAL::SessionID> { protect(this->page())->sessionID() } : std::nullopt)
     , m_client(DataTaskClient::create())
 {
     if (RefPtr networkProcess = m_networkProcess.get())

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -40,22 +40,22 @@ WKTypeID WKBackForwardListGetTypeID()
 
 WKBackForwardListItemRef WKBackForwardListGetCurrentItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toProtectedImpl(listRef)->protectedCurrentItem().get());
+    return toAPI(protect(toProtectedImpl(listRef)->currentItem()).get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetBackItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toProtectedImpl(listRef)->protectedBackItem().get());
+    return toAPI(protect(toProtectedImpl(listRef)->backItem()).get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetForwardItem(WKBackForwardListRef listRef)
 {
-    return toAPI(toProtectedImpl(listRef)->protectedForwardItem().get());
+    return toAPI(protect(toProtectedImpl(listRef)->forwardItem()).get());
 }
 
 WKBackForwardListItemRef WKBackForwardListGetItemAtIndex(WKBackForwardListRef listRef, int index)
 {
-    return toAPI(toProtectedImpl(listRef)->protectedItemAtIndex(index).get());
+    return toAPI(protect(toProtectedImpl(listRef)->itemAtIndex(index)).get());
 }
 
 void WKBackForwardListClear(WKBackForwardListRef listRef)

--- a/Source/WebKit/UIProcess/API/C/WKFrame.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKFrame.cpp
@@ -92,7 +92,7 @@ WKStringRef WKFrameCopyTitle(WKFrameRef frameRef)
 
 WKPageRef WKFrameGetPage(WKFrameRef frameRef)
 {
-    return toAPI(toProtectedImpl(frameRef)->protectedPage().get());
+    return toAPI(protect(toProtectedImpl(frameRef)->page()).get());
 }
 
 WKCertificateInfoRef WKFrameGetCertificateInfo(WKFrameRef frameRef)

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -198,7 +198,7 @@ WKTypeID WKPageGetTypeID()
 
 WKContextRef WKPageGetContext(WKPageRef pageRef)
 {
-    return toAPI(toProtectedImpl(pageRef)->configuration().protectedProcessPool().ptr());
+    return toAPI(protect(toProtectedImpl(pageRef)->configuration().processPool()).ptr());
 }
 
 WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
@@ -450,7 +450,7 @@ void WKPageUpdateWebsitePolicies(WKPageRef pageRef, WKWebsitePoliciesRef website
 
 WKStringRef WKPageCopyTitle(WKPageRef pageRef)
 {
-    return toCopiedAPI(toProtectedImpl(pageRef)->protectedPageLoadState()->title());
+    return toCopiedAPI(protect(toProtectedImpl(pageRef)->pageLoadState())->title());
 }
 
 WKFrameRef WKPageGetMainFrame(WKPageRef pageRef)
@@ -1196,7 +1196,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         {
             if (!m_client.willEnterFullScreen)
                 return completionHandler(false);
-            m_client.willEnterFullScreen(toAPI(protectedPage().get()), toAPI(API::CompletionListener::create([completionHandler = WTF::move(completionHandler)] (WKTypeRef) mutable {
+            m_client.willEnterFullScreen(toAPI(protect(page()).get()), toAPI(API::CompletionListener::create([completionHandler = WTF::move(completionHandler)] (WKTypeRef) mutable {
                 completionHandler(true);
             }).ptr()), m_client.base.clientInfo);
         }
@@ -1205,7 +1205,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         {
             if (!m_client.beganEnterFullScreen)
                 return completionHandler(false);
-            m_client.beganEnterFullScreen(toAPI(protectedPage().get()), toAPI(initialFrame), toAPI(finalFrame), m_client.base.clientInfo);
+            m_client.beganEnterFullScreen(toAPI(protect(page()).get()), toAPI(initialFrame), toAPI(finalFrame), m_client.base.clientInfo);
             completionHandler(true);
         }
 
@@ -1213,7 +1213,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         {
             if (!m_client.exitFullScreen)
                 return completionHandler();
-            m_client.exitFullScreen(toAPI(protectedPage().get()), m_client.base.clientInfo);
+            m_client.exitFullScreen(toAPI(protect(page()).get()), m_client.base.clientInfo);
             completionHandler();
         }
 
@@ -1221,7 +1221,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         {
             if (!m_client.beganExitFullScreen)
                 return completionHandler();
-            m_client.beganExitFullScreen(toAPI(protectedPage().get()), toAPI(initialFrame), toAPI(finalFrame), toAPI(API::CompletionListener::create([completionHandler = WTF::move(completionHandler)] (WKTypeRef) mutable {
+            m_client.beganExitFullScreen(toAPI(protect(page()).get()), toAPI(initialFrame), toAPI(finalFrame), toAPI(API::CompletionListener::create([completionHandler = WTF::move(completionHandler)] (WKTypeRef) mutable {
                 completionHandler();
             }).ptr()), m_client.base.clientInfo);
         }
@@ -1230,7 +1230,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         void updateImageSource() override { }
 #endif
 
-        RefPtr<WebPageProxy> protectedPage() const { return m_page.get(); }
+        WebPageProxy* page() const { return m_page; }
 
         WeakPtr<WebPageProxy> m_page;
     };
@@ -2075,7 +2075,7 @@ void WKPageSetPageUIClient(WKPageRef pageRef, const WKPageUIClientBase* wkClient
             if (!m_client.shouldAllowDeviceOrientationAndMotionAccess)
                 return completionHandler(false);
 
-            auto origin = API::SecurityOrigin::create(SecurityOrigin::createFromString(page.protectedPageLoadState()->activeURL()).get());
+            auto origin = API::SecurityOrigin::create(SecurityOrigin::createFromString(protect(page.pageLoadState())->activeURL()).get());
             auto apiFrameInfo = API::FrameInfo::create(WTF::move(frameInfo));
             completionHandler(m_client.shouldAllowDeviceOrientationAndMotionAccess(toAPI(&page), toAPI(origin.ptr()), toAPI(apiFrameInfo.ptr()), m_client.base.clientInfo));
         }
@@ -2853,7 +2853,7 @@ WK_EXPORT WKURLRef WKPageCopyPendingAPIRequestURL(WKPageRef pageRef)
 
 WKURLRef WKPageCopyActiveURL(WKPageRef pageRef)
 {
-    return toCopiedURLAPI(toProtectedImpl(pageRef)->protectedPageLoadState()->activeURL());
+    return toCopiedURLAPI(protect(toProtectedImpl(pageRef)->pageLoadState())->activeURL());
 }
 
 WKURLRef WKPageCopyProvisionalURL(WKPageRef pageRef)
@@ -3376,7 +3376,7 @@ void WKPageSetMockCaptureDevicesInterrupted(WKPageRef pageRef, bool isCameraInte
 #if ENABLE(MEDIA_STREAM) && ENABLE(GPU_PROCESS)
     Ref preferences = toProtectedImpl(pageRef)->preferences();
     if (preferences->useGPUProcessForMediaEnabled()) {
-        Ref gpuProcess = toProtectedImpl(pageRef)->configuration().protectedProcessPool()->ensureGPUProcess();
+        Ref gpuProcess = protect(toProtectedImpl(pageRef)->configuration().processPool())->ensureGPUProcess();
         gpuProcess->setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
     }
 #endif
@@ -3400,7 +3400,7 @@ void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forCame
     if (!preferences->useGPUProcessForMediaEnabled())
         return;
 
-    Ref gpuProcess = toProtectedImpl(pageRef)->configuration().protectedProcessPool()->ensureGPUProcess();
+    Ref gpuProcess = protect(toProtectedImpl(pageRef)->configuration().processPool())->ensureGPUProcess();
     gpuProcess->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
 #endif // ENABLE(GPU_PROCESS)
 

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -49,7 +49,7 @@ WKPageConfigurationRef WKPageConfigurationCreate()
 
 WKContextRef WKPageConfigurationGetContext(WKPageConfigurationRef configuration)
 {
-    return toAPI(toProtectedImpl(configuration)->protectedProcessPool().get());
+    return toAPI(protect(toProtectedImpl(configuration)->processPool()).get());
 }
 
 void WKPageConfigurationSetContext(WKPageConfigurationRef configuration, WKContextRef context)
@@ -98,7 +98,7 @@ void WKPageConfigurationSetRelatedPage(WKPageConfigurationRef configuration, WKP
 
 WKWebsiteDataStoreRef WKPageConfigurationGetWebsiteDataStore(WKPageConfigurationRef configuration)
 {
-    return toAPI(toProtectedImpl(configuration)->protectedWebsiteDataStore().get());
+    return toAPI(protect(toProtectedImpl(configuration)->websiteDataStore()).get());
 }
 
 void WKPageConfigurationSetWebsiteDataStore(WKPageConfigurationRef configuration, WKWebsiteDataStoreRef websiteDataStore)

--- a/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp
@@ -172,7 +172,7 @@ void WKWebsitePoliciesSetPopUpPolicy(WKWebsitePoliciesRef websitePolicies, WKWeb
 
 WKWebsiteDataStoreRef WKWebsitePoliciesGetDataStore(WKWebsitePoliciesRef websitePolicies)
 {
-    return toAPI(toProtectedImpl(websitePolicies)->protectedWebsiteDataStore().get());
+    return toAPI(protect(toProtectedImpl(websitePolicies)->websiteDataStore()).get());
 }
 
 void WKWebsitePoliciesSetDataStore(WKWebsitePoliciesRef websitePolicies, WKWebsiteDataStoreRef websiteDataStore)

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -63,7 +63,7 @@ static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
     _page = WTF::move(page);
     Ref observer = WebKit::PageLoadStateObserver::create(self, @"URL");
     _observer = observer.get();
-    protectedPage(self)->protectedPageLoadState()->addObserver(observer.get());
+    protect(protectedPage(self)->pageLoadState())->addObserver(observer.get());
 
     return self;
 }
@@ -73,7 +73,7 @@ static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
     protect(*_observer)->clearObject();
 
     ensureOnMainRunLoop([page = WTF::move(_page), observer = std::exchange(_observer, nullptr)] {
-        page->protectedPageLoadState()->removeObserver(*observer);
+        protect(page->pageLoadState())->removeObserver(*observer);
     });
 
     [super dealloc];
@@ -81,22 +81,22 @@ static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
 
 - (BOOL)isLoading
 {
-    return protectedPage(self)->protectedPageLoadState()->isLoading();
+    return protect(protectedPage(self)->pageLoadState())->isLoading();
 }
 
 - (NSString *)title
 {
-    return protectedPage(self)->protectedPageLoadState()->title().createNSString().autorelease();
+    return protect(protectedPage(self)->pageLoadState())->title().createNSString().autorelease();
 }
 
 - (NSURL *)URL
 {
-    return [NSURL _web_URLWithWTFString:protectedPage(self)->protectedPageLoadState()->activeURL()];
+    return [NSURL _web_URLWithWTFString:protect(protectedPage(self)->pageLoadState())->activeURL()];
 }
 
 - (BOOL)hasOnlySecureContent
 {
-    return protectedPage(self)->protectedPageLoadState()->hasOnlySecureContent();
+    return protect(protectedPage(self)->pageLoadState())->hasOnlySecureContent();
 }
 
 - (BOOL)_webProcessIsResponsive
@@ -137,7 +137,7 @@ _WKRemoteObjectRegistry *WKPageGetObjectRegistry(WKPageRef pageRef)
 
 bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url)
 {
-    return WebKit::toProtectedImpl(page)->configuration().protectedProcessPool()->isURLKnownHSTSHost(WebKit::toImpl(url)->string());
+    return protect(WebKit::toProtectedImpl(page)->configuration().processPool())->isURLKnownHSTSHost(WebKit::toImpl(url)->string());
 }
 
 WKNavigation *WKPageLoadURLRequestReturningNavigation(WKPageRef pageRef, WKURLRequestRef urlRequestRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -54,22 +54,22 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKBackForwardListItem *)currentItem
 {
-    return WebKit::wrapper(self._protectedList->protectedCurrentItem().get());
+    return WebKit::wrapper(protect(self._protectedList->currentItem()).get());
 }
 
 - (WKBackForwardListItem *)backItem
 {
-    return WebKit::wrapper(self._protectedList->protectedBackItem().get());
+    return WebKit::wrapper(protect(self._protectedList->backItem()).get());
 }
 
 - (WKBackForwardListItem *)forwardItem
 {
-    return WebKit::wrapper(self._protectedList->protectedForwardItem().get());
+    return WebKit::wrapper(protect(self._protectedList->forwardItem()).get());
 }
 
 - (WKBackForwardListItem *)itemAtIndex:(NSInteger)index
 {
-    return WebKit::wrapper(self._protectedList->protectedItemAtIndex(index).get());
+    return WebKit::wrapper(protect(self._protectedList->itemAtIndex(index)).get());
 }
 
 - (NSArray *)backList

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -704,7 +704,7 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 
     for (auto& pair : pageConfiguration->urlSchemeHandlers())
         _page->setURLSchemeHandlerForScheme(pair.value.get(), pair.key);
-    _page->setURLSchemeHandlerForScheme(_page->protectedAboutSchemeHandler(), WebKit::AboutSchemeHandler::scheme);
+    _page->setURLSchemeHandlerForScheme(protect(_page->aboutSchemeHandler()), WebKit::AboutSchemeHandler::scheme);
 
     _page->setCocoaView(self);
 
@@ -1150,12 +1150,12 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 
 - (NSString *)title
 {
-    return _page->protectedPageLoadState()->title().createNSString().autorelease();
+    return protect(_page->pageLoadState())->title().createNSString().autorelease();
 }
 
 - (NSURL *)URL
 {
-    return [NSURL _web_URLWithWTFString:_page->protectedPageLoadState()->activeURL()];
+    return [NSURL _web_URLWithWTFString:protect(_page->pageLoadState())->activeURL()];
 }
 
 - (NSURL *)_resourceDirectoryURL
@@ -1165,17 +1165,17 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 
 - (BOOL)isLoading
 {
-    return _page->protectedPageLoadState()->isLoading();
+    return protect(_page->pageLoadState())->isLoading();
 }
 
 - (double)estimatedProgress
 {
-    return _page->protectedPageLoadState()->estimatedProgress();
+    return protect(_page->pageLoadState())->estimatedProgress();
 }
 
 - (BOOL)hasOnlySecureContent
 {
-    return _page->protectedPageLoadState()->hasOnlySecureContent();
+    return protect(_page->pageLoadState())->hasOnlySecureContent();
 }
 
 - (SecTrustRef)serverTrust
@@ -1199,13 +1199,13 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 - (BOOL)canGoBack
 {
     [self _didAccessBackForwardList];
-    return _page->protectedPageLoadState()->canGoBack();
+    return protect(_page->pageLoadState())->canGoBack();
 }
 
 - (BOOL)canGoForward
 {
     [self _didAccessBackForwardList];
-    return _page->protectedPageLoadState()->canGoForward();
+    return protect(_page->pageLoadState())->canGoForward();
 }
 
 - (WKNavigation *)goBack
@@ -3943,7 +3943,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 
 - (BOOL)_negotiatedLegacyTLS
 {
-    return _page->protectedPageLoadState()->hasNegotiatedLegacyTLS();
+    return protect(_page->pageLoadState())->hasNegotiatedLegacyTLS();
 }
 
 - (BOOL)_wasPrivateRelayed
@@ -5226,7 +5226,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_clearBackForwardCache
 {
     THROW_IF_SUSPENDED;
-    _page->configuration().protectedProcessPool()->backForwardCache().removeEntriesForPage(*_page);
+    protect(_page->configuration().processPool())->backForwardCache().removeEntriesForPage(*_page);
 }
 
 + (BOOL)_handlesSafeBrowsing

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -357,7 +357,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKProcessPool *)processPool
 {
-    return wrapper(self._protectedPageConfiguration->protectedProcessPool().get());
+    return wrapper(protect(self._protectedPageConfiguration->processPool()).get());
 }
 
 - (void)setProcessPool:(WKProcessPool *)processPool
@@ -470,7 +470,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKWebsiteDataStore *)websiteDataStore
 {
-    return wrapper(self._protectedPageConfiguration->protectedWebsiteDataStore().get());
+    return wrapper(protect(self._protectedPageConfiguration->websiteDataStore()).get());
 }
 
 - (WKAudiovisualMediaTypes)mediaTypesRequiringUserActionForPlayback

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -453,12 +453,12 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (BOOL)_hasServiceWorkerBackgroundActivityForTesting
 {
-    return _page ? _page->configuration().protectedProcessPool()->hasServiceWorkerBackgroundActivityForTesting() : false;
+    return _page ? protect(_page->configuration().processPool())->hasServiceWorkerBackgroundActivityForTesting() : false;
 }
 
 - (BOOL)_hasServiceWorkerForegroundActivityForTesting
 {
-    return _page ? _page->configuration().protectedProcessPool()->hasServiceWorkerForegroundActivityForTesting() : false;
+    return _page ? protect(_page->configuration().processPool())->hasServiceWorkerForegroundActivityForTesting() : false;
 }
 
 - (void)_denyNextUserMediaRequest

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm
@@ -53,7 +53,7 @@
 - (_WKHitTestResult *)hitTestResult
 {
     auto& hitTestResultData = _contextMenuElementInfoMac->hitTestResultData();
-    auto apiHitTestResult = API::HitTestResult::create(hitTestResultData, _contextMenuElementInfoMac->protectedPage().get());
+    auto apiHitTestResult = API::HitTestResult::create(hitTestResultData, protect(_contextMenuElementInfoMac->page()).get());
     return retainPtr(wrapper(apiHitTestResult)).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
@@ -53,7 +53,7 @@
 - (NSArray<_WKFrameTreeNode *> *)childFrames
 {
     return createNSArray(_node->childFrames(), [&] (auto& child) {
-        return wrapper(API::FrameTreeNode::create(WebKit::FrameTreeNodeData(child), Ref { *_node }->protectedPage()));
+        return wrapper(API::FrameTreeNode::create(WebKit::FrameTreeNodeData(child), protect(Ref { *_node }->page())));
     }).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -221,7 +221,7 @@ void BidiBrowsingContextAgent::getTree(const BrowsingContext& optionalRoot, std:
 
     Vector<Ref<WebPageProxy>> pagesToProcess;
 
-    for (Ref process : session->protectedProcessPool()->processes()) {
+    for (Ref process : protect(session->processPool())->processes()) {
         for (Ref page : process->pages()) {
             if (!page->isControlledByAutomation())
                 continue;

--- a/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp
@@ -56,7 +56,7 @@ BidiPermissionsAgent::~BidiPermissionsAgent() = default;
 static Vector<Ref<WebPageProxy>> allPageProxiesFor(const WebAutomationSession& session)
 {
     Vector<Ref<WebPageProxy>> pages;
-    for (Ref process : session.protectedProcessPool()->processes()) {
+    for (Ref process : protect(session.processPool())->processes()) {
         for (Ref page : process->pages()) {
             if (!page->isControlledByAutomation())
                 continue;
@@ -86,7 +86,7 @@ void BidiPermissionsAgent::setPermission(Ref<JSON::Object>&& descriptor, const S
         });
 
         for (auto page : allPageProxiesFor(*session)) {
-            auto pageOrigin = RegistrableDomain { page->protectedPageLoadState()->origin() };
+            auto pageOrigin = RegistrableDomain { protect(page->pageLoadState())->origin() };
             if (pageOrigin != topFrameOrigin)
                 continue;
 

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -205,7 +205,7 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
         pagesToProcess.append(*resolvedPageForContext);
     else {
         // Enumerate all controlled pages; filtering by context happens during collection
-        for (Ref process : session->protectedProcessPool()->processes()) {
+        for (Ref process : protect(session->processPool())->processes()) {
             for (Ref page : process->pages()) {
                 if (page->isControlledByAutomation())
                     pagesToProcess.append(page);
@@ -405,7 +405,7 @@ std::optional<String> BidiScriptAgent::contextHandleForFrame(const FrameInfoData
         return std::nullopt;
 
     if (frameInfo.webPageProxyID) {
-        for (Ref process : session->protectedProcessPool()->processes()) {
+        for (Ref process : protect(session->processPool())->processes()) {
             for (Ref page : process->pages()) {
                 if (page->identifier() == *frameInfo.webPageProxyID)
                     return session->handleForWebPageProxy(page);

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp
@@ -224,7 +224,7 @@ void SimulatedInputDispatcher::resolveLocation(const WebCore::IntPoint& currentL
         break;
     }
     case MouseMoveOrigin::Element: {
-        m_client.viewportInViewCenterPointOfElement(protectedPage(), m_frameID, nodeHandle.value(), [destination = location.value(), completionHandler = WTF::move(completionHandler)](std::optional<WebCore::IntPoint> inViewCenterPoint, std::optional<AutomationCommandError> error) mutable {
+        m_client.viewportInViewCenterPointOfElement(protect(m_page), m_frameID, nodeHandle.value(), [destination = location.value(), completionHandler = WTF::move(completionHandler)](std::optional<WebCore::IntPoint> inViewCenterPoint, std::optional<AutomationCommandError> error) mutable {
             if (error) {
                 completionHandler(std::nullopt, error);
                 return;
@@ -241,11 +241,6 @@ void SimulatedInputDispatcher::resolveLocation(const WebCore::IntPoint& currentL
         break;
     }
     }
-}
-
-Ref<WebPageProxy> SimulatedInputDispatcher::protectedPage() const
-{
-    return m_page.get();
 }
 
 void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource& inputSource, SimulatedInputSourceState& newState, AutomationCompletionHandler&& completionHandler)
@@ -308,7 +303,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
                     String mouseButtonName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(b.pressedMouseButton.value_or(MouseButton::None));
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating %s[button=%s] @ (%d, %d) for transition to %d.%d", this, interactionName.utf8().data(), mouseButtonName.utf8().data(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
 #endif
-                    m_client.simulateMouseInteraction(protectedPage(), b.mouseInteraction.value(), b.pressedMouseButton.value_or(MouseButton::None), b.location.value(), pointerType, WTF::move(eventDispatchFinished));
+                    m_client.simulateMouseInteraction(protect(m_page), b.mouseInteraction.value(), b.pressedMouseButton.value_or(MouseButton::None), b.location.value(), pointerType, WTF::move(eventDispatchFinished));
                 } else
                     eventDispatchFinished({ });
             } else
@@ -336,13 +331,13 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
             // The "dispatch a pointer{Down,Up,Move} action" algorithms (§17.4 Dispatching Actions).
             if (!a.pressedMouseButton && b.pressedMouseButton) {
                 LOG(Automation, "SimulatedInputDispatcher[%p]: simulating TouchDown @ (%d, %d) for transition to %d.%d", this, b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protectedPage(), TouchInteraction::TouchDown, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
+                m_client.simulateTouchInteraction(protect(m_page), TouchInteraction::TouchDown, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
             } else if (a.pressedMouseButton && !b.pressedMouseButton) {
                 LOG(Automation, "SimulatedInputDispatcher[%p]: simulating LiftUp @ (%d, %d) for transition to %d.%d", this, b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protectedPage(), TouchInteraction::LiftUp, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
+                m_client.simulateTouchInteraction(protect(m_page), TouchInteraction::LiftUp, b.location.value(), std::nullopt, WTF::move(eventDispatchFinished));
             } else if (a.location != b.location) {
                 LOG(Automation, "SimulatedInputDispatcher[%p]: simulating MoveTo from (%d, %d) to (%d, %d) for transition to %d.%d", this, a.location.value().x(), a.location.value().y(), b.location.value().x(), b.location.value().y(), m_keyframeIndex, m_inputSourceStateIndex);
-                m_client.simulateTouchInteraction(protectedPage(), TouchInteraction::MoveTo, b.location.value(), a.duration.value_or(0_s), WTF::move(eventDispatchFinished));
+                m_client.simulateTouchInteraction(protect(m_page), TouchInteraction::MoveTo, b.location.value(), a.duration.value_or(0_s), WTF::move(eventDispatchFinished));
             } else
                 eventDispatchFinished(std::nullopt);
         });
@@ -381,7 +376,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
 #else
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyPress[key=%c] for transition to %d.%d", this, charKey, m_keyframeIndex, m_inputSourceStateIndex);
 #endif
-                    m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyPress, charKey, WTF::move(eventDispatchFinished));
+                    m_client.simulateKeyboardInteraction(protect(m_page), KeyboardInteraction::KeyPress, charKey, WTF::move(eventDispatchFinished));
                 }
             }
 
@@ -399,7 +394,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
 #else
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyRelease[key=%c] for transition to %d.%d", this, charKey, m_keyframeIndex, m_inputSourceStateIndex);
 #endif
-                    m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyRelease, charKey, WTF::move(eventDispatchFinished));
+                    m_client.simulateKeyboardInteraction(protect(m_page), KeyboardInteraction::KeyRelease, charKey, WTF::move(eventDispatchFinished));
                 }
             }
         } else if (a.pressedVirtualKeys != b.pressedVirtualKeys) {
@@ -414,7 +409,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
                     String virtualKeyName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(iter.value);
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyPress[key=%s] for transition to %d.%d", this, virtualKeyName.utf8().data(), m_keyframeIndex, m_inputSourceStateIndex);
 #endif
-                    m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyPress, iter.value, WTF::move(eventDispatchFinished));
+                    m_client.simulateKeyboardInteraction(protect(m_page), KeyboardInteraction::KeyPress, iter.value, WTF::move(eventDispatchFinished));
                 }
             }
 
@@ -428,7 +423,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
                     String virtualKeyName = Inspector::Protocol::AutomationHelpers::getEnumConstantValue(iter.value);
                     LOG(Automation, "SimulatedInputDispatcher[%p]: simulating KeyRelease[key=%s] for transition to %d.%d", this, virtualKeyName.utf8().data(), m_keyframeIndex, m_inputSourceStateIndex);
 #endif
-                    m_client.simulateKeyboardInteraction(protectedPage(), KeyboardInteraction::KeyRelease, iter.value, WTF::move(eventDispatchFinished));
+                    m_client.simulateKeyboardInteraction(protect(m_page), KeyboardInteraction::KeyRelease, iter.value, WTF::move(eventDispatchFinished));
                 }
             }
         } else
@@ -462,7 +457,7 @@ void SimulatedInputDispatcher::transitionInputSourceToState(SimulatedInputSource
             if (!usedScrollDelta.isZero()) {
                 LOG(Automation, "SimulatedInputDispatcher[%p]: simulating Wheel from (%d, %d) to (%d, %d) for transition to %d.%d", this, aScrollDelta.width(), aScrollDelta.height(), bScrollDelta.width(), bScrollDelta.height(), m_keyframeIndex, m_inputSourceStateIndex);
                 // FIXME: This does not interpolate mouse scrolls per the "perform a scroll" algorithm (§15.4.4 Wheel actions).
-                m_client.simulateWheelInteraction(protectedPage(), b.location.value(), usedScrollDelta, WTF::move(eventDispatchFinished));
+                m_client.simulateWheelInteraction(protect(m_page), b.location.value(), usedScrollDelta, WTF::move(eventDispatchFinished));
             } else
                 eventDispatchFinished(std::nullopt);
         });

--- a/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
+++ b/Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h
@@ -178,8 +178,6 @@ private:
 
     void resolveLocation(const WebCore::IntPoint& currentLocation, std::optional<WebCore::IntPoint> location, MouseMoveOrigin, std::optional<String> nodeHandle, Function<void (std::optional<WebCore::IntPoint>, std::optional<AutomationCommandError>)>&&);
 
-    Ref<WebPageProxy> protectedPage() const;
-
     WeakRef<WebPageProxy> m_page;
     SimulatedInputDispatcher::Client& m_client;
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -159,7 +159,7 @@ public:
     void setSessionIdentifier(const String& sessionIdentifier) { m_sessionIdentifier = sessionIdentifier; }
     String sessionIdentifier() const { return m_sessionIdentifier; }
 
-    RefPtr<WebProcessPool> protectedProcessPool() const;
+    WebProcessPool* processPool() const;
     void setProcessPool(WebProcessPool*);
 
     void navigationOccurredForFrame(const WebFrameProxy&);

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -81,7 +81,7 @@ void BrowsingContextGroup::sharedProcessForSite(WebsiteDataStore& websiteDataSto
             return completionHandler(frameProcess.get());
         }
 
-        Ref process = pageConfiguration->protectedProcessPool()->processForSite(websiteDataStore.get(), WebProcessPool::IsSharedProcess::Yes, site, mainFrameSite, domainsWithUserInteraction, lockdownMode, enhancedSecurity, pageConfiguration.get(), ProcessSwapDisposition::Other);
+        Ref process = protect(pageConfiguration->processPool())->processForSite(websiteDataStore.get(), WebProcessPool::IsSharedProcess::Yes, site, mainFrameSite, domainsWithUserInteraction, lockdownMode, enhancedSecurity, pageConfiguration.get(), ProcessSwapDisposition::Other);
         ASSERT(!process->isInProcessCache());
         Ref frameProcess = FrameProcess::create(process, protectedThis, std::nullopt, mainFrameSite, preferences, LoadedWebArchive::No, BrowsingContextGroupUpdate::AddProcessAndInjectBrowsingContext);
         ASSERT(frameProcess->isSharedProcess());
@@ -300,11 +300,11 @@ void BrowsingContextGroup::transitionPageToRemotePage(WebPageProxy& page, const 
 
 void BrowsingContextGroup::transitionProvisionalPageToRemotePage(ProvisionalPageProxy& page, const Site& provisionalNavigationFailureSite)
 {
-    auto& set = m_remotePages.ensure(*page.protectedPage(), [] {
+    auto& set = m_remotePages.ensure(*protect(page.page()), [] {
         return HashSet<Ref<RemotePageProxy>> { };
     }).iterator->value;
 
-    Ref newRemotePage = RemotePageProxy::create(*page.protectedPage(), page.protectedProcess(), provisionalNavigationFailureSite, &page.messageReceiverRegistration(), page.webPageID());
+    Ref newRemotePage = RemotePageProxy::create(*protect(page.page()), protect(page.process()), provisionalNavigationFailureSite, &page.messageReceiverRegistration(), page.webPageID());
 #if ASSERT_ENABLED
     for (auto& existingPage : set) {
         ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->site() != newRemotePage->site());

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -132,7 +132,7 @@ NavigationState::NavigationState(WKWebView *webView)
     ASSERT(!navigationStates().contains(*page));
 
     navigationStates().add(*page, *this);
-    page->protectedPageLoadState()->addObserver(*this);
+    protect(page->pageLoadState())->addObserver(*this);
 }
 
 NavigationState::~NavigationState()
@@ -142,7 +142,7 @@ NavigationState::~NavigationState()
         ASSERT(navigationStates().get(*page) == this);
 
         navigationStates().remove(*page);
-        page->protectedPageLoadState()->removeObserver(*this);
+        protect(page->pageLoadState())->removeObserver(*this);
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -65,7 +65,7 @@ void NavigationSOAuthorizationSession::shouldStartInternal()
         setState(State::Waiting);
         page->addDidMoveToWindowObserver(*this);
         ASSERT(page->mainFrame());
-        m_waitingPageActiveURL = page->protectedPageLoadState()->activeURL();
+        m_waitingPageActiveURL = protect(page->pageLoadState())->activeURL();
         return;
     }
     start();
@@ -90,7 +90,7 @@ bool NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting() con
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("pageActiveURLDidChangeDuringWaiting");
     RefPtr page = this->page();
-    return !page || page->protectedPageLoadState()->activeURL() != m_waitingPageActiveURL;
+    return !page || protect(page->pageLoadState())->activeURL() != m_waitingPageActiveURL;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -591,7 +591,7 @@ void UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest(WebKit::W
         return;
 
     if (uiDelegate->m_delegateMethods.webViewRequestGeolocationPermissionForOriginDecisionHandler) {
-        auto securityOrigin = WebCore::SecurityOrigin::createFromString(page.protectedPageLoadState()->activeURL());
+        auto securityOrigin = WebCore::SecurityOrigin::createFromString(protect(page.pageLoadState())->activeURL());
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestGeolocationPermissionForOrigin:initiatedByFrame:decisionHandler:));
         auto decisionHandler = makeBlockPtr([completionHandler = std::exchange(completionHandler, nullptr), securityOrigin = securityOrigin->data(), checker = WTF::move(checker), page = WeakPtr { page }] (WKPermissionDecision decision) mutable {
             if (checker->completionHandlerHasBeenCalled())
@@ -1255,7 +1255,7 @@ void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUI
 #if ENABLE(DEVICE_ORIENTATION)
 void UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess(WebKit::WebPageProxy& page, WebFrameProxy& webFrameProxy, FrameInfoData&& frameInfo, CompletionHandler<void(bool)>&& completionHandler)
 {
-    Ref securityOrigin = WebCore::SecurityOrigin::createFromString(page.protectedPageLoadState()->activeURL());
+    Ref securityOrigin = WebCore::SecurityOrigin::createFromString(protect(page.pageLoadState())->activeURL());
     RefPtr uiDelegate = m_uiDelegate.get();
     if (!uiDelegate || !uiDelegate->m_delegate.get() || !uiDelegate->m_delegateMethods.webViewRequestDeviceOrientationAndMotionPermissionForOriginDecisionHandler) {
         alertForPermission(page, MediaPermissionReason::DeviceOrientation, securityOrigin->data(), WTF::move(completionHandler));

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1114,7 +1114,7 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
     UNUSED_PARAM(blocksReturnToFullscreenFromPictureInPicture);
     IntRect initialWindowRect;
     page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
-    interface->setupFullscreen(initialWindowRect, page->protectedPlatformWindow().get(), videoFullscreenMode, allowsPictureInPicture);
+    interface->setupFullscreen(initialWindowRect, protect(page->platformWindow()).get(), videoFullscreenMode, allowsPictureInPicture);
     interface->setupCaptionsLayer(retainPtr([view layer]).get(), initialSize);
 #endif
 }
@@ -1223,7 +1223,7 @@ void VideoPresentationManagerProxy::exitFullscreen(PlaybackSessionContextIdentif
 #if PLATFORM(IOS_FAMILY)
     completionHandler(ensureInterface(contextId)->exitFullscreen(finalRect));
 #else
-    completionHandler(ensureInterface(contextId)->exitFullscreen(finalWindowRect, page->protectedPlatformWindow().get()));
+    completionHandler(ensureInterface(contextId)->exitFullscreen(finalWindowRect, protect(page->platformWindow()).get()));
 #endif
 }
 
@@ -1324,7 +1324,7 @@ void VideoPresentationManagerProxy::preparedToReturnToInline(PlaybackSessionCont
 #if PLATFORM(IOS_FAMILY)
     ensureInterface(contextId)->preparedToReturnToInline(visible, inlineRect);
 #else
-    ensureInterface(contextId)->preparedToReturnToInline(visible, inlineWindowRect, page->protectedPlatformWindow().get());
+    ensureInterface(contextId)->preparedToReturnToInline(visible, inlineWindowRect, protect(page->platformWindow()).get());
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -94,7 +94,7 @@ std::optional<IPC::AsyncReplyID> WebPasteboardProxy::grantAccessToCurrentData(We
         return std::nullopt;
     }
     auto processIdentifier = process.coreProcessIdentifier();
-    return process.protectedWebsiteDataStore()->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(processIdentifier, paths), WTF::move(completionHandler));
+    return protect(process.websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(processIdentifier, paths), WTF::move(completionHandler));
 }
 
 void WebPasteboardProxy::grantAccess(WebProcessProxy& process, const String& pasteboardName, PasteboardAccessType type)
@@ -813,7 +813,7 @@ void WebPasteboardProxy::createOneWebArchiveFromFrames(WebProcessProxy& requeste
             continue;
         }
 
-        frameByProcess.ensure(currentFrame->protectedProcess(), [&] {
+        frameByProcess.ensure(protect(currentFrame->process()), [&] {
             return Vector<WebCore::FrameIdentifier> { };
         }).iterator->value.append(frameIdentifier);
     }

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
@@ -72,11 +72,6 @@ void DownloadProxyMap::deref() const
     m_process->deref();
 }
 
-Ref<NetworkProcessProxy> DownloadProxyMap::protectedProcess()
-{
-    return m_process.get();
-}
-
 #if !PLATFORM(COCOA)
 void DownloadProxyMap::platformCreate()
 {
@@ -100,7 +95,7 @@ Ref<DownloadProxy> DownloadProxyMap::createDownloadProxy(WebsiteDataStore& dataS
         RELEASE_LOG(ProcessSuspension, "UIProcess took 'WebKit downloads' assertion for UIProcess");
     }
 
-    protectedProcess()->addMessageReceiver(Messages::DownloadProxy::messageReceiverName(), downloadProxy->downloadID().toUInt64(), downloadProxy.get());
+    protect(process())->addMessageReceiver(Messages::DownloadProxy::messageReceiverName(), downloadProxy->downloadID().toUInt64(), downloadProxy.get());
 
     return downloadProxy;
 }
@@ -113,7 +108,7 @@ void DownloadProxyMap::downloadFinished(DownloadProxy& downloadProxy)
 
     ASSERT(m_downloads.contains(downloadID));
 
-    protectedProcess()->removeMessageReceiver(Messages::DownloadProxy::messageReceiverName(), downloadID.toUInt64());
+    protect(process())->removeMessageReceiver(Messages::DownloadProxy::messageReceiverName(), downloadID.toUInt64());
     downloadProxy.invalidate();
     m_downloads.remove(downloadID);
 
@@ -130,7 +125,7 @@ void DownloadProxyMap::invalidate()
     for (const auto& download : m_downloads.values()) {
         download->processDidClose();
         download->invalidate();
-        protectedProcess()->removeMessageReceiver(Messages::DownloadProxy::messageReceiverName(), download->downloadID().toUInt64());
+        protect(process())->removeMessageReceiver(Messages::DownloadProxy::messageReceiverName(), download->downloadID().toUInt64());
     }
 
     m_downloads.clear();

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -70,7 +70,7 @@ public:
     void deref() const;
 
 private:
-    Ref<NetworkProcessProxy> protectedProcess();
+    NetworkProcessProxy& process() const { return m_process; }
 
     void platformCreate();
     void platformDestroy();

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -136,7 +136,7 @@ MachSendRight DrawingAreaProxy::createFence()
 #if PLATFORM(MAC)
 void DrawingAreaProxy::didChangeViewExposedRect()
 {
-    if (!protectedPage()->hasRunningProcess())
+    if (!protect(page())->hasRunningProcess())
         return;
 
     if (!m_viewExposedRectChangedTimer.isActive())

--- a/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
+++ b/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
@@ -109,7 +109,7 @@ FindStringCallbackAggregator::~FindStringCallbackAggregator()
     };
 
     Ref targetFrame = frameContainingMatch ? *frameContainingMatch : *focusedFrame;
-    targetFrame->protectedProcess()->sendWithAsyncReply(WTF::move(message), WTF::move(completionHandler), protectedPage->webPageIDInProcess(targetFrame->protectedProcess()));
+    protect(targetFrame->process())->sendWithAsyncReply(WTF::move(message), WTF::move(completionHandler), protectedPage->webPageIDInProcess(protect(targetFrame->process())));
     if (frameContainingMatch && focusedFrame && focusedFrame->process() != frameContainingMatch->process())
         protectedPage->clearSelection(focusedFrame->frameID());
 }

--- a/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
@@ -66,12 +66,12 @@ WebFrameInspectorTargetProxy::~WebFrameInspectorTargetProxy() = default;
 void WebFrameInspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType connectionType)
 {
     if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        provisionalFrame->protectedProcess()->send(Messages::WebFrame::ConnectInspector(connectionType), provisionalFrame->protectedFrame()->frameID());
+        protect(provisionalFrame->process())->send(Messages::WebFrame::ConnectInspector(connectionType), provisionalFrame->protectedFrame()->frameID());
         return;
     }
 
     Ref frame = m_frame.get();
-    frame->protectedProcess()->send(Messages::WebFrame::ConnectInspector(connectionType), frame->frameID());
+    protect(frame->process())->send(Messages::WebFrame::ConnectInspector(connectionType), frame->frameID());
 }
 
 void WebFrameInspectorTargetProxy::disconnect()
@@ -80,23 +80,23 @@ void WebFrameInspectorTargetProxy::disconnect()
         resume();
 
     if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        provisionalFrame->protectedProcess()->send(Messages::WebFrame::DisconnectInspector(), provisionalFrame->protectedFrame()->frameID());
+        protect(provisionalFrame->process())->send(Messages::WebFrame::DisconnectInspector(), provisionalFrame->protectedFrame()->frameID());
         return;
     }
 
     Ref frame = m_frame.get();
-    frame->protectedProcess()->send(Messages::WebFrame::DisconnectInspector(), frame->frameID());
+    protect(frame->process())->send(Messages::WebFrame::DisconnectInspector(), frame->frameID());
 }
 
 void WebFrameInspectorTargetProxy::sendMessageToTargetBackend(const String& message)
 {
     if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        provisionalFrame->protectedProcess()->send(Messages::WebFrame::SendMessageToInspectorTarget(message), provisionalFrame->protectedFrame()->frameID());
+        protect(provisionalFrame->process())->send(Messages::WebFrame::SendMessageToInspectorTarget(message), provisionalFrame->protectedFrame()->frameID());
         return;
     }
 
     Ref frame = m_frame.get();
-    frame->protectedProcess()->send(Messages::WebFrame::SendMessageToInspectorTarget(message), frame->frameID());
+    protect(frame->process())->send(Messages::WebFrame::SendMessageToInspectorTarget(message), frame->frameID());
 }
 
 void WebFrameInspectorTargetProxy::didCommitProvisionalTarget()

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -606,7 +606,7 @@ void WebInspectorUIProxy::platformBringToFront()
 void WebInspectorUIProxy::platformBringInspectedPageToFront()
 {
     if (RefPtr inspectedPage = m_inspectedPage.get())
-        [inspectedPage->protectedPlatformWindow() makeKeyAndOrderFront:nil];
+        [protect(inspectedPage->platformWindow()) makeKeyAndOrderFront:nil];
 }
 
 bool WebInspectorUIProxy::platformIsFront()

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -141,11 +141,6 @@ void RemoteInspectorProtocolHandler::inspect(const String& hostAndPort, Connecti
         m_inspectorClient->inspect(connectionID, targetID, debuggableType.value());
 }
 
-Ref<WebPageProxy> RemoteInspectorProtocolHandler::protectedPage() const
-{
-    return m_page.get();
-}
-
 void RemoteInspectorProtocolHandler::runScript(const String& script)
 {
     constexpr bool wantsResult = true;
@@ -154,7 +149,7 @@ void RemoteInspectorProtocolHandler::runScript(const String& script)
         LOG_ERROR("Out of memory running script");
         return;
     }
-    protectedPage()->runJavaScriptInMainFrame(WebKit::RunJavaScriptParameters {
+    protect(m_page)->runJavaScriptInMainFrame(WebKit::RunJavaScriptParameters {
         WTF::move(*scriptString),
         JSC::SourceTaintedOrigin::Untainted,
         URL { },
@@ -213,7 +208,7 @@ void RemoteInspectorProtocolHandler::platformStartTask(WebPageProxy& pageProxy, 
     pageProxy.configuration().userContentController().addUserScriptMessageHandler(handler.get());
 
     // Setup loader client to get notified of page load
-    protectedPage()->setLoaderClient(makeUnique<LoaderClient>([this] {
+    protect(m_page)->setLoaderClient(makeUnique<LoaderClient>([this] {
         m_pageLoaded = true;
         updateTargetList();
     }));

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.h
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.h
@@ -61,7 +61,6 @@ private:
     void updateTargetList();
 
     void runScript(const String&);
-    Ref<WebPageProxy> protectedPage() const;
 
     std::unique_ptr<RemoteInspectorClient> m_inspectorClient;
     WeakRef<WebPageProxy> m_page;

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
@@ -70,14 +70,9 @@ void AudioSessionRoutingArbitratorProxy::endRoutingArbitration()
 
 #endif // ENABLE(AVAUDIO_ROUTING_ARBITER)
 
-Ref<WebProcessProxy> AudioSessionRoutingArbitratorProxy::protectedProcess()
-{
-    return m_process.get();
-}
-
 Logger& AudioSessionRoutingArbitratorProxy::logger()
 {
-    return protectedProcess()->logger();
+    return protect(m_process)->logger();
 }
 
 WTFLogChannel& AudioSessionRoutingArbitratorProxy::logChannel() const

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -79,8 +79,6 @@ protected:
     WTFLogChannel& logChannel() const;
 
 private:
-    Ref<WebProcessProxy> protectedProcess();
-
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp
@@ -46,11 +46,6 @@ void LegacyCustomProtocolManagerProxy::deref() const
     m_networkProcessProxy->deref();
 }
 
-Ref<NetworkProcessProxy> LegacyCustomProtocolManagerProxy::protectedProcess()
-{
-    return m_networkProcessProxy.get();
-}
-
 LegacyCustomProtocolManagerProxy::~LegacyCustomProtocolManagerProxy()
 {
     Ref<NetworkProcessProxy> networkProcessProxy = m_networkProcessProxy.get();
@@ -60,12 +55,12 @@ LegacyCustomProtocolManagerProxy::~LegacyCustomProtocolManagerProxy()
 
 void LegacyCustomProtocolManagerProxy::startLoading(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceRequest& request)
 {
-    protectedProcess()->customProtocolManagerClient().startLoading(*this, customProtocolID, request);
+    protect(m_networkProcessProxy)->customProtocolManagerClient().startLoading(*this, customProtocolID, request);
 }
 
 void LegacyCustomProtocolManagerProxy::stopLoading(LegacyCustomProtocolID customProtocolID)
 {
-    protectedProcess()->customProtocolManagerClient().stopLoading(*this, customProtocolID);
+    protect(m_networkProcessProxy)->customProtocolManagerClient().stopLoading(*this, customProtocolID);
 }
 
 void LegacyCustomProtocolManagerProxy::invalidate()
@@ -76,27 +71,27 @@ void LegacyCustomProtocolManagerProxy::invalidate()
 
 void LegacyCustomProtocolManagerProxy::wasRedirectedToRequest(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceRequest& request, const WebCore::ResourceResponse& redirectResponse)
 {
-    protectedProcess()->send(Messages::LegacyCustomProtocolManager::WasRedirectedToRequest(customProtocolID, request, redirectResponse), 0);
+    protect(m_networkProcessProxy)->send(Messages::LegacyCustomProtocolManager::WasRedirectedToRequest(customProtocolID, request, redirectResponse), 0);
 }
 
 void LegacyCustomProtocolManagerProxy::didReceiveResponse(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceResponse& response, CacheStoragePolicy cacheStoragePolicy)
 {
-    protectedProcess()->send(Messages::LegacyCustomProtocolManager::DidReceiveResponse(customProtocolID, response, cacheStoragePolicy), 0);
+    protect(m_networkProcessProxy)->send(Messages::LegacyCustomProtocolManager::DidReceiveResponse(customProtocolID, response, cacheStoragePolicy), 0);
 }
 
 void LegacyCustomProtocolManagerProxy::didLoadData(LegacyCustomProtocolID customProtocolID, std::span<const uint8_t> data)
 {
-    protectedProcess()->send(Messages::LegacyCustomProtocolManager::DidLoadData(customProtocolID, data), 0);
+    protect(m_networkProcessProxy)->send(Messages::LegacyCustomProtocolManager::DidLoadData(customProtocolID, data), 0);
 }
 
 void LegacyCustomProtocolManagerProxy::didFailWithError(LegacyCustomProtocolID customProtocolID, const WebCore::ResourceError& error)
 {
-    protectedProcess()->send(Messages::LegacyCustomProtocolManager::DidFailWithError(customProtocolID, error), 0);
+    protect(m_networkProcessProxy)->send(Messages::LegacyCustomProtocolManager::DidFailWithError(customProtocolID, error), 0);
 }
 
 void LegacyCustomProtocolManagerProxy::didFinishLoading(LegacyCustomProtocolID customProtocolID)
 {
-    protectedProcess()->send(Messages::LegacyCustomProtocolManager::DidFinishLoading(customProtocolID), 0);
+    protect(m_networkProcessProxy)->send(Messages::LegacyCustomProtocolManager::DidFinishLoading(customProtocolID), 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
+++ b/Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h
@@ -67,8 +67,6 @@ public:
     void deref() const final;
 
 private:
-    Ref<NetworkProcessProxy> protectedProcess();
-
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -50,11 +50,6 @@ void WebNotificationManagerMessageHandler::deref() const
     m_webPageProxy->deref();
 }
 
-Ref<WebPageProxy> WebNotificationManagerMessageHandler::protectedPage() const
-{
-    return m_webPageProxy.get();
-}
-
 void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& connection, const WebCore::NotificationData& data, RefPtr<WebCore::NotificationResources>&& resources, CompletionHandler<void()>&& callback)
 {
     RELEASE_LOG(Push, "WebNotificationManagerMessageHandler showNotification called");
@@ -63,7 +58,7 @@ void WebNotificationManagerMessageHandler::showNotification(IPC::Connection& con
         ServiceWorkerNotificationHandler::singleton().showNotification(connection, data, WTF::move(resources), WTF::move(callback));
         return;
     }
-    protectedPage()->showNotification(connection, data, WTF::move(resources));
+    protect(page())->showNotification(connection, data, WTF::move(resources));
     callback();
 }
 
@@ -74,7 +69,7 @@ void WebNotificationManagerMessageHandler::cancelNotification(WebCore::SecurityO
         serviceWorkerNotificationHandler->cancelNotification(WTF::move(origin), notificationID);
         return;
     }
-    protectedPage()->cancelNotification(notificationID);
+    protect(page())->cancelNotification(notificationID);
 }
 
 void WebNotificationManagerMessageHandler::clearNotifications(const Vector<WTF::UUID>& notificationIDs)
@@ -94,7 +89,7 @@ void WebNotificationManagerMessageHandler::clearNotifications(const Vector<WTF::
     if (!persistentNotifications.isEmpty())
         serviceWorkerNotificationHandler->clearNotifications(persistentNotifications);
     if (!pageNotifications.isEmpty())
-        protectedPage()->clearNotifications(pageNotifications);
+        protect(page())->clearNotifications(pageNotifications);
 }
 
 void WebNotificationManagerMessageHandler::didDestroyNotification(const WTF::UUID& notificationID)
@@ -104,12 +99,12 @@ void WebNotificationManagerMessageHandler::didDestroyNotification(const WTF::UUI
         serviceWorkerNotificationHandler->didDestroyNotification(notificationID);
         return;
     }
-    protectedPage()->didDestroyNotification(notificationID);
+    protect(page())->didDestroyNotification(notificationID);
 }
 
 void WebNotificationManagerMessageHandler::pageWasNotifiedOfNotificationPermission()
 {
-    protectedPage()->pageWillLikelyUseNotifications();
+    protect(page())->pageWillLikelyUseNotifications();
 }
 
 void WebNotificationManagerMessageHandler::requestPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&& completionHandler)
@@ -132,7 +127,7 @@ void WebNotificationManagerMessageHandler::getPermissionStateSync(WebCore::Secur
 
 std::optional<SharedPreferencesForWebProcess> WebNotificationManagerMessageHandler::sharedPreferencesForWebProcess(const IPC::Connection&) const
 {
-    return protect(protectedPage()->legacyMainFrameProcess())->sharedPreferencesForWebProcess();
+    return protect(protect(page())->legacyMainFrameProcess())->sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -51,7 +51,7 @@ private:
     void getPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
     void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const final;
-    Ref<WebPageProxy> protectedPage() const;
+    WebPageProxy& page() const { return m_webPageProxy; }
 
     WeakRef<WebPageProxy> m_webPageProxy;
 };

--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -83,11 +83,6 @@ void PageLoadState::endTransaction()
         commitChanges();
 }
 
-Ref<WebPageProxy> PageLoadState::protectedPage() const
-{
-    return m_webPageProxy.get();
-}
-
 void PageLoadState::ref() const
 {
     m_webPageProxy->ref();
@@ -143,7 +138,7 @@ void PageLoadState::commitChanges()
 
     m_committedState = m_uncommittedState;
 
-    protectedPage()->isLoadingChanged();
+    protect(page())->isLoadingChanged();
 
     // The "did" ordering is the reverse of the "will". This is a requirement of Cocoa Key-Value Observing.
     if (certificateInfoChanged)

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -255,7 +255,7 @@ private:
     static bool hasOnlySecureContent(const Data&);
     static double estimatedProgress(const Data&);
 
-    Ref<WebPageProxy> protectedPage() const;
+    WebPageProxy& page() const { return m_webPageProxy.get(); }
 
     WeakRef<WebPageProxy> m_webPageProxy;
 

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -174,8 +174,6 @@ private:
 
     class ProcessAssertionCache;
 
-    Ref<AuxiliaryProcessProxy> protectedProcess() const;
-
     const UniqueRef<ProcessAssertionCache> m_assertionCache;
     WeakRef<AuxiliaryProcessProxy> m_process;
     RefPtr<ProcessAssertion> m_assertion;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -101,13 +101,11 @@ public:
 
     WebPageProxy* page() { return m_page.get(); }
     const WebPageProxy* page() const { return m_page.get(); }
-    RefPtr<WebPageProxy> protectedPage() const;
 
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebFrameProxy* mainFrame() const { return m_mainFrame.get(); }
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup.get(); }
     WebProcessProxy& process();
-    Ref<WebProcessProxy> protectedProcess();
     ProcessSwapRequestedByClient processSwapRequestedByClient() const { return m_processSwapRequestedByClient; }
     WebCore::NavigationIdentifier navigationID() const { return m_navigationID; }
     const URL& provisionalURL() const { return m_provisionalLoadURL; }
@@ -157,8 +155,6 @@ public:
 
 private:
     ProvisionalPageProxy(WebPageProxy&, Ref<FrameProcess>&&, BrowsingContextGroup&, RefPtr<SuspendedPageProxy>&&, API::Navigation&, bool isServerRedirect, const WebCore::ResourceRequest&, ProcessSwapRequestedByClient, bool isProcessSwappingOnNavigationResponse, API::WebsitePolicies*, WebsiteDataStore* replacedDataStoreForWebArchiveLoad = nullptr);
-
-    RefPtr<WebFrameProxy> protectedMainFrame() const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -143,8 +143,8 @@ bool RemoteLayerTreeHost::updateBannerLayers(const std::optional<MainFrameData>&
     if (!page)
         return false;
 
-    bool headerBannerLayerChanged = updateBannerLayer(page->protectedHeaderBannerLayer().get(), scrolledContentsLayer.get());
-    bool footerBannerLayerChanged = updateBannerLayer(page->protectedFooterBannerLayer().get(), scrolledContentsLayer.get());
+    bool headerBannerLayerChanged = updateBannerLayer(protect(page->headerBannerLayer()).get(), scrolledContentsLayer.get());
+    bool footerBannerLayerChanged = updateBannerLayer(protect(page->footerBannerLayer()).get(), scrolledContentsLayer.get());
     return headerBannerLayerChanged || footerBannerLayerChanged;
 }
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -121,7 +121,7 @@ DelegatedScrollingMode RemoteLayerTreeDrawingAreaProxyMac::delegatedScrollingMod
 
 std::unique_ptr<RemoteScrollingCoordinatorProxy> RemoteLayerTreeDrawingAreaProxyMac::createScrollingCoordinatorProxy() const
 {
-    return makeUnique<RemoteScrollingCoordinatorProxyMac>(*protectedPage());
+    return makeUnique<RemoteScrollingCoordinatorProxyMac>(*protect(page()));
 }
 
 DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink()
@@ -140,7 +140,7 @@ DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::displayLink()
 {
     ASSERT(m_displayID);
 
-    auto& displayLinks = protectedPage()->configuration().processPool().displayLinks();
+    auto& displayLinks = protect(page())->configuration().processPool().displayLinks();
     return displayLinks.displayLinkForDisplay(*m_displayID);
 }
 
@@ -619,7 +619,7 @@ MachSendRight RemoteLayerTreeDrawingAreaProxyMac::createFence()
     if (!page)
         return MachSendRight();
 
-    RetainPtr<CAContext> rootLayerContext = [page->protectedAcceleratedCompositingRootLayer() context];
+    RetainPtr<CAContext> rootLayerContext = [protect(page->acceleratedCompositingRootLayer()) context];
     if (!rootLayerContext)
         return MachSendRight();
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
@@ -178,7 +178,7 @@ void SpeechRecognitionPermissionManager::continueProcessingRequest()
     }
     ASSERT(m_userPermissionCheck == CheckResult::Granted);
 
-    if (!protectedPage()->isViewVisible()) {
+    if (!protect(page())->isViewVisible()) {
         completeCurrentRequest(WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::NotAllowed, "Page is not visible to user"_s });
         return;
     }
@@ -255,7 +255,7 @@ void SpeechRecognitionPermissionManager::requestUserPermission(WebCore::SpeechRe
 
         protectedThis->continueProcessingRequest();
     };
-    protectedPage()->requestUserMediaPermissionForSpeechRecognition(recognitionRequest.mainFrameIdentifier(), WTF::move(frameInfo), requestingOrigin, topOrigin, WTF::move(decisionHandler));
+    protect(page())->requestUserMediaPermissionForSpeechRecognition(recognitionRequest.mainFrameIdentifier(), WTF::move(frameInfo), requestingOrigin, topOrigin, WTF::move(decisionHandler));
 }
 
 void SpeechRecognitionPermissionManager::decideByDefaultAction(const WebCore::SecurityOriginData& origin, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -288,7 +288,7 @@ void SuspendedPageProxy::didProcessRequestToSuspend(SuspensionState newSuspensio
 void SuspendedPageProxy::suspensionTimedOut()
 {
     RELEASE_LOG_ERROR(ProcessSwapping, "%p - SuspendedPageProxy::suspensionTimedOut() destroying the suspended page because it failed to suspend in time", this);
-    protectedBackForwardCache()->removeEntry(*this); // Will destroy |this|.
+    protect(backForwardCache())->removeEntry(*this); // Will destroy |this|.
 }
 
 WebPageProxy* SuspendedPageProxy::page() const

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -812,7 +812,7 @@ void UserMediaPermissionRequestManagerProxy::decidePolicyForUserMediaPermissionR
     // If page navigated, there is no need to call the page client for authorization.
     RefPtr webFrame = WebFrameProxy::webFrame(currentUserMediaRequest->frameID());
     RefPtr page = m_page.get();
-    if (!webFrame || !page || !protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), currentUserMediaRequest->topLevelDocumentSecurityOrigin().data().toURL())) {
+    if (!webFrame || !page || !protocolHostAndPortAreEqual(URL(protect(page->pageLoadState())->activeURL()), currentUserMediaRequest->topLevelDocumentSecurityOrigin().data().toURL())) {
         denyRequest(*currentUserMediaRequest, UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::NoConstraints);
         return;
     }
@@ -827,7 +827,7 @@ void UserMediaPermissionRequestManagerProxy::checkUserMediaPermissionForSpeechRe
 {
     RefPtr page = m_page.get();
     RefPtr frame = WebFrameProxy::webFrame(frameInfo.frameID);
-    if (!page || !frame || !protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), topOrigin.data().toURL())) {
+    if (!page || !frame || !protocolHostAndPortAreEqual(URL(protect(page->pageLoadState())->activeURL()), topOrigin.data().toURL())) {
         completionHandler(false);
         return;
     }
@@ -859,7 +859,7 @@ bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera
     if (!page)
         return false;
 
-    if (!protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), origin.topOrigin.toURL()))
+    if (!protocolHostAndPortAreEqual(URL(protect(page->pageLoadState())->activeURL()), origin.topOrigin.toURL()))
         return true;
 
     return std::ranges::none_of(m_deniedRequests, [](auto& request) { return request.isVideoDenied; })
@@ -873,7 +873,7 @@ bool UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrop
     if (!page)
         return false;
 
-    if (!protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), origin.topOrigin.toURL()))
+    if (!protocolHostAndPortAreEqual(URL(protect(page->pageLoadState())->activeURL()), origin.topOrigin.toURL()))
         return true;
 
     return std::ranges::none_of(m_deniedRequests, [](auto& request) { return request.isAudioDenied; })
@@ -934,7 +934,7 @@ void UserMediaPermissionRequestManagerProxy::getUserMediaPermissionInfo(FrameIde
 {
     RefPtr page = m_page.get();
     RefPtr webFrame = WebFrameProxy::webFrame(frameID);
-    if (!page || !webFrame || !protocolHostAndPortAreEqual(URL(page->protectedPageLoadState()->activeURL()), topLevelDocumentOrigin->data().toURL())) {
+    if (!page || !webFrame || !protocolHostAndPortAreEqual(URL(protect(page->pageLoadState())->activeURL()), topLevelDocumentOrigin->data().toURL())) {
         handler(PermissionState::Prompt, PermissionState::Prompt);
         return;
     }
@@ -1158,10 +1158,10 @@ void UserMediaPermissionRequestManagerProxy::syncWithWebCorePrefs() const
 
 #if ENABLE(GPU_PROCESS)
     if (preferences->captureAudioInGPUProcessEnabled() && preferences->useMicrophoneMuteStatusAPI())
-        page->legacyMainFrameProcess().protectedProcessPool()->ensureProtectedGPUProcess()->enableMicrophoneMuteStatusAPI();
+        protect(page->legacyMainFrameProcess().processPool())->ensureProtectedGPUProcess()->enableMicrophoneMuteStatusAPI();
 
     if (preferences->captureAudioInGPUProcessEnabled() || preferences->captureVideoInGPUProcessEnabled())
-        page->legacyMainFrameProcess().protectedProcessPool()->ensureProtectedGPUProcess()->setUseMockCaptureDevices(mockDevicesEnabled);
+        protect(page->legacyMainFrameProcess().processPool())->ensureProtectedGPUProcess()->setUseMockCaptureDevices(mockDevicesEnabled);
 #endif
 
     if (MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled() == mockDevicesEnabled)

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
@@ -180,7 +180,7 @@ void UserMediaPermissionRequestProxy::promptForGetDisplayMedia(UserMediaDisplayC
         return;
     }
 
-    alertForPermission(*manager->protectedPage(), MediaPermissionReason::ScreenCapture, topLevelDocumentSecurityOrigin().data(), [this, protectedThis = Ref { *this }](bool granted) {
+    alertForPermission(*protect(manager->page()), MediaPermissionReason::ScreenCapture, topLevelDocumentSecurityOrigin().data(), [this, protectedThis = Ref { *this }](bool granted) {
         if (!granted)
             deny(UserMediaAccessDenialReason::PermissionDenied);
         else
@@ -203,7 +203,7 @@ void UserMediaPermissionRequestProxy::promptForGetUserMedia()
     if (requiresAudioCapture())
         reason = requiresVideoCapture() ? MediaPermissionReason::CameraAndMicrophone : MediaPermissionReason::Microphone;
 
-    alertForPermission(*manager->protectedPage(), reason, topLevelDocumentSecurityOrigin().data(), [this, protectedThis = Ref { *this }](bool granted) {
+    alertForPermission(*protect(manager->page()), reason, topLevelDocumentSecurityOrigin().data(), [this, protectedThis = Ref { *this }](bool granted) {
         if (!granted)
             deny(UserMediaAccessDenialReason::PermissionDenied);
         else

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -304,7 +304,7 @@ void ViewGestureController::didSameDocumentNavigationForMainFrame(SameDocumentNa
 void ViewGestureController::checkForActiveLoads()
 {
     RefPtr page = m_webPageProxy.get();
-    if (page && page->protectedPageLoadState()->isLoading()) {
+    if (page && protect(page->pageLoadState())->isLoading()) {
         if (!m_swipeActiveLoadMonitoringTimer.isActive())
             m_swipeActiveLoadMonitoringTimer.startRepeating(swipeSnapshotRemovalActiveLoadMonitoringInterval);
         return;

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -67,13 +67,9 @@ public:
     void clear();
 
     WebBackForwardListItem* currentItem() const;
-    RefPtr<WebBackForwardListItem> protectedCurrentItem() const;
     WebBackForwardListItem* backItem() const;
-    RefPtr<WebBackForwardListItem> protectedBackItem() const;
     WebBackForwardListItem* forwardItem() const;
-    RefPtr<WebBackForwardListItem> protectedForwardItem() const;
     WebBackForwardListItem* itemAtIndex(int) const;
-    RefPtr<WebBackForwardListItem> protectedItemAtIndex(int) const;
 
     RefPtr<WebBackForwardListItem> goBackItemSkippingItemsWithoutUserGesture() const;
     RefPtr<WebBackForwardListItem> goForwardItemSkippingItemsWithoutUserGesture() const;
@@ -110,8 +106,6 @@ private:
     BackForwardListItemVector allItems() const { return m_entries; }
     WebBackForwardListCounts counts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
-
-    RefPtr<WebPageProxy> protectedPage();
 
     // IPC messages
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -146,7 +146,6 @@ public:
 
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
     WebPageProxy* page() const;
-    RefPtr<WebPageProxy> protectedPage() const;
 
     bool pageIsClosed() const { return !m_page; } // Needs to be thread-safe.
 
@@ -229,7 +228,6 @@ public:
     RefPtr<WebFrameProxy> childFrame(uint64_t index) const;
 
     WebProcessProxy& process() const;
-    Ref<WebProcessProxy> protectedProcess() const;
     void setProcess(FrameProcess&);
     const FrameProcess& frameProcess() const { return m_frameProcess.get(); }
     FrameProcess& frameProcess() { return m_frameProcess.get(); }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -768,7 +768,6 @@ public:
     WebInspectorUIProxy* inspector() const;
 
     GeolocationPermissionRequestManagerProxy& geolocationPermissionRequestManager();
-    Ref<GeolocationPermissionRequestManagerProxy> protectedGeolocationPermissionRequestManager();
 
     void resourceLoadDidSendRequest(ResourceLoadInfo&&, WebCore::ResourceRequest&&);
     void resourceLoadDidPerformHTTPRedirection(ResourceLoadInfo&&, WebCore::ResourceResponse&&, WebCore::ResourceRequest&&);
@@ -821,7 +820,6 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManagerProxy* fullScreenManager();
-    RefPtr<WebFullScreenManagerProxy> protectedFullScreenManager();
     void setFullScreenClientForTesting(std::unique_ptr<WebKit::WebFullScreenManagerProxyClient>&&);
 
     API::FullscreenClient& fullscreenClient() const { return *m_fullscreenClient; }
@@ -830,14 +828,11 @@ public:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     PlaybackSessionManagerProxy* playbackSessionManager() { return m_playbackSessionManager.get(); }
-    RefPtr<PlaybackSessionManagerProxy> protectedPlaybackSessionManager();
     VideoPresentationManagerProxy* videoPresentationManager();
-    RefPtr<VideoPresentationManagerProxy> protectedVideoPresentationManager();
     void setMockVideoPresentationModeEnabled(bool);
 #endif
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
-    RefPtr<WebDeviceOrientationUpdateProviderProxy> protectedWebDeviceOrientationUpdateProviderProxy();
 #endif
 
     WebScreenOrientationManagerProxy* screenOrientationManager() { return m_screenOrientationManager.get(); }
@@ -1313,12 +1308,9 @@ public:
 
 #if PLATFORM(MAC)
     CALayer *acceleratedCompositingRootLayer() const;
-    RetainPtr<CALayer> protectedAcceleratedCompositingRootLayer() const;
 
     CALayer *headerBannerLayer() const;
-    RetainPtr<CALayer> protectedHeaderBannerLayer() const;
     CALayer *footerBannerLayer() const;
-    RetainPtr<CALayer> protectedFooterBannerLayer() const;
     int headerBannerHeight() const;
     int footerBannerHeight() const;
 #endif
@@ -1362,7 +1354,6 @@ public:
 
     void startWindowDrag();
     NSWindow *platformWindow();
-    RetainPtr<NSWindow> protectedPlatformWindow();
     void rootViewToWindow(const WebCore::IntRect& viewRect, WebCore::IntRect& windowRect);
 
     RetainPtr<NSView> inspectorAttachmentView();
@@ -1799,7 +1790,6 @@ public:
     ProcessID modelProcessID() const;
 
     WebBackForwardCache& backForwardCache() const;
-    Ref<WebBackForwardCache> protectedBackForwardCache() const;
 
     const WebPreferences& preferences() const { return m_preferences; }
     WebPreferences& preferences() { return m_preferences; }
@@ -1890,8 +1880,6 @@ public:
 
     const PageLoadState& pageLoadState() const;
     PageLoadState& pageLoadState();
-    Ref<const PageLoadState> protectedPageLoadState() const;
-    Ref<PageLoadState> protectedPageLoadState();
 
 #if PLATFORM(COCOA)
     void handleAlternativeTextUIResult(const String& result);
@@ -2248,7 +2236,6 @@ public:
     void updateCurrentModifierState();
 
     ProvisionalPageProxy* provisionalPageProxy() const { return m_provisionalPage.get(); }
-    RefPtr<ProvisionalPageProxy> protectedProvisionalPageProxy() const;
     void commitProvisionalPage(IPC::Connection&, WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, std::optional<WebCore::NavigationIdentifier>, String&& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, String&& proxyName, WebCore::ResourceResponseSource, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, WebCore::DocumentSecurityPolicy&&, const UserData&);
     void destroyProvisionalPage();
 
@@ -2780,11 +2767,9 @@ public:
     void didAdjustVisibilityWithSelectors(Vector<String>&&);
 
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup; }
-    Ref<BrowsingContextGroup> protectedBrowsingContextGroup() const;
     std::optional<WebCore::FrameIdentifier> openerFrameIdentifier() const { return m_openerFrameIdentifier; }
 
     WebPageProxyTesting* pageForTesting() const;
-    RefPtr<WebPageProxyTesting> protectedPageForTesting() const;
 
     void hasActiveNowPlayingSessionChanged(bool);
 
@@ -2840,7 +2825,7 @@ public:
     bool hasAccessibilityActivityForTesting();
 #endif
 
-    Ref<AboutSchemeHandler> protectedAboutSchemeHandler();
+    AboutSchemeHandler& aboutSchemeHandler() const { return m_aboutSchemeHandler; }
 
     bool hasProvisionalPage() const { return m_provisionalPage; }
     bool isRemoteFrameNavigation(Ref<WebProcessProxy>);
@@ -3061,7 +3046,6 @@ private:
 
 #if ENABLE(MEDIA_STREAM)
     UserMediaPermissionRequestManagerProxy& userMediaPermissionRequestManager();
-    Ref<UserMediaPermissionRequestManagerProxy> protectedUserMediaPermissionRequestManager();
     void requestUserMediaPermissionForFrame(IPC::Connection&, WebCore::UserMediaRequestIdentifier, FrameInfoData&&, const WebCore::SecurityOriginData& userMediaDocumentOriginIdentifier, const WebCore::SecurityOriginData& topLevelDocumentOriginIdentifier, WebCore::MediaStreamRequest&&);
     void enumerateMediaDevicesForFrame(IPC::Connection&, WebCore::FrameIdentifier, const WebCore::SecurityOriginData& userMediaDocumentOriginData, const WebCore::SecurityOriginData& topLevelDocumentOriginData, CompletionHandler<void(const Vector<WebCore::CaptureDeviceWithCapabilities>&, WebCore::MediaDeviceHashSalts&&)>&&);
     void beginMonitoringCaptureDevices();
@@ -3071,7 +3055,6 @@ private:
 
 #if ENABLE(ENCRYPTED_MEDIA)
     MediaKeySystemPermissionRequestManagerProxy& mediaKeySystemPermissionRequestManager();
-    Ref<MediaKeySystemPermissionRequestManagerProxy> protectedMediaKeySystemPermissionRequestManager();
 #endif
     void requestMediaKeySystemPermissionForFrame(IPC::Connection&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, WebCore::ClientOrigin&&, const String&);
 
@@ -3549,7 +3532,7 @@ private:
     void takeTextExtractionAssertion();
     void dropTextExtractionAssertion();
 
-    RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionManager();
+    SpeechRecognitionPermissionManager* speechRecognitionPermissionManager() const { return m_speechRecognitionPermissionManager; }
 
 #if PLATFORM(COCOA)
     String presentingApplicationBundleIdentifier() const;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -452,8 +452,6 @@ public:
 
     explicit Internals(WebPageProxy&, std::optional<WebCore::SecurityOriginData>);
 
-    Ref<WebPageProxy> protectedPage() const;
-
 #if ENABLE(SPEECH_SYNTHESIS)
     SpeechSynthesisData& speechSynthesisData();
 #endif
@@ -518,7 +516,7 @@ public:
     void externalOutputDeviceAvailableDidChange(WebCore::PlaybackTargetClientContextIdentifier, bool) final;
     void setShouldPlayToPlaybackTarget(WebCore::PlaybackTargetClientContextIdentifier, bool) final;
     void playbackTargetPickerWasDismissed(WebCore::PlaybackTargetClientContextIdentifier) final;
-    bool alwaysOnLoggingAllowed() const final { return protectedPage()->isAlwaysOnLoggingAllowed(); }
+    bool alwaysOnLoggingAllowed() const final { return protect(page)->isAlwaysOnLoggingAllowed(); }
     RetainPtr<CocoaView> platformView() const final;
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
@@ -48,8 +48,8 @@ void WebPageProxyMessageReceiverRegistration::startReceivingMessages(WebProcessP
 void WebPageProxyMessageReceiverRegistration::stopReceivingMessages()
 {
     if (auto data = std::exchange(m_data, std::nullopt)) {
-        data->protectedProcess()->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
-        data->protectedProcess()->removeMessageReceiver(Messages::WebBackForwardList::messageReceiverName(), data->webPageID);
+        protect(data->process)->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
+        protect(data->process)->removeMessageReceiver(Messages::WebBackForwardList::messageReceiverName(), data->webPageID);
     }
 }
 
@@ -57,8 +57,8 @@ void WebPageProxyMessageReceiverRegistration::transferMessageReceivingFrom(WebPa
 {
     ASSERT(!m_data);
     if (auto data = std::exchange(oldRegistration.m_data, std::nullopt)) {
-        data->protectedProcess()->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
-        data->protectedProcess()->removeMessageReceiver(Messages::WebBackForwardList::messageReceiverName(), data->webPageID);
+        protect(data->process)->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), data->webPageID);
+        protect(data->process)->removeMessageReceiver(Messages::WebBackForwardList::messageReceiverName(), data->webPageID);
         startReceivingMessages(data->process, data->webPageID, newWebPageProxyReceiver, newBackForwardListReceiver);
     } else {
         stopReceivingMessages();

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -56,27 +56,27 @@ WebPageProxyTesting::WebPageProxyTesting(WebPageProxy& page)
 
 bool WebPageProxyTesting::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions)
 {
-    return protect(protectedPage()->legacyMainFrameProcess())->sendMessage(WTF::move(encoder), sendOptions);
+    return protect(protect(page())->legacyMainFrameProcess())->sendMessage(WTF::move(encoder), sendOptions);
 }
 
 bool WebPageProxyTesting::sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&& encoder, AsyncReplyHandler handler, OptionSet<IPC::SendOption> sendOptions)
 {
-    return protect(protectedPage()->legacyMainFrameProcess())->sendMessage(WTF::move(encoder), sendOptions, WTF::move(handler));
+    return protect(protect(page())->legacyMainFrameProcess())->sendMessage(WTF::move(encoder), sendOptions, WTF::move(handler));
 }
 
 IPC::Connection* WebPageProxyTesting::messageSenderConnection() const
 {
-    return &protectedPage()->legacyMainFrameProcess().connection();
+    return &protect(protect(page())->legacyMainFrameProcess())->connection();
 }
 
 uint64_t WebPageProxyTesting::messageSenderDestinationID() const
 {
-    return protectedPage()->webPageIDInMainFrameProcess().toUInt64();
+    return protect(page())->webPageIDInMainFrameProcess().toUInt64();
 }
 
 void WebPageProxyTesting::dispatchActivityStateUpdate()
 {
-    RunLoop::currentSingleton().dispatch([protectedPage = protectedPage()] {
+    RunLoop::currentSingleton().dispatch([protectedPage = protect(page())] {
         protectedPage->updateActivityState();
         protectedPage->dispatchActivityStateChange();
     });
@@ -89,12 +89,12 @@ void WebPageProxyTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& comp
 
 void WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->setCrossSiteLoadWithLinkDecorationForTesting(protectedPage()->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->setCrossSiteLoadWithLinkDecorationForTesting(protect(page())->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPermissionLevel(const String& origin, bool allowed)
 {
-    protectedPage()->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+    protect(page())->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.send(Messages::WebPageTesting::SetPermissionLevel(origin, allowed), pageID);
     });
 }
@@ -103,7 +103,7 @@ bool WebPageProxyTesting::isEditingCommandEnabled(const String& commandName)
 {
     RefPtr focusedOrMainFrame = m_page->focusedOrMainFrame();
     auto targetFrameID = focusedOrMainFrame ? std::optional(focusedOrMainFrame->frameID()) : std::nullopt;
-    auto sendResult = protectedPage()->sendSyncToProcessContainingFrame(targetFrameID, Messages::WebPageTesting::IsEditingCommandEnabled(commandName), Seconds::infinity());
+    auto sendResult = protect(page())->sendSyncToProcessContainingFrame(targetFrameID, Messages::WebPageTesting::IsEditingCommandEnabled(commandName), Seconds::infinity());
     if (!sendResult.succeeded())
         return false;
     auto [result] = sendResult.takeReply();
@@ -112,62 +112,62 @@ bool WebPageProxyTesting::isEditingCommandEnabled(const String& commandName)
 
 void WebPageProxyTesting::dumpPrivateClickMeasurement(CompletionHandler<void(const String&)>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::clearPrivateClickMeasurement(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs(const URL& sourceURL, const URL& destinationURL, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::markPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPCMFraudPreventionValues(const String& unlinkableToken, const String& secretToken, const String& signature, const String& keyID, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAppBundleID(const String& appBundleIDForTesting, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protectedPage()->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTF::move(completionHandler));
+    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTF::move(completionHandler));
 }
 
 #if ENABLE(NOTIFICATIONS)
@@ -179,7 +179,7 @@ void WebPageProxyTesting::clearNotificationPermissionState()
 
 void WebPageProxyTesting::clearWheelEventTestMonitor()
 {
-    if (!protectedPage()->hasRunningProcess())
+    if (!protect(page())->hasRunningProcess())
         return;
     send(Messages::WebPageTesting::ClearWheelEventTestMonitor());
 }
@@ -201,19 +201,14 @@ void WebPageProxyTesting::setObscuredContentInsets(float top, float right, float
     sendWithAsyncReply(Messages::WebPageTesting::SetObscuredContentInsets(top, right, bottom, left), WTF::move(completionHandler));
 }
 
-Ref<WebPageProxy> WebPageProxyTesting::protectedPage() const
-{
-    return m_page.get();
-}
-
 void WebPageProxyTesting::resetStateBetweenTests()
 {
-    protect(protectedPage()->legacyMainFrameProcess())->resetState();
+    protect(protect(page())->legacyMainFrameProcess())->resetState();
 
     if (RefPtr mainFrame = m_page->mainFrame())
         mainFrame->disownOpener();
 
-    protectedPage()->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+    protect(page())->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.send(Messages::WebPageTesting::ResetStateBetweenTests(), pageID);
     });
 }
@@ -232,7 +227,7 @@ void WebPageProxyTesting::clearBackForwardList(CompletionHandler<void()>&& compl
 void WebPageProxyTesting::setTracksRepaints(bool trackRepaints, CompletionHandler<void()>&& completionHandler)
 {
     Ref callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
-    protectedPage()->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+    protect(page())->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.sendWithAsyncReply(Messages::WebPageTesting::SetTracksRepaints(trackRepaints), [callbackAggregator] { }, pageID);
     });
 }
@@ -240,7 +235,7 @@ void WebPageProxyTesting::setTracksRepaints(bool trackRepaints, CompletionHandle
 void WebPageProxyTesting::displayAndTrackRepaints(CompletionHandler<void()>&& completionHandler)
 {
     Ref callbackAggregator = CallbackAggregator::create(WTF::move(completionHandler));
-    protectedPage()->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+    protect(page())->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.sendWithAsyncReply(Messages::WebPageTesting::DisplayAndTrackRepaints(), [callbackAggregator] { }, pageID);
     });
 }

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -92,7 +92,7 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
-    Ref<WebPageProxy> protectedPage() const;
+    WebPageProxy& page() const { return m_page; }
 
     WeakRef<WebPageProxy> m_page;
 };

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -457,7 +457,7 @@ WebProcessCache::CachedProcess::CachedProcess(Ref<WebProcessProxy>&& process, Se
     RELEASE_ASSERT(!m_process->pageCount());
     RefPtr dataStore = m_process->websiteDataStore();
     RELEASE_ASSERT_WITH_MESSAGE(dataStore && !dataStore->processes().contains(*m_process), "Only processes with pages should be registered with the data store");
-    protectedProcess()->setIsInProcessCache(true);
+    protect(this->process())->setIsInProcessCache(true);
     m_evictionTimer.startOneShot(cachedProcessEvictionDelay);
 }
 
@@ -507,7 +507,7 @@ void WebProcessCache::CachedProcess::evictionTimerFired()
 {
     ASSERT(m_process);
     auto process = m_process.copyRef();
-    process->protectedProcessPool()->webProcessCache().removeProcess(*process, ShouldShutDownProcess::Yes);
+    protect(process->processPool())->webProcessCache().removeProcess(*process, ShouldShutDownProcess::Yes);
 }
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
@@ -526,7 +526,7 @@ void WebProcessCache::CachedProcess::suspensionTimerFired()
 {
     ASSERT(m_process);
     m_backgroundActivity = nullptr;
-    protectedProcess()->platformSuspendProcess();
+    protect(process())->platformSuspendProcess();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -1087,11 +1087,6 @@ inline WebProcessPool& WebProcessProxy::processPool() const
     return *m_processPool.get();
 }
 
-inline Ref<WebProcessPool> WebProcessProxy::protectedProcessPool() const
-{
-    return processPool();
-}
-
 } // namespace WebKit
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebProcessPool)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -208,7 +208,6 @@ public:
 
     WebProcessPool* processPoolIfExists() const;
     inline WebProcessPool& processPool() const; // This function is implemented in WebProcessPool.h.
-    inline Ref<WebProcessPool> protectedProcessPool() const; // This function is implemented in WebProcessPool.h.
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
     const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const { return m_sharedPreferencesForWebProcess; }
@@ -238,7 +237,6 @@ public:
     void disableRemoteWorkers(OptionSet<RemoteWorkerType>);
 
     WebsiteDataStore* websiteDataStore() const { ASSERT(m_websiteDataStore); return m_websiteDataStore.get(); }
-    RefPtr<WebsiteDataStore> protectedWebsiteDataStore() const;
     void setWebsiteDataStore(WebsiteDataStore&);
     
     PAL::SessionID sessionID() const;
@@ -500,7 +498,7 @@ public:
 #if ENABLE(MEDIA_STREAM)
     static void muteCaptureInPagesExcept(WebCore::PageIdentifier);
     SpeechRecognitionRemoteRealtimeMediaSourceManager& ensureSpeechRecognitionRemoteRealtimeMediaSourceManager();
-    RefPtr<SpeechRecognitionRemoteRealtimeMediaSourceManager> protectedSpeechRecognitionRemoteRealtimeMediaSourceManager();
+    SpeechRecognitionRemoteRealtimeMediaSourceManager* speechRecognitionRemoteRealtimeMediaSourceManager() const { return m_speechRecognitionRemoteRealtimeMediaSourceManager.get(); }
 #endif
     void pageMutedStateChanged(WebCore::PageIdentifier, WebCore::MediaProducerMutedStateFlags);
     void pageIsBecomingInvisible(WebCore::PageIdentifier);

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
@@ -45,7 +45,7 @@ WebDeviceOrientationAndMotionAccessController::WebDeviceOrientationAndMotionAcce
 
 void WebDeviceOrientationAndMotionAccessController::shouldAllowAccess(WebPageProxy& page, WebFrameProxy& frame, FrameInfoData&& frameInfo, bool mayPrompt, CompletionHandler<void(DeviceOrientationOrMotionPermissionState)>&& completionHandler)
 {
-    auto originData = SecurityOrigin::createFromString(page.protectedPageLoadState()->activeURL())->data();
+    auto originData = SecurityOrigin::createFromString(protect(page.pageLoadState())->activeURL())->data();
     auto currentPermission = cachedDeviceOrientationPermission(originData);
     if (currentPermission != DeviceOrientationOrMotionPermissionState::Prompt || !mayPrompt)
         return completionHandler(currentPermission);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2688,7 +2688,7 @@ void WebsiteDataStore::openWindowFromServiceWorker(const String& urlString, cons
             return;
         }
 
-        if (!newPage->protectedPageLoadState()->isLoading()) {
+        if (!protect(newPage->pageLoadState())->isLoading()) {
             RELEASE_LOG(Loading, "The WKWebView provided in response to a ServiceWorker openWindow request was not in the loading state");
             callback(std::nullopt);
             return;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1762,9 +1762,9 @@ void WebPageProxy::processWillBecomeForeground()
 void WebPageProxy::Internals::isUserFacingChanged(bool isUserFacing)
 {
     if (!isUserFacing)
-        protectedPage()->suspendAllMediaPlayback([] { });
+        protect(page)->suspendAllMediaPlayback([] { });
     else
-        protectedPage()->resumeAllMediaPlayback([] { });
+        protect(page)->resumeAllMediaPlayback([] { });
 }
 
 #endif
@@ -1882,7 +1882,7 @@ FloatSize WebPageProxy::viewLayoutSize() const
 
 void WebPageProxy::didRefreshDisplay()
 {
-    m_configuration->protectedProcessPool()->didRefreshDisplay();
+    protect(m_configuration->processPool())->didRefreshDisplay();
 }
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -214,7 +214,7 @@ void DisplayCaptureSessionManager::promptForGetDisplayMedia(UserMediaPermissionR
             return;
         }
 
-        Ref gpuProcess = page.configuration().protectedProcessPool()->ensureGPUProcess();
+        Ref gpuProcess = protect(page.configuration().processPool())->ensureGPUProcess();
         gpuProcess->updateSandboxAccess(false, false, true);
         gpuProcess->promptForGetDisplayMedia(toScreenCaptureKitPromptType(promptType), WTF::move(completionHandler));
         return;

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -177,7 +177,7 @@ MachSendRight TiledCoreAnimationDrawingAreaProxy::createFence()
     if (!page)
         return MachSendRight();
 
-    RetainPtr<CAContext> rootLayerContext = [page->protectedAcceleratedCompositingRootLayer() context];
+    RetainPtr<CAContext> rootLayerContext = [protect(page->acceleratedCompositingRootLayer()) context];
     if (!rootLayerContext)
         return MachSendRight();
 

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -374,7 +374,7 @@ static void pageDidComputePageRects(const Vector<WebCore::IntRect>& pageRects, d
         std::unique_ptr<IPCCallbackContext> contextDeleter(context);
         pageDidComputePageRects(pageRects, totalScaleFactorForPrinting, computedPageMargin, context);
     };
-    _expectedComputedPagesCallback = webFrame->protectedPage()->computePagesForPrinting(webFrame->frameID(), WebKit::PrintInfo([_printOperation.get() printInfo]), WTF::move(callback));
+    _expectedComputedPagesCallback = protect(webFrame->page())->computePagesForPrinting(webFrame->frameID(), WebKit::PrintInfo([_printOperation.get() printInfo]), WTF::move(callback));
     context->view = self;
     context->callbackID = _expectedComputedPagesCallback;
 
@@ -570,7 +570,7 @@ static RetainPtr<NSString> linkDestinationName(PDFDocument *document, PDFDestina
     WebCore::GraphicsContextCG context([[NSGraphicsContext currentContext] CGContext]);
     WebCore::GraphicsContextStateSaver stateSaver(context);
 
-    bitmap->paint(context, protectedWebFrame(self)->protectedPage()->deviceScaleFactor(), WebCore::IntPoint(nsRect.origin), bitmap->bounds());
+    bitmap->paint(context, protect(protectedWebFrame(self)->page())->deviceScaleFactor(), WebCore::IntPoint(nsRect.origin), bitmap->bounds());
 }
 
 - (void)drawRect:(NSRect)nsRect

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
@@ -176,7 +176,7 @@
 
     // FIXME: We should adopt replaceSelectionWithAttributedString instead of bouncing through the (fake) pasteboard.
     if (RefPtr menuProxy = _menuProxy.get())
-        menuProxy->protectedPage()->replaceSelectionWithPasteboardData(types, dataReference);
+        protect(menuProxy->page())->replaceSelectionWithPasteboardData(types, dataReference);
 }
 
 - (NSWindow *)sharingService:(NSSharingService *)sharingService sourceWindowForShareItems:(NSArray *)items sharingContentScope:(NSSharingContentScope *)sharingContentScope

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -254,13 +254,13 @@ void WebContextMenuProxyMac::contextMenuItemSelected(const WebContextMenuItemDat
     clearServicesMenu();
 #endif
 
-    protectedPage()->contextMenuItemSelected(item, m_frameInfo);
+    protect(page())->contextMenuItemSelected(item, m_frameInfo);
 }
 
 #if ENABLE(WRITING_TOOLS)
 void WebContextMenuProxyMac::handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool tool)
 {
-    protectedPage()->handleContextMenuWritingTools(tool);
+    protect(page())->handleContextMenuWritingTools(tool);
 }
 #endif
 
@@ -277,7 +277,7 @@ void WebContextMenuProxyMac::setupServicesMenu()
     bool includeEditorServices = m_context.controlledDataIsEditable();
     bool hasControlledImage = m_context.controlledImage();
     bool isPDFAttachment = false;
-    auto attachment = protectedPage()->attachmentForIdentifier(m_context.controlledImageAttachmentID());
+    auto attachment = protect(page())->attachmentForIdentifier(m_context.controlledImageAttachmentID());
     if (attachment)
         isPDFAttachment = attachment->utiType() == String(UTTypePDF.identifier);
     NSArray *items = nil;
@@ -550,7 +550,7 @@ void WebContextMenuProxyMac::show()
 bool WebContextMenuProxyMac::showAfterPostProcessingContextData()
 {
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
-    if (!protect(protectedPage()->preferences())->contextMenuQRCodeDetectionEnabled())
+    if (!protect(page()->preferences())->contextMenuQRCodeDetectionEnabled())
         return false;
 
     ASSERT(m_context.webHitTestResultData());
@@ -807,7 +807,7 @@ void WebContextMenuProxyMac::getContextMenuFromItems(const Vector<WebContextMenu
 #endif // ENABLE(IMAGE_ANALYSIS)
 
 #if HAVE(TRANSLATION_UI_SERVICES)
-    if (!protectedPage()->canHandleContextMenuTranslation() || isPopover) {
+    if (!protect(page())->canHandleContextMenuTranslation() || isPopover) {
         filteredItems.removeAllMatching([] (auto& item) {
             return item.action() == ContextMenuItemTagTranslate;
         });
@@ -815,7 +815,7 @@ void WebContextMenuProxyMac::getContextMenuFromItems(const Vector<WebContextMenu
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    if (!protectedPage()->canHandleContextMenuWritingTools() || isPopover) {
+    if (!protect(page())->canHandleContextMenuWritingTools() || isPopover) {
         filteredItems.removeAllMatching([] (auto& item) {
             auto action = item.action();
             return action == ContextMenuItemTagWritingTools || action == ContextMenuItemTagProofread || action == ContextMenuItemTagRewrite || action == ContextMenuItemTagSummarize;
@@ -1104,12 +1104,12 @@ WKMenuDelegate *WebContextMenuProxyMac::menuDelegate()
 
 void WebContextMenuProxyMac::didShowContextMenu(NSMenu *)
 {
-    protectedPage()->didShowContextMenu();
+    protect(page())->didShowContextMenu();
 }
 
 void WebContextMenuProxyMac::didDismissContextMenu(NSMenu *menu)
 {
-    protectedPage()->didDismissContextMenu();
+    protect(page())->didDismissContextMenu();
 
     if (m_captionStyleMenuController && [m_captionStyleMenuController hasAncestor:menu])
         captionStyleMenuDidClose();
@@ -1118,13 +1118,13 @@ void WebContextMenuProxyMac::didDismissContextMenu(NSMenu *menu)
 void WebContextMenuProxyMac::captionStyleMenuWillOpen()
 {
     if (auto identifier = m_context.mediaElementIdentifier())
-        protectedPage()->showCaptionDisplaySettingsPreview(m_frameInfo, *identifier);
+        protect(page())->showCaptionDisplaySettingsPreview(m_frameInfo, *identifier);
 }
 
 void WebContextMenuProxyMac::captionStyleMenuDidClose()
 {
     if (auto identifier = m_context.mediaElementIdentifier())
-        protectedPage()->hideCaptionDisplaySettingsPreview(m_frameInfo, *identifier);
+        protect(page())->hideCaptionDisplaySettingsPreview(m_frameInfo, *identifier);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -534,31 +534,16 @@ CALayer *WebPageProxy::acceleratedCompositingRootLayer() const
     return pageClient ? pageClient->acceleratedCompositingRootLayer() : nullptr;
 }
 
-RetainPtr<CALayer> WebPageProxy::protectedAcceleratedCompositingRootLayer() const
-{
-    return acceleratedCompositingRootLayer();
-}
-
 CALayer *WebPageProxy::headerBannerLayer() const
 {
     RefPtr pageClient = this->pageClient();
     return pageClient ? pageClient->headerBannerLayer() : nullptr;
 }
 
-RetainPtr<CALayer> WebPageProxy::protectedHeaderBannerLayer() const
-{
-    return headerBannerLayer();
-}
-
 CALayer *WebPageProxy::footerBannerLayer() const
 {
     RefPtr pageClient = this->pageClient();
     return pageClient ? pageClient->footerBannerLayer() : nullptr;
-}
-
-RetainPtr<CALayer> WebPageProxy::protectedFooterBannerLayer() const
-{
-    return footerBannerLayer();
 }
 
 int WebPageProxy::headerBannerHeight() const
@@ -766,11 +751,6 @@ NSWindow *WebPageProxy::platformWindow()
     return pageClient ? pageClient->platformWindow() : nullptr;
 }
 
-RetainPtr<NSWindow> WebPageProxy::protectedPlatformWindow()
-{
-    return platformWindow();
-}
-
 void WebPageProxy::rootViewToWindow(const WebCore::IntRect& viewRect, WebCore::IntRect& windowRect)
 {
     RefPtr pageClient = this->pageClient();
@@ -836,7 +816,7 @@ std::optional<IPC::AsyncReplyID> WebPageProxy::willPerformPasteCommand(DOMPasteA
 
 RetainPtr<NSView> WebPageProxy::Internals::platformView() const
 {
-    RefPtr pageClient = protectedPage()->pageClient();
+    RefPtr pageClient = protect(page)->pageClient();
     if (!pageClient)
         return nullptr;
     RetainPtr window = pageClient->platformWindow();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1396,7 +1396,7 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
 WebViewImpl::~WebViewImpl()
 {
     if (m_remoteObjectRegistry) {
-        m_page->configuration().protectedProcessPool()->removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier());
+        protect(m_page->configuration().processPool())->removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier());
         [m_remoteObjectRegistry _invalidate];
         m_remoteObjectRegistry = nil;
     }
@@ -2197,7 +2197,7 @@ void WebViewImpl::windowWillClose()
 
 void WebViewImpl::screenDidChangeColorSpace()
 {
-    m_page->configuration().protectedProcessPool()->screenPropertiesChanged();
+    protect(m_page->configuration().processPool())->screenPropertiesChanged();
 }
 
 void WebViewImpl::applicationShouldSuppressHDR(bool suppress)
@@ -4187,7 +4187,7 @@ _WKRemoteObjectRegistry *WebViewImpl::remoteObjectRegistry()
     if (!m_remoteObjectRegistry) {
         m_remoteObjectRegistry = adoptNS([[_WKRemoteObjectRegistry alloc] _initWithWebPageProxy:m_page.get()]);
         Ref webRemoteObjectRegistry = [m_remoteObjectRegistry remoteObjectRegistry];
-        m_page->configuration().protectedProcessPool()->addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier(), webRemoteObjectRegistry);
+        protect(m_page->configuration().processPool())->addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier(), webRemoteObjectRegistry);
     }
 
     return m_remoteObjectRegistry.get();

--- a/Source/WebKit/UIProcess/win/AutomationClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationClientWin.cpp
@@ -44,14 +44,6 @@ AutomationClient::~AutomationClient()
     Inspector::RemoteInspector::singleton().setClient(nullptr);
 }
 
-RefPtr<WebProcessPool> AutomationClient::protectedProcessPool() const
-{
-    if (RefPtr processPool = m_processPool.get())
-        return processPool;
-
-    return nullptr;
-}
-
 void AutomationClient::requestAutomationSession(const String& sessionIdentifier, const Inspector::RemoteInspector::Client::SessionCapabilities& capabilities)
 {
     ASSERT(isMainRunLoop());
@@ -65,7 +57,7 @@ void AutomationClient::requestAutomationSession(const String& sessionIdentifier,
 void AutomationClient::closeAutomationSession()
 {
     RunLoop::mainSingleton().dispatch([this] {
-        auto processPool = protectedProcessPool();
+        RefPtr processPool = m_processPool;
         if (!processPool || !processPool->automationSession())
             return;
 

--- a/Source/WebKit/UIProcess/win/AutomationClientWin.h
+++ b/Source/WebKit/UIProcess/win/AutomationClientWin.h
@@ -45,8 +45,6 @@ private:
     String browserName() const override { return "MiniBrowser"_s; }
     String browserVersion() const override { return "1.0"_s; }
 
-    RefPtr<WebProcessPool> protectedProcessPool() const;
-
     void requestAutomationSession(const String&, const Inspector::RemoteInspector::Client::SessionCapabilities&) override;
     void closeAutomationSession() override;
 

--- a/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
+++ b/Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp
@@ -47,7 +47,7 @@ AutomationSessionClient::AutomationSessionClient(const String& sessionIdentifier
 
 void AutomationSessionClient::requestNewPageWithOptions(WebKit::WebAutomationSession& session, API::AutomationSessionBrowsingContextOptions options, CompletionHandler<void(WebKit::WebPageProxy*)>&& completionHandler)
 {
-    RefPtr<WebProcessPool> processPool = session.protectedProcessPool();
+    RefPtr<WebProcessPool> processPool = protect(session.processPool());
     if (processPool && processPool->processes().size()) {
         auto& processProxy = processPool->processes()[0];
         if (processProxy->pageCount()) {
@@ -148,7 +148,7 @@ void AutomationSessionClient::didDisconnectFromRemote(WebKit::WebAutomationSessi
     session.setClient(nullptr);
 
     RunLoop::mainSingleton().dispatch([&session] {
-        auto processPool = session.protectedProcessPool();
+        auto processPool = protect(session.processPool());
         if (processPool) {
             processPool->setAutomationSession(nullptr);
             processPool->setPagesControlledByAutomation(false);


### PR DESCRIPTION
#### 128b2c246b166dabaf8e85483f4bd7b7325f413d
<pre>
Drop more `protected*()` getters in Source/WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=306206fewer_protected_getters_UIProcess">https://bugs.webkit.org/show_bug.cgi?id=306206fewer_protected_getters_UIProcess</a>

Reviewed by Darin Adler.

Drop more `protected*()` getters in Source/WebKit/UIProcess and adopt
protect() instead.

* Source/WTF/wtf/WeakPtr.h:
(WTF::protect):
* Source/WTF/wtf/WeakRef.h:
(WTF::protect):
* Source/WebKit/UIProcess/API/APIDataTask.cpp:
(API::DataTask::DataTask):
(API::m_sessionID):
* Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp:
(WKBackForwardListGetCurrentItem):
(WKBackForwardListGetBackItem):
(WKBackForwardListGetForwardItem):
(WKBackForwardListGetItemAtIndex):
* Source/WebKit/UIProcess/API/C/WKFrame.cpp:
(WKFrameGetPage):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetContext):
(WKPageCopyTitle):
(WKPageSetFullScreenClientForTesting):
(WKPageSetPageUIClient):
(WKPageCopyActiveURL):
(WKPageSetMockCaptureDevicesInterrupted):
(WKPageTriggerMockCaptureConfigurationChange):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationGetContext):
(WKPageConfigurationGetWebsiteDataStore):
* Source/WebKit/UIProcess/API/C/WKWebsitePolicies.cpp:
(WKWebsitePoliciesGetDataStore):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState initWithPage:]):
(-[WKObservablePageState dealloc]):
(-[WKObservablePageState isLoading]):
(-[WKObservablePageState title]):
(-[WKObservablePageState URL]):
(-[WKObservablePageState hasOnlySecureContent]):
(WKPageIsURLKnownHSTSHost):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
(-[WKBackForwardList currentItem]):
(-[WKBackForwardList backItem]):
(-[WKBackForwardList forwardItem]):
(-[WKBackForwardList itemAtIndex:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView title]):
(-[WKWebView URL]):
(-[WKWebView isLoading]):
(-[WKWebView estimatedProgress]):
(-[WKWebView hasOnlySecureContent]):
(-[WKWebView canGoBack]):
(-[WKWebView canGoForward]):
(-[WKWebView _negotiatedLegacyTLS]):
(-[WKWebView _clearBackForwardCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration processPool]):
(-[WKWebViewConfiguration websiteDataStore]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _hasServiceWorkerBackgroundActivityForTesting]):
(-[WKWebView _hasServiceWorkerForegroundActivityForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfo.mm:
(-[_WKContextMenuElementInfo hitTestResult]):
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm:
(-[_WKFrameTreeNode childFrames]):
* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::getTree):
* Source/WebKit/UIProcess/Automation/BidiPermissionsAgent.cpp:
(WebKit::allPageProxiesFor):
(WebKit::BidiPermissionsAgent::setPermission):
* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::getRealms):
(WebKit::BidiScriptAgent::contextHandleForFrame):
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.cpp:
(WebKit::SimulatedInputDispatcher::resolveLocation):
(WebKit::SimulatedInputDispatcher::transitionInputSourceToState):
(WebKit::SimulatedInputDispatcher::protectedPage const): Deleted.
* Source/WebKit/UIProcess/Automation/SimulatedInputDispatcher.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::processPool const):
(WebKit::WebAutomationSession::buildBrowsingContextForPage):
(WebKit::WebAutomationSession::getBrowsingContexts):
(WebKit::WebAutomationSession::waitForNavigationToComplete):
(WebKit::WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout):
(WebKit::WebAutomationSession::willShowJavaScriptDialog):
(WebKit::WebAutomationSession::navigationOccurredForFrame):
(WebKit::WebAutomationSession::addSingleCookie):
(WebKit::WebAutomationSession::deleteAllCookies):
(WebKit::WebAutomationSession::protectedProcessPool const): Deleted.
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::sharedProcessForSite):
(WebKit::BrowsingContextGroup::transitionProvisionalPageToRemotePage):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationState):
(WebKit::NavigationState::~NavigationState):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm:
(WebKit::NavigationSOAuthorizationSession::shouldStartInternal):
(WebKit::NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting const):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::decidePolicyForGeolocationPermissionRequest):
(WebKit::UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::exitFullscreen):
(WebKit::VideoPresentationManagerProxy::preparedToReturnToInline):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::grantAccessToCurrentPasteboardData):
(WebKit::WebPageProxy::Internals::sharedPreferencesForWebPaymentMessages const):
(WebKit::WebPageProxy::Internals::paymentCoordinatorPresentingWindow const):
(WebKit::WebPageProxy::Internals::paymentCoordinatorAddMessageReceiver):
(WebKit::WebPageProxy::Internals::paymentCoordinatorRemoveMessageReceiver):
(WebKit::WebPageProxy::deactivateMediaCapability):
(WebKit::WebPageProxy::updateMediaCapability):
(WebKit::WebPageProxy::getWebArchiveDataWithSelectedFrames):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::grantAccessToCurrentData):
(WebKit::WebPasteboardProxy::createOneWebArchiveFromFrames):
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp:
(WebKit::DownloadProxyMap::createDownloadProxy):
(WebKit::DownloadProxyMap::downloadFinished):
(WebKit::DownloadProxyMap::invalidate):
(WebKit::DownloadProxyMap::protectedProcess): Deleted.
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
(WebKit::DownloadProxyMap::process const):
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::didChangeViewExposedRect):
* Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp:
(WebKit::FindStringCallbackAggregator::~FindStringCallbackAggregator):
* Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp:
(WebKit::WebFrameInspectorTargetProxy::connect):
(WebKit::WebFrameInspectorTargetProxy::disconnect):
(WebKit::WebFrameInspectorTargetProxy::sendMessageToTargetBackend):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformBringInspectedPageToFront):
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp:
(WebKit::RemoteInspectorProtocolHandler::runScript):
(WebKit::RemoteInspectorProtocolHandler::platformStartTask):
(WebKit::RemoteInspectorProtocolHandler::protectedPage const): Deleted.
* Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.h:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp:
(WebKit::AudioSessionRoutingArbitratorProxy::logger):
(WebKit::AudioSessionRoutingArbitratorProxy::protectedProcess): Deleted.
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.cpp:
(WebKit::LegacyCustomProtocolManagerProxy::startLoading):
(WebKit::LegacyCustomProtocolManagerProxy::stopLoading):
(WebKit::LegacyCustomProtocolManagerProxy::wasRedirectedToRequest):
(WebKit::LegacyCustomProtocolManagerProxy::didReceiveResponse):
(WebKit::LegacyCustomProtocolManagerProxy::didLoadData):
(WebKit::LegacyCustomProtocolManagerProxy::didFailWithError):
(WebKit::LegacyCustomProtocolManagerProxy::didFinishLoading):
(WebKit::LegacyCustomProtocolManagerProxy::protectedProcess): Deleted.
* Source/WebKit/UIProcess/Network/CustomProtocols/LegacyCustomProtocolManagerProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::showNotification):
(WebKit::WebNotificationManagerMessageHandler::cancelNotification):
(WebKit::WebNotificationManagerMessageHandler::clearNotifications):
(WebKit::WebNotificationManagerMessageHandler::didDestroyNotification):
(WebKit::WebNotificationManagerMessageHandler::pageWasNotifiedOfNotificationPermission):
(WebKit::WebNotificationManagerMessageHandler::sharedPreferencesForWebProcess const):
(WebKit::WebNotificationManagerMessageHandler::protectedPage const): Deleted.
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
(WebKit::WebNotificationManagerMessageHandler::page const):
* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::commitChanges):
(WebKit::PageLoadState::protectedPage const): Deleted.
* Source/WebKit/UIProcess/PageLoadState.h:
(WebKit::PageLoadState::page const):
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::assertionName const):
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::updateThrottleStateIfNeeded):
(WebKit::ProcessThrottler::clearAssertion):
(WebKit::ProcessThrottler::dropLastAssertion):
(WebKit::ProcessThrottler::protectedProcess const): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
(WebKit::ProvisionalPageProxy::takeDrawingArea):
(WebKit::ProvisionalPageProxy::loadData):
(WebKit::ProvisionalPageProxy::loadRequest):
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
(WebKit::ProvisionalPageProxy::didPerformClientRedirect):
(WebKit::ProvisionalPageProxy::didStartProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::didFailProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::didNavigateWithNavigationData):
(WebKit::ProvisionalPageProxy::didChangeProvisionalURLForFrame):
(WebKit::ProvisionalPageProxy::decidePolicyForResponse):
(WebKit::ProvisionalPageProxy::didPerformServerRedirect):
(WebKit::ProvisionalPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame):
(WebKit::ProvisionalPageProxy::startURLSchemeTask):
(WebKit::ProvisionalPageProxy::didDestroyNavigation):
(WebKit::ProvisionalPageProxy::sendMessage):
(WebKit::ProvisionalPageProxy::sendMessageWithAsyncReply):
(WebKit::ProvisionalPageProxy::protectedProcess): Deleted.
(WebKit::ProvisionalPageProxy::protectedPage const): Deleted.
(WebKit::ProvisionalPageProxy::protectedMainFrame const): Deleted.
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::updateBannerLayers):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::createScrollingCoordinatorProxy const):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::createFence):
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
(WebKit::SpeechRecognitionPermissionManager::continueProcessingRequest):
(WebKit::SpeechRecognitionPermissionManager::requestUserPermission):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::suspensionTimedOut):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::decidePolicyForUserMediaPermissionRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::checkUserMediaPermissionForSpeechRecognition):
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForCamera const):
(WebKit::UserMediaPermissionRequestManagerProxy::shouldChangeDeniedToPromptForMicrophone const):
(WebKit::UserMediaPermissionRequestManagerProxy::getUserMediaPermissionInfo):
(WebKit::UserMediaPermissionRequestManagerProxy::syncWithWebCorePrefs const):
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp:
(WebKit::UserMediaPermissionRequestProxy::promptForGetDisplayMedia):
(WebKit::UserMediaPermissionRequestProxy::promptForGetUserMedia):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::checkForActiveLoads):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::removeAllItems):
(WebKit::WebBackForwardList::didRemoveItem):
(WebKit::itemSkippingBackForwardItemsAddedByJSWithoutUserGesture):
(WebKit::WebBackForwardList::protectedCurrentItem const): Deleted.
(WebKit::WebBackForwardList::protectedBackItem const): Deleted.
(WebKit::WebBackForwardList::protectedForwardItem const): Deleted.
(WebKit::WebBackForwardList::protectedItemAtIndex const): Deleted.
(WebKit::WebBackForwardList::protectedPage): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::sendWithAsyncReply):
(WebKit::WebFrameProxy::send):
(WebKit::WebFrameProxy::navigateServiceWorkerClient):
(WebKit::WebFrameProxy::loadData):
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::WebFrameProxy::remoteProcessDidTerminate):
(WebKit::WebFrameProxy::webPageIDInCurrentProcess):
(WebKit::WebFrameProxy::protectedPage const): Deleted.
(WebKit::WebFrameProxy::protectedProcess const): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::notifyProcessPoolToPrewarm):
(WebKit::WebPageProxy::finishAttachingToWebProcess):
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::updateActivityState):
(WebKit::WebPageProxy::updateHiddenPageThrottlingAutoIncreases):
(WebKit::WebPageProxy::processNextQueuedGestureEvent):
(WebKit::WebPageProxy::updateDataStoreForWebArchiveLoad):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::receivedNavigationResponsePolicyDecision):
(WebKit::WebPageProxy::setUserAgent):
(WebKit::WebPageProxy::accessibilitySettingsDidChange):
(WebKit::WebPageProxy::estimatedProgress const):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didChangeMainDocument):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::WebPageProxy::didNavigateWithNavigationDataShared):
(WebKit::WebPageProxy::didPerformServerRedirectShared):
(WebKit::WebPageProxy::runOpenPanel):
(WebKit::WebPageProxy::resumeDownload):
(WebKit::WebPageProxy::downloadRequest):
(WebKit::WebPageProxy::Internals::setTextFromItemForPopupMenu):
(WebKit::WebPageProxy::startDeferringResizeEvents):
(WebKit::WebPageProxy::flushDeferredResizeEvents):
(WebKit::WebPageProxy::startDeferringScrollEvents):
(WebKit::WebPageProxy::flushDeferredScrollEvents):
(WebKit::WebPageProxy::startDeferringIntersectionObservations):
(WebKit::WebPageProxy::flushDeferredIntersectionObservations):
(WebKit::WebPageProxy::Internals::failedToShowPopupMenu):
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::willChangeProcessIsResponsive):
(WebKit::WebPageProxy::didChangeProcessIsResponsive):
(WebKit::WebPageProxy::currentURL const):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::requestGeolocationPermissionForFrame):
(WebKit::WebPageProxy::revokeGeolocationAuthorizationToken):
(WebKit::WebPageProxy::setMockCaptureDevicesEnabledOverride):
(WebKit::WebPageProxy::willStartCapture):
(WebKit::WebPageProxy::requestUserMediaPermissionForFrame):
(WebKit::WebPageProxy::enumerateMediaDevicesForFrame):
(WebKit::WebPageProxy::beginMonitoringCaptureDevices):
(WebKit::WebPageProxy::validateCaptureStateUpdate):
(WebKit::WebPageProxy::syncIfMockDevicesEnabledChanged):
(WebKit::WebPageProxy::requestMediaKeySystemPermissionForFrame):
(WebKit::WebPageProxy::showNotification):
(WebKit::WebPageProxy::cancelNotification):
(WebKit::WebPageProxy::clearNotifications):
(WebKit::WebPageProxy::didDestroyNotification):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
(WebKit::WebPageProxy::gpuProcessExited):
(WebKit::WebPageProxy::requestSpeechRecognitionPermission):
(WebKit::WebPageProxy::requestUserMediaPermissionForSpeechRecognition):
(WebKit::WebPageProxy::sendToWebPage):
(WebKit::WebPageProxy::Internals::protectedPage const): Deleted.
(WebKit::WebPageProxy::protectedBackForwardCache const): Deleted.
(WebKit::WebPageProxy::protectedProvisionalPageProxy const): Deleted.
(WebKit::WebPageProxy::protectedFullScreenManager): Deleted.
(WebKit::WebPageProxy::protectedPlaybackSessionManager): Deleted.
(WebKit::WebPageProxy::protectedVideoPresentationManager): Deleted.
(WebKit::WebPageProxy::protectedWebDeviceOrientationUpdateProviderProxy): Deleted.
(WebKit::WebPageProxy::protectedPageForTesting const): Deleted.
(WebKit::WebPageProxy::protectedUserMediaPermissionRequestManager): Deleted.
(WebKit::WebPageProxy::protectedMediaKeySystemPermissionRequestManager): Deleted.
(WebKit::WebPageProxy::protectedSpeechRecognitionPermissionManager): Deleted.
(WebKit::WebPageProxy::protectedPageLoadState): Deleted.
(WebKit::WebPageProxy::protectedPageLoadState const): Deleted.
(WebKit::WebPageProxy::protectedGeolocationPermissionRequestManager): Deleted.
(WebKit::WebPageProxy::protectedBrowsingContextGroup const): Deleted.
(WebKit::WebPageProxy::protectedAboutSchemeHandler): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp:
(WebKit::WebPageProxyMessageReceiverRegistration::stopReceivingMessages):
(WebKit::WebPageProxyMessageReceiverRegistration::transferMessageReceivingFrom):
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::sendMessage):
(WebKit::WebPageProxyTesting::sendMessageWithAsyncReply):
(WebKit::WebPageProxyTesting::messageSenderConnection const):
(WebKit::WebPageProxyTesting::messageSenderDestinationID const):
(WebKit::WebPageProxyTesting::dispatchActivityStateUpdate):
(WebKit::WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::WebPageProxyTesting::setPermissionLevel):
(WebKit::WebPageProxyTesting::isEditingCommandEnabled):
(WebKit::WebPageProxyTesting::dumpPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::clearPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer):
(WebKit::WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement):
(WebKit::WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs):
(WebKit::WebPageProxyTesting::markPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPCMFraudPreventionValues):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAppBundleID):
(WebKit::WebPageProxyTesting::clearWheelEventTestMonitor):
(WebKit::WebPageProxyTesting::resetStateBetweenTests):
(WebKit::WebPageProxyTesting::setTracksRepaints):
(WebKit::WebPageProxyTesting::displayAndTrackRepaints):
(WebKit::WebPageProxyTesting::protectedPage const): Deleted.
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
(WebKit::WebPageProxyTesting::page const):
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::WebProcessActivityState):
(WebKit::WebProcessActivityState::takeVisibleActivity):
(WebKit::WebProcessActivityState::takeTextExtractionAssertion):
(WebKit::WebProcessActivityState::takeAudibleActivity):
(WebKit::WebProcessActivityState::takeCapturingActivity):
(WebKit::WebProcessActivityState::takeMutedCaptureAssertion):
(WebKit::WebProcessActivityState::takeNetworkActivity):
(WebKit::WebProcessActivityState::dropVisibleActivity):
(WebKit::WebProcessActivityState::dropNetworkActivity):
(WebKit::WebProcessActivityState::takeOpeningAppLinkActivity):
(WebKit::WebProcessActivityState::updateWebProcessSuspensionDelay):
(WebKit::WebProcessActivityState::takeAccessibilityActivity):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::CachedProcess::CachedProcess):
(WebKit::WebProcessCache::CachedProcess::evictionTimerFired):
(WebKit::WebProcessCache::CachedProcess::suspensionTimerFired):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::processForNavigationInternal):
* Source/WebKit/UIProcess/WebProcessPool.h:
(WebKit::WebProcessProxy::protectedProcessPool const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setWebsiteDataStore):
(WebKit::WebProcessProxy::isDummyProcessProxy const):
(WebKit::WebProcessProxy::addProvisionalPageProxy):
(WebKit::WebProcessProxy::addRemotePageProxy):
(WebKit::WebProcessProxy::getLaunchOptions):
(WebKit::WebProcessProxy::startDisplayLink):
(WebKit::WebProcessProxy::stopDisplayLink):
(WebKit::WebProcessProxy::setDisplayLinkPreferredFramesPerSecond):
(WebKit::WebProcessProxy::setDisplayLinkForDisplayWantsFullSpeedUpdates):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::removeWebPage):
(WebKit::WebProcessProxy::createGPUProcessConnection):
(WebKit::WebProcessProxy::gpuProcessConnectionDidBecomeUnresponsive):
(WebKit::WebProcessProxy::createModelProcessConnection):
(WebKit::WebProcessProxy::dispatchMessage):
(WebKit::WebProcessProxy::dispatchSyncMessage):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::didFinishLaunching):
(WebKit::WebProcessProxy::canBeAddedToWebProcessCache const):
(WebKit::WebProcessProxy::maybeShutDown):
(WebKit::WebProcessProxy::canTerminateAuxiliaryProcess):
(WebKit::WebProcessProxy::transformHandlesToObjects):
(WebKit::WebProcessProxy::didChangeThrottleState):
(WebKit::WebProcessProxy::updateAudibleMediaAssertions):
(WebKit::WebProcessProxy::updateMediaStreamingActivity):
(WebKit::WebProcessProxy::didExceedMemoryFootprintThreshold):
(WebKit::WebProcessProxy::didCollectPrewarmInformation):
(WebKit::WebProcessProxy::ensureSpeechRecognitionRemoteRealtimeMediaSourceManager):
(WebKit::WebProcessProxy::disableRemoteWorkers):
(WebKit::WebProcessProxy::enableRemoteWorkers):
(WebKit::WebProcessProxy::setAppBadgeFromWorker):
(WebKit::WebProcessProxy::protectedSpeechRecognitionRemoteRealtimeMediaSourceManager): Deleted.
(WebKit::WebProcessProxy::protectedWebsiteDataStore const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp:
(WebKit::WebDeviceOrientationAndMotionAccessController::shouldAllowAccess):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::openWindowFromServiceWorker):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::Internals::isUserFacingChanged):
(WebKit::WebPageProxy::didRefreshDisplay):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::promptForGetDisplayMedia):
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::createFence):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _askPageToComputePageRects]):
(-[WKPrintingView _drawPreview:]):
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm:
(-[WKSharingServicePickerDelegate sharingService:didShareItems:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::contextMenuItemSelected):
(WebKit::WebContextMenuProxyMac::handleContextMenuWritingTools):
(WebKit::WebContextMenuProxyMac::setupServicesMenu):
(WebKit::WebContextMenuProxyMac::showAfterPostProcessingContextData):
(WebKit::WebContextMenuProxyMac::getContextMenuFromItems):
(WebKit::WebContextMenuProxyMac::didShowContextMenu):
(WebKit::WebContextMenuProxyMac::didDismissContextMenu):
(WebKit::WebContextMenuProxyMac::captionStyleMenuWillOpen):
(WebKit::WebContextMenuProxyMac::captionStyleMenuDidClose):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::Internals::platformView const):
(WebKit::WebPageProxy::protectedAcceleratedCompositingRootLayer const): Deleted.
(WebKit::WebPageProxy::protectedHeaderBannerLayer const): Deleted.
(WebKit::WebPageProxy::protectedFooterBannerLayer const): Deleted.
(WebKit::WebPageProxy::protectedPlatformWindow): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::~WebViewImpl):
(WebKit::WebViewImpl::screenDidChangeColorSpace):
(WebKit::WebViewImpl::remoteObjectRegistry):
* Source/WebKit/UIProcess/win/AutomationClientWin.cpp:
(WebKit::AutomationClient::closeAutomationSession):
(WebKit::AutomationClient::protectedProcessPool const): Deleted.
* Source/WebKit/UIProcess/win/AutomationClientWin.h:
* Source/WebKit/UIProcess/win/AutomationSessionClientWin.cpp:
(WebKit::AutomationSessionClient::requestNewPageWithOptions):
(WebKit::AutomationSessionClient::didDisconnectFromRemote):

Canonical link: <a href="https://commits.webkit.org/306184@main">https://commits.webkit.org/306184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992161e63ee29403695ade48f3d8c5320ea0d3e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148951 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe7ea6f7-e1ae-4166-bab0-da9d75bc6c92) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107820 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28a20dac-3ca4-485c-b1e8-5ebf9b673b64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88720 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/117e927c-c836-4732-b7ad-088a5e033fa2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10200 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7754 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9045 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132590 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151575 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1410 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12682 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116127 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116463 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12309 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67779 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12724 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171885 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76424 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12662 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->