### PR TITLE
[GStreamer][WebRTC] Improve WPT WebRTC tests expectations accuracy

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2245,6 +2245,11 @@ webkit.org/b/264805 imported/w3c/web-platform-tests/websockets/basic-auth.any.se
 webkit.org/b/264805 imported/w3c/web-platform-tests/websockets/basic-auth.any.sharedworker.html?wss [ Failure ]
 webkit.org/b/264805 imported/w3c/web-platform-tests/websockets/basic-auth.any.worker.html?wss [ Failure ]
 
+webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ Pass Crash ]
+webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some-override.https.sub.html [ Pass Crash ]
+webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html [ Pass Crash ]
+webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html [ Pass Crash ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of SOUP and Networking-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////
@@ -2716,6 +2721,7 @@ imported/w3c/web-platform-tests/webrtc/RTCIceTransport.html [ Skip ]
 # Pending investigation.
 webkit.org/b/235885 fast/mediastream/mediastreamtrack-video-clone.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-addIceCandidate.html [ Failure ]
+webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-local-offer.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-local-pranswer.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-offer.html [ Failure ]
 webkit.org/b/235885 fast/mediastream/RTCPeerConnection-have-remote-pranswer.html [ Failure ]
@@ -2770,24 +2776,123 @@ imported/w3c/web-platform-tests/mediacapture-insertable-streams/VideoTrackGenera
 # out, awaiting forever a remote mediastream.
 webkit.org/b/235885 webrtc/canvas-to-peer-connection-vp8.html [ Failure ]
 
-# Pending investigation. Current status is out of 143 tests, only 44 run as
-# expected. The whole suite takes an hour(!) to run but ("only") reports 14
-# tests unexpected timeouts.
+# Skip WebRTC WPT tests and allow-list the ones passing or failing. The Skip (Timeout) expectations
+# hang the test runner forever, likely due to promises not properly configured to time out.
 imported/w3c/web-platform-tests/webrtc/ [ Skip ]
-imported/w3c/web-platform-tests/webrtc/RTCConfiguration-validation.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceCandidatePoolSize.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCConfiguration-iceServers.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCConfiguration-rtcpMuxPolicy.html [ Pass ]
-imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-canTrickleIceCandidates.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCConfiguration-validation.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-GC.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-binaryType.window.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-bufferedAmount.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-close.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-iceRestart.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-id.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-local-close.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-blob-order.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer-negotiated.window.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-blob-negotiated.window.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-blob.window.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string-negotiated.window.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string.window.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCDataChannel-worker-GC.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-GC.https.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-SLD-SRD-timing.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-add-track-no-deadlock.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-connectionSetup.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-timing.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTcpIceCandidate.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTrack.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver-renegotiation.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-canTrickleIceCandidates.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-candidate-in-sdp.https.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-capture-video.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-connectionState.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-constructor.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createAnswer.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createDataChannel.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-createOffer.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-description-attributes-timing.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-generateCertificate.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getStats-timestamp.https.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-getTransceivers.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-helper-test.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-iceConnectionState-disconnected.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-iceConnectionState.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-ondatachannel.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-onicecandidateerror.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-onnegotiationneeded.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-onsignalingstatechanged.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-ontrack.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-operations.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-perfect-negotiation-stress-glare-linear.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-perfect-negotiation-stress-glare.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-perfect-negotiation.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-plan-b-is-not-supported.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-relay-canvas.https.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-remote-track-currentTime.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-remote-track-mute.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-remote-track-properties.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-removeTrack.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-restartIce-onnegotiationneeded.https.html [ Pass Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setDescription-transceiver.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-answer.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-rollback.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-answer.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-nomsid.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-offer.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-replaceTrack.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-simulcast.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-transceivers.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-transport-stats.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-videoDetectorTest.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-headerExtensions.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-rtcp.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getCapabilities.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getContributingSources.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getParameters.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getStats.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-jitterBufferTarget.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-track-settings.tentative.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-anyCodec.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-encode-same-track-twice.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getCapabilities.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getParameters.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getStats.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-replaceTrack.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-setParameters-keyFrame.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-setStreams.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCRtpSender-transport.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-direction.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stop.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stopping.https.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-constructor.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-events.html [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxChannels.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-maxMessageSize.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/RTCTrackEvent-constructor.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/RTCTrackEvent-fire.html  [ Skip ] # Timeout
+imported/w3c/web-platform-tests/webrtc/simplecall.https.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/toJSON.html [ Pass ]
+imported/w3c/web-platform-tests/webrtc/transfer-datachannel.html [ Skip ] # Timeout
 
-webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html [ Pass Crash ]
-webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some-override.https.sub.html [ Pass Crash ]
-webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-some.https.sub.html [ Pass Crash ]
-webkit.org/b/305972 imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-disallowed-for-all.https.sub.html [ Pass Crash ]
+# Triggers an assert in webrtcbin.
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-offer.html [ Skip ] # Crash
 
 # The last promise test here fails because webrtcbin doesn't rely on a singleton signaling thread.
 # See also comments in:
@@ -2809,7 +2914,7 @@ imported/w3c/web-platform-tests/webrtc/protocol/crypto-suite.https.html [ Failur
 
 # Our video encoder is not enforcing video resolution capping based on the configured H.264 level.
 # See also: https://en.wikipedia.org/wiki/Advanced_Video_Coding#Levels
-imported/w3c/web-platform-tests/webrtc/protocol/h264-profile-levels.https.html [ Failure ]
+webkit.org/b/301687 imported/w3c/web-platform-tests/webrtc/protocol/h264-profile-levels.https.html [ Failure ]
 
 # offerPc doesn't receive a datachannel event for the "second back" channel created by
 # answerPcSecond, leading to the test timing out.
@@ -2827,7 +2932,7 @@ imported/w3c/web-platform-tests/webrtc/protocol/ice-ufragpwd.html [ Failure ]
 
 # Missing support for multiple MediaStreams per track/transceiver.
 # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3954
-imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-tracks.https.html [ Skip ]
+imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-tracks.https.html [ Skip ] # Timeout
 imported/w3c/web-platform-tests/webrtc/protocol/msid-generate.html [ Failure ]
 
 imported/w3c/web-platform-tests/webrtc/protocol/additional-codecs.html [ Failure ]
@@ -2847,6 +2952,7 @@ imported/w3c/web-platform-tests/webrtc/simulcast [ Pass ]
 imported/w3c/web-platform-tests/webrtc/simulcast/negotiation-encodings.https.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/simulcast/setParameters-encodings.https.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/simulcast/setParameters-maxFramerate.https.html [ Failure ]
+imported/w3c/web-platform-tests/webrtc/simulcast/vp9-scalability-mode.https.html [ Skip ] 
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/simulcast-answer.html [ Skip ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/simulcast-offer.html [ Skip ]
 webkit.org/b/306018 imported/w3c/web-platform-tests/webrtc/simulcast/av1.https.html [ Pass Failure ]
@@ -2867,8 +2973,7 @@ webrtc/video-getParameters.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/legacy/RTCPeerConnection-createOffer-offerToReceive.optional.html [ Pass ]
 
 # Fails because the transceiver state.currentDirection is expected to be null but isn't.
-# Crash due to webkit.org/b/286859
-imported/w3c/web-platform-tests/webrtc/legacy/RTCRtpTransceiver-with-OfferToReceive-options.optional.https.html [ Failure Crash ]
+imported/w3c/web-platform-tests/webrtc/legacy/RTCRtpTransceiver-with-OfferToReceive-options.optional.https.html [ Failure ]
 
 # Missing support for ICE restarts
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-explicit-rollback-iceGatheringState.html [ Skip ]
@@ -2880,12 +2985,11 @@ webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc-extensions/RTCRtpSync
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Skip ]
 webkit.org/b/235885 imported/w3c/web-platform-tests/webrtc/protocol/rtp-clockrate.html [ Skip ]
 
-imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-insertDTMF.https.html [ Pass ]
+# "insertDTMF() should throw InvalidStateError if transceiver.currentDirection is inactive" test failing.
+imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-insertDTMF.https.html [ Failure ]
+
 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange.https.html [ Pass ]
 imported/w3c/web-platform-tests/webrtc/RTCDTMFSender-ontonechange-long.https.html [ Pass ]
-
-imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-audio-jitterBufferTarget-stats.https.html [ Pass ]
-imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-video-jitterBufferTarget-stats.html [ Pass ]
 
 # Also skipped on mac, timing out because relying on MediaStream::onactive event which is not exposed.
 webkit.org/b/151344 fast/mediastream/MediaStream-add-ended-tracks.html [ Skip ]
@@ -2902,8 +3006,7 @@ imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-par
 # Creates 256 PeerConnections. The test takes around 30 seconds to complete.
 webrtc/datachannel/multiple-connections.html [ Slow ]
 
-# Skia crash in GrResourceCache::notifyARefCntReachedZero
-webkit.org/b/286859 imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html [ Crash Pass ]
+webkit.org/b/306207 imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html [ Crash Pass ]
 
 # This test is almost the same as http/wpt/webrtc/transfer-datachannel-service-worker.https.html.
 # The main difference is that in this test an additional message is sent on the data-channel.

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer-negotiated.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer-negotiated.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Negotiated datachannel should be able to send and receive all arraybuffer messages on close
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Datachannel should be able to send and receive all arraybuffer messages on close
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string-negotiated.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string-negotiated.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Negotiated datachannel should be able to send and receive all string messages on close
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string.window-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Datachannel should be able to send and receive all string messages on close
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver.https-expected.txt
@@ -1,0 +1,22 @@
+
+PASS addTransceiver() with string argument as invalid kind should throw TypeError
+PASS addTransceiver('audio') should return an audio transceiver
+PASS addTransceiver('video') should return a video transceiver
+PASS addTransceiver() with direction sendonly should have result transceiver.direction be the same
+PASS addTransceiver() with direction inactive should have result transceiver.direction be the same
+PASS addTransceiver() with invalid direction should throw TypeError
+PASS addTransceiver(track) should have result with sender.track be given track
+PASS addTransceiver(track) multiple times should create multiple transceivers
+PASS addTransceiver("video") with rid containing invalid non-alphanumeric characters should throw TypeError
+PASS addTransceiver("video") with rid longer than 16 characters should throw TypeError
+PASS addTransceiver("video") with duplicate rids should throw TypeError
+PASS addTransceiver("video") with valid rid value should succeed
+PASS addTransceiver("video") with multiple rid values should succeed
+PASS addTransceiver("video") with valid sendEncodings should succeed
+PASS addTransceiver("audio") with rid containing invalid non-alphanumeric characters should throw TypeError
+PASS addTransceiver("audio") with rid longer than 16 characters should throw TypeError
+PASS addTransceiver("audio") with duplicate rids should throw TypeError
+PASS addTransceiver("audio") with valid rid value should succeed
+PASS addTransceiver("audio") with multiple rid values should succeed
+PASS addTransceiver("audio") with valid sendEncodings should succeed
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-answer-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-answer-expected.txt
@@ -1,0 +1,9 @@
+
+PASS setLocalDescription() with valid answer should succeed
+PASS setLocalDescription() with type answer and null sdp should use lastAnswer generated from createAnswer
+PASS setLocalDescription() with answer not created by own createAnswer() should reject with InvalidModificationError
+PASS Calling setLocalDescription(answer) from stable state should reject with InvalidStateError
+PASS Calling setLocalDescription(answer) from have-local-offer state should reject with InvalidStateError
+PASS Setting previously generated answer after a call to createOffer should work
+PASS setLocalDescription(answer) should update internal state with a queued task, in the right order
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-expected.txt
@@ -1,0 +1,9 @@
+
+PASS setRemoteDescription with invalid type and invalid SDP should reject with TypeError
+PASS setRemoteDescription() with invalid SDP and stable state should reject with InvalidStateError
+PASS Negotiation should fire signalingsstate events
+PASS Calling setRemoteDescription() again after one round of remote-offer/local-answer should succeed
+PASS Switching role from offerer to answerer after going back to stable state should succeed
+PASS Closing on setRemoteDescription() neither resolves nor rejects
+PASS Closing on rollback neither resolves nor rejects
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-simulcast.https-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-simulcast.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS createAnswer() attaches to an existing transceiver with a remote simulcast offer
+

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -86,7 +86,8 @@ std::optional<RTCRtpTransceiverDirection> GStreamerRtpTransceiverBackend::curren
     GstWebRTCRTPTransceiverDirection gstDirection;
     g_object_get(m_rtcTransceiver.get(), "current-direction", &gstDirection, nullptr);
     if (!gstDirection)
-        return RTCRtpTransceiverDirection::Inactive;
+        return { };
+
     return toRTCRtpTransceiverDirection(gstDirection);
 }
 
@@ -139,7 +140,11 @@ bool GStreamerRtpTransceiverBackend::stopped() const
         // VP9 profile 2 requires a 10bit pixel input format, so a conversion might be needed just
         // before encoding. This is taken care of in the webkitvideoencoder itself.
         for (auto& attribute : codec.sdpFmtpLine.split(';')) {
+            if (!attribute.contains('='))
+                continue;
             auto components = attribute.split('=');
+            if (components.size() < 2) [[unlikely]]
+                continue;
             gst_caps_set_simple(caps.get(), components[0].ascii().data(), G_TYPE_STRING, components[1].ascii().data(), nullptr);
         }
     }


### PR DESCRIPTION
#### 15aefed14ee959d965659e1a91d7829ec66016ac
<pre>
[GStreamer][WebRTC] Improve WPT WebRTC tests expectations accuracy
<a href="https://bugs.webkit.org/show_bug.cgi?id=306209">https://bugs.webkit.org/show_bug.cgi?id=306209</a>

Reviewed by Xabier Rodriguez-Calvar.

Some of the previously skipped tests are now unskipped, some are passing and some are failing. Those
hanging-up the test runner remain skipped. This allowed us to find and fix a couple issues in the
GStreamer backend.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer-negotiated.window-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string-negotiated.window-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string.window-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addTransceiver.https-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setLocalDescription-answer-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-simulcast.https-expected.txt: Added.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::setDescription):
(WebCore::GStreamerMediaEndpoint::createTransceiverBackends):
(WebCore::GStreamerMediaEndpoint::preprocessStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::GStreamerRtpTransceiverBackend::currentDirection const):
(WebCore::toRtpCodecCapability):

Canonical link: <a href="https://commits.webkit.org/306195@main">https://commits.webkit.org/306195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1037a48edcfb99a385582909330243249b4d2a34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107772 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78244 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10145 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7703 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119386 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151520 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12627 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116415 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12177 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67711 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12669 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1890 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76369 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->