### PR TITLE
[iOS] Improve page load performance with Site Isolation enabled

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -321,11 +321,10 @@ void WebProcessCache::updateCapacity(WebProcessPool& processPool)
     } else if (capacityOverride >= 0) {
         m_capacity = capacityOverride;
     } else {
+        constexpr unsigned maxProcesses = 32;
 #if PLATFORM(IOS_FAMILY)
-        constexpr unsigned maxProcesses = 10;
         size_t memorySize = WTF::ramSizeDisregardingJetsamLimit();
 #else
-        constexpr unsigned maxProcesses = 30;
         size_t memorySize = WTF::ramSize();
 #endif
         WEBPROCESSCACHE_RELEASE_LOG("memory size %zu bytes", 0, memorySize);


### PR DESCRIPTION
#### 4e90adc39229598305c2660a490d25aa4665017b
<pre>
[iOS] Improve page load performance with Site Isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306271">https://bugs.webkit.org/show_bug.cgi?id=306271</a>
<a href="https://rdar.apple.com/168918854">rdar://168918854</a>

Reviewed by Chris Dumez.

Improve page load performance with Site Isolation enabled on iOS by adjusting the Web process max cache size.
This patch unifies the max size for all platforms. The actual cache size is computed based on the memory size
of the device, so this patch will not change the cache size for devices with less memory. For higher end
devices, this will increase the cache size. This should not increase jetsam events, since we are terminating
Web processes on memory pressure. This change is a significant improvement in page load performance on iOS
with Site Isolation enabled.

* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::updateCapacity):

Canonical link: <a href="https://commits.webkit.org/306363@main">https://commits.webkit.org/306363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/222b1b50ee1efda2c25f54ff72092c9b0821fecd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93793 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fce13aa5-fa92-435f-9198-19cedda969a3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107899 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78329 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3812d93c-295b-4386-ac12-3e9e7f843c17) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88801 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/090854b7-6910-4bf3-86dc-1d254bfac7dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10273 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7833 "Passed tests") | [⏳ wpe-libwebrtc ](None "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119519 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151669 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12776 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2138 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116198 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116536 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12502 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67911 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21776 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12818 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2037 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12757 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12602 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->