### PR TITLE
Drop unnecessary usage of ternary operator in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -125,7 +125,7 @@ bool isARM64E_FPAC()
         uint32_t val = 0;
         size_t valSize = sizeof(val);
         int rc = sysctlbyname("hw.optional.arm.FEAT_FPAC", &val, &valSize, nullptr, 0);
-        g_jscConfig.canUseFPAC = rc < 0 ? false : !!val;
+        g_jscConfig.canUseFPAC = rc >= 0 && val;
     });
     return g_jscConfig.canUseFPAC;
 #else

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.cpp
@@ -113,7 +113,7 @@ DeleteByStatus DeleteByStatus::computeForStubInfoWithoutExitSiteFeedback(const C
             switch (access.type()) {
             case AccessCase::DeleteMiss:
             case AccessCase::DeleteNonConfigurable: {
-                DeleteByVariant variant(access.identifier(), access.type() == AccessCase::DeleteMiss ? true : false, structure, nullptr, invalidOffset);
+                DeleteByVariant variant(access.identifier(), access.type() == AccessCase::DeleteMiss, structure, nullptr, invalidOffset);
                 if (!result.appendVariant(variant))
                     return DeleteByStatus(JSC::slowVersion(summary), *stubInfo);
                 break;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -4660,7 +4660,7 @@ void BytecodeGenerator::emitTryWithFinallyThatDoesNotShadowException(FinallyCont
 
 void BytecodeGenerator::emitGenericEnumeration(ThrowableExpressionData* node, ExpressionNode* subjectNode, const ScopedLambda<void(BytecodeGenerator&, RegisterID*)>& callBack, ForOfNode* forLoopNode, RegisterID* forLoopSymbolTable)
 {
-    bool isForAwait = forLoopNode ? forLoopNode->isForAwait() : false;
+    bool isForAwait = forLoopNode && forLoopNode->isForAwait();
     auto shouldEmitAwait = isForAwait ? EmitAwait::Yes : EmitAwait::No;
     ASSERT(!isForAwait || (isAsyncFunctionParseMode(parseMode()) || isModuleParseMode(parseMode())));
 

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4093,7 +4093,7 @@ RegisterID* ShortCircuitReadModifyResolveNode::emitBytecode(BytecodeGenerator& g
 
     generator.emitNode(uncheckedResult.get(), m_right); // Execute side effects first.
 
-    bool threwException = isReadOnly ? generator.emitReadOnlyExceptionIfNeeded(var) : false;
+    bool threwException = isReadOnly && generator.emitReadOnlyExceptionIfNeeded(var);
 
     if (!threwException)
         generator.emitExpressionInfo(divot(), divotStart(), divotEnd());

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3591,7 +3591,7 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             
         case IsFinalTierIntrinsic: {
             insertChecks();
-            setResult(jsConstant(jsBoolean(Options::useFTLJIT() ? m_graph.m_plan.isFTL() : true)));
+            setResult(jsConstant(jsBoolean(!Options::useFTLJIT() || m_graph.m_plan.isFTL())));
             return CallOptimizationResult::Inlined;
         }
             

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -107,12 +107,12 @@ StatementNode* BlockNode::singleStatement() const
 
 bool BlockNode::hasCompletionValue() const
 {
-    return m_statements ? m_statements->hasCompletionValue() : false;
+    return m_statements && m_statements->hasCompletionValue();
 }
 
 bool BlockNode::hasEarlyBreakOrContinue() const
 {
-    return m_statements ? m_statements->hasEarlyBreakOrContinue() : false;
+    return m_statements && m_statements->hasEarlyBreakOrContinue();
 }
 
 // ------------------------------ ScopeNode -----------------------------
@@ -155,12 +155,12 @@ StatementNode* ScopeNode::singleStatement() const
 
 bool ScopeNode::hasCompletionValue() const
 {
-    return m_statements ? m_statements->hasCompletionValue() : false;
+    return m_statements && m_statements->hasCompletionValue();
 }
 
 bool ScopeNode::hasEarlyBreakOrContinue() const
 {
-    return m_statements ? m_statements->hasEarlyBreakOrContinue() : false;
+    return m_statements && m_statements->hasEarlyBreakOrContinue();
 }
 
 // ------------------------------ ProgramNode -----------------------------

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -2456,8 +2456,8 @@ namespace JSC {
         const Identifier& ecmaName() { return m_ecmaName ? *m_ecmaName : m_name; }
         void setEcmaName(const Identifier& name) { m_ecmaName = m_name.isNull() ? &name : &m_name; }
 
-        bool hasStaticProperty(const Identifier& propName) { return m_classElements ? m_classElements->hasStaticallyNamedProperty(propName) : false; }
-        bool hasInstanceFields() const { return m_classElements ? m_classElements->hasInstanceFields() : false; }
+        bool hasStaticProperty(const Identifier& propName) { return m_classElements && m_classElements->hasStaticallyNamedProperty(propName); }
+        bool hasInstanceFields() const { return m_classElements && m_classElements->hasInstanceFields(); }
 
     private:
         RegisterID* emitBytecode(BytecodeGenerator&, RegisterID* = nullptr) final;

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -2244,8 +2244,8 @@ template <class TreeBuilder> TreeFunctionBody Parser<LexerType>::parseFunctionBo
     TreeBuilder& context, SyntaxChecker& syntaxChecker, const JSTokenLocation& startLocation, int startColumn, unsigned functionStart, int functionNameStart, int parametersStart,
     ConstructorKind constructorKind, SuperBinding superBinding, FunctionBodyType bodyType, unsigned parameterCount)
 {
-    SetForScope overrideParsingClassFieldInitializer(m_parserState.isParsingClassFieldInitializer, bodyType == StandardFunctionBodyBlock ? false : m_parserState.isParsingClassFieldInitializer);
-    SetForScope maybeUnmaskAsync(m_parserState.classFieldInitMasksAsync, isAsyncFunctionParseMode(m_parseMode) ? false : m_parserState.classFieldInitMasksAsync);
+    SetForScope overrideParsingClassFieldInitializer(m_parserState.isParsingClassFieldInitializer, bodyType != StandardFunctionBodyBlock && m_parserState.isParsingClassFieldInitializer);
+    SetForScope maybeUnmaskAsync(m_parserState.classFieldInitMasksAsync, !isAsyncFunctionParseMode(m_parseMode) && m_parserState.classFieldInitMasksAsync);
     bool isArrowFunctionBodyExpression = bodyType == ArrowFunctionBodyExpression;
     if (!isArrowFunctionBodyExpression) {
         next();

--- a/Source/JavaScriptCore/runtime/Butterfly.h
+++ b/Source/JavaScriptCore/runtime/Butterfly.h
@@ -140,7 +140,7 @@ public:
     
     static size_t totalSize(size_t preCapacity, size_t propertyCapacity, bool hasIndexingHeader, size_t indexingPayloadSizeInBytes)
     {
-        ASSERT(indexingPayloadSizeInBytes ? hasIndexingHeader : true);
+        ASSERT(!indexingPayloadSizeInBytes || hasIndexingHeader);
         ASSERT(sizeof(EncodedJSValue) == sizeof(IndexingHeader));
         return (preCapacity + propertyCapacity) * sizeof(EncodedJSValue) + (hasIndexingHeader ? sizeof(IndexingHeader) : 0) + indexingPayloadSizeInBytes;
     }

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1494,7 +1494,7 @@ JSValue LiteralParser<CharType, reviverMode>::parseRecursively(VM& vm, uint8_t* 
                         m_parseErrorMessage = "Attempted to redefine __proto__ property"_s;
                         return { };
                     }
-                    PutPropertySlot slot(object, m_nullOrCodeBlock ? m_nullOrCodeBlock->ownerExecutable()->isInStrictContext() : false);
+                    PutPropertySlot slot(object, m_nullOrCodeBlock && m_nullOrCodeBlock->ownerExecutable()->isInStrictContext());
                     JSValue(object).put(m_globalObject, ident, value, slot);
                     RETURN_IF_EXCEPTION(scope, { });
                 } else if (std::optional<uint32_t> index = parseIndex(ident)) {
@@ -1672,7 +1672,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
                             m_parseErrorMessage = "Attempted to redefine __proto__ property"_s;
                             return { };
                         }
-                        PutPropertySlot slot(object, m_nullOrCodeBlock ? m_nullOrCodeBlock->ownerExecutable()->isInStrictContext() : false);
+                        PutPropertySlot slot(object, m_nullOrCodeBlock && m_nullOrCodeBlock->ownerExecutable()->isInStrictContext());
                         JSValue(object).put(m_globalObject, ident, primitive, slot);
                         RETURN_IF_EXCEPTION(scope, { });
                     } else {
@@ -1767,7 +1767,7 @@ JSValue LiteralParser<CharType, reviverMode>::parse(VM& vm, ParserState initialS
                     m_parseErrorMessage = "Attempted to redefine __proto__ property"_s;
                     return { };
                 }
-                PutPropertySlot slot(object, m_nullOrCodeBlock ? m_nullOrCodeBlock->ownerExecutable()->isInStrictContext() : false);
+                PutPropertySlot slot(object, m_nullOrCodeBlock && m_nullOrCodeBlock->ownerExecutable()->isInStrictContext());
                 JSValue(object).put(m_globalObject, ident, lastValue, slot);
                 RETURN_IF_EXCEPTION(scope, { });
             } else {

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -519,9 +519,9 @@ bool OptionRange::isInRange(unsigned count) const
         return true;
 
     if ((m_lowLimit <= count) && (count <= m_highLimit))
-        return m_state == Normal ? true : false;
+        return m_state == Normal;
 
-    return m_state == Normal ? false : true;
+    return m_state != Normal;
 }
 
 void OptionRange::dump(PrintStream& out) const

--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -235,7 +235,7 @@ public:
 
     ALWAYS_INLINE static bool isValidVM(VM* vm)
     {
-        return vm == s_recentVM ? true : isValidVMSlow(vm);
+        return vm == s_recentVM || isValidVMSlow(vm);
     }
 
     // StopTheWorld APIs ======================================================


### PR DESCRIPTION
#### c4e25ac3fb225a92faf47134e6d8dd0c5b52a756
<pre>
Drop unnecessary usage of ternary operator in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=306221">https://bugs.webkit.org/show_bug.cgi?id=306221</a>
<a href="https://rdar.apple.com/168876630">rdar://168876630</a>

Reviewed by Darin Adler.

This improves readability and enforces more idiomatic C++ by resorting to
equivalent binary boolean operations.

* Source/JavaScriptCore/assembler/CPU.cpp:
(JSC::isARM64E_FPAC):
* Source/JavaScriptCore/bytecode/DeleteByStatus.cpp:
(JSC::DeleteByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitGenericEnumeration):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ShortCircuitReadModifyResolveNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/parser/Nodes.cpp:
(JSC::BlockNode::hasCompletionValue const):
(JSC::BlockNode::hasEarlyBreakOrContinue const):
(JSC::ScopeNode::hasCompletionValue const):
(JSC::ScopeNode::hasEarlyBreakOrContinue const):
* Source/JavaScriptCore/parser/Nodes.h:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseFunctionBody):
* Source/JavaScriptCore/runtime/Butterfly.h:
(JSC::Butterfly::totalSize):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::requires):
(JSC::reviverMode&gt;::parse):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::OptionRange::isInRange const):
* Source/JavaScriptCore/runtime/VMManager.h:
(JSC::VMManager::isValidVM):

Canonical link: <a href="https://commits.webkit.org/306188@main">https://commits.webkit.org/306188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37d80a85f02dc55f0d90df9a5beb53cca1bf7f36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/12961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93666 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107786 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78263 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10168 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7723 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9012 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132557 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151542 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1377 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2004 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/10956 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29618 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12231 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12691 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1912 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171852 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76391 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44601 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->