### PR TITLE
Swift WebBackForwardList (off by default) - dependent types

### DIFF
--- a/Source/WebKit/Shared/WebKit-Swift.h
+++ b/Source/WebKit/Shared/WebKit-Swift.h
@@ -32,10 +32,17 @@
 // - select between the headers generated using built-in or custom build
 //   actions on different SDK versions
 
-// #include statements should go here when the generated header
-// file depends upon C++ types. rdar://165068038 may resolve the need for
-// this.
+// If Swift function parameters or return types depend on C++ types, the
+// relevant headers must be included here. rdar://165068038
+#include "APIArray.h"
 #include "IPCTesterReceiverMessages.h"
+#include "WebBackForwardListItem.h"
+#include "WebBackForwardListMessages.h"
+#include "WebBackForwardListSwiftUtilities.h"
+
+#ifdef __OBJC__
+#include "WKUIDelegatePrivate.h"
+#endif
 
 // rdar://165192318
 IGNORE_CLANG_WARNINGS_BEGIN("arc-bridge-casts-disallowed-in-nonarc")


### PR DESCRIPTION
#### 5f682140ae0d0d494c57494fa5cbc6908453417b
<pre>
Swift WebBackForwardList (off by default) - dependent types
<a href="https://bugs.webkit.org/show_bug.cgi?id=305483">https://bugs.webkit.org/show_bug.cgi?id=305483</a>
<a href="https://rdar.apple.com/159589815">rdar://159589815</a>

Reviewed by Richard Robinson.

We&apos;re introducing a Swift version of the Back Forward List. For the general
design and rationale, see
<a href="https://github.com/WebKit/WebKit/pull/55393">https://github.com/WebKit/WebKit/pull/55393</a>
It will be landed as a series of separate commits in order to ease code review.

This commit adds a small set of extra #includes to WebKit-Swift.h.
Subsequent commits are going to add a substantial amount of Swift APIs which
are exposed to C++ by being placed into WebKit-Swift-Generated.h.
Those APIs may refer to C++ types (for example taking them as function
parameters).

Unfortunately, there&apos;s no way to instruct the Swift compiler to include
relevant #includes into that generated header (this is known as
<a href="https://rdar.apple.com/165068038">rdar://165068038</a>).

For that reason, we have to ensure that any C++ which includes
WebKit-Swift-Generated.h also #includes the headers required to declare
the types on which Swift APIs depend. To be sure this happens, nobody
includes WebKit-Swift-Generated.h directly, but instead must include
WebKit-Swift.h which adds these extra #includes.

A concrete fictional example: we add a Swift API like this
  func doThing(param: Foo)
where Foo is a C++ type declared in Foo.h.

In WebKit-Swift-Generated.h, this would result in something like:
  void doThing(Foo foo)
(simplifying muchly) but no #include &quot;Foo.h&quot;. To solve this problem
we would #include &quot;Foo.h&quot; from WebKit-Swift.h, and encourage everyone
to #include &quot;WebKit-Swift.h&quot; rather than WebKit-Swift-Generated.h directly.

Canonical link: <a href="https://commits.webkit.org/306407@main">https://commits.webkit.org/306407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f4b440eb26c28e44f744654101c859ddb104fbe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93871 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd50a5c2-1953-4df9-9690-a0cc4f588163) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/107979 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78370 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c36aa79-c2dc-4fbc-958c-b7ec4fd23293) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88882 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ab520bb-0c50-4676-8666-8b3b70a36f52) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10325 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7890 "Passed tests") | [⏳ wpe-libwebrtc ](None "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119571 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151746 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116258 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29769 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12589 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/67993 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12895 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2138 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76596 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->