### PR TITLE
Cache GlyphOverflow with widths for calls that need both

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -78,7 +78,7 @@ void FontCascadeCache::invalidate()
 void FontCascadeCache::clearMeasurementCaches()
 {
     for (auto& value : m_entries.values())
-        value->fonts.get().widthCache().clear();
+        value->fonts.get().glyphGeometryCache().clear();
 }
 
 void FontCascadeCache::pruneUnreferencedEntries()

--- a/Source/WebCore/platform/graphics/TextMeasurementCache.h
+++ b/Source/WebCore/platform/graphics/TextMeasurementCache.h
@@ -77,7 +77,7 @@ private:
         friend bool operator==(const SmallStringKey&, const SmallStringKey&) = default;
 
     private:
-        static constexpr unsigned s_capacity = 16;
+        static constexpr unsigned s_capacity = 64;
         static constexpr unsigned s_deletedValueLength = s_capacity + 1;
 
         template<typename CharacterType>

--- a/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
@@ -65,9 +65,9 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
                     auto glyphData = fontCascade.glyphDataForCharacter(character, false);
                     if (!glyphData.isValid() || glyphData.font != fontCascade.primaryFont().ptr())
                         continue;
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->glyphGeometryCache().clear();
                     float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->glyphGeometryCache().clear();
                     float originalWidth = fontCascade.widthForTextUsingSimplifiedMeasuring(content);
                     EXPECT_EQ(originalWidth , width);
                 }
@@ -77,9 +77,9 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
                     };
                     StringView content(characters);
                     constexpr bool whitespaceIsCollapsed = false;
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->glyphGeometryCache().clear();
                     float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->glyphGeometryCache().clear();
                     float originalWidth = fontCascade.widthForTextUsingSimplifiedMeasuring(content);
                     EXPECT_EQ(originalWidth , width);
                 }


### PR DESCRIPTION
#### 5bc70c9bb57be8ea68ce676112183d98df4cda71
<pre>
Cache GlyphOverflow with widths for calls that need both
<a href="https://bugs.webkit.org/show_bug.cgi?id=306235">https://bugs.webkit.org/show_bug.cgi?id=306235</a>
<a href="https://rdar.apple.com/168526001">rdar://168526001</a>

Reviewed by Simon Fraser.

Add GlyphOverflow to the cache, to be used by FontCascade::width() when
a GlyphOverflow is needed, for example from
CanvasRenderingContext2D::measureText().
If other code paths only needs the width, the same cache can provide it.

This new GlyphGeometryCache allows for longer strings as keys,
based on the typical usage found in canvas-based applications.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::width const):
(WebCore::FontCascade::widthForSimpleTextSlow const):
(WebCore::FontCascade::widthForSimpleTextWithFixedPitch const):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::widthForTextUsingSimplifiedMeasuring const):
(WebCore::GlyphOverflow): Moved to FontCascadeFonts.h.
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::FontCascadeCache::clearMeasurementCaches):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::GlyphOverflow): Moved from FontCascade.h.
(WTF::MarkableTraits&lt;WebCore::GlyphOverflow&gt;::isEmptyValue):
(WTF::MarkableTraits&lt;WebCore::GlyphOverflow&gt;::emptyValue):
(WebCore::FontCascadeFonts::glyphGeometryCache):
(WebCore::FontCascadeFonts::glyphGeometryCache const):
(WebCore::FontCascadeFonts::widthCache): Deleted.
(WebCore::FontCascadeFonts::widthCache const): Deleted.
* Source/WebCore/platform/graphics/TextMeasurementCache.h:
* Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp:
(TestWebKitAPI::TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)):

Canonical link: <a href="https://commits.webkit.org/306839@main">https://commits.webkit.org/306839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/426f3547cc562c4e578ac3a10e3c8fbec048a46a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95651 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/884c8e37-5826-4284-9b55-db4dcc893ce4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109555 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90436b44-4c20-49cb-a275-b9c3c49d4a82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90462 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11572 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9232 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1132 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153447 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14573 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117583 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117916 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13957 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124787 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70251 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3748 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78304 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14411 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->