### PR TITLE
Fix -Wlifetime-safety-permissive warning in XPathNodeSet::findRootNode()

### DIFF
--- a/Source/WebCore/xml/XPathNodeSet.cpp
+++ b/Source/WebCore/xml/XPathNodeSet.cpp
@@ -180,17 +180,16 @@ void NodeSet::sort() const
     m_isSorted = true;
 }
 
-static Node* findRootNode(Node* node)
+static inline RefPtr<Node> findRootNode(Node* node)
 {
-    if (RefPtr attr = dynamicDowncast<Attr>(*node))
-        node = attr->ownerElement();
-    if (node->isConnected())
-        node = &node->document();
-    else {
-        while (RefPtr parent = node->parentNode())
-            node = parent.get();
-    }
-    return node;
+    RefPtr<Node> current = node;
+    if (RefPtr attr = dynamicDowncast<Attr>(*current))
+        current = attr->ownerElement();
+    if (current->isConnected())
+        return current->protectedDocument();
+    for (RefPtr parent = current->parentNode(); parent; parent = current->parentNode())
+        current = WTF::move(parent);
+    return current;
 }
 
 void NodeSet::traversalSort() const


### PR DESCRIPTION
#### 7a9af69f9b93c41f55a6861f2896b75c9648d621
<pre>
Fix -Wlifetime-safety-permissive warning in XPathNodeSet::findRootNode()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306226">https://bugs.webkit.org/show_bug.cgi?id=306226</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/168880148">rdar://problem/168880148</a>&gt;

Reviewed by Geoffrey Garen.

Clang&apos;s -Wlifetime-safety-permissive warning detected a potential issue
in the findRootNode() function.

The fix introduces `RefPtr&lt;Node&gt; current` to maintain proper lifetime
management throughout the function.  This is necessary because
`attr-&gt;ownerElement()` returns a raw pointer from a `WeakPtr&lt;Element&gt;`,
so when the `RefPtr attr` goes out of scope after the if statement,
nothing would keep the ownerElement alive if we stored it in a raw
pointer.

Similarly, the while loop&apos;s `RefPtr parent` was destroyed at the end of
each loop iteration while `node` held a raw pointer to it.  The while
loop is also changed to a for loop to avoid recreating the `RefPtr
parent` variable on each loop iteration.

findRootNode() is also changed to inline and to return `RefPtr&lt;Node&gt;`
since its single caller stores the result in a `RefPtr`.

No new tests since no change in behavior.

* Source/WebCore/xml/XPathNodeSet.cpp:
(WebCore::XPath::findRootNode):

Canonical link: <a href="https://commits.webkit.org/306240@main">https://commits.webkit.org/306240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dbd3a6a4c0831c07c49bf03220e0084e082d124

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93722 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3f968d8-2d59-4e16-983e-ef71521c687c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107834 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78289 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c92c2a5c-d8a1-4216-9c88-0b2b7930671a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88734 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ef282cb-df24-4d30-a6d6-7d19d5d679aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7769 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9068 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151598 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12705 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116141 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116477 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12339 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67802 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21721 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12747 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1953 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76447 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12685 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->