### PR TITLE
Add a way to send a _WKJSHandle over _WKRemoteObjectRegistry

### DIFF
--- a/Source/WebKit/UIProcess/API/APIJSHandle.h
+++ b/Source/WebKit/UIProcess/API/APIJSHandle.h
@@ -33,13 +33,15 @@ namespace API {
 class JSHandle final : public ObjectImpl<Object::Type::JSHandle> {
 public:
     static Ref<JSHandle> create(WebKit::JSHandleInfo&&);
+
+    // FIXME: This public constructor can be made private once _WKJSHandle no longer conforms to NSSecureCoding.
+    JSHandle(WebKit::JSHandleInfo&&);
+
     virtual ~JSHandle();
 
     const WebKit::JSHandleInfo& info() const { return m_info; }
 
 private:
-    JSHandle(WebKit::JSHandleInfo&&);
-
     const WebKit::JSHandleInfo m_info;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h
@@ -30,8 +30,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Note: NSSecureCoding should not be made public API.
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
-@interface _WKJSHandle : NSObject<NSCopying>
+@interface _WKJSHandle : NSObject<NSCopying, NSSecureCoding>
 
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFramePrivate.h
@@ -28,12 +28,14 @@
 @class JSContext;
 @class JSValue;
 @class WKWebProcessPlugInBrowserContextController;
+@class _WKJSHandle;
 
 @interface WKWebProcessPlugInFrame (WKPrivate)
 
 + (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle;
 + (instancetype)lookUpFrameFromJSContext:(JSContext *)context;
 + (instancetype)lookUpContentFrameFromWindowOrFrameElement:(JSValue *)value;
++ (_WKJSHandle *)jsHandleFromValue:(JSValue *)value withContext:(JSContext *)context;
 
 @property (nonatomic, readonly) WKWebProcessPlugInBrowserContextController *_browserContextController;
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1513,6 +1513,7 @@
 		F6D67D3826F90206006E0349 /* Int128.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6D67D3626F90206006E0349 /* Int128.cpp */; };
 		F6F49C6B15545CA70007F39D /* DOMWindowExtensionNoCache_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F6F49C6615545C8D0007F39D /* DOMWindowExtensionNoCache_Bundle.cpp */; };
 		FAC1FE462F19C3EB0030C30E /* open-in-new-tab.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = FAC1FE452F19C3EB0030C30E /* open-in-new-tab.html */; };
+		FAC1FE572F21AD890030C30E /* JSHandlePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAC1FE4F2F2152270030C30E /* JSHandlePlugIn.mm */; };
 		FE2BCDC72470FDA300DEC33B /* StdLibExtrasTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2BCDC62470FC7000DEC33B /* StdLibExtrasTests.cpp */; };
 		FE2D9474245EB2F400E48135 /* BitSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE2D9473245EB2DF00E48135 /* BitSet.cpp */; };
 		FE9CD7E42D10CE7500266FDD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
@@ -4478,6 +4479,8 @@
 		FA8650332C7D047B00117287 /* WebTransport.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebTransport.mm; sourceTree = "<group>"; };
 		FAC1FE442F197F4E0030C30E /* FocusWebView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FocusWebView.mm; sourceTree = "<group>"; };
 		FAC1FE452F19C3EB0030C30E /* open-in-new-tab.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "open-in-new-tab.html"; sourceTree = "<group>"; };
+		FAC1FE4F2F2152270030C30E /* JSHandlePlugIn.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = JSHandlePlugIn.mm; sourceTree = "<group>"; };
+		FAC1FE582F21B1820030C30E /* JSHandlePlugInProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSHandlePlugInProtocol.h; sourceTree = "<group>"; };
 		FAD420BF2E4AB7AA00069B2E /* SerializedNode.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SerializedNode.mm; sourceTree = "<group>"; };
 		FE2BCDC62470FC7000DEC33B /* StdLibExtrasTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StdLibExtrasTests.cpp; sourceTree = "<group>"; };
 		FE2D9473245EB2DF00E48135 /* BitSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BitSet.cpp; sourceTree = "<group>"; };
@@ -4987,6 +4990,8 @@
 				5C0160C021A132320077FA32 /* JITEnabled.mm */,
 				FA4F24EB2E99923700B2247F /* JSBuffer.mm */,
 				FA58F4572E1E062B0098E1C8 /* JSHandle.mm */,
+				FAC1FE4F2F2152270030C30E /* JSHandlePlugIn.mm */,
+				FAC1FE582F21B1820030C30E /* JSHandlePlugInProtocol.h */,
 				335406B42E3BEA96008B3349 /* LegacyPDFPluginTests.mm */,
 				C25CCA051E51380B0026CB8A /* LineBreaking.mm */,
 				37D36ED61AF42ECD00BAF5D9 /* LoadAlternateHTMLString.mm */,
@@ -8343,6 +8348,7 @@
 				F460F65B261119580064F2B6 /* InjectedBundleHitTestPlugIn.mm in Sources */,
 				0E404A8C2166DE0A008271BA /* InjectedBundleNodeHandleIsSelectElement.mm in Sources */,
 				79C5D431209D768300F1E7CA /* InjectedBundleNodeHandleIsTextField.mm in Sources */,
+				FAC1FE572F21AD890030C30E /* JSHandlePlugIn.mm in Sources */,
 				2D3CA3A8221DF4B40088E803 /* PageOverlayPlugin.mm in Sources */,
 				F44C7A0020F9EEBF0014478C /* ParserYieldTokenPlugIn.mm in Sources */,
 				A13EBBAB1B87434600097110 /* PlatformUtilitiesCocoa.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "JSHandlePlugInProtocol.h"
+#import "PlatformUtilities.h"
+#import <JavaScriptCore/JSRetainPtr.h>
+#import <JavaScriptCore/JSStringRef.h>
+#import <WebKit/WKBundlePage.h>
+#import <WebKit/WKBundlePageOverlay.h>
+#import <WebKit/WKWebProcessPlugIn.h>
+#import <WebKit/WKWebProcessPlugInBrowserContextControllerPrivate.h>
+#import <WebKit/WKWebProcessPlugInFramePrivate.h>
+#import <WebKit/WKWebProcessPlugInLoadDelegate.h>
+#import <WebKit/WKWebProcessPlugInScriptWorld.h>
+#import <WebKit/_WKJSHandle.h>
+#import <WebKit/_WKRemoteObjectInterface.h>
+#import <WebKit/_WKRemoteObjectRegistry.h>
+#import <wtf/RetainPtr.h>
+
+static WKWebProcessPlugInBrowserContextController *globalBrowserContextController;
+
+@interface JSHandlePlugIn : NSObject <WKWebProcessPlugIn, WKWebProcessPlugInLoadDelegate>
+@end
+
+@implementation JSHandlePlugIn
+
+- (void)webProcessPlugIn:(WKWebProcessPlugInController *)plugInController didCreateBrowserContextController:(WKWebProcessPlugInBrowserContextController *)browserContextController
+{
+    ASSERT(!globalBrowserContextController);
+    globalBrowserContextController = browserContextController;
+
+    browserContextController.loadDelegate = self;
+
+    static RetainPtr<WKWebProcessPlugInScriptWorld> world { [WKWebProcessPlugInScriptWorld world] };
+    [world allowJSHandleCreation];
+}
+
+static JSValueRef javaScriptFunction(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    if (argumentCount == 1) {
+        JSContext *jsContext = [JSContext contextWithJSGlobalContextRef:JSContextGetGlobalContext(context)];
+        JSValue *jsValue = [JSValue valueWithJSValueRef:arguments[0] inContext:jsContext];
+        if (_WKJSHandle *handle = [WKWebProcessPlugInFrame jsHandleFromValue:jsValue withContext:jsContext]) {
+            _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(JSHandlePlugInProtocol)];
+
+            id<JSHandlePlugInProtocol> remoteObject = [globalBrowserContextController._remoteObjectRegistry remoteObjectProxyWithInterface:interface];
+            [remoteObject receiveDictionaryFromWebProcess:@{ @"testkey" : handle }];
+        }
+    }
+    return JSValueMakeUndefined(context);
+}
+
+- (void)webProcessPlugInBrowserContextController:(WKWebProcessPlugInBrowserContextController*)controller globalObjectIsAvailableForFrame:(WKWebProcessPlugInFrame *)frame inScriptWorld:(WKWebProcessPlugInScriptWorld *)scriptWorld
+{
+    if (scriptWorld == WKWebProcessPlugInScriptWorld.normalWorld)
+        return;
+
+    JSContext *context = [frame jsContextForWorld:scriptWorld];
+
+    JSValue *value = [JSValue valueWithNewObjectInContext:context];
+
+    JSValueRef nativeImplementationValueRef = JSObjectMakeFunctionWithCallback((JSContextRef)context.JSGlobalContextRef, adopt(JSStringCreateWithCharacters((const JSChar *)L"testFunction", 12)).get(), javaScriptFunction);
+    JSValue *nativeImplementationValue = [JSValue valueWithJSValueRef:nativeImplementationValueRef inContext:context];
+    [value setValue:nativeImplementationValue forProperty:@"testFunction"];
+
+    [context.globalObject setValue:value forProperty:@"testProperty"];
+
+    [context evaluateScript:@"onload = () => { window.testProperty.testFunction(window.webkit.createJSHandle(document.getElementById('testelement'))) }"];
+}
+
+@end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugInProtocol.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugInProtocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,34 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "APIJSHandle.h"
+#import <Foundation/Foundation.h>
 
-#include "WebProcessMessages.h"
-#include "WebProcessProxy.h"
-#include <wtf/RuntimeApplicationChecks.h>
+@protocol JSHandlePlugInProtocol <NSObject>
 
-namespace API {
+- (void)receiveDictionaryFromWebProcess:(NSDictionary *)dictionary;
 
-Ref<JSHandle> JSHandle::create(WebKit::JSHandleInfo&& info)
-{
-    return adoptRef(*new JSHandle(WTF::move(info)));
-}
-
-JSHandle::JSHandle(WebKit::JSHandleInfo&& info)
-    : m_info(WTF::move(info))
-{
-}
-
-JSHandle::~JSHandle()
-{
-    // FIXME: Remove this once _WKRemoteObjectRegistry is no longer needed to help Safari transition away from the injected bundle.
-    // Once that's gone, we should only be in the UI process.
-    if (isInWebProcess())
-        return;
-
-    if (RefPtr webProcess = WebKit::WebProcessProxy::processForIdentifier(m_info.identifier.processIdentifier()))
-        webProcess->send(Messages::WebProcess::JSHandleDestroyed(m_info.identifier), 0);
-}
-
-} // namespace API
+@end


### PR DESCRIPTION
#### 28077417bfbfaa460a3d0038068baa10d7ba2cd7
<pre>
Add a way to send a _WKJSHandle over _WKRemoteObjectRegistry
<a href="https://bugs.webkit.org/show_bug.cgi?id=306285">https://bugs.webkit.org/show_bug.cgi?id=306285</a>
<a href="https://rdar.apple.com/168934712">rdar://168934712</a>

Reviewed by Ryosuke Niwa.

This is needed to help facilitate the incremental transition of Safari
off of the injected bundle SPI.  This allows native code that is on its
way to being removed send a _WKJSHandle to the replacement code in the
UI process.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugInProtocol.h
       Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm

* Source/WebKit/UIProcess/API/APIJSHandle.cpp:
(API::JSHandle::~JSHandle):
* Source/WebKit/UIProcess/API/APIJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm:
(+[_WKJSHandle supportsSecureCoding]):
(-[_WKJSHandle initWithCoder:]):
(-[_WKJSHandle encodeWithCoder:]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(+[WKWebProcessPlugInFrame jsHandleFromValue:withContext:]):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFramePrivate.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm: Added.
(-[JSHandlePlugIn webProcessPlugIn:didCreateBrowserContextController:]):
(javaScriptFunction):
(-[JSHandlePlugIn webProcessPlugInBrowserContextController:globalObjectIsAvailableForFrame:inScriptWorld:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugInProtocol.h: Copied from Source/WebKit/UIProcess/API/APIJSHandle.h.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(-[JSHandleReceiver receiveDictionaryFromWebProcess:]):
(TestWebKitAPI::TEST(TextExtractionTests, InjectedBundle)):

Canonical link: <a href="https://commits.webkit.org/306304@main">https://commits.webkit.org/306304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd0dc40ef3b873db5be4fd470c94660d2755d9fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149383 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108161 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89064 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10430 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8015 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9375 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119681 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151905 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13011 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116378 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116718 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12779 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68172 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21754 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13054 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12793 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76755 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->