### PR TITLE
Swift WebBackForwardList (off by default) - Swift utilities

### DIFF
--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -92,6 +92,8 @@ private:
     Vector<RefPtr<Object>> m_elements;
 } SWIFT_SHARED_REFERENCE(refArray, derefArray);
 
+using RefAPIArray = Ref<Array>;
+
 } // namespace API
 
 inline void refArray(API::Array* WTF_NONNULL obj)

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -318,6 +318,9 @@ inline API::Object* Object::unwrap(void* object)
 }
 #endif
 
+using VectorRefPtrAPIObject = Vector<RefPtr<Object>>;
+using RefPtrAPIObject = RefPtr<Object>;
+
 } // namespace API
 
 inline void refObject(API::Object* WTF_NONNULL obj)

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -161,6 +161,10 @@ struct SessionState {
     bool isEqualForTesting(const SessionState&) const;
 };
 
+using RefFrameState = Ref<FrameState>;
+using RefPtrFrameState = RefPtr<FrameState>;
+using VectorRefFrameState = Vector<Ref<FrameState>>;
+
 } // namespace WebKit
 
 inline void refFrameState(WebKit::FrameState* obj)

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -129,6 +129,14 @@ private:
 
 typedef Vector<Ref<WebBackForwardListItem>> BackForwardListItemVector;
 
+using RefWebBackForwardListItem = Ref<WebKit::WebBackForwardListItem>;
+using RefPtrWebBackForwardListItem = RefPtr<WebKit::WebBackForwardListItem>;
+
+// Workaround for rdar://85881664
+inline API::Object* WTF_NONNULL toAPIObject(WebBackForwardListItem* WTF_NONNULL item) SWIFT_RETURNS_UNRETAINED {
+    return item;
+}
+
 } // namespace WebKit
 
 inline void refBackForwardListItem(WebKit::WebBackForwardListItem* WTF_NONNULL obj)

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -167,6 +167,8 @@ private:
     WebCore::SecurityOriginData m_origin;
 };
 
+using RefPtrViewSnapshot = RefPtr<ViewSnapshot>;
+
 class ViewSnapshotStore {
     WTF_MAKE_NONCOPYABLE(ViewSnapshotStore);
     friend class ViewSnapshot;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -34,6 +34,7 @@
 #include "WebBackForwardCache.h"
 #include "WebBackForwardListCounts.h"
 #include "WebBackForwardListFrameItem.h"
+#include "WebBackForwardListSwiftUtilities.h"
 #include "WebFrameProxy.h"
 #include "WebInspectorUtilities.h"
 #include "WebPageProxy.h"
@@ -856,3 +857,33 @@ String WebBackForwardListWrapper::loggingString()
 #endif // ENABLE(BACK_FORWARD_LIST_SWIFT)
 
 } // namespace WebKit
+
+#if ENABLE(BACK_FORWARD_LIST_SWIFT)
+
+WebCore::BackForwardFrameItemIdentifier generateBackForwardFrameItemIdentifier()
+{
+    return WebCore::BackForwardFrameItemIdentifier::generate();
+}
+
+WebCore::BackForwardItemIdentifier generateBackForwardItemIdentifier()
+{
+    return WebCore::BackForwardItemIdentifier::generate();
+}
+
+// rdar://168139823 is the task of doing a productionized version of WebKit Swift logging
+void doLog(const char* WTF_NONNULL msg)
+{
+    LOG(BackForward, "%s", msg);
+}
+
+void doLoadingReleaseLog(const char* WTF_NONNULL msg)
+{
+    RELEASE_LOG(Loading, "%s", msg);
+}
+// rdar://168139740 is the task of doing a productionized Swift MESSAGE_CHECK
+void messageCheckFailed(Ref<WebKit::WebProcessProxy> process)
+{
+    MESSAGE_CHECK_BASE(false, process->connection());
+}
+
+#endif // ENABLE(BACK_FORWARD_LIST_SWIFT)

--- a/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
+++ b/Source/WebKit/UIProcess/WebBackForwardListSwiftUtilities.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Logging.h"
+#include "WebBackForwardListItem.h"
+#include "WebBackForwardListMessages.h"
+#include "WebProcessProxy.h"
+#include <cstdint>
+#include <wtf/Function.h>
+#include <wtf/Markable.h>
+#include <wtf/RefCountable.h>
+#include <wtf/RefCounted.h>
+#include <wtf/SwiftBridging.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+
+#if ENABLE(BACK_FORWARD_LIST_SWIFT)
+
+// Workaround for rdar://162358154
+using SpanConstChar = std::span<const char>;
+
+// These can't be inline due to rdar://162531519
+void doLog(const char* WTF_NONNULL msg); // rdar://168139823
+void doLoadingReleaseLog(const char* WTF_NONNULL msg); // rdar://168139823
+void messageCheckFailed(Ref<WebKit::WebProcessProxy>); // rdar://168139740
+
+// Workaround for rdar://162357139
+template<typename T>
+inline bool contentsMatch(const T& lhs, const T& rhs)
+{
+    return lhs == rhs;
+}
+
+// Workaround for rdar://162193891
+WebCore::BackForwardFrameItemIdentifier generateBackForwardFrameItemIdentifier();
+WebCore::BackForwardItemIdentifier generateBackForwardItemIdentifier();
+
+// Workaround for rdar://129159672
+inline void setOptionalUInt32Value(std::optional<uint32_t>& optional, uint32_t value)
+{
+    optional = value;
+}
+
+using WebBackForwardListItemFilter = WTF::RefCountable<WTF::Function<bool (WebKit::WebBackForwardListItem&)>>;
+
+#endif // ENABLE(BACK_FORWARD_LIST_SWIFT)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -387,6 +387,8 @@ template<typename> class RectEdges;
 
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 using BackForwardFrameItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardFrameItemIdentifierType>>;
+using MarkableBackForwardItemIdentifier = WTF::Markable<BackForwardItemIdentifier>;
+using MarkableBackForwardFrameItemIdentifier = WTF::Markable<BackForwardFrameItemIdentifier>;
 using DictationContext = ObjectIdentifier<DictationContextType>;
 using FramesPerSecond = unsigned;
 using FloatBoxExtent = RectEdges<float>;
@@ -4132,6 +4134,8 @@ private:
 
     HashSet<CheckedRef<WebProcessProxy>> m_unresponsiveProcesses;
 } SWIFT_SHARED_REFERENCE(refWebPageProxy, derefWebPageProxy);
+
+using WeakPtrWebPageProxy = WeakPtr<WebPageProxy>;
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -954,6 +954,14 @@ private:
 
 WTF::TextStream& operator<<(WTF::TextStream&, const WebProcessProxy&);
 
+using RefWebProcessProxy = Ref<WebProcessProxy>;
+
+// Workaround for rdar://162519380
+inline RefPtr<WebProcessProxy> downcastToWebProcessProxy(AuxiliaryProcessProxy* WTF_NONNULL app)
+{
+    return downcast<WebProcessProxy>(app);
+}
+
 } // namespace WebKit
 
 inline void refWebProcessProxy(WebKit::WebProcessProxy* WTF_NONNULL obj)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1514,6 +1514,7 @@
 		5C7FB47021E97DC5009E3241 /* WebCookieJar.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7FB46F21E97C0C009E3241 /* WebCookieJar.h */; };
 		5C826D6B26D482EF008AEC91 /* PrivateClickMeasurementStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C826D6826D46B44008AEC91 /* PrivateClickMeasurementStore.h */; };
 		5C826D6C26D482F2008AEC91 /* PrivateClickMeasurementDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C826D6926D482EA008AEC91 /* PrivateClickMeasurementDatabase.h */; };
+		5C8653152EC38A6600B95ED4 /* WebBackForwardListSwiftUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C8653142EC38A6600B95ED4 /* WebBackForwardListSwiftUtilities.h */; };
 		5C86531A2EC38B3700B95ED4 /* WebKit-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C8653192EC38B3700B95ED4 /* WebKit-Swift.h */; };
 		5C8BC797218CBB4800813886 /* SafeBrowsing.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5C8BC796218CB58A00813886 /* SafeBrowsing.xcassets */; };
 		5C8DD3801FE4521600F2A556 /* WebsiteAutoplayPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C8DD37F1FE4519200F2A556 /* WebsiteAutoplayPolicy.h */; };
@@ -6568,6 +6569,7 @@
 		5C826D6F26D58A16008AEC91 /* DatabaseUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DatabaseUtilities.h; sourceTree = "<group>"; };
 		5C84CF901F96AC4E00B6705A /* NetworkSessionCreationParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkSessionCreationParameters.h; sourceTree = "<group>"; };
 		5C85C7861C3F23C50061A4FA /* PendingDownload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PendingDownload.cpp; sourceTree = "<group>"; };
+		5C8653142EC38A6600B95ED4 /* WebBackForwardListSwiftUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebBackForwardListSwiftUtilities.h; sourceTree = "<group>"; };
 		5C8653192EC38B3700B95ED4 /* WebKit-Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WebKit-Swift.h"; sourceTree = "<group>"; };
 		5C89817629353FBB006D899A /* ProvisionalFrameProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProvisionalFrameProxy.cpp; sourceTree = "<group>"; };
 		5C89817729353FBB006D899A /* ProvisionalFrameProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProvisionalFrameProxy.h; sourceTree = "<group>"; };
@@ -15525,6 +15527,7 @@
 				BC72BA1B11E64907001EB4EA /* WebBackForwardList.cpp */,
 				BC72BA1C11E64907001EB4EA /* WebBackForwardList.h */,
 				5CDEE4922DACEF3400D2400E /* WebBackForwardList.swift */,
+				5C8653142EC38A6600B95ED4 /* WebBackForwardListSwiftUtilities.h */,
 				F036978715F4BF0500C3A80E /* WebColorPicker.cpp */,
 				3F87B9BF158940D80090FF62 /* WebColorPicker.h */,
 				31A505F71680025500A930EB /* WebContextClient.cpp */,
@@ -18514,6 +18517,7 @@
 				020E13132CA5F2FE002C616E /* WebBackForwardListFrameItem.h in Headers */,
 				518D2CAE12D5153B003BB93B /* WebBackForwardListItem.h in Headers */,
 				BC72B9FB11E6476B001EB4EA /* WebBackForwardListProxy.h in Headers */,
+				5C8653152EC38A6600B95ED4 /* WebBackForwardListSwiftUtilities.h in Headers */,
 				512B6792294B8CB8000C0760 /* WebBadgeClient.h in Headers */,
 				46EE2849269E04AC00DD48AB /* WebBroadcastChannelRegistry.h in Headers */,
 				41897ED11F415D680016FA42 /* WebCacheStorageConnection.h in Headers */,


### PR DESCRIPTION
#### c4cab0f5e07be8625bbbcf8775ddf7ad02fa024c
<pre>
Swift WebBackForwardList (off by default) - Swift utilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=306874">https://bugs.webkit.org/show_bug.cgi?id=306874</a>
<a href="https://rdar.apple.com/169533295">rdar://169533295</a>

Reviewed by Richard Robinson.

We&apos;re introducing a Swift version of the Back Forward List. For the general
design and rationale, see
<a href="https://github.com/WebKit/WebKit/pull/55393">https://github.com/WebKit/WebKit/pull/55393</a>
It will be landed as a series of separate commits in order to ease code review.

In this commit, we introduce a series of C++ types and functions to call
from Swift. Specifically,
* Swift can&apos;t access templated C++ types so we declare concrete types using
  &apos;using&apos;
* We introduce a few functions that rely on C++ preprocessor macros.
* A few other utility functions which are workarounds for missing functionality
  on the Swift side.

A note on naming: it&apos;s messy that this file is called &apos;*Utilities.h&apos;;
if it contained just types it would be better to call it &apos;*Types.h&apos; but as it&apos;s
a mixture this seemed like the least bad name.

We are landing this commit separately in order to ease code review
of subsequent stages. In itself it&apos;s not useful and has no effect
until subsequent commits land.

Canonical link: <a href="https://commits.webkit.org/306864@main">https://commits.webkit.org/306864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f1cef4ddaa6e614f1c6558aaea3bcb10fb6ea1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151252 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109660 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12120 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90569 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef357fe7-8034-406f-8514-8b9752a278b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11630 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9303 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1244 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120990 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153558 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14671 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117671 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118006 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30098 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14029 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70362 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14713 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14450 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78415 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14658 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->