### PR TITLE
[Site Isolation] Fix ServiceWorker.ExtensionServiceWorker

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2259,7 +2259,8 @@ void WebProcessProxy::didStartProvisionalLoadForMainFrame(const URL& url)
     if (url.protocolIsAbout())
         return;
 
-    if (!url.protocolIsInHTTPFamily() && !processPool().configuration().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol()) {
+    bool siteIsolationEnabled = m_sharedPreferencesForWebProcess.siteIsolationEnabled;
+    if (!siteIsolationEnabled && !url.protocolIsInHTTPFamily() && !processPool().configuration().processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol()) {
         // Unless the processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol flag is set, we don't process swap on navigations withing the same
         // non HTTP(s) protocol. For this reason, we ignore the registrable domain and processes are not eligible for the process cache.
         m_site = makeUnexpected(SiteState::MultipleSites);
@@ -2278,7 +2279,7 @@ void WebProcessProxy::didStartProvisionalLoadForMainFrame(const URL& url)
         return;
     }
 
-    if (m_sharedPreferencesForWebProcess.siteIsolationEnabled)
+    if (siteIsolationEnabled)
         ASSERT((m_site && *m_site == site) || m_site.error() == SiteState::SharedProcess);
     else {
         // Associate the process with this site.


### PR DESCRIPTION
#### fc6fdd09da00731f2cb7d06f35beade75594e86a
<pre>
[Site Isolation] Fix ServiceWorker.ExtensionServiceWorker
<a href="https://bugs.webkit.org/show_bug.cgi?id=306245">https://bugs.webkit.org/show_bug.cgi?id=306245</a>
<a href="https://rdar.apple.com/168892797">rdar://168892797</a>

Reviewed by NOBODY (OOPS!).

The test creates two related WebViews (with `_relatedWebView`), uses them to load the same site (&quot;sw-ext://ABC&quot;) and
expects them to use the same web process for loading. The test currently fails under Site Isolation because a different
process is picked for the second WebView&apos;s loading. The cause is that `WebProcessProxy::m_site` of the web process is
set to be `SiteState::MultipleStates` in `WebProcessProxy::didStartProvisionalLoadForMainFrame` after loading
&quot;sw-ext://ABC&quot; in the first WebView. Then in `WebPageProxy::initializeWebPage` of second WebView, `m_site` is updated
(with `BrowsingContextGroup::ensureProcessForSite` and `WebProcessProxy::didStartUsingProcessForSiteIsolation`) to empty
site (as process is not associated with a single site), making it ineligible for loading &quot;sw-ext://ABC&quot; in the
second WebView (as process&apos;s site does not match target site).

To fix this, the patch avoids setting `SiteState::MultipleStates` in `didStartProvisionalLoadForMainFrame` under Site
Isolation. The change makes sense because in current implementation of Site Isolation, process will still be swapped
within the same non-HTTP protocol even when `processSwapsOnNavigationWithinSameNonHTTPFamilyProtocol` is false (see
`WebProcessPool::processForNavigationInternal`).

* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::didStartProvisionalLoadForMainFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc6fdd09da00731f2cb7d06f35beade75594e86a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93724 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1c89805-0ab4-41fc-a985-a970ae5b3c63) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107835 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78290 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5963a388-ad2a-4ccb-a0f4-491172bd638a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88735 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d58c356b-31a7-40e0-b981-62ceb53c7db2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10213 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7770 "Found 2 new API test failures: TestWebKitAPI.SiteIsolation.LoadWebArchive, TestWebKitAPI.SiteIsolation.LoadWebArchiveNestedFrame (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9070 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119456 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151600 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12707 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116143 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116479 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12345 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67804 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12749 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1973 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12489 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76449 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12533 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->