### PR TITLE
Reland the enablement of the EnhancedSecurity process by default

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -164,12 +164,6 @@ static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPol
 
 } // namespace WebKit
 
-// EnhancedSecurityFeatureEnabled is a temporary NSUserDefault, See: rdar://163369863
-static BOOL isEnhancedSecurityFeatureEnabled()
-{
-    return [[NSUserDefaults standardUserDefaults] boolForKey:@"EnhancedSecurityFeatureEnabled"];
-}
-
 static Ref<API::WebsitePolicies> protectedWebsitePolicies(WKWebpagePreferences *preferences)
 {
     return *preferences->_websitePolicies;
@@ -518,16 +512,11 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)_setEnhancedSecurityEnabled:(BOOL)isEnhancedSecurityEnabled
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return;
-
     _websitePolicies->setIsEnhancedSecurityEnabled(isEnhancedSecurityEnabled);
 }
 
 - (BOOL)_enhancedSecurityEnabled
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return NO;
     return _websitePolicies->isEnhancedSecurityEnabled();
 }
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
@@ -853,9 +842,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)setSecurityRestrictionMode:(WKSecurityRestrictionMode)mode
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return;
-
     switch (mode) {
     case WKSecurityRestrictionModeNone:
         _websitePolicies->setIsEnhancedSecurityEnabled(false);
@@ -874,8 +860,6 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (WKSecurityRestrictionMode)securityRestrictionMode
 {
-    if (!isEnhancedSecurityFeatureEnabled())
-        return WKSecurityRestrictionModeNone;
     if (Ref { *_websitePolicies }->lockdownModeEnabled())
         return WKSecurityRestrictionModeLockdown;
     if (_websitePolicies->isEnhancedSecurityEnabled())

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -43,19 +43,6 @@ namespace TestWebKitAPI {
 
 #if !PLATFORM(IOS)
 
-class EnhancedSecurityTest : public testing::Test {
-public:
-    virtual void SetUp()
-    {
-        [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"EnhancedSecurityFeatureEnabled"];
-    }
-
-    virtual void TearDown()
-    {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"EnhancedSecurityFeatureEnabled"];
-    }
-};
-
 static bool isEnhancedSecurityEnabled(WKWebView *webView)
 {
     __block bool gotResponse = false;
@@ -82,7 +69,7 @@ static bool isJITEnabled(WKWebView *webView)
     return isJITEnabledResult;
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)
+TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -95,7 +82,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)
     EXPECT_STREQ("security", processVariant.UTF8String);
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)
+TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -108,7 +95,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)
     EXPECT_STREQ("standard", processVariant.UTF8String);
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)
+TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -119,7 +106,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)
     EXPECT_EQ(false, isJITEnabled(webView.get()));
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -145,7 +132,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigati
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)
+TEST(EnhancedSecurity, PSONToEnhancedSecurity)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -183,7 +170,7 @@ TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)
     EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySamePage)
+TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeNone;
@@ -231,7 +218,7 @@ static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
     return processPoolConfiguration;
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)
+TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -277,7 +264,7 @@ TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)
+TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -323,7 +310,7 @@ TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)
     EXPECT_NE(pid1, [webView2 _webProcessIdentifier]);
 }
 
-TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)
+TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)
 {
     auto webViewConfiguration1 = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration1.get().defaultWebpagePreferences.securityRestrictionMode = WKSecurityRestrictionModeMaximizeCompatibility;
@@ -346,7 +333,7 @@ TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)
     EXPECT_STREQ("standard", [webView2 _webContentProcessVariantForFrame:nil].UTF8String);
 }
 
-TEST_F(EnhancedSecurityTest, ProcessCanLaunch)
+TEST(EnhancedSecurity, ProcessCanLaunch)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration.get().websiteDataStore = [WKWebsiteDataStore nonPersistentDataStore];
@@ -380,7 +367,7 @@ TEST_F(EnhancedSecurityTest, ProcessCanLaunch)
 
 }
 
-TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)
+TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)
 {
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:YES];
 
@@ -416,7 +403,7 @@ TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)
     [WKProcessPool _clearCaptivePortalModeEnabledGloballyForTesting];
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)
 {
     HTTPServer server({
         { "/example"_s, { "<iframe id='webkit_frame' src='https://example.com/webkit'></iframe>"_s } },
@@ -461,7 +448,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrame
 
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)
 {
 
     HTTPServer server({
@@ -507,7 +494,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrame
 
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)
 {
 
     HTTPServer server({
@@ -553,7 +540,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFram
 
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)
+TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)
 {
 
     HTTPServer server({
@@ -598,7 +585,7 @@ TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFram
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenWithNoopenerFromEnhancedSecurityPage)
+TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)
 {
     HTTPServer server({
         { "/example"_s, { "<script>w = window.open('https://webkit.org/webkit', '_blank', 'noopener')</script>"_s } },
@@ -638,7 +625,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenWithNoopenerFromEnhancedSecurityPage)
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenWithOpenerFromEnhancedSecurityPage)
+TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)
 {
     HTTPServer server({
         { "/example"_s, { "<script>w = window.open('https://webkit.org/webkit')</script>"_s } },
@@ -676,7 +663,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenWithOpenerFromEnhancedSecurityPage)
     EXPECT_EQ([openerWebView _webProcessIdentifier], [openedWebView _webProcessIdentifier]);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
+TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)
 {
     HTTPServer server({
         { "/target"_s, { "target page"_s } },
@@ -740,7 +727,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhan
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)
+TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)
 {
     HTTPServer server({
         { "/opener"_s, { "<script>function openwithnoopener() {w = window.open('https://webkit.org/opened', '_blank', 'noopener')}</script>"_s } },
@@ -806,7 +793,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromStandardWithEnhancedSecurityV
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)
+TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)
 {
     HTTPServer server({
         { "/opener"_s, { "<script>function openwithnoopener() {w = window.open('https://webkit.org/opened', '_blank', 'noopener')}</script>"_s } },
@@ -866,7 +853,7 @@ TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityWithStandardV
     EXPECT_FALSE(hasOpener);
 }
 
-TEST_F(EnhancedSecurityTest, LockdownModeTakesPrecedenceOverEnhancedSecurity)
+TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences._enhancedSecurityEnabled = YES;
@@ -882,7 +869,7 @@ TEST_F(EnhancedSecurityTest, LockdownModeTakesPrecedenceOverEnhancedSecurity)
     EXPECT_STREQ("lockdown", [webView _webContentProcessVariantForFrame:nil].UTF8String);
 }
 
-TEST_F(EnhancedSecurityTest, EnhancedSecurityRequestedWhenLockdownModeActive)
+TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)
 {
     auto webViewConfiguration = adoptNS([WKWebViewConfiguration new]);
     webViewConfiguration.get().defaultWebpagePreferences.lockdownModeEnabled = YES;


### PR DESCRIPTION
#### 5ed624178e3d5fabbdc517cc7dcef20aa7016535
<pre>
Reland the enablement of the EnhancedSecurity process by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=306263">https://bugs.webkit.org/show_bug.cgi?id=306263</a>
<a href="https://rdar.apple.com/168909909">rdar://168909909</a>

Reviewed by Per Arne Vollan.

Reland of 303003@main: Remove EnhancedSecurityFeatureEnabled UserDefault

The change was reverted due to a regression in an adopter. Now this has been
addressed, this change re-enables EnhancedSecurity for adopters of
WKSecurityRestrictionModeMaximizeCompatibility.

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setEnhancedSecurityEnabled:]):
(-[WKWebpagePreferences _enhancedSecurityEnabled]):
(-[WKWebpagePreferences setSecurityRestrictionMode:]):
(-[WKWebpagePreferences securityRestrictionMode]):
(isEnhancedSecurityFeatureEnabled): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnablesTrue)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityEnableFalse)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityDisablesJIT)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterNavigation)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPool)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySharedProcessPoolReverse)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessVariantMatchesConfiguration)):
(TestWebKitAPI::TEST(EnhancedSecurity, ProcessCanLaunch)):
(TestWebKitAPI::TEST(EnhancedSecurity, CaptivePortalProcessCanLaunch)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenWithOpenerFromEnhancedSecurityPage)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)):
(TestWebKitAPI::TEST(EnhancedSecurity, LockdownModeTakesPrecedenceOverEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityRequestedWhenLockdownModeActive)):
(TestWebKitAPI::EnhancedSecurityTest::SetUp): Deleted.
(TestWebKitAPI::EnhancedSecurityTest::TearDown): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityEnablesTrue)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityEnableFalse)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityDisablesJIT)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterNavigation)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecurity)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySamePage)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPool)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, PSONToEnhancedSecuritySharedProcessPoolReverse)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, ProcessVariantMatchesConfiguration)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, ProcessCanLaunch)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, CaptivePortalProcessCanLaunch)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisables)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabled)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenWithNoopenerFromEnhancedSecurityPage)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenWithOpenerFromEnhancedSecurityPage)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityInheritsEnhancedSecurity)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromStandardWithEnhancedSecurityViaDelegate)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, WindowOpenNoopenerFromEnhancedSecurityWithStandardViaDelegate)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, LockdownModeTakesPrecedenceOverEnhancedSecurity)): Deleted.
(TestWebKitAPI::TEST_F(EnhancedSecurityTest, EnhancedSecurityRequestedWhenLockdownModeActive)): Deleted.

Canonical link: <a href="https://commits.webkit.org/306292@main">https://commits.webkit.org/306292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cadf3fa5f3c815ce94571ae9730886235bba0f20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c74d95d6-da9a-45be-bc73-77f771e20b70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107869 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78310 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aab32361-3b8a-4e73-a836-ab530f6b1a8f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88769 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8af3a20d-eb08-41ff-b3e6-3006af6eae58) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10248 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7806 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9108 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151638 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116174 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116510 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29678 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12436 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67856 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12787 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2016 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76487 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->