### PR TITLE
[GFC] Expand flex tracks for grids with definite free space

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/FreeSpaceScenario.h
+++ b/Source/WebCore/layout/formattingContexts/grid/FreeSpaceScenario.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+namespace Layout {
+// https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
+// Enumerate the three free space scenarios for flex track sizing (spec §11.7).
+enum class FreeSpaceScenario : uint8_t {
+    // Scenario 1: Free space is zero or sizing under min-content constraint.
+    // Flex tracks resolve to zero.
+    MinContent,
+
+    // Scenario 2: Free space is a definite length.
+    // Flex tracks distribute available space using findSizeOfFr().
+    Definite,
+
+    // Scenario 3: Free space is indefinite (e.g., max-content sizing).
+    // Flex tracks compute from max-content contributions.
+    Indefinite
+};
+
+} // namespace Layout
+} // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FreeSpaceScenario.h"
 #include <WebCore/GridFormattingContext.h>
 #include <WebCore/GridTypeAliases.h>
 #include <WebCore/StyleGridTrackBreadth.h>
@@ -66,7 +67,7 @@ private:
 
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
-    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridFormattingContext::GridLayoutConstraints&) const;
+    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&, const GridFormattingContext::GridLayoutConstraints&, FreeSpaceScenario columnFreeSpaceScenario, FreeSpaceScenario rowFreeSpaceScenario) const;
 
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const UsedTrackSizes&) const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FreeSpaceScenario.h"
 #include <WebCore/GridTypeAliases.h>
 #include <WebCore/LayoutUnit.h>
 
@@ -47,7 +48,7 @@ struct GridItemSizingFunctions {
 
 class TrackSizingAlgorithm {
 public:
-    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions&, const IntegrationUtils&);
+    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions&, FreeSpaceScenario, const IntegrationUtils&);
 
 private:
 


### PR DESCRIPTION
#### 7e125e789b46fa178bf3f15cd89cd1ad52670cb7
<pre>
[GFC] Expand flex tracks for grids with definite free space
<a href="https://bugs.webkit.org/show_bug.cgi?id=306121">https://bugs.webkit.org/show_bug.cgi?id=306121</a>
&lt;<a href="https://rdar.apple.com/168767170">rdar://168767170</a>&gt;

Reviewed by NOBODY (OOPS\!).

This PR finishes implementing flex track expansion for grid containers
with definite free space as well as setting the flex fraction to zero
for grid containers under a min-content constraint.

This covers scenarios 1 and 2 of:

<a href="https://www.w3.org/TR/css-grid-1/#algo-flex-tracks">https://www.w3.org/TR/css-grid-1/#algo-flex-tracks</a>

This PR also introduces a FreeSpaceScenario enum to track
whether free space is min-content, definite, or indefinite to
determine how flex factors are resolved.

Scenario 3 depends on intrinsic sizing support and will be
added in a follow up PR.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/layout/formattingContexts/grid/FreeSpaceScenario.h: Added.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):
(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::computeHypotheticalFrSize):
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/306568@main">https://commits.webkit.org/306568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22e90fe19a31e815a171c6941a10299649cf7cf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94797 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5699859-c169-47db-9602-a0cb0c28c09f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108869 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f9e0c45-1158-4e4a-a1f4-9ce74bd56144) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89769 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb2d92cf-7657-42b1-a084-9dba25af040d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10962 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8601 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/323 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2830 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152643 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13753 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116967 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117292 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29886 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13324 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69361 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13791 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2798 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13530 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77516 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13733 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13577 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->