### PR TITLE
Unreviewed, try to fix this visionOS build after 306157@main

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift
@@ -31,11 +31,11 @@ internal import WebKit_Internal
 @implementation
 extension WKSeparatedImageView {
     @nonobjc
-    var viewMode: ViewMode
+    final var viewMode: ViewMode
     @nonobjc
-    var cachedViewModeInfo: (NSString, ViewMode)?
+    final var cachedViewModeInfo: (NSString, ViewMode)?
     @nonobjc
-    var desiredViewingModeSpatial: Bool = true {
+    final var desiredViewingModeSpatial: Bool = true {
         didSet {
             #if canImport(RealityFoundation, _version: 387)
             self.portalEntity?.components[ImagePresentationComponent.self]?.desiredViewingMode =
@@ -48,49 +48,49 @@ extension WKSeparatedImageView {
     }
 
     @nonobjc
-    var cgImage: CGImage?
+    final var cgImage: CGImage?
     @nonobjc
-    var imageData: Data?
+    final var imageData: Data?
     @nonobjc
-    var imageHash: NSString?
+    final var imageHash: NSString?
 
     @nonobjc
-    var computeHashTask: Task<Void, Error>?
+    final var computeHashTask: Task<Void, Error>?
     @nonobjc
-    var pickViewModeTask: Task<ViewMode, Error>?
+    final var pickViewModeTask: Task<ViewMode, Error>?
     @nonobjc
-    var generate3DImageTask: Task<Void, Error>?
+    final var generate3DImageTask: Task<Void, Error>?
 
     #if canImport(RealityFoundation, _version: 387)
     @nonobjc
-    var spatial3DImage: ImagePresentationComponent.Spatial3DImage?
+    final var spatial3DImage: ImagePresentationComponent.Spatial3DImage?
     #endif
     @nonobjc
-    var portalEntity: Entity?
+    final var portalEntity: Entity?
     @nonobjc
-    var contentView: UIView
+    final var contentView: UIView
     @nonobjc
-    var cornerView: UIView
+    final var cornerView: UIView
     @nonobjc
-    var spinner: UIActivityIndicatorView?
+    final var spinner: UIActivityIndicatorView?
     @nonobjc
-    var toggleHostingView: UIView?
+    final var toggleHostingView: UIView?
 
     @nonobjc
-    var isSeparated: Bool = false
+    final var isSeparated: Bool = false
     @nonobjc
-    var isAttached: Bool = false
+    final var isAttached: Bool = false
     @nonobjc
-    var isRenderingIPC: Bool = false
+    final var isRenderingIPC: Bool = false
 
     @nonobjc
-    var updateScheduled = false
+    final var updateScheduled = false
 
     @nonobjc
-    var logPrefix: String = ""
+    final var logPrefix: String = ""
 
     @nonobjc
-    private var scaleObservation: NSKeyValueObservation?
+    final private var scaleObservation: NSKeyValueObservation?
 
     @objc
     fileprivate init() {


### PR DESCRIPTION
#### c4a826e9cc97b5bb65e1ddc797812dd7ff059034
<pre>
Unreviewed, try to fix this visionOS build after 306157@main

Add the `final` keyword to these @nonobjc variables to suppress:

```
Setter for property &apos;…&apos; is not valid in an &apos;@objc @implementation&apos; extension because it is an
overridable Swift-only setter for property
```

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift:
(WKSeparatedImageView.viewMode):
(WKSeparatedImageView.cachedViewModeInfo):
(WKSeparatedImageView.desiredViewingModeSpatial):
(WKSeparatedImageView.cgImage):
(WKSeparatedImageView.imageData):
(WKSeparatedImageView.imageHash):
(WKSeparatedImageView.computeHashTask):
(WKSeparatedImageView.pickViewModeTask):
(WKSeparatedImageView.generate3DImageTask):
(WKSeparatedImageView.spatial3DImage):
(WKSeparatedImageView.portalEntity):
(WKSeparatedImageView.contentView):
(WKSeparatedImageView.cornerView):
(WKSeparatedImageView.spinner):
(WKSeparatedImageView.toggleHostingView):
(WKSeparatedImageView.isSeparated):
(WKSeparatedImageView.isAttached):
(WKSeparatedImageView.isRenderingIPC):
(WKSeparatedImageView.logPrefix):
(WKSeparatedImageView.scaleObservation):

Canonical link: <a href="https://commits.webkit.org/306168@main">https://commits.webkit.org/306168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1954d1d96c3c3acfe58373e81b7eba97b591a351

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93642 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13091 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107770 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b05757a8-539a-41c4-9066-fc8ab9b90ba7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143506 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/125830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/88669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa830350-078c-46b0-8ef0-634a4d720c95) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7702 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8988 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151518 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12625 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/1975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116077 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12640 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/10924 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116413 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12169 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67709 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21688 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12667 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/1888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12407 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76367 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12605 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->