### PR TITLE
[macOS] Adopt several `NSTextInputClient` and `NSTextInputContext` APIs

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8087,6 +8087,16 @@ TextExtractionFilterEnabled:
       "ENABLE(TEXT_EXTRACTION_FILTER)": true
       default: false
 
+TextInputClientSelectionUpdatesEnabled:
+  type: bool
+  status: embedder
+  webcoreBinding: none
+  condition: PLATFORM(MAC)
+  exposed: [ WebKit ]
+  defaultValue:
+    WebKit:
+      default: WebKit::defaultTextInputClientSelectionUpdatesEnabled()
+
 TextInteractionEnabled:
   type: bool
   status: embedder

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -49,22 +49,33 @@ static bool platformIsLiquidGlassEnabled()
 #endif
 
 namespace WebKit {
+
 #if ENABLE(VIDEO)
+
 bool defaultCaptionDisplaySettingsEnabled()
 {
     return false;
 }
+
 #endif
 
 #if PLATFORM(MAC)
+
 bool defaultUseAppKitGestures()
 {
     return false;
 }
-#endif
+
+bool defaultTextInputClientSelectionUpdatesEnabled()
+{
+    return false;
 }
 
-#endif
+#endif // PLATFORM(MAC)
+
+}
+
+#endif // namespace WebKit
 
 namespace WebKit {
 

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -105,6 +105,7 @@ bool defaultPassiveWheelListenersAsDefaultOnDocument();
 bool defaultWheelEventGesturesBecomeNonBlocking();
 bool defaultAppleMailPaginationQuirkEnabled();
 bool defaultUseAppKitGestures();
+bool defaultTextInputClientSelectionUpdatesEnabled();
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -739,6 +739,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
     _impl->removeTextPlaceholder(placeholder, willInsertText, completionHandler);
 }
 
+- (NSRect)unionRectInVisibleSelectedRange
+{
+    return _impl->unionRectInVisibleSelectedRange();
+}
+
+- (NSRect)documentVisibleRect
+{
+    return _impl->documentVisibleRect();
+}
+
 - (void)showContextMenuForSelection:(id)sender
 {
     _page->handleContextMenuKeyEvent();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -675,6 +675,9 @@ public:
     void characterIndexForPoint(NSPoint, void(^)(NSUInteger));
     void typingAttributesWithCompletionHandler(void(^)(NSDictionary<NSString *, id> *));
 
+    NSRect unionRectInVisibleSelectedRange() const;
+    NSRect documentVisibleRect() const;
+
     bool isContentRichlyEditable() const;
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
@@ -850,6 +853,9 @@ private:
     void fulfillDeferredImageAnalysisOverlayViewHierarchyTask();
 #endif
 
+    bool pageIsScrolledToTop() const { return m_lastPageScrollPosition.y() <= 0; }
+    void pageScrollingHysteresisFired(PAL::HysteresisState);
+
     bool hasContentRelativeChildViews() const;
 
     void suppressContentRelativeChildViews();
@@ -994,6 +1000,7 @@ private:
     id m_flagsChangedEventMonitor { nullptr };
 
     const UniqueRef<PAL::HysteresisActivity> m_contentRelativeViewsHysteresis;
+    std::unique_ptr<PAL::HysteresisActivity> m_pageScrollingHysteresis;
 
     RetainPtr<NSColorSpace> m_colorSpace;
 
@@ -1077,7 +1084,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<WKTextAnimationManager> m_textAnimationTypeManager;
 #endif
 
-    bool m_pageIsScrolledToTop { true };
+    WebCore::IntPoint m_lastPageScrollPosition;
     bool m_isRegisteredScrollViewSeparatorTrackingAdapter { false };
     NSRect m_lastScrollViewFrame { NSZeroRect };
 


### PR DESCRIPTION
#### 7547947782451bc6f8978b4d865fb3b447abb629
<pre>
[macOS] Adopt several `NSTextInputClient` and `NSTextInputContext` APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=306230">https://bugs.webkit.org/show_bug.cgi?id=306230</a>
<a href="https://rdar.apple.com/165725855">rdar://165725855</a>

Reviewed by Abrar Rahman Protyasha.

Add support for several `NSTextInputClient` methods, as well as calls to the text input context
when the selection changes (or when scrolling starts or stops). See below for more details.

Test: EditorStateTests.UnionRectInVisibleSelectedRangeAndDocumentVisibleRect

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultTextInputClientSelectionUpdatesEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:

Add a new flag to guard the call to `-textInputClientDidUpdateSelection` below.

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView unionRectInVisibleSelectedRange]):
(-[WKWebView documentVisibleRect]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:

Replace `m_pageIsScrolledToTop` with an `IntPoint m_lastPageScrollPosition`, and add a new getter
for `pageIsScrolledToTop()` based on the `m_lastPageScrollPosition`.

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::pageDidScroll):
(WebKit::WebViewImpl::updateScrollPocketVisibilityWhenScrolledToTop):
(WebKit::WebViewImpl::hasScrolledContentsUnderTitlebar):
(WebKit::WebViewImpl::selectionDidChange):

Add a call to `-[NSTextInputContext textInputClientDidUpdateSelection]` when the selection changes.
Put this behind a runtime setting, to keep existing caret decoration UI updates working (see
<a href="https://rdar.apple.com/165160994">rdar://165160994</a> for more details).

(WebKit::WebViewImpl::unionRectInVisibleSelectedRange const):

Implement `-[NSTextInputClient unionRectInVisibleSelectedRange]` in terms of
`WebPageProxy::selectionBoundingRectInRootViewCoordinates()`.

(WebKit::WebViewImpl::documentVisibleRect const):

Implement `-[NSTextInputClient documentVisibleRect]`.

(WebKit::WebViewImpl::pageScrollingHysteresisFired):

Add calls to `-[NSTextInputContext textInputClientWillStartScrollingOrZooming]` and
`-[NSTextInputContext textInputClientDidEndScrollingOrZooming]` by adding a 500 ms hysteresis
activity, triggered when the page scrolls.

(WebKit::WebViewImpl::updatePrefersSolidColorHardPocket):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeAndDocumentVisibleRect)):

Canonical link: <a href="https://commits.webkit.org/306235@main">https://commits.webkit.org/306235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ced57c0d8039b0cef11b9421ace9f901076f877

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149088 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142608 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107925 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143686 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88827 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7857 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9168 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132713 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151698 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1533 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116225 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116563 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29642 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12549 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67945 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12847 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172027 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76547 "") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44630 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12631 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->