### PR TITLE
[TextureMapper] Remove unused hole punch helpers

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h
@@ -45,10 +45,6 @@ public:
 
     void setClient(TextureMapperPlatformLayer::Client* client) { m_client = client; }
 
-    virtual bool isHolePunchBuffer() const { return false; }
-    virtual void notifyVideoPosition(const FloatRect&, const TransformationMatrix&) { };
-    virtual void paintTransparentRectangle(TextureMapper&, const FloatRect&, const TransformationMatrix&) { };
-
 protected:
     TextureMapperPlatformLayer::Client* client() { return m_client; }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -68,8 +68,6 @@ protected:
     {
     }
 
-    bool isHolePunchBuffer() const final { return m_type == Type::HolePunch; }
-
     Type m_type;
     IntSize m_size;
     OptionSet<TextureMapperFlags> m_flags;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
@@ -72,22 +72,6 @@ void CoordinatedPlatformLayerBufferHolePunch::paintToTextureMapper(TextureMapper
     textureMapper.drawSolidColor(targetRect, modelViewMatrix, Color::transparentBlack, false);
 }
 
-void CoordinatedPlatformLayerBufferHolePunch::notifyVideoPosition(const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix)
-{
-#if USE(GSTREAMER)
-    if (m_videoSink && m_quirksManager)
-        m_quirksManager->setHolePunchVideoRectangle(m_videoSink.get(), enclosingIntRect(modelViewMatrix.mapRect(targetRect)));
-#else
-    UNUSED_PARAM(targetRect);
-    UNUSED_PARAM(modelViewMatrix);
-#endif
-}
-
-void CoordinatedPlatformLayerBufferHolePunch::paintTransparentRectangle(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix)
-{
-    textureMapper.drawSolidColor(targetRect, modelViewMatrix, Color::transparentBlack, false);
-}
-
 } // namespace WebCore
 
 #endif // USE(COORDINATED_GRAPHICS) && ENABLE(VIDEO)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
@@ -49,9 +49,6 @@ public:
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
-    void notifyVideoPosition(const FloatRect&, const TransformationMatrix&) override;
-    void paintTransparentRectangle(TextureMapper&, const FloatRect&, const TransformationMatrix&) override;
-
 #if USE(GSTREAMER)
     GRefPtr<GstElement> m_videoSink;
     RefPtr<GStreamerQuirksManager> m_quirksManager;


### PR DESCRIPTION
#### 32f17d3212d4736929f74da5fa8ad955ce168898
<pre>
[TextureMapper] Remove unused hole punch helpers
<a href="https://bugs.webkit.org/show_bug.cgi?id=306259">https://bugs.webkit.org/show_bug.cgi?id=306259</a>

Reviewed by Miguel Gomez.

The notifyVideoPosition() and paintTransparentRectangle() helpers have been
introduced in commit 4df9391bfafa (286146@main):
&quot;Regression(280901@main)? [WPE][TextureMapper] Incorrect extra hole punches with fixed body position&quot;

But they are unused since commit d40d59e4e550 (286605@main):
&quot;[TextureMapper] Fix preserve-3D intersection rendering&quot;

The last usage of isHolePunchBuffer() has also been removed in this commit.

* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayer.h:
(WebCore::TextureMapperPlatformLayer::isHolePunchBuffer const): Deleted.
(WebCore::TextureMapperPlatformLayer::notifyVideoPosition): Deleted.
(WebCore::TextureMapperPlatformLayer::paintTransparentRectangle): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h:
(): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp:
(WebCore::CoordinatedPlatformLayerBufferHolePunch::notifyVideoPosition): Deleted.
(WebCore::CoordinatedPlatformLayerBufferHolePunch::paintTransparentRectangle): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h:

Canonical link: <a href="https://commits.webkit.org/306275@main">https://commits.webkit.org/306275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72269f16d17728ad2d6115d978788c211aa2051

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149038 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107885 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78318 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88785 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10263 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7823 "Found 1 new API test failure: TestWebKitAPI.WebKit2.CaptureMute2 (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9125 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151655 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116187 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116523 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12476 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122578 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67887 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12804 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2028 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12544 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76504 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->