### PR TITLE
Add evaluation-time zoom for SVG stroke-width

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt
@@ -73,6 +73,10 @@ PASS Property -webkit-text-stroke-width value '4px' no zoom
 PASS Property -webkit-text-stroke-width value 'inherit' no zoom
 PASS Property -webkit-text-stroke-width value '4px' zoom: 2
 PASS Property -webkit-text-stroke-width value 'inherit' zoom: 2
+PASS Property stroke-width value '4px' no zoom
+PASS Property stroke-width value 'inherit' no zoom
+PASS Property stroke-width value '4px' zoom: 2
+PASS Property stroke-width value 'inherit' zoom: 2
 PASS Property width value '19px' no zoom
 PASS Property width value 'inherit' no zoom
 PASS Property width value '19px' zoom: 2

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html
@@ -88,6 +88,10 @@
       "value": "2px",
       "otherValues": ["4px"]
     },
+    "stroke-width": {
+      "value": "2px",
+      "otherValues": ["4px"]
+    },
     "width": {
       "value": "9px",
       "otherValues": ["19px"]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS zoom does not scale SVG stroke-width when defined on svg element - reference</title>
+<style>
+body { margin: 0; }
+</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 100 100"
+     fill="none" stroke="black" stroke-width="2">
+    <rect x="10" y="10" width="80" height="80"/>
+</svg>
+
+<div>
+    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 100 100"
+        fill="none" stroke="black" stroke-width="2">
+        <rect x="10" y="10" width="80" height="80"/>
+    </svg>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS zoom does not scale SVG stroke-width when defined on svg element - reference</title>
+<style>
+body { margin: 0; }
+</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 100 100"
+     fill="none" stroke="black" stroke-width="2">
+    <rect x="10" y="10" width="80" height="80"/>
+</svg>
+
+<div>
+    <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 100 100"
+        fill="none" stroke="black" stroke-width="2">
+        <rect x="10" y="10" width="80" height="80"/>
+    </svg>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS zoom does not scale SVG stroke-width when defined on svg element</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="help" href="https://drafts.fxtf.org/fill-stroke-3/#propdef-stroke-width">
+<link rel="match" href="svg-stroke-width-ref.html">
+<style>
+body { margin: 0; }
+.zoom { zoom: 2; }
+</style>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"
+     fill="none" stroke="black" stroke-width="2" style="zoom: 2;">
+    <rect x="10" y="10" width="80" height="80"/>
+</svg>
+
+<div class="zoom">
+    <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"
+         fill="none" stroke="black" stroke-width="2">
+        <rect x="10" y="10" width="80" height="80"/>
+    </svg>
+</div>

--- a/LayoutTests/svg/zoom/page/zoom-stroke-width-expected.html
+++ b/LayoutTests/svg/zoom/page/zoom-stroke-width-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>SVG stroke-width should not scale with page zoom - reference</title>
+<style>
+body { margin: 0; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 100 100">
+    <rect x="10" y="10" width="80" height="80" fill="none" stroke="black" stroke-width="2"/>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/zoom/page/zoom-stroke-width.html
+++ b/LayoutTests/svg/zoom/page/zoom-stroke-width.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>SVG stroke-width should not scale with page zoom</title>
+<link rel="match" href="zoom-stroke-width-expected.html">
+<style>
+body { margin: 0; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+    <rect x="10" y="10" width="80" height="80" fill="none" stroke="black" stroke-width="2"/>
+</svg>
+
+<script>
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+if (window.internals)
+    internals.setPageZoomFactor(2);
+
+requestAnimationFrame(function() {
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -310,7 +310,7 @@ float RenderStyle::usedStrokeWidth(const IntSize& viewportSize) const
 
     return WTF::switchOn(strokeWidth(),
         [&](const Style::StrokeWidth::Fixed& fixedStrokeWidth) -> float {
-            return Style::evaluate<float>(fixedStrokeWidth, Style::ZoomNeeded { });
+            return Style::evaluate<float>(fixedStrokeWidth, usedZoomForLength());
         },
         [&](const Style::StrokeWidth::Percentage& percentageStrokeWidth) -> float {
             // According to the spec, https://drafts.fxtf.org/paint/#stroke-width, the percentage is relative to the scaled viewport size.
@@ -319,7 +319,7 @@ float RenderStyle::usedStrokeWidth(const IntSize& viewportSize) const
         },
         [&](const Style::StrokeWidth::Calc& calcStrokeWidth) -> float {
             // FIXME: It is almost certainly wrong that calc and percentage are being handled differently - https://bugs.webkit.org/show_bug.cgi?id=296482
-            return Style::evaluate<float>(calcStrokeWidth, viewportSize.width(), Style::ZoomNeeded { });
+            return Style::evaluate<float>(calcStrokeWidth, viewportSize.width(), usedZoomForLength());
         }
     );
 }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -390,7 +390,7 @@ FloatRect RenderSVGShape::calculateApproximateStrokeBoundingBox() const
 float RenderSVGShape::strokeWidth() const
 {
     SVGLengthContext lengthContext(protectedGraphicsElement().ptr());
-    auto strokeWidth = lengthContext.valueForLength(style().strokeWidth(), Style::ZoomNeeded { });
+    auto strokeWidth = lengthContext.valueForLength(style().strokeWidth(), style().usedZoomForLength());
     return std::isnan(strokeWidth) ? 0 : strokeWidth;
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -937,7 +937,7 @@ FloatRect RenderSVGText::strokeBoundingBox() const
 
     Ref textElement = this->textElement();
     SVGLengthContext lengthContext(textElement.ptr());
-    strokeBoundaries.inflate(lengthContext.valueForLength(style().strokeWidth(), Style::ZoomNeeded { }));
+    strokeBoundaries.inflate(lengthContext.valueForLength(style().strokeWidth(), style().usedZoomForLength()));
     return strokeBoundaries;
 }
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -521,7 +521,7 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
     }
 
     SVGLengthContext lengthContext(element.get());
-    context.setStrokeThickness(lengthContext.valueForLength(style.strokeWidth(), Style::ZoomNeeded { }));
+    context.setStrokeThickness(lengthContext.valueForLength(style.strokeWidth(), style.usedZoomForLength()));
     context.setLineCap(style.capStyle());
     context.setLineJoin(style.joinStyle());
     if (style.joinStyle() == LineJoin::Miter)

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -205,7 +205,7 @@ static void writeSVGStrokePaintingResource(TextStream& ts, const RenderElement& 
 
     SVGLengthContext lengthContext(&shape);
     double dashOffset = lengthContext.valueForLength(style.strokeDashOffset(), Style::ZoomNeeded { });
-    double strokeWidth = lengthContext.valueForLength(style.strokeWidth(), Style::ZoomNeeded { });
+    double strokeWidth = lengthContext.valueForLength(style.strokeWidth(), style.usedZoomForLength());
     auto dashArray = DashArray::map(style.strokeDashArray(), [&](auto& length) -> DashArrayElement {
         return lengthContext.valueForLength(length, Style::ZoomNeeded { });
     });

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -461,7 +461,7 @@ float LegacyRenderSVGShape::strokeWidth() const
 {
     Ref graphicsElement = this->graphicsElement();
     SVGLengthContext lengthContext(graphicsElement.ptr());
-    auto strokeWidth = lengthContext.valueForLength(style().strokeWidth(), Style::ZoomNeeded { });
+    auto strokeWidth = lengthContext.valueForLength(style().strokeWidth(), style().usedZoomForLength());
     return std::isnan(strokeWidth) ? 0 : strokeWidth;
 }
 

--- a/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.h
+++ b/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 namespace Style {
 
-struct StrokeWidthLength : LengthWrapperBase<LengthPercentage<CSS::Nonnegative>> {
+struct StrokeWidthLength : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>> {
     using Base::Base;
 };
 

--- a/Source/WebCore/svg/SVGLengthContext.cpp
+++ b/Source/WebCore/svg/SVGLengthContext.cpp
@@ -195,9 +195,9 @@ float SVGLengthContext::valueForLength(const Style::SVGStrokeDashoffset& size, S
     return valueForSizeType(size, zoomNeeded, lengthMode);
 }
 
-float SVGLengthContext::valueForLength(const Style::StrokeWidth& size, Style::ZoomNeeded zoomNeeded, SVGLengthMode lengthMode)
+float SVGLengthContext::valueForLength(const Style::StrokeWidth& size, Style::ZoomFactor usedZoom, SVGLengthMode lengthMode)
 {
-    return valueForSizeType(size, zoomNeeded, lengthMode);
+    return valueForSizeType(size, usedZoom, lengthMode);
 }
 
 float SVGLengthContext::computeNonCalcLength(float inputValue, CSS::LengthUnit unit) const

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -73,7 +73,7 @@ public:
     float valueForLength(const Style::SVGRadiusComponent&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
     float valueForLength(const Style::SVGStrokeDasharrayValue&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
     float valueForLength(const Style::SVGStrokeDashoffset&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
-    float valueForLength(const Style::StrokeWidth&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);
+    float valueForLength(const Style::StrokeWidth&, Style::ZoomFactor usedZoom, SVGLengthMode = SVGLengthMode::Other);
 
     ExceptionOr<float> resolveValueToUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;
     ExceptionOr<CSS::LengthPercentage<>> resolveValueFromUserUnits(float, const CSS::LengthPercentageUnit&, SVGLengthMode) const;


### PR DESCRIPTION
#### 08d2ee6137250e55869456ccbd9400774dfaca74
<pre>
Add evaluation-time zoom for SVG stroke-width
<a href="https://bugs.webkit.org/show_bug.cgi?id=306344">https://bugs.webkit.org/show_bug.cgi?id=306344</a>
<a href="https://rdar.apple.com/169013256">rdar://169013256</a>

Reviewed by Tim Nguyen.

Mark stroke-width as Unzoomed so zoom is not baked in at style build time.
This ensures stroke-width is not affected by page zoom or CSS zoom,
as SVG handles scaling via an affine transform at the root rather than
scaling individual property values.

Test: svg/zoom/page/zoom-stroke-width.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-computed-style.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-stroke-width.html: Added.
* LayoutTests/svg/zoom/page/zoom-stroke-width-expected.html: Added.
* LayoutTests/svg/zoom/page/zoom-stroke-width.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::usedStrokeWidth const):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::strokeWidth const):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::strokeBoundingBox const):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGStrokePaintingResource):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::strokeWidth const):
* Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.h:
* Source/WebCore/svg/SVGLengthContext.cpp:
(WebCore::SVGLengthContext::valueForLength):
* Source/WebCore/svg/SVGLengthContext.h:

Canonical link: <a href="https://commits.webkit.org/306305@main">https://commits.webkit.org/306305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/393de1c4fda12b2a97be6a3b6500fe4977ab55c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94008 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13456 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89083 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8000 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9354 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151884 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12990 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2384 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116362 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11350 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12771 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122810 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68151 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13033 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12772 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->