### PR TITLE
[threaded-animations] several test in `compositing` are failures with "Threaded Time-based Animations" enabled

### DIFF
--- a/LayoutTests/compositing/animation/layer-for-filling-animation.html
+++ b/LayoutTests/compositing/animation/layer-for-filling-animation.html
@@ -13,32 +13,26 @@
         }
         
         .animating {
-            -webkit-animation: spin 1 0.1s forwards;
+            animation: spin 1 0.1s forwards;
         }
 
-        @-webkit-keyframes spin {
-            from { -webkit-transform: rotate(0); }
-            to   { -webkit-transform: rotate(3deg); }
+        @keyframes spin {
+            from { transform: rotate(0); }
+            to   { transform: rotate(3deg); }
         }
     </style>
+    <script src="../../webanimations/threaded-animations/threaded-animations-utils.js"></script>
     <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
+        window.testRunner?.dumpAsText();
+        window.testRunner?.waitUntilDone();
             
-        function doTest()
-        {
-            document.getElementById('box').addEventListener('webkitAnimationEnd', function() {
-                requestAnimationFrame(() => {
-                    if (window.testRunner) {
-                        document.getElementById('results').innerText = window.internals.layerTreeAsText(document);
-                        testRunner.notifyDone();
-                    }
-                });
-            })
-        }
-        window.addEventListener('load', doTest, false);
+        window.addEventListener('load', async () => {
+            const animation = document.getElementById('box').getAnimations()[0];
+            await animation.finished;
+            await threadedAnimationsCommit();
+            document.getElementById('results').innerText = window.internals?.layerTreeAsText(document);
+            window.testRunner?.notifyDone();
+        });
     </script>
 </head>
 <body>

--- a/LayoutTests/compositing/backing/animate-into-view-with-descendant.html
+++ b/LayoutTests/compositing/backing/animate-into-view-with-descendant.html
@@ -43,19 +43,6 @@
             100% { transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1); }
         }
     </style>
-    <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
-
-        function dumpLayers()
-        {
-            var layersResult = document.getElementById('layers');
-            if (window.testRunner)
-                layersResult.innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
-        }
-    </script>
 </head>
 <body>
 
@@ -67,15 +54,21 @@
 
 <pre id="layers">Layer tree goes here in DRT</pre>
 
+<script src="../../webanimations/threaded-animations/threaded-animations-utils.js"></script>
 <script>
-    let animator = document.getElementById('target');
-    animator.addEventListener('animationstart', () => {
-        requestAnimationFrame(() => {
-            dumpLayers();
-            if (window.testRunner)
-                testRunner.notifyDone();
-        });
-    });
+
+(async function () {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    const animation = document.getElementById('target').getAnimations()[0];
+    await animationAcceleration(animation);
+
+    document.getElementById('layers').innerText = window.internals?.layerTreeAsText(document, window.internals?.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
+
+    window.testRunner?.notifyDone();
+})();
+
 </script>
 </body>
 </html>

--- a/LayoutTests/compositing/backing/animate-into-view.html
+++ b/LayoutTests/compositing/backing/animate-into-view.html
@@ -46,31 +46,6 @@
             100% { transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1); }
         }
     </style>
-    <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
-
-        function dumpLayers()
-        {
-            var layersResult = document.getElementById('layers');
-            if (window.testRunner)
-                layersResult.innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
-        }
-
-        window.addEventListener('load', () => {
-            let animator = document.getElementById('target');
-            animator.addEventListener('animationstart', () => {
-                requestAnimationFrame(() => {
-                    dumpLayers();
-                    if (window.testRunner)
-                        testRunner.notifyDone();
-                });
-            });
-            animator.classList.add('animating');
-        }, false);
-    </script>
 </head>
 <body>
 
@@ -81,6 +56,25 @@
 </div>
 
 <pre id="layers">Layer tree goes here in DRT</pre>
+
+<script src="../../webanimations/threaded-animations/threaded-animations-utils.js"></script>
+<script>
+
+(async function () {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    const target = document.getElementById('target');
+    target.classList.add('animating');
+    const animation = target.getAnimations()[0];
+    await animationAcceleration(animation);
+
+    document.getElementById('layers').innerText = window.internals?.layerTreeAsText(document, window.internals?.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
+
+    window.testRunner?.notifyDone();
+})();
+
+</script>
 
 </body>
 </html>

--- a/LayoutTests/compositing/backing/transform-transition-from-outside-view.html
+++ b/LayoutTests/compositing/backing/transform-transition-from-outside-view.html
@@ -27,6 +27,7 @@
             transform: translateX(0px);
         }
     </style>
+    <script src="../../webanimations/threaded-animations/threaded-animations-utils.js"></script>
     <script>
         if (window.testRunner) {
             testRunner.dumpAsText();
@@ -48,9 +49,11 @@
             }
         }
 
-        window.addEventListener("load", function() {
+        window.addEventListener("load", async () => {
             document.body.classList.add('changed');
-            requestAnimationFrame(dumpLayers);
+            const animation = document.getAnimations()[0];
+            await animationAcceleration(animation);
+            dumpLayers();
         });
     </script>
 </head>

--- a/LayoutTests/compositing/geometry/limit-layer-bounds-opacity-transition.html
+++ b/LayoutTests/compositing/geometry/limit-layer-bounds-opacity-transition.html
@@ -22,11 +22,10 @@
       -webkit-transition: opacity 0.1s;
     }
   </style>
+  <script src="../../webanimations/threaded-animations/threaded-animations-utils.js"></script>
   <script type="text/javascript" charset="utf-8">
-    if (window.testRunner) {
-      testRunner.waitUntilDone();
-      testRunner.dumpAsText();
-    }
+    window.testRunner?.waitUntilDone();
+    window.testRunner?.dumpAsText();
 
     function startFade()
     {
@@ -37,14 +36,11 @@
       document.getElementById('fading').style.opacity = 1;
     }
     
-    function fadeDone()
+    async function fadeDone()
     {
-      if (window.testRunner) {
-          requestAnimationFrame(() => {
-              document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
-              testRunner.notifyDone();
-          })
-      }
+        await threadedAnimationsCommit();
+        document.getElementById('layers').innerText = window.internals?.layerTreeAsText(document);
+        testRunner?.notifyDone();
     }
   </script>
 <head>


### PR DESCRIPTION
#### 29184116d060d195d4464f1d34b440c38b1530e1
<pre>
[threaded-animations] several test in `compositing` are failures with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306270">https://bugs.webkit.org/show_bug.cgi?id=306270</a>
<a href="https://rdar.apple.com/168918523">rdar://168918523</a>

Reviewed by Anne van Kesteren.

Several tests under the `compositing` directory made timing assumptions that are incompatible with
how threaded animations are committed. We update them to use the utility functions that abstract such
minutia. These tests now pass regardless of the &quot;Threaded Time-based Animations&quot; setting.

* LayoutTests/compositing/animation/layer-for-filling-animation.html:
* LayoutTests/compositing/backing/animate-into-view-with-descendant.html:
* LayoutTests/compositing/backing/animate-into-view.html:
* LayoutTests/compositing/backing/transform-transition-from-outside-view.html:
* LayoutTests/compositing/geometry/limit-layer-bounds-opacity-transition.html:

Canonical link: <a href="https://commits.webkit.org/306212@main">https://commits.webkit.org/306212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3f55c63640e753268d7cb2d0b93f91da6ac0faa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93791 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04ba1494-612e-4053-862f-920507403110) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bfa8f50-5d16-49c8-8345-91f58c422b56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125965 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61d8759b-bba9-4c62-b87a-ec18abcdfa67) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10271 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7831 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9137 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119517 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1975 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151667 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12774 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2134 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116196 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12789 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116534 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12492 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67908 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21707 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12816 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12556 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12755 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12600 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->