### PR TITLE
Fix -Wlifetime-safety-permissive warning in FontRanges::glyphDataForCharacter()

### DIFF
--- a/Source/WebCore/platform/graphics/FontRanges.cpp
+++ b/Source/WebCore/platform/graphics/FontRanges.cpp
@@ -81,7 +81,7 @@ FontRanges::~FontRanges() = default;
 
 GlyphData FontRanges::glyphDataForCharacter(char32_t character, ExternalResourceDownloadPolicy policy) const
 {
-    const Font* resultFont = nullptr;
+    RefPtr<const Font> resultFont;
     if (isGenericFontFamily() && isPrivateUseAreaCharacter(character))
         return GlyphData();
 
@@ -91,7 +91,7 @@ GlyphData FontRanges::glyphDataForCharacter(char32_t character, ExternalResource
                 if (font->isInterstitial()) {
                     policy = ExternalResourceDownloadPolicy::Forbid;
                     if (!resultFont)
-                        resultFont = font.get();
+                        resultFont = WTF::move(font);
                 } else {
                     auto glyphData = font->glyphDataForCharacter(character);
                     if (glyphData.isValid()) {


### PR DESCRIPTION
#### 3118028cc9ac7136c21d9051272a74cdfd39bbd9
<pre>
Fix -Wlifetime-safety-permissive warning in FontRanges::glyphDataForCharacter()
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306244">https://bugs.webkit.org/show_bug.cgi?id=306244</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/168892583">rdar://problem/168892583</a>&gt;

Reviewed by Darin Adler.

Clang&apos;s lifetime safety warning detected a potential issue where a raw
pointer was assigned from a RefPtr that goes out of scope.  Even though
the code was safe (the Font is kept alive by the FontAccessor), the
analyzer couldn&apos;t prove the lifetime relationship.

The fix changes `resultFont` from `const Font*` to `RefPtr&lt;const Font&gt;`
to make the lifetime relationship explicit.  Also uses `WTF::move(font)`
to avoid ref count churn since `font` isn&apos;t used after that point in
the `isInterstitial()` branch.

No new tests since no change in behavior.

* Source/WebCore/platform/graphics/FontRanges.cpp:
(WebCore::FontRanges::glyphDataForCharacter):

Canonical link: <a href="https://commits.webkit.org/306238@main">https://commits.webkit.org/306238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/280f0b86681bc808fb90ea888be28c85496bb43a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93718 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/271855e7-c3f8-4417-90de-528791ba2c18) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107830 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78288 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f57b633c-f330-461f-ab99-888e4a8189a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88730 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/693b42c4-f3fc-45bb-a880-a48d7074615f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10208 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7765 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9064 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151594 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116138 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116474 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12333 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67798 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21720 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12743 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1956 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12681 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12527 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->