### PR TITLE
[threaded-animations] repeated crash on https://nerdy.dev/anchor-interpolated-morphing

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/underlying-style-has-reference-filter-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/underlying-style-has-reference-filter-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The presence of a reference filter precludes a threaded filter animation with an implicit keyframe.
+

--- a/LayoutTests/webanimations/threaded-animations/underlying-style-has-reference-filter.html
+++ b/LayoutTests/webanimations/threaded-animations/underlying-style-has-reference-filter.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<body>
+
+<script src="threaded-animations-utils.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+
+<script>
+
+promise_test(async t => {
+    const target = createDiv(t);
+    
+    target.animate({ filter: "blur(10px)" }, 1000 * 1000);
+    await threadedAnimationsCommit();
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 1);
+
+    target.style.filter = `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='blur'><feGaussianBlur stdDeviation='4' /></filter></svg>#blur")`;
+    await threadedAnimationsCommit();
+    assert_equals(window.internals?.acceleratedAnimationsForElement(target).length, 0);
+}, "The presence of a reference filter precludes a threaded filter animation with an implicit keyframe.");
+
+</script>
+</body>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -3053,8 +3053,15 @@ static bool acceleratedPropertyDidChange(AnimatableCSSProperty property, const R
 void KeyframeEffect::lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle)
 {
 #if ENABLE(THREADED_ANIMATIONS)
+    auto wasRunningAccelerated = isRunningAccelerated();
+#endif
+
+    if (currentStyle)
+        computeHasReferenceFilter();
+
+#if ENABLE(THREADED_ANIMATIONS)
     if (canHaveAcceleratedRepresentation()) {
-        if (!isRunningAccelerated())
+        if (!wasRunningAccelerated)
             return;
 
         if ((previousStyle && !currentStyle) || (!previousStyle && currentStyle)) {

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -133,8 +133,10 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         }
     }
 
-    filter = Style::toPlatform(style.filter(), style);
-    backdropFilter = Style::toPlatform(style.backdropFilter(), style);
+    if (!style.filter().hasReferenceFilter())
+        filter = Style::toPlatform(style.filter(), style);
+    if (!style.backdropFilter().hasReferenceFilter())
+        backdropFilter = Style::toPlatform(style.backdropFilter(), style);
 }
 
 TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const FloatRect& boundingBox) const


### PR DESCRIPTION
#### 0fdb9b7d2bffda58084c155ec81422a8f5a3130a
<pre>
[threaded-animations] repeated crash on <a href="https://nerdy.dev/anchor-interpolated-morphing">https://nerdy.dev/anchor-interpolated-morphing</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306253">https://bugs.webkit.org/show_bug.cgi?id=306253</a>
<a href="https://rdar.apple.com/168778245">rdar://168778245</a>

Reviewed by Anne van Kesteren.

We would unconditionally encode the `filter` and `backdrop-filter` underlying styles even
when we had a filter referencing an SVG filter which we don&apos;t know how to encode. We now
check for those.

Fixing this made me realize that we also did not correctly interrupt a threaded animation
if its underlying style changed to include an SVG-referencing filter that was required for
animation, as is the case with an animation without an explicit &quot;from&quot; or &quot;to&quot; keyframe, so
we add a test that checks this behavior which incidentally would have crashed if we hadn&apos;t
fixed the encoding issue above.

This new test used to fail but now passes due to ensuring we call `computeHasReferenceFilter()`
under `KeyframeEffect::lastStyleChangeEventStyleDidChange()` and caching whether the animation
was running accelerated prior to calling that method since it will change the acceleration status.

Test: webanimations/threaded-animations/underlying-style-has-reference-filter.html

* LayoutTests/webanimations/threaded-animations/underlying-style-has-reference-filter-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/underlying-style-has-reference-filter.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::lastStyleChangeEventStyleDidChange):
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):

Canonical link: <a href="https://commits.webkit.org/306204@main">https://commits.webkit.org/306204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bcab84b65bf25d201544ff842899f61bd7d8cb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2230 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93775 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c9ed8d3-50bc-429e-9896-902ecf9d95f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107883 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/414f5f7e-32b2-4c65-b972-5206904d6a07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10257 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7819 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9121 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151651 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12758 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116181 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11094 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116517 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12460 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67880 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21705 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12800 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12738 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12584 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->