### PR TITLE
WebAuthn Authentication over NFC is broken in Safari Technology Preview 234 (SEED)

### DIFF
--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp
@@ -100,6 +100,7 @@ bool isCtapDeviceResponseCode(CtapDeviceResponseCode code)
     case CtapDeviceResponseCode::kCtap2ErrKeepAliveCancel:
     case CtapDeviceResponseCode::kCtap2ErrNoCredentials:
     case CtapDeviceResponseCode::kCtap2ErrUserActionTimeout:
+    case CtapDeviceResponseCode::kCtap2ErrUserPresenceRequired:
     case CtapDeviceResponseCode::kCtap2ErrNotAllowed:
     case CtapDeviceResponseCode::kCtap2ErrPinInvalid:
     case CtapDeviceResponseCode::kCtap2ErrPinBlocked:

--- a/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
+++ b/Source/WebCore/Modules/webauthn/fido/FidoConstants.h
@@ -110,6 +110,7 @@ enum class CtapDeviceResponseCode : uint8_t {
     kCtap2ErrPinTokenExpired = 0x38,
     kCtap2ErrRequestTooLarge = 0x39,
     kCtap2ErrActionTimeout = 0x3A,
+    kCtap2ErrUserPresenceRequired = 0x3B,
     kCtap2ErrOther = 0x7F,
     kCtap2ErrSpecLast = 0xDF,
     kCtap2ErrExtensionFirst = 0xE0,

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -115,12 +115,12 @@ void AuthenticatorPresenterCoordinator::updatePresenter(WebAuthenticationStatus 
     switch (status) {
     case WebAuthenticationStatus::PinBlocked: {
         auto error = adoptNS([[NSError alloc] initWithDomain:ASCAuthorizationErrorDomain code:ASCAuthorizationErrorAuthenticatorPermanentlyLocked userInfo:nil]);
-        m_credentialRequestHandler(nil, error.get());
+        [m_presenter updateInterfaceForUserVisibleError:error.get()];
         break;
     }
     case WebAuthenticationStatus::PinAuthBlocked: {
         auto error = adoptNS([[NSError alloc] initWithDomain:ASCAuthorizationErrorDomain code:ASCAuthorizationErrorAuthenticatorTemporarilyLocked userInfo:nil]);
-        m_credentialRequestHandler(nil, error.get());
+        [m_presenter updateInterfaceForUserVisibleError:error.get()];
         break;
     }
     case WebAuthenticationStatus::PinInvalid: {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
@@ -51,7 +51,8 @@ public:
     void didConnectTag();
 
     void updateSlots(NSArray *slots);
-    void onValidCard(RetainPtr<TKSmartCard>&&);
+    void onValidCard(RetainPtr<TKSmartCard>&&, RetainPtr<TKSmartCardSlot>&&);
+    void onCardRemoved();
 
 protected:
     explicit CcidService(AuthenticatorTransportServiceObserver&);

--- a/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm
@@ -82,7 +82,7 @@ void MockCcidService::platformStartDiscovery()
 {
     if (!!m_configuration.ccid) {
         auto card = adoptNS([[_WKMockTKSmartCard alloc] initWithService:this]);
-        onValidCard(WTF::move(card));
+        onValidCard(WTF::move(card), nullptr);
         return;
     }
     LOG_ERROR("No ccid authenticators is available.");

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1095,9 +1095,8 @@ TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)
 
     webAuthenticationPanelPin = "1234"_s;
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
-    [webView waitForMessage:@"Unknown internal error. Error code: 52"];
+    Util::run(&webAuthenticationPanelUpdatePINAuthBlocked);
     EXPECT_FALSE(webAuthenticationPanelUpdatePINInvalid);
-    EXPECT_TRUE(webAuthenticationPanelUpdatePINAuthBlocked);
 }
 
 TEST(WebAuthenticationPanel, MakeCredentialPinInvalidErrorAndRetry)
@@ -1192,9 +1191,8 @@ TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)
 
     webAuthenticationPanelPin = "1234"_s;
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
-    [webView waitForMessage:@"Unknown internal error. Error code: 52"];
+    Util::run(&webAuthenticationPanelUpdatePINAuthBlocked);
     EXPECT_FALSE(webAuthenticationPanelUpdatePINInvalid);
-    EXPECT_TRUE(webAuthenticationPanelUpdatePINAuthBlocked);
 }
 
 // FIXME rdar://145102423


### PR DESCRIPTION
#### e140358f974609f057d7f90454aa10d75cdc9629
<pre>
WebAuthn Authentication over NFC is broken in Safari Technology Preview 234 (SEED)
<a href="https://rdar.apple.com/168456474">rdar://168456474</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306279">https://bugs.webkit.org/show_bug.cgi?id=306279</a>

Reviewed by Brent Fulgham.

This patch makes a few changes to make CCID authenticators behave better.

1. Some newer authenticators have inconsistent behavior whenever we start a session
per-message. This change moves us to maintaining a session with a smart card until
invalidated and queuing messages as-needed.

2. We do not handle the kCtap2ErrUserPresenceRequired, which the authenticator
returns when it was left on an NFC reader for too long. We were looping on this
terminal error until we encountered the next issue fixed.

3. At one point we stopped handling the kCtap2ErrPinAuthBlocked error properly. This
error can be delievered before pin entry is attempted for an already locked
authenticator and this error gets returned whenever the platform ignores kCtap2ErrUserPresenceRequired.
This also required an internal change in <a href="https://rdar.apple.com/168804001">rdar://168804001</a>.

* Source/WebCore/Modules/webauthn/fido/FidoConstants.cpp:
(fido::isCtapDeviceResponseCode):
* Source/WebCore/Modules/webauthn/fido/FidoConstants.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm:
(WebKit::AuthenticatorPresenterCoordinator::updatePresenter):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(-[WKSmartCardObserver initWithCard:invalidationHandler:]):
(-[WKSmartCardObserver dealloc]):
(-[WKSmartCardObserver observeValueForKeyPath:ofObject:change:context:]):
(WebKit::CcidConnection::create):
(WebKit::CcidConnection::CcidConnection):
(WebKit::CcidConnection::~CcidConnection):
(WebKit::CcidConnection::detectContactless):
(WebKit::CcidConnection::transact):
(WebKit::CcidConnection::processPendingRequests):
(WebKit::CcidConnection::stop):
(WebKit::CcidConnection::startPolling):
(WebKit::CcidConnection::transact const): Deleted.
(WebKit::CcidConnection::stop const): Deleted.
(WebKit::CcidConnection::restartPolling): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm:
(WebKit::CcidService::~CcidService):
(WebKit::CcidService::platformStartDiscovery):
(WebKit::CcidService::onValidCard):
(WebKit::CcidService::onCardRemoved):
(-[_WKSmartCardSlotStateObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockCcidService.mm:
(WebKit::MockCcidService::platformStartDiscovery):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::continueSilentlyCheckCredentials):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
(WebKit::CtapAuthenticator::continueGetAssertionAfterResponseReceived):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST(WebAuthenticationPanel, MakeCredentialPinAuthBlockedError)):
(TestWebKitAPI::TEST(WebAuthenticationPanel, GetAssertionPinAuthBlockedError)):

Canonical link: <a href="https://commits.webkit.org/306280@main">https://commits.webkit.org/306280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb4201d7faa059b76ea253debadac7739ae3e377

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149212 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93907 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108025 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78383 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88927 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10353 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7914 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9253 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151782 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116289 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12904 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11223 "Found 1 new test failure: http/tests/media/modern-media-controls/skip-back-support/skip-back-support-button-click.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116627 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29667 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12636 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122705 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68029 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12932 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12671 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76632 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12870 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->