### PR TITLE
AX: VoiceOver isn't able to access aria-owned rows and their cells in grids / tables

### DIFF
--- a/LayoutTests/accessibility/aria-owns-grid-parts-expected.txt
+++ b/LayoutTests/accessibility/aria-owns-grid-parts-expected.txt
@@ -1,0 +1,52 @@
+This tests that ARIA grids correctly recognize rows and cells via aria-owns, including after dynamic attribute changes.
+
+Testing grid with aria-owned rows:
+PASS: ownedRowsGrid.rowCount === 2
+PASS: ownedRowsGrid.columnCount === 2
+PASS: ownedRowsGrid.width >= 2 === true
+PASS: ownedRowsGrid.height >= 2 === true
+PASS: ownedRowsGrid.cellForColumnAndRow(0, 0).domIdentifier === 'owned-row-cell-1-1'
+PASS: ownedRowsGrid.cellForColumnAndRow(1, 1).domIdentifier === 'owned-row-cell-2-2'
+
+Testing grid with aria-owned cells:
+PASS: ownedCellsGrid.rowCount === 1
+PASS: ownedCellsGrid.columnCount === 2
+PASS: ownedCellsGrid.width >= 2 === true
+PASS: ownedCellsGrid.height >= 2 === true
+PASS: ownedCellsGrid.cellForColumnAndRow(0, 0).domIdentifier === 'owned-cell-1'
+PASS: ownedCellsGrid.cellForColumnAndRow(1, 0).domIdentifier === 'owned-cell-2'
+
+Testing grid with DOM children that are also aria-owned (ordering test):
+PASS: domAndOwnedGrid.rowCount === 3
+PASS: domAndOwnedGrid.width >= 2 === true
+PASS: domAndOwnedGrid.height >= 2 === true
+PASS: domAndOwnedGrid.cellForColumnAndRow(0, 0).domIdentifier === 'dom-row-C-cell'
+PASS: domAndOwnedGrid.cellForColumnAndRow(0, 1).domIdentifier === 'dom-row-B-cell'
+PASS: domAndOwnedGrid.cellForColumnAndRow(0, 2).domIdentifier === 'dom-row-A-cell'
+
+Adding row-3 to aria-owns...
+PASS: ownedRowsGrid.rowCount === 3
+PASS: ownedRowsGrid.cellForColumnAndRow(0, 2).domIdentifier === 'owned-row-cell-3-1'
+
+Adding owned-cell-3 to row...
+PASS: ownedCellsGrid.cellForColumnAndRow(2, 0).domIdentifier === 'owned-cell-3'
+
+Removing owned-row-1 from aria-owns...
+PASS: ownedRowsGrid.rowCount === 2
+PASS: ownedRowsGrid.cellForColumnAndRow(0, 0).domIdentifier === 'owned-row-cell-2-1'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Owned Row 1 Cell 1
+Owned Row 1 Cell 2
+Owned Row 2 Cell 1
+Owned Row 2 Cell 2
+Owned Row 3 Cell 1
+Owned Row 3 Cell 2
+Owned Cell 1
+Owned Cell 2
+Owned Cell 3
+Row A Cell
+Row B Cell
+Row C Cell

--- a/LayoutTests/accessibility/aria-owns-grid-parts.html
+++ b/LayoutTests/accessibility/aria-owns-grid-parts.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<!-- Grid with aria-owned rows -->
+<div id="grid-with-owned-rows" role="grid" aria-label="Grid with owned rows" aria-owns="owned-row-1 owned-row-2"></div>
+<div id="owned-row-1" role="row">
+    <div id="owned-row-cell-1-1" role="gridcell">Owned Row 1 Cell 1</div>
+    <div id="owned-row-cell-1-2" role="gridcell">Owned Row 1 Cell 2</div>
+</div>
+<div id="owned-row-2" role="row">
+    <div id="owned-row-cell-2-1" role="gridcell">Owned Row 2 Cell 1</div>
+    <div id="owned-row-cell-2-2" role="gridcell">Owned Row 2 Cell 2</div>
+</div>
+<div id="owned-row-3" role="row">
+    <div id="owned-row-cell-3-1" role="gridcell">Owned Row 3 Cell 1</div>
+    <div id="owned-row-cell-3-2" role="gridcell">Owned Row 3 Cell 2</div>
+</div>
+
+<!-- Grid with aria-owned cells in a row -->
+<div id="grid-with-owned-cells" role="grid" aria-label="Grid with owned cells">
+    <div id="row-with-owned-cells" role="row" aria-owns="owned-cell-1 owned-cell-2"></div>
+</div>
+<div id="owned-cell-1" role="gridcell">Owned Cell 1</div>
+<div id="owned-cell-2" role="gridcell">Owned Cell 2</div>
+<div id="owned-cell-3" role="gridcell">Owned Cell 3</div>
+
+<!-- Grid where rows are both DOM children AND aria-owned (tests ordering) -->
+<div id="grid-with-dom-and-owned-rows" role="grid" aria-label="Grid with DOM and owned rows" aria-owns="dom-row-B dom-row-A">
+    <div id="dom-row-A" role="row">
+        <div id="dom-row-A-cell" role="gridcell">Row A Cell</div>
+    </div>
+    <div id="dom-row-B" role="row">
+        <div id="dom-row-B-cell" role="gridcell">Row B Cell</div>
+    </div>
+    <div id="dom-row-C" role="row">
+        <div id="dom-row-C-cell" role="gridcell">Row C Cell</div>
+    </div>
+</div>
+
+<script>
+var output = "This tests that ARIA grids correctly recognize rows and cells via aria-owns, including after dynamic attribute changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += "Testing grid with aria-owned rows:\n";
+    var ownedRowsGrid = accessibilityController.accessibleElementById("grid-with-owned-rows");
+    output += expect("ownedRowsGrid.rowCount", "2");
+    output += expect("ownedRowsGrid.columnCount", "2");
+    output += expect("ownedRowsGrid.width >= 2", "true");
+    output += expect("ownedRowsGrid.height >= 2", "true");
+    output += expect("ownedRowsGrid.cellForColumnAndRow(0, 0).domIdentifier", "'owned-row-cell-1-1'");
+    output += expect("ownedRowsGrid.cellForColumnAndRow(1, 1).domIdentifier", "'owned-row-cell-2-2'");
+
+    output += "\nTesting grid with aria-owned cells:\n";
+    var ownedCellsGrid = accessibilityController.accessibleElementById("grid-with-owned-cells");
+    output += expect("ownedCellsGrid.rowCount", "1");
+    output += expect("ownedCellsGrid.columnCount", "2");
+    output += expect("ownedCellsGrid.width >= 2", "true");
+    output += expect("ownedCellsGrid.height >= 2", "true");
+    output += expect("ownedCellsGrid.cellForColumnAndRow(0, 0).domIdentifier", "'owned-cell-1'");
+    output += expect("ownedCellsGrid.cellForColumnAndRow(1, 0).domIdentifier", "'owned-cell-2'");
+
+    // Test grid where rows are both DOM children AND aria-owned.
+    // aria-owns="dom-row-B dom-row-A" should reorder: C (not owned, DOM order), then B, then A.
+    output += "\nTesting grid with DOM children that are also aria-owned (ordering test):\n";
+    var domAndOwnedGrid = accessibilityController.accessibleElementById("grid-with-dom-and-owned-rows");
+    output += expect("domAndOwnedGrid.rowCount", "3");
+    output += expect("domAndOwnedGrid.width >= 2", "true");
+    output += expect("domAndOwnedGrid.height >= 2", "true");
+    // Row C is not aria-owned, so it comes first (DOM order for non-owned children).
+    output += expect("domAndOwnedGrid.cellForColumnAndRow(0, 0).domIdentifier", "'dom-row-C-cell'");
+    // Row B is first in aria-owns, so it comes second.
+    output += expect("domAndOwnedGrid.cellForColumnAndRow(0, 1).domIdentifier", "'dom-row-B-cell'");
+    // Row A is second in aria-owns, so it comes third.
+    output += expect("domAndOwnedGrid.cellForColumnAndRow(0, 2).domIdentifier", "'dom-row-A-cell'");
+
+    output += "\nAdding row-3 to aria-owns...\n";
+    document.getElementById("grid-with-owned-rows").setAttribute("aria-owns", "owned-row-1 owned-row-2 owned-row-3");
+
+    setTimeout(async function() {
+        output += await expectAsync("ownedRowsGrid.rowCount", "3");
+        output += expect("ownedRowsGrid.cellForColumnAndRow(0, 2).domIdentifier", "'owned-row-cell-3-1'");
+
+        output += "\nAdding owned-cell-3 to row...\n";
+        document.getElementById("row-with-owned-cells").setAttribute("aria-owns", "owned-cell-1 owned-cell-2 owned-cell-3");
+
+        await waitFor(() => ownedCellsGrid.cellForColumnAndRow(2, 0) !== null);
+        output += expect("ownedCellsGrid.cellForColumnAndRow(2, 0).domIdentifier", "'owned-cell-3'");
+
+        output += "\nRemoving owned-row-1 from aria-owns...\n";
+        document.getElementById("grid-with-owned-rows").setAttribute("aria-owns", "owned-row-2 owned-row-3");
+
+        output += await expectAsync("ownedRowsGrid.rowCount", "2");
+        output += expect("ownedRowsGrid.cellForColumnAndRow(0, 0).domIdentifier", "'owned-row-cell-2-1'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### cab0b7e28656803df363cfdecec9624985665214
<pre>
AX: VoiceOver isn&apos;t able to access aria-owned rows and their cells in grids / tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=306130">https://bugs.webkit.org/show_bug.cgi?id=306130</a>
<a href="https://rdar.apple.com/168770938">rdar://168770938</a>

Reviewed by Joshua Hoffman.

This commit updates AccessibilityNodeObject::computeCellSlots() to look for and handle aria-owned elements of the
table we are computing cell slots for, mostly fixing the bug. Even after this though, I noticed VoiceOver still
wouldn&apos;t navigate into the table testcases in new test aria-owns-grid-parts.html.

The reason for that was because we were returning an empty frame for the grid, and VoiceOver generally ignores things
with an empty frame. This makes sense — the isolated tree gets geometry from paint, and these grids have no actual DOM
children, just aria-owns children, so they don&apos;t have any meaningful geometry from non-ARIA means.

Fix this by adding more robust frame fallbacks in AXIsolatedObject::relativeFrame. The tests verify we don&apos;t return
an empty frame for any of these grids.

* LayoutTests/accessibility/aria-owns-grid-parts-expected.txt: Added.
* LayoutTests/accessibility/aria-owns-grid-parts.html: Added.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::computeCellSlots):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::relativeFrame const):

Canonical link: <a href="https://commits.webkit.org/308087@main">https://commits.webkit.org/308087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b885fb50aca519d7b4f616a9c9388faddc3c59c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148902 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93650 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b946987a-030d-42ad-a256-fd64f4346da0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107776 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78252 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c71fd734-efee-43f3-88f2-69c399ab9c64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88675 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bad1fc0-7570-4086-a6f1-4d6e47ac86a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10151 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7709 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151526 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116083 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10936 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30997 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67726 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1895 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76375 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12415 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->