### PR TITLE
[JSC] Remove feature flag of `Math.sumPrecise`

### DIFF
--- a/JSTests/microbenchmarks/math-sumPrecise-10.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-10.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useMathSumPreciseMethod=1")
 (function () {
   var result = 0;
   var values = Array(10).fill([1e20, 0.1, -1e20]).flat();

--- a/JSTests/microbenchmarks/math-sumPrecise-100.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-100.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useMathSumPreciseMethod=1")
 (function () {
   var result = 0;
   var values = Array(100).fill([1e20, 0.1, -1e20]).flat();

--- a/JSTests/microbenchmarks/math-sumPrecise-1000.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-1000.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useMathSumPreciseMethod=1")
 (function () {
   var result = 0;
   var values = Array(1_000).fill([1e20, 0.1, -1e20]).flat();

--- a/JSTests/microbenchmarks/math-sumPrecise-10000.js
+++ b/JSTests/microbenchmarks/math-sumPrecise-10000.js
@@ -1,4 +1,3 @@
-//@ requireOptions("--useMathSumPreciseMethod=1")
 (function () {
   var result = 0;
   var values = Array(10_000).fill([1e20, 0.1, -1e20]).flat();

--- a/JSTests/stress/math-sum-precise.js
+++ b/JSTests/stress/math-sum-precise.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useMathSumPreciseMethod=1")
-
 // Copyright (C) 2024 Kevin Gibbons. All rights reserved.
 // This code is governed by the BSD license found in the https://github.com/tc39/test262/blob/main/LICENSE file.
 

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -5,7 +5,6 @@ flags:
   Atomics: useSharedArrayBuffer
   Temporal: useTemporal
   ShadowRealm: useShadowRealm
-  Math.sumPrecise: useMathSumPreciseMethod
   json-parse-with-source: useJSONSourceTextAccess
   iterator-sequencing: useIteratorSequencing
   explicit-resource-management: useExplicitResourceManagement

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -126,9 +126,7 @@ void MathObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "trunc"_s), 1, mathProtoFuncTrunc, ImplementationVisibility::Public, TruncIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "imul"_s), 2, mathProtoFuncIMul, ImplementationVisibility::Public, IMulIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "f16round"_s), 1, mathProtoFuncF16Round, ImplementationVisibility::Public, F16RoundIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
-
-    if (Options::useMathSumPreciseMethod())
-        putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sumPrecise"_s), 1, mathProtoFuncSumPrecise, ImplementationVisibility::Public, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sumPrecise"_s), 1, mathProtoFuncSumPrecise, ImplementationVisibility::Public, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 // ------------------------------ Functions --------------------------------

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -653,7 +653,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorSequencing, true, Normal, "Expose the Iterator.concat method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
-    v(Bool, useMathSumPreciseMethod, true, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \


### PR DESCRIPTION
#### fdd2af6e866e2cc8b85d2b2c22ac78879211a62d
<pre>
[JSC] Remove feature flag of `Math.sumPrecise`
<a href="https://bugs.webkit.org/show_bug.cgi?id=306251">https://bugs.webkit.org/show_bug.cgi?id=306251</a>

Reviewed by Yusuke Suzuki.

This patch removes the feature flag for `Math.sumPrecise`
since it has reached stage4 and has been publicly available.

* JSTests/microbenchmarks/math-sumPrecise-10.js:
* JSTests/microbenchmarks/math-sumPrecise-100.js:
* JSTests/microbenchmarks/math-sumPrecise-1000.js:
* JSTests/microbenchmarks/math-sumPrecise-10000.js:
* JSTests/stress/math-sum-precise.js:
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::MathObject::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/306330@main">https://commits.webkit.org/306330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a56ec2a3ed8c61b57156210337ec8e3156087bea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/148998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93744 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107857 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78306 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10237 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7792 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9090 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132635 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151620 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1455 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12727 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116164 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116500 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12402 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122533 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67827 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21763 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12769 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/1986 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/171949 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76469 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44624 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->