### PR TITLE
[Cocoa] On caption menu does not enable tracks with kind="subtitle"

### DIFF
--- a/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-expected.txt
+++ b/LayoutTests/media/modern-media-controls/tracks-support/sorted-by-user-preferred-languages-expected.txt
@@ -9,19 +9,19 @@ Tapping tracks button...
 Subtitles: [
   "Off",
   "Auto (Recommended)",
+  "label-en",
   "label-en Captions",
   "Descriptions",
-  "label-en",
-  "Spanish Captions",
   "Spanish",
+  "Spanish Captions",
   "Spanish Descriptions",
   "no-srclang",
   "Chinese (China mainland)",
-  "French Captions (label-fr)",
   "French (label-fr)",
+  "French Captions (label-fr)",
   "French Descriptions",
-  "German Captions",
   "German",
+  "German Captions",
   "German Descriptions"
 ]
 PASS successfullyParsed is true

--- a/LayoutTests/media/on-item-enables-subtitles-expected.txt
+++ b/LayoutTests/media/on-item-enables-subtitles-expected.txt
@@ -1,0 +1,16 @@
+
+RUN(internals.settings.setShouldDisplayTrackKind("Captions", true))
+RUN(video.src = findMediaFile("video", "content/test"))
+EVENT(canplay)
+RUN(host = internals.controlsHostForMediaElement(video))
+RUN(host.setSelectedTextTrack(host.captionMenuOffItem))
+RUN(track = document.createElement("track"))
+RUN(track.kind = "subtitles")
+RUN(track.srclang = "en")
+RUN(track.src = "content/lorem-ipsum.vtt")
+RUN(video.appendChild(track))
+RUN(host.setSelectedTextTrack(host.captionMenuOnItem))
+EVENT(change)
+EXPECTED (video.textTracks[0].mode == 'showing') OK
+END OF TEST
+

--- a/LayoutTests/media/on-item-enables-subtitles.html
+++ b/LayoutTests/media/on-item-enables-subtitles.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>on-item-enables-subtitles</title>
+	<script src=video-test.js></script>
+	<script src=media-file.js></script>
+	<script>
+	window.addEventListener('load', event => {
+		runTest().then(endTest).catch(failTest);
+	});
+
+	async function runTest() {
+		findMediaElement();
+
+		run('internals.settings.setShouldDisplayTrackKind("Captions", true)')
+		run('video.src = findMediaFile("video", "content/test")');
+		await waitFor(video, 'canplay');
+
+		run ('host = internals.controlsHostForMediaElement(video)');
+		run('host.setSelectedTextTrack(host.captionMenuOffItem)');
+
+		run('track = document.createElement("track")');
+
+		run('track.kind = "subtitles"');
+		run('track.srclang = "en"');
+		run('track.src = "content/lorem-ipsum.vtt"');
+		run('video.appendChild(track)');
+
+		run('host.setSelectedTextTrack(host.captionMenuOnItem)');
+		await waitFor(video.textTracks, 'change');
+		await testExpectedEventually('video.textTracks[0].mode', 'showing');
+	}
+	</script>
+</head>
+<body>
+	<video controls>
+	</video>
+</body>
+</html>

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -603,8 +603,8 @@ bool TextTrack::isMainProgramContent() const
     // "Main program" content is intrinsic to the presentation of the media file, regardless of locale. Content such as
     // directors commentary is not "main program" because it is not essential for the presentation. HTML5 doesn't have
     // a way to express this in a machine-reable form, it is typically done with the track label, so we assume that caption
-    // tracks are main content and all other track types are not.
-    return m_kind == Kind::Captions;
+    // and subtitle tracks are main content and all other track types are not.
+    return m_kind == Kind::Captions || m_kind == Kind::Subtitles;
 }
 
 bool TextTrack::containsOnlyForcedSubtitles() const


### PR DESCRIPTION
#### 36e2729f79f4525c161106fb5cb47f4f1eb59a5d
<pre>
[Cocoa] On caption menu does not enable tracks with kind=&quot;subtitle&quot;
<a href="https://rdar.apple.com/168103697">rdar://168103697</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306151">https://bugs.webkit.org/show_bug.cgi?id=306151</a>

Reviewed by Eric Carlson.

Count &quot;subtitle&quot; tracks as main program content, so they can be
selected automatically when the caption display mode is set to
&quot;always on&quot;.

Test: media/on-item-enables-subtitles.html

* LayoutTests/media/on-item-enables-subtitles-expected.txt: Added.
* LayoutTests/media/on-item-enables-subtitles.html: Added.
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::isMainProgramContent const):

Canonical link: <a href="https://commits.webkit.org/306291@main">https://commits.webkit.org/306291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/682e7f54be5be1a4910866fa1e8bf793ddd75a86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149357 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13445 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108139 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89039 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7987 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9343 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151872 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12979 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2374 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116353 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116692 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12762 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122803 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68140 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21747 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13022 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12960 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12805 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->