### PR TITLE
Fixed uncounted local variable warnings in WebCore/rendering

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -207,7 +207,6 @@ rendering/RenderIterator.h
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
-rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderLayerScrollableArea.cpp
 rendering/RenderLayoutState.cpp
@@ -221,7 +220,6 @@ rendering/RenderMultiColumnFlow.cpp
 rendering/RenderMultiColumnSet.cpp
 rendering/RenderObject.cpp
 rendering/RenderObject.h
-rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
 rendering/RenderReplaced.cpp
 rendering/RenderTable.cpp
@@ -317,7 +315,6 @@ rendering/updating/RenderTreeBuilderMultiColumn.cpp
 rendering/updating/RenderTreeBuilderRuby.cpp
 rendering/updating/RenderTreeBuilderSVG.cpp
 rendering/updating/RenderTreeBuilderTable.cpp
-rendering/updating/RenderTreePosition.cpp
 rendering/updating/RenderTreeUpdater.cpp
 rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
 rendering/updating/RenderTreeUpdaterViewTransition.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -86,47 +86,10 @@ platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
 [ iOS ] platform/ios/DragImageIOS.mm
 [ iOS ] platform/ios/LegacyTileGrid.mm
 [ iOS ] platform/ios/WebVideoFullscreenControllerAVKit.mm
-rendering/HitTestResult.cpp
-rendering/ImageQualityController.cpp
-rendering/MarkedText.cpp
-rendering/RenderBlock.cpp
-rendering/RenderBlockFlow.cpp
-rendering/RenderBox.cpp
-rendering/RenderBoxModelObject.cpp
 rendering/RenderCounter.cpp
-rendering/RenderDeprecatedFlexibleBox.cpp
-rendering/RenderElement.cpp
-rendering/RenderEmbeddedObject.cpp
-rendering/RenderFileUploadControl.cpp
-rendering/RenderFlexibleBox.cpp
-rendering/RenderGeometryMap.cpp
-rendering/RenderGrid.cpp
-rendering/RenderImage.cpp
 rendering/RenderLayer.cpp
-rendering/RenderLayerBacking.cpp
-rendering/RenderLayerCompositor.cpp
-rendering/RenderLayerFilters.cpp
-rendering/RenderLayerModelObject.cpp
-rendering/RenderLayerScrollableArea.cpp
-rendering/RenderListBox.cpp
-rendering/RenderListItem.cpp
-rendering/RenderMenuList.cpp
-rendering/RenderObject.cpp
-rendering/RenderProgress.cpp
-rendering/RenderQuote.cpp
-rendering/RenderTableCell.cpp
-rendering/RenderTextControlSingleLine.cpp
 rendering/RenderTreeAsText.cpp
-rendering/RenderView.cpp
-rendering/RenderWidget.cpp
 [ iOS ] rendering/ios/RenderThemeIOS.mm
-rendering/mathml/MathMLStyle.cpp
-rendering/style/StyleCachedImage.cpp
-rendering/style/StyleCanvasImage.cpp
-rendering/svg/RenderSVGPath.cpp
-rendering/svg/SVGTextLayoutAttributesBuilder.cpp
-rendering/updating/RenderTreePosition.cpp
-rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
 style/ElementRuleCollector.cpp
 style/MatchResultCache.cpp
 style/PageRuleCollector.cpp

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -165,11 +165,11 @@ static Node* moveOutOfUserAgentShadowTree(Node& node)
 
 void HitTestResult::setToNonUserAgentShadowAncestor()
 {
-    if (Node* node = innerNode()) {
+    if (RefPtr node = innerNode()) {
         node = moveOutOfUserAgentShadowTree(*node);
         setInnerNode(node);
     }
-    if (Node *node = innerNonSharedNode()) {
+    if (RefPtr node = innerNonSharedNode()) {
         node = moveOutOfUserAgentShadowTree(*node);
         setInnerNonSharedNode(node);
     }
@@ -246,7 +246,7 @@ bool HitTestResult::isSelected() const
     if (!m_innerNonSharedNode)
         return false;
 
-    auto* frame = m_innerNonSharedNode->document().frame();
+    RefPtr frame = m_innerNonSharedNode->document().frame();
     if (!frame)
         return false;
 
@@ -292,7 +292,7 @@ String HitTestResult::selectedText() const
     if (!m_innerNonSharedNode)
         return emptyString();
 
-    auto* frame = m_innerNonSharedNode->document().frame();
+    RefPtr frame = m_innerNonSharedNode->document().frame();
     if (!frame)
         return emptyString();
 
@@ -353,7 +353,7 @@ String HitTestResult::title(TextDirection& dir) const
     dir = TextDirection::LTR;
     // Find the title in the nearest enclosing DOM node.
     // For <area> tags in image maps, walk the tree for the <area>, not the <img> using it.
-    for (Node* titleNode = m_innerNode.get(); titleNode; titleNode = titleNode->parentInComposedTree()) {
+    for (RefPtr titleNode = m_innerNode.get(); titleNode; titleNode = titleNode->parentInComposedTree()) {
         if (RefPtr titleElement = dynamicDowncast<Element>(*titleNode)) {
             auto title = titleElement->title();
             if (!title.isNull()) {
@@ -368,8 +368,8 @@ String HitTestResult::title(TextDirection& dir) const
 
 String HitTestResult::innerTextIfTruncated(TextDirection& dir) const
 {
-    for (auto* truncatedNode = m_innerNode.get(); truncatedNode; truncatedNode = truncatedNode->parentInComposedTree()) {
-        auto* element = dynamicDowncast<Element>(*truncatedNode);
+    for (RefPtr truncatedNode = m_innerNode.get(); truncatedNode; truncatedNode = truncatedNode->parentInComposedTree()) {
+        RefPtr element = dynamicDowncast<Element>(*truncatedNode);
         if (!element)
             continue;
 
@@ -459,7 +459,7 @@ bool HitTestResult::hasEntireImage() const
     if (imageURL.isEmpty() || imageRect().isEmpty())
         return false;
 
-    auto* innerFrame = innerNodeFrame();
+    RefPtr innerFrame = innerNodeFrame();
     if (!innerFrame)
         return false;
 
@@ -733,7 +733,7 @@ bool HitTestResult::isOverTextInsideFormControlElement() const
     if (!element || !element->isTextField())
         return false;
 
-    auto* frame = element->document().frame();
+    RefPtr frame = element->document().frame();
     if (!frame)
         return false;
 
@@ -812,7 +812,7 @@ bool HitTestResult::isContentEditable() const
 }
 
 template<typename RectType>
-inline HitTestProgress HitTestResult::addNodeToListBasedTestResultCommon(Node* node, const HitTestRequest& request, const HitTestLocation& locationInContainer, const RectType& rect)
+inline HitTestProgress HitTestResult::addNodeToListBasedTestResultCommon(Node* nodeArg, const HitTestRequest& request, const HitTestLocation& locationInContainer, const RectType& rect)
 {
     // If it is not a list-based hit test, this method has to be no-op.
     if (!request.resultIsElementList()) {
@@ -820,8 +820,10 @@ inline HitTestProgress HitTestResult::addNodeToListBasedTestResultCommon(Node* n
         return HitTestProgress::Stop;
     }
 
-    if (!node)
+    if (!nodeArg)
         return HitTestProgress::Continue;
+
+    RefPtr node = nodeArg;
 
     if ((request.disallowsUserAgentShadowContent() && node->isInUserAgentShadowTree())
         || (request.disallowsUserAgentShadowContentExceptForImageOverlays() && !ImageOverlay::isInsideOverlay(*node) && node->isInUserAgentShadowTree()))
@@ -906,7 +908,7 @@ RefPtr<Node> HitTestResult::protectedTargetNode() const
 
 Element* HitTestResult::targetElement() const
 {
-    for (Node* node = m_innerNode.get(); node; node = node->parentInComposedTree()) {
+    for (RefPtr node = m_innerNode.get(); node; node = node->parentInComposedTree()) {
         if (auto* element = dynamicDowncast<Element>(*node))
             return element;
     }
@@ -930,7 +932,7 @@ Element* HitTestResult::innerNonSharedElement() const
 
 String HitTestResult::linkSuggestedFilename() const
 {
-    auto* urlElement = URLElement();
+    RefPtr urlElement = URLElement();
     if (!is<HTMLAnchorElement>(urlElement))
         return nullAtom();
     return ResourceResponse::sanitizeSuggestedFilename(urlElement->attributeWithoutSynchronization(HTMLNames::downloadAttr));
@@ -990,7 +992,7 @@ HTMLImageElement* HitTestResult::imageElement() const
 
 bool HitTestResult::isAnimating() const
 {
-    if (auto* imageElement = this->imageElement())
+    if (RefPtr imageElement = this->imageElement())
         return imageElement->allowsAnimation();
     return false;
 }
@@ -1007,7 +1009,7 @@ void HitTestResult::pauseAnimation() const
 
 void HitTestResult::setAllowsAnimation(bool allowAnimation) const
 {
-    if (auto* imageElement = this->imageElement()) {
+    if (RefPtr imageElement = this->imageElement()) {
         imageElement->setAllowsAnimation(allowAnimation);
         if (auto* renderer = m_innerNonSharedNode->renderer())
             renderer->repaint();

--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -156,7 +156,7 @@ InterpolationQuality ImageQualityController::chooseInterpolationQuality(Graphics
     }
 
     // If the containing FrameView is being resized, paint at low quality until resizing is finished.
-    if (auto* frame = object->document().frame()) {
+    if (RefPtr frame = object->document().frame()) {
         bool frameViewIsCurrentlyInLiveResize = frame->view() && frame->view()->inLiveResize();
         if (frameViewIsCurrentlyInLiveResize) {
             set(object, innerMap, layer, size);

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -128,8 +128,8 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
                 // FIXME: Potentially move this check elsewhere, to where we collect this range information.
                 auto hasRenderer = [&] {
                     IntersectingNodeRange nodes(makeSimpleRange(highlightRange->range()));
-                    for (auto& iterator : nodes) {
-                        if (iterator.renderer())
+                    for (Ref iterator : nodes) {
+                        if (iterator->renderer())
                             return true;
                     }
                     return false;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1462,7 +1462,7 @@ void RenderBlock::paintSelection(PaintInfo& paintInfo, const LayoutPoint& paintO
 
         LayoutRect gapRectsBounds = selectionGaps(*this, paintOffset, LayoutSize(), lastTop, lastLeft, lastRight, cache, &paintInfo);
         if (!gapRectsBounds.isEmpty()) {
-            if (RenderLayer* layer = enclosingLayer()) {
+            if (CheckedPtr layer = enclosingLayer()) {
                 gapRectsBounds.moveBy(-paintOffset);
                 if (!hasLayer()) {
                     LayoutRect localBounds(gapRectsBounds);

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1239,7 +1239,7 @@ void RenderBlockFlow::adjustOutOfFlowBlock(RenderBox& child, const MarginInfo& m
         logicalTop += collapsedBeforePos - collapsedBeforeNeg;
     }
 
-    RenderLayer* childLayer = child.layer();
+    CheckedPtr childLayer = child.layer();
     if (childLayer->staticBlockPosition() != logicalTop) {
         childLayer->setStaticBlockPosition(logicalTop);
         if (hasStaticBlockPosition)
@@ -4267,16 +4267,16 @@ void RenderBlockFlow::setStaticPositionsForSimpleOutOfFlowContent()
 
     for (auto walker = InlineWalker(*this); !walker.atEnd(); walker.advance()) {
         auto& renderer = downcast<RenderBox>(*walker.current());
-        auto& layer = *renderer.layer();
+        CheckedRef layer = *renderer.layer();
 
         ASSERT(renderer.isOutOfFlowPositioned());
 
-        auto previousStaticPosition = LayoutPoint { layer.staticInlinePosition(), layer.staticBlockPosition() };
+        auto previousStaticPosition = LayoutPoint { layer->staticInlinePosition(), layer->staticBlockPosition() };
         auto delta = staticPosition - previousStaticPosition;
         auto hasStaticInlinePositioning = renderer.style().hasStaticInlinePosition(isHorizontalWritingMode());
 
-        layer.setStaticInlinePosition(staticPosition.x());
-        layer.setStaticBlockPosition(staticPosition.y());
+        layer->setStaticInlinePosition(staticPosition.x());
+        layer->setStaticBlockPosition(staticPosition.y());
 
         if (!delta.isZero() && hasStaticInlinePositioning)
             renderer.setChildNeedsLayout(MarkOnlyThis);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -517,8 +517,8 @@ void RenderBox::updateFromStyle()
             // (2) We are the primary <body> (can be checked by looking at document.body).
             // (3) The root element has visible overflow.
             // (4) No containment is set either on the body or on the html document element.
-            auto& documentElement = *document().documentElement();
-            auto& documentElementRenderer = *documentElement.renderer();
+            Ref documentElement = *document().documentElement();
+            auto& documentElementRenderer = *documentElement->renderer();
             if (is<HTMLHtmlElement>(documentElement)
                 && document().body() == element()
                 && documentElementRenderer.effectiveOverflowX() == Overflow::Visible
@@ -651,10 +651,10 @@ void RenderBox::resetLogicalHeightBeforeLayoutIfNeeded()
 
 static void setupWheelEventMonitor(RenderLayerScrollableArea& scrollableArea)
 {
-    Page& page = scrollableArea.layer().renderer().page();
-    if (!page.isMonitoringWheelEvents())
+    Ref page = scrollableArea.layer().renderer().page();
+    if (!page->isMonitoringWheelEvents())
         return;
-    scrollableArea.scrollAnimator().setWheelEventTestMonitor(page.wheelEventTestMonitor());
+    scrollableArea.scrollAnimator().setWheelEventTestMonitor(page->wheelEventTestMonitor());
 }
 
 void RenderBox::setScrollLeft(int newLeft, const ScrollPositionChangeOptions& options)
@@ -1775,7 +1775,7 @@ void RenderBox::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint& pai
     // The theme will tell us whether or not we should also paint the CSS background.
     bool borderOrBackgroundPaintingIsNeeded = true;
     if (style().hasUsedAppearance()) {
-        if (auto* control = ensureControlPartForRenderer())
+        if (RefPtr control = ensureControlPartForRenderer())
             borderOrBackgroundPaintingIsNeeded = theme().paint(*this, *control, paintInfo, paintRect);
         else
             borderOrBackgroundPaintingIsNeeded = theme().paint(*this, paintInfo, paintRect);
@@ -1790,7 +1790,7 @@ void RenderBox::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint& pai
         backgroundPainter.paintBackground(paintRect, bleedAvoidance);
 
         if (style().hasUsedAppearance()) {
-            if (auto* control = ensureControlPartForDecorations())
+            if (RefPtr control = ensureControlPartForDecorations())
                 theme().paint(*this, *control, paintInfo, paintRect);
             else
                 theme().paintDecorations(*this, paintInfo, paintRect);
@@ -1806,7 +1806,7 @@ void RenderBox::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint& pai
             paintCSSBorder = true;
         else if (borderOrBackgroundPaintingIsNeeded) {
             // The theme will tell us whether or not we should also paint the CSS border.
-            if (auto* control = ensureControlPartForBorderOnly())
+            if (RefPtr control = ensureControlPartForBorderOnly())
                 paintCSSBorder = theme().paint(*this, *control, paintInfo, paintRect);
             else
                 paintCSSBorder = theme().paintBorderOnly(*this, paintInfo);
@@ -1897,7 +1897,7 @@ static bool isCandidateForOpaquenessTest(const RenderBox& childBox)
         return false;
     if (!childBox.width() || !childBox.height())
         return false;
-    if (RenderLayer* childLayer = childBox.layer()) {
+    if (CheckedPtr childLayer = childBox.layer()) {
         if (childLayer->isComposited())
             return false;
         // FIXME: Deal with z-index.
@@ -2158,7 +2158,7 @@ bool RenderBox::repaintLayerRectsForImage(WrappedImagePtr image, const Layers& l
                     // (since root backgrounds cover the canvas, not just the element). If the root element
                     // is composited though, we need to issue the repaint to that root element.
                     auto documentElementRenderer = downcast<RenderBox>(document().documentElement()->renderer());
-                    auto rendererLayer = documentElementRenderer->layer();
+                    CheckedPtr rendererLayer = documentElementRenderer->layer();
                     if (rendererLayer && rendererLayer->isComposited())
                         layerRenderer = documentElementRenderer;
                 } else {

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -513,7 +513,7 @@ LayoutPoint RenderBoxModelObject::adjustedPositionRelativeToOffsetParent(const L
 std::pair<const RenderBox&, const RenderLayer*> RenderBoxModelObject::enclosingClippingBoxForStickyPosition() const
 {
     ASSERT(isStickilyPositioned());
-    RenderLayer* clipLayer = hasLayer() ? layer()->enclosingOverflowClipLayer(ExcludeSelf) : nullptr;
+    CheckedPtr clipLayer = hasLayer() ? layer()->enclosingOverflowClipLayer(ExcludeSelf) : nullptr;
     const RenderBox& box = clipLayer ? downcast<RenderBox>(clipLayer->renderer()) : view();
     return { box, clipLayer };
 }
@@ -650,7 +650,7 @@ void RenderBoxModelObject::computeStickyPositionConstraints(StickyPositionViewpo
 
 FloatRect RenderBoxModelObject::constrainingRectForStickyPosition() const
 {
-    RenderLayer* enclosingClippingLayer = hasLayer() ? layer()->enclosingOverflowClipLayer(ExcludeSelf) : nullptr;
+    CheckedPtr enclosingClippingLayer = hasLayer() ? layer()->enclosingOverflowClipLayer(ExcludeSelf) : nullptr;
 
     if (enclosingClippingLayer) {
         RenderBox& enclosingClippingBox = downcast<RenderBox>(enclosingClippingLayer->renderer());
@@ -833,7 +833,7 @@ bool RenderBoxModelObject::fixedBackgroundPaintsInLocalCoordinates() const
     if (view().frameView().paintBehavior().contains(PaintBehavior::FlattenCompositingLayers))
         return false;
 
-    RenderLayer* rootLayer = view().layer();
+    CheckedPtr rootLayer = view().layer();
     if (!rootLayer || !rootLayer->isComposited())
         return false;
 

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -534,7 +534,7 @@ void RenderDeprecatedFlexibleBox::layoutHorizontalBox(RelayoutChildren relayoutC
         for (RenderBox* child = iterator.first(); child; child = iterator.next()) {
             if (child->isOutOfFlowPositioned()) {
                 child->containingBlock()->addOutOfFlowBox(*child);
-                RenderLayer* childLayer = child->layer();
+                CheckedPtr childLayer = child->layer();
                 childLayer->setStaticInlinePosition(xPos); // FIXME: Not right for regions.
                 if (childLayer->staticBlockPosition() != yPos) {
                     childLayer->setStaticBlockPosition(yPos);
@@ -802,7 +802,7 @@ void RenderDeprecatedFlexibleBox::layoutVerticalBox(RelayoutChildren relayoutChi
 
             if (child->isOutOfFlowPositioned()) {
                 child->containingBlock()->addOutOfFlowBox(*child);
-                RenderLayer* childLayer = child->layer();
+                CheckedPtr childLayer = child->layer();
                 childLayer->setStaticInlinePosition(borderAndPaddingStart()); // FIXME: Not right for regions.
                 if (childLayer->staticBlockPosition() != height()) {
                     childLayer->setStaticBlockPosition(height());

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -336,8 +336,8 @@ Style::Difference RenderElement::adjustStyleDifference(Style::Difference diff) c
     }
     
     if ((diff.contextSensitiveProperties & Style::DifferenceContextSensitiveProperty::Filter) && hasLayer()) {
-        auto& layer = *downcast<RenderLayerModelObject>(*this).layer();
-        if (!layer.isComposited() || layer.shouldPaintWithFilters())
+        CheckedRef layer = *downcast<RenderLayerModelObject>(*this).layer();
+        if (!layer->isComposited() || layer->shouldPaintWithFilters())
             diff.result = std::max(diff.result, Style::DifferenceResult::RepaintLayer);
         else
             diff.result = std::max(diff.result, Style::DifferenceResult::RecompositeLayer);
@@ -721,7 +721,7 @@ RenderPtr<RenderObject> RenderElement::detachRendererInternal(RenderObject& rend
 static RenderLayer* findNextLayer(const RenderElement& currRenderer, const RenderLayer& parentLayer, const RenderObject* siblingToTraverseFrom, bool checkParent = true)
 {
     // Step 1: If our layer is a child of the desired parent, then return our layer.
-    auto* ourLayer = currRenderer.hasLayer() ? downcast<RenderLayerModelObject>(currRenderer).layer() : nullptr;
+    SUPPRESS_UNCOUNTED_LOCAL auto* ourLayer = currRenderer.hasLayer() ? downcast<RenderLayerModelObject>(currRenderer).layer() : nullptr;
     if (ourLayer && ourLayer->parent() == &parentLayer)
         return ourLayer;
 
@@ -1739,7 +1739,7 @@ void RenderElement::notifyFinished(CachedResource& resource, const NetworkLoadMe
 
 bool RenderElement::allowsAnimation() const
 {
-    if (auto* imageElement = dynamicDowncast<HTMLImageElement>(element()))
+    if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element()))
         return imageElement->allowsAnimation();
     return page().imageAnimationEnabled();
 }
@@ -1832,9 +1832,9 @@ std::unique_ptr<RenderStyle> RenderElement::getUncachedPseudoStyle(const Style::
         return nullptr;
 
     Ref element = *this->element();
-    auto& styleResolver = element->styleResolver();
+    Ref styleResolver = element->styleResolver();
 
-    auto resolvedStyle = styleResolver.styleForPseudoElement(element, pseudoElementRequest, { parentStyle });
+    auto resolvedStyle = styleResolver->styleForPseudoElement(element, pseudoElementRequest, { parentStyle });
     if (!resolvedStyle)
         return nullptr;
 
@@ -2297,7 +2297,7 @@ bool RenderElement::checkForRepaintDuringLayout() const
 
 ImageOrientation RenderElement::imageOrientation() const
 {
-    auto* imageElement = dynamicDowncast<HTMLImageElement>(element());
+    RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element());
     return (imageElement && !imageElement->allowsOrientationOverride())
         ? ImageOrientation(ImageOrientation::Orientation::FromImage)
         : Style::toPlatform(style().imageOrientation());

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -104,7 +104,7 @@ bool RenderEmbeddedObject::requiresAcceleratedCompositing() const
     if (RenderWidget::requiresAcceleratedCompositing())
         return true;
 
-    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    RefPtr pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
     if (!pluginViewBase)
         return false;
     return pluginViewBase->layerHostingStrategy() != PluginLayerHostingStrategy::None;
@@ -376,19 +376,19 @@ bool RenderEmbeddedObject::nodeAtPoint(const HitTestRequest& request, HitTestRes
     if (!is<PluginViewBase>(widget()))
         return true;
 
-    PluginViewBase& view = downcast<PluginViewBase>(*widget());
+    Ref view = downcast<PluginViewBase>(*widget());
     IntPoint roundedPoint = locationInContainer.roundedPoint();
 
-    if (Scrollbar* horizontalScrollbar = view.horizontalScrollbar()) {
+    if (RefPtr horizontalScrollbar = view->horizontalScrollbar()) {
         if (horizontalScrollbar->shouldParticipateInHitTesting() && horizontalScrollbar->frameRect().contains(roundedPoint)) {
-            result.setScrollbar(horizontalScrollbar);
+            result.setScrollbar(WTF::move(horizontalScrollbar));
             return true;
         }
     }
 
-    if (Scrollbar* verticalScrollbar = view.verticalScrollbar()) {
+    if (RefPtr verticalScrollbar = view->verticalScrollbar()) {
         if (verticalScrollbar->shouldParticipateInHitTesting() && verticalScrollbar->frameRect().contains(roundedPoint)) {
-            result.setScrollbar(verticalScrollbar);
+            result.setScrollbar(WTF::move(verticalScrollbar));
             return true;
         }
     }

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -88,7 +88,7 @@ void RenderFileUploadControl::updateFromElement()
 {
     ASSERT(inputElement().isFileUpload());
 
-    if (HTMLInputElement* button = uploadButton()) {
+    if (RefPtr button = uploadButton()) {
         bool newCanReceiveDroppedFilesState = inputElement().canReceiveDroppedFiles();
         if (m_canReceiveDroppedFiles != newCanReceiveDroppedFilesState) {
             m_canReceiveDroppedFiles = newCanReceiveDroppedFilesState;
@@ -98,7 +98,7 @@ void RenderFileUploadControl::updateFromElement()
 
     // This only supports clearing out the files, but that's OK because for
     // security reasons that's the only change the DOM is allowed to make.
-    FileList* files = inputElement().files();
+    RefPtr files = inputElement().files();
     ASSERT(files);
     if (files && files->isEmpty())
         repaint();
@@ -169,7 +169,7 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
         else
             contentLogicalLeft -= textIndentOffset();
 
-        HTMLInputElement* button = uploadButton();
+        RefPtr button = uploadButton();
         if (!button)
             return;
 
@@ -289,9 +289,10 @@ void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogic
 
     const String label = theme().fileListDefaultLabel(inputElement().multiple());
     float defaultLabelWidth = font.width(constructTextRun(label, style(), ExpansionBehavior::allowRightOnly()));
-    if (HTMLInputElement* button = uploadButton())
+    if (RefPtr button = uploadButton()) {
         if (CheckedPtr buttonRenderer = dynamicDowncast<RenderBox>(button->renderer()))
             defaultLabelWidth += buttonRenderer->maxPreferredLogicalWidth() + afterButtonSpacing;
+    }
     maxLogicalWidth = static_cast<int>(ceilf(std::max(minDefaultLabelWidth, defaultLabelWidth)));
 
     auto& logicalWidth = style().logicalWidth();
@@ -331,7 +332,7 @@ HTMLInputElement* RenderFileUploadControl::uploadButton() const
 
 String RenderFileUploadControl::buttonValue()
 {
-    if (HTMLInputElement* button = uploadButton())
+    if (RefPtr button = uploadButton())
         return button->value();
     
     return String();
@@ -339,16 +340,16 @@ String RenderFileUploadControl::buttonValue()
 
 String RenderFileUploadControl::fileTextValue() const
 {
-    auto& input = inputElement();
-    if (!input.files())
+    Ref input = inputElement();
+    if (!input->files())
         return { };
-    if (input.files()->length() && !input.displayString().isEmpty()) {
-        if (input.files()->length() == 1)
-            return StringTruncator::centerTruncate(input.displayString(), maxFilenameLogicalWidth(), style().fontCascade());
+    if (input->files()->length() && !input->displayString().isEmpty()) {
+        if (input->files()->length() == 1)
+            return StringTruncator::centerTruncate(input->displayString(), maxFilenameLogicalWidth(), style().fontCascade());
 
-        return StringTruncator::rightTruncate(input.displayString(), maxFilenameLogicalWidth(), style().fontCascade());
+        return StringTruncator::rightTruncate(input->displayString(), maxFilenameLogicalWidth(), style().fontCascade());
     }
-    return theme().fileListNameForWidth(input.files(), style().fontCascade(), maxFilenameLogicalWidth(), input.multiple());
+    return theme().fileListNameForWidth(input->files(), style().fontCascade(), maxFilenameLogicalWidth(), input->multiple());
 }
     
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2126,7 +2126,7 @@ LayoutUnit RenderFlexibleBox::staticBlockPositionForPositionedFlexItem(const Ren
 bool RenderFlexibleBox::setStaticPositionForPositionedLayout(const RenderBox& flexItem)
 {
     bool positionChanged = false;
-    auto* layer = flexItem.layer();
+    CheckedPtr layer = flexItem.layer();
     if (flexItem.style().hasStaticInlinePosition(writingMode().isHorizontal())) {
         LayoutUnit inlinePosition = staticInlinePositionForPositionedFlexItem(flexItem);
         if (layer->staticInlinePosition() != inlinePosition) {
@@ -2179,7 +2179,7 @@ void RenderFlexibleBox::prepareFlexItemForPositionedLayout(RenderBox& flexItem)
 {
     ASSERT(flexItem.isOutOfFlowPositioned());
     flexItem.containingBlock()->addOutOfFlowBox(flexItem);
-    auto* layer = flexItem.layer();
+    CheckedPtr layer = flexItem.layer();
     LayoutUnit staticInlinePosition = flowAwareBorderStart() + flowAwarePaddingStart();
     if (layer->staticInlinePosition() != staticInlinePosition) {
         layer->setStaticInlinePosition(staticInlinePosition);

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -166,13 +166,14 @@ static bool canMapBetweenRenderersViaLayers(const RenderLayerModelObject& render
     return true;
 }
 
-void RenderGeometryMap::pushMappingsToAncestor(const RenderLayer* layer, const RenderLayer* ancestorLayer, bool respectTransforms)
+void RenderGeometryMap::pushMappingsToAncestor(const RenderLayer* layerArg, const RenderLayer* ancestorLayer, bool respectTransforms)
 {
     if (!ancestorLayer) {
         ASSERT(!m_mapping.size());
-        pushMappingsToAncestor(&layer->renderer().view(), nullptr);
+        pushMappingsToAncestor(&layerArg->renderer().view(), nullptr);
 
         SetForScope positionChange(m_insertionPosition, m_mapping.size());
+        CheckedPtr layer = layerArg;
         while (layer->parent()) {
             pushMappingsToAncestor(layer, layer->parent(), respectTransforms);
             layer = layer->parent();
@@ -187,12 +188,12 @@ void RenderGeometryMap::pushMappingsToAncestor(const RenderLayer* layer, const R
 
     SetForScope flagsChange(m_mapCoordinatesFlags, newFlags);
 
-    const RenderLayerModelObject& renderer = layer->renderer();
+    const RenderLayerModelObject& renderer = layerArg->renderer();
 
     // We have to visit all the renderers to detect flipped blocks. This might defeat the gains
     // from mapping via layers.
     if (canMapBetweenRenderersViaLayers(renderer, ancestorLayer->renderer())) {
-        LayoutSize layerOffset = layer->offsetFromAncestor(ancestorLayer);
+        LayoutSize layerOffset = layerArg->offsetFromAncestor(ancestorLayer);
         
         // The RenderView must be pushed first.
         if (!m_mapping.size()) {

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1645,7 +1645,7 @@ void RenderGrid::prepareGridItemForPositionedLayout(RenderBox& gridItem)
     ASSERT(gridItem.isOutOfFlowPositioned());
     gridItem.containingBlock()->addOutOfFlowBox(gridItem);
 
-    RenderLayer* gridItemLayer = gridItem.layer();
+    CheckedPtr gridItemLayer = gridItem.layer();
     // Static position of a positioned grid item should use the content-box (https://drafts.csswg.org/css-grid/#static-position).
     gridItemLayer->setStaticInlinePosition(borderAndPaddingStart());
     gridItemLayer->setStaticBlockPosition(borderAndPaddingBefore());

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -463,7 +463,7 @@ bool RenderImage::isDimensionlessSVG() const
     auto* cachedImage = this->cachedImage();
     if (!cachedImage)
         return false;
-    auto* svgImage = dynamicDowncast<SVGImage>(cachedImage->image());
+    RefPtr svgImage = dynamicDowncast<SVGImage>(cachedImage->image());
     if (!svgImage)
         return false;
     RefPtr rootElement = svgImage->rootElement();
@@ -484,7 +484,7 @@ bool RenderImage::shouldRespectZeroIntrinsicWidth() const
     auto* cachedImage = this->cachedImage();
     if (!cachedImage)
         return false;
-    if (auto* svgImage = dynamicDowncast<SVGImage>(cachedImage->image())) {
+    if (RefPtr svgImage = dynamicDowncast<SVGImage>(cachedImage->image())) {
         if (auto rootElement = svgImage->rootElement())
             return rootElement->hasIntrinsicWidth();
     }
@@ -866,7 +866,7 @@ LayoutUnit RenderImage::minimumReplacedHeight() const
 
 RefPtr<HTMLMapElement> RenderImage::imageMap() const
 {
-    auto* imageElement = dynamicDowncast<HTMLImageElement>(element());
+    RefPtr imageElement = dynamicDowncast<HTMLImageElement>(element());
     return imageElement ? imageElement->associatedMapElement() : nullptr;
 }
 
@@ -899,9 +899,9 @@ void RenderImage::updateAltText()
     if (!element())
         return;
 
-    if (auto* input = dynamicDowncast<HTMLInputElement>(*element()))
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element()))
         m_altText = input->altText();
-    else if (auto* image = dynamicDowncast<HTMLImageElement>(*element()))
+    else if (RefPtr image = dynamicDowncast<HTMLImageElement>(*element()))
         m_altText = image->altText();
 
     if (m_altText.isNull()) {
@@ -976,7 +976,7 @@ bool RenderImage::shouldInvalidatePreferredWidths() const
 RenderBox* RenderImage::embeddedContentBox() const
 {
     if (auto* cachedImage = this->cachedImage()) {
-        if (auto* image = dynamicDowncast<SVGImage>(cachedImage->image()))
+        if (RefPtr image = dynamicDowncast<SVGImage>(cachedImage->image()))
             return image->embeddedContentBox();
     }
     return nullptr;

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -87,7 +87,7 @@ void RenderLayerFilters::notifyFinished(CachedResource&, const NetworkLoadMetric
 
     // FIXME: This really shouldn't have to invalidate layer composition,
     // but tests like css3/filters/effect-reference-delete.html fail if that doesn't happen.
-    if (auto* enclosingElement = layer->enclosingElement())
+    if (RefPtr enclosingElement = layer->enclosingElement())
         enclosingElement->invalidateStyleAndLayerComposition();
     layer->renderer().repaint();
 }

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -204,7 +204,7 @@ void RenderLayerModelObject::styleDidChange(Style::Difference diff, const Render
         if (isDocumentElementRenderer()) {
             LocalFrameView& frameView = view().frameView();
             frameView.updateScrollbarSteps();
-        } else if (RenderLayer* renderLayer = layer())
+        } else if (CheckedPtr renderLayer = layer())
             renderLayer->updateScrollbarSteps();
     }
 
@@ -467,7 +467,7 @@ RenderSVGResourceClipper* RenderLayerModelObject::svgClipperResourceFromStyle() 
                     return referencedClipperRenderer;
             }
 
-            if (auto* svgElement = dynamicDowncast<SVGElement>(this->element()))
+            if (RefPtr svgElement = dynamicDowncast<SVGElement>(this->element()))
                 document().addPendingSVGResource(clipPath.fragment(), *svgElement);
 
             return nullptr;
@@ -521,7 +521,7 @@ RenderSVGResourceMasker* RenderLayerModelObject::svgMaskerResourceFromStyle() co
             return referencedMaskerRenderer;
     }
 
-    if (auto* element = this->element())
+    if (RefPtr element = this->element())
         document().addPendingSVGResource(resourceID, downcast<SVGElement>(*element));
 
     return nullptr;
@@ -556,7 +556,7 @@ RenderSVGResourceMarker* RenderLayerModelObject::svgMarkerResourceFromStyle(cons
             return referencedMarkerRenderer;
     }
 
-    if (auto* element = dynamicDowncast<SVGElement>(this->element()))
+    if (RefPtr element = dynamicDowncast<SVGElement>(this->element()))
         document().addPendingSVGResource(AtomString(markerResourceURL->resolved.string()), *element);
 
     return nullptr;
@@ -576,7 +576,7 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgFillPaintServerResource
             return referencedPaintServerRenderer;
     }
 
-    if (auto* element = this->element())
+    if (RefPtr element = this->element())
         document().addPendingSVGResource(AtomString(fillURL->resolved.string()), downcast<SVGElement>(*element));
 
     return nullptr;
@@ -596,7 +596,7 @@ RenderSVGResourcePaintServer* RenderLayerModelObject::svgStrokePaintServerResour
             return referencedPaintServerRenderer;
     }
 
-    if (auto* element = this->element())
+    if (RefPtr element = this->element())
         document().addPendingSVGResource(AtomString(strokeURL->resolved.string()), downcast<SVGElement>(*element));
 
     return nullptr;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -458,7 +458,7 @@ void RenderLayerScrollableArea::updateCompositingLayersAfterScroll()
     if (m_layer.compositor().hasContentCompositingLayers()) {
         // Our stacking container is guaranteed to contain all of our descendants that may need
         // repositioning, so update compositing layers from there.
-        if (RenderLayer* compositingAncestor = m_layer.stackingContext()->enclosingCompositingLayer()) {
+        if (CheckedPtr compositingAncestor = m_layer.stackingContext()->enclosingCompositingLayer()) {
             if (usesCompositedScrolling())
                 m_layer.compositor().updateCompositingLayers(CompositingUpdateType::OnCompositedScroll, compositingAncestor);
             else {
@@ -985,7 +985,7 @@ bool RenderLayerScrollableArea::isScrollableOrRubberbandable()
 
 bool RenderLayerScrollableArea::hasScrollableOrRubberbandableAncestor()
 {
-    for (auto* nextLayer = m_layer.enclosingContainingBlockLayer(CrossFrameBoundaries::Yes); nextLayer; nextLayer = nextLayer->enclosingContainingBlockLayer(CrossFrameBoundaries::Yes)) {
+    for (CheckedPtr nextLayer = m_layer.enclosingContainingBlockLayer(CrossFrameBoundaries::Yes); nextLayer; nextLayer = nextLayer->enclosingContainingBlockLayer(CrossFrameBoundaries::Yes)) {
         if (nextLayer->renderer().isScrollableOrRubberbandableBox())
             return true;
     }
@@ -1487,7 +1487,7 @@ void RenderLayerScrollableArea::paintOverflowControls(GraphicsContext& context, 
         if (!overflowControlsIntersectRect(localDamgeRect))
             return;
 
-        RenderLayer* paintingRoot = m_layer.enclosingCompositingLayer();
+        CheckedPtr paintingRoot = m_layer.enclosingCompositingLayer();
         if (!paintingRoot)
             paintingRoot = renderer.view().layer();
 
@@ -2017,7 +2017,7 @@ void RenderLayerScrollableArea::scrollByRecursively(const IntSize& delta, Scroll
         IntSize remainingScrollOffset = newScrollOffset - scrollOffset();
         if (!remainingScrollOffset.isZero() && renderer.parent()) {
             // FIXME: This skips scrollable frames.
-            if (auto* enclosingScrollableLayer = m_layer.enclosingScrollableLayer(IncludeSelfOrNot::ExcludeSelf, CrossFrameBoundaries::Yes)) {
+            if (CheckedPtr enclosingScrollableLayer = m_layer.enclosingScrollableLayer(IncludeSelfOrNot::ExcludeSelf, CrossFrameBoundaries::Yes)) {
                 if (CheckedPtr scrollableArea = enclosingScrollableLayer->scrollableArea())
                     scrollableArea->scrollByRecursively(remainingScrollOffset, scrolledArea);
             }

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -310,7 +310,7 @@ LayoutRect RenderListBox::itemBoundingBoxRect(const LayoutPoint& additionalOffse
     LayoutUnit x = additionalOffset.x() + borderLeft() + paddingLeft();
     LayoutUnit y = additionalOffset.y() + borderTop() + paddingTop();
 
-    if (auto* vBar = verticalScrollbar(); vBar && shouldPlaceVerticalScrollbarOnLeft())
+    if (RefPtr vBar = verticalScrollbar(); vBar && shouldPlaceVerticalScrollbarOnLeft())
         x += vBar->occupiedWidth();
 
     auto itemOffset = itemLogicalHeight() * (index - indexOffset());
@@ -535,7 +535,7 @@ void RenderListBox::paintItemBackground(PaintInfo& paintInfo, const LayoutPoint&
         return;
 
     Color backColor;
-    if (auto* option = dynamicDowncast<HTMLOptionElement>(*listItemElement); option && option->selected()) {
+    if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*listItemElement); option && option->selected()) {
         if (frame().selection().isFocusedAndActive() && document().focusedElement() == &selectElement())
             backColor = theme().activeListBoxSelectionBackgroundColor(styleColorOptions());
         else
@@ -554,7 +554,7 @@ void RenderListBox::paintItemBackground(PaintInfo& paintInfo, const LayoutPoint&
 
 bool RenderListBox::isPointInOverflowControl(HitTestResult& result, const LayoutPoint& locationInContainer, const LayoutPoint& accumulatedOffset)
 {
-    auto* activeScrollbar = verticalScrollbar();
+    RefPtr activeScrollbar = verticalScrollbar();
     if (!activeScrollbar)
         activeScrollbar = horizontalScrollbar();
 
@@ -567,7 +567,7 @@ bool RenderListBox::isPointInOverflowControl(HitTestResult& result, const Layout
     if (!scrollbarRect.contains(locationInContainer))
         return false;
 
-    result.setScrollbar(activeScrollbar);
+    result.setScrollbar(WTF::move(activeScrollbar));
     return true;
 }
 
@@ -577,14 +577,14 @@ int RenderListBox::listIndexAtOffset(const LayoutSize& offset) const
         return -1;
 
     int scrollbarHeight = 0;
-    if (auto* hBar = horizontalScrollbar())
+    if (RefPtr hBar = horizontalScrollbar())
         scrollbarHeight = hBar->height();
 
     if (offset.height() < borderTop() || offset.height() > height() - borderBottom() - scrollbarHeight)
         return -1;
 
     int scrollbarWidth = 0;
-    if (auto* vBar = verticalScrollbar())
+    if (RefPtr vBar = verticalScrollbar())
         scrollbarWidth = vBar->width();
 
     if (shouldPlaceVerticalScrollbarOnLeft() && (offset.width() < borderLeft() + paddingLeft() + scrollbarWidth || offset.width() > width() - borderRight() - paddingRight()))
@@ -831,7 +831,7 @@ LayoutUnit RenderListBox::itemLogicalHeight() const
 
 int RenderListBox::verticalScrollbarWidth() const
 {
-    if (auto* vBar = verticalScrollbar())
+    if (RefPtr vBar = verticalScrollbar())
         return vBar->occupiedWidth();
 
     return 0;
@@ -839,7 +839,7 @@ int RenderListBox::verticalScrollbarWidth() const
 
 int RenderListBox::horizontalScrollbarHeight() const
 {
-    if (auto* hBar = horizontalScrollbar())
+    if (RefPtr hBar = horizontalScrollbar())
         return hBar->occupiedHeight();
 
     return 0;
@@ -1094,11 +1094,11 @@ bool RenderListBox::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() con
 
 ScrollableArea* RenderListBox::enclosingScrollableArea() const
 {
-    auto* layer = enclosingLayer();
+    CheckedPtr layer = enclosingLayer();
     if (!layer)
         return nullptr;
 
-    auto* enclosingScrollableLayer = layer->enclosingScrollableLayer(IncludeSelfOrNot::ExcludeSelf, CrossFrameBoundaries::No);
+    CheckedPtr enclosingScrollableLayer = layer->enclosingScrollableLayer(IncludeSelfOrNot::ExcludeSelf, CrossFrameBoundaries::No);
     if (!enclosingScrollableLayer)
         return nullptr;
 

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -96,10 +96,10 @@ bool isHTMLListElement(const Node& node)
 // Returns the enclosing list with respect to the DOM order.
 static Element* enclosingList(const RenderListItem& listItem)
 {
-    auto* element = listItem.element();
-    auto* pseudoElement = dynamicDowncast<PseudoElement>(element);
-    auto* parent = pseudoElement ? pseudoElement->hostElement() : element->parentElement();
-    for (auto* ancestor = parent; ancestor; ancestor = ancestor->parentElement()) {
+    SUPPRESS_UNCOUNTED_LOCAL auto* element = listItem.element();
+    SUPPRESS_UNCOUNTED_LOCAL auto* pseudoElement = dynamicDowncast<PseudoElement>(element);
+    SUPPRESS_UNCOUNTED_LOCAL auto* parent = pseudoElement ? pseudoElement->hostElement() : element->parentElement();
+    for (SUPPRESS_UNCOUNTED_LOCAL auto* ancestor = parent; ancestor; ancestor = ancestor->parentElement()) {
         if (isHTMLListElement(*ancestor) || (ancestor->renderer() && ancestor->renderer()->shouldApplyStyleContainment()))
             return ancestor;
     }
@@ -112,7 +112,7 @@ static Element* enclosingList(const RenderListItem& listItem)
 
 static RenderListItem* nextListItemHelper(const Element& list, const Element& element)
 {
-    auto* current = &element;
+    RefPtr current = &element;
     auto advance = [&] {
         if (!current->renderOrDisplayContentsStyle())
             current = ElementTraversal::nextIncludingPseudoSkippingChildren(*current, &list);
@@ -126,7 +126,7 @@ static RenderListItem* nextListItemHelper(const Element& list, const Element& el
             advance();
             continue;
         }
-        auto* otherList = enclosingList(*item);
+        RefPtr otherList = enclosingList(*item);
         if (!otherList) {
             advance();
             continue;
@@ -155,7 +155,7 @@ static inline RenderListItem* firstListItem(const Element& list)
 
 static RenderListItem* previousListItem(const Element& list, const RenderListItem& item)
 {
-    auto* current = item.element();
+    RefPtr current = item.element();
     auto advance = [&] {
         current = ElementTraversal::previousIncludingPseudo(*current, &list);
     };
@@ -166,7 +166,7 @@ static RenderListItem* previousListItem(const Element& list, const RenderListIte
             advance();
             continue;
         }
-        auto* otherList = enclosingList(*item);
+        RefPtr otherList = enclosingList(*item);
         if (!otherList) {
             advance();
             continue;
@@ -200,8 +200,8 @@ unsigned RenderListItem::itemCountForOrderedList(const HTMLOListElement& list)
 
 void RenderListItem::updateValueNow() const
 {
-    auto* list = enclosingList(*this);
-    auto* orderedList = dynamicDowncast<HTMLOListElement>(list);
+    RefPtr list = enclosingList(*this);
+    RefPtr orderedList = dynamicDowncast<HTMLOListElement>(list);
 
     // The start item is either the closest item before this one in the list that already has a value,
     // or the first item in the list if none have before this have values yet.
@@ -305,7 +305,7 @@ void RenderListItem::usedCounterDirectivesChanged()
         m_marker->setNeedsLayoutAndPreferredWidthsUpdate();
 
     updateValue();
-    auto* list = enclosingList(*this);
+    RefPtr list = enclosingList(*this);
     if (!list)
         return;
     auto* item = this;
@@ -315,7 +315,7 @@ void RenderListItem::usedCounterDirectivesChanged()
 
 void RenderListItem::updateListMarkerNumbers()
 {
-    auto* list = enclosingList(*this);
+    RefPtr list = enclosingList(*this);
     if (!list)
         return;
 
@@ -335,7 +335,7 @@ void RenderListItem::updateListMarkerNumbers()
 
 bool RenderListItem::isInReversedOrderedList() const
 {
-    auto* list = dynamicDowncast<HTMLOListElement>(enclosingList(*this));
+    RefPtr list = dynamicDowncast<HTMLOListElement>(enclosingList(*this));
     return list && list->isReversed();
 }
 

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -433,7 +433,7 @@ void RenderMenuList::getItemBackgroundColor(unsigned listIndex, Color& itemBackg
         itemHasCustomBackgroundColor = false;
         return;
     }
-    HTMLElement* element = listItems[listIndex].get();
+    RefPtr element = listItems[listIndex].get();
 
     Color backgroundColor;
     if (auto* style = element->computedStyleForEditability())

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2143,7 +2143,7 @@ RenderObject::RenderObjectRareData::~RenderObjectRareData() = default;
 bool RenderObject::hasEmptyVisibleRectRespectingParentFrames() const
 {
     auto enclosingFrameRenderer = [] (const RenderObject& renderer) {
-        auto* ownerElement = renderer.document().ownerElement();
+        RefPtr ownerElement = renderer.document().ownerElement();
         return ownerElement ? ownerElement->renderer() : nullptr;
     };
 
@@ -2260,7 +2260,7 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
     // Don't include elements at the end of the range that are only partially selected.
     // FIXME: What about the start of the range? The asymmetry here does not make sense. Seems likely this logic is not quite right in other respects, too.
     if (RefPtr lastNode = nodeAfter(range.end)) {
-        for (auto& ancestor : lineageOfType<Element>(*lastNode))
+        for (CheckedRef ancestor : lineageOfType<Element>(*lastNode))
             selectedElementsSet.remove(ancestor);
     }
 
@@ -2338,7 +2338,7 @@ ScrollAnchoringController* RenderObject::searchParentChainForScrollAnchoringCont
                 return controller;
         }
     }
-    for (auto* enclosingLayer = renderer.enclosingLayer(); enclosingLayer; enclosingLayer = enclosingLayer->parent()) {
+    for (CheckedPtr enclosingLayer = renderer.enclosingLayer(); enclosingLayer; enclosingLayer = enclosingLayer->parent()) {
         if (RenderLayerScrollableArea* scrollableArea = enclosingLayer->scrollableArea()) {
             auto controller = scrollableArea->scrollAnchoringController();
             if (controller && controller->anchorElement())

--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -51,7 +51,7 @@ void RenderProgress::willBeDestroyed()
 
 void RenderProgress::updateFromElement()
 {
-    HTMLProgressElement* element = progressElement();
+    RefPtr element = progressElement();
     if (m_position == element->position())
         return;
     m_position = element->position();

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -434,14 +434,14 @@ static StringImpl* stringForQuoteCharacter(char16_t character)
 
 static inline StringImpl* quotationMarkString()
 {
-    static StringImpl* quotationMarkString = stringForQuoteCharacter(quotationMark);
-    return quotationMarkString;
+    static NeverDestroyed<Ref<StringImpl>> quotationMarkString { *stringForQuoteCharacter(quotationMark) };
+    return quotationMarkString->ptr();
 }
 
 static inline StringImpl* apostropheString()
 {
-    static StringImpl* apostropheString = stringForQuoteCharacter(apostrophe);
-    return apostropheString;
+    static NeverDestroyed<Ref<StringImpl>> apostropheString { *stringForQuoteCharacter(apostrophe) };
+    return apostropheString->ptr();
 }
 
 void RenderQuote::updateTextRenderer(RenderTreeBuilder& builder)

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -127,10 +127,10 @@ void RenderTableCell::willBeRemovedFromTree()
 unsigned RenderTableCell::parseColSpanFromDOM() const
 {
     ASSERT(element());
-    if (auto* cell = dynamicDowncast<HTMLTableCellElement>(*element()))
+    if (RefPtr cell = dynamicDowncast<HTMLTableCellElement>(*element()))
         return std::min<unsigned>(cell->colSpan(), maxColumnIndex);
 #if ENABLE(MATHML)
-    auto* mathMLElement = dynamicDowncast<MathMLElement>(*element());
+    RefPtr mathMLElement = dynamicDowncast<MathMLElement>(*element());
     if (mathMLElement && mathMLElement->hasTagName(MathMLNames::mtdTag))
         return std::min<unsigned>(mathMLElement->colSpan(), maxColumnIndex);
 #endif
@@ -140,10 +140,10 @@ unsigned RenderTableCell::parseColSpanFromDOM() const
 unsigned RenderTableCell::parseRowSpanFromDOM() const
 {
     ASSERT(element());
-    if (auto* cell = dynamicDowncast<HTMLTableCellElement>(*element()))
+    if (RefPtr cell = dynamicDowncast<HTMLTableCellElement>(*element()))
         return std::min<unsigned>(cell->rowSpan(), maxRowIndex);
 #if ENABLE(MATHML)
-    auto* mathMLElement = dynamicDowncast<MathMLElement>(*element());
+    RefPtr mathMLElement = dynamicDowncast<MathMLElement>(*element());
     if (mathMLElement && mathMLElement->hasTagName(MathMLNames::mtdTag))
         return std::min<unsigned>(mathMLElement->rowSpan(), maxRowIndex);
 #endif

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -104,7 +104,7 @@ void RenderTextControlSingleLine::layout()
 
     CheckedPtr innerTextRenderer = this->innerTextRenderer();
     RenderBox* innerBlockRenderer = innerBlockElement() ? innerBlockElement()->renderBox() : nullptr;
-    HTMLElement* container = containerElement();
+    RefPtr container = containerElement();
     RenderBox* containerRenderer = container ? container->renderBox() : nullptr;
 
     // To ensure consistency between layouts, we need to reset any conditionally overridden height.
@@ -221,7 +221,7 @@ void RenderTextControlSingleLine::layout()
 
     bool innerTextSizeChanged = innerTextRenderer && innerTextRenderer->size() != oldInnerTextSize;
 
-    HTMLElement* placeholderElement = inputElement().placeholderElement();
+    RefPtr placeholderElement = inputElement().placeholderElement();
     if (RenderBox* placeholderBox = placeholderElement ? placeholderElement->renderBox() : 0) {
         auto innerTextWidth = LayoutUnit { };
         auto usedZoomForLength = placeholderBox->style().usedZoomForLength().value;
@@ -289,7 +289,7 @@ bool RenderTextControlSingleLine::nodeAtPoint(const HitTestRequest& request, Hit
     //  - we hit a node inside the inner text element,
     //  - we hit the <input> element (e.g. we're over the border or padding), or
     //  - we hit regions not in any decoration buttons.
-    HTMLElement* container = containerElement();
+    RefPtr container = containerElement();
     if (result.innerNode()->isDescendantOf(innerTextElement().get()) || result.innerNode() == &inputElement() || (container && container == result.innerNode())) {
         LayoutPoint pointInParent = locationInContainer.point();
         if (container && innerBlockElement()) {
@@ -309,12 +309,12 @@ void RenderTextControlSingleLine::styleDidChange(Style::Difference diff, const R
 
     // We may have set the width and the height in the old style in layout().
     // Reset them now to avoid getting a spurious layout hint.
-    HTMLElement* innerBlock = innerBlockElement();
+    RefPtr innerBlock = innerBlockElement();
     if (auto* innerBlockRenderer = innerBlock ? innerBlock->renderer() : nullptr) {
         innerBlockRenderer->mutableStyle().setHeight(CSS::Keyword::Auto { });
         innerBlockRenderer->mutableStyle().setWidth(CSS::Keyword::Auto { });
     }
-    HTMLElement* container = containerElement();
+    RefPtr container = containerElement();
     if (auto* containerRenderer = container ? container->renderer() : nullptr) {
         containerRenderer->mutableStyle().setHeight(CSS::Keyword::Auto { });
         containerRenderer->mutableStyle().setWidth(CSS::Keyword::Auto { });
@@ -322,7 +322,7 @@ void RenderTextControlSingleLine::styleDidChange(Style::Difference diff, const R
     if (diff == Style::DifferenceResult::Layout) {
         if (CheckedPtr innerTextRenderer = this->innerTextRenderer())
             innerTextRenderer->setNeedsLayout(MarkContainingBlockChain);
-        if (auto* placeholder = inputElement().placeholderElement()) {
+        if (RefPtr placeholder = inputElement().placeholderElement()) {
             if (placeholder->renderer())
                 placeholder->renderer()->setNeedsLayout(MarkContainingBlockChain);
         }

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -156,7 +156,7 @@ static bool isEmptyOrUnstyledAppleStyleSpan(const Node* node)
     if (!node->hasChildNodes())
         return true;
 
-    const StyleProperties* inlineStyleDecl = element->inlineStyle();
+    SUPPRESS_UNCOUNTED_LOCAL const StyleProperties* inlineStyleDecl = element->inlineStyle();
     return (!inlineStyleDecl || inlineStyleDecl->isEmpty());
 }
 
@@ -390,7 +390,7 @@ void RenderTreeAsText::writeRenderObject(TextStream& ts, const RenderObject& o, 
 void writeDebugInfo(TextStream& ts, const RenderObject& object, OptionSet<RenderAsTextFlag> behavior)
 {
     if (behavior.contains(RenderAsTextFlag::ShowIDAndClass)) {
-        if (auto* element = dynamicDowncast<Element>(object.node())) {
+        if (RefPtr element = dynamicDowncast<Element>(object.node())) {
             if (element->hasID())
                 ts << " id=\"" << element->getIdAttribute() << '"';
 
@@ -690,7 +690,7 @@ static void writeLayers(TextStream& ts, const RenderLayer& rootLayer, RenderLaye
             ts.increaseIndent();
         }
         
-        for (auto* currLayer : negativeZOrderLayers)
+        for (CheckedPtr currLayer : negativeZOrderLayers)
             writeLayers(ts, rootLayer, *currLayer, paintDirtyRect, behavior);
 
         if (behavior.contains(RenderAsTextFlag::ShowLayerNesting))
@@ -723,7 +723,7 @@ static void writeLayers(TextStream& ts, const RenderLayer& rootLayer, RenderLaye
             ts.increaseIndent();
         }
         
-        for (auto* currLayer : normalFlowLayers)
+        for (CheckedPtr currLayer : normalFlowLayers)
             writeLayers(ts, rootLayer, *currLayer, paintDirtyRect, behavior);
 
         if (behavior.contains(RenderAsTextFlag::ShowLayerNesting))
@@ -740,7 +740,7 @@ static void writeLayers(TextStream& ts, const RenderLayer& rootLayer, RenderLaye
                 ts.increaseIndent();
             }
 
-            for (auto* currLayer : positiveZOrderLayers)
+            for (CheckedPtr currLayer : positiveZOrderLayers)
                 writeLayers(ts, rootLayer, *currLayer, paintDirtyRect, behavior);
 
             if (behavior.contains(RenderAsTextFlag::ShowLayerNesting))
@@ -753,9 +753,9 @@ static String nodePosition(Node* node)
 {
     StringBuilder result;
 
-    auto* body = node->document().bodyOrFrameset();
-    Node* parent;
-    for (Node* n = node; n; n = parent) {
+    RefPtr body = node->document().bodyOrFrameset();
+    RefPtr<Node> parent;
+    for (RefPtr n = node; n; n = parent) {
         parent = n->parentOrShadowHostNode();
         if (n != node)
             result.append(" of "_s);
@@ -781,7 +781,7 @@ static void writeSelection(TextStream& ts, const RenderBox& renderer)
     if (!renderer.isRenderView())
         return;
 
-    auto* frame = renderer.document().frame();
+    RefPtr frame = renderer.document().frame();
     if (!frame)
         return;
 
@@ -821,8 +821,8 @@ static String externalRepresentation(RenderBox& renderer, OptionSet<RenderAsText
     LOG(Layout, "externalRepresentation: dumping layer tree");
 
     ScriptDisallowedScope scriptDisallowedScope;
-    RenderLayer& layer = *renderer.layer();
-    writeLayers(ts, layer, layer, layer.rect(), behavior);
+    CheckedRef layer = *renderer.layer();
+    writeLayers(ts, layer, layer, layer->rect(), behavior);
     writeSelection(ts, renderer);
     return ts.release();
 }
@@ -894,9 +894,9 @@ String counterValueForElement(Element* element)
     auto stream = createTextStream(element->document());
     bool isFirstCounter = true;
     // The counter renderers should be children of :before or :after pseudo-elements.
-    if (PseudoElement* before = element->beforePseudoElement())
+    if (RefPtr before = element->beforePseudoElement())
         writeCounterValuesFromChildren(stream, before->renderer(), isFirstCounter);
-    if (PseudoElement* after = element->afterPseudoElement())
+    if (RefPtr after = element->afterPseudoElement())
         writeCounterValuesFromChildren(stream, after->renderer(), isFirstCounter);
     return stream.release();
 }

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -415,13 +415,13 @@ void RenderView::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint&)
     // a transform, transparency layer, etc.
     Ref document = this->document();
     for (RefPtr element = document->ownerElement(); element && element->renderer(); element = element->protectedDocument()->ownerElement()) {
-        RenderLayer* layer = element->renderer()->enclosingLayer();
+        CheckedPtr layer = element->renderer()->enclosingLayer();
         if (layer->cannotBlitToWindow()) {
             frameView().setCannotBlitToWindow();
             break;
         }
 
-        if (auto* compositingLayer = layer->enclosingCompositingLayerForRepaint().layer) {
+        if (CheckedPtr compositingLayer = layer->enclosingCompositingLayerForRepaint().layer) {
             if (!compositingLayer->backing()->paintsIntoWindow()) {
                 frameView().setCannotBlitToWindow();
                 break;

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -75,7 +75,7 @@ void WidgetHierarchyUpdatesSuspensionScope::moveWidgets()
         auto map = std::exchange(widgetNewParentMap(), { });
         for (auto& entry : map) {
             Ref child = entry.key;
-            auto* currentParent = child->parent();
+            RefPtr currentParent = child->parent();
             CheckedPtr newParent = entry.value.get();
             if (newParent != currentParent) {
                 if (currentParent)
@@ -245,7 +245,7 @@ void RenderWidget::styleDidChange(Style::Difference diff, const RenderStyle* old
     // If this is an iframe and the zoom property changed, notify the iframe's content frame
     // to trigger a resize event since devicePixelRatio will have changed.
     if (oldStyle && oldStyle->zoom() != style().zoom()) {
-        if (auto* frameView = dynamicDowncast<LocalFrameView>(m_widget.get())) {
+        if (RefPtr frameView = dynamicDowncast<LocalFrameView>(m_widget.get())) {
             frameView->frame().deviceOrPageScaleFactorChanged();
             frameView->scheduleResizeEventIfNeeded();
         }
@@ -257,7 +257,7 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
     ASSERT(!isSkippedContentRoot(*this));
 
     if (paintInfo.requireSecurityOriginAccessForWidgets) {
-        if (auto contentDocument = frameOwnerElement().contentDocument()) {
+        if (RefPtr contentDocument = frameOwnerElement().contentDocument()) {
             if (!document().protectedSecurityOrigin()->isSameOriginDomain(contentDocument->securityOrigin()))
                 return;
         }
@@ -337,7 +337,7 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     // FIXME: Shouldn't check if the frame view needs layout during event region painting. This is a workaround
     // for the fact that non-composited frames depend on their enclosing compositing layer to perform an event
     // region update on their behalf. See <https://webkit.org/b/210311> for more details.
-    auto* frameView = dynamicDowncast<LocalFrameView>(m_widget.get());
+    RefPtr frameView = dynamicDowncast<LocalFrameView>(m_widget.get());
     bool needsEventRegionContentPaint = paintInfo.phase == PaintPhase::EventRegion && frameView && !frameView->needsLayout();
     if (paintInfo.phase != PaintPhase::Foreground && !needsEventRegionContentPaint)
         return;
@@ -428,7 +428,7 @@ RenderWidget* RenderWidget::find(const Widget& widget)
 bool RenderWidget::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction action)
 {
     auto shouldHitTestChildFrameContent = request.allowsChildFrameContent() || (request.allowsVisibleChildFrameContent() && visibleToHitTesting(request));
-    auto* childFrameView = dynamicDowncast<LocalFrameView>(widget());
+    RefPtr childFrameView = dynamicDowncast<LocalFrameView>(widget());
     if (shouldHitTestChildFrameContent && childFrameView && childFrameView->renderView()) {
         LayoutPoint adjustedLocation = accumulatedOffset + location();
         LayoutPoint contentOffset = LayoutPoint(borderLeft() + paddingLeft(), borderTop() + paddingTop()) - toIntSize(childFrameView->scrollPosition());
@@ -436,7 +436,7 @@ bool RenderWidget::nodeAtPoint(const HitTestRequest& request, HitTestResult& res
         HitTestRequest newHitTestRequest(request.type() | HitTestRequest::Type::ChildFrameHitTest);
         HitTestResult childFrameResult(newHitTestLocation);
 
-        auto* document = childFrameView->frame().document();
+        RefPtr document = childFrameView->frame().document();
         if (!document)
             return false;
         bool isInsideChildFrame = document->hitTest(newHitTestRequest, newHitTestLocation, childFrameResult);

--- a/Source/WebCore/rendering/mathml/MathMLStyle.cpp
+++ b/Source/WebCore/rendering/mathml/MathMLStyle.cpp
@@ -96,7 +96,7 @@ void MathMLStyle::resolveMathMLStyle(RenderObject* renderer)
 
     auto oldMathVariant = m_mathVariant;
     auto* parentRenderer = getMathMLParentNode(renderer);
-    const MathMLStyle* parentStyle = getMathMLStyle(parentRenderer);
+    const RefPtr parentStyle = getMathMLStyle(parentRenderer);
 
     // By default, we just inherit the style from our parent.
     m_mathVariant = MathVariant::None;
@@ -111,7 +111,7 @@ void MathMLStyle::resolveMathMLStyle(RenderObject* renderer)
     }
 
     // The mathvariant attributes override the default behavior.
-    if (auto* element = dynamicDowncast<MathMLElement>(downcast<RenderElement>(renderer)->element())) {
+    if (RefPtr element = dynamicDowncast<MathMLElement>(downcast<RenderElement>(renderer)->element())) {
         auto mathVariant = element->specifiedMathVariant();
         if (mathVariant)
             m_mathVariant = mathVariant.value();

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -130,7 +130,7 @@ LegacyRenderSVGResourceContainer* StyleCachedImage::uncheckedRenderSVGResource(c
         return uncheckedRenderSVGResource(renderer->treeScopeForSVGReferences(), fragmentIdentifier);
     }
 
-    auto image = dynamicDowncast<SVGImage>(m_cachedImage->image());
+    RefPtr image = dynamicDowncast<SVGImage>(m_cachedImage->image());
     if (!image)
         return nullptr;
 
@@ -167,7 +167,7 @@ RenderSVGResourceContainer* StyleCachedImage::renderSVGResource(const RenderElem
         return nullptr;
     }
 
-    auto image = dynamicDowncast<SVGImage>(m_cachedImage->image());
+    RefPtr image = dynamicDowncast<SVGImage>(m_cachedImage->image());
     if (!image)
         return nullptr;
 

--- a/Source/WebCore/rendering/style/StyleCanvasImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCanvasImage.cpp
@@ -102,13 +102,13 @@ FloatSize StyleCanvasImage::fixedSize(const RenderElement& renderer) const
 
 void StyleCanvasImage::didAddClient(RenderElement& renderer)
 {
-    if (auto* element = this->element(renderer.document()))
+    if (RefPtr element = this->element(renderer.document()))
         InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
 }
 
 void StyleCanvasImage::didRemoveClient(RenderElement& renderer)
 {
-    if (auto* element = this->element(renderer.document()))
+    if (RefPtr element = this->element(renderer.document()))
         InspectorInstrumentation::didChangeCSSCanvasClientNodes(*element);
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -90,9 +90,9 @@ FloatRect RenderSVGPath::adjustStrokeBoundingBoxForZeroLengthLinecaps(RepaintRec
 
 static void useStrokeStyleToFill(GraphicsContext& context)
 {
-    if (auto gradient = context.strokeGradient())
+    if (RefPtr gradient = context.strokeGradient())
         context.setFillGradient(*gradient, context.strokeGradientSpaceTransform());
-    else if (Pattern* pattern = context.strokePattern())
+    else if (RefPtr pattern = context.strokePattern())
         context.setFillPattern(*pattern);
     else
         context.setFillColor(context.strokeColor());

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -165,27 +165,27 @@ void SVGTextLayoutAttributesBuilder::buildCharacterDataMap(RenderSVGText& textRo
 void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& position)
 {
     RefPtr element = position.element.get();
-    const auto& xList = element->x();
-    const auto& yList = element->y();
-    const auto& dxList = element->dx();
-    const auto& dyList = element->dy();
-    const auto& rotateList = element->rotate();
+    Ref xList = element->x();
+    Ref yList = element->y();
+    Ref dxList = element->dx();
+    Ref dyList = element->dy();
+    Ref rotateList = element->rotate();
 
-    unsigned xListSize = xList.size();
-    unsigned yListSize = yList.size();
-    unsigned dxListSize = dxList.size();
-    unsigned dyListSize = dyList.size();
-    unsigned rotateListSize = rotateList.items().size();
+    unsigned xListSize = xList->size();
+    unsigned yListSize = yList->size();
+    unsigned dxListSize = dxList->size();
+    unsigned dyListSize = dyList->size();
+    unsigned rotateListSize = rotateList->items().size();
     if (!xListSize && !yListSize && !dxListSize && !dyListSize && !rotateListSize)
         return;
 
     SVGLengthContext lengthContext(element.get());
     for (unsigned i = 0; i < position.length; ++i) {
-        const SVGLengthList* xListPtr = i < xListSize ? &xList : nullptr;
-        const SVGLengthList* yListPtr = i < yListSize ? &yList : nullptr;
-        const SVGLengthList* dxListPtr = i < dxListSize ? &dxList : nullptr;
-        const SVGLengthList* dyListPtr = i < dyListSize ? &dyList : nullptr;
-        const SVGNumberList* rotateListPtr = rotateListSize ? &rotateList : nullptr;
+        const SVGLengthList* xListPtr = i < xListSize ? xList.ptr() : nullptr;
+        const SVGLengthList* yListPtr = i < yListSize ? yList.ptr() : nullptr;
+        const SVGLengthList* dxListPtr = i < dxListSize ? dxList.ptr() : nullptr;
+        const SVGLengthList* dyListPtr = i < dyListSize ? dyList.ptr() : nullptr;
+        const SVGNumberList* rotateListPtr = rotateListSize ? rotateList.ptr() : nullptr;
         if (!xListPtr && !yListPtr && !dxListPtr && !dyListPtr && !rotateListPtr)
             break;
 
@@ -194,17 +194,17 @@ void SVGTextLayoutAttributesBuilder::fillCharacterDataMap(const TextPosition& po
         }).iterator->value;
 
         if (xListPtr)
-            data.x = xList.items()[i]->value().value(lengthContext);
+            data.x = xList->items()[i]->value().value(lengthContext);
         if (yListPtr)
-            data.y = yList.items()[i]->value().value(lengthContext);
+            data.y = yList->items()[i]->value().value(lengthContext);
         if (dxListPtr)
-            data.dx = dxList.items()[i]->value().value(lengthContext);
+            data.dx = dxList->items()[i]->value().value(lengthContext);
         if (dyListPtr)
-            data.dy = dyList.items()[i]->value().value(lengthContext);
+            data.dy = dyList->items()[i]->value().value(lengthContext);
 
         if (rotateListPtr) {
             unsigned rotateIndex = std::min(i, rotateListSize - 1);
-            data.rotate = rotateList.items()[rotateIndex]->value();
+            data.rotate = rotateList->items()[rotateIndex]->value();
         }
     }
 }

--- a/Source/WebCore/rendering/updating/RenderTreePosition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.cpp
@@ -64,7 +64,7 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
 {
     ASSERT(!node.renderer());
 
-    auto* parentElement = m_parent->element();
+    RefPtr parentElement = m_parent->element();
     if (!parentElement)
         return nullptr;
     // FIXME: PlugingReplacement shadow trees are very wrong.
@@ -74,9 +74,9 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
     Vector<Element*, 30> elementStack;
 
     // In the common case ancestor == parentElement immediately and this just pushes parentElement into stack.
-    auto* ancestor = node.parentElementInComposedTree();
+    RefPtr ancestor = node.parentElementInComposedTree();
     while (true) {
-        elementStack.append(ancestor);
+        elementStack.append(ancestor.get());
         if (ancestor == parentElement)
             break;
         ancestor = ancestor->parentElementInComposedTree();
@@ -88,7 +88,7 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
 
     auto initializeIteratorConsideringPseudoElements = [&] {
         if (auto* pseudoElement = dynamicDowncast<PseudoElement>(node)) {
-            auto* host = pseudoElement->hostElement();
+            RefPtr host = pseudoElement->hostElement();
             if (node.isBeforePseudoElement()) {
                 if (host != parentElement)
                     return composedDescendants.at(*host).traverseNext();
@@ -115,8 +115,8 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
 
     auto popCheckingForAfterPseudoElementRenderers = [&] (unsigned iteratorDepthToMatch) -> RenderElement* {
         while (elementStack.size() > iteratorDepthToMatch) {
-            auto& element = *elementStack.takeLast();
-            if (auto* after = element.afterPseudoElement()) {
+            RefPtr element = elementStack.takeLast();
+            if (auto* after = element->afterPseudoElement()) {
                 if (auto* renderer = after->renderer())
                     return renderer;
             }
@@ -134,7 +134,7 @@ RenderObject* RenderTreePosition::nextSiblingRenderer(const Node& node) const
         if (auto* renderer = it->renderer())
             return renderer;
 
-        if (auto* element = dynamicDowncast<Element>(*it)) {
+        if (RefPtr element = dynamicDowncast<Element>(*it)) {
             if (element->hasDisplayContents()) {
                 if (auto* renderer = pushCheckingForAfterPseudoElementRenderer(*element))
                     return renderer;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -188,7 +188,7 @@ void RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement(Eleme
 {
     ASSERT(pseudoElementType == PseudoElementType::Before || pseudoElementType == PseudoElementType::After);
 
-    PseudoElement* pseudoElement = pseudoElementType == PseudoElementType::Before ? current.beforePseudoElement() : current.afterPseudoElement();
+    RefPtr pseudoElement = pseudoElementType == PseudoElementType::Before ? current.beforePseudoElement() : current.afterPseudoElement();
 
     if (auto* renderer = pseudoElement ? pseudoElement->renderer() : nullptr)
         m_updater.renderTreePosition().invalidateNextSibling(*renderer);
@@ -307,7 +307,7 @@ bool RenderTreeUpdater::GeneratedContent::needsPseudoElement(const RenderStyle* 
 
 void RenderTreeUpdater::GeneratedContent::removeBeforePseudoElement(Element& element, RenderTreeBuilder& builder)
 {
-    auto* pseudoElement = element.beforePseudoElement();
+    RefPtr pseudoElement = element.beforePseudoElement();
     if (!pseudoElement)
         return;
     tearDownRenderers(*pseudoElement, TeardownType::Full, builder);
@@ -316,7 +316,7 @@ void RenderTreeUpdater::GeneratedContent::removeBeforePseudoElement(Element& ele
 
 void RenderTreeUpdater::GeneratedContent::removeAfterPseudoElement(Element& element, RenderTreeBuilder& builder)
 {
-    auto* pseudoElement = element.afterPseudoElement();
+    RefPtr pseudoElement = element.afterPseudoElement();
     if (!pseudoElement)
         return;
     tearDownRenderers(*pseudoElement, TeardownType::Full, builder);
@@ -329,9 +329,9 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
         if (!renderer.element())
             return;
 
-        auto& editor = renderer.element()->document().editor();
+        Ref editor = renderer.element()->document().editor();
 
-        if (WeakPtr writingSuggestionsRenderer = editor.writingSuggestionRenderer())
+        if (WeakPtr writingSuggestionsRenderer = editor->writingSuggestionRenderer())
             m_updater.m_builder.destroy(*writingSuggestionsRenderer);
     };
 
@@ -341,15 +341,15 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
     if (!renderer.element())
         return;
 
-    auto& editor = renderer.element()->document().editor();
-    RefPtr nodeBeforeWritingSuggestions = editor.nodeBeforeWritingSuggestions();
+    Ref editor = renderer.element()->document().editor();
+    RefPtr nodeBeforeWritingSuggestions = editor->nodeBeforeWritingSuggestions();
     if (!nodeBeforeWritingSuggestions)
         return;
 
     if (renderer.element() != nodeBeforeWritingSuggestions->parentElement())
         return;
 
-    auto* writingSuggestionData = editor.writingSuggestionData();
+    auto* writingSuggestionData = editor->writingSuggestionData();
     if (!writingSuggestionData) {
         destroyWritingSuggestionsIfNeeded();
         return;
@@ -388,7 +388,7 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
     auto newStyle = RenderStyle::clone(*style);
     newStyle.setDisplay(DisplayType::Inline);
 
-    if (auto writingSuggestionsRenderer = editor.writingSuggestionRenderer()) {
+    if (auto writingSuggestionsRenderer = editor->writingSuggestionRenderer()) {
         writingSuggestionsRenderer->setStyle(WTF::move(newStyle), minimalStyleDifference);
 
         auto* writingSuggestionsText = dynamicDowncast<RenderText>(writingSuggestionsRenderer->firstChild());
@@ -419,7 +419,7 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
         auto writingSuggestionsText = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, renderer.document(), writingSuggestionData->content());
         m_updater.m_builder.attach(*newWritingSuggestionsRenderer, WTF::move(writingSuggestionsText));
 
-        editor.setWritingSuggestionRenderer(*newWritingSuggestionsRenderer.get());
+        editor->setWritingSuggestionRenderer(*newWritingSuggestionsRenderer.get());
         m_updater.m_builder.attach(*parentForWritingSuggestions, WTF::move(newWritingSuggestionsRenderer), rendererAfterWritingSuggestions.get());
 
         if (!parentForWritingSuggestions) {
@@ -427,7 +427,7 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
             return;
         }
 
-        auto* prefixNode = nodeBeforeWritingSuggestionsTextRenderer->textNode();
+        RefPtr prefixNode = nodeBeforeWritingSuggestionsTextRenderer->textNode();
         if (!prefixNode) {
             ASSERT_NOT_REACHED();
             destroyWritingSuggestionsIfNeeded();


### PR DESCRIPTION
#### ddac9f7dfe479b14a5e327e06b7aedb04ab4be2c
<pre>
Fixed uncounted local variable warnings in WebCore/rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=306302">https://bugs.webkit.org/show_bug.cgi?id=306302</a>
<a href="https://rdar.apple.com/168955254">rdar://168955254</a>

Reviewed by David Kilzer and Rupin Mittal.

Mechanical fixes dictated by the SaferCPP bot.

I used SUPPRESS_UNCOUNTED_LOCAL in performance-cases and/or cases where we return the declared pointer.

(When we return a declared pointer, we can&apos;t return a smart pointer without changing all callers. We do
want to change all callers if needed! But that&apos;s too much to bite off in one patch. I think it&apos;s best
to get SaferCPP enforcement enabled in every file now, and search/replace SUPPRESS_UNCOUNTED_LOCAL later.)

Canonical link: <a href="https://commits.webkit.org/306315@main">https://commits.webkit.org/306315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0142dcac251ec7742b3a7fa22119e3b684abde9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149461 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13482 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108226 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89129 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10434 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8020 "Found 1 new API test failure: TestWebKitAPI.WebCoreNSURLSessionTest.InvalidateEmpty (failure)") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9380 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151910 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13016 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116383 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13031 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116723 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12786 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68177 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21757 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13059 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12798 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12842 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->