### PR TITLE
[ImageLoader] Refactor updateFromElement() with early returns and cleaner structure

### DIFF
--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -205,6 +205,8 @@ void ImageLoader::clearImageWithoutConsideringPendingLoadEvent()
 
 void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 {
+    // This is implementing https://html.spec.whatwg.org/#update-the-image-data
+    //
     // If we're not making renderers for the page, then don't load images. We don't want to slow
     // down the raw HTML parsing case by loading images we don't intend to display.
     Ref element = this->element();
@@ -220,111 +222,123 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     if (!m_failedLoadURL.isEmpty() && attr == m_failedLoadURL)
         return;
 
-    // Do not load any image if the 'src' attribute is missing or if it is
-    // an empty string.
     CachedResourceHandle<CachedImage> newImage;
-    if (!attr.isNull() && !StringView(attr).containsOnly<isASCIIWhitespace<char16_t>>()) {
-        ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
-        auto loadingForElementInShadowTree = element->isInUserAgentShadowTree() || m_elementIsUserAgentShadowRootResource;
-        options.contentSecurityPolicyImposition = loadingForElementInShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
-        options.shouldEnableContentExtensionsCheck = loadingForElementInShadowTree ? ShouldEnableContentExtensionsCheck::No : ShouldEnableContentExtensionsCheck::Yes;
-        options.loadedFromPluginElement = is<HTMLPlugInElement>(element) ? LoadedFromPluginElement::Yes : LoadedFromPluginElement::No;
-        options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
-        options.serviceWorkersMode = is<HTMLPlugInElement>(element) ? ServiceWorkersMode::None : ServiceWorkersMode::All;
-        RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element);
-        if (imageElement) {
-            options.referrerPolicy = imageElement->referrerPolicy();
-            options.fetchPriority = imageElement->fetchPriority();
-            if (imageElement->usesSrcsetOrPicture())
-                options.initiator = Initiator::Imageset;
-        }
 
-        auto crossOriginAttribute = element->attributeWithoutSynchronization(HTMLNames::crossoriginAttr);
+    // Do not load any image if the 'src' attribute is missing.
+    if (attr.isNull()) {
+        didUpdateCachedImage(relevantMutation, WTF::move(newImage));
+        return;
+    }
 
-        // Use URL from original request for same URL loads in order to preserve the original base URL.
-        URL imageURL;
-        if (m_image && attr == m_pendingURL)
-            imageURL = m_image->url();
-        else {
-            if (imageElement) {
-                // It is possible that attributes are bulk-set via Element::parserSetAttributes. In that case, it is possible that attribute vectors are already configured,
-                // but corresponding attributeChanged is not called yet. This causes inconsistency in HTMLImageElement. Eventually, we will get the consistent state, but
-                // if "src" attributeChanged is not called yet, imageURL can be null and it does not work well for ResourceRequest.
-                // In this case, we should behave same as attr.isNull().
-                imageURL = imageElement->currentURL();
-                if (imageURL.isNull()) {
-                    didUpdateCachedImage(relevantMutation, WTF::move(newImage));
-                    return;
-                }
-            } else
-                imageURL = document->completeURL(attr);
-            m_pendingURL = attr;
-        }
-        ResourceRequest resourceRequest(WTF::move(imageURL));
-        resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(element));
-
-        auto request = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), document, crossOriginAttribute);
-        request.setInitiator(element);
-
-        if (m_loadManually) {
-            Ref cachedResourceLoader = document->cachedResourceLoader();
-            bool autoLoadOtherImages = cachedResourceLoader->autoLoadImages();
-            cachedResourceLoader->setAutoLoadImages(false);
-            RefPtr page = m_element->document().page();
-            // FIXME: We shouldn't do an explicit `new` here.
-            newImage = new CachedImage(WTF::move(request), page->sessionID(), &page->cookieJar());
-            newImage->setStatus(CachedResource::Pending);
-            newImage->setLoading(true);
-            cachedResourceLoader->m_documentResources.set(newImage->url().string(), newImage.get());
-            cachedResourceLoader->setAutoLoadImages(autoLoadOtherImages);
-        } else {
-#if !LOG_DISABLED
-            auto oldState = m_lazyImageLoadState;
-#endif
-            if (m_lazyImageLoadState == LazyImageLoadState::None && imageElement) {
-                if (imageElement->isLazyLoadable() && document->settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
-                    m_lazyImageLoadState = LazyImageLoadState::Deferred;
-                    request.setIgnoreForRequestCount(true);
-                }
-            }
-            auto imageLoading = (m_lazyImageLoadState == LazyImageLoadState::Deferred) ? ImageLoading::DeferredUntilVisible : ImageLoading::Immediate;
-            newImage = protect(document->cachedResourceLoader())->requestImage(WTF::move(request), imageLoading).value_or(nullptr);
-            LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement " << element.get() << " - state changed from " << oldState << " to " << m_lazyImageLoadState << ", loading is " << imageLoading << " new image " << newImage.get());
-        }
-
-#if ENABLE(MULTI_REPRESENTATION_HEIC)
-        // Adaptive image glyphs need to load both the high fidelity HEIC and the
-        // fallback PNG resource, as both resources are treated as an atomic unit.
-        if (imageElement && imageElement->isMultiRepresentationHEIC()) {
-            auto fallbackURL = imageElement->getURLAttribute(HTMLNames::srcAttr);
-            if (!fallbackURL.isNull()) {
-                ResourceRequest resourceRequest(WTF::move(fallbackURL));
-                resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*imageElement));
-
-                auto request = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), document, crossOriginAttribute);
-                request.setInitiator(*imageElement);
-
-                protect(document->cachedResourceLoader())->requestImage(WTF::move(request));
-            }
-        }
-#endif
-
-        // If we do not have an image here, it means that a cross-site
-        // violation occurred, or that the image was blocked via Content
-        // Security Policy, or the page is being dismissed. Trigger an
-        // error event if the page is not being dismissed.
-        if (!newImage && !pageIsBeingDismissed(document)) {
-            m_failedLoadURL = attr;
-            m_hasPendingErrorEvent = true;
-            loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
-        } else
-            clearFailedLoadURL();
-    } else if (!attr.isNull()) {
-        // Fire an error event if the url is empty.
+    // Fire an error event if the URL contains only whitespace.
+    if (StringView(attr).containsOnly<isASCIIWhitespace<char16_t>>()) {
         m_failedLoadURL = attr;
         m_hasPendingErrorEvent = true;
         loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
+        didUpdateCachedImage(relevantMutation, WTF::move(newImage));
+        return;
     }
+
+    // Set up resource loading options.
+    ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
+    auto loadingForElementInShadowTree = element->isInUserAgentShadowTree() || m_elementIsUserAgentShadowRootResource;
+    options.contentSecurityPolicyImposition = loadingForElementInShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
+    options.shouldEnableContentExtensionsCheck = loadingForElementInShadowTree ? ShouldEnableContentExtensionsCheck::No : ShouldEnableContentExtensionsCheck::Yes;
+    options.loadedFromPluginElement = is<HTMLPlugInElement>(element) ? LoadedFromPluginElement::Yes : LoadedFromPluginElement::No;
+    options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
+    options.serviceWorkersMode = is<HTMLPlugInElement>(element) ? ServiceWorkersMode::None : ServiceWorkersMode::All;
+    RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element);
+    if (imageElement) {
+        options.referrerPolicy = imageElement->referrerPolicy();
+        options.fetchPriority = imageElement->fetchPriority();
+        if (imageElement->usesSrcsetOrPicture())
+            options.initiator = Initiator::Imageset;
+    }
+
+    auto crossOriginAttribute = element->attributeWithoutSynchronization(HTMLNames::crossoriginAttr);
+
+    // Use URL from original request for same URL loads in order to preserve the original base URL.
+    URL imageURL;
+    if (m_image && attr == m_pendingURL)
+        imageURL = m_image->url();
+    else {
+        if (imageElement) {
+            // It is possible that attributes are bulk-set via Element::parserSetAttributes. In that case, it is possible that attribute vectors are already configured,
+            // but corresponding attributeChanged is not called yet. This causes inconsistency in HTMLImageElement. Eventually, we will get the consistent state, but
+            // if "src" attributeChanged is not called yet, imageURL can be invalid and it does not work well for ResourceRequest.
+            // In this case, we should behave same as attr.isNull().
+            imageURL = imageElement->currentURL();
+            if (imageURL.isNull()) {
+                didUpdateCachedImage(relevantMutation, WTF::move(newImage));
+                return;
+            }
+        } else
+            imageURL = document->completeURL(attr);
+        m_pendingURL = attr;
+    }
+    ResourceRequest resourceRequest(WTF::move(imageURL));
+    resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(element));
+
+    auto request = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), document, crossOriginAttribute);
+    request.setInitiator(element);
+
+    if (m_loadManually) {
+        Ref cachedResourceLoader = document->cachedResourceLoader();
+        bool autoLoadOtherImages = cachedResourceLoader->autoLoadImages();
+        cachedResourceLoader->setAutoLoadImages(false);
+        RefPtr page = m_element->document().page();
+        // FIXME: We shouldn't do an explicit `new` here.
+        newImage = new CachedImage(WTF::move(request), page->sessionID(), &page->cookieJar());
+        newImage->setStatus(CachedResource::Pending);
+        newImage->setLoading(true);
+        cachedResourceLoader->m_documentResources.set(newImage->url().string(), newImage.get());
+        cachedResourceLoader->setAutoLoadImages(autoLoadOtherImages);
+    } else {
+#if !LOG_DISABLED
+        auto oldState = m_lazyImageLoadState;
+#endif
+        if (m_lazyImageLoadState == LazyImageLoadState::None && imageElement) {
+            if (imageElement->isLazyLoadable() && document->settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
+                m_lazyImageLoadState = LazyImageLoadState::Deferred;
+                request.setIgnoreForRequestCount(true);
+            }
+        }
+        auto imageLoading = (m_lazyImageLoadState == LazyImageLoadState::Deferred) ? ImageLoading::DeferredUntilVisible : ImageLoading::Immediate;
+        newImage = protect(document->cachedResourceLoader())->requestImage(WTF::move(request), imageLoading).value_or(nullptr);
+        LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement " << element.get() << " - state changed from " << oldState << " to " << m_lazyImageLoadState << ", loading is " << imageLoading << " new image " << newImage.get());
+    }
+
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    // Adaptive image glyphs need to load both the high fidelity HEIC and the
+    // fallback PNG resource, as both resources are treated as an atomic unit.
+    if (imageElement && imageElement->isMultiRepresentationHEIC()) {
+        auto fallbackURL = imageElement->getURLAttribute(HTMLNames::srcAttr);
+        if (!fallbackURL.isNull()) {
+            ResourceLoaderOptions fallbackOptions = CachedResourceLoader::defaultCachedResourceOptions();
+            fallbackOptions.contentSecurityPolicyImposition = loadingForElementInShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
+            fallbackOptions.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
+
+            ResourceRequest fallbackResourceRequest(WTF::move(fallbackURL));
+            fallbackResourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*imageElement));
+
+            auto fallbackRequest = createPotentialAccessControlRequest(WTF::move(fallbackResourceRequest), WTF::move(fallbackOptions), document, crossOriginAttribute);
+            fallbackRequest.setInitiator(*imageElement);
+
+            protect(document->cachedResourceLoader())->requestImage(WTF::move(fallbackRequest));
+        }
+    }
+#endif
+
+    // If we do not have an image here, it means that a cross-site
+    // violation occurred, or that the image was blocked via Content
+    // Security Policy, or the page is being dismissed. Trigger an
+    // error event if the page is not being dismissed.
+    if (!newImage && !pageIsBeingDismissed(document)) {
+        m_failedLoadURL = attr;
+        m_hasPendingErrorEvent = true;
+        loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
+    } else
+        clearFailedLoadURL();
 
     didUpdateCachedImage(relevantMutation, WTF::move(newImage));
 }


### PR DESCRIPTION
### Related PRs
- PR 1: https://github.com/WebKit/WebKit/pull/57251 
- PR 2: https://github.com/WebKit/WebKit/pull/57252
- PR 3: https://github.com/WebKit/WebKit/pull/57253


#### f93a23d146509aa942534c9dc4bf1a1dac43d97e
<pre>
[ImageLoader] Refactor updateFromElement() with early returns and cleaner structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=190031">https://bugs.webkit.org/show_bug.cgi?id=190031</a>

Reviewed by Brent Fulgham.

Refactor ImageLoader::updateFromElement() to use early returns and reduce
nesting. This prepares for adding microtask-based loading in a follow-up.

* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):

Canonical link: <a href="https://commits.webkit.org/307625@main">https://commits.webkit.org/307625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c9f5c735b5bcda6c716428194b3538cbb52a230

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111430 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92325 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1038 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17453 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119435 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119763 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30728 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15565 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128141 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73075 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17075 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6439 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16811 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80854 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->