### PR TITLE
[ImageLoader] Defer image loading to microtask per HTML spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/attribute-order-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/attribute-order-expected.txt
@@ -1,0 +1,6 @@
+
+PASS srcset and src setting order does not matter
+PASS srcset and sizes setting order does not matter
+PASS srcset and loading setting order does not matter
+PASS Image loading is triggered after a microtask
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/attribute-order.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/attribute-order.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<title>Verify srcset attribute setting order does not impact the outcome</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async function attribute_order_test(set_attributes, unexpected_request, description) {
+  promise_test(async t => {
+    const img = new Image();
+    set_attributes(img);
+    await new Promise((resolve, reject) => {
+      const observer = new PerformanceObserver(list => {
+        const entries = list.getEntries();
+        for (const entry of entries) {
+          if (entry.name.endsWith(unexpected_request)) {
+            reject(`The ${unexpected_request} resource should not be fetched`);
+            observer.disconnect();
+          }
+        }
+      });
+      observer.observe({entryTypes: ["resource"]});
+      t.step_timeout(resolve, 500);
+    });
+  }, description);
+}
+
+async function microtask_test(set_attributes_once, set_attributes_twice, expected_requests, unexpected_requests, description) {
+  promise_test(async t => {
+    const img = new Image();
+    set_attributes_once(img);
+    await window.queueMicrotask(()=>{});
+    set_attributes_twice(img);
+    let expected_requests_counter = 0;
+    await new Promise((resolve, reject) => {
+      const observer = new PerformanceObserver(list => {
+        const entries = list.getEntries();
+        for (const entry of entries) {
+          for (const unexpected_request of unexpected_requests) {
+            if (entry.name.endsWith(unexpected_request)) {
+              reject(`The ${unexpected_request} resource should not be fetched`);
+              observer.disconnect();
+            }
+          }
+          for (const expected_request of expected_requests) {
+            if (entry.name.endsWith(expected_request)) {
+              ++expected_requests_counter;
+            }
+          }
+        }
+      });
+      observer.observe({entryTypes: ["resource"]});
+      t.step_timeout(resolve, 500);
+    });
+    assert_equals(expected_requests_counter, expected_requests.length);
+  }, description);
+}
+
+attribute_order_test(img => {
+  img.src = "/images/green.png?src";
+  img.srcset = "/images/green.png?srcset 1x";
+}, "?src", "srcset and src setting order does not matter");
+
+attribute_order_test(img => {
+  img.srcset = "/images/green.png?tiny 100w, /images/green.png?huge 1000w";
+  img.sizes = "1vw";
+}, "?huge", "srcset and sizes setting order does not matter");
+
+attribute_order_test(img => {
+  img.srcset = "/images/green.png?srcset_lazy 1x";
+  img.loading = "lazy"
+}, "?srcset_lazy", "srcset and loading setting order does not matter");
+
+microtask_test(img => {
+  img.src = "/images/green.png?src1";
+  img.srcset = "/images/green.png?srcset1 1x";
+},
+img => {
+  img.src = "/images/green.png?src2";
+  img.srcset = "/images/green.png?srcset2 1x";
+}, ["?srcset1", "?srcset2"],
+["?src1", "?src2"], "Image loading is triggered after a microtask");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/list-of-available-images-matching.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/list-of-available-images-matching.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS registering service worker
-FAIL list of available images tuple-matching logic assert_false: The image is not fetched with mode: no-cors expected false got true
+PASS list of available images tuple-matching logic
 PASS unregistering service worker
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-image-data/lazy-out-of-band-load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-image-data/lazy-out-of-band-load-expected.txt
@@ -1,4 +1,5 @@
 
+
 FAIL src = /images/green.png assert_unreached: load: should never try to load Reached unreachable code
 FAIL src = /images/not-found assert_unreached: error: should never try to load Reached unreachable code
 FAIL srcset = /images/green.png assert_unreached: load: should never try to load Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-image-data/src-then-lazy-load-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/update-the-image-data/src-then-lazy-load-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL src = /images/green.png 1 time(s) assert_unreached: load: should never try to load Reached unreachable code
-FAIL src = /images/green.png 2 time(s) assert_unreached: load: should never try to load Reached unreachable code
-FAIL src = /images/not-found 1 time(s) assert_unreached: error: should never try to load Reached unreachable code
-FAIL src = /images/not-found 2 time(s) assert_unreached: error: should never try to load Reached unreachable code
-FAIL srcset = /images/green.png 1 time(s) assert_unreached: load: should never try to load Reached unreachable code
-FAIL srcset = /images/green.png 2 time(s) assert_unreached: load: should never try to load Reached unreachable code
-FAIL srcset = /images/not-found 1 time(s) assert_unreached: error: should never try to load Reached unreachable code
-FAIL srcset = /images/not-found 2 time(s) assert_unreached: error: should never try to load Reached unreachable code
+PASS src = /images/green.png 1 time(s)
+PASS src = /images/green.png 2 time(s)
+PASS src = /images/not-found 1 time(s)
+PASS src = /images/not-found 2 time(s)
+PASS srcset = /images/green.png 1 time(s)
+PASS srcset = /images/green.png 2 time(s)
+PASS srcset = /images/not-found 1 time(s)
+PASS srcset = /images/not-found 2 time(s)
 

--- a/LayoutTests/inspector/worker/resources/resource-utilities.js
+++ b/LayoutTests/inspector/worker/resources/resource-utilities.js
@@ -9,6 +9,8 @@ function loadResourceFetch(path) {
 }
 
 function loadResourceDOM(path) {
-    let img = document.body.appendChild(document.createElement("img"));
-    img.src = path + "?" + Math.random();
+    let style = document.createElement("link");
+    style.rel = "stylesheet";
+    style.href = path + "?" + Math.random();
+    document.head.appendChild(style);
 }

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2096,6 +2096,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/WorkerClient.h
 
     page/csp/CSPViolationReportBody.h
+    page/csp/CodePosition.h
     page/csp/ContentSecurityPolicy.h
     page/csp/ContentSecurityPolicyClient.h
     page/csp/ContentSecurityPolicyHash.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -3967,6 +3967,7 @@
 		97BC849B12370A4B000C6161 /* HTMLInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 97BC849A12370A4B000C6161 /* HTMLInputStream.h */; };
 		97BC84B412371180000C6161 /* TextDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 97BC84B212371180000C6161 /* TextDocument.h */; };
 		97C078501165D5BE003A32EF /* SuffixTree.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C0784F1165D5BE003A32EF /* SuffixTree.h */; };
+		0AEF5B8A1990F165BA3EDB84 /* CodePosition.h in Headers */ = {isa = PBXBuildFile; fileRef = B25D4C610E006AF4FE140BD1 /* CodePosition.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		97C471DC12F925BD0086354B /* ContentSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C471DA12F925BD0086354B /* ContentSecurityPolicy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		97D2AD0414B823A60093DF32 /* LocalDOMWindowProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D2AD0214B823A60093DF32 /* LocalDOMWindowProperty.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		97DCE20210807C750057D394 /* HistoryController.h in Headers */ = {isa = PBXBuildFile; fileRef = 97DCE20010807C750057D394 /* HistoryController.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -16454,6 +16455,7 @@
 		97C1F552122855CB00EDE616 /* HTMLToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HTMLToken.h; sourceTree = "<group>"; };
 		97C1F552122855CB00EDE617 /* AtomHTMLToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AtomHTMLToken.h; sourceTree = "<group>"; };
 		97C471D912F925BC0086354B /* ContentSecurityPolicy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ContentSecurityPolicy.cpp; path = csp/ContentSecurityPolicy.cpp; sourceTree = "<group>"; };
+		B25D4C610E006AF4FE140BD1 /* CodePosition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CodePosition.h; path = csp/CodePosition.h; sourceTree = "<group>"; };
 		97C471DA12F925BD0086354B /* ContentSecurityPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ContentSecurityPolicy.h; path = csp/ContentSecurityPolicy.h; sourceTree = "<group>"; };
 		97D2AD0114B823A60093DF32 /* LocalDOMWindowProperty.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LocalDOMWindowProperty.cpp; sourceTree = "<group>"; };
 		97D2AD0214B823A60093DF32 /* LocalDOMWindowProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LocalDOMWindowProperty.h; sourceTree = "<group>"; };
@@ -39544,6 +39546,7 @@
 			isa = PBXGroup;
 			children = (
 				97C471D912F925BC0086354B /* ContentSecurityPolicy.cpp */,
+				B25D4C610E006AF4FE140BD1 /* CodePosition.h */,
 				97C471DA12F925BD0086354B /* ContentSecurityPolicy.h */,
 				CE5FA253209E48C50051D700 /* ContentSecurityPolicyClient.h */,
 				CEF59B251CA0E11D005C3E13 /* ContentSecurityPolicyDirective.cpp */,
@@ -43652,6 +43655,7 @@
 				A1038D472AB2165900F57BA4 /* ContentKeyGroupFactoryAVFObjC.h in Headers */,
 				E7AA0A0C2E4519DF00ABEF7F /* ContentRuleListMatchedRule.h in Headers */,
 				5C9C2DB52241A67B00996B0B /* ContentRuleListResults.h in Headers */,
+				0AEF5B8A1990F165BA3EDB84 /* CodePosition.h in Headers */,
 				97C471DC12F925BD0086354B /* ContentSecurityPolicy.h in Headers */,
 				CE5FA255209E48C50051D700 /* ContentSecurityPolicyClient.h in Headers */,
 				CE799FA41C6A503A0097B518 /* ContentSecurityPolicyDirective.h in Headers */,

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <WebCore/AsyncNodeDeletionQueue.h>
+#include <WebCore/CodePosition.h>
 #include <WebCore/Color.h>
 #include <WebCore/ContainerNode.h>
 #include <WebCore/ContextDestructionObserver.h>
@@ -1217,6 +1218,10 @@ public:
 
     void NODELETE overrideLastModified(const std::optional<WallTime>&);
     WEBCORE_EXPORT String lastModified() const;
+
+    // CodePosition for preserving source location across async boundaries (e.g., microtasks).
+    std::optional<CodePosition> codePosition() const { return m_codePosition; }
+    void setCodePosition(std::optional<CodePosition> position) { m_codePosition = position; }
 
     // The cookieURL is used to query the cookie database for this document's
     // cookies. For example, if the cookie URL is http://example.com, we'll
@@ -2836,6 +2841,7 @@ private:
 
     mutable std::unique_ptr<CSSParserContext> m_cachedCSSParserContext;
     mutable std::unique_ptr<PermissionsPolicy> m_permissionsPolicy;
+    std::optional<CodePosition> m_codePosition;
 
     mutable std::unique_ptr<AXObjectCache> m_axObjectCache;
 #if !ENABLE_ACCESSIBILITY_LOCAL_FRAME

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -29,6 +29,7 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "ContainerNodeInlines.h"
+#include "ContentSecurityPolicy.h"
 #include "CookieJar.h"
 #include "CrossOriginAccessControl.h"
 #include "DocumentLoader.h"
@@ -266,11 +267,20 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
             // It is possible that attributes are bulk-set via Element::parserSetAttributes. In that case, it is possible that attribute vectors are already configured,
             // but corresponding attributeChanged is not called yet. This causes inconsistency in HTMLImageElement. Eventually, we will get the consistent state, but
             // if "src" attributeChanged is not called yet, imageURL can be invalid and it does not work well for ResourceRequest.
-            // In this case, we should behave same as attr.isNull().
             imageURL = imageElement->currentURL();
             if (imageURL.isNull()) {
-                didUpdateCachedImage(relevantMutation, WTF::move(newImage));
-                return;
+                // For srcset/picture and lazy-loading, keep behavior equivalent to missing/invalid src while we wait for consistent image source state.
+                if (imageElement->usesSrcsetOrPicture() || imageElement->isLazyLoadable()) {
+                    didUpdateCachedImage(relevantMutation, WTF::move(newImage));
+                    return;
+                }
+
+                // For plain src loads, fall back to attribute URL so we still issue the request.
+                imageURL = document->completeURL(attr);
+                if (imageURL.isNull()) {
+                    didUpdateCachedImage(relevantMutation, WTF::move(newImage));
+                    return;
+                }
             }
         } else
             imageURL = document->completeURL(attr);
@@ -281,6 +291,79 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 
     auto request = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), document, crossOriginAttribute);
     request.setInitiator(element);
+    m_imageComplete = false;
+
+    // Bypass microtask deferral for non-HTML image elements, shadow tree resources,
+    // image documents, blob/data URLs, and images already available in the memory cache,
+    // as deferral is only needed to batch attribute changes on HTML image elements.
+    if (!imageElement || loadingForElementInShadowTree || imageElement->document().isImageDocument() || request.resourceRequest().url().protocolIsBlob() || request.resourceRequest().url().protocolIsData() || (!imageElement->usesSrcsetOrPicture() && canReuseFromListOfAvailableImages(request, document))) {
+        updateFromElementWithLatestAttributeValues(relevantMutation, WTF::move(request));
+        return;
+    }
+
+    if (m_microtaskQueued)
+        return;
+
+    // Capture source location now so CSP violation reports inside the microtask
+    // can attribute the violation to the script that set the image attributes.
+    auto codePosition = ContentSecurityPolicy::currentCodePosition();
+
+    m_microtaskQueued = true;
+    // https://html.spec.whatwg.org/C#update-the-image-data step 8
+    Ref protectedThis { *this };
+    document->eventLoop().queueMicrotask(document->vm(), [imageLoader = WTF::move(protectedThis), relevantMutation, movedRequest = WTF::move(request), codePosition = WTF::move(codePosition)] mutable {
+        imageLoader->m_microtaskQueued = false;
+        Ref document = imageLoader->document();
+        if (codePosition)
+            document->setCodePosition(*codePosition);
+        imageLoader->updateFromElementWithLatestAttributeValues(relevantMutation, WTF::move(movedRequest));
+    });
+}
+
+void ImageLoader::updateFromElementWithLatestAttributeValues(RelevantMutation relevantMutation, CachedResourceRequest&& request)
+{
+    Ref element = this->element();
+    Ref document = element->document();
+    auto clearCodePosition = makeScopeExit([&] {
+        document->setCodePosition(std::nullopt);
+    });
+
+    CachedResourceHandle<CachedImage> newImage;
+
+    RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element);
+    if (imageElement) {
+        URL imageURL = imageElement->currentURL();
+        if (imageURL.isNull()) {
+            if (imageElement->usesSrcsetOrPicture() || imageElement->isLazyLoadable()) {
+                didUpdateCachedImage(relevantMutation, WTF::move(newImage));
+                return;
+            }
+            imageURL = request.resourceRequest().url();
+            if (imageURL.isNull()) {
+                didUpdateCachedImage(relevantMutation, WTF::move(newImage));
+                return;
+            }
+        }
+
+        auto loadingForElementInShadowTree = element->isInUserAgentShadowTree() || m_elementIsUserAgentShadowRootResource;
+        ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
+        options.contentSecurityPolicyImposition = loadingForElementInShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
+        options.shouldEnableContentExtensionsCheck = loadingForElementInShadowTree ? ShouldEnableContentExtensionsCheck::No : ShouldEnableContentExtensionsCheck::Yes;
+        options.loadedFromPluginElement = LoadedFromPluginElement::No;
+        options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
+        options.serviceWorkersMode = ServiceWorkersMode::All;
+        options.referrerPolicy = imageElement->referrerPolicy();
+        options.fetchPriority = imageElement->fetchPriority();
+        if (imageElement->usesSrcsetOrPicture())
+            options.initiator = Initiator::Imageset;
+
+        auto crossOriginAttribute = element->attributeWithoutSynchronization(HTMLNames::crossoriginAttr);
+        ResourceRequest resourceRequest(WTF::move(imageURL));
+        resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(element));
+
+        request = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), document, crossOriginAttribute);
+        request.setInitiator(element);
+    }
 
     if (m_loadManually) {
         Ref cachedResourceLoader = document->cachedResourceLoader();
@@ -288,10 +371,11 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         cachedResourceLoader->setAutoLoadImages(false);
         RefPtr page = m_element->document().page();
         // FIXME: We shouldn't do an explicit `new` here.
-        newImage = adoptRef(*new CachedImage(WTF::move(request), page->sessionID(), &page->cookieJar()));
-        newImage->setStatus(CachedResource::Pending);
-        newImage->setLoading(true);
-        cachedResourceLoader->m_documentResources.set(newImage->url().string(), *newImage);
+        Ref manualImage = adoptRef(*new CachedImage(WTF::move(request), page->sessionID(), &page->cookieJar()));
+        manualImage->setStatus(CachedResource::Pending);
+        manualImage->setLoading(true);
+        cachedResourceLoader->m_documentResources.set(manualImage->url().string(), manualImage.copyRef());
+        newImage = WTF::move(manualImage);
         cachedResourceLoader->setAutoLoadImages(autoLoadOtherImages);
     } else {
 #if !LOG_DISABLED
@@ -314,10 +398,13 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     if (imageElement && imageElement->isMultiRepresentationHEIC()) {
         auto fallbackURL = imageElement->getURLAttribute(HTMLNames::srcAttr);
         if (!fallbackURL.isNull()) {
+            auto loadingForElementInShadowTree = element->isInUserAgentShadowTree() || m_elementIsUserAgentShadowRootResource;
             ResourceLoaderOptions fallbackOptions = CachedResourceLoader::defaultCachedResourceOptions();
             fallbackOptions.contentSecurityPolicyImposition = loadingForElementInShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
+            fallbackOptions.shouldEnableContentExtensionsCheck = loadingForElementInShadowTree ? ShouldEnableContentExtensionsCheck::No : ShouldEnableContentExtensionsCheck::Yes;
             fallbackOptions.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
 
+            auto crossOriginAttribute = element->attributeWithoutSynchronization(HTMLNames::crossoriginAttr);
             ResourceRequest fallbackResourceRequest(WTF::move(fallbackURL));
             fallbackResourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*imageElement));
 
@@ -334,6 +421,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     // Security Policy, or the page is being dismissed. Trigger an
     // error event if the page is not being dismissed.
     if (!newImage && !pageIsBeingDismissed(document)) {
+        auto attr = element->imageSourceURL();
         m_failedLoadURL = attr;
         m_hasPendingErrorEvent = true;
         loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
@@ -372,6 +460,9 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, RefPtr
         m_hasPendingBeforeLoadEvent = !document->isImageDocument() && newImage;
         m_hasPendingLoadEvent = newImage;
         m_imageComplete = !newImage;
+
+        if (!newImage && hasPendingDecodePromises())
+            rejectDecodePromises("Loading error."_s);
 
         if (newImage) {
             if (!document->isImageDocument())
@@ -482,7 +573,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
 
         if (hasPendingDecodePromises())
             rejectDecodePromises("Access control error."_s);
-        
+
         ASSERT(!m_hasPendingLoadEvent);
 
         // Only consider updating the protection ref-count of the Element immediately before returning
@@ -592,7 +683,7 @@ void ImageLoader::updatedHasPendingEvent()
     } else {
         ASSERT(!m_derefElementTimer.isActive());
         m_derefElementTimer.startOneShot(0_s);
-    }   
+    }
 }
 
 void ImageLoader::decode(Ref<DeferredPromise>&& promise)
@@ -617,7 +708,7 @@ void ImageLoader::decode(Ref<DeferredPromise>&& promise)
 void ImageLoader::decode()
 {
     ASSERT(hasPendingDecodePromises());
-    
+
     if (!element().document().window()) {
         rejectDecodePromises("Inactive document."_s);
         return;
@@ -656,7 +747,8 @@ bool ImageLoader::hasPendingActivity() const
     // We are using SUPPRESS_UNCOUNTED_ARG and not ref'ing m_image here because this function
     // may get called on the GC thread, and it would trip threading assertion in RefCounted.
     SUPPRESS_UNCOUNTED_ARG bool imageWillBeLoadedLater = m_image && !m_image->isLoading() && m_image->stillNeedsLoad();
-    return (m_hasPendingLoadEvent && !imageWillBeLoadedLater) || m_hasPendingErrorEvent;
+    // Also consider microtask queued as pending activity to prevent GC while waiting.
+    return (m_hasPendingLoadEvent && !imageWillBeLoadedLater) || m_hasPendingErrorEvent || m_microtaskQueued;
 }
 
 void ImageLoader::dispatchPendingEvent(ImageEventSender* eventSender, const AtomString& eventType)

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class CachedResourceRequest;
 class DeferredPromise;
 class Document;
 class ImageLoader;
@@ -103,6 +104,7 @@ protected:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) override;
 
 private:
+    void updateFromElementWithLatestAttributeValues(RelevantMutation, CachedResourceRequest&&);
     void resetLazyImageLoading(Document&);
 
     virtual void dispatchLoadEvent() = 0;
@@ -145,6 +147,7 @@ private:
     bool m_loadManually : 1;
     bool m_elementIsProtected : 1;
     bool m_elementIsUserAgentShadowRootResource : 1 { false };
+    bool m_microtaskQueued : 1 { false };
     LazyImageLoadState m_lazyImageLoadState { LazyImageLoadState::None };
 };
 

--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -182,8 +182,19 @@ void FrameConsoleClient::addMessage(MessageSource source, MessageLevel level, co
     String url;
     unsigned line = 0;
     unsigned column = 0;
-    if (document)
+    if (document) {
         document->getParserLocation(url, line, column);
+        if (url.isEmpty()) {
+            if (auto codePosition = document->codePosition()) {
+                url = codePosition->sourceURL;
+                line = codePosition->line.oneBasedInt();
+                column = codePosition->column.oneBasedInt();
+            } else if (source == MessageSource::Security) {
+                url = document->url().string();
+                line = 1;
+            }
+        }
+    }
 
     addMessage(source, level, message, url, line, column, nullptr, JSExecState::currentState(), requestIdentifier);
 }

--- a/Source/WebCore/page/csp/CodePosition.h
+++ b/Source/WebCore/page/csp/CodePosition.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/OrdinalNumber.h>
+#include <wtf/text/TextPosition.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+// CodePosition captures source file location for CSP violation reporting.
+// This is used to preserve source location across async boundaries (e.g., microtasks).
+struct CodePosition {
+    String sourceURL;
+    OrdinalNumber line;
+    OrdinalNumber column;
+
+    CodePosition() = default;
+    CodePosition(const String& url, OrdinalNumber l, OrdinalNumber c)
+        : sourceURL(url), line(l), column(c) { }
+    CodePosition(const String& url, const TextPosition& pos)
+        : sourceURL(url), line(pos.m_line), column(pos.m_column) { }
+
+    bool isEmpty() const { return sourceURL.isEmpty() && line == OrdinalNumber::beforeFirst(); }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -652,9 +652,9 @@ bool ContentSecurityPolicy::allowResourceFromSource(const URL& url, std::optiona
         return true;
     String sourceURL;
     const auto& blockedURL = !preRedirectURL.isNull() ? preRedirectURL : url;
-    auto handleViolatedDirective = [checkedThis = CheckedRef { *this }, &sourceURL, &blockedURL, sourcePosition = WTF::move(sourcePosition), &url](const ContentSecurityPolicyDirective& violatedDirective) mutable {
+    auto handleViolatedDirective = [checkedThis = CheckedRef { *this }, &sourceURL, &blockedURL, sourcePosition = WTF::move(sourcePosition), &url, &preRedirectURL](const ContentSecurityPolicyDirective& violatedDirective) mutable {
         String consoleMessage = consoleMessageForViolation(violatedDirective, url, "Refused to load"_s);
-        checkedThis->reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), WTF::move(sourcePosition));
+        checkedThis->reportViolation(violatedDirective, blockedURL.string(), consoleMessage, sourceURL, StringView(), WTF::move(sourcePosition), preRedirectURL, JSExecState::currentState());
     };
     return allPoliciesAllow(handleViolatedDirective, resourcePredicate, url, redirectResponseReceived == RedirectResponseReceived::Yes);
 }
@@ -880,7 +880,7 @@ String ContentSecurityPolicy::createURLForReporting(const URL& url, const String
     return SecurityOrigin::create(url)->toString();
 }
 
-std::optional<CodePosition> ContentSecurityPolicy::getCurrentCodePosition()
+std::optional<CodePosition> ContentSecurityPolicy::currentCodePosition()
 {
     auto stack = createScriptCallStack(JSExecState::currentState(), 2);
     if (auto* callFrame = stack->firstNonNativeCallFrame()) {
@@ -949,12 +949,57 @@ void ContentSecurityPolicy::reportViolation(const String& effectiveViolatedDirec
 
         info.documentURI = shouldReportProtocolOnly(document->url()) ? document->url().protocol().toString() : document->url().strippedForUseAsReferrer().string;
 
-        auto stack = createScriptCallStack(JSExecState::currentState(), 2);
-        auto* callFrame = stack->firstNonNativeCallFrame();
-        if (callFrame && callFrame->lineNumber()) {
-            info.sourceFile = createURLForReporting(URL { callFrame->preRedirectURL().isEmpty() ? callFrame->sourceURL() : callFrame->preRedirectURL() }, effectiveViolatedDirective, usesReportTo);
-            info.lineNumber = callFrame->lineNumber();
-            info.columnNumber = callFrame->columnNumber();
+        std::optional<CodePosition> javaScriptCodePosition = currentCodePosition();
+        std::optional<CodePosition> parserCodePosition;
+
+        String parserURL;
+        unsigned parserLine = 0;
+        unsigned parserColumn = 0;
+        document->getParserLocation(parserURL, parserLine, parserColumn);
+        if (!parserURL.isEmpty()) {
+            parserCodePosition = CodePosition {
+                parserURL,
+                OrdinalNumber::fromOneBasedInt(parserLine),
+                OrdinalNumber::fromOneBasedInt(parserColumn)
+            };
+        }
+
+        auto documentCodePosition = [&] () -> std::optional<CodePosition> {
+            auto codePosition = document->codePosition();
+            if (!codePosition)
+                return std::nullopt;
+            bool positionMatchesParserLocation = parserCodePosition
+                && codePosition->sourceURL == parserCodePosition->sourceURL
+                && codePosition->line == parserCodePosition->line
+                && codePosition->column == parserCodePosition->column;
+            if (positionMatchesParserLocation)
+                return std::nullopt;
+            if (codePosition->line == OrdinalNumber::beforeFirst())
+                return std::nullopt;
+            return codePosition;
+        };
+
+        std::optional<CodePosition> position;
+        if (usesReportTo) {
+            if (state) {
+                if (sourcePosition.m_line != OrdinalNumber::beforeFirst())
+                    position = CodePosition { document->url().string(), sourcePosition.m_line, sourcePosition.m_column };
+                else if (javaScriptCodePosition)
+                    position = javaScriptCodePosition;
+                else
+                    position = documentCodePosition();
+            }
+        } else {
+            if (javaScriptCodePosition)
+                position = javaScriptCodePosition;
+            else
+                position = documentCodePosition();
+        }
+
+        if (position) {
+            info.sourceFile = createURLForReporting(URL { position->sourceURL }, effectiveViolatedDirective, usesReportTo);
+            info.lineNumber = position->line.oneBasedInt();
+            info.columnNumber = usesReportTo ? 0 : position->column.oneBasedInt();
         }
     }
     ASSERT(m_client || is<Document>(m_scriptExecutionContext.get()));

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <WebCore/CodePosition.h>
 #include <WebCore/ContentSecurityPolicyClient.h>
 #include <WebCore/ContentSecurityPolicyHash.h>
 #include <WebCore/ContentSecurityPolicyResponseHeaders.h>
@@ -56,22 +57,6 @@ class OrdinalNumber;
 }
 
 namespace WebCore {
-
-// CodePosition captures source file location for CSP violation reporting.
-// This is used to preserve source location across async boundaries (e.g., microtasks).
-struct CodePosition {
-    String sourceURL;
-    OrdinalNumber line;
-    OrdinalNumber column;
-
-    CodePosition() = default;
-    CodePosition(const String& url, OrdinalNumber l, OrdinalNumber c)
-        : sourceURL(url), line(l), column(c) { }
-    CodePosition(const String& url, const TextPosition& pos)
-        : sourceURL(url), line(pos.m_line), column(pos.m_column) { }
-
-    bool isEmpty() const { return sourceURL.isEmpty() && line == OrdinalNumber::beforeFirst(); }
-};
 
 class ContentSecurityPolicyDirective;
 class ContentSecurityPolicyDirectiveList;
@@ -262,7 +247,7 @@ public:
 
     // Captures the current JavaScript source location from the call stack.
     // Used to preserve source location across async boundaries for CSP violation reporting.
-    WEBCORE_EXPORT static std::optional<CodePosition> getCurrentCodePosition();
+    WEBCORE_EXPORT static std::optional<CodePosition> currentCodePosition();
 
 private:
     void logToConsole(const String& message, const String& contextURL = String(), const OrdinalNumber& contextLine = OrdinalNumber::beforeFirst(), const OrdinalNumber& contextColumn = OrdinalNumber::beforeFirst(), JSC::JSGlobalObject* = nullptr) const;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ResourceLoadDelegate.mm
@@ -192,8 +192,8 @@ TEST(ResourceLoadDelegate, ResourceType)
         _WKResourceLoadInfoResourceTypeFetch,
         _WKResourceLoadInfoResourceTypeXMLHTTPRequest,
         _WKResourceLoadInfoResourceTypeBeacon,
-        _WKResourceLoadInfoResourceTypeImage,
         _WKResourceLoadInfoResourceTypeStylesheet,
+        _WKResourceLoadInfoResourceTypeImage,
         _WKResourceLoadInfoResourceTypeFont,
     };
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=276586

Reviewed by NOBODY (OOPS!).

**PR 3 of 3** for implementing microtask-based image loading per HTML spec.

Per HTML spec, image loading should be deferred to a microtask to allow
batching of multiple attribute changes. When JavaScript sets img.src
followed by img.srcset, only the final srcset should be loaded.

This change queues a microtask when updateFromElement() is called for
HTMLImageElement, allowing subsequent attribute changes to be batched.
The CodePosition is captured before the microtask to preserve CSP
source location for violation reporting.

### Related PRs
- PR 1: https://github.com/WebKit/WebKit/pull/57251 (merged)
- PR 2: https://github.com/WebKit/WebKit/pull/57252 (merged)
- PR 3: https://github.com/WebKit/WebKit/pull/57253 (this PR)

* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::doUpdateFromElement):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d36e77d679dfc4c41d3ebb70436d11a7f4c5323

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159956 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122421 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103090 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23764 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22084 "1 api test failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169403 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130607 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141569 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/89002 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25444 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18375 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96191 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->