### PR TITLE
[ews][GLIB] Add WebDriver queues with stable subset of tests for smoke testing in EWS

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1353,6 +1353,9 @@ class RunWebDriverTests(shell.Test, CustomFlagsMixin, ShellMixin):
     def __init__(self, **kwargs):
         kwargs['timeout'] = 90 * 60
         super().__init__(**kwargs)
+        self.failuresCount = 0
+        self.timeoutCount = 0
+        self.newPassesCount = 0
 
     @defer.inlineCallbacks
     def run(self):
@@ -1370,9 +1373,6 @@ class RunWebDriverTests(shell.Test, CustomFlagsMixin, ShellMixin):
 
         logText = self.log_observer.getStdout()
 
-        self.failuresCount = 0
-        self.timeoutCount = 0
-        self.newPassesCount = 0
         foundFailures = re.findall(r"Unexpected failures \((\d+)\)", logText, re.MULTILINE)
         if foundFailures:
             self.failuresCount = int(foundFailures[0])

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1993,13 +1993,14 @@ class TestRunWebDriverTests(BuildStepMixinAdditions, unittest.TestCase):
     def test_success(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'gtk')
+        self.setProperty('platform', 'gtk')
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 log_environ=True,
                 logfiles={'json': self.jsonFileName},
-                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --gtk 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
                 timeout=5400
             )
             .log('stdio', stdout='All tests run as expected\n')
@@ -2010,14 +2011,15 @@ class TestRunWebDriverTests(BuildStepMixinAdditions, unittest.TestCase):
 
     def test_failure(self):
         self.configureStep()
-        self.setProperty('fullPlatform', 'gtk')
+        self.setProperty('fullPlatform', 'wpe')
+        self.setProperty('platform', 'wpe')
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 log_environ=True,
                 logfiles={'json': self.jsonFileName},
-                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --wpe 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
                 timeout=5400
             )
             .log('stdio', stdout='Unexpected failures (554)\n')
@@ -2037,13 +2039,14 @@ class TestRunWebDriverTests(BuildStepMixinAdditions, unittest.TestCase):
     def test_new_passes(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'gtk')
+        self.setProperty('platform', 'gtk')
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 log_environ=True,
                 logfiles={'json': self.jsonFileName},
-                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --gtk 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
                 timeout=5400
             )
             .log('stdio', stdout='Expected to fail, but passed (1)\n')
@@ -2063,13 +2066,14 @@ class TestRunWebDriverTests(BuildStepMixinAdditions, unittest.TestCase):
     def test_failures_and_new_passes(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'gtk')
+        self.setProperty('platform', 'gtk')
         self.setProperty('configuration', 'release')
         self.expectRemoteCommands(
             ExpectShell(
                 workdir='wkdir',
                 log_environ=True,
                 logfiles={'json': self.jsonFileName},
-                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --gtk 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
                 timeout=5400
             )
             .log('stdio', stdout='''filter-test-logs progress: 11300 lines processed

--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -40,6 +40,7 @@
     { "name": "igalia17-wpe-ews", "platform": "wpe" },
     { "name": "igalia18-wpe-ews", "platform": "wpe" },
     { "name": "igalia19-wpe-ews", "platform": "wpe" },
+    { "name": "igalia20-wpe-ews", "platform": "wpe" },
     { "name": "aperez-wpe-ews", "platform": "wpe" },
     { "name": "playstation-ews-001", "platform": "playstation" },
     { "name": "playstation-ews-002", "platform": "playstation" },
@@ -487,6 +488,13 @@
       "configuration": "release", "architectures": ["x86_64"],
       "triggered_by": ["wpe-build-ews"],
       "workernames": ["igalia12-wpe-ews", "igalia13-wpe-ews", "igalia14-wpe-ews", "igalia15-wpe-ews"]
+    },
+    {
+      "name": "WebDriver-Tests-WPE-EWS", "shortname": "wpe-webdriver", "icon": "testOnly",
+      "factory": "WebDriverTestsFactory", "platform": "wpe",
+      "configuration": "release", "architectures": ["x86_64"],
+      "triggered_by": ["wpe-build-ews"],
+      "workernames": ["igalia20-wpe-ews"]
     },
     {
       "name": "Services-EWS", "shortname": "services", "icon": "testOnly",

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -147,6 +147,7 @@ class BuildFactory(Factory):
 class TestFactory(Factory):
     LayoutTestClass = None
     APITestClass = None
+    WebDriverTestClass = None
     willTriggerCrashLogSubmission = False
     skipBuildIfNoResult = False
 
@@ -169,9 +170,11 @@ class TestFactory(Factory):
             self.addStep(self.LayoutTestClass())
         if self.APITestClass:
             self.addStep(self.APITestClass())
+        if self.WebDriverTestClass:
+            self.addStep(self.WebDriverTestClass())
         if self.willTriggerCrashLogSubmission:
             self.addStep(TriggerCrashLogSubmission())
-        if self.LayoutTestClass or self.APITestClass:
+        if self.LayoutTestClass or self.APITestClass or self.WebDriverTestClass:
             self.addStep(SetBuildSummary())
 
 
@@ -227,6 +230,10 @@ class JSCTestsFactory(Factory):
 
 class APITestsFactory(TestFactory):
     APITestClass = RunAPITests
+
+
+class WebDriverTestsFactory(TestFactory):
+    WebDriverTestClass = RunWebDriverTests
 
 
 class iOSBuildFactory(BuildFactory):

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -793,6 +793,25 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'run-api-tests',
             'set-build-summary'
         ],
+        'WebDriver-Tests-WPE-EWS': [
+            'configure-build',
+            'validate-change',
+            'configuration',
+            'clean-up-git-repo',
+            'set-credential-helper',
+            'checkout-source',
+            'fetch-branch-references',
+            'checkout-specific-revision',
+            'show-identifier',
+            'apply-patch',
+            'checkout-pull-request',
+            'jhbuild',
+            'kill-old-processes',
+            'download-built-product',
+            'extract-built-product',
+            'run-webdriver-tests',
+            'set-build-summary'
+        ],
         'Services-EWS': [
             'configure-build',
             'check-change-relevance',

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -36,7 +36,7 @@ from twisted.internet import defer
 
 from .factories import (APITestsFactory, BindingsFactory, BuildFactory, CommitQueueFactory, Factory, GTKBuildFactory,
                         GTKTestsFactory, JSCBuildFactory, JSCBuildAndTestsFactory, JSCBuildO3AndTestsFactory, JSCTestsFactory, MergeQueueFactory, SafeMergeQueueFactory, StressTestFactory,
-                        StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPECairoLibWebRTCBuildFactory, WPETestsFactory, WebKitPerlFactory, WebKitPyFactory, PlayStationBuildFactory,
+                        StyleFactory, TestFactory, tvOSBuildFactory, WPEBuildFactory, WPECairoLibWebRTCBuildFactory, WPETestsFactory, WebDriverTestsFactory, WebKitPerlFactory, WebKitPyFactory, PlayStationBuildFactory,
                         WinBuildFactory, WinTestsFactory, iOSBuildFactory, iOSEmbeddedBuildFactory, iOSTestsFactory,  visionOSBuildFactory, visionOSEmbeddedBuildFactory, visionOSTestsFactory, macOSBuildFactory, macOSBuildOnlyFactory,
                         macOSWK1Factory, macOSWK2Factory, ServicesFactory, SaferCPPStaticAnalyzerFactory, UnsafeMergeQueueFactory, watchOSBuildFactory)
 

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6028,6 +6028,105 @@ class AnalyzeAPITestsResults(buildstep.BuildStep, AddToLogMixin):
             print('Error in sending email for pre-existing failure: {}'.format(e))
 
 
+class RunWebDriverTests(shell.Test, ShellMixin):
+    name = "run-webdriver-tests"
+    description = ["webdriver-tests running"]
+    descriptionDone = ["webdriver-tests"]
+    jsonFileName = "webdriver_tests.json"
+    command = ["python3", "Tools/Scripts/run-webdriver-tests", "--verbose", f"--json-output={jsonFileName}", WithProperties("--%(configuration)s")]
+    logfiles = {"json": jsonFileName}
+
+    def __init__(self, **kwargs):
+        kwargs['timeout'] = 90 * 60
+        super().__init__(**kwargs)
+        self.failuresCount = 0
+        self.timeoutCount = 0
+        self.newPassesCount = 0
+
+    @defer.inlineCallbacks
+    def run(self):
+        additionalArguments = self.getProperty('additionalArguments')
+        if additionalArguments:
+            self.command += additionalArguments
+
+        platform = self.getProperty('platform')
+        self.command += customBuildFlag(platform, self.getProperty('fullPlatform'))
+        self.command = self.shell_command(' '.join(self.command) + ' 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver')
+
+        self.log_observer = logobserver.BufferLogObserver()
+        self.addLogObserver('stdio', self.log_observer)
+
+        rc = yield super().run()
+
+        logText = self.log_observer.getStdout()
+
+        foundFailures = re.findall(r"Unexpected failures \((\d+)\)", logText, re.MULTILINE)
+        if foundFailures:
+            self.failuresCount = int(foundFailures[0])
+        foundTimeouts = re.findall(r"Unexpected timeouts \((\d+)\)", logText, re.MULTILINE)
+        if foundTimeouts:
+            self.timeoutCount = int(foundTimeouts[0])
+        foundNewPasses = re.findall(r"Expected to .+, but passed \((\d+)\)", logText, re.MULTILINE)
+        if foundNewPasses:
+            self.newPassesCount = int(foundNewPasses[0])
+
+        steps_to_add = [
+            GenerateS3URL(
+                f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
+                additions=f'{self.build.number}',
+                extension='txt',
+                content_type='text/plain',
+            ), UploadFileToS3(
+                'logs.txt',
+                links={self.name: 'Full logs'},
+                content_type='text/plain',
+            )
+        ]
+        self.build.addStepsAfterCurrentStep(steps_to_add)
+
+        if rc != 0:
+            defer.returnValue(FAILURE)
+        elif self.failuresCount:
+            defer.returnValue(FAILURE)
+        elif self.newPassesCount:
+            defer.returnValue(WARNINGS)
+        else:
+            defer.returnValue(SUCCESS)
+
+    def getResultSummary(self):
+        if self.results != SUCCESS:
+            summaries = []
+            summary = None
+            shouldReportBuild = False
+            if self.failuresCount:
+                suffix = "" if self.failuresCount == 1 else "s"
+                summaries.append(f"{self.failuresCount} failure{suffix}")
+                shouldReportBuild = True
+            if self.timeoutCount:
+                suffix = "" if self.timeoutCount == 1 else "s"
+                summaries.append(f"{self.timeoutCount} timeout{suffix}")
+                shouldReportBuild = True
+            if self.newPassesCount:
+                suffix = "" if self.newPassesCount == 1 else "es"
+                summaries.append(f"{self.newPassesCount} new pass{suffix}")
+
+            if len(summaries) >= 2:
+                last = summaries.pop()
+                summary = ', '.join(summaries) + ' and ' + last
+            elif summaries:
+                summary = summaries[0]
+
+            if summary:
+                result = {'step': summary}
+                if shouldReportBuild:
+                    result['build'] = summary
+
+                return result
+        return super().getResultSummary()
+
+
+
+
 class ArchiveTestResults(shell.ShellCommand):
     command = ['python3', 'Tools/CISupport/test-result-archive',
                Interpolate('--platform=%(prop:platform)s'), Interpolate('--%(prop:configuration)s'), 'archive']

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -6035,6 +6035,7 @@ class RunWebDriverTests(shell.Test, ShellMixin):
     jsonFileName = "webdriver_tests.json"
     command = ["python3", "Tools/Scripts/run-webdriver-tests", "--verbose", f"--json-output={jsonFileName}", WithProperties("--%(configuration)s")]
     logfiles = {"json": jsonFileName}
+    suffix = 'first_run'
 
     def __init__(self, **kwargs):
         kwargs['timeout'] = 90 * 60
@@ -6042,6 +6043,7 @@ class RunWebDriverTests(shell.Test, ShellMixin):
         self.failuresCount = 0
         self.timeoutCount = 0
         self.newPassesCount = 0
+        self.steps_to_add = []
 
     @defer.inlineCallbacks
     def run(self):
@@ -6070,7 +6072,7 @@ class RunWebDriverTests(shell.Test, ShellMixin):
         if foundNewPasses:
             self.newPassesCount = int(foundNewPasses[0])
 
-        steps_to_add = [
+        self.steps_to_add.extend([
             GenerateS3URL(
                 f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
                 additions=f'{self.build.number}',
@@ -6081,17 +6083,22 @@ class RunWebDriverTests(shell.Test, ShellMixin):
                 links={self.name: 'Full logs'},
                 content_type='text/plain',
             )
-        ]
-        self.build.addStepsAfterCurrentStep(steps_to_add)
+        ])
 
         if rc != 0:
-            defer.returnValue(FAILURE)
+            retVal = FAILURE
+            self.doOnFailure()
         elif self.failuresCount:
-            defer.returnValue(FAILURE)
+            retVal = FAILURE
+            self.doOnFailure()
         elif self.newPassesCount:
-            defer.returnValue(WARNINGS)
+            retVal = WARNINGS
         else:
-            defer.returnValue(SUCCESS)
+            retVal = SUCCESS
+
+        self.build.addStepsAfterCurrentStep(self.steps_to_add)
+
+        defer.returnValue(retVal)
 
     def getResultSummary(self):
         if self.results != SUCCESS:
@@ -6123,6 +6130,47 @@ class RunWebDriverTests(shell.Test, ShellMixin):
 
                 return result
         return super().getResultSummary()
+
+    def doOnFailure(self):
+        self.steps_to_add.extend([
+            ValidateChange(verifyBugClosed=False, addURLs=False),
+            KillOldProcesses(),
+            ReRunWebDriverTests(),
+        ])
+
+
+class ReRunWebDriverTests(RunWebDriverTests):
+    name = 're-run-webdriver-tests'
+    suffix = 'second_run'
+
+    def doOnFailure(self):
+        self.steps_to_add += [RevertAppliedChanges(), CleanWorkingDirectory(), ValidateChange(verifyBugClosed=False, addURLs=False)]
+        platform = self.getProperty('platform')
+        if platform == 'wpe':
+            self.steps_to_add.append(InstallWpeDependencies())
+        elif platform == 'gtk':
+            self.steps_to_add.append(InstallGtkDependencies())
+        self.steps_to_add.append(CompileWebKitWithoutChange(retry_build_on_failure=True))
+        self.steps_to_add.append(ValidateChange(verifyBugClosed=False, addURLs=False))
+        self.steps_to_add.append(KillOldProcesses())
+        self.steps_to_add.append(RunWebDriverTestsWithoutChange())
+        self.steps_to_add.append(AnalyzeWebDriverTestsResults())
+
+class RunWebDriverTestsWithoutChange(RunWebDriverTests):
+    name = 'run-webdriver-tests-without-change'
+
+    def doOnFailure(self):
+        pass
+
+    def analyze_failures(self):
+        pass
+
+
+class AnalyzeWebDriverTestsResults(buildstep.BuildStep, AddToLogMixin):
+    name = 'analyze-webdriver-tests-results'
+    description = ['analyze-webdriver-test-results']
+    descriptionDone = ['analyze-webdriver-tests-results']
+
 
 
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2442,6 +2442,83 @@ class TestRunWebDriverTests(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=SUCCESS, state_string='webdriver-tests')
         return self.run_step()
 
+    def test_success_flaky(self):
+        self.setup_step(ReRunWebDriverTests())
+        self.setProperty('fullPlatform', 'wpe')
+        self.setProperty('platform', 'wpe')
+        self.setProperty('configuration', 'release')
+
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=True,
+                logfiles={'json': self.jsonFileName},
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --wpe 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                timeout=5400
+            )
+            .log('stdio', stdout='All tests run as expected\n')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='webdriver-tests')
+
+        d = self.run_step()
+
+        @d.addCallback
+        def verify_post_flaky_state(_):
+            step = self.get_nth_step(0)
+            self.assertFalse(
+                any(isinstance(s, RunWebDriverTestsWithoutChange) for s in step.steps_to_add),
+                f"ReRunWebDriverTests should not be in scheduled steps: {step.steps_to_add}"
+            )
+
+        return d
+
+    def test_failure_triggers_run_wihtout_change(self):
+        self.setup_step(ReRunWebDriverTests())
+        self.setProperty('fullPlatform', 'wpe')
+        self.setProperty('platform', 'wpe')
+        self.setProperty('configuration', 'release')
+
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=True,
+                logfiles={'json': self.jsonFileName},
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --wpe 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                timeout=5400
+            )
+            .log('stdio', stdout='Unexpected failures (1)\n')
+            .exit(1),
+        )
+        self.expect_outcome(result=FAILURE, state_string='1 failure')
+
+        d = self.run_step()
+
+        @d.addCallback
+        def verify_triggered_clean_run(_):
+            step = self.get_nth_step(0)
+            self.assertTrue(
+                any(isinstance(s, RevertAppliedChanges) for s in step.steps_to_add),
+                f"RevertAppliedChanges not found: {step.steps_to_add}"
+            )
+            self.assertTrue(
+                any(isinstance(s, CompileWebKitWithoutChange) for s in step.steps_to_add),
+                f"CompileWebKitWithoutChange not found: {step.steps_to_add}"
+            )
+            self.assertTrue(
+                any(isinstance(s, RunWebDriverTestsWithoutChange) for s in step.steps_to_add),
+                f"RunWebDriverTestsWithoutChange not found: {step.steps_to_add}"
+            )
+            self.assertTrue(
+                any(isinstance(s, AnalyzeWebDriverTestsResults) for s in step.steps_to_add),
+                f"AnalyzeWebDriverTestsResults not found: {step.steps_to_add}"
+            )
+            self.assertTrue(
+                any(isinstance(s, InstallWpeDependencies) for s in step.steps_to_add),
+                f"InstallWpeDependencies not found for WPE: {step.steps_to_add}"
+            )
+        return d
+
     def test_one_failure(self):
         self.configureStep()
         self.setProperty('fullPlatform', 'gtk')
@@ -2462,10 +2539,15 @@ class TestRunWebDriverTests(BuildStepMixinAdditions, unittest.TestCase):
         d = self.run_step()
 
         @d.addCallback
-        def verify_no_build_summary(_):
+        def verify_post_failure_state(_):
             step = self.get_nth_step(0)
             summary = step.getResultSummary()
             self.assertIn('build', summary)
+
+            self.assertTrue(
+                any(isinstance(s, ReRunWebDriverTests) for s in step.steps_to_add),
+                f"ReRunWebDriverTests not found in scheduled steps: {step.steps_to_add}"
+            )
 
         return d
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2408,6 +2408,136 @@ class TestRunWebKitTestsInStressMode(BuildStepMixinAdditions, unittest.TestCase)
         return self.run_step()
 
 
+class TestRunWebDriverTests(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        self.jsonFileName = 'webdriver_tests.json'
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self):
+        self.setup_step(RunWebDriverTests())
+        self.setProperty('buildername', 'GTK-Linux-64-bit-Release-WebDriver-Tests')
+        self.setProperty('buildnumber', '101')
+        self.setProperty('workername', 'gtk-linux-bot-14')
+
+    def test_success_wpe(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'wpe')
+        self.setProperty('platform', 'wpe')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=True,
+                logfiles={'json': self.jsonFileName},
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --wpe 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                timeout=5400
+            )
+            .log('stdio', stdout='All tests run as expected\n')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='webdriver-tests')
+        return self.run_step()
+
+    def test_one_failure(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'gtk')
+        self.setProperty('platform', 'gtk')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=True,
+                logfiles={'json': self.jsonFileName},
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --gtk 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                timeout=5400
+            )
+            .log('stdio', stdout='Unexpected failures (1)\n')
+            .exit(1),
+        )
+        self.expect_outcome(result=FAILURE, state_string='1 failure')
+        d = self.run_step()
+
+        @d.addCallback
+        def verify_no_build_summary(_):
+            step = self.get_nth_step(0)
+            summary = step.getResultSummary()
+            self.assertIn('build', summary)
+
+        return d
+
+    def test_new_passes(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'gtk')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=True,
+                logfiles={'json': self.jsonFileName},
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                timeout=5400
+            )
+            .log('stdio', stdout='Expected to fail, but passed (1)\n')
+            .exit(1),
+        )
+        self.expect_outcome(result=FAILURE, state_string='1 new pass')
+        d = self.run_step()
+
+        @d.addCallback
+        def verify_build_summary(_):
+            step = self.get_nth_step(0)
+            summary = step.getResultSummary()
+            self.assertNotIn('build', summary)
+
+        return d
+
+    def test_failures_and_new_passes(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'gtk')
+        self.setProperty('platform', 'gtk')
+        self.setProperty('configuration', 'release')
+        self.expectRemoteCommands(
+            ExpectShell(
+                workdir='wkdir',
+                log_environ=True,
+                logfiles={'json': self.jsonFileName},
+                command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webdriver-tests --verbose --json-output=webdriver_tests.json --release --gtk 2>&1 | python3 Tools/Scripts/filter-test-logs webdriver'],
+                timeout=5400
+            )
+            .log('stdio', stdout='''filter-test-logs progress: 11300 lines processed
+filter-test-logs progress: 20000 lines processed
+filter-test-logs progress: 44000 lines processed
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO] 6228 tests ran as expected, 554 didn't
+
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO] Expected to fail, but passed (92)
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO]   imported/selenium/py/test/selenium/webdriver/common/bidi_script_tests.py::test_get_realms[wpewebkit]
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO]   imported/selenium/py/test/selenium/webdriver/common/bidi_script_tests.py::test_get_realms_filtered_by_context[wpewebkit]
+
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO] Unexpected failures (42)
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO]   imported/w3c/webdriver/tests/bidi/network/subscribe_test.py::test_subscribe_to_module[wpewebkit]
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO]   imported/w3c/webdriver/tests/bidi/script/evaluate_test.py::test_evaluate_exception[wpewebkit]
+
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO] Unexpected timeouts (7)
+webkitpy.webdriver_tests.webdriver_test_runner: [INFO]   imported/w3c/webdriver/tests/bidi/browsing_context/navigate_test.py::test_navigate_slow_page[wpewebkit]
+  ''')
+            .exit(1),
+        )
+        self.expect_outcome(result=FAILURE, state_string='42 failures, 7 timeouts and 92 new passes')
+        d = self.run_step()
+
+        @d.addCallback
+        def verify_build_summary(_):
+            step = self.get_nth_step(0)
+            summary = step.getResultSummary()
+            self.assertIn('build', summary)
+
+        return d
+
+
 class TestRunWebKitTestsInStressGuardmallocMode(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True


### PR DESCRIPTION
#### 14dbc770622b0b2d67b6ebca864f6dfd30f0b0c7
<pre>
WIP ews-rerun-webdriver tests support
</pre>
----------------------------------------------------------------------
#### 9828f9f3621cfffe20de0e7b07e471dcef783109
<pre>
[ews][GLIB] Add WebDriver queues with stable subset of tests for smoke testing in EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=291052">https://bugs.webkit.org/show_bug.cgi?id=291052</a>

Reviewed by NOBODY (OOPS!).

Initial implementaiton, without the retry steps
</pre>
----------------------------------------------------------------------
#### 5eb2c8149335ef4afd43c75e39c370106f866482
<pre>
build-webkit-org Ensure RunWebDriverTests tests check the platform properly
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14dbc770622b0b2d67b6ebca864f6dfd30f0b0c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140639 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107837 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78291 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7772 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9072 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151602 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116145 "Passed tests") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/140062 "Failed EWS unit tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116481 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12348 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122506 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67806 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12751 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1958 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->