### PR TITLE
crypto/openssl: fix build with OpenSSL 3.x

### DIFF
--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
@@ -45,13 +45,13 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgo
     if (!digest)
         return Exception { ExceptionCode::OperationError };
 
-    EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey().get());
+    const EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey().get());
     if (!ecKey)
         return Exception { ExceptionCode::OperationError };
 
     // We use ECDSA_do_sign rather than EVP API because the latter handles ECDSA signature in DER format
     // while this function is supposed to return simply concatinated "r" and "s".
-    auto sig = ECDSASigPtr(ECDSA_do_sign(digest->span().data(), digest->size(), ecKey));
+    auto sig = ECDSASigPtr(ECDSA_do_sign(digest->span().data(), digest->size(), const_cast<EC_KEY*>(ecKey)));
     if (!sig)
         return Exception { ExceptionCode::OperationError };
 
@@ -89,11 +89,11 @@ ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcds
     if (!digest)
         return Exception { ExceptionCode::OperationError };
 
-    EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey().get());
+    const EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey().get());
     if (!ecKey)
         return Exception { ExceptionCode::OperationError };
 
-    int ret = ECDSA_do_verify(digest->span().data(), digest->size(), sig.get(), ecKey);
+    int ret = ECDSA_do_verify(digest->span().data(), digest->size(), sig.get(), const_cast<EC_KEY*>(ecKey));
     return ret == 1;
 }
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp
@@ -30,7 +30,34 @@
 #include "CryptoKeyRaw.h"
 #include "ExceptionOr.h"
 #include "OpenSSLUtilities.h"
+
+#if __has_include(<openssl/hkdf.h>)
 #include <openssl/hkdf.h>
+#else
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+
+// This function is available in hkdf.h but that only exists for LibreSSL and BoringSSL, not
+// plain OpenSSL. Therefore we provide our own implementation here.
+int HKDF(unsigned char* output, size_t outSize, const evp_md_st* algorithm,
+    const unsigned char* inKey, size_t inKeySize,
+    const unsigned char* inSalt, size_t inSaltSize,
+    const unsigned char* inInfo, size_t inInfoSize)
+{
+    EVP_PKEY_CTX* kctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr);
+
+    EVP_PKEY_CTX_set_hkdf_md(kctx, EVP_sha256());
+    EVP_PKEY_CTX_set1_hkdf_salt(kctx, inSalt, inSaltSize);
+    EVP_PKEY_CTX_set1_hkdf_key(kctx, inKey, inKeySize);
+    EVP_PKEY_CTX_add1_hkdf_info(kctx, inInfo, inInfoSize);
+
+    int ret = EVP_PKEY_derive(kctx, output, &outSize);
+
+    EVP_PKEY_CTX_free(kctx);
+
+    return ret;
+}
+#endif
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/openssl/CryptoKeyECOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoKeyECOpenSSL.cpp
@@ -368,14 +368,14 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     if (!verifyCurve(EC_KEY_get0_group(ecKey), curve))
         return nullptr;
 
-    EC_KEY_set_asn1_flag(ecKey, OPENSSL_EC_NAMED_CURVE);
+    EC_KEY_set_asn1_flag(const_cast<EC_KEY*>(ecKey), OPENSSL_EC_NAMED_CURVE);
 
     return adoptRef(new CryptoKeyEC(identifier, curve, CryptoKeyType::Private, WTF::move(pkey), extractable, usages));
 }
 
 Vector<uint8_t> CryptoKeyEC::platformExportRaw() const
 {
-    EC_KEY* key = EVP_PKEY_get0_EC_KEY(platformKey().get());
+    const EC_KEY* key = EVP_PKEY_get0_EC_KEY(platformKey().get());
     if (!key)
         return { };
     
@@ -396,7 +396,7 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
 {
     size_t keySizeInBytes = (keySizeInBits() + 7) / 8;
 
-    EC_KEY* key = EVP_PKEY_get0_EC_KEY(platformKey().get());
+    const EC_KEY* key = EVP_PKEY_get0_EC_KEY(platformKey().get());
     if (!key)
         return false;
 


### PR DESCRIPTION
#### 8822b0bb3624d5b31f9b17a22fa1b5e7685cc6a1
<pre>
crypto/openssl: fix build with OpenSSL 3.x
<a href="https://bugs.webkit.org/show_bug.cgi?id=245146">https://bugs.webkit.org/show_bug.cgi?id=245146</a>

Reviewed by Adrian Perez de Castro.

Existing code is written against BoringSSL and LibreSSL.
There are two main incompatibilities with OpenSSL 3.x:

- BoringSSL and LibreSSL have implemented HKDF with a different
  (simpler) API. Provide a wrapper to call the more complicated OpenSSL
  API.
- OpenSSL has added some const pointers, but not consistently. So the
  variable must be const and then the const must be casted away to call
  other functions.

No new tests: no functional changes to existing platforms.
* Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp:
(WebCore::CryptoAlgorithmECDSA::platformSign): add const and const_cast
(WebCore::CryptoAlgorithmECDSA::platformVerify): add const and const_cast
* Source/WebCore/crypto/openssl/CryptoAlgorithmHKDFOpenSSL.cpp:
(WebCore::HKDF): add HKDF function implementation using OpenSSL3 APIs
* Source/WebCore/crypto/openssl/CryptoKeyECOpenSSL.cpp:
(WebCore::CryptoKeyEC::platformImportPkcs8): add const and const_cast
(WebCore::CryptoKeyEC::platformExportRaw const): add const and const_cast
(WebCore::CryptoKeyEC::platformAddFieldElements const): add const and const_cast

Canonical link: <a href="https://commits.webkit.org/306425@main">https://commits.webkit.org/306425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67838db603a012f77a590b58409ffa1b07a8778e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108567 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11117 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10689 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8301 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152277 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13379 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116664 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117004 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29783 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13057 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123119 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68553 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13422 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77128 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->