### PR TITLE
[threaded-animations] test `webanimations/accelerated-animation-suspension.html` fails with "Threaded Time-based Animations" enabled

### DIFF
--- a/LayoutTests/webanimations/accelerated-animation-suspension.html
+++ b/LayoutTests/webanimations/accelerated-animation-suspension.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
 <html>
 <head>
 <style>

--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-suspension-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-suspension-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Suspending animations should pause running accelerated animations.
+

--- a/LayoutTests/webanimations/threaded-animations/threaded-animation-suspension.html
+++ b/LayoutTests/webanimations/threaded-animations/threaded-animation-suspension.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
+<html>
+<head>
+<style>
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+</head>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/rendering-frames.js"></script>
+<div id="target"></div>
+
+<script>
+
+promise_test(async () => {
+    const target = document.getElementById("target");
+    target.animate({ transform: ["translateX(100px)", "none"] }, 1000 * 1000);
+
+    await renderingFrames(3);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1, "There should be a single accelerated animation before suspension.");
+
+    internals.suspendAnimations();
+    await renderingFrames(2);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0, "There should be no accelerated animation after suspension.");
+
+    internals.resumeAnimations();
+    await renderingFrames(2);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1, "There should be a single accelerated animation after resumption.");
+
+    await new Promise(setTimeout);
+}, "Suspending animations should pause running accelerated animations.");
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 22559b42f12dd42ce8e9a5bb3ff249994811a806
<pre>
[threaded-animations] test `webanimations/accelerated-animation-suspension.html` fails with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306273">https://bugs.webkit.org/show_bug.cgi?id=306273</a>
<a href="https://rdar.apple.com/168920943">rdar://168920943</a>

Reviewed by Anne van Kesteren.

The test `webanimations/accelerated-animation-suspension.html` tests that accelerated animations
are suspended as the page is suspended by setting their speed to 0. This is true of the codepath
where Core Animation is used to run accelerated animations.

However, with threaded animations, accelerated animations are removed as animations are suspended.
We update the existing test to disable &quot;Threaded Time-based Animations&quot; and add a new test that
checks the behavior of threaded animations with that flag explicitly enabled.

* LayoutTests/webanimations/accelerated-animation-suspension.html:
* LayoutTests/webanimations/threaded-animations/threaded-animation-suspension-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/threaded-animation-suspension.html: Added.

Canonical link: <a href="https://commits.webkit.org/306214@main">https://commits.webkit.org/306214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c5a2a3b005cd733ea0dc7200619619f02c464f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149063 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13244 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/107906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/125971 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/88808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10276 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7835 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9141 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/1981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151671 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12778 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116200 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116538 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12501 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67913 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21708 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12820 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12560 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12604 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->