### PR TITLE
Drop remaining `protected*()` member functions in Source/WebKit/UIProcess

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -318,6 +318,15 @@ template<typename T> inline RetainPtr<RetainPtrType<T>> retainPtr(T ptr)
     return ptr;
 }
 
+#if USE(CF)
+template<typename T>
+    requires (std::is_pointer_v<T> && std::is_convertible_v<T, CFTypeRef> && !IsNSType<T>)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION RetainPtr<RetainPtrType<T>> protect(T ptr)
+{
+    return ptr;
+}
+#endif
+
 #ifdef __OBJC__
 template<typename T>
     requires IsNSType<T>

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -565,7 +565,7 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    applyPropertiesToLayer(node.protectedLayer().get(), &node, layerTreeHost, properties);
+    applyPropertiesToLayer(protect(node.layer()).get(), &node, layerTreeHost, properties);
     if (properties.changedProperties & LayerChange::EventRegionChanged)
         node.setEventRegion(properties.eventRegion);
     updateMask(node, properties, relatedLayers);

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
@@ -44,7 +44,6 @@ public:
 
     const WebKit::WebHitTestResultData& hitTestResultData() const { return m_hitTestResultData; }
     WebKit::WebPageProxy* page() { return m_page.get(); }
-    RefPtr<WebKit::WebPageProxy> protectedPage() { return page(); }
     const WTF::String& qrCodePayloadString() const { return m_qrCodePayloadString; }
     bool hasEntireImage() const { return m_hasEntireImage; }
     bool allowsFollowingLink() const { return m_allowsFollowingLink; }

--- a/Source/WebKit/UIProcess/API/APIDataTask.cpp
+++ b/Source/WebKit/UIProcess/API/APIDataTask.cpp
@@ -35,11 +35,6 @@ namespace API {
 
 DataTask::~DataTask() = default;
 
-Ref<DataTaskClient> DataTask::protectedClient() const
-{
-    return m_client;
-}
-
 void DataTask::setClient(Ref<DataTaskClient>&& client)
 {
     m_client = WTF::move(client);
@@ -57,7 +52,7 @@ void DataTask::cancel()
 void DataTask::networkProcessCrashed()
 {
     m_activity = nullptr;
-    protectedClient()->didCompleteWithError(*this, WebCore::internalError(m_originalURL));
+    protect(client())->didCompleteWithError(*this, WebCore::internalError(m_originalURL));
 }
 
 DataTask::DataTask(std::optional<WebKit::DataTaskIdentifier> identifier, WeakPtr<WebKit::WebPageProxy>&& page, WTF::URL&& originalURL, bool shouldRunAtForegroundPriority)
@@ -69,13 +64,13 @@ DataTask::DataTask(std::optional<WebKit::DataTaskIdentifier> identifier, WeakPtr
     , m_client(DataTaskClient::create())
 {
     if (RefPtr networkProcess = m_networkProcess.get())
-        m_activity = shouldRunAtForegroundPriority ? networkProcess->protectedThrottler()->foregroundActivity("WKDataTask"_s) : networkProcess->protectedThrottler()->backgroundActivity("WKDataTask"_s);
+        m_activity = shouldRunAtForegroundPriority ? protect(networkProcess->throttler())->foregroundActivity("WKDataTask"_s) : protect(networkProcess->throttler())->backgroundActivity("WKDataTask"_s);
 }
 
 void DataTask::didCompleteWithError(WebCore::ResourceError&& error)
 {
     m_activity = nullptr;
-    protectedClient()->didCompleteWithError(*this, WTF::move(error));
+    protect(client())->didCompleteWithError(*this, WTF::move(error));
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIDataTask.h
+++ b/Source/WebKit/UIProcess/API/APIDataTask.h
@@ -58,10 +58,8 @@ public:
     void cancel();
 
     WebKit::WebPageProxy* page() { return m_page.get(); }
-    RefPtr<WebKit::WebPageProxy> protectedPage() const { return m_page.get(); }
     const WTF::URL& originalURL() const { return m_originalURL; }
     const DataTaskClient& client() const { return m_client.get(); }
-    Ref<DataTaskClient> protectedClient() const;
     void setClient(Ref<DataTaskClient>&&);
     void networkProcessCrashed();
     void didCompleteWithError(WebCore::ResourceError&&);

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp
@@ -32,9 +32,4 @@ namespace API {
 
 FrameTreeNode::~FrameTreeNode() = default;
 
-Ref<WebKit::WebPageProxy> FrameTreeNode::protectedPage()
-{
-    return page();
-}
-
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
@@ -42,7 +42,6 @@ public:
     virtual ~FrameTreeNode();
 
     WebKit::WebPageProxy& page() { return m_page.get(); }
-    Ref<WebKit::WebPageProxy> protectedPage();
     const WebKit::FrameInfoData& info() const { return m_data.info; }
     const Vector<WebKit::FrameTreeNodeData>& childFrames() const { return m_data.children; }
 

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -119,7 +119,6 @@ public:
     bool currentRequestIsCrossSiteRedirect() const;
 
     WebKit::WebBackForwardListItem* targetItem() const;
-    RefPtr<WebKit::WebBackForwardListItem> protectedTargetItem() const { return targetItem(); }
     WebKit::WebBackForwardListFrameItem* targetFrameItem() const { return m_targetFrameItem.get(); }
     WebKit::WebBackForwardListItem* fromItem() const { return m_fromItem.get(); }
     std::optional<WebCore::FrameLoadType> backForwardFrameLoadType() const { return m_backForwardFrameLoadType; }
@@ -180,7 +179,6 @@ public:
 
     void setWebsitePolicies(RefPtr<API::WebsitePolicies>&& policies) { m_websitePolicies = WTF::move(policies); }
     API::WebsitePolicies* websitePolicies() { return m_websitePolicies.get(); }
-    RefPtr<API::WebsitePolicies> protectedWebsitePolicies() const { return m_websitePolicies; }
 
     void setOriginatorAdvancedPrivacyProtections(OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections) { m_originatorAdvancedPrivacyProtections = advancedPrivacyProtections; }
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> originatorAdvancedPrivacyProtections() const { return m_originatorAdvancedPrivacyProtections; }

--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -45,7 +45,6 @@ public:
 
     FrameInfo* sourceFrame() const { return m_sourceFrame.get(); }
     FrameInfo* targetFrame() const { return m_targetFrame.get(); }
-    RefPtr<FrameInfo> protectedTargetFrame() const { return m_targetFrame; }
     const WTF::String& targetFrameName() const { return m_targetFrameName; }
 
     const WebCore::ResourceRequest& request() const { return m_request; }
@@ -71,10 +70,8 @@ public:
     bool isProcessingUserGesture() const { return m_userInitiatedAction; }
     bool isProcessingUnconsumedUserGesture() const { return m_userInitiatedAction && !m_userInitiatedAction->consumed(); }
     UserInitiatedAction* userInitiatedAction() const { return m_userInitiatedAction.get(); }
-    RefPtr<UserInitiatedAction> protectedUserInitiatedAction() const { return m_userInitiatedAction; }
 
     Navigation* mainFrameNavigation() const { return m_mainFrameNavigation.get(); }
-    RefPtr<Navigation> protectedMainFrameNavigation() const { return m_mainFrameNavigation; }
 
 #if HAVE(APP_SSO)
     bool shouldPerformSOAuthorization() { return m_shouldPerformSOAuthorization; }

--- a/Source/WebKit/UIProcess/API/APINavigationResponse.h
+++ b/Source/WebKit/UIProcess/API/APINavigationResponse.h
@@ -44,7 +44,6 @@ public:
     ~NavigationResponse();
 
     FrameInfo& frame() { return m_frame.get(); }
-    Ref<FrameInfo> protectedFrame() { return m_frame.get(); }
 
     const WebCore::ResourceRequest& request() const { return m_request; }
     const WebCore::ResourceResponse& response() const { return m_response; }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -164,11 +164,6 @@ WebProcessPool& PageConfiguration::processPool() const
     return m_data.processPool.get();
 }
 
-Ref<WebKit::WebProcessPool> PageConfiguration::protectedProcessPool() const
-{
-    return processPool();
-}
-
 void PageConfiguration::setProcessPool(RefPtr<WebProcessPool>&& processPool)
 {
     m_data.processPool = WTF::move(processPool);
@@ -177,11 +172,6 @@ void PageConfiguration::setProcessPool(RefPtr<WebProcessPool>&& processPool)
 WebUserContentControllerProxy& PageConfiguration::userContentController() const
 {
     return m_data.userContentController.get();
-}
-
-Ref<WebUserContentControllerProxy> PageConfiguration::protectedUserContentController() const
-{
-    return userContentController();
 }
 
 void PageConfiguration::setUserContentController(RefPtr<WebUserContentControllerProxy>&& userContentController)
@@ -205,11 +195,6 @@ WebExtensionController* PageConfiguration::webExtensionController() const
     return m_data.webExtensionController.get();
 }
 
-RefPtr<WebExtensionController> PageConfiguration::protectedWebExtensionController() const
-{
-    return webExtensionController();
-}
-
 void PageConfiguration::setWebExtensionController(RefPtr<WebExtensionController>&& webExtensionController)
 {
     m_data.webExtensionController = WTF::move(webExtensionController);
@@ -218,11 +203,6 @@ void PageConfiguration::setWebExtensionController(RefPtr<WebExtensionController>
 WebExtensionController* PageConfiguration::weakWebExtensionController() const
 {
     return m_data.weakWebExtensionController.get();
-}
-
-RefPtr<WebExtensionController> PageConfiguration::protectedWeakWebExtensionController() const
-{
-    return weakWebExtensionController();
 }
 
 void PageConfiguration::setWeakWebExtensionController(WebExtensionController* webExtensionController)
@@ -258,11 +238,6 @@ WebPreferences& PageConfiguration::preferences() const
     return m_data.preferences.get();
 }
 
-Ref<WebPreferences> PageConfiguration::protectedPreferences() const
-{
-    return preferences();
-}
-
 void PageConfiguration::setPreferences(RefPtr<WebPreferences>&& preferences)
 {
     m_data.preferences = WTF::move(preferences);
@@ -271,11 +246,6 @@ void PageConfiguration::setPreferences(RefPtr<WebPreferences>&& preferences)
 WebPageProxy* PageConfiguration::relatedPage() const
 {
     return m_data.relatedPage.get();
-}
-
-RefPtr<WebPageProxy> PageConfiguration::protectedRelatedPage() const
-{
-    return relatedPage();
 }
 
 WebPageProxy* PageConfiguration::pageToCloneSessionStorageFrom() const
@@ -303,11 +273,6 @@ WebKit::VisitedLinkStore& PageConfiguration::visitedLinkStore() const
     return m_data.visitedLinkStore.get();
 }
 
-Ref<WebKit::VisitedLinkStore> PageConfiguration::protectedVisitedLinkStore() const
-{
-    return visitedLinkStore();
-}
-
 void PageConfiguration::setVisitedLinkStore(RefPtr<WebKit::VisitedLinkStore>&& visitedLinkStore)
 {
     m_data.visitedLinkStore = WTF::move(visitedLinkStore);
@@ -325,16 +290,6 @@ WebKit::WebsiteDataStore* PageConfiguration::websiteDataStoreIfExists() const
     return m_data.websiteDataStore.get();
 }
 
-RefPtr<WebKit::WebsiteDataStore> PageConfiguration::protectedWebsiteDataStoreIfExists() const
-{
-    return websiteDataStoreIfExists();
-}
-
-Ref<WebsiteDataStore> PageConfiguration::protectedWebsiteDataStore() const
-{
-    return websiteDataStore();
-}
-
 void PageConfiguration::setWebsiteDataStore(RefPtr<WebsiteDataStore>&& websiteDataStore)
 {
     m_data.websiteDataStore = WTF::move(websiteDataStore);
@@ -343,11 +298,6 @@ void PageConfiguration::setWebsiteDataStore(RefPtr<WebsiteDataStore>&& websiteDa
 WebsitePolicies& PageConfiguration::defaultWebsitePolicies() const
 {
     return m_data.defaultWebsitePolicies.get();
-}
-
-Ref<WebsitePolicies> PageConfiguration::protectedDefaultWebsitePolicies() const
-{
-    return defaultWebsitePolicies();
 }
 
 void PageConfiguration::setDefaultWebsitePolicies(RefPtr<WebsitePolicies>&& policies)
@@ -397,7 +347,7 @@ void PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(bool delaysWebPr
 
 bool PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() const
 {
-    if (protectedPreferences()->siteIsolationEnabled())
+    if (protect(preferences())->siteIsolationEnabled())
         return true;
     if (RefPtr processPool = m_data.processPool.getIfExists(); processPool && isInspectorProcessPool(*processPool)) {
         // Never delay process launch for inspector pages as inspector pages do not know how to transition from a terminated process.
@@ -430,11 +380,6 @@ ApplicationManifest* PageConfiguration::applicationManifest() const
     return m_data.applicationManifest.get();
 }
 
-RefPtr<ApplicationManifest> PageConfiguration::protectedApplicationManifest() const
-{
-    return applicationManifest();
-}
-
 void PageConfiguration::setApplicationManifest(RefPtr<ApplicationManifest>&& applicationManifest)
 {
     m_data.applicationManifest = WTF::move(applicationManifest);
@@ -448,7 +393,7 @@ bool PageConfiguration::applePayEnabled() const
     if (auto applePayEnabledOverride = m_data.applePayEnabledOverride)
         return *applePayEnabledOverride;
 
-    return protectedPreferences()->applePayEnabled();
+    return protect(preferences())->applePayEnabled();
 }
 
 void PageConfiguration::setApplePayEnabled(bool enabled)

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -145,11 +145,9 @@ public:
     void setWindowFeatures(WebCore::WindowFeatures&&);
 
     WebKit::WebProcessPool& processPool() const;
-    Ref<WebKit::WebProcessPool> protectedProcessPool() const;
     void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);
 
     WebKit::WebUserContentControllerProxy& userContentController() const;
-    Ref<WebKit::WebUserContentControllerProxy> protectedUserContentController() const;
     void setUserContentController(RefPtr<WebKit::WebUserContentControllerProxy>&&);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -157,11 +155,9 @@ public:
     void setRequiredWebExtensionBaseURL(WTF::URL&&);
 
     WebKit::WebExtensionController* webExtensionController() const;
-    RefPtr<WebKit::WebExtensionController> protectedWebExtensionController() const;
     void setWebExtensionController(RefPtr<WebKit::WebExtensionController>&&);
 
     WebKit::WebExtensionController* weakWebExtensionController() const;
-    RefPtr<WebKit::WebExtensionController> protectedWeakWebExtensionController() const;
     void setWeakWebExtensionController(WebKit::WebExtensionController*);
 #endif
 
@@ -169,12 +165,10 @@ public:
     void setPageGroup(RefPtr<WebKit::WebPageGroup>&&);
 
     WebKit::WebPreferences& preferences() const;
-    Ref<WebKit::WebPreferences> protectedPreferences() const;
     void setPreferences(RefPtr<WebKit::WebPreferences>&&);
 
     WebKit::WebPageProxy* relatedPage() const;
     void setRelatedPage(WeakPtr<WebKit::WebPageProxy>&& relatedPage) { m_data.relatedPage = WTF::move(relatedPage); }
-    RefPtr<WebKit::WebPageProxy> protectedRelatedPage() const;
 
     WebKit::WebPageProxy* pageToCloneSessionStorageFrom() const;
     void setPageToCloneSessionStorageFrom(WeakPtr<WebKit::WebPageProxy>&&);
@@ -183,17 +177,13 @@ public:
     void setAlternateWebViewForNavigationGestures(WeakPtr<WebKit::WebPageProxy>&&);
 
     WebKit::VisitedLinkStore& visitedLinkStore() const;
-    Ref<WebKit::VisitedLinkStore> protectedVisitedLinkStore() const;
     void setVisitedLinkStore(RefPtr<WebKit::VisitedLinkStore>&&);
 
     WebKit::WebsiteDataStore& websiteDataStore() const;
     WebKit::WebsiteDataStore* websiteDataStoreIfExists() const;
-    RefPtr<WebKit::WebsiteDataStore> protectedWebsiteDataStoreIfExists() const;
-    Ref<WebKit::WebsiteDataStore> protectedWebsiteDataStore() const;
     void setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&&);
 
     WebsitePolicies& defaultWebsitePolicies() const;
-    Ref<WebsitePolicies> protectedDefaultWebsitePolicies() const;
     void setDefaultWebsitePolicies(RefPtr<WebsitePolicies>&&);
 
 #if PLATFORM(IOS_FAMILY)
@@ -279,7 +269,6 @@ public:
 
 #if ENABLE(APPLICATION_MANIFEST)
     ApplicationManifest* applicationManifest() const;
-    RefPtr<ApplicationManifest> protectedApplicationManifest() const;
     void setApplicationManifest(RefPtr<ApplicationManifest>&&);
 #endif
 

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
@@ -50,7 +50,6 @@ public:
     void setLAContext(LAContext *context) { m_response->setLAContext(context); }
 
     WebCore::AuthenticatorAssertionResponse& response() { return m_response.get(); }
-    Ref<WebCore::AuthenticatorAssertionResponse> protectedResponse() { return m_response; }
 
 private:
     WebAuthenticationAssertionResponse(Ref<WebCore::AuthenticatorAssertionResponse>&&);

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp
@@ -46,17 +46,7 @@ WebAuthenticationPanel::WebAuthenticationPanel()
     : m_manager(AuthenticatorManager::create())
     , m_client(WebAuthenticationPanelClient::create())
 {
-    protectedManager()->enableNativeSupport();
-}
-
-RefPtr<WebKit::AuthenticatorManager> WebAuthenticationPanel::protectedManager() const
-{
-    return m_manager;
-}
-
-Ref<WebAuthenticationPanelClient> WebAuthenticationPanel::protectedClient() const
-{
-    return m_client;
+    protect(m_manager)->enableNativeSupport();
 }
 
 WebAuthenticationPanel::WebAuthenticationPanel(const AuthenticatorManager& manager, const WTF::String& rpId, const TransportSet& transports, ClientDataType type, const WTF::String& userName)
@@ -81,7 +71,7 @@ void WebAuthenticationPanel::handleRequest(WebAuthenticationRequestData&& reques
 {
     ASSERT(m_manager);
     request.weakPanel = *this;
-    protectedManager()->handleRequest(WTF::move(request), WTF::move(callback));
+    protect(m_manager)->handleRequest(WTF::move(request), WTF::move(callback));
 }
 
 void WebAuthenticationPanel::cancel() const
@@ -91,7 +81,7 @@ void WebAuthenticationPanel::cancel() const
         return;
     }
 
-    protectedManager()->cancel();
+    protect(m_manager)->cancel();
 }
 
 void WebAuthenticationPanel::setMockConfiguration(WebCore::MockWebAuthenticationConfiguration&& configuration)

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
@@ -65,7 +65,6 @@ public:
     void setMockConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
 
     const WebAuthenticationPanelClient& client() const { return m_client.get(); }
-    Ref<WebAuthenticationPanelClient> protectedClient() const;
     void setClient(Ref<WebAuthenticationPanelClient>&&);
 
     // FIXME: <rdar://problem/71509848> Remove the following deprecated methods.
@@ -80,7 +79,6 @@ private:
     // FIXME: <rdar://problem/71509848> Remove the following deprecated method.
     WebAuthenticationPanel(const WebKit::AuthenticatorManager&, const WTF::String& rpId, const TransportSet&, WebCore::ClientDataType, const WTF::String& userName);
 
-    RefPtr<WebKit::AuthenticatorManager> protectedManager() const;
 
     RefPtr<WebKit::AuthenticatorManager> m_manager; // FIXME: <rdar://problem/71509848> Change to Ref.
     Ref<WebAuthenticationPanelClient> m_client;

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp
@@ -57,11 +57,6 @@ Ref<WebsitePolicies> WebsitePolicies::copy() const
 
 WebsitePolicies::~WebsitePolicies() = default;
 
-RefPtr<WebKit::WebsiteDataStore> WebsitePolicies::protectedWebsiteDataStore() const
-{
-    return m_websiteDataStore;
-}
-
 void WebsitePolicies::setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&& websiteDataStore)
 {
     m_websiteDataStore = WTF::move(websiteDataStore);

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -73,7 +73,6 @@ public:
     WebKit::WebsitePopUpPolicy popUpPolicy() const { return m_data.popUpPolicy; }
     void setPopUpPolicy(WebKit::WebsitePopUpPolicy policy) { m_data.popUpPolicy = policy; }
 
-    RefPtr<WebKit::WebsiteDataStore> protectedWebsiteDataStore() const;
     WebKit::WebsiteDataStore* websiteDataStore() const { return m_websiteDataStore.get(); }
     void setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&&);
     

--- a/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp
@@ -46,12 +46,12 @@ WKAuthenticationDecisionListenerRef WKAuthenticationChallengeGetDecisionListener
 
 WKProtectionSpaceRef WKAuthenticationChallengeGetProtectionSpace(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(toProtectedImpl(challenge)->protectedProtectionSpace().get());
+    return toAPI(protect(toProtectedImpl(challenge)->protectionSpace()).get());
 }
 
 WKCredentialRef WKAuthenticationChallengeGetProposedCredential(WKAuthenticationChallengeRef challenge)
 {
-    return toAPI(toProtectedImpl(challenge)->protectedProposedCredential().get());
+    return toAPI(protect(toProtectedImpl(challenge)->proposedCredential()).get());
 }
 
 int WKAuthenticationChallengeGetPreviousFailureCount(WKAuthenticationChallengeRef challenge)

--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -399,7 +399,7 @@ WKWebsiteDataStoreRef WKContextGetWebsiteDataStore(WKContextRef)
 
 WKGeolocationManagerRef WKContextGetGeolocationManager(WKContextRef contextRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(contextRef)->protectedSupplement<WebKit::WebGeolocationManagerProxy>().get());
+    return WebKit::toAPI(protect(WebKit::toProtectedImpl(contextRef)->supplement<WebKit::WebGeolocationManagerProxy>()).get());
 }
 
 WKIconDatabaseRef WKContextGetIconDatabase(WKContextRef)
@@ -414,7 +414,7 @@ WKKeyValueStorageManagerRef WKContextGetKeyValueStorageManager(WKContextRef cont
 
 WKNotificationManagerRef WKContextGetNotificationManager(WKContextRef contextRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(contextRef)->protectedSupplement<WebKit::WebNotificationManagerProxy>().get());
+    return WebKit::toAPI(protect(WebKit::toProtectedImpl(contextRef)->supplement<WebKit::WebNotificationManagerProxy>()).get());
 }
 
 WKResourceCacheManagerRef WKContextGetResourceCacheManager(WKContextRef context)

--- a/Source/WebKit/UIProcess/API/C/WKInspector.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKInspector.cpp
@@ -42,7 +42,7 @@ WKTypeID WKInspectorGetTypeID()
 
 WKPageRef WKInspectorGetPage(WKInspectorRef inspectorRef)
 {
-    return toAPI(toProtectedImpl(inspectorRef)->protectedInspectedPage().get());
+    return toAPI(protect(toProtectedImpl(inspectorRef)->inspectedPage()).get());
 }
 
 bool WKInspectorIsConnected(WKInspectorRef inspectorRef)

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -68,7 +68,7 @@ void WKPageConfigurationSetPageGroup(WKPageConfigurationRef, WKPageGroupRef)
 
 WKUserContentControllerRef WKPageConfigurationGetUserContentController(WKPageConfigurationRef configuration)
 {
-    return toAPI(toProtectedImpl(configuration)->protectedUserContentController().get());
+    return toAPI(protect(toProtectedImpl(configuration)->userContentController()).get());
 }
 
 void WKPageConfigurationSetUserContentController(WKPageConfigurationRef configuration, WKUserContentControllerRef userContentController)
@@ -78,7 +78,7 @@ void WKPageConfigurationSetUserContentController(WKPageConfigurationRef configur
 
 WKPreferencesRef WKPageConfigurationGetPreferences(WKPageConfigurationRef configuration)
 {
-    return toAPI(toProtectedImpl(configuration)->protectedPreferences().get());
+    return toAPI(protect(toProtectedImpl(configuration)->preferences()).get());
 }
 
 void WKPageConfigurationSetPreferences(WKPageConfigurationRef configuration, WKPreferencesRef preferences)
@@ -88,7 +88,7 @@ void WKPageConfigurationSetPreferences(WKPageConfigurationRef configuration, WKP
 
 WKPageRef WKPageConfigurationGetRelatedPage(WKPageConfigurationRef configuration)
 {
-    return toAPI(toProtectedImpl(configuration)->protectedRelatedPage().get());
+    return toAPI(protect(toProtectedImpl(configuration)->relatedPage()).get());
 }
 
 void WKPageConfigurationSetRelatedPage(WKPageConfigurationRef configuration, WKPageRef relatedPage)
@@ -133,7 +133,7 @@ void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfi
 
 WKWebsitePoliciesRef WKPageConfigurationGetDefaultWebsitePolicies(WKPageConfigurationRef configuration)
 {
-    return toAPI(toProtectedImpl(configuration)->protectedDefaultWebsitePolicies().get());
+    return toAPI(protect(toProtectedImpl(configuration)->defaultWebsitePolicies()).get());
 }
 
 void WKPageConfigurationSetDefaultWebsitePolicies(WKPageConfigurationRef configuration, WKWebsitePoliciesRef policies)

--- a/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp
@@ -56,7 +56,7 @@ WKTypeID WKWebsiteDataStoreGetTypeID()
 
 WKWebsiteDataStoreRef WKWebsiteDataStoreGetDefaultDataStore()
 {
-    return WebKit::toAPI(WebKit::WebsiteDataStore::protectedDefaultDataStore().get());
+    return WebKit::toAPI(protect(WebKit::WebsiteDataStore::defaultDataStore()).get());
 }
 
 WKWebsiteDataStoreRef WKWebsiteDataStoreCreateNonPersistentDataStore()
@@ -142,7 +142,7 @@ void WKWebsiteDataStoreSyncLocalStorage(WKWebsiteDataStoreRef dataStore, void* c
 
 WKHTTPCookieStoreRef WKWebsiteDataStoreGetHTTPCookieStore(WKWebsiteDataStoreRef dataStoreRef)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(dataStoreRef)->protectedCookieStore().get());
+    return WebKit::toAPI(protect(WebKit::toProtectedImpl(dataStoreRef)->cookieStore()).get());
 }
 
 void WKWebsiteDataStoreSetAllowsAnySSLCertificateForWebSocketTesting(WKWebsiteDataStoreRef, bool)
@@ -677,7 +677,7 @@ void WKWebsiteDataStoreSetPerOriginStorageQuota(WKWebsiteDataStoreRef, uint64_t)
 void WKWebsiteDataStoreClearAllDeviceOrientationPermissions(WKWebsiteDataStoreRef dataStoreRef)
 {
 #if ENABLE(DEVICE_ORIENTATION)
-    WebKit::toProtectedImpl(dataStoreRef)->protectedDeviceOrientationAndMotionAccessController()->clearPermissions();
+    protect(WebKit::toProtectedImpl(dataStoreRef)->deviceOrientationAndMotionAccessController())->clearPermissions();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -500,7 +500,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPathsSingleton()
 
         contentNavigation = loadWebContent(webView.get());
         if (!finished)
-            attributedStringActivity = protect([webView _protectedPage]->legacyMainFrameProcess())->protectedThrottler()->foregroundActivity("NSAttributedString serialization"_s);
+            attributedStringActivity = protect(protect([webView _protectedPage]->legacyMainFrameProcess())->throttler())->foregroundActivity("NSAttributedString serialization"_s);
 
         ASSERT(contentNavigation);
         ASSERT(webView.get().loading);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -119,7 +119,7 @@ private:
         if (!delegate)
             return completionHandler(WebKit::AllowOverwrite::No, { });
 
-        [delegate download:protectedWrapper(download).get() decideDestinationUsingResponse:response.protectedNSURLResponse().get() suggestedFilename:suggestedFilename.createNSString().get() completionHandler:makeBlockPtr([download = Ref { download }, completionHandler = WTF::move(completionHandler), checker = WebKit::CompletionHandlerCallChecker::create(m_delegate.get().get(), @selector(download:decideDestinationUsingResponse:suggestedFilename:completionHandler:))] (NSURL *destination) mutable {
+        [delegate download:protectedWrapper(download).get() decideDestinationUsingResponse:protect(response.nsURLResponse()).get() suggestedFilename:suggestedFilename.createNSString().get() completionHandler:makeBlockPtr([download = Ref { download }, completionHandler = WTF::move(completionHandler), checker = WebKit::CompletionHandlerCallChecker::create(m_delegate.get().get(), @selector(download:decideDestinationUsingResponse:suggestedFilename:completionHandler:))] (NSURL *destination) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -206,7 +206,7 @@ private:
         if (!delegate || !m_respondsToDidFailWithError)
             return;
 
-        [delegate download:protectedWrapper(download).get() didFailWithError:error.protectedNSError().get() resumeData:protectedWrapper(resumeData).get()];
+        [delegate download:protectedWrapper(download).get() didFailWithError:protect(error.nsError()).get() resumeData:protectedWrapper(resumeData).get()];
     }
 
     void processDidCrash(WebKit::DownloadProxy& download) final
@@ -301,7 +301,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSURLRequest *)originalRequest
 {
-    return _download->request().protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody).autorelease();
+    return protect(_download->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody)).autorelease();
 }
 
 - (WKWebView *)webView

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -110,7 +110,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKFrameInfo *)targetFrame
 {
-    return wrapper(_navigationAction->protectedTargetFrame().get());
+    return wrapper(protect(_navigationAction->targetFrame()).get());
 }
 
 - (WKNavigationType)navigationType
@@ -216,7 +216,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (_WKUserInitiatedAction *)_userInitiatedAction
 {
-    return wrapper(_navigationAction->protectedUserInitiatedAction().get());
+    return wrapper(protect(_navigationAction->userInitiatedAction()).get());
 }
 
 - (BOOL)isContentRuleListRedirect
@@ -236,7 +236,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKNavigation *)_mainFrameNavigation
 {
-    return wrapper(_navigationAction->protectedMainFrameNavigation().get());
+    return wrapper(protect(_navigationAction->mainFrameNavigation()).get());
 }
 
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -78,7 +78,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (WKFrameInfo *)_frame
 {
     // FIXME: This RefPtr should not be necessary. Remove it once clang static analyzer is fixed.
-    return wrapper(RefPtr { _navigationResponse.get() }->protectedFrame().get());
+    return wrapper(protect(RefPtr { _navigationResponse.get() }->frame()).get());
 }
 
 - (WKFrameInfo *)_navigationInitiatingFrame

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -256,7 +256,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)_objectForBundleParameter:(NSString *)parameter
 {
-    return [protectedProcessPool(self)->protectedBundleParameters() objectForKey:parameter];
+    return [protect(protectedProcessPool(self)->bundleParameters()) objectForKey:parameter];
 }
 
 - (void)_setObject:(id <NSCopying, NSSecureCoding>)object forBundleParameter:(NSString *)parameter
@@ -679,7 +679,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (WKNotificationManagerRef)_notificationManagerForTesting
 {
-    return WebKit::toAPI(protectedProcessPool(self)->protectedSupplement<WebKit::WebNotificationManagerProxy>().get());
+    return WebKit::toAPI(protect(protectedProcessPool(self)->supplement<WebKit::WebNotificationManagerProxy>()).get());
 }
 
 + (_WKProcessInfo *)_gpuProcessInfo

--- a/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm
@@ -100,7 +100,7 @@ static Ref<WebKit::WebURLSchemeTask> protectedURLSchemeTask(WKURLSchemeTaskImpl 
 
 - (BOOL)_requestOnlyIfCached
 {
-    return protectedURLSchemeTask(self)->protectedNSRequest().get().cachePolicy == NSURLRequestReturnCacheDataDontLoad;
+    return protect(protectedURLSchemeTask(self)->nsRequest()).get().cachePolicy == NSURLRequestReturnCacheDataDontLoad;
 }
 
 - (void)_willPerformRedirection:(NSURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -96,12 +96,12 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionContext, WebExtensionContext
 
 - (WKWebExtension *)webExtension
 {
-    return wrapper(Ref { *_webExtensionContext }->protectedExtension().get());
+    return wrapper(protect(Ref { *_webExtensionContext }->extension()).get());
 }
 
 - (WKWebExtensionController *)webExtensionController
 {
-    return wrapper(Ref { *_webExtensionContext }->protectedExtensionController().get());
+    return wrapper(protect(Ref { *_webExtensionContext }->extensionController()).get());
 }
 
 - (BOOL)isLoaded

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm
@@ -73,7 +73,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionController, WebExtensionCont
 
 - (WKWebExtensionControllerConfiguration *)configuration
 {
-    return Ref { *_webExtensionController }->protectedConfiguration()->copy()->wrapper();
+    return protect(Ref { *_webExtensionController }->configuration())->copy()->wrapper();
 }
 
 - (BOOL)loadExtensionContext:(WKWebExtensionContext *)extensionContext error:(NSError **)outError

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm
@@ -181,7 +181,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionControllerConfiguration, Web
 
 - (WKWebsiteDataStore *)defaultWebsiteDataStore
 {
-    return wrapper(self._protectedWebExtensionControllerConfiguration->protectedDefaultWebsiteDataStore().get());
+    return wrapper(protect(self._protectedWebExtensionControllerConfiguration->defaultWebsiteDataStore()).get());
 }
 
 - (void)setDefaultWebsiteDataStore:(WKWebsiteDataStore *)dataStore

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4785,8 +4785,8 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     _page->loadAndDecodeImage(request, sizeConstraint, maximumBytesFromNetwork, [completionHandler = makeBlockPtr(completionHandler), url](Expected<Ref<WebCore::ShareableBitmap>, WebCore::ResourceError>&& result) mutable {
         if (!result) {
             if (result.error().isNull())
-                return completionHandler(nil, WebCore::internalError(url).protectedNSError().get()); // This can happen if IPC fails.
-            return completionHandler(nil, result.error().protectedNSError().get());
+                return completionHandler(nil, protect(WebCore::internalError(url).nsError()).get()); // This can happen if IPC fails.
+            return completionHandler(nil, protect(result.error().nsError()).get());
         }
         Ref bitmap = result.value();
 #if PLATFORM(MAC)
@@ -5613,7 +5613,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 - (void)_getContentsAsStringWithCompletionHandlerKeepIPCConnectionAliveForTesting:(void (^)(NSString *, NSError *))completionHandler
 {
     THROW_IF_SUSPENDED;
-    _page->getContentsAsString(WebKit::ContentAsStringIncludesChildFrames::No, [handler = makeBlockPtr(completionHandler), connection = _page->legacyMainFrameProcess().protectedConnection()](String string) {
+    _page->getContentsAsString(WebKit::ContentAsStringIncludesChildFrames::No, [handler = makeBlockPtr(completionHandler), connection = protect(_page->legacyMainFrameProcess().connection())](String string) {
         handler(string.createNSString().get(), nil);
     });
 }
@@ -6705,7 +6705,7 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
     if (!popupMenu->isVisible())
         return nil;
 
-    return popupMenu->protectedPopup();
+    return protect(popupMenu->popup());
 }
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -367,7 +367,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKPreferences *)preferences
 {
-    return wrapper(self._protectedPageConfiguration->protectedPreferences().get());
+    return wrapper(protect(self._protectedPageConfiguration->preferences()).get());
 }
 
 - (void)setPreferences:(WKPreferences *)preferences
@@ -377,7 +377,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKUserContentController *)userContentController
 {
-    return wrapper(self._protectedPageConfiguration->protectedUserContentController().get());
+    return wrapper(protect(self._protectedPageConfiguration->userContentController()).get());
 }
 
 - (void)setUserContentController:(WKUserContentController *)userContentController
@@ -404,7 +404,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WKWebExtensionController *)_strongWebExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return wrapper(self._protectedPageConfiguration->protectedWebExtensionController().get());
+    return wrapper(protect(self._protectedPageConfiguration->webExtensionController()).get());
 #else
     return nil;
 #endif
@@ -413,7 +413,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WKWebExtensionController *)_weakWebExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return wrapper(self._protectedPageConfiguration->protectedWeakWebExtensionController().get());
+    return wrapper(protect(self._protectedPageConfiguration->weakWebExtensionController()).get());
 #else
     return nil;
 #endif
@@ -520,7 +520,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKWebpagePreferences *)defaultWebpagePreferences
 {
-    return wrapper(self._protectedPageConfiguration->protectedDefaultWebsitePolicies().get());
+    return wrapper(protect(self._protectedPageConfiguration->defaultWebsitePolicies()).get());
 }
 
 - (void)setDefaultWebpagePreferences:(WKWebpagePreferences *)defaultWebpagePreferences
@@ -554,7 +554,7 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (_WKVisitedLinkStore *)_visitedLinkStore
 {
-    return wrapper(self._protectedPageConfiguration->protectedVisitedLinkStore().get());
+    return wrapper(protect(self._protectedPageConfiguration->visitedLinkStore()).get());
 }
 
 - (void)_setVisitedLinkStore:(_WKVisitedLinkStore *)visitedLinkStore
@@ -1069,7 +1069,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (WKWebsiteDataStore *)_websiteDataStoreIfExists
 {
-    return wrapper(self._protectedPageConfiguration->protectedWebsiteDataStoreIfExists().get());
+    return wrapper(protect(self._protectedPageConfiguration->websiteDataStoreIfExists()).get());
 }
 
 - (NSArray<NSString *> *)_corsDisablingPatterns
@@ -1228,7 +1228,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (_WKApplicationManifest *)_applicationManifest
 {
-    return wrapper(self._protectedPageConfiguration->protectedApplicationManifest().get());
+    return wrapper(protect(self._protectedPageConfiguration->applicationManifest()).get());
 }
 
 - (void)_setApplicationManifest:(_WKApplicationManifest *)applicationManifest

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1219,7 +1219,7 @@ struct WKWebsiteData {
 
 - (void)_synthesizeAppIsBackground:(BOOL)background
 {
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->synthesizeAppIsBackground(background);
+    protect(protectedWebsiteDataStore(self)->networkProcess())->synthesizeAppIsBackground(background);
 }
 
 - (pid_t)_networkProcessIdentifier
@@ -1240,7 +1240,7 @@ struct WKWebsiteData {
 - (void)_forceNetworkProcessToTaskSuspendForTesting
 {
     if (RefPtr networkProcess = _websiteDataStore->networkProcessIfExists())
-        networkProcess->protectedThrottler()->invalidateAllActivitiesAndDropAssertion();
+        protect(networkProcess->throttler())->invalidateAllActivitiesAndDropAssertion();
 }
 
 - (BOOL)_networkProcessExists
@@ -1269,7 +1269,7 @@ struct WKWebsiteData {
 {
     RELEASE_LOG(Push, "Getting pending push message");
 
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->getPendingPushMessage(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (const auto& message) {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->getPendingPushMessage(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (const auto& message) {
         RetainPtr<NSDictionary> result;
         if (message)
             result = message->toDictionary();
@@ -1283,7 +1283,7 @@ struct WKWebsiteData {
 {
     RELEASE_LOG(Push, "Getting pending push messages");
 
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->getPendingPushMessages(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (const Vector<WebKit::WebPushMessage>& messages) {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->getPendingPushMessages(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (const Vector<WebKit::WebPushMessage>& messages) {
         auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:messages.size()]);
         for (auto& message : messages)
             [result addObject:message.toDictionary().get()];
@@ -1325,7 +1325,7 @@ struct WKWebsiteData {
     RELEASE_LOG(Push, "Sending persistent notification click from origin %" SENSITIVE_LOG_STRING " to network process to handle", notificationData.originString.utf8().data());
 
     notificationData.sourceSession = _websiteDataStore->sessionID();
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->processNotificationEvent(notificationData, WebCore::NotificationEventType::Click, [completionHandler = makeBlockPtr(completionHandler)] (bool wasProcessed) {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->processNotificationEvent(notificationData, WebCore::NotificationEventType::Click, [completionHandler = makeBlockPtr(completionHandler)] (bool wasProcessed) {
         RELEASE_LOG(Push, "Notification click event processing complete. Callback result: %d", wasProcessed);
         completionHandler(wasProcessed);
     });
@@ -1347,7 +1347,7 @@ struct WKWebsiteData {
 {
     RELEASE_LOG(Push, "Sending persistent notification close from origin %" SENSITIVE_LOG_STRING " to network process to handle", notificationData.originString.utf8().data());
 
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->processNotificationEvent(notificationData, WebCore::NotificationEventType::Close, [completionHandler = makeBlockPtr(completionHandler)] (bool wasProcessed) {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->processNotificationEvent(notificationData, WebCore::NotificationEventType::Close, [completionHandler = makeBlockPtr(completionHandler)] (bool wasProcessed) {
         RELEASE_LOG(Push, "Notification close event processing complete. Callback result: %d", wasProcessed);
         completionHandler(wasProcessed);
     });
@@ -1367,7 +1367,7 @@ struct WKWebsiteData {
 
 -(void)_getAllBackgroundFetchIdentifiers:(void(^)(NSArray<NSString *> *identifiers))completionHandler
 {
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->getAllBackgroundFetchIdentifiers(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (auto identifiers) {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->getAllBackgroundFetchIdentifiers(_websiteDataStore->sessionID(), [completionHandler = makeBlockPtr(completionHandler)] (auto identifiers) {
         auto result = adoptNS([[NSMutableArray alloc] initWithCapacity:identifiers.size()]);
         for (auto identifier : identifiers)
             [result addObject:identifier.createNSString().get()];
@@ -1377,7 +1377,7 @@ struct WKWebsiteData {
 
 -(void)_getBackgroundFetchState:(NSString *) identifier completionHandler:(void(^)(NSDictionary *state))completionHandler
 {
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->getBackgroundFetchState(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] (auto state) {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->getBackgroundFetchState(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] (auto state) {
         completionHandler(state ? state->toDictionary() : nil);
     });
 }
@@ -1387,7 +1387,7 @@ struct WKWebsiteData {
     if (!completionHandler)
         completionHandler = [] { };
 
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->abortBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->abortBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -1396,7 +1396,7 @@ struct WKWebsiteData {
     if (!completionHandler)
         completionHandler = [] { };
 
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->pauseBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->pauseBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -1406,7 +1406,7 @@ struct WKWebsiteData {
     if (!completionHandler)
         completionHandler = [] { };
 
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->resumeBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->resumeBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -1419,7 +1419,7 @@ struct WKWebsiteData {
     if (!completionHandler)
         completionHandler = [] { };
 
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()->clickBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
+    protect(protectedWebsiteDataStore(self)->networkProcess())->clickBackgroundFetch(_websiteDataStore->sessionID(), identifier, [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -1439,7 +1439,7 @@ struct WKWebsiteData {
 -(void)_scopeURL:(NSURL *)scopeURL hasPushSubscriptionForTesting:(void(^)(BOOL))completionHandler
 {
     auto completionHandlerCopy = makeBlockPtr(completionHandler);
-    protectedWebsiteDataStore(self)->protectedNetworkProcess()
+    protect(protectedWebsiteDataStore(self)->networkProcess())
         ->hasPushSubscriptionForTesting(_websiteDataStore->sessionID(), scopeURL, [completionHandlerCopy](bool result) {
             completionHandlerCopy(result);
         });

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
@@ -78,7 +78,7 @@ private:
         if (!delegate || !m_respondsToWillPerformHTTPRedirection)
             return completionHandler(true);
         auto checker = WebKit::CompletionHandlerCallChecker::create(delegate.get(), @selector(dataTask:willPerformHTTPRedirection:newRequest:decisionHandler:));
-        [delegate dataTask:protectedWrapper(task).get() willPerformHTTPRedirection:RetainPtr { checked_objc_cast<NSHTTPURLResponse>(response.nsURLResponse()) }.get() newRequest:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get() decisionHandler:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)] (_WKDataTaskRedirectPolicy policy) mutable {
+        [delegate dataTask:protectedWrapper(task).get() willPerformHTTPRedirection:RetainPtr { checked_objc_cast<NSHTTPURLResponse>(response.nsURLResponse()) }.get() newRequest:protect(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)).get() decisionHandler:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)] (_WKDataTaskRedirectPolicy policy) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -92,7 +92,7 @@ private:
         if (!delegate || !m_respondsToDidReceiveResponse)
             return completionHandler(true);
         auto checker = WebKit::CompletionHandlerCallChecker::create(delegate.get(), @selector(dataTask:didReceiveResponse:decisionHandler:));
-        [delegate dataTask:protectedWrapper(task).get() didReceiveResponse:response.protectedNSURLResponse().get() decisionHandler:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)] (_WKDataTaskResponsePolicy policy) mutable {
+        [delegate dataTask:protectedWrapper(task).get() didReceiveResponse:protect(response.nsURLResponse()).get() decisionHandler:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)] (_WKDataTaskResponsePolicy policy) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -113,7 +113,7 @@ private:
         RetainPtr delegate = m_delegate.get();
         if (!delegate || !m_respondsToDidCompleteWithError)
             return;
-        [delegate dataTask:protectedWrapper(task).get() didCompleteWithError:error.protectedNSError().get()];
+        [delegate dataTask:protectedWrapper(task).get() didCompleteWithError:protect(error.nsError()).get()];
         wrapper(task)->_delegate = nil;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm
@@ -73,7 +73,7 @@ IGNORE_WARNINGS_END
 - (void)cancel
 {
     Ref { *_download->_download }->cancel([download = Ref { *_download->_download }] (auto*) {
-        download->protectedClient()->legacyDidCancel(download.get());
+        protect(download->client())->legacyDidCancel(download.get());
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm
@@ -248,7 +248,7 @@ Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *inspector)
         return;
     }
 
-    protectedInspector(self)->protectedExtensionController()->registerExtension(extensionID, extensionBundleIdentifier, displayName, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<Ref<API::InspectorExtension>, Inspector::ExtensionError> result) mutable {
+    protect(protectedInspector(self)->extensionController())->registerExtension(extensionID, extensionBundleIdentifier, displayName, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<Ref<API::InspectorExtension>, Inspector::ExtensionError> result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
@@ -270,7 +270,7 @@ Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *inspector)
         return;
     }
 
-    protectedInspector(self)->protectedExtensionController()->unregisterExtension(extension.extensionID, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError> result) mutable {
+    protect(protectedInspector(self)->extensionController())->unregisterExtension(extension.extensionID, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError> result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
@@ -292,7 +292,7 @@ Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *inspector)
         return;
     }
 
-    protectedInspector(self)->protectedExtensionController()->showExtensionTab(extensionTabIdentifier, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError>&& result) mutable {
+    protect(protectedInspector(self)->extensionController())->showExtensionTab(extensionTabIdentifier, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError>&& result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
@@ -312,7 +312,7 @@ Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *inspector)
         return;
     }
 
-    protectedInspector(self)->protectedExtensionController()->navigateTabForExtension(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (const std::optional<Inspector::ExtensionError>&& result) mutable {
+    protect(protectedInspector(self)->extensionController())->navigateTabForExtension(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (const std::optional<Inspector::ExtensionError>&& result) mutable {
         if (result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()).createNSString().get() }]).get());
             return;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
@@ -83,7 +83,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     for (auto pair : _configuration->urlSchemeHandlers()) {
         Ref handler = downcast<WebKit::WebURLSchemeHandlerCocoa>(pair.first.get());
-        [configuration setURLSchemeHandler:handler->protectedAPIHandler().get() forURLScheme:pair.second.createNSString().get()];
+        [configuration setURLSchemeHandler:protect(handler->apiHandler()).get() forURLScheme:pair.second.createNSString().get()];
     }
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
@@ -101,7 +101,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     for (auto pair : _configuration->urlSchemeHandlers()) {
         Ref handler = downcast<WebKit::WebURLSchemeHandlerCocoa>(pair.first.get());
-        [configuration setURLSchemeHandler:handler->protectedAPIHandler().get() forURLScheme:pair.second.createNSString().get()];
+        [configuration setURLSchemeHandler:protect(handler->apiHandler()).get() forURLScheme:pair.second.createNSString().get()];
     }
 
     if (auto* processPool = self.processPool)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
@@ -184,7 +184,7 @@ private:
         return;
     }
 
-    m_remoteInspectorProxy->protectedExtensionController()->registerExtension(extensionID, extensionBundleIdentifier, displayName, [protectedExtensionID = retainPtr(extensionID), protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<Ref<API::InspectorExtension>, Inspector::ExtensionError> result) mutable {
+    protect(m_remoteInspectorProxy->extensionController())->registerExtension(extensionID, extensionBundleIdentifier, displayName, [protectedExtensionID = retainPtr(extensionID), protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<Ref<API::InspectorExtension>, Inspector::ExtensionError> result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
@@ -205,7 +205,7 @@ private:
         completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(Inspector::ExtensionError::InvalidRequest).createNSString().get() }]).get());
         return;
     }
-    m_remoteInspectorProxy->protectedExtensionController()->unregisterExtension(extension.extensionID, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError> result) mutable {
+    protect(m_remoteInspectorProxy->extensionController())->unregisterExtension(extension.extensionID, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError> result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
@@ -237,7 +237,7 @@ private:
         return;
     }
 
-    m_remoteInspectorProxy->protectedExtensionController()->showExtensionTab(extensionTabIdentifier, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError>&& result) mutable {
+    protect(m_remoteInspectorProxy->extensionController())->showExtensionTab(extensionTabIdentifier, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<void, Inspector::ExtensionError>&& result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;
@@ -257,7 +257,7 @@ private:
         return;
     }
 
-    m_remoteInspectorProxy->protectedExtensionController()->navigateTabForExtension(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (const std::optional<Inspector::ExtensionError> result) mutable {
+    protect(m_remoteInspectorProxy->extensionController())->navigateTabForExtension(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (const std::optional<Inspector::ExtensionError> result) mutable {
         if (result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()).createNSString().get() }]).get());
             return;

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp
@@ -67,22 +67,12 @@ WebCredential* AuthenticationChallengeProxy::proposedCredential() const
     return m_webCredential.get();
 }
 
-RefPtr<WebCredential> AuthenticationChallengeProxy::protectedProposedCredential() const
-{
-    return proposedCredential();
-}
-
 WebProtectionSpace* AuthenticationChallengeProxy::protectionSpace() const
 {
     if (!m_webProtectionSpace)
         m_webProtectionSpace = WebProtectionSpace::create(m_coreAuthenticationChallenge.protectionSpace());
 
     return m_webProtectionSpace.get();
-}
-
-RefPtr<WebProtectionSpace> AuthenticationChallengeProxy::protectedProtectionSpace() const
-{
-    return protectionSpace();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
+++ b/Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h
@@ -57,10 +57,8 @@ public:
     virtual ~AuthenticationChallengeProxy();
 
     WebCredential* proposedCredential() const;
-    RefPtr<WebCredential> protectedProposedCredential() const;
 
     WebProtectionSpace* protectionSpace() const;
-    RefPtr<WebProtectionSpace> protectedProtectionSpace() const;
 
     AuthenticationDecisionListener& listener() const { return m_listener.get(); }
     const WebCore::AuthenticationChallenge& core() { return m_coreAuthenticationChallenge; }

--- a/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
@@ -56,7 +56,7 @@ void AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc(IPC::C
     xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCCertificatesKey, certificateDataArray.get());
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCPersistenceKey, static_cast<uint64_t>(nsCredential.get().persistence));
 
-    xpc_connection_send_message(connection.protectedXPCConnection().get(), message.get());
+    xpc_connection_send_message(protect(connection.xpcConnection()).get(), message.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1959,7 +1959,7 @@ CommandResult<String /* authenticatorId */> WebAutomationSession::addVirtualAuth
     auto page = webPageProxyForHandle(browsingContextHandle);
     SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
 
-    return protect(page->websiteDataStore())->protectedVirtualAuthenticatorManager()->createAuthenticator({
+    return protect(protect(page->websiteDataStore())->virtualAuthenticatorManager())->createAuthenticator({
         .protocol = protocol,
         .transport = toAuthenticatorTransport(parsedTransport.value()),
         .hasResidentKey = *hasResidentKey,
@@ -1978,7 +1978,7 @@ CommandResult<void> WebAutomationSession::removeVirtualAuthenticator(const Strin
     auto page = webPageProxyForHandle(browsingContextHandle);
     SYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, WindowNotFound);
 
-    bool success = protect(page->websiteDataStore())->protectedVirtualAuthenticatorManager()->removeAuthenticator(authenticatorId);
+    bool success = protect(protect(page->websiteDataStore())->virtualAuthenticatorManager())->removeAuthenticator(authenticatorId);
     SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!success, InvalidParameter, "No such authenticator exists."_s);
 
     return { };

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -105,8 +105,6 @@ public:
 
     ProcessThrottler& throttler() { return m_throttler; }
     const ProcessThrottler& throttler() const { return m_throttler; }
-    Ref<ProcessThrottler> protectedThrottler() { return m_throttler; }
-    Ref<const ProcessThrottler> protectedThrottler() const { return m_throttler; }
 
     template<typename T> bool send(T&& message, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions = { });
 
@@ -141,7 +139,6 @@ public:
         return *m_connection;
     }
 
-    Ref<IPC::Connection> protectedConnection() const { return connection(); }
 
     bool hasConnection() const
     {
@@ -209,7 +206,6 @@ public:
     void checkForResponsiveness(CompletionHandler<void()>&& = nullptr, UseLazyStop = UseLazyStop::No);
 
     ResponsivenessTimer& responsivenessTimer() const { return m_responsivenessTimer.get(); }
-    Ref<ResponsivenessTimer> protectedResponsivenessTimer() const { return m_responsivenessTimer; }
 
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -48,11 +48,6 @@ BackgroundProcessResponsivenessTimer::~BackgroundProcessResponsivenessTimer()
 {
 }
 
-Ref<WebProcessProxy> BackgroundProcessResponsivenessTimer::protectedWebProcessProxy() const
-{
-    return const_cast<WebProcessProxy&>(m_webProcessProxy.get());
-}
-
 void BackgroundProcessResponsivenessTimer::updateState()
 {
     if (!shouldBeActive()) {
@@ -98,7 +93,7 @@ void BackgroundProcessResponsivenessTimer::responsivenessCheckTimerFired()
     ASSERT(!m_timeoutTimer.isActive());
 
     m_timeoutTimer.startOneShot(responsivenessTimeout);
-    protectedWebProcessProxy()->send(Messages::WebProcess::BackgroundResponsivenessPing(), 0);
+    protect(m_webProcessProxy)->send(Messages::WebProcess::BackgroundResponsivenessPing(), 0);
 }
 
 void BackgroundProcessResponsivenessTimer::timeoutTimerFired()
@@ -109,13 +104,13 @@ void BackgroundProcessResponsivenessTimer::timeoutTimerFired()
 
     // This shouldn't happen but still check to be 100% sure we don't report
     // suspended processes as unresponsive.
-    if (protectedWebProcessProxy()->throttler().isSuspended())
+    if (protect(m_webProcessProxy)->throttler().isSuspended())
         return;
 
     if (!m_isResponsive)
         return;
 
-    if (!protectedClient()->mayBecomeUnresponsive())
+    if (!protect(client())->mayBecomeUnresponsive())
         return;
 
     setResponsive(false);

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
@@ -49,7 +49,6 @@ public:
     void processTerminated();
 
 private:
-    Ref<WebProcessProxy> protectedWebProcessProxy() const;
     void responsivenessCheckTimerFired();
     void timeoutTimerFired();
     void setResponsive(bool);
@@ -58,7 +57,6 @@ private:
     bool isActive() const;
     void scheduleNextResponsivenessCheck();
     ResponsivenessTimer::Client& client() const;
-    Ref<ResponsivenessTimer::Client> protectedClient() const { return client(); }
 
     WeakRef<WebProcessProxy> m_webProcessProxy;
     Seconds m_checkingInterval;

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -140,14 +140,14 @@ GroupActivitiesCoordinator::GroupActivitiesCoordinator(GroupActivitiesSession& s
             protectedThis->sessionStateChanged(session, state);
     }))
 {
-    [session.protectedGroupSession() coordinateWithCoordinator:m_playbackCoordinator.get()];
+    [protect(session.groupSession()) coordinateWithCoordinator:m_playbackCoordinator.get()];
     session.addStateChangeObserver(m_stateChangeObserver);
 }
 
 GroupActivitiesCoordinator::~GroupActivitiesCoordinator()
 {
-    m_session->protectedGroupSession().get().newActivityCallback = nil;
-    m_session->protectedGroupSession().get().stateChangedCallback = nil;
+    protect(m_session->groupSession()).get().newActivityCallback = nil;
+    protect(m_session->groupSession()).get().stateChangedCallback = nil;
 }
 
 void GroupActivitiesCoordinator::sessionStateChanged(const GroupActivitiesSession& session, GroupActivitiesSession::State state)

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h
@@ -69,7 +69,6 @@ private:
     friend class GroupActivitiesCoordinator;
     GroupActivitiesSession(RetainPtr<WKGroupSession>&&);
     WKGroupSession* groupSession() { return m_groupSession.get(); }
-    RetainPtr<WKGroupSession> protectedGroupSession() { return m_groupSession; }
 
     RetainPtr<WKGroupSession> m_groupSession;
     WeakHashSet<StateChangeObserver> m_stateChangeObservers;

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -80,7 +80,7 @@ void LegacyDownloadClient::legacyDidStart(DownloadProxy& downloadProxy)
 void LegacyDownloadClient::didReceiveResponse(DownloadProxy& downloadProxy, const WebCore::ResourceResponse& response)
 {
     if (m_delegateMethods.downloadDidReceiveResponse)
-        [m_delegate.get() _download:[_WKDownload downloadWithDownload:RetainPtr { wrapper(downloadProxy) }.get()] didReceiveResponse:response.protectedNSURLResponse().get()];
+        [m_delegate.get() _download:[_WKDownload downloadWithDownload:RetainPtr { wrapper(downloadProxy) }.get()] didReceiveResponse:protect(response.nsURLResponse()).get()];
 }
 
 void LegacyDownloadClient::didReceiveData(DownloadProxy& downloadProxy, uint64_t bytesWritten, uint64_t totalBytesWritten, uint64_t totalBytesExpectedToWrite)

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -106,7 +106,6 @@ private:
         ~NavigationClient();
 
     private:
-        RefPtr<NavigationState> protectedNavigationState() const { return m_navigationState.get(); }
 
         void didStartProvisionalNavigation(WebPageProxy&, const WebCore::ResourceRequest&, API::Navigation*, API::Object*) override;
         void didStartProvisionalLoadForFrame(WebPageProxy&, WebCore::ResourceRequest&&, FrameInfoData&&) override;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -262,7 +262,6 @@ public:
 
     bool canEnterVideoFullscreen() const { return !!m_controlsManagerContextId && m_controlsManagerContextIsVideo; }
     WebCore::PlatformPlaybackSessionInterface* controlsManagerInterface();
-    RefPtr<WebCore::PlatformPlaybackSessionInterface> protectedControlsManagerInterface();
     void requestControlledElementID();
 
     bool isPaused(PlaybackSessionContextIdentifier) const;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -1164,11 +1164,6 @@ PlatformPlaybackSessionInterface* PlaybackSessionManagerProxy::controlsManagerIn
     return &ensureInterface(*m_controlsManagerContextId);
 }
 
-RefPtr<WebCore::PlatformPlaybackSessionInterface> PlaybackSessionManagerProxy::protectedControlsManagerInterface()
-{
-    return controlsManagerInterface();
-}
-
 bool PlaybackSessionManagerProxy::isPaused(PlaybackSessionContextIdentifier identifier) const
 {
     auto iterator = m_contextMap.find(identifier);

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
@@ -88,7 +88,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didSendRequest(WebKit::ResourceLo
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didSendRequest:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didSendRequest:protect(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceRequest&& request) const
@@ -100,7 +100,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection(WebKit:
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didPerformHTTPRedirection:response.protectedNSURLResponse().get() newRequest:request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody).get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didPerformHTTPRedirection:protect(response.nsURLResponse()).get() newRequest:protect(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody)).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge(WebKit::ResourceLoadInfo&& loadInfo, WebCore::AuthenticationChallenge&& challenge) const
@@ -124,7 +124,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse(WebKit::Resour
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didReceiveResponse:response.protectedNSURLResponse().get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didReceiveResponse:protect(response.nsURLResponse()).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceError&& error) const
@@ -136,7 +136,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError(WebKit::Reso
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didCompleteWithError:error.protectedNSError().get() response:response.protectedNSURLResponse().get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didCompleteWithError:protect(error.nsError()).get() response:protect(response.nsURLResponse()).get()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -363,7 +363,7 @@ void SOAuthorizationSession::complete(NSHTTPURLResponse *httpResponse, NSData *d
         AUTHORIZATIONSESSION_RELEASE_LOG("complete: Setting %zu cookies with total header size ~%zu bytes in data store %p", cookies.size(), totalHeaderSize, protect(page->websiteDataStore()).ptr());
     }
 
-    protect(page->websiteDataStore())->protectedCookieStore()->setCookies(WTF::move(cookies), [weakThis = ThreadSafeWeakPtr { *this }, response = WTF::move(response), data = adoptNS([[NSData alloc] initWithData:data])] () mutable {
+    protect(protect(page->websiteDataStore())->cookieStore())->setCookies(WTF::move(cookies), [weakThis = ThreadSafeWeakPtr { *this }, response = WTF::move(response), data = adoptNS([[NSData alloc] initWithData:data])] () mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -603,7 +603,7 @@ void SystemPreviewController::takeActivityToken()
     if (!page)
         return;
 
-    m_activity = page->legacyMainFrameProcess().protectedThrottler()->backgroundActivity("System preview download"_s);
+    m_activity = protect(page->legacyMainFrameProcess().throttler())->backgroundActivity("System preview download"_s);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -221,7 +221,6 @@ private:
 #endif
 
         id<WKUIDelegatePrivate> uiDelegatePrivate();
-        RetainPtr<id<WKUIDelegatePrivate>> protectedUIDelegatePrivate();
 
         WeakPtr<UIDelegate> m_uiDelegate;
     };

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -325,11 +325,6 @@ id<WKUIDelegatePrivate> UIDelegate::UIClient::uiDelegatePrivate()
     return m_uiDelegate ? (id<WKUIDelegatePrivate>)m_uiDelegate->m_delegate.getAutoreleased() : nil;
 }
 
-RetainPtr<id<WKUIDelegatePrivate>> UIDelegate::UIClient::protectedUIDelegatePrivate()
-{
-    return uiDelegatePrivate();
-}
-
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
 void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy& page, const WebHitTestResultData& data, OptionSet<WebEventModifier> modifiers)
 {
@@ -376,7 +371,7 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
     // FIXME: Remove this once the cause of rdar://148942809 is found and fixed.
     RetainPtr relatedWebView = [protectedWrapper(configuration) _relatedWebView];
     ALLOW_DEPRECATED_DECLARATIONS_END
-    bool siteIsolationEnabled = configuration->protectedPreferences()->siteIsolationEnabled();
+    bool siteIsolationEnabled = protect(configuration->preferences())->siteIsolationEnabled();
 
     if (uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeaturesAsync) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:completionHandler:));
@@ -901,7 +896,7 @@ bool UIDelegate::UIClient::focusFromServiceWorker(WebKit::WebPageProxy& proxy)
         return false;
 #endif
     }
-    return [protectedUIDelegatePrivate() _focusWebViewFromServiceWorker:uiDelegate->m_webView.get().get()];
+    return [protect(uiDelegatePrivate()) _focusWebViewFromServiceWorker:uiDelegate->m_webView.get().get()];
 }
 
 bool UIDelegate::UIClient::runOpenPanel(WebPageProxy& page, WebFrameProxy* webFrameProxy, FrameInfoData&& frameInfo, API::OpenPanelParameters* openPanelParameters, WebOpenPanelResultListenerProxy* listener)

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(UIRemoteObjectRegistry);
 RefPtr<ProcessThrottler::BackgroundActivity> UIRemoteObjectRegistry::backgroundActivity(ASCIILiteral name)
 {
     if (RefPtr page = m_page.get())
-        return protect(page->legacyMainFrameProcess())->protectedThrottler()->backgroundActivity(name);
+        return protect(protect(page->legacyMainFrameProcess())->throttler())->backgroundActivity(name);
     return nullptr;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1538,7 +1538,7 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
         setVisibilityPropagationViewForLayerHostView(nil, layerHostView.get());
 #endif
 
-    [interface->protectedLayerHostView() removeFromSuperview];
+    [protect(interface->layerHostView()) removeFromSuperview];
     interface->removeCaptionsLayer();
     if (RetainPtr playerLayer = interface->playerLayer()) {
         // Return the video layer to the player layer
@@ -1547,7 +1547,7 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
         [playerLayer layoutSublayers];
     } else {
         [CATransaction flush];
-        [interface->protectedLayerHostView() removeFromSuperview];
+        [protect(interface->layerHostView()) removeFromSuperview];
         interface->setLayerHostView(nullptr);
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h
@@ -47,7 +47,6 @@ public:
     void deref() const final;
 
 private:
-    RefPtr<API::WebsitePolicies> protectedPolicies();
 
     void willChangeLockdownMode() final;
     void didChangeLockdownMode() final;

--- a/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm
@@ -48,14 +48,9 @@ WebPagePreferencesLockdownModeObserver::~WebPagePreferencesLockdownModeObserver(
     removeLockdownModeObserver(*this);
 }
 
-RefPtr<API::WebsitePolicies> WebPagePreferencesLockdownModeObserver::protectedPolicies()
-{
-    return m_policies.get();
-}
-
 void WebPagePreferencesLockdownModeObserver::willChangeLockdownMode()
 {
-    if (RetainPtr preferences = wrapper(protectedPolicies().get())) {
+    if (RetainPtr preferences = wrapper(protect(m_policies).get())) {
         [preferences willChangeValueForKey:@"_captivePortalModeEnabled"];
         [preferences willChangeValueForKey:@"lockdownModeEnabled"];
     }
@@ -63,7 +58,7 @@ void WebPagePreferencesLockdownModeObserver::willChangeLockdownMode()
 
 void WebPagePreferencesLockdownModeObserver::didChangeLockdownMode()
 {
-    if (RetainPtr preferences = wrapper(protectedPolicies().get())) {
+    if (RetainPtr preferences = wrapper(protect(m_policies).get())) {
         [preferences didChangeValueForKey:@"_captivePortalModeEnabled"];
         [preferences didChangeValueForKey:@"lockdownModeEnabled"];
     }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -349,7 +349,7 @@ void WebPageProxy::createSandboxExtensionsIfNeeded(const Vector<String>& files, 
         return;
 
     auto createSandboxExtension = [protectedThis = Ref { *this }] (const String& path) {
-        auto token = protect(protectedThis->legacyMainFrameProcess())->protectedConnection()->getAuditToken();
+        auto token = protect(protect(protectedThis->legacyMainFrameProcess())->connection())->getAuditToken();
         ASSERT(token);
 
         if (token) {
@@ -1610,7 +1610,7 @@ bool WebPageProxy::tryToSendCommandToActiveControlledVideo(PlatformMediaSession:
     if (!hasActiveVideoForControlsManager())
         return false;
 
-    WeakPtr model = protect(playbackSessionManager())->protectedControlsManagerInterface()->playbackSessionModel();
+    WeakPtr model = protect(protect(playbackSessionManager())->controlsManagerInterface())->playbackSessionModel();
     if (!model)
         return false;
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -94,7 +94,7 @@ std::optional<IPC::AsyncReplyID> WebPasteboardProxy::grantAccessToCurrentData(We
         return std::nullopt;
     }
     auto processIdentifier = process.coreProcessIdentifier();
-    return protect(process.websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(processIdentifier, paths), WTF::move(completionHandler));
+    return protect(protect(process.websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::AllowFilesAccessFromWebProcess(processIdentifier, paths), WTF::move(completionHandler));
 }
 
 void WebPasteboardProxy::grantAccess(WebProcessProxy& process, const String& pasteboardName, PasteboardAccessType type)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -270,11 +270,6 @@ RetainPtr<NSMutableDictionary> WebProcessPool::ensureProtectedBundleParameters()
     return ensureBundleParameters();
 }
 
-RetainPtr<NSMutableDictionary> WebProcessPool::protectedBundleParameters()
-{
-    return bundleParameters();
-}
-
 static AccessibilityPreferences accessibilityPreferences()
 {
     AccessibilityPreferences preferences;
@@ -1257,7 +1252,7 @@ void WebProcessPool::setProcessesShouldSuspend(bool shouldSuspend)
 
     m_processesShouldSuspend = shouldSuspend;
     for (auto& process : m_processes) {
-        process->protectedThrottler()->setAllowsActivities(!m_processesShouldSuspend);
+        protect(process->throttler())->setAllowsActivities(!m_processesShouldSuspend);
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
         if (!m_processesShouldSuspend) {

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -262,7 +262,7 @@ std::optional<audit_token_t> WebProcessProxy::auditToken() const
     if (!hasConnection())
         return std::nullopt;
     
-    return protectedConnection()->getAuditToken();
+    return protect(connection())->getAuditToken();
 }
 
 std::optional<Vector<SandboxExtension::Handle>> WebProcessProxy::fontdMachExtensionHandles()
@@ -292,7 +292,7 @@ void WebProcessProxy::createLogStream(IPC::StreamServerConnectionHandle&& server
 void WebProcessProxy::createLogStream(LogStreamIdentifier identifier, CompletionHandler<void()>&& completionHandler)
 {
     MESSAGE_CHECK(!m_logStream.get());
-    Ref logStream = LogStream::create(*this, protectedConnection(), identifier);
+    Ref logStream = LogStream::create(*this, protect(connection()), identifier);
     addMessageReceiver(Messages::LogStream::messageReceiverName(), logStream->identifier(), logStream);
     m_logStream = WTF::move(logStream);
     completionHandler();
@@ -371,14 +371,14 @@ void WebProcessProxy::platformResumeProcess()
 {
     if (m_platformSuspendDidReleaseNearSuspendedAssertion) {
         m_platformSuspendDidReleaseNearSuspendedAssertion = false;
-        protectedThrottler()->setShouldTakeNearSuspendedAssertion(true);
+        protect(throttler())->setShouldTakeNearSuspendedAssertion(true);
     }
 }
 
 void WebProcessProxy::platformSuspendProcess()
 {
     m_platformSuspendDidReleaseNearSuspendedAssertion = throttler().isHoldingNearSuspendedAssertion();
-    protectedThrottler()->setShouldTakeNearSuspendedAssertion(false);
+    protect(throttler())->setShouldTakeNearSuspendedAssertion(false);
 }
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)

--- a/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
@@ -39,7 +39,6 @@ public:
     static Ref<WebURLSchemeHandlerCocoa> create(id<WKURLSchemeHandler>);
 
     id<WKURLSchemeHandler> apiHandler() const { return m_apiHandler.get(); }
-    RetainPtr<id<WKURLSchemeHandler>> protectedAPIHandler() const;
 
     bool isAPIHandler() final { return true; }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm
@@ -62,9 +62,4 @@ void WebURLSchemeHandlerCocoa::platformStopTask(WebPageProxy& page, WebURLScheme
         task.suppressTaskStoppedExceptions();
 }
 
-RetainPtr<id<WKURLSchemeHandler>> WebURLSchemeHandlerCocoa::protectedAPIHandler() const
-{
-    return apiHandler();
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -110,7 +110,6 @@ public:
     API::FrameInfo& frameInfo() { return m_frameInfo.get(); }
 
     API::DownloadClient& client() { return m_client.get(); }
-    Ref<API::DownloadClient> protectedClient() const;
 
     void setClient(Ref<API::DownloadClient>&&);
     void setDidStartCallback(CompletionHandler<void(DownloadProxy*)>&& callback) { m_didStartCallback = WTF::move(callback); }
@@ -139,7 +138,6 @@ public:
 private:
     explicit DownloadProxy(DownloadProxyMap&, WebsiteDataStore&, API::DownloadClient&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, WebPageProxy*);
 
-    RefPtr<WebsiteDataStore> protectedDataStore() { return m_dataStore; }
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm
@@ -56,7 +56,7 @@ void DownloadProxy::publishProgress(const URL& url)
     if (!handle)
         return;
 
-    protectedDataStore()->protectedNetworkProcess()->send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, url, WTF::move(*handle)), 0);
+    protect(protect(m_dataStore)->networkProcess())->send(Messages::NetworkProcess::PublishDownloadProgress(m_downloadID, url, WTF::move(*handle)), 0);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.cpp
@@ -121,11 +121,6 @@ WebPageProxy* DrawingAreaProxy::page() const
     return m_webPageProxy.get();
 }
 
-RefPtr<WebPageProxy> DrawingAreaProxy::protectedPage() const
-{
-    return page();
-}
-
 #if PLATFORM(COCOA)
 MachSendRight DrawingAreaProxy::createFence()
 {

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -155,7 +155,6 @@ public:
 protected:
     DrawingAreaProxy(WebPageProxy&, WebProcessProxy&);
 
-    RefPtr<WebPageProxy> protectedPage() const;
     WebProcessProxy& webProcessProxy() const { return m_webProcessProxy; }
 
     void removeOutstandingPresentationUpdateCallback(IPC::Connection&, AsyncReplyID);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm
@@ -176,7 +176,7 @@ void WebExtensionContext::actionOpenPopup(WebPageProxyIdentifier identifier, std
 {
     static NSString * const apiName = @"action.openPopup()";
 
-    if (!protectedDefaultAction()->canProgrammaticallyPresentPopup()) {
+    if (!protect(defaultAction())->canProgrammaticallyPresentPopup()) {
         completionHandler(toWebExtensionError(apiName, nullString(), @"it is not implemented"));
         return;
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm
@@ -43,7 +43,7 @@ namespace WebKit {
 
 bool WebExtensionContext::isCommandsMessageAllowed(IPC::Decoder& message)
 {
-    return isLoadedAndPrivilegedMessage(message) && protectedExtension()->hasCommands();
+    return isLoadedAndPrivilegedMessage(message) && protect(extension())->hasCommands();
 }
 
 void WebExtensionContext::commandsGetAll(CompletionHandler<void(Vector<WebExtensionCommandParameters>)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -110,9 +110,9 @@ void WebExtensionContext::fetchCookies(WebsiteDataStore& dataStore, const URL& u
     };
 
     if (url.isValid())
-        dataStore.protectedCookieStore()->cookiesForURL(url.isolatedCopy(), WTF::move(internalCompletionHandler));
+        protect(dataStore.cookieStore())->cookiesForURL(url.isolatedCopy(), WTF::move(internalCompletionHandler));
     else
-        dataStore.protectedCookieStore()->cookies(WTF::move(internalCompletionHandler));
+        protect(dataStore.cookieStore())->cookies(WTF::move(internalCompletionHandler));
 }
 
 void WebExtensionContext::cookiesGet(std::optional<PAL::SessionID> sessionID, const String& name, const URL& url, CompletionHandler<void(Expected<std::optional<WebExtensionCookieParameters>, WebExtensionError>&&)>&& completionHandler)
@@ -225,7 +225,7 @@ void WebExtensionContext::cookiesGetAllCookieStores(CompletionHandler<void(Expec
 {
     HashMap<PAL::SessionID, Vector<WebExtensionTabIdentifier>> stores;
 
-    auto defaultSessionID = extensionController()->protectedConfiguration()->defaultWebsiteDataStore().sessionID();
+    auto defaultSessionID = protect(extensionController()->configuration())->defaultWebsiteDataStore().sessionID();
     stores.set(defaultSessionID, Vector<WebExtensionTabIdentifier> { });
 
     for (Ref tab : openTabs()) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -51,7 +51,7 @@ void WebExtensionContext::loadDeclarativeNetRequestRulesetStateFromStorage()
     auto *savedRulesetState = objectForKey<NSDictionary>(m_state, declarativeNetRequestRulesetStateKey);
     if (!savedRulesetState.count) {
         // Populate with the default enabled state.
-        for (auto& ruleset : protectedExtension()->declarativeNetRequestRulesets()) {
+        for (auto& ruleset : protect(extension())->declarativeNetRequestRulesets()) {
             if (ruleset.enabled)
                 m_enabledStaticRulesetIDs.add(ruleset.rulesetID);
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -55,7 +55,7 @@ void WebExtensionContext::addListener(WebCore::FrameIdentifier frameIdentifier, 
 
     RELEASE_LOG_DEBUG(Extensions, "Registered event listener for type %{public}hhu in %{public}@ world", enumToUnderlyingType(listenerType), toDebugString(contentWorldType).createNSString().get());
 
-    if (!protectedExtension()->backgroundContentIsPersistent() && isBackgroundPage(frameIdentifier))
+    if (!protect(extension())->backgroundContentIsPersistent() && isBackgroundPage(frameIdentifier))
         m_backgroundContentEventListeners.add(listenerType);
 
     auto result = m_eventListenerFrames.add({ listenerType, contentWorldType }, WeakFrameCountedSet { });
@@ -95,7 +95,7 @@ void WebExtensionContext::removeListener(WebCore::FrameIdentifier frameIdentifie
 
     RELEASE_LOG_DEBUG(Extensions, "Unregistered %{public}llu event listener(s) for type %{public}hhu in %{public}@ world", removedCount, enumToUnderlyingType(listenerType), toDebugString(contentWorldType).createNSString().get());
 
-    if (!protectedExtension()->backgroundContentIsPersistent() && isBackgroundPage(frameIdentifier)) {
+    if (!protect(extension())->backgroundContentIsPersistent() && isBackgroundPage(frameIdentifier)) {
         for (size_t i = 0; i < removedCount; ++i)
             m_backgroundContentEventListeners.remove(listenerType);
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
@@ -68,7 +68,7 @@ void WebExtensionContext::permissionsGetAll(CompletionHandler<void(Vector<String
     }
 
     if (hasGrantedAccessToAllURLsOrHosts) {
-        auto combinedPermissionMatchPatterns = protectedExtension()->combinedPermissionMatchPatterns();
+        auto combinedPermissionMatchPatterns = protect(extension())->combinedPermissionMatchPatterns();
         bool appendedMatchAllURLsOrHostsPattern = false;
 
         for (auto& matchPattern : combinedPermissionMatchPatterns) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -454,7 +454,7 @@ void WebExtensionContext::runtimeWebPageSendMessage(const String& extensionID, c
     completeSenderParameters.tabParameters = tab->parameters();
 
     auto url = completeSenderParameters.url;
-    auto validMatchPatterns = destinationExtension->protectedExtension()->externallyConnectableMatchPatterns();
+    auto validMatchPatterns = protect(destinationExtension->extension())->externallyConnectableMatchPatterns();
     if (!hasPermission(url, tab.get()) || !WebExtensionMatchPattern::patternsMatchURL(validMatchPatterns, url)) {
         callAfterRandomDelay([completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler({ });
@@ -516,7 +516,7 @@ void WebExtensionContext::runtimeWebPageConnect(const String& extensionID, WebEx
     completeSenderParameters.tabParameters = tab->parameters();
 
     auto url = completeSenderParameters.url;
-    auto validMatchPatterns = destinationExtension->protectedExtension()->externallyConnectableMatchPatterns();
+    auto validMatchPatterns = protect(destinationExtension->extension())->externallyConnectableMatchPatterns();
     if (!hasPermission(url, tab.get()) || !WebExtensionMatchPattern::patternsMatchURL(validMatchPatterns, url)) {
         callAfterRandomDelay([=, this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler({ });

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -395,7 +395,7 @@ static void* kvoContext = &kvoContext;
     self.popoverPresentationController.delegate = self;
 
     UINavigationItem *navigationItem = self.navigationItem;
-    navigationItem.title = extensionContext->protectedExtension()->displayName().createNSString().get();
+    navigationItem.title = protect(extensionContext->extension())->displayName().createNSString().get();
     navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(_dismissPopup)];
 
     [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(_viewControllerDismissalTransitionDidEnd:) name:UIPresentationControllerDismissalTransitionDidEndNotification object:nil];
@@ -750,13 +750,13 @@ RefPtr<WebCore::Icon> WebExtensionAction::icon(WebCore::FloatSize idealSize)
 
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
         if (m_customIconVariants) {
-            result = extensionContext->protectedExtension()->bestIconVariant(m_customIconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
+            result = protect(extensionContext->extension())->bestIconVariant(m_customIconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
                 extensionContext->recordError(error);
             });
         } else
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
         if (m_customIcons) {
-            result = extensionContext->protectedExtension()->bestIcon(m_customIcons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
+            result = protect(extensionContext->extension())->bestIcon(m_customIcons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
                 extensionContext->recordError(error);
             });
         }
@@ -778,7 +778,7 @@ RefPtr<WebCore::Icon> WebExtensionAction::icon(WebCore::FloatSize idealSize)
         return fallback->icon(idealSize);
 
     // Default
-    return extensionContext->protectedExtension()->actionIcon(WebCore::FloatSize(idealSize));
+    return protect(extensionContext->extension())->actionIcon(WebCore::FloatSize(idealSize));
 }
 
 void WebExtensionAction::setIcons(RefPtr<JSON::Object> icons)
@@ -829,7 +829,7 @@ String WebExtensionAction::popupPath() const
         return fallback->popupPath();
 
     // Default
-    return extensionContext->protectedExtension()->actionPopupPath();
+    return protect(extensionContext->extension())->actionPopupPath();
 }
 
 void WebExtensionAction::setPopupPath(String path)
@@ -851,7 +851,7 @@ NSString *WebExtensionAction::popupWebViewInspectionName()
 {
     if (m_popupWebViewInspectionName.isEmpty()) {
         if (RefPtr extensionContext = this->extensionContext())
-            m_popupWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Popup Page", "Label for an inspectable Web Extension popup page", extensionContext->protectedExtension()->displayShortName().createCFString().get());
+            m_popupWebViewInspectionName = WEB_UI_FORMAT_CFSTRING("%@ — Extension Popup Page", "Label for an inspectable Web Extension popup page", protect(extensionContext->extension())->displayShortName().createCFString().get());
     }
     return m_popupWebViewInspectionName.createNSString().autorelease();
 }
@@ -992,7 +992,7 @@ WKWebView *WebExtensionAction::popupWebView()
     m_popupWebView.get().navigationDelegate = m_popupWebViewDelegate.get();
     m_popupWebView.get().UIDelegate = m_popupWebViewDelegate.get();
     m_popupWebView.get().inspectable = extensionContext->isInspectable();
-    m_popupWebView.get().accessibilityLabel = extensionContext->protectedExtension()->displayName().createNSString().get();
+    m_popupWebView.get().accessibilityLabel = protect(extensionContext->extension())->displayName().createNSString().get();
     m_popupWebView.get()._remoteInspectionNameOverride = popupWebViewInspectionName();
 
 #if PLATFORM(MAC)
@@ -1181,7 +1181,7 @@ String WebExtensionAction::label(FallbackWhenEmpty fallback) const
         if (!m_customLabel.isEmpty() || fallback == FallbackWhenEmpty::No)
             return m_customLabel;
 
-        return extensionContext->protectedExtension()->displayName();
+        return protect(extensionContext->extension())->displayName();
     }
 
     if (RefPtr fallback = fallbackAction())

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
@@ -287,7 +287,7 @@ CocoaMenuItem *WebExtensionCommand::platformMenuItem() const
     result.keyEquivalent = activationKey().createNSString().get();
     result.keyEquivalentModifierMask = modifierFlags().toRaw();
     if (RefPtr context = extensionContext())
-        result.image = toCocoaImage(context->protectedExtension()->icon(WebCore::FloatSize(16, 16)));
+        result.image = toCocoaImage(protect(context->extension())->icon(WebCore::FloatSize(16, 16)));
 
     return result;
 #else

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -501,7 +501,7 @@ void WebExtensionController::addWebsiteDataStore(WebsiteDataStore& dataStore)
     if (!m_cookieStoreObserver)
         m_cookieStoreObserver = HTTPCookieStoreObserver::create(*this);
 
-    dataStore.protectedCookieStore()->registerObserver(*protectedCookieStoreObserver());
+    protect(dataStore.cookieStore())->registerObserver(*protect(m_cookieStoreObserver));
 }
 
 void WebExtensionController::removeWebsiteDataStore(WebsiteDataStore& dataStore)
@@ -515,7 +515,7 @@ void WebExtensionController::removeWebsiteDataStore(WebsiteDataStore& dataStore)
     m_websiteDataStores.remove(dataStore);
 
     if (RefPtr observer = m_cookieStoreObserver)
-        dataStore.protectedCookieStore()->unregisterObserver(*observer);
+        protect(dataStore.cookieStore())->unregisterObserver(*observer);
 
     if (m_websiteDataStores.isEmptyIgnoringNullReferences())
         m_cookieStoreObserver = nullptr;
@@ -531,7 +531,7 @@ void WebExtensionController::cookiesDidChange(API::HTTPCookieStore& cookieStore)
 
 bool WebExtensionController::isFeatureEnabled(const String& featureName) const
 {
-    WKPreferences *preferences = protectedConfiguration()->webViewConfiguration().preferences;
+    WKPreferences *preferences = protect(configuration())->webViewConfiguration().preferences;
 
     auto *cocoaFeatureName = featureName.createNSString().get();
     for (_WKFeature *feature in WKPreferences._features) {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm
@@ -372,13 +372,13 @@ RefPtr<WebCore::Icon> WebExtensionMenuItem::icon(WebCore::FloatSize idealSize) c
 
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_iconVariants) {
-        result = extensionContext->protectedExtension()->bestIconVariant(m_iconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
+        result = protect(extensionContext->extension())->bestIconVariant(m_iconVariants, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
             extensionContext->recordError(error);
         });
     } else
 #endif // ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
     if (m_icons) {
-        result = extensionContext->protectedExtension()->bestIcon(m_icons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
+        result = protect(extensionContext->extension())->bestIcon(m_icons, WebCore::FloatSize(idealSize), [&](Ref<API::Error> error) {
             extensionContext->recordError(error);
         });
     }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp
@@ -54,7 +54,7 @@ bool WebExtensionCommand::isActionCommand() const
     if (!context)
         return false;
 
-    if (context->protectedExtension()->supportsManifestVersion(3))
+    if (protect(context->extension())->supportsManifestVersion(3))
         return identifier() == "_execute_action"_s;
 
     return identifier() == "_execute_browser_action"_s || identifier() == "_execute_page_action"_s;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -111,7 +111,7 @@ Ref<API::Error> WebExtensionContext::createError(Error error, const String& cust
 
 Vector<Ref<API::Error>> WebExtensionContext::errors()
 {
-    auto array = protectedExtension()->errors();
+    auto array = protect(extension())->errors();
     array.appendVector(m_errors);
     return array;
 }
@@ -162,7 +162,7 @@ void WebExtensionContext::setUniqueIdentifier(String&& uniqueIdentifier)
 RefPtr<WebExtensionLocalization> WebExtensionContext::localization()
 {
     if (!m_localization)
-        m_localization = WebExtensionLocalization::create(protectedExtension()->localization()->localizationJSON(), baseURL().host().toString());
+        m_localization = WebExtensionLocalization::create(protect(extension())->localization()->localizationJSON(), baseURL().host().toString());
     return m_localization;
 }
 
@@ -936,7 +936,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     if (skipRequestedPermissions)
         return cacheResultAndReturn(PermissionState::Unknown);
 
-    auto requestedMatchPatterns = protectedExtension()->allRequestedMatchPatterns();
+    auto requestedMatchPatterns = protect(extension())->allRequestedMatchPatterns();
     for (auto& requestedMatchPattern : requestedMatchPatterns) {
         if (urlMatchesPatternIgnoringWildcardHostPatterns(requestedMatchPattern))
             return cacheResultAndReturn(PermissionState::RequestedExplicitly);
@@ -955,7 +955,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
         return PermissionState::RequestedImplicitly;
 
     if (options.contains(PermissionStateOptions::IncludeOptionalPermissions)) {
-        if (WebExtensionMatchPattern::patternsMatchURL(protectedExtension()->optionalPermissionMatchPatterns(), url))
+        if (WebExtensionMatchPattern::patternsMatchURL(protect(extension())->optionalPermissionMatchPatterns(), url))
             return cacheResultAndReturn(PermissionState::RequestedImplicitly);
     }
 
@@ -1028,7 +1028,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     if (options.contains(PermissionStateOptions::SkipRequestedPermissions))
         return PermissionState::Unknown;
 
-    auto requestedMatchPatterns = protectedExtension()->allRequestedMatchPatterns();
+    auto requestedMatchPatterns = protect(extension())->allRequestedMatchPatterns();
     for (auto& requestedMatchPattern : requestedMatchPatterns) {
         if (urlMatchesPatternIgnoringWildcardHostPatterns(requestedMatchPattern))
             return PermissionState::RequestedExplicitly;
@@ -1041,7 +1041,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
         return PermissionState::RequestedImplicitly;
 
     if (options.contains(PermissionStateOptions::IncludeOptionalPermissions)) {
-        if (WebExtensionMatchPattern::patternsMatchPattern(protectedExtension()->optionalPermissionMatchPatterns(), pattern))
+        if (WebExtensionMatchPattern::patternsMatchPattern(protect(extension())->optionalPermissionMatchPatterns(), pattern))
             return PermissionState::RequestedImplicitly;
     }
 
@@ -1136,7 +1136,7 @@ bool WebExtensionContext::hasContentModificationRules()
 
 WebExtensionContext::InjectedContentVector WebExtensionContext::injectedContents() const
 {
-    InjectedContentVector result = protectedExtension()->staticInjectedContents();
+    InjectedContentVector result = protect(extension())->staticInjectedContents();
 
     for (auto& entry : m_registeredScriptsMap)
         result.append(entry.value->injectedContent());
@@ -1704,7 +1704,7 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventList
 
 String WebExtensionContext::processDisplayName()
 {
-    return WEB_UI_FORMAT_STRING("%s Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension", protectedExtension()->displayShortName().utf8().data());
+    return WEB_UI_FORMAT_STRING("%s Web Extension", "Extension's process name that appears in Activity Monitor where the parameter is the name of the extension", protect(extension())->displayShortName().utf8().data());
 }
 
 Vector<String> WebExtensionContext::corsDisablingPatterns()
@@ -1732,7 +1732,7 @@ URL WebExtensionContext::backgroundContentURL()
 
 void WebExtensionContext::loadBackgroundContent(CompletionHandler<void(RefPtr<API::Error>)>&& completionHandler)
 {
-    if (!protectedExtension()->hasBackgroundContent()) {
+    if (!protect(extension())->hasBackgroundContent()) {
         if (completionHandler)
             completionHandler(createError(Error::NoBackgroundContent));
         return;
@@ -1782,17 +1782,17 @@ const String& WebExtensionContext::backgroundWebViewInspectionName()
     if (!m_backgroundWebViewInspectionName.isEmpty())
         return m_backgroundWebViewInspectionName;
 
-    if (protectedExtension()->backgroundContentIsServiceWorker())
-        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_STRING("%s — Extension Service Worker", "Label for an inspectable Web Extension service worker", protectedExtension()->displayShortName().utf8().data());
+    if (protect(extension())->backgroundContentIsServiceWorker())
+        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_STRING("%s — Extension Service Worker", "Label for an inspectable Web Extension service worker", protect(extension())->displayShortName().utf8().data());
     else
-        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_STRING("%s — Extension Background Page", "Label for an inspectable Web Extension background page", protectedExtension()->displayShortName().utf8().data());
+        m_backgroundWebViewInspectionName = WEB_UI_FORMAT_STRING("%s — Extension Background Page", "Label for an inspectable Web Extension background page", protect(extension())->displayShortName().utf8().data());
 
     return m_backgroundWebViewInspectionName;
 }
 
 void WebExtensionContext::wakeUpBackgroundContentIfNecessary(Function<void()>&& completionHandler)
 {
-    if (!protectedExtension()->hasBackgroundContent()) {
+    if (!protect(extension())->hasBackgroundContent()) {
         completionHandler();
         return;
     }
@@ -1850,7 +1850,7 @@ URL WebExtensionContext::inspectorBackgroundPageURL() const
 RefPtr<WebInspectorUIProxy> WebExtensionContext::inspector(const API::InspectorExtension& inspectorExtension) const
 {
     ASSERT(isLoaded());
-    ASSERT(protectedExtension()->hasInspectorBackgroundPage());
+    ASSERT(protect(extension())->hasInspectorBackgroundPage());
 
     for (auto entry : m_inspectorContextMap) {
         if (entry.value.extension == &inspectorExtension)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -352,9 +352,7 @@ public:
     bool isLoaded() const { return !!m_extensionController; }
 
     WebExtension& extension() const { return *m_extension; }
-    Ref<WebExtension> protectedExtension() const { return extension(); }
     WebExtensionController* extensionController() const { return m_extensionController.get(); }
-    RefPtr<WebExtensionController> protectedExtensionController() const { return m_extensionController.get(); }
 
     const URL& baseURL() const { return m_baseURL; }
     void setBaseURL(URL&&);
@@ -508,7 +506,6 @@ public:
 #endif
 
     WebExtensionAction& defaultAction();
-    Ref<WebExtensionAction> protectedDefaultAction() { return defaultAction(); }
     Ref<WebExtensionAction> getAction(WebExtensionWindow*);
     Ref<WebExtensionAction> getAction(WebExtensionTab*);
     Ref<WebExtensionAction> getOrCreateAction(WebExtensionWindow*);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -112,7 +112,6 @@ public:
     enum class ForPrivateBrowsing { No, Yes };
 
     WebExtensionControllerConfiguration& configuration() const { return m_configuration.get(); }
-    Ref<WebExtensionControllerConfiguration> protectedConfiguration() const { return m_configuration; }
     WebExtensionControllerParameters parameters(const API::PageConfiguration&) const;
 
     bool operator==(const WebExtensionController& other) const { return (this == &other); }
@@ -197,8 +196,7 @@ public:
 
 #ifdef __OBJC__
     WKWebExtensionController *wrapper() const { return (WKWebExtensionController *)API::ObjectImpl<API::Object::Type::WebExtensionController>::wrapper(); }
-    RetainPtr<WKWebExtensionController> protectedWrapper() const { return wrapper(); }
-    WKWebExtensionControllerDelegatePrivate *delegate() const { return (WKWebExtensionControllerDelegatePrivate *)protectedWrapper().get().delegate; }
+    WKWebExtensionControllerDelegatePrivate *delegate() const { return (WKWebExtensionControllerDelegatePrivate *)protect(wrapper()).get().delegate; }
 #endif
 
 private:
@@ -269,7 +267,6 @@ private:
         WeakPtr<WebExtensionController> m_extensionController;
     };
 
-    RefPtr<HTTPCookieStoreObserver> protectedCookieStoreObserver() { return m_cookieStoreObserver; }
 
     const Ref<WebExtensionControllerConfiguration> m_configuration;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -71,7 +71,6 @@ public:
 #endif
 
     WebsiteDataStore& defaultWebsiteDataStore() const;
-    Ref<WebsiteDataStore> protectedDefaultWebsiteDataStore() const { return defaultWebsiteDataStore(); }
     void setDefaultWebsiteDataStore(WebsiteDataStore* dataStore) { m_defaultWebsiteDataStore = dataStore; }
 
     bool operator==(const WebExtensionControllerConfiguration&) const;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -407,7 +407,7 @@ void GPUProcessProxy::updateSandboxAccess(bool allowAudioCapture, bool allowVide
         m_hasSentMicrophoneSandboxExtension = true;
 
 #if HAVE(SCREEN_CAPTURE_KIT)
-    if (allowDisplayCapture && !m_hasSentDisplayCaptureSandboxExtension && addDisplayCaptureSandboxExtension(protectedConnection()->getAuditToken(), extensions))
+    if (allowDisplayCapture && !m_hasSentDisplayCaptureSandboxExtension && addDisplayCaptureSandboxExtension(protect(connection())->getAuditToken(), extensions))
         m_hasSentDisplayCaptureSandboxExtension = true;
 #endif
 
@@ -687,13 +687,13 @@ void GPUProcessProxy::updateProcessAssertion()
 
     if (hasAnyForegroundWebProcesses) {
         if (!ProcessThrottler::isValidForegroundActivity(m_activityFromWebProcesses.get())) {
-            m_activityFromWebProcesses = protectedThrottler()->foregroundActivity("GPU for foreground view(s)"_s);
+            m_activityFromWebProcesses = protect(throttler())->foregroundActivity("GPU for foreground view(s)"_s);
         }
         return;
     }
     if (hasAnyBackgroundWebProcesses) {
         if (!ProcessThrottler::isValidBackgroundActivity(m_activityFromWebProcesses.get())) {
-            m_activityFromWebProcesses = protectedThrottler()->backgroundActivity("GPU for background view(s)"_s);
+            m_activityFromWebProcesses = protect(throttler())->backgroundActivity("GPU for background view(s)"_s);
         }
         return;
     }

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -58,18 +58,6 @@ RemoteWebInspectorUIProxy::~RemoteWebInspectorUIProxy()
     ASSERT(!m_inspectorPage);
 }
 
-RefPtr<WebPageProxy> RemoteWebInspectorUIProxy::protectedInspectorPage()
-{
-    return m_inspectorPage.get();
-}
-
-#if ENABLE(INSPECTOR_EXTENSIONS)
-RefPtr<WebInspectorUIExtensionControllerProxy> RemoteWebInspectorUIProxy::protectedExtensionController() const
-{
-    return m_extensionController;
-}
-#endif
-
 void RemoteWebInspectorUIProxy::invalidate()
 {
     closeFrontendPageAndWindow();
@@ -134,7 +122,7 @@ void RemoteWebInspectorUIProxy::sendMessageToFrontend(const String& message)
 void RemoteWebInspectorUIProxy::frontendLoaded()
 {
 #if ENABLE(INSPECTOR_EXTENSIONS)
-    protectedExtensionController()->inspectorFrontendLoaded();
+    protect(extensionController())->inspectorFrontendLoaded();
 #endif
 }
 
@@ -265,7 +253,7 @@ void RemoteWebInspectorUIProxy::closeFrontendPageAndWindow()
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // This extension controller may be kept alive by the IPC dispatcher beyond the point
     // when m_inspectorPage is cleared below. Notify the controller so it can clean up before then.
-    protectedExtensionController()->inspectorFrontendWillClose();
+    protect(extensionController())->inspectorFrontendWillClose();
     m_extensionController = nullptr;
 #endif
 

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -106,13 +106,11 @@ public:
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WebInspectorUIExtensionControllerProxy* extensionController() const { return m_extensionController.get(); }
-    RefPtr<WebInspectorUIExtensionControllerProxy> protectedExtensionController() const;
 #endif
     
 #if PLATFORM(MAC)
     NSWindow *window() const { return m_window.get(); }
     WKWebView *webView() const;
-    RetainPtr<WKWebView> protectedWebView() const;
 
     const WebCore::FloatRect& sheetRect() const { return m_sheetRect; }
 
@@ -134,7 +132,6 @@ public:
 
 private:
     RemoteWebInspectorUIProxy();
-    RefPtr<WebPageProxy> protectedInspectorPage();
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp
@@ -66,7 +66,7 @@ WebFrameInspectorTargetProxy::~WebFrameInspectorTargetProxy() = default;
 void WebFrameInspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType connectionType)
 {
     if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        protect(provisionalFrame->process())->send(Messages::WebFrame::ConnectInspector(connectionType), provisionalFrame->protectedFrame()->frameID());
+        protect(provisionalFrame->process())->send(Messages::WebFrame::ConnectInspector(connectionType), protect(provisionalFrame->frame())->frameID());
         return;
     }
 
@@ -80,7 +80,7 @@ void WebFrameInspectorTargetProxy::disconnect()
         resume();
 
     if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        protect(provisionalFrame->process())->send(Messages::WebFrame::DisconnectInspector(), provisionalFrame->protectedFrame()->frameID());
+        protect(provisionalFrame->process())->send(Messages::WebFrame::DisconnectInspector(), protect(provisionalFrame->frame())->frameID());
         return;
     }
 
@@ -91,7 +91,7 @@ void WebFrameInspectorTargetProxy::disconnect()
 void WebFrameInspectorTargetProxy::sendMessageToTargetBackend(const String& message)
 {
     if (RefPtr provisionalFrame = m_provisionalFrame.get()) {
-        protect(provisionalFrame->process())->send(Messages::WebFrame::SendMessageToInspectorTarget(message), provisionalFrame->protectedFrame()->frameID());
+        protect(provisionalFrame->process())->send(Messages::WebFrame::SendMessageToInspectorTarget(message), protect(provisionalFrame->frame())->frameID());
         return;
     }
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
@@ -31,44 +31,44 @@ namespace WebKit {
 
 void WebInspectorBackendProxy::requestOpenLocalInspectorFrontend()
 {
-    protectedProxy()->requestOpenLocalInspectorFrontend();
+    protect(m_proxy)->requestOpenLocalInspectorFrontend();
 }
 
 void WebInspectorBackendProxy::didClose()
 {
-    protectedProxy()->didClose();
+    protect(m_proxy)->didClose();
 }
 
 void WebInspectorBackendProxy::bringToFront()
 {
-    protectedProxy()->bringToFront();
+    protect(m_proxy)->bringToFront();
 }
 
 void WebInspectorBackendProxy::elementSelectionChanged(bool active)
 {
-    protectedProxy()->elementSelectionChanged(active);
+    protect(m_proxy)->elementSelectionChanged(active);
 }
 
 void WebInspectorBackendProxy::timelineRecordingChanged(bool active)
 {
-    protectedProxy()->timelineRecordingChanged(active);
+    protect(m_proxy)->timelineRecordingChanged(active);
 }
 
 void WebInspectorBackendProxy::setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)
 {
-    protectedProxy()->setDeveloperPreferenceOverride(developerPreference, overrideValue);
+    protect(m_proxy)->setDeveloperPreferenceOverride(developerPreference, overrideValue);
 }
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
 void WebInspectorBackendProxy::setEmulatedConditions(std::optional<int64_t> bytesPerSecondLimit)
 {
-    protectedProxy()->setEmulatedConditions(bytesPerSecondLimit);
+    protect(m_proxy)->setEmulatedConditions(bytesPerSecondLimit);
 }
 #endif
 
 void WebInspectorBackendProxy::attachAvailabilityChanged(bool available)
 {
-    protectedProxy()->attachAvailabilityChanged(available);
+    protect(m_proxy)->attachAvailabilityChanged(available);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
@@ -64,7 +64,6 @@ public:
     void attachAvailabilityChanged(bool);
 
 private:
-    Ref<WebInspectorUIProxy> protectedProxy() const { return m_proxy.get(); }
 
     const WeakRef<WebInspectorUIProxy> m_proxy;
 };

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -63,11 +63,6 @@ Ref<WebInspectorUIExtensionControllerProxy> WebInspectorUIExtensionControllerPro
     return adoptRef(*new WebInspectorUIExtensionControllerProxy(inspectorPage));
 }
 
-RefPtr<WebPageProxy> WebInspectorUIExtensionControllerProxy::protectedInspectorPage() const
-{
-    return m_inspectorPage.get();
-}
-
 void WebInspectorUIExtensionControllerProxy::whenFrontendHasLoaded(Function<void()>&& callback)
 {
     if (m_frontendLoaded && m_inspectorPage) {
@@ -94,7 +89,7 @@ void WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose()
     if (!m_inspectorPage)
         return;
 
-    protect(protectedInspectorPage()->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protect(m_inspectorPage)->legacyMainFrameProcess())->removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess());
     m_inspectorPage = nullptr;
 
     m_extensionAPIObjectMap.clear();
@@ -110,7 +105,7 @@ void WebInspectorUIExtensionControllerProxy::registerExtension(const Inspector::
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::RegistrationFailed));
                 return;
@@ -137,7 +132,7 @@ void WebInspectorUIExtensionControllerProxy::unregisterExtension(const Inspector
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::InvalidRequest));
                 return;
@@ -163,7 +158,7 @@ void WebInspectorUIExtensionControllerProxy::createTabForExtension(const Inspect
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::CreateTabForExtension { extensionID, tabName, tabIconURL, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::CreateTabForExtension { extensionID, tabName, tabIconURL, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -175,7 +170,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension(const In
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError> error) mutable {
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError> error) mutable {
             if (error)
                 return completionHandler(makeUnexpected(error.value()));
 
@@ -192,7 +187,7 @@ void WebInspectorUIExtensionControllerProxy::reloadForExtension(const Inspector:
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ReloadForExtension { extensionID, ignoreCache, userAgent, injectedScript }, [completionHandler = WTF::move(completionHandler)] (const std::optional<Inspector::ExtensionError> error) mutable {
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ReloadForExtension { extensionID, ignoreCache, userAgent, injectedScript }, [completionHandler = WTF::move(completionHandler)] (const std::optional<Inspector::ExtensionError> error) mutable {
             if (error) {
                 completionHandler(makeUnexpected(error.value()));
                 return;
@@ -211,7 +206,7 @@ void WebInspectorUIExtensionControllerProxy::showExtensionTab(const Inspector::E
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ShowExtensionTab { extensionTabIdentifier }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ShowExtensionTab { extensionTabIdentifier }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -223,7 +218,7 @@ void WebInspectorUIExtensionControllerProxy::navigateTabForExtension(const Inspe
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::NavigateTabForExtension { extensionTabIdentifier, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::NavigateTabForExtension { extensionTabIdentifier, sourceURL }, WTF::move(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -237,7 +232,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab(const 
             return;
         }
 
-        protect(weakThis->protectedInspectorPage()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError>& error) mutable {
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTF::move(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError>& error) mutable {
             if (error)
                 return completionHandler(makeUnexpected(error.value()));
             completionHandler(WTF::move(result));

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h
@@ -84,7 +84,6 @@ public:
 private:
     explicit WebInspectorUIExtensionControllerProxy(WebPageProxy& inspectorPage);
 
-    RefPtr<WebPageProxy> protectedInspectorPage() const;
 
     void whenFrontendHasLoaded(Function<void()>&&);
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -121,13 +121,10 @@ public:
 
     // Public APIs
     WebPageProxy* inspectedPage() const { return m_inspectedPage; }
-    RefPtr<WebPageProxy> protectedInspectedPage() const { return m_inspectedPage; }
     WebPageProxy* inspectorPage() const { return m_inspectorPage; }
-    RefPtr<WebPageProxy> protectedInspectorPage() const { return m_inspectorPage; }
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     WebInspectorUIExtensionControllerProxy* extensionController() const { return m_extensionController.get(); }
-    RefPtr<WebInspectorUIExtensionControllerProxy> protectedExtensionController() const;
 #endif
 
     bool isConnected() const { return !!m_inspectorPage; }
@@ -311,7 +308,6 @@ private:
     unsigned inspectionLevel() const;
 
     WebPreferences& inspectorPagePreferences() const;
-    Ref<WebPreferences> protectedInspectorPagePreferences() const;
 
 #if PLATFORM(MAC)
     void applyForcedAppearance();

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -67,11 +67,6 @@ WebPageInspectorController::WebPageInspectorController(WebPageProxy& inspectedPa
 
 WebPageInspectorController::~WebPageInspectorController() = default;
 
-Ref<WebPageProxy> WebPageInspectorController::protectedInspectedPage()
-{
-    return m_inspectedPage.get();
-}
-
 void WebPageInspectorController::init()
 {
     String pageTargetId = WebPageInspectorTarget::toTargetID(m_inspectedPage->webPageIDInMainFrameProcess());
@@ -170,7 +165,7 @@ void WebPageInspectorController::setIndicating(bool indicating)
 
 void WebPageInspectorController::createWebPageInspectorTarget(const String& targetId, Inspector::InspectorTargetType type)
 {
-    addTarget(WebPageInspectorTargetProxy::create(protectedInspectedPage(), targetId, type));
+    addTarget(WebPageInspectorTargetProxy::create(protect(m_inspectedPage), targetId, type));
 }
 
 void WebPageInspectorController::createWebFrameInspectorTarget(WebFrameProxy& frame, const String& targetId)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -90,7 +90,6 @@ public:
     void browserExtensionsDisabled(HashSet<String>&&);
 
 private:
-    Ref<WebPageProxy> protectedInspectedPage();
     CheckedPtr<Inspector::InspectorTargetAgent> checkedTargetAgent() { return m_targetAgent; }
     WebPageAgentContext webPageAgentContext();
     void createLazyAgents();

--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -158,7 +158,7 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
     GRefPtr<GFile> file = adoptGRef(gtk_file_chooser_get_file(chooser));
     GUniquePtr<char> path(g_file_get_path(file.get()));
     g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
-        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, remoteFileReplaceContentsCallback, protectedInspectorPage().get());
+        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, remoteFileReplaceContentsCallback, protect(m_inspectorPage).get());
 }
 
 void RemoteWebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -139,7 +139,7 @@ static void decidePolicyForNavigationAction(WKPageRef pageRef, WKNavigationActio
     toImpl(listenerRef)->ignore();
 
     // And instead load it in the inspected page.
-    inspector->protectedInspectedPage()->loadRequest(WTF::move(request));
+    protect(inspector->inspectedPage())->loadRequest(WTF::move(request));
 }
 
 static void getContextMenuFromProposedMenu(WKPageRef pageRef, WKArrayRef proposedMenuRef, WKArrayRef* newMenuRef, WKHitTestResultRef, WKTypeRef, const void*)
@@ -191,11 +191,11 @@ RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
     });
     if (m_underTest)
         preferences->setHiddenPageDOMTimerThrottlingEnabled(false);
-    Ref inspectedPagePreferences = protectedInspectedPage()->preferences();
+    Ref inspectedPagePreferences = protect(inspectedPage())->preferences();
     preferences->setAcceleratedCompositingEnabled(inspectedPagePreferences->acceleratedCompositingEnabled());
     preferences->setForceCompositingMode(inspectedPagePreferences->forceCompositingMode());
     preferences->setThreadedScrollingEnabled(inspectedPagePreferences->threadedScrollingEnabled());
-    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(protectedInspectedPage().get()));
+    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(protect(inspectedPage()).get()));
     auto websiteDataStore = inspectorWebsiteDataStore();
     auto& processPool = WebKit::defaultInspectorProcessPool(inspectionLevel());
 
@@ -456,11 +456,11 @@ void WebInspectorUIProxy::platformAttach()
     }
 
     if (m_attachmentSide == AttachmentSide::Bottom) {
-        unsigned inspectedWindowHeight = gtk_widget_get_allocated_height(protectedInspectedPage()->viewWidget());
+        unsigned inspectedWindowHeight = gtk_widget_get_allocated_height(protect(inspectedPage())->viewWidget());
         unsigned maximumAttachedHeight = inspectedWindowHeight * 3 / 4;
         platformSetAttachedWindowHeight(std::max(s_minimumAttachedHeight, std::min(s_defaultAttachedSize, maximumAttachedHeight)));
     } else {
-        unsigned inspectedWindowWidth = gtk_widget_get_allocated_width(protectedInspectedPage()->viewWidget());
+        unsigned inspectedWindowWidth = gtk_widget_get_allocated_width(protect(inspectedPage())->viewWidget());
         unsigned maximumAttachedWidth = inspectedWindowWidth * 3 / 4;
         platformSetAttachedWindowWidth(std::max(s_minimumAttachedWidth, std::min(s_defaultAttachedSize, maximumAttachedWidth)));
     }
@@ -468,13 +468,13 @@ void WebInspectorUIProxy::platformAttach()
     if (m_client && m_client->attach(*this))
         return;
 
-    webkitWebViewBaseAddWebInspector(WEBKIT_WEB_VIEW_BASE(protectedInspectedPage()->viewWidget()), m_inspectorView.get(), m_attachmentSide);
+    webkitWebViewBaseAddWebInspector(WEBKIT_WEB_VIEW_BASE(protect(inspectedPage())->viewWidget()), m_inspectorView.get(), m_attachmentSide);
     gtk_widget_show(m_inspectorView.get());
 }
 
 void WebInspectorUIProxy::platformDetach()
 {
-    if (!protectedInspectedPage()->hasRunningProcess())
+    if (!protect(inspectedPage())->hasRunningProcess())
         return;
 
     GRefPtr<GtkWidget> inspectorView = m_inspectorView.get();
@@ -506,7 +506,7 @@ void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned height)
 
     if (m_client)
         m_client->didChangeAttachedHeight(*this, height);
-    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(protectedInspectedPage()->viewWidget()), height);
+    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(protect(inspectedPage())->viewWidget()), height);
 }
 
 void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
@@ -516,7 +516,7 @@ void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
 
     if (m_client)
         m_client->didChangeAttachedWidth(*this, width);
-    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(protectedInspectedPage()->viewWidget()), width);
+    webkitWebViewBaseSetInspectorViewSize(WEBKIT_WEB_VIEW_BASE(protect(inspectedPage())->viewWidget()), width);
 }
 
 void WebInspectorUIProxy::platformSetSheetRect(const WebCore::FloatRect&)
@@ -578,7 +578,7 @@ void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::
     GRefPtr<GFile> file = adoptGRef(gtk_file_chooser_get_file(chooser));
     GUniquePtr<char> path(g_file_get_path(file.get()));
     g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
-        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, fileReplaceContentsCallback, protectedInspectorPage().get());
+        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, fileReplaceContentsCallback, protect(inspectorPage()).get());
 }
 
 void WebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -110,7 +110,7 @@ WKWebView *RemoteWebInspectorUIProxy::webView() const
 
 void RemoteWebInspectorUIProxy::didBecomeActive()
 {
-    protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protect(m_inspectorPage)->legacyMainFrameProcess())->send(Messages::RemoteWebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
@@ -158,7 +158,7 @@ void RemoteWebInspectorUIProxy::platformResetState()
 void RemoteWebInspectorUIProxy::platformBringToFront()
 {
     [m_window makeKeyAndOrderFront:nil];
-    [m_window makeFirstResponder:protectedWebView().get()];
+    [m_window makeFirstResponder:protect(webView()).get()];
 }
 
 void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
@@ -228,7 +228,7 @@ void RemoteWebInspectorUIProxy::platformSetForcedAppearance(InspectorFrontendCli
         break;
     }
 
-    protectedWebView().get().appearance = platformAppearance;
+    protect(webView()).get().appearance = platformAppearance;
 
     RetainPtr window = m_window.get();
     ASSERT(window);
@@ -237,7 +237,7 @@ void RemoteWebInspectorUIProxy::platformSetForcedAppearance(InspectorFrontendCli
 
 void RemoteWebInspectorUIProxy::platformStartWindowDrag()
 {
-    protectedWebView().get()._protectedPage->startWindowDrag();
+    protect(webView()).get()._protectedPage->startWindowDrag();
 }
 
 void RemoteWebInspectorUIProxy::platformOpenURLExternally(const String& url)
@@ -265,11 +265,6 @@ void RemoteWebInspectorUIProxy::platformShowCertificate(const CertificateInfo& c
     [certificateView setEditableTrust:NO];
     [certificateView setDisplayDetails:YES];
     [certificateView setDetailsDisclosed:YES];
-}
-
-RetainPtr<WKWebView> RemoteWebInspectorUIProxy::protectedWebView() const
-{
-    return webView();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -150,7 +150,7 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
 #if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
     if (inspectedPage) {
         if (RefPtr webExtensionController = inspectedPage->webExtensionController())
-            configuration.get().webExtensionController = webExtensionController->protectedWrapper().get();
+            configuration.get().webExtensionController = protect(webExtensionController->wrapper()).get();
     }
 #endif
 

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -338,7 +338,7 @@ using namespace WebCore;
 
 void WebInspectorUIProxy::didBecomeActive()
 {
-    protect(protectedInspectorPage()->legacyMainFrameProcess())->send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
+    protect(protect(inspectorPage())->legacyMainFrameProcess())->send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::attachmentViewDidChange(NSView *oldView, NSView *newView)
@@ -498,7 +498,7 @@ void WebInspectorUIProxy::platformCreateFrontendWindow()
         savedWindowFrame = NSRectFromString(savedWindowFrameString.get());
     }
 
-    m_inspectorWindow = WebInspectorUIProxy::createFrontendWindow(savedWindowFrame, InspectionTargetType::Local, protectedInspectedPage().get());
+    m_inspectorWindow = WebInspectorUIProxy::createFrontendWindow(savedWindowFrame, InspectionTargetType::Local, protect(inspectedPage()).get());
     [m_inspectorWindow setDelegate:m_objCAdapter.get()];
 
     RetainPtr<WKWebView> inspectorView = [m_inspectorViewController webView];
@@ -855,8 +855,8 @@ void WebInspectorUIProxy::inspectedViewFrameDidChange(CGFloat currentDimension)
 
 void WebInspectorUIProxy::platformAttach()
 {
-    ASSERT(protectedInspectedPage());
-    RetainPtr inspectedView = protectedInspectedPage()->inspectorAttachmentView();
+    ASSERT(protect(inspectedPage()));
+    RetainPtr inspectedView = protect(inspectedPage())->inspectorAttachmentView();
     RetainPtr<WKWebView> inspectorView = [m_inspectorViewController webView];
 
     if (m_inspectorWindow) {
@@ -871,15 +871,15 @@ void WebInspectorUIProxy::platformAttach()
     switch (m_attachmentSide) {
     case AttachmentSide::Bottom:
         [inspectorView setAutoresizingMask:NSViewWidthSizable | NSViewMaxYMargin];
-        currentDimension = protectedInspectorPagePreferences()->inspectorAttachedHeight();
+        currentDimension = protect(inspectorPagePreferences())->inspectorAttachedHeight();
         break;
     case AttachmentSide::Right:
         [inspectorView setAutoresizingMask:NSViewHeightSizable | NSViewMinXMargin];
-        currentDimension = protectedInspectorPagePreferences()->inspectorAttachedWidth();
+        currentDimension = protect(inspectorPagePreferences())->inspectorAttachedWidth();
         break;
     case AttachmentSide::Left:
         [inspectorView setAutoresizingMask:NSViewHeightSizable | NSViewMaxXMargin];
-        currentDimension = protectedInspectorPagePreferences()->inspectorAttachedWidth();
+        currentDimension = protect(inspectorPagePreferences())->inspectorAttachedWidth();
         break;
     }
 

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -244,7 +244,7 @@ static void decidePolicyForNavigationAction(WKPageRef pageRef, WKNavigationActio
     toImpl(listenerRef)->ignore();
 
     // And instead load it in the inspected page.
-    inspector->protectedInspectedPage()->loadRequest(WTF::move(request));
+    protect(inspector->inspectedPage())->loadRequest(WTF::move(request));
 }
 
 static void webProcessDidCrash(WKPageRef, const void* clientInfo)
@@ -265,7 +265,7 @@ RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
     preferences->setLogsPageMessagesToSystemConsoleEnabled(true);
 #endif
     preferences->setJavaScriptRuntimeFlags({ });
-    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(protectedInspectedPage().get()));
+    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(protect(inspectedPage()).get()));
     auto pageConfiguration = API::PageConfiguration::create();
     pageConfiguration->setProcessPool(&WebKit::defaultInspectorProcessPool(inspectionLevel()));
     pageConfiguration->setPreferences(preferences.ptr());
@@ -370,7 +370,7 @@ bool WebInspectorUIProxy::platformCanAttach(bool)
 
 void WebInspectorUIProxy::platformAttach()
 {
-    auto deviceScaleFactor = protectedInspectorPage()->deviceScaleFactor();
+    auto deviceScaleFactor = protect(inspectorPage())->deviceScaleFactor();
 
     if (m_inspectorDetachWindow && ::GetParent(m_inspectorViewWindow) == m_inspectorDetachWindow) {
         ::SetParent(m_inspectorViewWindow, m_inspectedViewParentWindow);
@@ -396,7 +396,7 @@ void WebInspectorUIProxy::platformAttach()
 
 void WebInspectorUIProxy::platformDetach()
 {
-    if (!protectedInspectedPage()->hasRunningProcess())
+    if (!protect(inspectedPage())->hasRunningProcess())
         return;
 
     if (!m_inspectorDetachWindow) {
@@ -422,7 +422,7 @@ void WebInspectorUIProxy::platformDetach()
 
 void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned height)
 {
-    auto deviceScaleFactor = protectedInspectorPage()->deviceScaleFactor();
+    auto deviceScaleFactor = protect(inspectorPage())->deviceScaleFactor();
     height *= deviceScaleFactor;
     auto windowInfo = getInspectedWindowInfo(m_inspectedViewWindow, m_inspectedViewParentWindow);
     ::SetWindowPos(m_inspectorViewWindow, 0, windowInfo.left, windowInfo.parentHeight - height, windowInfo.parentWidth - windowInfo.left, height, SWP_NOZORDER);
@@ -431,7 +431,7 @@ void WebInspectorUIProxy::platformSetAttachedWindowHeight(unsigned height)
 
 void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned width)
 {
-    auto deviceScaleFactor = protectedInspectorPage()->deviceScaleFactor();
+    auto deviceScaleFactor = protect(inspectorPage())->deviceScaleFactor();
     width *= deviceScaleFactor;
     auto windowInfo = getInspectedWindowInfo(m_inspectedViewWindow, m_inspectedViewParentWindow);
     ::SetWindowPos(m_inspectorViewWindow, 0, windowInfo.parentWidth - width, windowInfo.top, width, windowInfo.parentHeight - windowInfo.top, SWP_NOZORDER);

--- a/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
@@ -125,7 +125,7 @@ RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
     if (m_underTest)
         preferences->setHiddenPageDOMTimerThrottlingEnabled(false);
 
-    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(protectedInspectedPage().get()));
+    auto pageGroup = WebPageGroup::create(WebKit::defaultInspectorPageGroupIdentifierForPage(protect(inspectedPage()).get()));
     auto websiteDataStore = inspectorWebsiteDataStore();
     auto& processPool = WebKit::defaultInspectorProcessPool(inspectionLevel());
 

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.h
@@ -101,7 +101,6 @@ protected:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    Ref<const Logger> protectedLogger() const { return logger(); }
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -69,7 +69,7 @@ RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy(WebPagePr
 
 RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy()
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(m_webPageProxy)->legacyMainFrameProcess())->removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 std::optional<SharedPreferencesForWebProcess> RemoteMediaSessionCoordinatorProxy::sharedPreferencesForWebProcess(IPC::Connection& connection) const
@@ -165,32 +165,27 @@ void RemoteMediaSessionCoordinatorProxy::trackIdentifierChanged(const String& id
 
 void RemoteMediaSessionCoordinatorProxy::seekSessionToTime(double time, CompletionHandler<void(bool)>&& callback)
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(m_webPageProxy)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::playSession(std::optional<double> atTime, std::optional<MonotonicTime> hostTime, CompletionHandler<void(bool)>&& callback)
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTF::move(atTime), WTF::move(hostTime) }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(m_webPageProxy)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTF::move(atTime), WTF::move(hostTime) }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::pauseSession(CompletionHandler<void(bool)>&& callback)
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(m_webPageProxy)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::setSessionTrack(const String& trackId, CompletionHandler<void(bool)>&& callback)
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(m_webPageProxy)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged(WebCore::MediaSessionCoordinatorState state)
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy->webPageIDInMainFrameProcess());
-}
-
-Ref<WebPageProxy> RemoteMediaSessionCoordinatorProxy::protectedWebPageProxy()
-{
-    return m_webPageProxy.get();
+    protect(protect(m_webPageProxy)->legacyMainFrameProcess())->send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h
@@ -88,7 +88,6 @@ private:
     void setSessionTrack(const String&, CompletionHandler<void(bool)>&&) final;
     void coordinatorStateChanged(WebCore::MediaSessionCoordinatorState) final;
 
-    Ref<WebPageProxy> protectedWebPageProxy();
 
 #if !RELEASE_LOG_DISABLED
     const WTF::Logger& logger() const { return m_logger; }

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h
@@ -83,7 +83,6 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return m_logger; }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     uint64_t logIdentifier() const { return m_sessionState.logIdentifier; }
 #endif
 

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -301,12 +301,12 @@ void ModelProcessProxy::updateProcessAssertion()
 
     if (hasAnyForegroundWebProcesses) {
         if (!ProcessThrottler::isValidForegroundActivity(m_activityFromWebProcesses.get()))
-            m_activityFromWebProcesses = protectedThrottler()->foregroundActivity("Model for foreground view(s)"_s);
+            m_activityFromWebProcesses = protect(throttler())->foregroundActivity("Model for foreground view(s)"_s);
         return;
     }
     if (hasAnyBackgroundWebProcesses) {
         if (!ProcessThrottler::isValidBackgroundActivity(m_activityFromWebProcesses.get()))
-            m_activityFromWebProcesses = protectedThrottler()->backgroundActivity("Model for background view(s)"_s);
+            m_activityFromWebProcesses = protect(throttler())->backgroundActivity("Model for background view(s)"_s);
         return;
     }
 

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -447,7 +447,6 @@ private:
 #endif
 
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
-    Ref<LegacyCustomProtocolManagerProxy> protectedCustomProtocolManagerProxy() { return m_customProtocolManagerProxy; }
 #endif
 
     const std::unique_ptr<DownloadProxyMap> m_downloadProxyMap;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -202,7 +202,7 @@ static void dispatchDidClickNotification(WebNotification* notification)
 
     if (notification->isPersistentNotification()) {
         if (RefPtr dataStore = WebsiteDataStore::existingDataStoreForSessionID(notification->sessionID()))
-            dataStore->protectedNetworkProcess()->processNotificationEvent(notification->data(), NotificationEventType::Click, [](bool) { });
+            protect(dataStore->networkProcess())->processNotificationEvent(notification->data(), NotificationEventType::Click, [](bool) { });
         else
             RELEASE_LOG_ERROR(Notifications, "WebsiteDataStore not found from sessionID %" PRIu64 ", dropping notification click", notification->sessionID().toUInt64());
         return;
@@ -263,7 +263,7 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
 
         if (notification->isPersistentNotification()) {
             if (RefPtr dataStore = WebsiteDataStore::existingDataStoreForSessionID(notification->sessionID()))
-                dataStore->protectedNetworkProcess()->processNotificationEvent(notification->data(), NotificationEventType::Close, [](bool) { });
+                protect(dataStore->networkProcess())->processNotificationEvent(notification->data(), NotificationEventType::Close, [](bool) { });
             else
                 RELEASE_LOG_ERROR(Notifications, "WebsiteDataStore not found from sessionID %" PRIu64 ", dropping notification close", notification->sessionID().toUInt64());
             return;
@@ -286,7 +286,7 @@ static void setPushesAndNotificationsEnabledForOrigin(const WebCore::SecurityOri
 {
     WebsiteDataStore::forEachWebsiteDataStore([&origin, enabled](WebsiteDataStore& dataStore) {
         if (dataStore.isPersistent())
-            dataStore.protectedNetworkProcess()->setPushAndNotificationsEnabledForOrigin(dataStore.sessionID(), origin, enabled, []() { });
+            protect(dataStore.networkProcess())->setPushAndNotificationsEnabledForOrigin(dataStore.sessionID(), origin, enabled, []() { });
     });
 }
 
@@ -295,7 +295,7 @@ static void removePushSubscriptionsForOrigins(const Vector<WebCore::SecurityOrig
     WebsiteDataStore::forEachWebsiteDataStore([&origins](WebsiteDataStore& dataStore) {
         if (dataStore.isPersistent()) {
             for (auto& origin : origins)
-                dataStore.protectedNetworkProcess()->removePushSubscriptionsForOrigin(dataStore.sessionID(), origin, [originString = origin.toString()](auto&&) { });
+                protect(dataStore.networkProcess())->removePushSubscriptionsForOrigin(dataStore.sessionID(), origin, [originString = origin.toString()](auto&&) { });
         }
     });
 }

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -532,7 +532,6 @@ public:
     virtual bool useFormSemanticContext() const = 0;
     
     virtual NSView *viewForPresentingRevealPopover() const = 0;
-    RetainPtr<NSView> protectedViewForPresentingRevealPopover() const;
 
     virtual void showPlatformContextMenu(NSMenu *, WebCore::IntPoint) = 0;
 

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -66,20 +66,10 @@ RefPtr<FrameProcess> ProvisionalFrameProxy::takeFrameProcess()
     return std::exchange(m_frameProcess, nullptr).releaseNonNull();
 }
 
-Ref<WebFrameProxy> ProvisionalFrameProxy::protectedFrame() const
-{
-    return m_frame.get();
-}
-
 WebProcessProxy& ProvisionalFrameProxy::process() const
 {
     ASSERT(m_frameProcess);
     return m_frameProcess->process();
-}
-
-Ref<WebProcessProxy> ProvisionalFrameProxy::protectedProcess() const
-{
-    return process();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -47,9 +47,7 @@ public:
     ~ProvisionalFrameProxy();
 
     WebFrameProxy& frame() const { return m_frame.get(); }
-    Ref<WebFrameProxy> protectedFrame() const;
     WebProcessProxy& process() const;
-    Ref<WebProcessProxy> protectedProcess() const;
 
     RefPtr<FrameProcess> takeFrameProcess();
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -88,7 +88,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     , m_shouldReuseMainFrame(protect(page.preferences())->siteIsolationEnabled() && (page.openedByDOM() || page.hasPageOpenedByMainFrame()))
     , m_provisionalLoadURL(isProcessSwappingOnNavigationResponse ? request.url() : URL())
 #if USE(RUNNINGBOARD)
-    , m_provisionalLoadActivity(m_frameProcess->process().protectedThrottler()->foregroundActivity("Provisional Load"_s))
+    , m_provisionalLoadActivity(protect(m_frameProcess->process().throttler())->foregroundActivity("Provisional Load"_s))
 #endif
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     , m_contextIDForVisibilityPropagationInWebProcess(suspendedPage ? suspendedPage->contextIDForVisibilityPropagationInWebProcess() : 0)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -475,7 +475,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
                 if (!m_replyForUnhidingContent) {
                     if (m_hasDetachedRootLayer)
                         RELEASE_LOG(RemoteLayerTree, "RemoteLayerTreeDrawingAreaProxy(%" PRIu64 ") Unhiding layer tree", identifier().toUInt64());
-                    page->setRemoteLayerTreeRootNode(m_remoteLayerTreeHost->protectedRootNode().get());
+                    page->setRemoteLayerTreeRootNode(protect(m_remoteLayerTreeHost->rootNode()).get());
                     m_hasDetachedRootLayer = false;
                 } else
                     m_remoteLayerTreeHost->detachRootLayer();
@@ -527,7 +527,7 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
             scrollPosition = layerTreeTransaction.scrollPosition();
 #endif
             updateDebugIndicator(layerTreeTransaction.contentsSize(), rootLayerChanged, scale, scrollPosition);
-            m_debugIndicatorLayerTreeHost->protectedRootLayer().get().name = @"Indicator host root";
+            protect(m_debugIndicatorLayerTreeHost->rootLayer()).get().name = @"Indicator host root";
         }
     }
 
@@ -624,7 +624,7 @@ void RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator(IntSize contentsSize,
 
     if (rootLayerChanged) {
         [m_tileMapHostLayer setSublayers:@[]];
-        [m_tileMapHostLayer addSublayer:m_debugIndicatorLayerTreeHost->protectedRootLayer().get()];
+        [m_tileMapHostLayer addSublayer:protect(m_debugIndicatorLayerTreeHost->rootLayer()).get()];
         [m_tileMapHostLayer addSublayer:m_exposedRectIndicatorLayer.get()];
     }
     
@@ -829,7 +829,7 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(IPC::Connection* connect
     } else {
         forEachProcessState([&](ProcessState& state, WebProcessProxy& webProcess) {
             if (webProcess.hasConnection())
-                didRefreshDisplay(state, webProcess.protectedConnection());
+                didRefreshDisplay(state, protect(webProcess.connection()));
         });
     }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -64,12 +64,10 @@ public:
 
     RemoteLayerTreeNode* nodeForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
     RemoteLayerTreeNode* rootNode() const { return m_rootNode.get(); }
-    RefPtr<RemoteLayerTreeNode> protectedRootNode() const { return m_rootNode.get(); }
 
     CALayer *layerForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
     RetainPtr<CALayer> protectedLayerForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
     CALayer *rootLayer() const;
-    RetainPtr<CALayer> protectedRootLayer() const;
 
     RemoteLayerTreeDrawingAreaProxy& drawingArea() const;
 
@@ -109,7 +107,6 @@ public:
     void remotePageProcessDidTerminate(WebCore::ProcessIdentifier);
 
 private:
-    Ref<RemoteLayerTreeDrawingAreaProxy> protectedDrawingArea() const;
 
     void createLayer(const RemoteLayerTreeTransaction::LayerCreationProperties&);
     RefPtr<RemoteLayerTreeNode> makeNode(const RemoteLayerTreeTransaction::LayerCreationProperties&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -61,7 +61,6 @@ public:
     static Ref<RemoteLayerTreeNode> createWithPlainLayer(WebCore::PlatformLayerIdentifier);
 
     CALayer *layer() const { return m_layer.get(); }
-    RetainPtr<CALayer> protectedLayer() const;
 #if ENABLE(GAZE_GLOW_FOR_INTERACTION_REGIONS) || HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     const Markable<WebCore::FloatRect> visibleRect() const { return m_visibleRect; }
     void setVisibleRect(const WebCore::FloatRect& value) { m_visibleRect = value; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -115,7 +115,7 @@ void RemoteLayerTreeNode::detachFromParent()
         return;
     }
 #endif
-    [protectedLayer() removeFromSuperlayer];
+    [protect(layer()) removeFromSuperlayer];
 }
 
 void RemoteLayerTreeNode::setEventRegion(const WebCore::EventRegion& eventRegion)
@@ -290,7 +290,7 @@ void RemoteLayerTreeNode::addToHostingNode(RemoteLayerTreeNode& hostingNode)
 #if PLATFORM(IOS_FAMILY)
     [hostingNode.uiView() addSubview:uiView()];
 #else
-    [hostingNode.protectedLayer() addSublayer:protectedLayer().get()];
+    [protect(hostingNode.layer()) addSublayer:protect(layer()).get()];
 #endif
 }
 
@@ -299,7 +299,7 @@ void RemoteLayerTreeNode::removeFromHostingNode()
 #if PLATFORM(IOS_FAMILY)
     [uiView() removeFromSuperview];
 #else
-    [protectedLayer() removeFromSuperlayer];
+    [protect(layer()) removeFromSuperlayer];
 #endif
 }
 
@@ -333,10 +333,5 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
     host.animationsWereAddedToNode(*this);
 }
 #endif
-
-RetainPtr<CALayer> RemoteLayerTreeNode::protectedLayer() const
-{
-    return layer();
-}
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -67,11 +67,6 @@ WebPageProxy& RemoteScrollingCoordinatorProxy::webPageProxy() const
     return m_webPageProxy.get();
 }
 
-Ref<WebPageProxy> RemoteScrollingCoordinatorProxy::protectedWebPageProxy() const
-{
-    return m_webPageProxy.get();
-}
-
 std::optional<ScrollingNodeID> RemoteScrollingCoordinatorProxy::rootScrollingNodeID() const
 {
     // FIXME: Locking
@@ -118,7 +113,7 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
 
 void RemoteScrollingCoordinatorProxy::stickyScrollingTreeNodeBeganSticking(ScrollingNodeID)
 {
-    protectedWebPageProxy()->stickyScrollingTreeNodeBeganSticking();
+    protect(webPageProxy())->stickyScrollingTreeNodeBeganSticking();
 }
 
 void RemoteScrollingCoordinatorProxy::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
@@ -153,7 +148,7 @@ void RemoteScrollingCoordinatorProxy::handleWheelEvent(const WebWheelEvent& whee
 void RemoteScrollingCoordinatorProxy::continueWheelEventHandling(const WebWheelEvent& wheelEvent, WheelEventHandlingResult result)
 {
     bool willStartSwipe = m_scrollingTree->willWheelEventStartSwipeGesture(platform(wheelEvent));
-    protectedWebPageProxy()->continueWheelEventHandling(wheelEvent, result, willStartSwipe);
+    protect(webPageProxy())->continueWheelEventHandling(wheelEvent, result, willStartSwipe);
 }
 
 TrackingType RemoteScrollingCoordinatorProxy::eventTrackingTypeForPoint(WebCore::EventTrackingRegions::EventType eventType, IntPoint p) const
@@ -176,7 +171,7 @@ void RemoteScrollingCoordinatorProxy::applyScrollingTreeLayerPositionsAfterCommi
 
 void RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical)
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(webPageProxy())->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate()
@@ -344,7 +339,7 @@ void RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary()
     if (!m_uiState.changes())
         return;
 
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(webPageProxy())->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState), m_webPageProxy->webPageIDInMainFrameProcess());
     m_uiState.clearChanges();
 }
 
@@ -357,7 +352,7 @@ void RemoteScrollingCoordinatorProxy::resetStateAfterProcessExited()
 
 void RemoteScrollingCoordinatorProxy::reportFilledVisibleFreshTile(MonotonicTime timestamp, unsigned unfilledArea)
 {
-    protectedWebPageProxy()->logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::FilledTile), timestamp, unfilledArea);
+    protect(webPageProxy())->logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::FilledTile), timestamp, unfilledArea);
 }
 
 void RemoteScrollingCoordinatorProxy::reportExposedUnfilledArea(MonotonicTime, unsigned)
@@ -372,19 +367,19 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
 
 void RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
-    protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase), m_webPageProxy->webPageIDInMainFrameProcess());
+    protect(protect(webPageProxy())->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason(std::optional<ScrollingNodeID> nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
+        protect(protect(webPageProxy())->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason(std::optional<ScrollingNodeID> nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        protect(protectedWebPageProxy()->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
+        protect(protect(webPageProxy())->legacyMainFrameProcess())->send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(*nodeID, reason), m_webPageProxy->webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::viewWillStartLiveResize()
@@ -423,12 +418,12 @@ bool RemoteScrollingCoordinatorProxy::scrollingPerformanceTestingEnabled() const
 
 void RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID nodeID, ScrollbarOrientation orientation, bool isVisible)
 {
-    protectedWebPageProxy()->sendToProcessContainingFrame(m_scrollingTree->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible));
+    protect(webPageProxy())->sendToProcessContainingFrame(m_scrollingTree->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarVisibilityDidChange(nodeID, orientation, isVisible));
 }
 
 void RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID nodeID, ScrollbarOrientation orientation, int minimumThumbLength)
 {
-    protectedWebPageProxy()->sendToProcessContainingFrame(m_scrollingTree->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(nodeID, orientation, minimumThumbLength));
+    protect(webPageProxy())->sendToProcessContainingFrame(m_scrollingTree->frameIDForScrollingNodeID(nodeID), Messages::RemoteScrollingCoordinator::ScrollingTreeNodeScrollbarMinimumThumbLengthDidChange(nodeID, orientation, minimumThumbLength));
 }
 
 bool RemoteScrollingCoordinatorProxy::isMonitoringWheelEvents()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -113,7 +113,6 @@ public:
 
     const RemoteLayerTreeHost* layerTreeHost() const;
     WebPageProxy& webPageProxy() const;
-    Ref<WebPageProxy> protectedWebPageProxy() const;
 
     void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -478,13 +478,13 @@ FloatRect RemoteScrollingCoordinatorProxyIOS::currentLayoutViewport() const
 
 void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartPanGesture(ScrollingNodeID nodeID)
 {
-    protectedWebPageProxy()->scrollingNodeScrollViewWillStartPanGesture(nodeID);
+    protect(webPageProxy())->scrollingNodeScrollViewWillStartPanGesture(nodeID);
 }
 
 // This is not called for the main scroll view.
 void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
 {
-    protectedWebPageProxy()->scrollingNodeScrollWillStartScroll(nodeID);
+    protect(webPageProxy())->scrollingNodeScrollWillStartScroll(nodeID);
 
     m_uiState.addNodeWithActiveUserScroll(nodeID);
     sendUIStateChangedIfNecessary();
@@ -493,7 +493,7 @@ void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartScroll(Scroll
 // This is not called for the main scroll view.
 void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
 {
-    protectedWebPageProxy()->scrollingNodeScrollDidEndScroll(nodeID);
+    protect(webPageProxy())->scrollingNodeScrollDidEndScroll(nodeID);
 
     m_uiState.removeNodeWithActiveUserScroll(nodeID);
     sendUIStateChangedIfNecessary();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -536,7 +536,7 @@ bool ScrollingTreeScrollingNodeDelegateIOS::shouldAllowPanGestureRecognizerToRec
     if (!scrollingCoordinatorProxy)
         return true;
 
-    if (RefPtr pageClient = scrollingCoordinatorProxy->protectedWebPageProxy()->pageClient())
+    if (RefPtr pageClient = protect(scrollingCoordinatorProxy->webPageProxy())->pageClient())
         return !pageClient->isSimulatingCompatibilityPointerTouches();
 
     return true;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -136,7 +136,6 @@ private:
     DisplayLink* displayLink() const;
     DisplayLink* existingDisplayLink() const;
     RemoteLayerTreeDrawingAreaProxyMac& drawingAreaMac() const;
-    Ref<RemoteLayerTreeDrawingAreaProxyMac> protectedDrawingAreaMac() const;
 
     void startDisplayLinkObserver();
     void stopDisplayLinkObserver();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -326,7 +326,7 @@ void RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted(const PlatformW
         auto result = scrollingTree->handleWheelEventAfterDefaultHandling(wheelEvent, scrollingNodeID, gestureState);
         RunLoop::mainSingleton().dispatch([protectedThis, wasHandled, result]() {
             if (CheckedPtr scrollingCoordinator = protectedThis->m_scrollingCoordinator.get())
-                scrollingCoordinator->protectedWebPageProxy()->wheelEventHandlingCompleted(wasHandled || result.wasHandled);
+                protect(scrollingCoordinator->webPageProxy())->wheelEventHandlingCompleted(wasHandled || result.wasHandled);
         });
 
     });
@@ -350,11 +350,6 @@ RemoteLayerTreeDrawingAreaProxyMac& RemoteLayerTreeEventDispatcher::drawingAreaM
     return *downcast<RemoteLayerTreeDrawingAreaProxyMac>(CheckedRef { *m_scrollingCoordinator }->webPageProxy().drawingArea());
 }
 
-Ref<RemoteLayerTreeDrawingAreaProxyMac> RemoteLayerTreeEventDispatcher::protectedDrawingAreaMac() const
-{
-    return drawingAreaMac();
-}
-
 DisplayLink* RemoteLayerTreeEventDispatcher::displayLink() const
 {
     ASSERT(isMainRunLoop());
@@ -362,7 +357,7 @@ DisplayLink* RemoteLayerTreeEventDispatcher::displayLink() const
     if (!m_scrollingCoordinator)
         return nullptr;
 
-    return &protectedDrawingAreaMac()->displayLink();
+    return &protect(drawingAreaMac())->displayLink();
 }
 
 DisplayLink* RemoteLayerTreeEventDispatcher::existingDisplayLink() const
@@ -372,7 +367,7 @@ DisplayLink* RemoteLayerTreeEventDispatcher::existingDisplayLink() const
     if (!m_scrollingCoordinator)
         return nullptr;
 
-    return protectedDrawingAreaMac()->existingDisplayLink();
+    return protect(drawingAreaMac())->existingDisplayLink();
 }
 
 void RemoteLayerTreeEventDispatcher::startOrStopDisplayLink()
@@ -657,7 +652,7 @@ void RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode(RemoteLayerTr
     ASSERT(isMainRunLoop());
     assertIsHeld(m_animationLock);
     if (auto animationStack = m_animationStacks.take(node.layerID()))
-        animationStack->clear(node.protectedLayer().get());
+        animationStack->clear(protect(node.layer()).get());
 }
 
 void RemoteLayerTreeEventDispatcher::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -104,7 +104,7 @@ void RemoteScrollingCoordinatorProxyMac::setRubberBandingInProgressForNode(Scrol
 #if ENABLE(THREADED_ANIMATIONS)
             m_eventDispatcher->didStartRubberbanding();
 #endif
-            protectedWebPageProxy()->logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::StartedRubberbanding), MonotonicTime::now(), 0);
+            protect(webPageProxy())->logScrollingEvent(static_cast<uint32_t>(PerformanceLoggingClient::ScrollingEvent::StartedRubberbanding), MonotonicTime::now(), 0);
         }
         m_uiState.addNodeWithActiveRubberband(nodeID);
     } else

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -220,11 +220,6 @@ void RemotePageProxy::didReceiveSyncMessage(IPC::Connection& connection, IPC::De
     }
 }
 
-RefPtr<WebPageProxy> RemotePageProxy::protectedPage() const
-{
-    return m_page.get();
-}
-
 WebPageProxy* RemotePageProxy::page() const
 {
     return m_page.get();

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -94,7 +94,6 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     WebPageProxy* page() const;
-    RefPtr<WebPageProxy> protectedPage() const;
 
     void injectPageIntoNewProcess();
     void processDidTerminate(WebProcessProxy&, ProcessTerminationReason);

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp
@@ -85,11 +85,6 @@ SpeechRecognitionPermissionManager::~SpeechRecognitionPermissionManager()
         protect(request)->complete(WebCore::SpeechRecognitionError { WebCore::SpeechRecognitionErrorType::NotAllowed, "Permission manager has exited"_s });
 }
 
-RefPtr<WebPageProxy> SpeechRecognitionPermissionManager::protectedPage() const
-{
-    return m_page.get();
-}
-
 void SpeechRecognitionPermissionManager::request(WebCore::SpeechRecognitionRequest& request, FrameInfoData&& frameInfo, SpeechRecognitionPermissionRequestCallback&& completiontHandler)
 {
     m_requests.append({ SpeechRecognitionPermissionRequest::create(request, WTF::move(completiontHandler)), WTF::move(frameInfo) });

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -50,7 +50,6 @@ public:
 
 private:
     explicit SpeechRecognitionPermissionManager(WebPageProxy&);
-    RefPtr<WebPageProxy> protectedPage() const;
 
     void startNextRequest();
     void startProcessingRequest();

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -125,7 +125,7 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
     , m_shouldDelayClosingUntilFirstLayerFlush(shouldDelayClosingUntilFirstLayerFlush)
     , m_suspensionTimeoutTimer(RunLoop::mainSingleton(), "SuspendedPageProxy::SuspensionTimeoutTimer"_s, this, &SuspendedPageProxy::suspensionTimedOut)
 #if USE(RUNNINGBOARD)
-    , m_suspensionActivity(m_process->protectedThrottler()->backgroundActivity("Page suspension for back/forward cache"_s))
+    , m_suspensionActivity(protect(m_process->throttler())->backgroundActivity("Page suspension for back/forward cache"_s))
 #endif
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     , m_contextIDForVisibilityPropagationInWebProcess(page.contextIDForVisibilityPropagationInWebProcess())
@@ -181,11 +181,6 @@ void SuspendedPageProxy::didDestroyNavigation(WebCore::NavigationIdentifier navi
 {
     if (RefPtr page = m_page.get())
         page->didDestroyNavigationShared(m_process.copyRef(), navigationID);
-}
-
-Ref<WebBackForwardCache> SuspendedPageProxy::protectedBackForwardCache() const
-{
-    return backForwardCache();
 }
 
 WebBackForwardCache& SuspendedPageProxy::backForwardCache() const

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -71,12 +71,10 @@ public:
     WebPageProxy* page() const;
     WebCore::PageIdentifier webPageID() const { return m_webPageID; }
     WebProcessProxy& process() const { return m_process.get(); }
-    Ref<WebProcessProxy> protectedProcess() const { return process(); }
     WebFrameProxy& mainFrame() { return m_mainFrame.get(); }
     const BrowsingContextGroup& browsingContextGroup() { return m_browsingContextGroup.get(); }
 
     WebBackForwardCache& backForwardCache() const;
-    Ref<WebBackForwardCache> protectedBackForwardCache() const;
 
     WebPageProxyMessageReceiverRegistration& messageReceiverRegistration() { return m_messageReceiverRegistration; }
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -155,11 +155,6 @@ WebPageProxy* UserMediaPermissionRequestManagerProxy::page() const
     return m_page.get();
 }
 
-RefPtr<WebPageProxy> UserMediaPermissionRequestManagerProxy::protectedPage() const
-{
-    return m_page.get();
-}
-
 void UserMediaPermissionRequestManagerProxy::invalidatePendingRequests()
 {
     if (RefPtr currentUserMediaRequest = std::exchange(m_currentUserMediaRequest, nullptr))

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -79,7 +79,6 @@ public:
     ~UserMediaPermissionRequestManagerProxy();
 
     WebPageProxy* page() const;
-    RefPtr<WebPageProxy> protectedPage() const;
 
     void disconnectFromPage();
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp
@@ -64,11 +64,6 @@ UserMediaPermissionRequestManagerProxy* UserMediaPermissionRequestProxy::manager
     return m_manager.get();
 }
 
-RefPtr<UserMediaPermissionRequestManagerProxy> UserMediaPermissionRequestProxy::protectedManager() const
-{
-    return m_manager.get();
-}
-
 #if ENABLE(MEDIA_STREAM)
 static inline void setDeviceAsFirst(Vector<CaptureDevice>& devices, const String& deviceID)
 {

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h
@@ -107,7 +107,6 @@ protected:
     UserMediaPermissionRequestProxy(UserMediaPermissionRequestManagerProxy&, std::optional<WebCore::UserMediaRequestIdentifier>, WebCore::FrameIdentifier mainFrameID, FrameInfoData&&, Ref<WebCore::SecurityOrigin>&& userMediaDocumentOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, Vector<WebCore::CaptureDevice>&& audioDevices, Vector<WebCore::CaptureDevice>&& videoDevices, WebCore::MediaStreamRequest&&, CompletionHandler<void(bool)>&&);
 
     UserMediaPermissionRequestManagerProxy* manager() const;
-    RefPtr<UserMediaPermissionRequestManagerProxy> protectedManager() const;
 
 private:
     WeakPtr<UserMediaPermissionRequestManagerProxy> m_manager;

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -475,11 +475,6 @@ ViewGestureController::PendingSwipeTracker::PendingSwipeTracker(WebPageProxy& we
 {
 }
 
-Ref<ViewGestureController> ViewGestureController::PendingSwipeTracker::protectedViewGestureController() const
-{
-    return m_viewGestureController.get();
-}
-
 bool ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe(PlatformScrollEvent event, ViewGestureController::SwipeDirection& potentialSwipeDirection)
 {
     if (!scrollEventCanStartSwipe(event) || !scrollEventCanInfluenceSwipe(event))
@@ -503,7 +498,7 @@ bool ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe(Platf
         return false;
 
     potentialSwipeDirection = tryingToSwipeBack ? SwipeDirection::Back : SwipeDirection::Forward;
-    return protectedViewGestureController()->canSwipeInDirection(potentialSwipeDirection, DeferToConflictingGestures::No);
+    return protect(m_viewGestureController)->canSwipeInDirection(potentialSwipeDirection, DeferToConflictingGestures::No);
 }
 
 bool ViewGestureController::PendingSwipeTracker::handleEvent(PlatformScrollEvent event)
@@ -570,7 +565,7 @@ bool ViewGestureController::PendingSwipeTracker::tryToStartSwipe(PlatformScrollE
     }
 
     if (std::abs(m_cumulativeDelta.width()) >= minimumHorizontalSwipeDistance)
-        protectedViewGestureController()->startSwipeGesture(event, m_direction);
+        protect(m_viewGestureController)->startSwipeGesture(event, m_direction);
     else
         m_state = State::InsufficientMagnitude;
 

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -337,7 +337,6 @@ private:
         void setShouldIgnorePinnedState(bool ignore) { m_shouldIgnorePinnedState = ignore; }
 
     private:
-        Ref<ViewGestureController> protectedViewGestureController() const;
 
         bool tryToStartSwipe(PlatformScrollEvent);
         bool scrollEventCanBecomeSwipe(PlatformScrollEvent, SwipeDirection&);

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
@@ -75,7 +75,6 @@ protected:
     Authenticator() = default;
 
     AuthenticatorObserver* observer() const { return m_observer.get(); }
-    RefPtr<AuthenticatorObserver> protectedObserver() const { return m_observer.get(); }
     const WebAuthenticationRequestData& requestData() const { return m_pendingRequestData; }
 
     void receiveRespond(AuthenticatorObserverRespond&&) const;

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -289,7 +289,7 @@ void AuthenticatorManager::serviceStatusUpdated(WebAuthenticationStatus status)
     }
 
     dispatchPanelClientCall([status] (const API::WebAuthenticationPanel& panel) {
-        panel.protectedClient()->updatePanel(status);
+        protect(panel.client())->updatePanel(status);
     });
 }
 
@@ -346,7 +346,7 @@ void AuthenticatorManager::authenticatorStatusUpdated(WebAuthenticationStatus st
     }
 
     dispatchPanelClientCall([status] (const API::WebAuthenticationPanel& panel) {
-        panel.protectedClient()->updatePanel(status);
+        protect(panel.client())->updatePanel(status);
     });
 }
 
@@ -377,7 +377,7 @@ void AuthenticatorManager::requestPin(uint64_t retries, CompletionHandler<void(c
     }
 
     dispatchPanelClientCall([retries, callback = WTF::move(callback)] (const API::WebAuthenticationPanel& panel) mutable {
-        panel.protectedClient()->requestPin(retries, WTF::move(callback));
+        protect(panel.client())->requestPin(retries, WTF::move(callback));
     });
 }
 
@@ -399,7 +399,7 @@ void AuthenticatorManager::requestNewPin(uint64_t minLength, CompletionHandler<v
     }
 
     dispatchPanelClientCall([minLength, callback = WTF::move(callback)] (const API::WebAuthenticationPanel& panel) mutable {
-        panel.protectedClient()->requestNewPin(minLength, WTF::move(callback));
+        protect(panel.client())->requestNewPin(minLength, WTF::move(callback));
     });
 }
 
@@ -412,14 +412,14 @@ void AuthenticatorManager::selectAssertionResponse(Vector<Ref<WebCore::Authentic
     }
 
     dispatchPanelClientCall([responses = WTF::move(responses), source, completionHandler = WTF::move(completionHandler)] (const API::WebAuthenticationPanel& panel) mutable {
-        panel.protectedClient()->selectAssertionResponse(WTF::move(responses), source, WTF::move(completionHandler));
+        protect(panel.client())->selectAssertionResponse(WTF::move(responses), source, WTF::move(completionHandler));
     });
 }
 
 void AuthenticatorManager::decidePolicyForLocalAuthenticator(CompletionHandler<void(LocalAuthenticatorPolicy)>&& completionHandler)
 {
     dispatchPanelClientCall([completionHandler = WTF::move(completionHandler)] (const API::WebAuthenticationPanel& panel) mutable {
-        panel.protectedClient()->decidePolicyForLocalAuthenticator(WTF::move(completionHandler));
+        protect(panel.client())->decidePolicyForLocalAuthenticator(WTF::move(completionHandler));
     });
 }
 
@@ -431,7 +431,7 @@ void AuthenticatorManager::requestLAContextForUserVerification(CompletionHandler
     }
 
     dispatchPanelClientCall([completionHandler = WTF::move(completionHandler)] (const API::WebAuthenticationPanel& panel) mutable {
-        panel.protectedClient()->requestLAContextForUserVerification(WTF::move(completionHandler));
+        protect(panel.client())->requestLAContextForUserVerification(WTF::move(completionHandler));
     });
 }
 
@@ -555,7 +555,7 @@ void AuthenticatorManager::invokePendingCompletionHandler(Respond&& respond)
         presenter->dimissPresenter(result);
     else {
         dispatchPanelClientCall([result] (const API::WebAuthenticationPanel& panel) {
-            panel.protectedClient()->dismissPanel(result);
+            protect(panel.client())->dismissPanel(result);
         });
     }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -770,7 +770,7 @@ void LocalAuthenticator::continueGetAssertionAfterResponseSelected(Ref<WebCore::
     auto callback = [weakThis = WeakPtr { *this }, response = WTF::move(response)] (LocalConnection::UserVerification verification) mutable {
         ASSERT(RunLoop::isMain());
         if (RefPtr protectedThis = weakThis.get())
-            protectedThis->continueGetAssertionAfterUserVerification(WTF::move(response), verification, response->protectedLAContext().get());
+            protectedThis->continueGetAssertionAfterUserVerification(WTF::move(response), verification, protect(response->laContext()).get());
     };
 
     m_connection->verifyUser(accessControlRef.get(), context.get(), WTF::move(callback));

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -218,7 +218,7 @@ void WebAuthenticationPanelClient::selectAssertionResponse(Vector<Ref<WebCore::A
             completionHandler(nullptr);
             return;
         }
-        completionHandler(downcast<API::WebAuthenticationAssertionResponse>([response _apiObject]).protectedResponse().ptr());
+        completionHandler(protect(downcast<API::WebAuthenticationAssertionResponse>([response _apiObject]).response()).ptr());
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
@@ -51,11 +51,6 @@ CtapDriver& FidoAuthenticator::driver() const
     return *m_driver;
 }
 
-Ref<CtapDriver> FidoAuthenticator::protectedDriver() const
-{
-    return driver();
-}
-
 Ref<CtapDriver> FidoAuthenticator::releaseDriver()
 {
     ASSERT(m_driver);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
@@ -41,7 +41,6 @@ protected:
     explicit FidoAuthenticator(Ref<CtapDriver>&&);
 
     CtapDriver& driver() const;
-    Ref<CtapDriver> protectedDriver() const;
     Ref<CtapDriver> releaseDriver();
 
     String transportForDebugging() const;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -132,7 +132,7 @@ void U2fAuthenticator::issueNewCommand(Vector<uint8_t>&& command, CommandType ty
 void U2fAuthenticator::issueCommand(const Vector<uint8_t>& command, CommandType type)
 {
     U2F_RELEASE_LOG("issueCommand: Sending %s", base64EncodeToString(command).utf8().data());
-    protectedDriver()->transact(Vector<uint8_t>(command), [weakThis = WeakPtr { *this }, type](Vector<uint8_t>&& data) {
+    protect(driver())->transact(Vector<uint8_t>(command), [weakThis = WeakPtr { *this }, type](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -136,7 +136,7 @@ Ref<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBackForwardLis
 
     ASSERT(m_itemsWithCachedPage.contains(item));
     ASSERT(item.backForwardCacheEntry());
-    Ref suspendedPage = item.protectedBackForwardCacheEntry()->takeSuspendedPage();
+    Ref suspendedPage = protect(item.backForwardCacheEntry())->takeSuspendedPage();
     removeEntry(item);
     return suspendedPage;
 }

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -69,7 +69,6 @@ public:
     Ref<SuspendedPageProxy> takeSuspendedPage(WebBackForwardListItem&);
 
 private:
-    Ref<WebProcessPool> protectedProcessPool() const;
 
     void removeOldestEntry();
     void removeEntriesMatching(NOESCAPE const Function<bool(WebBackForwardListItem&)>&);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -117,7 +117,7 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
 
         while (m_entries.size()) {
             Ref lastEntry = m_entries.last();
-            if (!lastEntry->isRemoteFrameNavigation() || lastEntry->protectedNavigatedFrameItem()->sharesAncestor(newItem->protectedNavigatedFrameItem()))
+            if (!lastEntry->isRemoteFrameNavigation() || protect(lastEntry->navigatedFrameItem())->sharesAncestor(protect(newItem->navigatedFrameItem())))
                 break;
             didRemoveItem(lastEntry);
             removedItems.append(WTF::move(lastEntry));
@@ -192,7 +192,7 @@ void WebBackForwardList::addChildItem(FrameIdentifier parentFrameID, Ref<FrameSt
     if (!currentItem)
         return;
 
-    RefPtr parentItem = currentItem->protectedMainFrameItem()->childItemForFrameID(parentFrameID);
+    RefPtr parentItem = protect(currentItem->mainFrameItem())->childItemForFrameID(parentFrameID);
     if (!parentItem)
         return;
 
@@ -741,7 +741,7 @@ void WebBackForwardList::backForwardAllItems(FrameIdentifier frameID, Completion
     for (Ref item : this->allItems()) {
         RefPtr<FrameState> frameState;
 
-        if (RefPtr frameItem = item->protectedMainFrameItem()->childItemForFrameID(frameID))
+        if (RefPtr frameItem = protect(item->mainFrameItem())->childItemForFrameID(frameID))
             frameState = frameItem->copyFrameStateWithChildren();
         else
             frameState = item->mainFrameState();
@@ -756,7 +756,7 @@ void WebBackForwardList::backForwardItemAtIndex(int32_t index, FrameIdentifier f
 {
     // FIXME: This should verify that the web process requesting the item hosts the specified frame.
     if (RefPtr item = itemAtIndex(index)) {
-        if (RefPtr frameItem = item->protectedMainFrameItem()->childItemForFrameID(frameID))
+        if (RefPtr frameItem = protect(item->mainFrameItem())->childItemForFrameID(frameID))
             return completionHandler(frameItem->copyFrameStateWithChildren());
         completionHandler(item->mainFrameState());
     } else

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
@@ -46,11 +46,6 @@ WebContextMenuProxy::WebContextMenuProxy(WebPageProxy& page, FrameInfoData&& fra
 
 WebContextMenuProxy::~WebContextMenuProxy() = default;
 
-RefPtr<WebPageProxy> WebContextMenuProxy::protectedPage() const
-{
-    return page();
-}
-
 Vector<Ref<WebContextMenuItem>> WebContextMenuProxy::proposedItems() const
 {
     return WTF::map(m_context.menuItems(), [](auto& item) {
@@ -69,7 +64,7 @@ void WebContextMenuProxy::show()
     Ref contextMenuListener = WebContextMenuListenerProxy::create(*this);
     m_contextMenuListener = contextMenuListener.copyRef();
     page->contextMenuClient().getContextMenuFromProposedMenu(*page, proposedItems(), contextMenuListener, m_context.webHitTestResultData().value(),
-        protect(page->legacyMainFrameProcess())->transformHandlesToObjects(m_userData.protectedObject().get()).get());
+        protect(page->legacyMainFrameProcess())->transformHandlesToObjects(protect(m_userData.object()).get()).get());
 }
 
 void WebContextMenuProxy::useContextMenuItems(Vector<Ref<WebContextMenuItem>>&& items)

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.h
@@ -53,7 +53,6 @@ public:
     virtual void show();
 
     WebPageProxy* page() const { return m_page.get(); }
-    RefPtr<WebPageProxy> protectedPage() const;
     const FrameInfoData& frameInfo() const { return m_frameInfo; }
     const WebCore::IntPoint& menuLocation() const { return m_context.menuLocation(); }
 

--- a/Source/WebKit/UIProcess/WebContextSupplement.h
+++ b/Source/WebKit/UIProcess/WebContextSupplement.h
@@ -41,7 +41,6 @@ public:
     virtual void processPoolDestroyed() { }
 
     WebProcessPool* processPool() { return m_processPool.get(); }
-    RefPtr<WebProcessPool> protectedProcessPool() { return processPool(); }
     void clearProcessPool() { m_processPool = nullptr; }
 
 protected:

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -437,7 +437,7 @@ bool WebFrameProxy::didHandleContentFilterUnblockNavigation(const ResourceReques
                 m_contentFilterUnblockHandler.configurationPath()
 #endif
             };
-            protect(page->websiteDataStore())->protectedNetworkProcess()->allowEvaluatedURL(parameters, [page](bool unblocked) {
+            protect(protect(page->websiteDataStore())->networkProcess())->allowEvaluatedURL(parameters, [page](bool unblocked) {
                 if (unblocked)
                     page->reload({ });
             });
@@ -529,7 +529,7 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
 
     m_provisionalFrame = nullptr;
     m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(site, mainFrameSite, process, protect(page->preferences())), commitTiming));
-    protect(page->websiteDataStore())->protectedNetworkProcess()->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [pageID = page->webPageIDInProcess(process), completionHandler = WTF::move(completionHandler)] mutable {
+    protect(protect(page->websiteDataStore())->networkProcess())->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [pageID = page->webPageIDInProcess(process), completionHandler = WTF::move(completionHandler)] mutable {
         completionHandler(pageID);
     });
 }

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp
@@ -53,7 +53,7 @@ Ref<WebGeolocationManagerProxy> WebGeolocationManagerProxy::create(WebProcessPoo
 WebGeolocationManagerProxy::WebGeolocationManagerProxy(WebProcessPool* processPool)
     : WebContextSupplement(processPool)
 {
-    WebContextSupplement::protectedProcessPool()->addMessageReceiver(Messages::WebGeolocationManagerProxy::messageReceiverName(), *this);
+    protect(WebContextSupplement::processPool())->addMessageReceiver(Messages::WebGeolocationManagerProxy::messageReceiverName(), *this);
 }
 
 WebGeolocationManagerProxy::~WebGeolocationManagerProxy() = default;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -175,7 +175,6 @@ struct SpeechSynthesisData {
     CompletionHandler<void()> speakingPausedCompletionHandler;
     CompletionHandler<void()> speakingResumedCompletionHandler;
 
-    Ref<WebCore::PlatformSpeechSynthesizer> protectedSynthesizer() { return synthesizer; }
 };
 #endif
 
@@ -520,12 +519,8 @@ public:
     RetainPtr<CocoaView> platformView() const final;
 #endif
 
-    Ref<PageLoadState> protectedPageLoadState() { return pageLoadState; }
-    Ref<WebNotificationManagerMessageHandler> protectedNotificationManagerMessageHandler() { return notificationManagerMessageHandler; }
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)
-    RefPtr<WebPageProxyFrameLoadStateObserver> protectedFrameLoadStateObserver() { return frameLoadStateObserver; }
 #endif
-    Ref<GeolocationPermissionRequestManagerProxy> protectedGeolocationPermissionRequestManager() { return geolocationPermissionRequestManager; }
 
     std::optional<WebCore::SecurityOriginData> openerOrigin;
 };

--- a/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp
@@ -66,9 +66,4 @@ void WebPageProxyMessageReceiverRegistration::transferMessageReceivingFrom(WebPa
     }
 }
 
-Ref<WebProcessProxy> WebPageProxyMessageReceiverRegistration::Data::protectedProcess()
-{
-    return process;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h
+++ b/Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h
@@ -46,7 +46,6 @@ private:
         WebCore::PageIdentifier webPageID;
         Ref<WebProcessProxy> process;
 
-        Ref<WebProcessProxy> protectedProcess();
     };
     std::optional<Data> m_data;
 };

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -89,7 +89,7 @@ void WebPageProxyTesting::isLayerTreeFrozen(CompletionHandler<void(bool)>&& comp
 
 void WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->setCrossSiteLoadWithLinkDecorationForTesting(protect(page())->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->setCrossSiteLoadWithLinkDecorationForTesting(protect(page())->sessionID(), WebCore::RegistrableDomain { fromURL }, WebCore::RegistrableDomain { toURL }, wasFiltered, WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPermissionLevel(const String& origin, bool allowed)
@@ -112,62 +112,62 @@ bool WebPageProxyTesting::isEditingCommandEnabled(const String& commandName)
 
 void WebPageProxyTesting::dumpPrivateClickMeasurement(CompletionHandler<void(const String&)>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::DumpPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::clearPrivateClickMeasurement(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::ClearPrivateClickMeasurement(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementOverrideTimerForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::MarkAttributedPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement(bool value, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementEphemeralMeasurementForTesting(m_page->websiteDataStore().sessionID(), value), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SimulatePrivateClickMeasurementSessionRestart(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenPublicKeyURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL(const URL& url, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementTokenSignatureURLForTesting(m_page->websiteDataStore().sessionID(), url), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs(const URL& sourceURL, const URL& destinationURL, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAttributionReportURLsForTesting(m_page->websiteDataStore().sessionID(), sourceURL, destinationURL), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::markPrivateClickMeasurementsAsExpired(CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::MarkPrivateClickMeasurementsAsExpiredForTesting(m_page->websiteDataStore().sessionID()), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPCMFraudPreventionValues(const String& unlinkableToken, const String& secretToken, const String& signature, const String& keyID, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SetPCMFraudPreventionValuesForTesting(m_page->websiteDataStore().sessionID(), unlinkableToken, secretToken, signature, keyID), WTF::move(completionHandler));
 }
 
 void WebPageProxyTesting::setPrivateClickMeasurementAppBundleID(const String& appBundleIDForTesting, CompletionHandler<void()>&& completionHandler)
 {
-    protect(protect(page())->websiteDataStore())->protectedNetworkProcess()->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTF::move(completionHandler));
+    protect(protect(protect(page())->websiteDataStore())->networkProcess())->sendWithAsyncReply(Messages::NetworkProcess::SetPrivateClickMeasurementAppBundleIDForTesting(m_page->websiteDataStore().sessionID(), appBundleIDForTesting), WTF::move(completionHandler));
 }
 
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -69,7 +69,7 @@ WebProcessActivityState::WebProcessActivityState(RemotePageProxy& page)
 
 void WebProcessActivityState::takeVisibleActivity()
 {
-    m_isVisibleActivity = protect(process())->protectedThrottler()->foregroundActivity("View is visible"_s);
+    m_isVisibleActivity = protect(protect(process())->throttler())->foregroundActivity("View is visible"_s);
 #if PLATFORM(MAC)
     m_wasRecentlyVisibleActivity->setActivity(nullptr);
 #endif
@@ -107,12 +107,12 @@ void WebProcessActivityState::dropTextExtractionAssertion()
 
 void WebProcessActivityState::takeAudibleActivity()
 {
-    m_isAudibleActivity = protect(process())->protectedThrottler()->foregroundActivity("View is playing audio"_s);
+    m_isAudibleActivity = protect(protect(process())->throttler())->foregroundActivity("View is playing audio"_s);
 }
 
 void WebProcessActivityState::takeCapturingActivity()
 {
-    m_isCapturingActivity = protect(process())->protectedThrottler()->foregroundActivity("View is capturing media"_s);
+    m_isCapturingActivity = protect(protect(process())->throttler())->foregroundActivity("View is capturing media"_s);
 }
 
 void WebProcessActivityState::takeMutedCaptureAssertion()
@@ -138,7 +138,7 @@ void WebProcessActivityState::takeMutedCaptureAssertion()
 void WebProcessActivityState::takeNetworkActivity()
 {
     RELEASE_LOG(Process, "Taking network activity on WebProcess with PID %d", protect(process())->processID());
-    m_networkActivity = protect(process())->protectedThrottler()->backgroundActivity("Page Load"_s);
+    m_networkActivity = protect(protect(process())->throttler())->backgroundActivity("Page Load"_s);
 }
 
 void WebProcessActivityState::reset()
@@ -159,9 +159,9 @@ void WebProcessActivityState::dropVisibleActivity()
 {
 #if PLATFORM(MAC)
     if (WTF::numberOfProcessorCores() > 4)
-        m_wasRecentlyVisibleActivity->setActivity(protect(process())->protectedThrottler()->backgroundActivity("View was recently visible"_s));
+        m_wasRecentlyVisibleActivity->setActivity(protect(protect(process())->throttler())->backgroundActivity("View was recently visible"_s));
     else
-        m_wasRecentlyVisibleActivity->setActivity(protect(process())->protectedThrottler()->foregroundActivity("View was recently visible"_s));
+        m_wasRecentlyVisibleActivity->setActivity(protect(protect(process())->throttler())->foregroundActivity("View was recently visible"_s));
 #endif
     m_isVisibleActivity = nullptr;
 }
@@ -215,7 +215,7 @@ bool WebProcessActivityState::hasValidMutedCaptureAssertion() const
 #if PLATFORM(IOS_FAMILY)
 void WebProcessActivityState::takeOpeningAppLinkActivity()
 {
-    m_openingAppLinkActivity = protect(process())->protectedThrottler()->backgroundActivity("Opening AppLink"_s);
+    m_openingAppLinkActivity = protect(protect(process())->throttler())->backgroundActivity("Opening AppLink"_s);
 }
 
 void WebProcessActivityState::dropOpeningAppLinkActivity()
@@ -262,7 +262,7 @@ void WebProcessActivityState::takeAccessibilityActivityWhenInWindow()
 
 void WebProcessActivityState::takeAccessibilityActivity()
 {
-    m_accessibilityActivity = protect(process())->protectedThrottler()->backgroundActivity("Remote AX element"_s);
+    m_accessibilityActivity = protect(protect(process())->throttler())->backgroundActivity("Remote AX element"_s);
 }
 
 bool WebProcessActivityState::hasAccessibilityActivityForTesting() const
@@ -294,11 +294,6 @@ WebProcessProxy& WebProcessActivityState::process() const
         else
             static_assert(std::is_same_v<T, std::false_type>, "Unhandled page type in WebProcessActivityState::process");
     }, m_page);
-}
-
-Ref<WebProcessProxy> WebProcessActivityState::protectedProcess() const
-{
-    return process();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessActivityState.h
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.h
@@ -80,7 +80,6 @@ public:
 
 private:
     WebProcessProxy& process() const;
-    Ref<WebProcessProxy> protectedProcess() const;
 
     Variant<WeakRef<WebPageProxy>, WeakRef<RemotePageProxy>> m_page;
 

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -518,7 +518,7 @@ void WebProcessCache::CachedProcess::startSuspensionTimer()
     // Allow the cached process to run for a while before dropping all assertions. This is useful
     // if the cached process will be reused fairly quickly after it goes into the cache, which
     // occurs in some benchmarks like PLT5.
-    m_backgroundActivity = m_process->protectedThrottler()->backgroundActivity("Cached process near-suspended"_s);
+    m_backgroundActivity = protect(m_process->throttler())->backgroundActivity("Cached process near-suspended"_s);
     m_suspensionTimer.startOneShot(cachedProcessSuspensionDelay);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -84,7 +84,6 @@ private:
 
         Ref<WebProcessProxy> takeProcess();
         WebProcessProxy& process() { ASSERT(m_process); return *m_process; }
-        RefPtr<WebProcessProxy> protectedProcess() const { return m_process; }
         void startSuspensionTimer();
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -184,12 +184,6 @@ public:
     }
 
     template <typename T>
-    RefPtr<T> protectedSupplement()
-    {
-        return supplement<T>();
-    }
-
-    template <typename T>
     void addSupplement()
     {
         m_supplements.add(T::supplementName(), T::create(this));
@@ -402,7 +396,6 @@ public:
     GPUProcessProxy& ensureGPUProcess();
     Ref<GPUProcessProxy> ensureProtectedGPUProcess();
     GPUProcessProxy* gpuProcess() const { return m_gpuProcess.get(); }
-    RefPtr<GPUProcessProxy> protectedGPUProcess() const { return gpuProcess(); }
 #endif
 
 #if ENABLE(MODEL_PROCESS)
@@ -452,7 +445,6 @@ public:
     NSMutableDictionary *ensureBundleParameters();
     RetainPtr<NSMutableDictionary> ensureProtectedBundleParameters();
     NSMutableDictionary *bundleParameters() { return m_bundleParameters.get(); }
-    RetainPtr<NSMutableDictionary> protectedBundleParameters();
 #else
     void updateProcessSuppressionState() const { }
 #endif

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -199,9 +199,4 @@ std::optional<WebCore::Exception> WebScreenOrientationManagerProxy::platformShou
 }
 #endif
 
-Ref<WebPageProxy> WebScreenOrientationManagerProxy::protectedPage() const
-{
-    return m_page.get();
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h
@@ -73,7 +73,6 @@ private:
 
     std::optional<WebCore::Exception> platformShouldRejectLockRequest() const;
 
-    Ref<WebPageProxy> protectedPage() const;
 
     WeakRef<WebPageProxy> m_page;
     WebCore::ScreenOrientationType m_currentOrientation;

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
@@ -246,11 +246,6 @@ NSURLRequest *WebURLSchemeTask::nsRequest() const
     Locker locker { m_requestLock };
     return m_request.protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).autorelease();
 }
-
-RetainPtr<NSURLRequest> WebURLSchemeTask::protectedNSRequest() const
-{
-    return nsRequest();
-}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.h
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.h
@@ -72,7 +72,6 @@ public:
 
 #if PLATFORM(COCOA)
     NSURLRequest *nsRequest() const;
-    RetainPtr<NSURLRequest> protectedNSRequest() const;
 #endif
 
     enum class ExceptionType {

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -932,7 +932,7 @@ void WebsiteDataStore::reinitializeManagedDomains()
 
 bool WebsiteDataStore::networkProcessHasEntitlementForTesting(const String& entitlement)
 {
-    return WTF::hasEntitlement(networkProcess().protectedConnection()->protectedXPCConnection().get(), entitlement);
+    return WTF::hasEntitlement(protect(protect(networkProcess().connection())->xpcConnection()).get(), entitlement);
 }
 
 std::optional<double> WebsiteDataStore::defaultOriginQuotaRatio()

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -129,7 +129,6 @@ using RemoveDataTaskCounter = RefCounter<RemoveDataTaskCounterType>;
 class WebsiteDataStore : public API::ObjectImpl<API::Object::Type::WebsiteDataStore>, public CanMakeWeakPtr<WebsiteDataStore> {
 public:
     static WebsiteDataStore& defaultDataStore();
-    static Ref<WebsiteDataStore> protectedDefaultDataStore();
     static bool defaultDataStoreExists();
     static void deleteDefaultDataStoreForTesting();
     static RefPtr<WebsiteDataStore> existingDataStoreForIdentifier(const WTF::UUID&);
@@ -147,7 +146,6 @@ public:
     
     NetworkProcessProxy& networkProcess() const;
     NetworkProcessProxy& networkProcess();
-    Ref<NetworkProcessProxy> protectedNetworkProcess() const;
     NetworkProcessProxy* networkProcessIfExists() { return m_networkProcess.get(); }
     void setNetworkProcess(NetworkProcessProxy&);
     
@@ -349,10 +347,8 @@ public:
 
 #if ENABLE(WEB_AUTHN)
     AuthenticatorManager& authenticatorManager() { return m_authenticatorManager.get(); }
-    Ref<AuthenticatorManager> protectedAuthenticatorManager();
     void setMockWebAuthenticationConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
     VirtualAuthenticatorManager& virtualAuthenticatorManager();
-    Ref<VirtualAuthenticatorManager> protectedVirtualAuthenticatorManager();
 #endif
 
     const WebsiteDataStoreConfiguration& configuration() const { return m_configuration.get(); }
@@ -361,7 +357,6 @@ public:
     void setClient(UniqueRef<WebsiteDataStoreClient>&& client) { m_client = WTF::move(client); }
 
     API::HTTPCookieStore& cookieStore();
-    Ref<API::HTTPCookieStore> protectedCookieStore();
     WebCore::LocalWebLockRegistry& webLockRegistry() { return m_webLockRegistry.get(); }
 
     void renameOriginInWebsiteData(WebCore::SecurityOriginData&&, WebCore::SecurityOriginData&&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
@@ -371,7 +366,6 @@ public:
 
 #if ENABLE(DEVICE_ORIENTATION)
     WebDeviceOrientationAndMotionAccessController& deviceOrientationAndMotionAccessController() { return m_deviceOrientationAndMotionAccessController; }
-    Ref<WebDeviceOrientationAndMotionAccessController> protectedDeviceOrientationAndMotionAccessController() { return m_deviceOrientationAndMotionAccessController; }
 #endif
 
 #if HAVE(APP_SSO)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -94,7 +94,7 @@ void PlatformXRSystem::ensureImmersiveSessionActivity()
     if (m_immersiveSessionActivity && m_immersiveSessionActivity->isValid())
         return;
 
-    m_immersiveSessionActivity = protect(page->legacyMainFrameProcess())->protectedThrottler()->foregroundActivity("XR immersive session"_s);
+    m_immersiveSessionActivity = protect(protect(page->legacyMainFrameProcess())->throttler())->foregroundActivity("XR immersive session"_s);
 }
 
 void PlatformXRSystem::enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
@@ -39,12 +39,12 @@ using namespace WebCore;
 
 void UserMediaPermissionRequestManagerProxy::validateUserMediaRequestConstraints(RealtimeMediaSourceCenter::ValidateHandler&& validateHandler, WebCore::MediaDeviceHashSalts&& deviceIDHashSalts)
 {
-    m_page->legacyMainFrameProcess().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::ValidateUserMediaRequestConstraints(m_currentUserMediaRequest->userRequest(), WTF::move(deviceIDHashSalts)), WTF::move(validateHandler));
+    protect(m_page->legacyMainFrameProcess().connection())->sendWithAsyncReply(Messages::UserMediaCaptureManager::ValidateUserMediaRequestConstraints(m_currentUserMediaRequest->userRequest(), WTF::move(deviceIDHashSalts)), WTF::move(validateHandler));
 }
 
 void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
 {
-    m_page->legacyMainFrameProcess().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(revealIdsAndLabels), WTF::move(completionHandler));
+    protect(m_page->legacyMainFrameProcess().connection())->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(revealIdsAndLabels), WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3300,7 +3300,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (![self _hasValidOutstandingPositionInformationRequest:request])
         [self requestAsynchronousPositionInformationUpdate:request];
 
-    bool receivedResponse = process->protectedConnection()->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageIDInMainFrameProcess(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
+    bool receivedResponse = protect(process->connection())->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageIDInMainFrameProcess(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
     _hasValidPositionInformation = receivedResponse && _positionInformation.canBeValid;
     return _hasValidPositionInformation;
 }
@@ -5129,7 +5129,7 @@ static UIPasteboard *pasteboardForAccessCategory(WebCore::DOMPasteAccessCategory
     if (auto pasteAccessCategory = std::exchange(_domPasteRequestCategory, std::nullopt)) {
         if (response == WebCore::DOMPasteAccessResponse::GrantedForCommand || response == WebCore::DOMPasteAccessResponse::GrantedForGesture) {
             if (auto replyID = _page->grantAccessToCurrentPasteboardData(pasteboardNameForAccessCategory(*pasteAccessCategory), [] () { }))
-                _page->websiteDataStore().protectedNetworkProcess()->connection().waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
+                protect(_page->websiteDataStore().networkProcess())->connection().waitForAsyncReplyAndDispatchImmediately<Messages::NetworkProcess::AllowFilesAccessFromWebProcess>(*replyID, 100_ms);
         }
     }
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -450,7 +450,7 @@ void WebPageProxy::selectTextWithGranularityAtPoint(const WebCore::IntPoint poin
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -462,7 +462,7 @@ void WebPageProxy::selectPositionAtBoundaryWithDirection(const WebCore::IntPoint
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtBoundaryWithDirection(point, granularity, direction, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::selectPositionAtBoundaryWithDirection"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtBoundaryWithDirection(point, granularity, direction, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::selectPositionAtBoundaryWithDirection"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -474,7 +474,7 @@ void WebPageProxy::moveSelectionAtBoundaryWithDirection(WebCore::TextGranularity
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionAtBoundaryWithDirection(granularity, direction), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::moveSelectionAtBoundaryWithDirection"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionAtBoundaryWithDirection(granularity, direction), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::moveSelectionAtBoundaryWithDirection"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -486,7 +486,7 @@ void WebPageProxy::selectPositionAtPoint(const WebCore::IntPoint point, bool isI
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtPoint(point, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::selectPositionAtPoint"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtPoint(point, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::selectPositionAtPoint"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -756,7 +756,7 @@ void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void(
         return;
     }
     
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionByOffset(offset), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::moveSelectionByOffset"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionByOffset(offset), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::moveSelectionByOffset"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -788,7 +788,7 @@ void WebPageProxy::registerWebProcessAccessibilityToken(std::span<const uint8_t>
 {
     // Note: The WebFrameProxy with this FrameIdentifier might not exist in the UI process. See rdar://130998804.
     if (RefPtr pageClient = this->pageClient())
-        pageClient->accessibilityWebProcessTokenReceived(data, protect(legacyMainFrameProcess())->protectedConnection()->remoteProcessID());
+        pageClient->accessibilityWebProcessTokenReceived(data, protect(protect(legacyMainFrameProcess())->connection())->remoteProcessID());
 }
 
 void WebPageProxy::relayAccessibilityNotification(String&& notificationName, std::span<const uint8_t> data)
@@ -1104,7 +1104,7 @@ void WebPageProxy::focusNextFocusedElement(bool isForward, CompletionHandler<voi
         return;
     }
     
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::FocusNextFocusedElement(isForward), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::focusNextFocusedElement"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::FocusNextFocusedElement(isForward), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::focusNextFocusedElement"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -641,7 +641,7 @@ void PageClientImpl::updateAcceleratedCompositingMode(const LayerTreeContext& la
 
 void PageClientImpl::setRemoteLayerTreeRootNode(RemoteLayerTreeNode* rootNode)
 {
-    checkedImpl()->setAcceleratedCompositingRootLayer(rootNode ? rootNode->protectedLayer().get() : nil);
+    checkedImpl()->setAcceleratedCompositingRootLayer(rootNode ? protect(rootNode->layer()).get() : nil);
 }
 
 CALayer *PageClientImpl::acceleratedCompositingRootLayer() const
@@ -829,7 +829,7 @@ bool PageClientImpl::isFullScreen()
     if (!impl->hasFullScreenWindowController())
         return false;
 
-    return impl->protectedFullScreenWindowController().get().isFullScreen;
+    return protect(impl->fullScreenWindowController()).get().isFullScreen;
 }
 
 void PageClientImpl::enterFullScreen(FloatSize, CompletionHandler<void(bool)>&& completionHandler)
@@ -1197,11 +1197,6 @@ void PageClientImpl::didChangeLocalInspectorAttachment()
 void PageClientImpl::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier identifier, const WebCore::ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
 {
     checkedImpl()->showCaptionDisplaySettings(identifier, options, WTF::move(completionHandler));
-}
-
-RetainPtr<NSView> PageClient::protectedViewForPresentingRevealPopover() const
-{
-    return viewForPresentingRevealPopover();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -156,7 +156,7 @@ void TiledCoreAnimationDrawingAreaProxy::waitForDidUpdateActivityState(ActivityS
         return;
 
     Seconds activityStateUpdateTimeout = Seconds::fromMilliseconds(250);
-    webProcessProxy().protectedConnection()->waitForAndDispatchImmediately<Messages::WebPageProxy::DidUpdateActivityState>(page->webPageIDInMainFrameProcess(), activityStateUpdateTimeout, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+    protect(webProcessProxy().connection())->waitForAndDispatchImmediately<Messages::WebPageProxy::DidUpdateActivityState>(page->webPageIDInMainFrameProcess(), activityStateUpdateTimeout, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::willSendUpdateGeometry()

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
@@ -51,7 +51,7 @@ void UserMediaPermissionRequestProxyMac::invalidate()
 {
 #if ENABLE(MEDIA_STREAM)
     if (m_hasPendingGetDisplayMediaPrompt) {
-        if (RefPtr page = protectedManager()->page())
+        if (RefPtr page = protect(manager())->page())
             DisplayCaptureSessionManager::singleton().cancelGetDisplayMediaPrompt(*page);
         m_hasPendingGetDisplayMediaPrompt = false;
     }
@@ -65,7 +65,7 @@ void UserMediaPermissionRequestProxyMac::promptForGetDisplayMedia(UserMediaDispl
     if (!manager())
         return;
 
-    RefPtr page = protectedManager()->page();
+    RefPtr page = protect(manager())->page();
     if (!page)
         return;
 

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm
@@ -83,7 +83,7 @@
 
     _effectView = adoptNS([PAL::alloc_WTTextEffectViewInstance() initWithAsyncSource:self]);
     [_effectView setClipsToBounds:YES];
-    [_effectView setFrame:webView.protectedView().get().bounds];
+    [_effectView setFrame:protect(webView.view()).get().bounds];
 
     return self;
 }
@@ -178,7 +178,7 @@
 
     if (![_effectView superview]) {
         CheckedRef viewImpl = *_webView;
-        [viewImpl->protectedView() addSubview:_effectView.get()];
+        [protect(viewImpl->view()) addSubview:_effectView.get()];
     }
     RetainPtr effectID = [_effectView addEffect:effect.get()];
     RetainPtr effectData = adoptNS([[WKTextAnimationTypeEffectData alloc] initWithEffectID:effectID.get() type:data.style]);

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -753,7 +753,7 @@ static RetainPtr<NSMenuItem> createMenuActionItem(const WebContextMenuItemData& 
     [menuItem setIdentifier:menuItemIdentifier(item.action()).get()];
 
     if (item.userData())
-        [menuItem setRepresentedObject:adoptNS([[WKUserDataWrapper alloc] initWithUserData:item.protectedUserData().get()]).get()];
+        [menuItem setRepresentedObject:adoptNS([[WKUserDataWrapper alloc] initWithUserData:protect(item.userData()).get()]).get()];
 
     return menuItem;
 }
@@ -1030,7 +1030,7 @@ void WebContextMenuProxyMac::useContextMenuItems(Vector<Ref<WebContextMenuItem>>
             webExtensionController->addItemsToContextMenu(page, m_context, menu);
 #endif
 
-        page->contextMenuClient().menuFromProposedMenu(page, menu, m_context, m_userData.protectedObject().get(), WTF::move(menuFromProposedMenu));
+        page->contextMenuClient().menuFromProposedMenu(page, menu, m_context, protect(m_userData.object()).get(), WTF::move(menuFromProposedMenu));
     });
 }
 

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h
@@ -51,7 +51,7 @@ public:
     void hidePopupMenu() override;
     void cancelTracking() override;
 
-    RetainPtr<NSPopUpButtonCell> protectedPopup() const;
+    NSPopUpButtonCell *popup() const;
     bool isVisible() const { return m_isVisible; }
 
 private:
@@ -59,7 +59,7 @@ private:
 
     void populate(const Vector<WebPopupItem>&, NSFont *, WebCore::TextDirection);
     bool isWebPopupMenuProxyMac() const final { return true; }
-    RetainPtr<NSMenu> protectedMenu() const;
+    NSMenu *menu() const;
 
     RetainPtr<NSPopUpButtonCell> m_popup;
     WeakObjCPtr<NSView> m_webView;

--- a/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm
@@ -70,7 +70,7 @@ void WebPopupMenuProxyMac::populate(const Vector<WebPopupItem>& items, NSFont *f
 
     for (int i = 0; i < size; i++) {
         if (items[i].m_type == WebPopupItem::Type::Separator)
-            [protectedMenu() addItem:[NSMenuItem separatorItem]];
+            [protect(menu()) addItem:[NSMenuItem separatorItem]];
         else {
             [m_popup addItemWithTitle:@""];
             RetainPtr menuItem = [m_popup lastItem];
@@ -222,21 +222,21 @@ void WebPopupMenuProxyMac::showPopupMenu(const IntRect& rect, TextDirection text
 
 void WebPopupMenuProxyMac::hidePopupMenu()
 {
-    [protectedMenu() cancelTracking];
+    [protect(menu()) cancelTracking];
 }
 
 void WebPopupMenuProxyMac::cancelTracking()
 {
-    [protectedMenu() cancelTracking];
+    [protect(menu()) cancelTracking];
     m_wasCanceled = true;
 }
 
-RetainPtr<NSPopUpButtonCell> WebPopupMenuProxyMac::protectedPopup() const
+NSPopUpButtonCell *WebPopupMenuProxyMac::popup() const
 {
-    return m_popup;
+    return m_popup.get();
 }
 
-RetainPtr<NSMenu> WebPopupMenuProxyMac::protectedMenu() const
+NSMenu *WebPopupMenuProxyMac::menu() const
 {
     return [m_popup menu];
 }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -247,7 +247,6 @@ public:
     WebPageProxy& page() { return m_page.get(); }
 
     WKWebView *view() const { return m_view.getAutoreleased(); }
-    RetainPtr<WKWebView> protectedView() const { return m_view.get(); };
 
     void processWillSwap();
     void processDidExit();
@@ -416,7 +415,6 @@ public:
 #if ENABLE(FULLSCREEN_API)
     bool hasFullScreenWindowController() const;
     WKFullScreenWindowController *fullScreenWindowController();
-    RetainPtr<WKFullScreenWindowController> protectedFullScreenWindowController();
     void closeFullScreenWindowController();
 #endif
     NSView *fullScreenPlaceholderView();
@@ -607,8 +605,7 @@ public:
 
     _WKWarningView *warningView() { return m_warningView.get(); }
 
-    ViewGestureController* gestureController() { return m_gestureController.get(); }
-    RefPtr<ViewGestureController> protectedGestureController() const;
+    ViewGestureController* gestureController() const { return m_gestureController.get(); }
     ViewGestureController& ensureGestureController();
     Ref<ViewGestureController> ensureProtectedGestureController();
     void setAllowsBackForwardNavigationGestures(bool);


### PR DESCRIPTION
#### a223b0bfcf20b670b555f5269082be6c8fd8f0a5
<pre>
Drop remaining `protected*()` member functions in Source/WebKit/UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=306264">https://bugs.webkit.org/show_bug.cgi?id=306264</a>

Reviewed by Timothy Hatcher.

Drop remaining `protected*()` member functions in Source/WebKit/UIProcess,
and use protect() at call sites instead.

* Source/WTF/wtf/RetainPtr.h:
(WTF::protect):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
* Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h:
* Source/WebKit/UIProcess/API/APIDataTask.cpp:
(API::DataTask::networkProcessCrashed):
(API::m_client):
(API::DataTask::didCompleteWithError):
(API::DataTask::protectedClient const): Deleted.
* Source/WebKit/UIProcess/API/APIDataTask.h:
(API::DataTask::page):
(API::DataTask::client const):
(API::DataTask::protectedPage const): Deleted.
* Source/WebKit/UIProcess/API/APIFrameTreeNode.cpp:
(API::FrameTreeNode::protectedPage): Deleted.
* Source/WebKit/UIProcess/API/APIFrameTreeNode.h:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::websitePolicies):
(API::Navigation::protectedTargetItem const): Deleted.
(API::Navigation::protectedWebsitePolicies const): Deleted.
* Source/WebKit/UIProcess/API/APINavigationAction.h:
* Source/WebKit/UIProcess/API/APINavigationResponse.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::delaysWebProcessLaunchUntilFirstLoad const):
(API::PageConfiguration::applePayEnabled const):
(API::PageConfiguration::protectedProcessPool const): Deleted.
(API::PageConfiguration::protectedUserContentController const): Deleted.
(API::PageConfiguration::protectedWebExtensionController const): Deleted.
(API::PageConfiguration::protectedWeakWebExtensionController const): Deleted.
(API::PageConfiguration::protectedPreferences const): Deleted.
(API::PageConfiguration::protectedRelatedPage const): Deleted.
(API::PageConfiguration::protectedVisitedLinkStore const): Deleted.
(API::PageConfiguration::protectedWebsiteDataStoreIfExists const): Deleted.
(API::PageConfiguration::protectedWebsiteDataStore const): Deleted.
(API::PageConfiguration::protectedDefaultWebsitePolicies const): Deleted.
(API::PageConfiguration::protectedApplicationManifest const): Deleted.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::setRelatedPage):
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp:
(API::WebAuthenticationPanel::WebAuthenticationPanel):
(API::WebAuthenticationPanel::handleRequest):
(API::WebAuthenticationPanel::cancel const):
(API::WebAuthenticationPanel::protectedManager const): Deleted.
(API::WebAuthenticationPanel::protectedClient const): Deleted.
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.cpp:
(API::WebsitePolicies::protectedWebsiteDataStore const): Deleted.
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/C/WKAuthenticationChallenge.cpp:
(WKAuthenticationChallengeGetProtectionSpace):
(WKAuthenticationChallengeGetProposedCredential):
* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextGetGeolocationManager):
(WKContextGetNotificationManager):
* Source/WebKit/UIProcess/API/C/WKInspector.cpp:
(WKInspectorGetPage):
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationGetUserContentController):
(WKPageConfigurationGetPreferences):
(WKPageConfigurationGetRelatedPage):
(WKPageConfigurationGetDefaultWebsitePolicies):
* Source/WebKit/UIProcess/API/C/WKWebsiteDataStoreRef.cpp:
(WKWebsiteDataStoreGetDefaultDataStore):
(WKWebsiteDataStoreGetHTTPCookieStore):
(WKWebsiteDataStoreClearAllDeviceOrientationPermissions):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload originalRequest]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction targetFrame]):
(-[WKNavigationAction _userInitiatedAction]):
(-[WKNavigationAction _mainFrameNavigation]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse _frame]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _objectForBundleParameter:]):
(-[WKProcessPool _notificationManagerForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm:
(-[WKURLSchemeTaskImpl _requestOnlyIfCached]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(-[WKWebExtensionContext webExtension]):
(-[WKWebExtensionContext webExtensionController]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionController.mm:
(-[WKWebExtensionController configuration]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfiguration.mm:
(-[WKWebExtensionControllerConfiguration defaultWebsiteDataStore]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _loadAndDecodeImage:constrainedToSize:maximumBytesFromNetwork:completionHandler:]):
(-[WKWebView _getContentsAsStringWithCompletionHandlerKeepIPCConnectionAliveForTesting:]):
(-[WKWebView _activePopupButtonCell]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration preferences]):
(-[WKWebViewConfiguration userContentController]):
(-[WKWebViewConfiguration _strongWebExtensionController]):
(-[WKWebViewConfiguration _weakWebExtensionController]):
(-[WKWebViewConfiguration defaultWebpagePreferences]):
(-[WKWebViewConfiguration _visitedLinkStore]):
(-[WKWebViewConfiguration _websiteDataStoreIfExists]):
(-[WKWebViewConfiguration _applicationManifest]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _synthesizeAppIsBackground:]):
(-[WKWebsiteDataStore _forceNetworkProcessToTaskSuspendForTesting]):
(-[WKWebsiteDataStore _getPendingPushMessage:]):
(-[WKWebsiteDataStore _getPendingPushMessages:]):
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClick:completionHandler:]):
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClose:completionHandler:]):
(-[WKWebsiteDataStore _getAllBackgroundFetchIdentifiers:]):
(-[WKWebsiteDataStore _getBackgroundFetchState:completionHandler:]):
(-[WKWebsiteDataStore _abortBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _pauseBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _resumeBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _clickBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _scopeURL:hasPushSubscriptionForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKDownload.mm:
(-[_WKDownload cancel]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
(-[_WKInspector unregisterExtension:completionHandler:]):
(-[_WKInspector showExtensionTabWithIdentifier:completionHandler:]):
(-[_WKInspector navigateExtensionTabWithIdentifier:toURL:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(-[_WKInspectorConfiguration applyToWebViewConfiguration:]):
(-[_WKInspectorConfiguration copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm:
(-[_WKRemoteWebInspectorViewController registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
(-[_WKRemoteWebInspectorViewController unregisterExtension:completionHandler:]):
(-[_WKRemoteWebInspectorViewController showExtensionTabWithIdentifier:completionHandler:]):
(-[_WKRemoteWebInspectorViewController navigateExtensionTabWithIdentifier:toURL:completionHandler:]):
* Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.cpp:
(WebKit::AuthenticationChallengeProxy::protectedProposedCredential const): Deleted.
(WebKit::AuthenticationChallengeProxy::protectedProtectionSpace const): Deleted.
* Source/WebKit/UIProcess/Authentication/AuthenticationChallengeProxy.h:
* Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm:
(WebKit::AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::removeVirtualAuthenticator):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::~AuxiliaryProcessProxy):
(WebKit::AuxiliaryProcessProxy::sendMessage):
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
(WebKit::AuxiliaryProcessProxy::wakeUpTemporarilyForIPC):
(WebKit::AuxiliaryProcessProxy::shutDownProcess):
(WebKit::AuxiliaryProcessProxy::setProcessSuppressionEnabled):
(WebKit::AuxiliaryProcessProxy::stopResponsivenessTimer):
(WebKit::AuxiliaryProcessProxy::startResponsivenessTimer):
(WebKit::AuxiliaryProcessProxy::initializationActivityAndGrant):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::throttler const):
(WebKit::AuxiliaryProcessProxy::responsivenessTimer const):
(WebKit::AuxiliaryProcessProxy::protectedThrottler): Deleted.
(WebKit::AuxiliaryProcessProxy::protectedThrottler const): Deleted.
(WebKit::AuxiliaryProcessProxy::protectedConnection const): Deleted.
(WebKit::AuxiliaryProcessProxy::protectedResponsivenessTimer const): Deleted.
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp:
(WebKit::BackgroundProcessResponsivenessTimer::responsivenessCheckTimerFired):
(WebKit::BackgroundProcessResponsivenessTimer::timeoutTimerFired):
(WebKit::BackgroundProcessResponsivenessTimer::protectedWebProcessProxy const): Deleted.
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h:
(WebKit::BackgroundProcessResponsivenessTimer::protectedClient const): Deleted.
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(WebKit::GroupActivitiesCoordinator::~GroupActivitiesCoordinator):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesSession.h:
(WebKit::GroupActivitiesSession::groupSession):
(WebKit::GroupActivitiesSession::protectedGroupSession): Deleted.
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::didReceiveResponse):
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
(WebKit::NavigationState::NavigationClient::didStartProvisionalLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailProvisionalLoadWithErrorForFrame):
(WebKit::NavigationState::NavigationClient::didCommitLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFinishLoadForFrame):
(WebKit::NavigationState::NavigationClient::didFailNavigationWithError):
(WebKit::NavigationState::NavigationClient::didFailLoadWithErrorForFrame):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::protectedControlsManagerInterface): Deleted.
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm:
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didSendRequest const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError const):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::complete):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::createNewPage):
(WebKit::UIDelegate::UIClient::focusFromServiceWorker):
(WebKit::UIDelegate::UIClient::protectedUIDelegatePrivate): Deleted.
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::backgroundActivity):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.h:
* Source/WebKit/UIProcess/Cocoa/WebPagePreferencesLockdownModeObserver.mm:
(WebKit::WebPagePreferencesLockdownModeObserver::willChangeLockdownMode):
(WebKit::WebPagePreferencesLockdownModeObserver::didChangeLockdownMode):
(WebKit::WebPagePreferencesLockdownModeObserver::protectedPolicies): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::createSandboxExtensionsIfNeeded):
(WebKit::WebPageProxy::tryToSendCommandToActiveControlledVideo):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::grantAccessToCurrentData):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::setProcessesShouldSuspend):
(WebKit::WebProcessPool::protectedBundleParameters): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::auditToken const):
(WebKit::WebProcessProxy::createLogStream):
(WebKit::WebProcessProxy::platformResumeProcess):
(WebKit::WebProcessProxy::platformSuspendProcess):
* Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h:
(WebKit::WebURLSchemeHandlerCocoa::apiHandler const):
* Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.mm:
(WebKit::WebURLSchemeHandlerCocoa::protectedAPIHandler const): Deleted.
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::cancel):
(WebKit::DownloadProxy::processDidClose):
(WebKit::DownloadProxy::didStart):
(WebKit::DownloadProxy::didReceiveAuthenticationChallenge):
(WebKit::DownloadProxy::willSendRequest):
(WebKit::DownloadProxy::didReceiveData):
(WebKit::DownloadProxy::decideDestinationWithSuggestedFilename):
(WebKit::DownloadProxy::didCreateDestination):
(WebKit::DownloadProxy::didFinish):
(WebKit::DownloadProxy::didFail):
(WebKit::DownloadProxy::protectedClient const): Deleted.
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
(WebKit::DownloadProxy::client):
(WebKit::DownloadProxy::protectedDataStore): Deleted.
* Source/WebKit/UIProcess/Downloads/DownloadProxyCocoa.mm:
(WebKit::DownloadProxy::publishProgress):
* Source/WebKit/UIProcess/DrawingAreaProxy.cpp:
(WebKit::DrawingAreaProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIActionCocoa.mm:
(WebKit::WebExtensionContext::actionOpenPopup):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICommandsCocoa.mm:
(WebKit::WebExtensionContext::isCommandsMessageAllowed):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::fetchCookies):
(WebKit::WebExtensionContext::cookiesGetAllCookieStores):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::loadDeclarativeNetRequestRulesetStateFromStorage):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
(WebKit::WebExtensionContext::removeListener):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsGetAll):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeWebPageSendMessage):
(WebKit::WebExtensionContext::runtimeWebPageConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(-[_WKWebExtensionActionViewController initWithWebExtensionAction:]):
(WebKit::WebExtensionAction::icon):
(WebKit::WebExtensionAction::popupPath const):
(WebKit::WebExtensionAction::popupWebViewInspectionName):
(WebKit::WebExtensionAction::popupWebView):
(WebKit::WebExtensionAction::label const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm:
(WebKit::WebExtensionCommand::platformMenuItem const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load):
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::getOrCreateSidebar):
(WebKit::WebExtensionContext::commands):
(WebKit::WebExtensionContext::singleMenuItemOrExtensionItemWithSubmenu const):
(WebKit::WebExtensionContext::backgroundPageIdentifier const):
(WebKit::WebExtensionContext::inspectorPageIdentifiers const):
(WebKit::WebExtensionContext::webViewConfiguration):
(WebKit::WebExtensionContext::loadBackgroundWebViewIfNeeded):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::scheduleBackgroundContentToUnload):
(WebKit::WebExtensionContext::unloadBackgroundContentIfPossible):
(WebKit::WebExtensionContext::loadBackgroundPageListenersFromStorage):
(WebKit::WebExtensionContext::saveBackgroundPageListenersToStorage):
(WebKit::WebExtensionContext::didFinishDocumentLoad):
(WebKit::WebExtensionContext::webViewWebContentProcessDidTerminate):
(WebKit::WebExtensionContext::openInspectors const):
(WebKit::WebExtensionContext::loadedInspectors const):
(WebKit::WebExtensionContext::inspectorExtension const):
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::isInspectorBackgroundPage const):
(WebKit::WebExtensionContext::isDevToolsMessageAllowed):
(WebKit::WebExtensionContext::loadInspectorBackgroundPagesDuringLoad):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPages):
(WebKit::WebExtensionContext::loadInspectorBackgroundPagesForPrivateBrowsing):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPagesForPrivateBrowsing):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
(WebKit::WebExtensionContext::unloadInspectorBackgroundPage):
(WebKit::WebExtensionContext::inspectorWillOpen):
(WebKit::WebExtensionContext::inspectorWillClose):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addWebsiteDataStore):
(WebKit::WebExtensionController::removeWebsiteDataStore):
(WebKit::WebExtensionController::isFeatureEnabled const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMenuItemCocoa.mm:
(WebKit::WebExtensionMenuItem::icon const):
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.cpp:
(WebKit::WebExtensionCommand::isActionCommand const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::errors):
(WebKit::WebExtensionContext::localization):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::injectedContents const):
(WebKit::WebExtensionContext::processDisplayName):
(WebKit::WebExtensionContext::loadBackgroundContent):
(WebKit::WebExtensionContext::backgroundWebViewInspectionName):
(WebKit::WebExtensionContext::wakeUpBackgroundContentIfNecessary):
(WebKit::WebExtensionContext::inspector const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::extension const):
(WebKit::WebExtensionContext::extensionController const):
(WebKit::WebExtensionContext::protectedExtension const): Deleted.
(WebKit::WebExtensionContext::protectedExtensionController const): Deleted.
(WebKit::WebExtensionContext::protectedDefaultAction): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
(WebKit::WebExtensionController::configuration const):
(WebKit::WebExtensionController::delegate const):
(WebKit::WebExtensionController::protectedConfiguration const): Deleted.
(WebKit::WebExtensionController::protectedWrapper const): Deleted.
(WebKit::WebExtensionController::protectedCookieStoreObserver): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
(WebKit::WebExtensionControllerConfiguration::protectedDefaultWebsiteDataStore const): Deleted.
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::updateSandboxAccess):
(WebKit::GPUProcessProxy::updateProcessAssertion):
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp:
(WebKit::RemoteWebInspectorUIProxy::frontendLoaded):
(WebKit::RemoteWebInspectorUIProxy::closeFrontendPageAndWindow):
(WebKit::RemoteWebInspectorUIProxy::protectedInspectorPage): Deleted.
(WebKit::RemoteWebInspectorUIProxy::protectedExtensionController const): Deleted.
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
(WebKit::RemoteWebInspectorUIProxy::extensionController const):
* Source/WebKit/UIProcess/Inspector/WebFrameInspectorTargetProxy.cpp:
(WebKit::WebFrameInspectorTargetProxy::connect):
(WebKit::WebFrameInspectorTargetProxy::disconnect):
(WebKit::WebFrameInspectorTargetProxy::sendMessageToTargetBackend):
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp:
(WebKit::WebInspectorBackendProxy::requestOpenLocalInspectorFrontend):
(WebKit::WebInspectorBackendProxy::didClose):
(WebKit::WebInspectorBackendProxy::bringToFront):
(WebKit::WebInspectorBackendProxy::elementSelectionChanged):
(WebKit::WebInspectorBackendProxy::timelineRecordingChanged):
(WebKit::WebInspectorBackendProxy::setDeveloperPreferenceOverride):
(WebKit::WebInspectorBackendProxy::setEmulatedConditions):
(WebKit::WebInspectorBackendProxy::attachAvailabilityChanged):
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h:
(WebKit::WebInspectorBackendProxy::protectedProxy const): Deleted.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose):
(WebKit::WebInspectorUIExtensionControllerProxy::registerExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::unregisterExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::createTabForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::reloadForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::showExtensionTab):
(WebKit::WebInspectorUIExtensionControllerProxy::navigateTabForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab):
(WebKit::WebInspectorUIExtensionControllerProxy::protectedInspectorPage const): Deleted.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::inspectionLevel const):
(WebKit::WebInspectorUIProxy::inspectorPagePreferences const):
(WebKit::WebInspectorUIProxy::updateForNewPageProcess):
(WebKit::WebInspectorUIProxy::attach):
(WebKit::WebInspectorUIProxy::detach):
(WebKit::WebInspectorUIProxy::setAttachedWindowHeight):
(WebKit::WebInspectorUIProxy::setAttachedWindowWidth):
(WebKit::WebInspectorUIProxy::createFrontendPage):
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::open):
(WebKit::WebInspectorUIProxy::closeFrontendPageAndWindow):
(WebKit::WebInspectorUIProxy::effectiveAppearanceDidChange):
(WebKit::WebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::WebInspectorUIProxy::save):
(WebKit::WebInspectorUIProxy::load):
(WebKit::WebInspectorUIProxy::pickColorFromScreen):
(WebKit::WebInspectorUIProxy::shouldOpenAttached):
(WebKit::WebInspectorUIProxy::protectedInspectorPagePreferences const): Deleted.
(WebKit::WebInspectorUIProxy::protectedExtensionController const): Deleted.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
(WebKit::WebInspectorUIProxy::inspectedPage const):
(WebKit::WebInspectorUIProxy::inspectorPage const):
(WebKit::WebInspectorUIProxy::extensionController const):
(WebKit::WebInspectorUIProxy::protectedInspectedPage const): Deleted.
(WebKit::WebInspectorUIProxy::protectedInspectorPage const): Deleted.
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::createWebPageInspectorTarget):
(WebKit::WebPageInspectorController::protectedInspectedPage): Deleted.
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::decidePolicyForNavigationAction):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowHeight):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowWidth):
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::didBecomeActive):
(WebKit::RemoteWebInspectorUIProxy::platformBringToFront):
(WebKit::RemoteWebInspectorUIProxy::platformSetForcedAppearance):
(WebKit::RemoteWebInspectorUIProxy::platformStartWindowDrag):
(WebKit::RemoteWebInspectorUIProxy::protectedWebView const): Deleted.
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::didBecomeActive):
(WebKit::WebInspectorUIProxy::platformCreateFrontendWindow):
(WebKit::WebInspectorUIProxy::platformAttach):
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::decidePolicyForNavigationAction):
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
(WebKit::WebInspectorUIProxy::platformAttach):
(WebKit::WebInspectorUIProxy::platformDetach):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowHeight):
(WebKit::WebInspectorUIProxy::platformSetAttachedWindowWidth):
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionClientProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
(WebKit::RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::seekSessionToTime):
(WebKit::RemoteMediaSessionCoordinatorProxy::playSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::pauseSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::setSessionTrack):
(WebKit::RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged):
(WebKit::RemoteMediaSessionCoordinatorProxy::protectedWebPageProxy): Deleted.
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionProxy.h:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::updateProcessAssertion):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::terminate):
(WebKit::NetworkProcessProxy::NetworkProcessProxy):
(WebKit::NetworkProcessProxy::dataTaskWithRequest):
(WebKit::NetworkProcessProxy::dataTaskReceivedChallenge):
(WebKit::NetworkProcessProxy::dataTaskWillPerformHTTPRedirection):
(WebKit::NetworkProcessProxy::dataTaskDidReceiveResponse):
(WebKit::NetworkProcessProxy::dataTaskDidReceiveData):
(WebKit::NetworkProcessProxy::deleteWebsiteData):
(WebKit::NetworkProcessProxy::networkProcessDidTerminate):
(WebKit::NetworkProcessProxy::updateProcessAssertion):
(WebKit::NetworkProcessProxy::cookiesDidChange):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::dispatchDidClickNotification):
(WebKit::WebNotificationManagerProxy::providerDidCloseNotifications):
(WebKit::setPushesAndNotificationsEnabledForOrigin):
(WebKit::removePushSubscriptionsForOrigins):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::protectedFrame const): Deleted.
(WebKit::ProvisionalFrameProxy::protectedProcess const): Deleted.
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
(WebKit::ProvisionalFrameProxy::frame const):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):
(WebKit::RemoteLayerTreeDrawingAreaProxy::updateDebugIndicator):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
(WebKit::RemoteLayerTreeHost::rootNode const):
(WebKit::RemoteLayerTreeHost::protectedRootNode const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::threadedAnimationsEnabled const):
(WebKit::RemoteLayerTreeHost::cssUnprefixedBackdropFilterEnabled const):
(WebKit::RemoteLayerTreeHost::updateBannerLayers):
(WebKit::RemoteLayerTreeHost::updateLayerTree):
(WebKit::RemoteLayerTreeHost::layerWillBeRemoved):
(WebKit::RemoteLayerTreeHost::animationDidStart):
(WebKit::RemoteLayerTreeHost::animationDidEnd):
(WebKit::RemoteLayerTreeHost::makeNode):
(WebKit::RemoteLayerTreeHost::animationsWereAddedToNode):
(WebKit::RemoteLayerTreeHost::animationsWereRemovedFromNode):
(WebKit::RemoteLayerTreeHost::timeline const):
(WebKit::RemoteLayerTreeHost::protectedDrawingArea const): Deleted.
(WebKit::RemoteLayerTreeHost::protectedRootLayer const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::detachFromParent):
(WebKit::RemoteLayerTreeNode::addToHostingNode):
(WebKit::RemoteLayerTreeNode::removeFromHostingNode):
(WebKit::RemoteLayerTreeNode::protectedLayer const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::stickyScrollingTreeNodeBeganSticking):
(WebKit::RemoteScrollingCoordinatorProxy::continueWheelEventHandling):
(WebKit::RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange):
(WebKit::RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxy::reportFilledVisibleFreshTile):
(WebKit::RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarVisibilityDidChange):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeScrollbarMinimumThumbLengthDidChange):
(WebKit::RemoteScrollingCoordinatorProxy::protectedWebPageProxy const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartPanGesture):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeDidEndScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::shouldAllowPanGestureRecognizerToReceiveTouches const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted):
(WebKit::RemoteLayerTreeEventDispatcher::displayLink const):
(WebKit::RemoteLayerTreeEventDispatcher::existingDisplayLink const):
(WebKit::RemoteLayerTreeEventDispatcher::animationsWereRemovedFromNode):
(WebKit::RemoteLayerTreeEventDispatcher::protectedDrawingAreaMac const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::setRubberBandingInProgressForNode):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.cpp:
(WebKit::SpeechRecognitionPermissionManager::protectedPage const): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
(WebKit::SuspendedPageProxy::protectedBackForwardCache const): Deleted.
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.cpp:
(WebKit::UserMediaPermissionRequestProxy::protectedManager const): Deleted.
* Source/WebKit/UIProcess/UserMediaPermissionRequestProxy.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::PendingSwipeTracker::scrollEventCanBecomeSwipe):
(WebKit::ViewGestureController::PendingSwipeTracker::tryToStartSwipe):
(WebKit::ViewGestureController::PendingSwipeTracker::protectedViewGestureController const): Deleted.
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.h:
(WebKit::Authenticator::observer const):
(WebKit::Authenticator::protectedObserver const): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::serviceStatusUpdated):
(WebKit::AuthenticatorManager::authenticatorStatusUpdated):
(WebKit::AuthenticatorManager::requestPin):
(WebKit::AuthenticatorManager::requestNewPin):
(WebKit::AuthenticatorManager::selectAssertionResponse):
(WebKit::AuthenticatorManager::decidePolicyForLocalAuthenticator):
(WebKit::AuthenticatorManager::requestLAContextForUserVerification):
(WebKit::AuthenticatorManager::invokePendingCompletionHandler):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueGetAssertionAfterResponseSelected):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::WebAuthenticationPanelClient::selectAssertionResponse const):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueSilentlyCheckCredentials):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterCheckExcludedCredentials):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
(WebKit::CtapAuthenticator::getAssertion):
(WebKit::CtapAuthenticator::continueGetAssertionAfterCheckAllowCredentials):
(WebKit::CtapAuthenticator::continueGetAssertionAfterResponseReceived):
(WebKit::CtapAuthenticator::continueGetNextAssertionAfterResponseReceived):
(WebKit::CtapAuthenticator::getRetries):
(WebKit::CtapAuthenticator::continueGetKeyAgreementAfterGetRetries):
(WebKit::CtapAuthenticator::continueGetPinTokenAfterRequestPin):
(WebKit::CtapAuthenticator::tryDowngrade):
(WebKit::CtapAuthenticator::continueSetupPinAfterCommand):
(WebKit::CtapAuthenticator::continueSetupPinAfterGetKeyAgreement):
(WebKit::CtapAuthenticator::setupPin):
(WebKit::CtapAuthenticator::performAuthenticatorSelectionForSetupPin):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp:
(WebKit::FidoAuthenticator::protectedDriver const): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::issueCommand):
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::takeSuspendedPage):
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::addItem):
(WebKit::WebBackForwardList::addChildItem):
(WebKit::WebBackForwardList::backForwardAllItems):
(WebKit::WebBackForwardList::backForwardItemAtIndex):
* Source/WebKit/UIProcess/WebContextMenuProxy.cpp:
(WebKit::WebContextMenuProxy::show):
(WebKit::WebContextMenuProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/WebContextMenuProxy.h:
(WebKit::WebContextMenuProxy::page const):
* Source/WebKit/UIProcess/WebContextSupplement.h:
(WebKit::WebContextSupplement::processPool):
(WebKit::WebContextSupplement::protectedProcessPool): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didHandleContentFilterUnblockNavigation):
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.cpp:
(WebKit::WebGeolocationManagerProxy::WebGeolocationManagerProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::addAllMessageReceivers):
(WebKit::WebPageProxy::handleMessage):
(WebKit::WebPageProxy::handleSynchronousMessage):
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadData):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::goForward):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::setControlledByAutomation):
(WebKit::WebPageProxy::setInitialFocus):
(WebKit::WebPageProxy::executeEditCommand):
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::performDragControllerAction):
(WebKit::WebPageProxy::disableServiceWorkerEntitlementInNetworkProcess):
(WebKit::WebPageProxy::clearServiceWorkerEntitlementOverride):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPageProxy::getContentsAsAttributedString):
(WebKit::WebPageProxy::didDestroyFrame):
(WebKit::WebPageProxy::preconnectTo):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrameShared):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFinishDocumentLoadForFrame):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::logFrameNavigation):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::WebPageProxy::willSubmitForm):
(WebKit::WebPageProxy::dataTaskWithRequest):
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::WebPageProxy::pageWillLikelyUseNotifications):
(WebKit::WebPageProxy::showNotification):
(WebKit::WebPageProxy::cancelNotification):
(WebKit::WebPageProxy::clearNotifications):
(WebKit::WebPageProxy::didDestroyNotification):
(WebKit::WebPageProxy::runModal):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
(WebKit::WebPageProxy::handleAutoFillButtonClick):
(WebKit::WebPageProxy::didResignInputElementStrongPasswordAppearance):
(WebKit::WebPageProxy::callAfterNextPresentationUpdate):
(WebKit::WebPageProxy::resetSpeechSynthesizer):
(WebKit::WebPageProxy::speechSynthesisVoiceList):
(WebKit::WebPageProxy::speechSynthesisSpeak):
(WebKit::WebPageProxy::speechSynthesisCancel):
(WebKit::WebPageProxy::speechSynthesisResetState):
(WebKit::WebPageProxy::speechSynthesisPause):
(WebKit::WebPageProxy::speechSynthesisResume):
(WebKit::WebPageProxy::appPrivacyReportTestingData):
(WebKit::WebPageProxy::clearAppPrivacyReportTestingData):
(WebKit::WebPageProxy::restoreSessionStorage):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
(WebKit::SpeechSynthesisData::protectedSynthesizer): Deleted.
* Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.cpp:
(WebKit::WebPageProxyMessageReceiverRegistration::Data::protectedProcess): Deleted.
* Source/WebKit/UIProcess/WebPageProxyMessageReceiverRegistration.h:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::WebPageProxyTesting::dumpPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::clearPrivateClickMeasurement):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementOverrideTimer):
(WebKit::WebPageProxyTesting::markAttributedPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementEphemeralMeasurement):
(WebKit::WebPageProxyTesting::simulatePrivateClickMeasurementSessionRestart):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenPublicKeyURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementTokenSignatureURL):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAttributionReportURLs):
(WebKit::WebPageProxyTesting::markPrivateClickMeasurementsAsExpired):
(WebKit::WebPageProxyTesting::setPCMFraudPreventionValues):
(WebKit::WebPageProxyTesting::setPrivateClickMeasurementAppBundleID):
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::takeVisibleActivity):
(WebKit::WebProcessActivityState::takeAudibleActivity):
(WebKit::WebProcessActivityState::takeCapturingActivity):
(WebKit::WebProcessActivityState::takeNetworkActivity):
(WebKit::WebProcessActivityState::dropVisibleActivity):
(WebKit::WebProcessActivityState::takeOpeningAppLinkActivity):
(WebKit::WebProcessActivityState::takeAccessibilityActivity):
(WebKit::WebProcessActivityState::protectedProcess const): Deleted.
* Source/WebKit/UIProcess/WebProcessActivityState.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::CachedProcess::startSuspensionTimer):
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::initializeNewWebProcess):
(WebKit::WebProcessPool::processDidFinishLaunching):
(WebKit::WebProcessPool::disconnectProcess):
(WebKit::WebProcessPool::createWebPage):
(WebKit::WebProcessPool::handleMessage):
(WebKit::WebProcessPool::handleSynchronousMessage):
(WebKit::WebProcessPool::processForNavigation):
(WebKit::WebProcessPool::prepareProcessForNavigation):
(WebKit::WebProcessPool::updateAudibleMediaAssertions):
(WebKit::WebProcessPool::memoryPressureStatusChangedForProcess):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::setWebsiteDataStore):
(WebKit::WebProcessProxy::assumeReadAccessToBaseURL):
(WebKit::WebProcessProxy::assumeReadAccessToBaseURLs):
(WebKit::WebProcessProxy::setIgnoreInvalidMessageForTesting):
(WebKit::WebProcessProxy::didFinishLaunching):
(WebKit::WebProcessProxy::didStartProvisionalLoadForMainFrame):
(WebKit::WebProcessProxy::startBackgroundActivityForFullscreenInput):
(WebKit::WebProcessProxy::updateRemoteWorkerProcessAssertion):
(WebKit::operator&lt;&lt;):
(WebKit::WebProcessProxy::takeInvalidMessageStringForTesting):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::protectedPage const): Deleted.
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/WebURLSchemeTask.cpp:
(WebKit::WebURLSchemeTask::nsRequest const):
(WebKit::WebURLSchemeTask::protectedNSRequest const): Deleted.
* Source/WebKit/UIProcess/WebURLSchemeTask.h:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::networkProcessHasEntitlementForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::defaultDataStore):
(WebKit::WebsiteDataStore::fetchDomainsWithUserInteraction):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::setServiceWorkerTimeoutForTesting):
(WebKit::WebsiteDataStore::resetServiceWorkerTimeoutForTesting):
(WebKit::WebsiteDataStore::runningOrTerminatingServiceWorkerCountForTesting):
(WebKit::WebsiteDataStore::setMaxStatisticsEntries):
(WebKit::WebsiteDataStore::setPruneEntriesDownTo):
(WebKit::WebsiteDataStore::setGrandfatheringTime):
(WebKit::WebsiteDataStore::setMinimumTimeBetweenDataRecordsRemoval):
(WebKit::WebsiteDataStore::dumpResourceLoadStatistics):
(WebKit::WebsiteDataStore::isPrevalentResource):
(WebKit::WebsiteDataStore::isGrandfathered):
(WebKit::WebsiteDataStore::setPrevalentResource):
(WebKit::WebsiteDataStore::setPrevalentResourceForDebugMode):
(WebKit::WebsiteDataStore::isVeryPrevalentResource):
(WebKit::WebsiteDataStore::setVeryPrevalentResource):
(WebKit::WebsiteDataStore::setShouldClassifyResourcesBeforeDataRecordsRemoval):
(WebKit::WebsiteDataStore::setSubframeUnderTopFrameDomain):
(WebKit::WebsiteDataStore::isRegisteredAsSubFrameUnder):
(WebKit::WebsiteDataStore::setSubresourceUnderTopFrameDomain):
(WebKit::WebsiteDataStore::isRegisteredAsSubresourceUnder):
(WebKit::WebsiteDataStore::setSubresourceUniqueRedirectTo):
(WebKit::WebsiteDataStore::setSubresourceUniqueRedirectFrom):
(WebKit::WebsiteDataStore::setTopFrameUniqueRedirectTo):
(WebKit::WebsiteDataStore::setTopFrameUniqueRedirectFrom):
(WebKit::WebsiteDataStore::isRegisteredAsRedirectingTo):
(WebKit::WebsiteDataStore::clearPrevalentResource):
(WebKit::WebsiteDataStore::resetParametersToDefaultValues):
(WebKit::WebsiteDataStore::scheduleClearInMemoryAndPersistent):
(WebKit::WebsiteDataStore::getResourceLoadStatisticsDataSummary):
(WebKit::WebsiteDataStore::scheduleCookieBlockingUpdate):
(WebKit::WebsiteDataStore::scheduleStatisticsAndDataRecordsProcessing):
(WebKit::WebsiteDataStore::statisticsDatabaseHasAllTables):
(WebKit::WebsiteDataStore::setLastSeen):
(WebKit::WebsiteDataStore::domainIDExistsInDatabase):
(WebKit::WebsiteDataStore::mergeStatisticForTesting):
(WebKit::WebsiteDataStore::insertExpiredStatisticForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsTimeAdvanceForTesting):
(WebKit::WebsiteDataStore::setStorageAccessPromptQuirkForTesting):
(WebKit::WebsiteDataStore::grantStorageAccessForTesting):
(WebKit::WebsiteDataStore::setIsRunningResourceLoadStatisticsTest):
(WebKit::WebsiteDataStore::getAllStorageAccessEntries):
(WebKit::WebsiteDataStore::setTimeToLiveUserInteraction):
(WebKit::WebsiteDataStore::logUserInteraction):
(WebKit::WebsiteDataStore::hasHadUserInteraction):
(WebKit::WebsiteDataStore::isRelationshipOnlyInDatabaseOnce):
(WebKit::WebsiteDataStore::clearUserInteraction):
(WebKit::WebsiteDataStore::setGrandfathered):
(WebKit::WebsiteDataStore::setCrossSiteLoadWithLinkDecorationForTesting):
(WebKit::WebsiteDataStore::resetCrossSiteLoadsWithLinkDecorationForTesting):
(WebKit::WebsiteDataStore::deleteCookiesForTesting):
(WebKit::WebsiteDataStore::hasLocalStorageOrCookies const):
(WebKit::WebsiteDataStore::hasLocalStorageForTesting const):
(WebKit::WebsiteDataStore::hasIsolatedSessionForTesting const):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsShouldDowngradeReferrerForTesting):
(WebKit::WebsiteDataStore::setThirdPartyCookieBlockingMode):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsShouldEnbleSameSiteStrictEnforcementForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsFirstPartyWebsiteDataRemovalModeForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsToSameSiteStrictCookiesForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsFirstPartyHostCNAMEDomainForTesting):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsThirdPartyCNAMEDomainForTesting):
(WebKit::WebsiteDataStore::syncLocalStorage):
(WebKit::WebsiteDataStore::storeServiceWorkerRegistrations):
(WebKit::WebsiteDataStore::setCacheMaxAgeCapForPrevalentResources):
(WebKit::WebsiteDataStore::resetCacheMaxAgeCapForPrevalentResources):
(WebKit::WebsiteDataStore::allowSpecificHTTPSCertificateForHost):
(WebKit::WebsiteDataStore::allowTLSCertificateChainForLocalPCMTesting):
(WebKit::WebsiteDataStore::sendNetworkProcessPrepareToSuspendForTesting):
(WebKit::WebsiteDataStore::sendNetworkProcessWillSuspendImminentlyForTesting):
(WebKit::WebsiteDataStore::sendNetworkProcessDidResume):
(WebKit::WebsiteDataStore::setStatisticsTestingCallback):
(WebKit::WebsiteDataStore::setResourceLoadStatisticsDebugMode):
(WebKit::WebsiteDataStore::isResourceLoadStatisticsEphemeral const):
(WebKit::WebsiteDataStore::setPrivateClickMeasurementDebugMode):
(WebKit::WebsiteDataStore::storePrivateClickMeasurement):
(WebKit::WebsiteDataStore::simulatePrivateClickMeasurementConversion):
(WebKit::WebsiteDataStore::setPrivateTokenIPCForTesting):
(WebKit::WebsiteDataStore::virtualAuthenticatorManager):
(WebKit::WebsiteDataStore::resetQuota):
(WebKit::WebsiteDataStore::resetStoragePersistedState):
(WebKit::WebsiteDataStore::renameOriginInWebsiteData):
(WebKit::WebsiteDataStore::originDirectoryForTesting):
(WebKit::WebsiteDataStore::hasAppBoundSession const):
(WebKit::WebsiteDataStore::clearAppBoundSession):
(WebKit::WebsiteDataStore::setAppBoundDomainsForITP):
(WebKit::WebsiteDataStore::setManagedDomainsForITP):
(WebKit::WebsiteDataStore::updateBundleIdentifierInNetworkProcess):
(WebKit::WebsiteDataStore::clearBundleIdentifierInNetworkProcess):
(WebKit::WebsiteDataStore::countNonDefaultSessionSets):
(WebKit::WebsiteDataStore::setEmulatedConditions):
(WebKit::WebsiteDataStore::createDownloadProxy):
(WebKit::WebsiteDataStore::download):
(WebKit::WebsiteDataStore::resumeDownload):
(WebKit::WebsiteDataStore::clearProxyConfigData):
(WebKit::WebsiteDataStore::setProxyConfigData):
(WebKit::WebsiteDataStore::processPushMessage):
(WebKit::WebsiteDataStore::fetchLocalStorage):
(WebKit::WebsiteDataStore::restoreLocalStorage):
(WebKit::WebsiteDataStore::resetResourceMonitorThrottlerForTesting):
(WebKit::WebsiteDataStore::setCookies):
(WebKit::WebsiteDataStore::setStorageAccessPermissionForTesting):
(WebKit::WebsiteDataStore::clearStorageAccessForTesting):
(WebKit::WebsiteDataStore::isStorageSuspendedForTesting const):
(WebKit::WebsiteDataStore::protectedDefaultDataStore): Deleted.
(WebKit::WebsiteDataStore::protectedNetworkProcess const): Deleted.
(WebKit::WebsiteDataStore::protectedAuthenticatorManager): Deleted.
(WebKit::WebsiteDataStore::protectedVirtualAuthenticatorManager): Deleted.
(WebKit::WebsiteDataStore::protectedCookieStore): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::authenticatorManager):
(WebKit::WebsiteDataStore::deviceOrientationAndMotionAccessController):
(WebKit::WebsiteDataStore::protectedDeviceOrientationAndMotionAccessController): Deleted.
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
* Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::validateUserMediaRequestConstraints):
(WebKit::UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView ensurePositionInformationIsUpToDate:]):
(-[WKContentView _handleDOMPasteRequestWithResult:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::selectTextWithGranularityAtPoint):
(WebKit::WebPageProxy::selectPositionAtBoundaryWithDirection):
(WebKit::WebPageProxy::moveSelectionAtBoundaryWithDirection):
(WebKit::WebPageProxy::selectPositionAtPoint):
(WebKit::WebPageProxy::moveSelectionByOffset):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::focusNextFocusedElement):
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::setRemoteLayerTreeRootNode):
(WebKit::PageClientImpl::isFullScreen):
(WebKit::PageClient::protectedViewForPresentingRevealPopover const): Deleted.
* Source/WebKit/UIProcess/mac/SecItemShimProxy.cpp:
(WebKit::SecItemShimProxy::secItemRequest):
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm:
(WebKit::UserMediaPermissionRequestProxyMac::invalidate):
(WebKit::UserMediaPermissionRequestProxyMac::promptForGetDisplayMedia):
* Source/WebKit/UIProcess/mac/WKTextAnimationManagerMac.mm:
(-[WKTextAnimationManager initWithWebViewImpl:]):
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::createMenuActionItem):
(WebKit::WebContextMenuProxyMac::useContextMenuItems):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::readSelectionFromPasteboard):
(WebKit::WebPageProxy::didPerformDictionaryLookup):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::acceptsFirstMouse):
(WebKit::WebPageProxy::showTelephoneNumberMenu):
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.h:
* Source/WebKit/UIProcess/mac/WebPopupMenuProxyMac.mm:
(WebKit::WebPopupMenuProxyMac::populate):
(WebKit::WebPopupMenuProxyMac::hidePopupMenu):
(WebKit::WebPopupMenuProxyMac::cancelTracking):
(WebKit::WebPopupMenuProxyMac::popup const):
(WebKit::WebPopupMenuProxyMac::menu const):
(WebKit::WebPopupMenuProxyMac::protectedPopup const): Deleted.
(WebKit::WebPopupMenuProxyMac::protectedMenu const): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKImageAnalysisOverlayViewDelegate firstResponderIsInsideImageOverlay]):
(-[WKImageAnalysisOverlayViewDelegate contentsRectForImageAnalysisOverlayView:]):
(WebKit::WebViewImpl::pageDidScroll):
(WebKit::WebViewImpl::videoControlsManagerDidChange):
(WebKit::WebViewImpl::toolTipOwnerForSendingMouseEvents const):
(WebKit::WebViewImpl::provideDataForPasteboard):
(WebKit::WebViewImpl::namesOfPromisedFilesDroppedAtDestination):
(WebKit::WebViewImpl::windowRelativeBoundsForCustomSwipeViews const):
(WebKit::WebViewImpl::ensureImageAnalyzer):
(WebKit::WebViewImpl::protectedFullScreenWindowController): Deleted.
(WebKit::WebViewImpl::protectedGestureController const): Deleted.

Canonical link: <a href="https://commits.webkit.org/306257@main">https://commits.webkit.org/306257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/240787e715fe104079bb60db175cf400a1f556a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149185 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108005 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143750 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88908 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7902 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9232 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132777 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151762 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1597 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116272 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12884 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116609 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29651 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/12610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122684 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12912 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172091 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76612 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/44641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12695 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->