### PR TITLE
Layout test `wheel-gesture-event-coordinates-in-iframe.html` is failing

### DIFF
--- a/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe-expected.txt
+++ b/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe-expected.txt
@@ -1,3 +1,4 @@
+
 This test verifies that gesture events (and wheel events generated from gestures) originating from an iframe have the correct coordinates relative to the iframe.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe.html
+++ b/LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe.html
@@ -84,5 +84,6 @@ addEventListener("load", async () => {
 </head>
 <body>
     <iframe id="iframe" src="resources/gesture-iframe.html"></iframe>
+    <div id="console"></div>
 </body>
 </html>


### PR DESCRIPTION
#### 05ec6ecdd8fb1153604ea69f50cdf251178e32ac
<pre>
Layout test `wheel-gesture-event-coordinates-in-iframe.html` is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=306241">https://bugs.webkit.org/show_bug.cgi?id=306241</a>
<a href="https://rdar.apple.com/168790057">rdar://168790057</a>

Reviewed by Wenson Hsieh.

In 303122@main, we resolved a race condition by ensuring that the web process
handles each gesture event before sending additional ones. As a result of this
change, layout test `wheel-gesture-event-coordinates-in-iframe` began to fail
as the `gesturechange` and `gestureend` coordinates were wrong. This is the
result of the test&apos;s PASS messages printing above the iframe before the
`gesturechange` and `gestureend` events are created, causing the iframe
to shift downwards and thus the gesture to end in a different location than
it began.

Move the test messages beneath the frame to resolve this issue.

* LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe-expected.txt:
* LayoutTests/fast/events/gesture/wheel-gesture-event-coordinates-in-iframe.html:

Canonical link: <a href="https://commits.webkit.org/306217@main">https://commits.webkit.org/306217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e995676300246efc5ae5400c8f99b74b96dc3827

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93710 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c39eb8e-4d7f-4446-9e5c-1f5d4ba51b92) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107822 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78283 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d260c018-bb2c-41bd-b581-93bb1d91566b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10593 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88722 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d5dd7ab-6775-4ffa-a3eb-5737cac6bbef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7759 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9056 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151586 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12693 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116130 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116466 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29632 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12318 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67790 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12735 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1947 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12475 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->