### PR TITLE
Swift WebBackForwardList (off by default) - WTF extras

### DIFF
--- a/Source/WebKit/Shared/API/APIArray.swift
+++ b/Source/WebKit/Shared/API/APIArray.swift
@@ -1,0 +1,45 @@
+// Copyright (C) 2025-2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if compiler(>=6.2)
+
+#if ENABLE_BACK_FORWARD_LIST_SWIFT
+
+internal import WebKit_Internal
+
+extension API.Array {
+    /// Create an API.Array from a Swift array.
+    // Can't be a designated initializer because we can't see private fields.
+    static func create(list: [API.Object]) -> API.RefAPIArray {
+        var vec = API.VectorRefPtrAPIObject()
+        vec.reserveCapacity(list.count)
+        for item in list {
+            vec.append(consuming: API.RefPtrAPIObject(item))
+        }
+        return API.Array.create(consuming: vec)
+    }
+}
+
+#endif // ENABLE_BACK_FORWARD_LIST_SWIFT
+
+#endif // compiler(>=6.2)

--- a/Source/WebKit/UIProcess/StdlibExtras.swift
+++ b/Source/WebKit/UIProcess/StdlibExtras.swift
@@ -1,0 +1,124 @@
+// Copyright (C) 2025-2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if compiler(>=6.2)
+
+// FIXME (rdar://164119356): Move parts of StdLibExtras.swift into WTF
+// (those parts which are not specific to WebKit-level types) - and enable
+// irrespective of BACK_FORWARD_LIST_SWIFT
+#if ENABLE_BACK_FORWARD_LIST_SWIFT
+
+internal import WebKit_Internal
+internal import wtf
+
+/// Conform any WTF::Ref<T> to this protocol to get useful extensions.
+protocol CxxRef {
+    associatedtype Pointee // you only need to specify this in your conformance
+    init(_ object: Pointee)
+    func copyRef() -> Self
+}
+
+/// Conform any WTF::Vector<WTF::Ref<T>> to this protocol to get useful extensions and iterators.
+protocol CxxRefVector {
+    associatedtype Element: CxxRef // you only need to specify this in your conformance
+    init()
+    mutating func append(consuming: Element)
+    mutating func reserveCapacity(_ newCapacity: Int)
+    func size() -> Int
+    // swift-format-ignore: AlwaysUseLowerCamelCase, NoLeadingUnderscores
+    func __atUnsafe(_ index: Int) -> UnsafePointer<Element>
+}
+
+extension WTF.String: LosslessStringConvertible {
+    /// Construct a `WTF.String` from a `Swift.String`.
+    public init(_ string: Swift.String) {
+        // rdar://162517354 prevents us from simply writing
+        // self = WTF.String.fromUTF8(swiftString.utf8CString.span);
+        // Safety - we are guaranteed to get a valid buffer from the Swift
+        // string for the duration that we're using it to construct the WTF::String.
+        // The WTF::String will take a copy.
+        let span = string.utf8CString.span
+        self = unsafe span.withUnsafeBufferPointer { ptr in
+            // Warning here is rdar://163018821
+            // swift-format-ignore: NeverForceUnwrap
+            let cppspan = unsafe SpanConstChar(ptr.baseAddress!, span.count)
+            return unsafe WTF.String.fromUTF8(cppspan)
+        }
+    }
+
+    /// Return a `Swift.String` from this `WTF.String`.
+    public var description: Swift.String {
+        // We could possibly make this quicker by treating a C++ span as
+        // a Sequence. For now, we want to avoid unsafe as much as possible.
+        String(utf8(WTF.LenientConversion).toStdString())
+    }
+}
+
+extension WTF.String: ExpressibleByStringLiteral {
+    /// Construct a `WTF.String` from a string literal.
+    public init(stringLiteral: Swift.String) {
+        self.init(stringLiteral)
+    }
+}
+
+extension CxxRefVector {
+    init(array: [Element.Pointee]) {
+        var vec = Self()
+        vec.reserveCapacity(array.count)
+        for item in array {
+            vec.append(consuming: Element(item))
+        }
+        self = vec
+    }
+}
+
+// Iterator for WTF::Vectors of Ref types.
+// rdar://169297366 when fixed will conform WTF::Vector directly to Sequence.
+// We can't do that manually since this would require C++ interop types to be public
+struct CxxRefVectorIterator<Vec: CxxRefVector>: Sequence, IteratorProtocol {
+    typealias Element = Vec.Element
+    var vec: Vec
+    var pos: Int
+
+    init(vec: Vec) {
+        self.vec = vec
+        self.pos = 0
+    }
+
+    mutating func next() -> Vec.Element? {
+        if pos >= vec.size() {
+            return nil
+        }
+        // Safety: we'll make a copy of the referent
+        // before the vector goes out of scope. It's guaranteed
+        // to have a valid lifetime, be initialized, and be
+        // within the vector bounds.
+        let item = unsafe vec.__atUnsafe(pos)
+        pos += 1
+        return unsafe item.pointee.copyRef()
+    }
+}
+
+#endif // ENABLE_BACK_FORWARD_LIST_SWIFT
+
+#endif // compiler(>=6.2)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1463,6 +1463,7 @@
 		58E7CD852E7862A100338ED0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC3DE46815A91763008D26FC /* Foundation.framework */; };
 		58E7CD862E7862A100338ED0 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* WebKit.framework */; };
 		58E7CD882E7862A100338ED0 /* WebContentProcess.xib in Resources */ = {isa = PBXBuildFile; fileRef = E1D26A4C1759634E0095BFD1 /* WebContentProcess.xib */; };
+		5C042DF42F33B06800FA849A /* APIArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C042DF32F33B06800FA849A /* APIArray.swift */; };
 		5C121E842410208D00486F9B /* FrameTreeNodeData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C121E8324101F7000486F9B /* FrameTreeNodeData.h */; };
 		5C121E89241029C900486F9B /* _WKFrameTreeNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C121E882410290D00486F9B /* _WKFrameTreeNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5C139DA629DB82E500D5117B /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* WebKit.framework */; };
@@ -1539,6 +1540,7 @@
 		5CB9310926E8439A0032B1C0 /* PrivateClickMeasurementXPCUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CB9310726E841CB0032B1C0 /* PrivateClickMeasurementXPCUtilities.h */; };
 		5CBC9B8E1C652CA000A8FDCF /* NetworkDataTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CBC9B891C6524A500A8FDCF /* NetworkDataTask.h */; };
 		5CBD595C2280EDF4002B22AA /* _WKCustomHeaderFields.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C5D2388227A1892000B9BDA /* _WKCustomHeaderFields.mm */; };
+		5CCD53272ED9D2F40001626D /* StdlibExtras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCD53262ED9D2F40001626D /* StdlibExtras.swift */; };
 		5CD286511E7235990094FDC8 /* WKContentRuleListStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CD2864D1E722F440094FDC8 /* WKContentRuleListStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5CD286531E7235AA0094FDC8 /* _WKUserContentFilterPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CD286491E722F440094FDC8 /* _WKUserContentFilterPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		5CD286541E7235B10094FDC8 /* WKContentRuleList.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CD2864A1E722F440094FDC8 /* WKContentRuleList.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -6413,6 +6415,7 @@
 		5ABF2BED2862353F000DCE74 /* GPUProcessPreferences.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GPUProcessPreferences.h; sourceTree = "<group>"; };
 		5C00993B2417FB7E00D53C25 /* ResourceLoadStatisticsParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceLoadStatisticsParameters.h; sourceTree = "<group>"; };
 		5C03D5DD28F765F800D096AF /* SessionState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SessionState.serialization.in; sourceTree = "<group>"; };
+		5C042DF32F33B06800FA849A /* APIArray.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIArray.swift; sourceTree = "<group>"; };
 		5C046A17290B268500FF7820 /* GPUProcessSessionParameters.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GPUProcessSessionParameters.serialization.in; sourceTree = "<group>"; };
 		5C046A19290B26CE00FF7820 /* MediaDescriptionInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaDescriptionInfo.h; sourceTree = "<group>"; };
 		5C046A1A290B26CF00FF7820 /* MediaDescriptionInfo.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = MediaDescriptionInfo.serialization.in; sourceTree = "<group>"; };
@@ -6680,6 +6683,7 @@
 		5CC8612728CA81FD0076F563 /* WebsiteDataFetchOption.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebsiteDataFetchOption.serialization.in; sourceTree = "<group>"; };
 		5CCB54DB2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemotePageDrawingAreaProxy.h; sourceTree = "<group>"; };
 		5CCB54DC2A4FEA6A0005FAA8 /* RemotePageDrawingAreaProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemotePageDrawingAreaProxy.cpp; sourceTree = "<group>"; };
+		5CCD53262ED9D2F40001626D /* StdlibExtras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdlibExtras.swift; sourceTree = "<group>"; };
 		5CCE5B5E29F73CDE0086A188 /* APIData.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = APIData.serialization.in; sourceTree = "<group>"; };
 		5CD286491E722F440094FDC8 /* _WKUserContentFilterPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKUserContentFilterPrivate.h; sourceTree = "<group>"; };
 		5CD2864A1E722F440094FDC8 /* WKContentRuleList.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKContentRuleList.h; sourceTree = "<group>"; };
@@ -15482,6 +15486,7 @@
 				93D6B76B254B89580058DD3A /* SpeechRecognitionServer.cpp */,
 				93D6B76C254B89580058DD3A /* SpeechRecognitionServer.h */,
 				93D6B77A254C984D0058DD3A /* SpeechRecognitionServer.messages.in */,
+				5CCD53262ED9D2F40001626D /* StdlibExtras.swift */,
 				515C415A207D74E000726E02 /* SuspendedPageProxy.cpp */,
 				515C415B207D74E100726E02 /* SuspendedPageProxy.h */,
 				5CFFD8472DEF511B00C421F5 /* SwiftDemoLogo.swift */,
@@ -16421,6 +16426,7 @@
 				BC64696D11DBE603006455B0 /* APIArray.cpp */,
 				BC64696E11DBE603006455B0 /* APIArray.h */,
 				FA9AFA692B2254F600953DC5 /* APIArray.serialization.in */,
+				5C042DF32F33B06800FA849A /* APIArray.swift */,
 				C68BA2622ADBA6EC00770791 /* APICaptionUserPreferencesTestingModeToken.h */,
 				1A3DD205125E5A2F004515E6 /* APIClient.h */,
 				1AAB037B185F99D800EDF501 /* APIData.cpp */,
@@ -21548,6 +21554,7 @@
 				EB517B802D7C09690019E451 /* AboutSchemeHandlerCocoa.mm in Sources */,
 				E37AE22D2D5E7A100010402E /* AdditionalFonts.mm in Sources */,
 				E3C3D1B02E007922004B306A /* AnnotatedMachSendRight.mm in Sources */,
+				5C042DF42F33B06800FA849A /* APIArray.swift in Sources */,
 				EBA8D3B227A5E33F00CB7900 /* ApplePushServiceConnection.mm in Sources */,
 				A1D615722B06C7C2002D0E19 /* AssertionCapability.mm in Sources */,
 				CD4570D424411D0F00A3DCEB /* AudioSessionRoutingArbitrator.cpp in Sources */,
@@ -21617,6 +21624,7 @@
 				93468E6D2714AF88009983E3 /* SharedFileHandleCocoa.cpp in Sources */,
 				9BF622522C3E8559007F7021 /* SharedPreferencesForWebProcess.cpp in Sources */,
 				575B1BB923CE9C0B0020639A /* SimulatedInputDispatcher.cpp in Sources */,
+				5CCD53272ED9D2F40001626D /* StdlibExtras.swift in Sources */,
 				5CFFD8482DEF511C00C421F5 /* SwiftDemoLogo.swift in Sources */,
 				5CAAA85029BFBE99003340AE /* TCCSoftLink.mm in Sources */,
 				E36A00E329CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm in Sources */,


### PR DESCRIPTION
#### 5ee6967eaa817f7f55158feaf55b168342f08aac
<pre>
Swift WebBackForwardList (off by default) - WTF extras
<a href="https://bugs.webkit.org/show_bug.cgi?id=306871">https://bugs.webkit.org/show_bug.cgi?id=306871</a>
<a href="https://rdar.apple.com/169532895">rdar://169532895</a>

Reviewed by Richard Robinson.

We&apos;re introducing a Swift version of the Back Forward List. For the general
design and rationale, see
<a href="https://github.com/WebKit/WebKit/pull/55393">https://github.com/WebKit/WebKit/pull/55393</a>
It will be landed as a series of separate commits in order to ease code review.

In this commit we introduce some WTF/Swift extensions. Specifically,
* Bidirectional constructors for WTF::String &lt;-&gt; Swift String
* An ability to iterate WTF::Vector&lt;WTF::Ref&lt;T&gt;&gt;

In the future these should become a formal part of WTF, a task represented by
<a href="https://rdar.apple.com/164119356">rdar://164119356</a> (there&apos;s similar code in WebGPU which should be merged
across equivalently) - this likely needs to wait for more comprehensive
enablement of Swift projects on a wider selection of targets, instead of just
off-by-default features.

We are adding these types and functions separately in order to ease code review
of subsequent stages. It&apos;s not useful until later commits also land.
It should however be harmless meanwhile.

Canonical link: <a href="https://commits.webkit.org/306853@main">https://commits.webkit.org/306853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89281be111428e147e4102cd6ecbf2a5a75e2288

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151223 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fdef483b-ae51-452f-8ad0-387ab3761e01) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0727f1da-516d-4765-a173-e3680df2b470) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90544 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b580e4a6-1a62-42b5-8583-044afefdee45) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11620 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1227 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120980 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153542 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14655 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117657 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14013 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124866 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70346 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14697 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3822 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14434 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78399 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14495 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->