### PR TITLE
build-and-analyze: WebKit checker lists diverged between --enable-webkit-checkers and --only-smart-pointers

### DIFF
--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -28,6 +28,25 @@ import subprocess
 import sys
 
 
+WEBKIT_CHECKERS = [
+    'alpha.webkit.ForwardDeclChecker',
+    'alpha.webkit.MemoryUnsafeCastChecker',
+    'alpha.webkit.NoUncheckedPtrMemberChecker',
+    'alpha.webkit.NoUnretainedMemberChecker',
+    'alpha.webkit.RetainPtrCtorAdoptChecker',
+    'alpha.webkit.UncheckedCallArgsChecker',
+    'alpha.webkit.UncheckedLocalVarsChecker',
+    'alpha.webkit.UncountedCallArgsChecker',
+    'alpha.webkit.UncountedLocalVarsChecker',
+    'alpha.webkit.UnretainedCallArgsChecker',
+    'alpha.webkit.UnretainedLambdaCapturesChecker',
+    'alpha.webkit.UnretainedLocalVarsChecker',
+    'webkit.NoUncountedMemberChecker',
+    'webkit.RefCntblBaseVirtualDtor',
+    'webkit.UncountedLambdaCapturesChecker',
+]
+
+
 def args_for_additional_checkers(checker_names):
     if not len(checker_names):
         return []
@@ -79,14 +98,7 @@ def make_analyzer_flags(output_dir, args):
         ])
 
     if args.enable_webkit_checkers:
-        additional_checkers.extend([
-            'webkit.NoUncountedMemberChecker',
-            'webkit.RefCntblBaseVirtualDtor',
-            'webkit.UncountedLambdaCapturesChecker',
-            'alpha.webkit.NoUncheckedPtrMemberChecker',
-            'alpha.webkit.UncountedCallArgsChecker',
-            'alpha.webkit.UncountedLocalVarsChecker'
-        ])
+        additional_checkers.extend(WEBKIT_CHECKERS)
 
     if args.enable_checkers:
         delimiters = re.compile(r'[\s,]+')
@@ -94,23 +106,7 @@ def make_analyzer_flags(output_dir, args):
         additional_checkers.extend(checkers)
 
     if args.only_smart_pointers:
-        additional_checkers.extend([
-            'alpha.webkit.ForwardDeclChecker',
-            'alpha.webkit.MemoryUnsafeCastChecker',
-            'alpha.webkit.NoUncheckedPtrMemberChecker',
-            'alpha.webkit.NoUnretainedMemberChecker',
-            'alpha.webkit.RetainPtrCtorAdoptChecker',
-            'alpha.webkit.UncheckedCallArgsChecker',
-            'alpha.webkit.UncheckedLocalVarsChecker',
-            'alpha.webkit.UncountedCallArgsChecker',
-            'alpha.webkit.UncountedLocalVarsChecker',
-            'alpha.webkit.UnretainedCallArgsChecker',
-            'alpha.webkit.UnretainedLambdaCapturesChecker',
-            'alpha.webkit.UnretainedLocalVarsChecker',
-            'webkit.NoUncountedMemberChecker',
-            'webkit.RefCntblBaseVirtualDtor',
-            'webkit.UncountedLambdaCapturesChecker',
-        ])
+        additional_checkers.extend(WEBKIT_CHECKERS)
 
     if additional_checkers:
         analyzer_flags.extend(args_for_additional_checkers(additional_checkers))


### PR DESCRIPTION
#### 7e19925f7d5a0ac8a10c2a0e31625b3ec3c59822
<pre>
build-and-analyze: WebKit checker lists diverged between --enable-webkit-checkers and --only-smart-pointers
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306214">https://bugs.webkit.org/show_bug.cgi?id=306214</a>&gt;
&lt;<a href="https://rdar.apple.com/168872496">rdar://168872496</a>&gt;

Reviewed by Ryosuke Niwa and Geoffrey Garen.

The WebKit checker list diverged between --enable-webkit-checkers
(6 checkers) and --only-smart-pointers (15 checkers). Extract the
complete list into a WEBKIT_CHECKERS global constant and use it in both
code paths.

* Tools/Scripts/build-and-analyze:
- Add WEBKIT_CHECKERS global constant with all 15 WebKit-specific
  checkers.
(make_analyzer_flags):
- Use WEBKIT_CHECKERS for --enable-webkit-checkers and
  --only-smart-pointers instead of hardcoded list.

Canonical link: <a href="https://commits.webkit.org/306247@main">https://commits.webkit.org/306247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ce4d07cf12d9655dbd0f203efc0c5e0cd4ef7d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93647 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/877005ca-0a33-4221-aaff-65ce3704664b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107774 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78247 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb961fab-e32b-46d7-9e38-49306c5026b2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88673 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d27a9904-ef2e-4b4e-b6a5-9959055f4f02) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7706 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/8993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151523 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12630 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/1983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116081 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12645 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116417 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12190 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67721 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21725 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12672 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1893 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76372 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12456 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->