### PR TITLE
Swift WebBackForwardList (off by default) - WebKit_Internal

### DIFF
--- a/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternalCxx.h
@@ -26,4 +26,3 @@
 // Add project-level C++ header files here to be able to access them from within Swift sources.
 
 #import "IPCTesterReceiverMessages.h"
-#import "UIProcess/SwiftDemoLogoConfirmation.h"

--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -165,6 +165,108 @@ module WebKit_Internal [system] {
         export *
     }
 
+    module APIArray {
+        requires cplusplus20
+        header "../../Shared/API/APIArray.h"
+        export *
+    }
+
+    module LoadedWebArchive {
+        requires cplusplus20
+        header "../../Shared/LoadedWebArchive.h"
+        export *
+    }
+
+    module SessionState {
+        requires cplusplus20
+        header "../../Shared/SessionState.h"
+        export *
+    }
+
+    module WebBackForwardCache {
+        requires cplusplus20
+        header "../../UIProcess/WebBackForwardCache.h"
+        export *
+    }
+
+    module WebBackForwardListCounts {
+        requires cplusplus20
+        header "../../Shared/WebBackForwardListCounts.h"
+        export *
+    }
+
+    module WebBackForwardListFrameItem {
+        requires cplusplus20
+        header "../../Shared/WebBackForwardListFrameItem.h"
+        export *
+    }
+
+    module WebBackForwardListItem {
+        requires cplusplus20
+        header "../../Shared/WebBackForwardListItem.h"
+        export *
+    }
+
+    module APICustomProtocolManagerClient {
+        requires cplusplus20
+        header "../../UIProcess/API/APICustomProtocolManagerClient.h"
+        export *
+    }
+
+    module APIHistoryClient {
+        requires cplusplus20
+        header "../../UIProcess/API/APIHistoryClient.h"
+        export *
+    }
+
+    module APINavigationClient {
+        requires cplusplus20
+        header "../../UIProcess/API/APINavigationClient.h"
+        export *
+    }
+
+    module AuxiliaryProcessProxy {
+        requires cplusplus20
+        header "../../UIProcess/AuxiliaryProcessProxy.h"
+        export *
+    }
+
+    module SwiftDemoLogoConfirmation {
+        requires cplusplus20
+        header "../../UIProcess/SwiftDemoLogoConfirmation.h"
+        export *
+    }
+
+    module WebBackForwardCacheEntry {
+        requires cplusplus20
+        header "../../UIProcess/WebBackForwardCacheEntry.h"
+        export *
+    }
+
+    module WebBackForwardListSwiftUtilities {
+        requires cplusplus20
+        header "../../UIProcess/WebBackForwardListSwiftUtilities.h"
+        export *
+    }
+
+    module WebFrameProxy {
+        requires cplusplus20
+        header "../../UIProcess/WebFrameProxy.h"
+        export *
+    }
+
+    module WebPermissionControllerProxy {
+        requires cplusplus20
+        header "../../UIProcess/WebPermissionControllerProxy.h"
+        export *
+    }
+
+    module WebProcessProxy {
+        requires cplusplus20
+        header "../../UIProcess/WebProcessProxy.h"
+        export *
+    }
+
     // FIXME: These parts of the module map needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
 
     module WebKit_Internal_Objc {


### PR DESCRIPTION
#### 45fa4fb56ac1f23d48084c6466c7c79d66f5d0ec
<pre>
Swift WebBackForwardList (off by default) - WebKit_Internal
<a href="https://bugs.webkit.org/show_bug.cgi?id=306872">https://bugs.webkit.org/show_bug.cgi?id=306872</a>
<a href="https://rdar.apple.com/169533203">rdar://169533203</a>

Reviewed by Richard Robinson.

We&apos;re introducing a Swift version of the Back Forward List. For the general
design and rationale, see
<a href="https://github.com/WebKit/WebKit/pull/55393">https://github.com/WebKit/WebKit/pull/55393</a>
It will be landed as a series of separate commits in order to ease code review.

This commit increases the set of header files which are considered to be part
of the WebKit_Internal clang module. That is, the set of headers and types
which are made available to Swift, such that Swift can use types and functions
within these files.

We are landing this commit separately in order to ease code review
of subsequent stages. In itself it&apos;s not useful and has no effect
until subsequent commits land.

* Source/WebKit/Modules/Internal/WebKitInternalCxx.h:
* Source/WebKit/Modules/Internal/module.modulemap:

Canonical link: <a href="https://commits.webkit.org/306944@main">https://commits.webkit.org/306944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e70b375787cb4be2f5d634850cb7369a3341b67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151535 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7101b53b-003e-4f59-a4a7-2a4c41de3e84) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109866 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/863f29bf-a64d-4db6-8fcc-0387901f701a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127821 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90775 "Found 1 new API test failure: WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edb1ee74-ee1c-4b5d-b5dc-b0ee50d91ec2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11824 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9507 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1534 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121205 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153848 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117882 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118216 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14206 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70656 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15002 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14945 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14799 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->