### PR TITLE
Eliminate unsafe buffer usage by adopting more C++20 std::ranges algorithms

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -71,10 +71,9 @@ void setNumberFormatDigitOptions(JSGlobalObject* globalObject, IntlType* intlIns
     static constexpr const unsigned roundingIncrementCandidates[] = {
         1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000
     };
-    if (std::none_of(roundingIncrementCandidates, roundingIncrementCandidates + std::size(roundingIncrementCandidates),
-        [&](unsigned candidate) {
-            return candidate == roundingIncrement;
-        })) {
+    if (std::ranges::none_of(roundingIncrementCandidates, [&](auto candidate) {
+        return candidate == roundingIncrement;
+    })) {
         throwRangeError(globalObject, scope, "roundingIncrement must be one of 1, 2, 5, 10, 20, 25, 50, 100, 200, 250, 500, 1000, 2000, 2500, 5000"_s);
         return;
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
@@ -63,29 +63,29 @@ TEST(WTF_ContextualizedNSString, getCharacters)
     auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
 
     unichar buffer[7];
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(0, 0)];
     EXPECT_EQ(buffer[0], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(0, 1)];
     EXPECT_EQ(buffer[0], 'a');
     EXPECT_EQ(buffer[1], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(0, 2)];
     EXPECT_EQ(buffer[0], 'a');
     EXPECT_EQ(buffer[1], 'b');
     EXPECT_EQ(buffer[2], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(0, 3)];
     EXPECT_EQ(buffer[0], 'a');
     EXPECT_EQ(buffer[1], 'b');
     EXPECT_EQ(buffer[2], 'c');
     EXPECT_EQ(buffer[3], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(0, 4)];
     EXPECT_EQ(buffer[0], 'a');
@@ -93,7 +93,7 @@ TEST(WTF_ContextualizedNSString, getCharacters)
     EXPECT_EQ(buffer[2], 'c');
     EXPECT_EQ(buffer[3], 'd');
     EXPECT_EQ(buffer[4], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(0, 5)];
     EXPECT_EQ(buffer[0], 'a');
@@ -102,7 +102,7 @@ TEST(WTF_ContextualizedNSString, getCharacters)
     EXPECT_EQ(buffer[3], 'd');
     EXPECT_EQ(buffer[4], 'e');
     EXPECT_EQ(buffer[5], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(0, 6)];
     EXPECT_EQ(buffer[0], 'a');
@@ -112,29 +112,29 @@ TEST(WTF_ContextualizedNSString, getCharacters)
     EXPECT_EQ(buffer[4], 'e');
     EXPECT_EQ(buffer[5], 'f');
     EXPECT_EQ(buffer[6], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(1, 0)];
     EXPECT_EQ(buffer[0], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(1, 1)];
     EXPECT_EQ(buffer[0], 'b');
     EXPECT_EQ(buffer[1], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(1, 2)];
     EXPECT_EQ(buffer[0], 'b');
     EXPECT_EQ(buffer[1], 'c');
     EXPECT_EQ(buffer[2], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(1, 3)];
     EXPECT_EQ(buffer[0], 'b');
     EXPECT_EQ(buffer[1], 'c');
     EXPECT_EQ(buffer[2], 'd');
     EXPECT_EQ(buffer[3], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(1, 4)];
     EXPECT_EQ(buffer[0], 'b');
@@ -142,7 +142,7 @@ TEST(WTF_ContextualizedNSString, getCharacters)
     EXPECT_EQ(buffer[2], 'd');
     EXPECT_EQ(buffer[3], 'e');
     EXPECT_EQ(buffer[4], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(1, 5)];
     EXPECT_EQ(buffer[0], 'b');
@@ -151,52 +151,52 @@ TEST(WTF_ContextualizedNSString, getCharacters)
     EXPECT_EQ(buffer[3], 'e');
     EXPECT_EQ(buffer[4], 'f');
     EXPECT_EQ(buffer[5], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(3, 0)];
     EXPECT_EQ(buffer[0], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(3, 1)];
     EXPECT_EQ(buffer[0], 'd');
     EXPECT_EQ(buffer[1], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(3, 2)];
     EXPECT_EQ(buffer[0], 'd');
     EXPECT_EQ(buffer[1], 'e');
     EXPECT_EQ(buffer[2], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(3, 3)];
     EXPECT_EQ(buffer[0], 'd');
     EXPECT_EQ(buffer[1], 'e');
     EXPECT_EQ(buffer[2], 'f');
     EXPECT_EQ(buffer[3], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(4, 0)];
     EXPECT_EQ(buffer[0], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(4, 1)];
     EXPECT_EQ(buffer[0], 'e');
     EXPECT_EQ(buffer[1], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(4, 2)];
     EXPECT_EQ(buffer[0], 'e');
     EXPECT_EQ(buffer[1], 'f');
     EXPECT_EQ(buffer[2], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(6, 0)];
     EXPECT_EQ(buffer[0], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 
     [contextualizedString getCharacters:buffer range:NSMakeRange(7, 0)];
     EXPECT_EQ(buffer[0], '\0');
-    std::fill(buffer, buffer + std::size(buffer), '\0');
+    std::ranges::fill(buffer, '\0');
 }
 
 TEST(WTF_ContextualizedNSString, nonPrimitive)


### PR DESCRIPTION
#### 16c70ed0778721d2b83deb26c649fabd6fe034a9
<pre>
Eliminate unsafe buffer usage by adopting more C++20 std::ranges algorithms
<a href="https://bugs.webkit.org/show_bug.cgi?id=306246">https://bugs.webkit.org/show_bug.cgi?id=306246</a>
<a href="https://rdar.apple.com/168893825">rdar://168893825</a>

Reviewed by Chris Dumez.

Test: Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::setNumberFormatDigitOptions):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm:
(TEST(WTF_ContextualizedNSString, getCharacters)):

Canonical link: <a href="https://commits.webkit.org/306208@main">https://commits.webkit.org/306208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37a1e8520dc9c4313771b0b532fdf2e413d62f62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148973 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107833 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78292 "7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88733 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7766 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9066 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132611 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151596 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1431 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12703 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116140 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116476 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29627 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12337 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67800 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12745 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1949 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171906 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12485 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76445 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44615 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->