### PR TITLE
X-Frame-Options should only strip tab or space

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split-expected.txt
@@ -3,4 +3,8 @@ PASS `,SAMEORIGIN,,DENY,` blocks same-origin framing
 PASS `,SAMEORIGIN,,DENY,` blocks cross-origin framing
 PASS `  SAMEORIGIN,    DENY` blocks same-origin framing
 PASS `  SAMEORIGIN,    DENY` blocks cross-origin framing
+PASS `DENY` allows same-origin framing
+PASS `DENY` allows cross-origin framing
+PASS `DENY` allows same-origin framing
+PASS `DENY` allows cross-origin framing
 

--- a/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html
@@ -20,4 +20,16 @@ xfo_simple_tests({
   sameOriginAllowed: false,
   crossOriginAllowed: false
 });
+
+xfo_simple_tests({
+  headerValue: `\x0BDENY`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
+
+xfo_simple_tests({
+  headerValue: `\x0CDENY`,
+  sameOriginAllowed: true,
+  crossOriginAllowed: true
+});
 </script>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1992,6 +1992,9 @@ imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html [ Crash 
 imported/w3c/web-platform-tests/event-timing/interaction-count-click.html [ Skip ]
 imported/w3c/web-platform-tests/event-timing/interaction-count-press-key.html [ Skip ]
 
+# Incorrect whitespace stripping might happen at the network layer?
+imported/w3c/web-platform-tests/x-frame-options/get-decode-split.html [ Skip ]
+
 # Timeout:
 webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-keydown-keyup.html [ Skip ]
 webkit.org/b/301110 imported/w3c/web-platform-tests/event-timing/gap-pointerdown-pointerup.html [ Skip ]

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -565,7 +565,7 @@ XFrameOptionsDisposition parseXFrameOptionsHeader(StringView header)
         return result;
 
     for (auto currentHeader : header.splitAllowingEmptyEntries(',')) {
-        currentHeader = currentHeader.trim(isUnicodeCompatibleASCIIWhitespace<char16_t>);
+        currentHeader = currentHeader.trim(isTabOrSpace<char16_t>);
         XFrameOptionsDisposition currentValue = XFrameOptionsDisposition::None;
         if (equalLettersIgnoringASCIICase(currentHeader, "deny"_s))
             currentValue = XFrameOptionsDisposition::Deny;


### PR DESCRIPTION
#### a9bbaa7e6d3e9c2a6f0c05749deca6748b9c91b8
<pre>
X-Frame-Options should only strip tab or space
<a href="https://bugs.webkit.org/show_bug.cgi?id=272745">https://bugs.webkit.org/show_bug.cgi?id=272745</a>
<a href="https://rdar.apple.com/126915315">rdar://126915315</a>

Reviewed by Youenn Fablet.

As per

    <a href="https://html.spec.whatwg.org/multipage/speculative-loading.html#the-x-frame-options-header">https://html.spec.whatwg.org/multipage/speculative-loading.html#the-x-frame-options-header</a>

which calls into

    <a href="https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split">https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split</a>

New tests:

    <a href="https://github.com/web-platform-tests/wpt/pull/57341">https://github.com/web-platform-tests/wpt/pull/57341</a>

Canonical link: <a href="https://commits.webkit.org/306279@main">https://commits.webkit.org/306279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/480944b5e90bba196343acaf1a8cf277cdd450c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140902 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/13286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/2526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149328 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142775 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/13996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/13438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143853 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/13996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/2526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/89020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/13996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/2526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9336 "Failed to checkout and rebase branch from PR 57273") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/13996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/2526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151865 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/2526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/12987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/13438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/116690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/2526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21741 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/13015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/2526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/76716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/12798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->