### PR TITLE
[JSC] Unify NewGenerator and NewAsyncGenerator into NewInternalFieldObject

### DIFF
--- a/JSTests/microbenchmarks/generator-object-sinking.js
+++ b/JSTests/microbenchmarks/generator-object-sinking.js
@@ -1,0 +1,14 @@
+function* gen(x) { return x; }
+
+function test(count) {
+    var sum = 0;
+    for (var i = 0; i < count; ++i) {
+        var g = gen(i);
+        if (i < 0) sum += g.next().value;
+        else sum += i * 2;
+    }
+    return sum;
+}
+noInline(test);
+
+test(1e6);

--- a/JSTests/stress/async-generator-function-declaration-sinking-osrexit.js
+++ b/JSTests/stress/async-generator-function-declaration-sinking-osrexit.js
@@ -1,0 +1,42 @@
+function shouldBe(expected, actual, msg = "") {
+    if (msg)
+        msg = " for " + msg;
+    if (actual !== expected)
+        throw new Error("bad value" + msg + ": " + actual + ". Expected " + expected);
+}
+
+function shouldBeAsyncValue(expected, promise, msg) {
+    let actual;
+    var hadError = false;
+    promise.then(function(value) { actual = value; },
+                 function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+
+    if (hadError)
+        throw actual;
+
+    shouldBe(expected, actual, msg);
+}
+
+var AsyncGeneratorFunctionPrototype = (async function*(){}).__proto__;
+
+function sink (p, q) {
+    async function *g(x) { yield x; };
+    if (p) { if (q) OSRExit(); return g; }
+    async function *f(x) { yield x; };
+    return f;
+}
+noInline(sink);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var f = sink(true, false);
+    shouldBe(AsyncGeneratorFunctionPrototype, f.__proto__);
+    shouldBeAsyncValue(42, f(42).next().then(r => r.value));
+}
+
+// At this point, the function should be compiled down to the FTL
+
+// Check that the function is properly allocated on OSR exit
+var f = sink(true, true);
+shouldBe(AsyncGeneratorFunctionPrototype, f.__proto__);
+shouldBeAsyncValue(42, f(42).next().then(r => r.value));

--- a/JSTests/stress/async-generator-object-sinking-osrexit.js
+++ b/JSTests/stress/async-generator-object-sinking-osrexit.js
@@ -1,0 +1,38 @@
+function shouldBe(expected, actual, msg = "") {
+    if (msg)
+        msg = " for " + msg;
+    if (actual !== expected)
+        throw new Error("bad value" + msg + ": " + actual + ". Expected " + expected);
+}
+
+function shouldBeAsyncValue(expected, promise, msg) {
+    let actual;
+    var hadError = false;
+    promise.then(function(value) { actual = value; },
+                 function(error) { hadError = true; actual = error; });
+    drainMicrotasks();
+
+    if (hadError)
+        throw actual;
+
+    shouldBe(expected, actual, msg);
+}
+
+function sink(p, q) {
+    async function* gen(x) { return x; }
+    var g = gen(42);
+    if (p) { if (q) OSRExit(); return g; }
+    return {};
+}
+noInline(sink);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var g = sink(true, false);
+    shouldBeAsyncValue(42, g.next().then(r => r.value));
+}
+
+// At this point, the function should be compiled down to the FTL
+
+// Check that the async generator object is properly allocated on OSR exit
+var g = sink(true, true);
+shouldBeAsyncValue(42, g.next().then(r => r.value));

--- a/JSTests/stress/generator-object-sinking-osrexit.js
+++ b/JSTests/stress/generator-object-sinking-osrexit.js
@@ -1,0 +1,25 @@
+function shouldBe(expected, actual, msg = "") {
+    if (msg)
+        msg = " for " + msg;
+    if (actual !== expected)
+        throw new Error("bad value" + msg + ": " + actual + ". Expected " + expected);
+}
+
+function sink(p, q) {
+    function* gen(x) { return x; }
+    var g = gen(42);
+    if (p) { if (q) OSRExit(); return g; }
+    return { next() { return { value: 0, done: true }; } };
+}
+noInline(sink);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var g = sink(true, false);
+    shouldBe(42, g.next().value);
+}
+
+// At this point, the function should be compiled down to the FTL
+
+// Check that the generator object is properly allocated on OSR exit
+var g = sink(true, true);
+shouldBe(42, g.next().value);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3936,8 +3936,6 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
-    case NewGenerator:
-    case NewAsyncGenerator:    
     case NewInternalFieldObject:
     case NewObject:
     case MaterializeNewInternalFieldObject:

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -7239,12 +7239,12 @@ void ByteCodeParser::parseBlock(unsigned limit)
         }
 
         case op_create_generator: {
-            handleCreateInternalFieldObject(JSGenerator::info(), CreateGenerator, NewGenerator, currentInstruction->as<OpCreateGenerator>());
+            handleCreateInternalFieldObject(JSGenerator::info(), CreateGenerator, NewInternalFieldObject, currentInstruction->as<OpCreateGenerator>());
             NEXT_OPCODE(op_create_generator);
         }
 
         case op_create_async_generator: {
-            handleCreateInternalFieldObject(JSAsyncGenerator::info(), CreateAsyncGenerator, NewAsyncGenerator, currentInstruction->as<OpCreateAsyncGenerator>());
+            handleCreateInternalFieldObject(JSAsyncGenerator::info(), CreateAsyncGenerator, NewInternalFieldObject, currentInstruction->as<OpCreateAsyncGenerator>());
             NEXT_OPCODE(op_create_async_generator);
         }
 
@@ -7267,7 +7267,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
         case op_new_generator: {
             auto bytecode = currentInstruction->as<OpNewGenerator>();
             JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
-            set(bytecode.m_dst, addToGraph(NewGenerator, OpInfo(m_graph.registerStructure(globalObject->generatorStructure()))));
+            set(bytecode.m_dst, addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->generatorStructure()))));
             NEXT_OPCODE(op_new_generator);
         }
             

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2151,8 +2151,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case NewObject:
-    case NewGenerator:
-    case NewAsyncGenerator:
     case NewInternalFieldObject:
     case NewRegExp:
     case NewStringObject:

--- a/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
@@ -56,8 +56,6 @@ bool clobbersExitState(Graph& graph, Node* node)
     case ArrayifyToStructure:
     case Arrayify:
     case NewObject:
-    case NewGenerator:
-    case NewAsyncGenerator:
     case NewInternalFieldObject:
     case NewRegExp:
     case NewMap:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1007,7 +1007,7 @@ private:
 
             case CreateGenerator:
             case CreateAsyncGenerator: {
-                auto foldConstant = [&] (NodeType newOp, const ClassInfo* classInfo) {
+                auto foldConstant = [&] (const ClassInfo* classInfo) {
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                     if (JSValue base = m_state.forNode(node->child1()).m_value) {
                         if (auto* function = jsDynamicCast<JSFunction*>(base)) {
@@ -1019,7 +1019,7 @@ private:
                                         && structure->globalObject() == globalObject) {
                                         m_graph.freeze(rareData);
                                         m_graph.watchpoints().addLazily(rareData->allocationProfileWatchpointSet());
-                                        node->convertToNewInternalFieldObjectWithInlineFields(newOp, m_graph.registerStructure(structure));
+                                        node->convertToNewInternalFieldObject(m_graph.registerStructure(structure));
                                         changed = true;
                                         return;
                                     }
@@ -1031,10 +1031,10 @@ private:
 
                 switch (node->op()) {
                 case CreateGenerator:
-                    foldConstant(NewGenerator, JSGenerator::info());
+                    foldConstant(JSGenerator::info());
                     break;
                 case CreateAsyncGenerator:
-                    foldConstant(NewAsyncGenerator, JSAsyncGenerator::info());
+                    foldConstant(JSAsyncGenerator::info());
                     break;
                 default:
                     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -410,8 +410,6 @@ bool doesGC(Graph& graph, Node* node)
     case Arrayify:
     case ArrayifyToStructure:
     case NewObject:
-    case NewGenerator:
-    case NewAsyncGenerator:
     case NewArray:
     case NewArrayWithSpread:
     case NewInternalFieldObject:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3508,8 +3508,6 @@ private:
         case TailCallInlinedCallerWasm:
         case ProfileControlFlow:
         case NewObject:
-        case NewGenerator:
-        case NewAsyncGenerator:
         case NewInternalFieldObject:
         case NewRegExp:
         case NewMap:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -904,17 +904,8 @@ public:
 
     void convertToNewInternalFieldObject(RegisteredStructure structure)
     {
-        ASSERT(m_op == CreatePromise);
+        ASSERT(m_op == CreatePromise || m_op == CreateAsyncGenerator || m_op == CreateGenerator);
         setOpAndDefaultFlags(NewInternalFieldObject);
-        children.reset();
-        m_opInfo = structure;
-        m_opInfo2 = OpInfoWrapper();
-    }
-
-    void convertToNewInternalFieldObjectWithInlineFields(NodeType newOp, RegisteredStructure structure)
-    {
-        ASSERT(m_op == CreateAsyncGenerator || m_op == CreateGenerator);
-        setOpAndDefaultFlags(newOp);
         children.reset();
         m_opInfo = structure;
         m_opInfo2 = OpInfoWrapper();
@@ -2395,8 +2386,6 @@ public:
         case ArrayifyToStructure:
         case MaterializeNewInternalFieldObject:
         case NewObject:
-        case NewGenerator:
-        case NewAsyncGenerator:
         case NewInternalFieldObject:
         case NewStringObject:
         case NewRegExpUntyped:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -407,8 +407,6 @@ namespace JSC { namespace DFG {
     \
     /* Allocations. */\
     macro(NewObject, NodeResultJS) \
-    macro(NewGenerator, NodeResultJS) \
-    macro(NewAsyncGenerator, NodeResultJS) \
     /* FIXME: A lot of these could likely be consolidated but there's some subtle differences between them, particularly when having a bad time. */ \
     macro(NewArray, NodeResultJS | NodeHasVarArgs) \
     macro(NewArrayWithSpread, NodeResultJS | NodeHasVarArgs) \

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -42,6 +42,8 @@
 #include "DFGValidate.h"
 #include "JSArrayIterator.h"
 #include "JSAsyncFromSyncIterator.h"
+#include "JSAsyncGenerator.h"
+#include "JSGenerator.h"
 #include "JSInternalPromise.h"
 #include "JSIteratorHelper.h"
 #include "JSMapIterator.h"
@@ -292,7 +294,7 @@ public:
 
     bool isFunctionAllocation() const
     {
-        return m_kind == Kind::Function || m_kind == Kind::GeneratorFunction || m_kind == Kind::AsyncFunction;
+        return m_kind == Kind::Function || m_kind == Kind::GeneratorFunction || m_kind == Kind::AsyncFunction || m_kind == Kind::AsyncGeneratorFunction;
     }
 
     bool isInternalFieldObjectAllocation() const
@@ -1141,6 +1143,12 @@ private:
                 break;
             case JSRegExpStringIteratorType:
                 target = handleInternalFieldClass<JSRegExpStringIterator>(node, writes);
+                break;
+            case JSGeneratorType:
+                target = handleInternalFieldClass<JSGenerator>(node, writes);
+                break;
+            case JSAsyncGeneratorType:
+                target = handleInternalFieldClass<JSAsyncGenerator>(node, writes);
                 break;
             case JSPromiseType:
                 if (node->structure()->classInfoForCells() == JSInternalPromise::info())

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1326,9 +1326,7 @@ private:
             break;
 
         case CreateGenerator:
-        case NewGenerator:
         case CreateAsyncGenerator:
-        case NewAsyncGenerator:
             setPrediction(SpecObjectOther);
             break;
 

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -652,8 +652,6 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case CallForwardVarargs:
     case ConstructForwardVarargs:
     case NewObject:
-    case NewGenerator:
-    case NewAsyncGenerator:
     case NewArray:
     case NewArrayWithSize:
     case NewArrayWithButterfly:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15646,16 +15646,6 @@ void SpeculativeJIT::compileNewInternalFieldObjectImpl(Node* node, Operation ope
     cellResult(resultGPR, node);
 }
 
-void SpeculativeJIT::compileNewGenerator(Node* node)
-{
-    compileNewInternalFieldObjectImpl<JSGenerator>(node, operationNewGenerator);
-}
-
-void SpeculativeJIT::compileNewAsyncGenerator(Node* node)
-{
-    compileNewInternalFieldObjectImpl<JSAsyncGenerator>(node, operationNewAsyncGenerator);
-}
-
 void SpeculativeJIT::compileNewInternalFieldObject(Node* node)
 {
     switch (node->structure()->typeInfo().type()) {
@@ -15679,6 +15669,12 @@ void SpeculativeJIT::compileNewInternalFieldObject(Node* node)
         break;
     case JSRegExpStringIteratorType:
         compileNewInternalFieldObjectImpl<JSRegExpStringIterator>(node, operationNewRegExpStringIterator);
+        break;
+    case JSGeneratorType:
+        compileNewInternalFieldObjectImpl<JSGenerator>(node, operationNewGenerator);
+        break;
+    case JSAsyncGeneratorType:
+        compileNewInternalFieldObjectImpl<JSAsyncGenerator>(node, operationNewAsyncGenerator);
         break;
     case JSPromiseType: {
         if (node->structure()->classInfoForCells() == JSInternalPromise::info())

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1773,8 +1773,6 @@ public:
     void compileCreateGenerator(Node*);
     void compileCreateAsyncGenerator(Node*);
     void compileNewObject(Node*);
-    void compileNewGenerator(Node*);
-    void compileNewAsyncGenerator(Node*);
     void compileNewInternalFieldObject(Node*);
     void compileToPrimitive(Node*);
     void compileToPropertyKey(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3305,16 +3305,6 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case NewGenerator: {
-        compileNewGenerator(node);
-        break;
-    }
-
-    case NewAsyncGenerator: {
-        compileNewAsyncGenerator(node);
-        break;
-    }
-
     case NewInternalFieldObject: {
         compileNewInternalFieldObject(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4667,16 +4667,6 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case NewGenerator: {
-        compileNewGenerator(node);
-        break;
-    }
-
-    case NewAsyncGenerator: {
-        compileNewAsyncGenerator(node);
-        break;
-    }
-
     case NewInternalFieldObject: {
         compileNewInternalFieldObject(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -387,8 +387,6 @@ private:
             
             switch (m_node->op()) {
             case NewObject:
-            case NewGenerator:
-            case NewAsyncGenerator:
             case NewArray:
             case NewArrayWithSize:
             case NewArrayWithButterfly:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -75,8 +75,6 @@ inline CapabilityLevel canCompile(Node* node)
     case PutStructure:
     case GetButterfly:
     case NewObject:
-    case NewGenerator:
-    case NewAsyncGenerator:
     case NewStringObject:
     case NewRegExpUntyped:
     case NewSymbol:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1227,12 +1227,6 @@ private:
         case NewObject:
             compileNewObject();
             break;
-        case NewGenerator:
-            compileNewGenerator();
-            break;
-        case NewAsyncGenerator:
-            compileNewAsyncGenerator();
-            break;
         case NewInternalFieldObject:
             compileNewInternalFieldObject();
             break;
@@ -9501,16 +9495,6 @@ IGNORE_CLANG_WARNINGS_END
         setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
     }
 
-    void compileNewGenerator()
-    {
-        compileNewInternalFieldObjectImpl<JSGenerator>(operationNewGenerator);
-    }
-
-    void compileNewAsyncGenerator()
-    {
-        compileNewInternalFieldObjectImpl<JSAsyncGenerator>(operationNewAsyncGenerator);
-    }
-
     void compileNewInternalFieldObject()
     {
         switch (m_node->structure()->typeInfo().type()) {
@@ -9534,6 +9518,12 @@ IGNORE_CLANG_WARNINGS_END
             break;
         case JSRegExpStringIteratorType:
             compileNewInternalFieldObjectImpl<JSRegExpStringIterator>(operationNewRegExpStringIterator);
+            break;
+        case JSGeneratorType:
+            compileNewInternalFieldObjectImpl<JSGenerator>(operationNewGenerator);
+            break;
+        case JSAsyncGeneratorType:
+            compileNewInternalFieldObjectImpl<JSAsyncGenerator>(operationNewAsyncGenerator);
             break;
         case JSPromiseType:
             if (m_node->structure()->classInfoForCells() == JSInternalPromise::info())
@@ -18164,6 +18154,12 @@ IGNORE_CLANG_WARNINGS_END
             break;
         case JSRegExpStringIteratorType:
             compileMaterializeNewInternalFieldObjectImpl<JSRegExpStringIterator>(operationNewRegExpStringIterator);
+            break;
+        case JSGeneratorType:
+            compileMaterializeNewInternalFieldObjectImpl<JSGenerator>(operationNewGenerator);
+            break;
+        case JSAsyncGeneratorType:
+            compileMaterializeNewInternalFieldObjectImpl<JSAsyncGenerator>(operationNewAsyncGenerator);
             break;
         case JSPromiseType:
             if (m_node->structure()->classInfoForCells() == JSInternalPromise::info())

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -39,9 +39,11 @@
 #include "JSArrayIterator.h"
 #include "JSAsyncFromSyncIterator.h"
 #include "JSAsyncFunction.h"
+#include "JSAsyncGenerator.h"
 #include "JSAsyncGeneratorFunction.h"
 #include "JSCellButterfly.h"
 #include "JSCInlines.h"
+#include "JSGenerator.h"
 #include "JSGeneratorFunction.h"
 #include "JSInternalPromise.h"
 #include "JSIteratorHelper.h"
@@ -189,6 +191,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             break;
         case JSRegExpStringIteratorType:
             materialize(jsCast<JSRegExpStringIterator*>(target));
+            break;
+        case JSGeneratorType:
+            materialize(jsCast<JSGenerator*>(target));
+            break;
+        case JSAsyncGeneratorType:
+            materialize(jsCast<JSAsyncGenerator*>(target));
             break;
         case JSPromiseType:
             if (target->classInfo() == JSInternalPromise::info())
@@ -486,6 +494,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             return create.operator()<JSAsyncFromSyncIterator>();
         case JSRegExpStringIteratorType:
             return create.operator()<JSRegExpStringIterator>();
+        case JSGeneratorType:
+            return create.operator()<JSGenerator>();
+        case JSAsyncGeneratorType:
+            return create.operator()<JSAsyncGenerator>();
         case JSPromiseType:
             if (structure->classInfoForCells() == JSInternalPromise::info())
                 return create.operator()<JSInternalPromise>();

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp
@@ -43,6 +43,13 @@ JSAsyncGenerator* JSAsyncGenerator::create(VM& vm, Structure* structure)
     return generator;
 }
 
+JSAsyncGenerator* JSAsyncGenerator::createWithInitialValues(VM& vm, Structure* structure)
+{
+    JSAsyncGenerator* generator = new (NotNull, allocateCell<JSAsyncGenerator>(vm)) JSAsyncGenerator(vm, structure);
+    generator->finishCreation(vm);
+    return generator;
+}
+
 Structure* JSAsyncGenerator::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSAsyncGeneratorType, StructureFlags), info());

--- a/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSAsyncGenerator.h
@@ -95,12 +95,17 @@ public:
         } };
     }
 
+    using Base::internalField;
+    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
+
     static JSAsyncGenerator* create(VM&, Structure*);
+    static JSAsyncGenerator* createWithInitialValues(VM&, Structure*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     int32_t state() const
     {
-        return Base::internalField(static_cast<unsigned>(Field::State)).get().asInt32AsAnyInt();
+        return internalField(Field::State).get().asInt32AsAnyInt();
     }
 
     void setState(int32_t state)

--- a/Source/JavaScriptCore/runtime/JSGenerator.cpp
+++ b/Source/JavaScriptCore/runtime/JSGenerator.cpp
@@ -40,6 +40,13 @@ JSGenerator* JSGenerator::create(VM& vm, Structure* structure)
     return generator;
 }
 
+JSGenerator* JSGenerator::createWithInitialValues(VM& vm, Structure* structure)
+{
+    JSGenerator* generator = new (NotNull, allocateCell<JSGenerator>(vm)) JSGenerator(vm, structure);
+    generator->finishCreation(vm);
+    return generator;
+}
+
 Structure* JSGenerator::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSGeneratorType, StructureFlags), info());

--- a/Source/JavaScriptCore/runtime/JSGenerator.h
+++ b/Source/JavaScriptCore/runtime/JSGenerator.h
@@ -81,12 +81,17 @@ public:
         } };
     }
 
+    using Base::internalField;
+    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
+    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
+
     static JSGenerator* create(VM&, Structure*);
+    static JSGenerator* createWithInitialValues(VM&, Structure*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     int32_t state() const
     {
-        return Base::internalField(static_cast<unsigned>(Field::State)).get().asInt32AsAnyInt();
+        return internalField(Field::State).get().asInt32AsAnyInt();
     }
 
     void setState(int32_t state)


### PR DESCRIPTION
#### 158fbd182b79b51d1fd1c2901d2c722a14079bb7
<pre>
[JSC] Unify NewGenerator and NewAsyncGenerator into NewInternalFieldObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=306232">https://bugs.webkit.org/show_bug.cgi?id=306232</a>

Reviewed by Yusuke Suzuki.

This patch removes the separate DFG node types NewGenerator and NewAsyncGenerator,
and instead uses NewInternalFieldObject with dispatch based on JSType
(JSGeneratorType/JSAsyncGeneratorType) at compile time.

This unification:
  1. Reduces code duplication across DFG and FTL
  2. Simplifies the node type hierarchy
  3. Enables allocation sinking for generator objects through the existing
     InternalFieldObject infrastructure

                                  TipOfTree                  Patched

generator-object-sinking        8.8991+-0.1698     ^      2.2616+-0.1200        ^ definitely 3.9349x faster

Tests: JSTests/microbenchmarks/generator-object-sinking.js
       JSTests/stress/async-generator-function-declaration-sinking-osrexit.js
       JSTests/stress/async-generator-object-sinking-osrexit.js
       JSTests/stress/generator-object-sinking-osrexit.js

* JSTests/microbenchmarks/generator-object-sinking.js: Added.
(gen):
(test):
* JSTests/stress/async-generator-function-declaration-sinking-osrexit.js: Added.
(shouldBe):
(shouldBeAsyncValue):
(AsyncGeneratorFunctionPrototype):
(async g):
(async f):
(sink):
(async __proto__):
* JSTests/stress/async-generator-object-sinking-osrexit.js: Added.
(shouldBe):
(shouldBeAsyncValue):
(async gen):
(sink):
* JSTests/stress/generator-object-sinking-osrexit.js: Added.
(shouldBe):
(gen):
(sink):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp:
(JSC::DFG::clobbersExitState):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToNewInternalFieldObject):
(JSC::DFG::Node::hasStructure):
(JSC::DFG::Node::convertToNewInternalFieldObjectWithInlineFields): Deleted.
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileNewInternalFieldObject):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
(JSC::FTL::DFG::LowerDFGToB3::compileNewGenerator): Deleted.
(JSC::FTL::DFG::LowerDFGToB3::compileNewAsyncGenerator): Deleted.
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSAsyncGenerator.cpp:
(JSC::JSAsyncGenerator::createWithInitialValues):
* Source/JavaScriptCore/runtime/JSAsyncGenerator.h:
* Source/JavaScriptCore/runtime/JSGenerator.cpp:
(JSC::JSGenerator::create):
(JSC::JSGenerator::createWithInitialValues):
* Source/JavaScriptCore/runtime/JSGenerator.h:

Canonical link: <a href="https://commits.webkit.org/306701@main">https://commits.webkit.org/306701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1c2f14703cd81337a75c97320a083b7846de7ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95185 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109156 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78911 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90053 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11240 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8889 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/675 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133993 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152992 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2813 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117236 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117553 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29978 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13600 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124175 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14133 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3287 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173298 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77849 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44857 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->