### PR TITLE
Add unit test for 306219@main

### DIFF
--- a/LayoutTests/http/tests/loading/mouse-click-prefetch-null-url.https-expected.txt
+++ b/LayoutTests/http/tests/loading/mouse-click-prefetch-null-url.https-expected.txt
@@ -1,0 +1,2 @@
+Clicking this prefetches something.
+Clicking this link without an href therafter should not crash.

--- a/LayoutTests/http/tests/loading/mouse-click-prefetch-null-url.https.html
+++ b/LayoutTests/http/tests/loading/mouse-click-prefetch-null-url.https.html
@@ -1,0 +1,24 @@
+<script type="speculationrules">
+    {"prefetch":[{"source":"document","where":{"and":[{"href_matches":"/*"}]},"eagerness":"conservative"}]}
+</script>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+    function clickElement(id) {
+        if (window.eventSender) {
+            let r = document.getElementById(id).getBoundingClientRect();
+            window.eventSender.mouseMoveTo((r.right + r.left) / 2, (r.top + r.bottom) / 2);
+            window.eventSender.mouseDown();
+            window.eventSender.mouseUp();
+        }
+    }
+    onload = () => {
+        clickElement('firstanchor');
+        clickElement('secondanchor');
+        setTimeout(()=>{ testRunner.notifyDone() }, 50);
+    }
+</script>
+<a id="firstanchor" href="resources/pass.html" onclick="event.preventDefault();">Clicking this prefetches something.</a><br/>
+<a id="secondanchor" >Clicking this link without an href therafter should not crash.</a>


### PR DESCRIPTION
#### 26b02b4eb3bc0375a15b694a1058c14983f082bc
<pre>
Add unit test for 306219@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=306299">https://bugs.webkit.org/show_bug.cgi?id=306299</a>
<a href="https://rdar.apple.com/168949525">rdar://168949525</a>

Reviewed by Simon Fraser and Wenson Hsieh.

The crash only happened when m_prefetchedData was not empty.  Otherwise,
HashTable::contains returns false without actually checking the key.
This unit test hit the crash from <a href="https://rdar.apple.com/168835297">rdar://168835297</a> before 306219@main to
make sure we don&apos;t reintroduce the crash in the future.

* LayoutTests/http/tests/loading/mouse-click-prefetch-null-url.https-expected.txt: Added.
* LayoutTests/http/tests/loading/mouse-click-prefetch-null-url.https.html: Added.

Canonical link: <a href="https://commits.webkit.org/306264@main">https://commits.webkit.org/306264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8804da7ef01aa6d935f0fefafddf746ba23c0d5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93864 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108010 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88913 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10324 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7885 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9209 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151739 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12846 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2208 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11185 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116588 "Found 1 new API test failure: TestWebCore:MIMETypeRegistry.CanShowMIMEType (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12592 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122662 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67986 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21735 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12888 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12628 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12672 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->