### PR TITLE
[JSC] Fix `Proxy` Construct Trap to Throw `TypeError` from the current Realm to Align with ECMA-262

### DIFF
--- a/JSTests/stress/proxy-revoke.js
+++ b/JSTests/stress/proxy-revoke.js
@@ -139,7 +139,6 @@ function allHandlersShouldThrow(proxy) {
     shouldThrowNullHandler(() => Reflect.deleteProperty(proxy, "x"));
     shouldThrowNullHandler(() => Reflect.defineProperty(proxy, "x", {value: 40, enumerable: true, configurable: true}));
     shouldThrowNullHandler(() => Reflect.ownKeys(proxy));
-    shouldThrowNullHandler(() => Reflect.apply(proxy, this, []));
     shouldThrowNullHandler(() => Reflect.construct(proxy, []));
 }
 

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -34,27 +34,6 @@ test/built-ins/Proxy/apply/trap-is-not-callable-realm.js:
 test/built-ins/Proxy/construct/arguments-realm.js:
   default: 'Test262Error: Expected SameValue(«function Array() {'
   strict mode: 'Test262Error: Expected SameValue(«function Array() {'
-test/built-ins/Proxy/construct/null-handler-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-boolean-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-null-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-number-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-string-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-symbol-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/Proxy/construct/return-not-object-throws-undefined-realm.js:
-  default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-  strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
 test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -661,7 +661,10 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
     ProxyObject* proxy = uncheckedDowncast<ProxyObject>(callFrame->jsCallee());
     JSValue handlerValue = proxy->handler();
     if (handlerValue.isNull())
-        return throwVMTypeError(globalObject, scope, s_proxyAlreadyRevokedErrorMessage);
+        // Proxies, unlike other spec provided callable/constructable objects,
+        // don't switch the realm when called/constructed
+        // see: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
+        return throwVMTypeError(CallFrame::globalObjectOfClosestCodeBlock(vm, callFrame), scope, s_proxyAlreadyRevokedErrorMessage);
 
     JSObject* handler = uncheckedDowncast<JSObject>(handlerValue);
     CallData callData;
@@ -684,7 +687,10 @@ JSC_DEFINE_HOST_FUNCTION(performProxyConstruct, (JSGlobalObject* globalObject, C
     JSValue result = call(globalObject, constructMethod, callData, handler, arguments);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
     if (!result.isObject())
-        return throwVMTypeError(globalObject, scope, "Result from Proxy handler's 'construct' method should be an object"_s);
+        // Proxies, unlike other spec provided callable/constructable objects,
+        // don't switch the realm when called/constructed
+        // see: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget
+        return throwVMTypeError(CallFrame::globalObjectOfClosestCodeBlock(vm, callFrame), scope, "Result from Proxy handler's 'construct' method should be an object"_s);
     return JSValue::encode(result);
 }
 


### PR DESCRIPTION
#### 26cc47d853a89def4d0bef67512dd158c3e7e56d
<pre>
[JSC] Fix `Proxy` Construct Trap to Throw `TypeError` from the current Realm to Align with ECMA-262
<a href="https://bugs.webkit.org/show_bug.cgi?id=306217">https://bugs.webkit.org/show_bug.cgi?id=306217</a>

Reviewed by Keith Miller.

This patch fixes Proxy construct to throw `TypeError`
from the current Realm to align with ECMA-262 [1].

[1]: <a href="https://tc39.es/ecma262/#sec-proxycreate">https://tc39.es/ecma262/#sec-proxycreate</a>

* JSTests/stress/proxy-revoke.js:
(allHandlersShouldThrow):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/313966@main">https://commits.webkit.org/313966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0514a504814c6a21007cc1346f4c6f6d0d46a29a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120199 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127156 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89625 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147177 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28491 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20351 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155859 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175153 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24599 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135462 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36862 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135445 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36701 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146689 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99737 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23543 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109503 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51133 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35855 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1573 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36002 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->