### PR TITLE
PDF background should adapt to system appearance changes

### DIFF
--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -35,6 +35,7 @@
 #include "HTMLEmbedElement.h"
 #include "HTMLHeadElement.h"
 #include "HTMLHtmlElement.h"
+#include "HTMLMetaElement.h"
 #include "HTMLNames.h"
 #include "HTMLStyleElement.h"
 #include "LocalFrame.h"
@@ -110,7 +111,15 @@ void PluginDocumentParser::createDocumentStructure()
     headElement->appendChild(styleElement);
     rootElement->appendChild(headElement);
 
-    if (RefPtr frame = document->frame())
+    RefPtr frame = document->frame();
+    if (frame && frame->isMainFrame()) {
+        Ref metaElement = HTMLMetaElement::create(document);
+        metaElement->setAttributeWithoutSynchronization(nameAttr, "color-scheme"_s);
+        metaElement->setAttributeWithoutSynchronization(contentAttr, "light dark"_s);
+        headElement->appendChild(metaElement);
+    }
+
+    if (frame)
         frame->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 
     Ref body = HTMLBodyElement::create(document);

--- a/Source/WebCore/style/values/color/StyleColorOptions.h
+++ b/Source/WebCore/style/values/color/StyleColorOptions.h
@@ -36,6 +36,6 @@ enum class StyleColorOptions : uint8_t {
     UseElevatedUserInterfaceLevel   = 1 << 3
 };
 
-WTF::TextStream& operator<<(WTF::TextStream&, StyleColorOptions);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, StyleColorOptions);
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -344,6 +344,8 @@ public:
 
     virtual bool delegatesScrollingToMainFrame() const { return false; }
 
+    virtual void effectiveAppearanceDidChange() { }
+
 protected:
     virtual double contentScaleFactor() const = 0;
     virtual bool platformPopulateEditorStateIfNeeded(EditorState&) const { return false; }
@@ -469,7 +471,7 @@ protected:
 
     std::optional<WebCore::PageIdentifier> pageIdentifier() const;
 
-    static WebCore::Color pluginBackgroundColor();
+    WebCore::Color pluginBackgroundColor() const;
 
     RefPtr<PluginView> protectedView() const;
     RefPtr<WebFrame> protectedFrame() const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -82,10 +82,12 @@
 #import <WebCore/RenderEmbeddedObject.h>
 #import <WebCore/RenderLayer.h>
 #import <WebCore/RenderLayerScrollableArea.h>
+#import <WebCore/RenderTheme.h>
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/ScrollAnimator.h>
 #import <WebCore/Settings.h>
 #import <WebCore/SharedBuffer.h>
+#import <WebCore/StyleColorOptions.h>
 #import <WebCore/VoidCallback.h>
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/StdLibExtras.h>
@@ -1631,16 +1633,18 @@ String PDFPluginBase::annotationStyle() const
     "}"_s;
 }
 
-Color PDFPluginBase::pluginBackgroundColor()
+Color PDFPluginBase::pluginBackgroundColor() const
 {
-    static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr {
 #if HAVE(LIQUID_GLASS)
-        [CocoaColor whiteColor].CGColor
+    RefPtr element = m_element.get();
+    OptionSet<WebCore::StyleColorOptions> options;
+    if (RefPtr element = m_element.get())
+        options = element->checkedRenderer()->styleColorOptions();
+    return WebCore::RenderTheme::singleton().systemColor(CSSValueAppleSystemBackground, WTF::move(options));
 #else
-        [CocoaColor grayColor].CGColor
-#endif
-    }.get());
+    static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr { [CocoaColor grayColor].CGColor }.get());
     return color.get();
+#endif
 }
 
 unsigned PDFPluginBase::countFindMatches(const String& target, WebCore::FindOptions options, unsigned maxMatchCount)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -238,6 +238,8 @@ public:
 
     bool hasSelection() const;
 
+    void effectiveAppearanceDidChange() final;
+
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
     bool isUnifiedPDFPlugin() const override { return true; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4859,6 +4859,15 @@ RefPtr<WebCore::GraphicsLayer> UnifiedPDFPlugin::protectedOverflowControlsContai
     return m_overflowControlsContainer;
 }
 
+void UnifiedPDFPlugin::effectiveAppearanceDidChange()
+{
+    if (!isFullMainFramePlugin())
+        return;
+
+    if (RefPtr rootLayer = m_rootLayer)
+        rootLayer->setBackgroundColor(pluginBackgroundColor());
+}
+
 ViewportConfiguration::Parameters UnifiedPDFPlugin::viewportParameters()
 {
     ViewportConfiguration::Parameters parameters;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1253,6 +1253,13 @@ bool PluginView::isPresentingLockedContent() const
     return m_isInitialized && m_plugin->isLocked();
 }
 
+void PluginView::effectiveAppearanceDidChange()
+{
+    if (!m_isInitialized)
+        return;
+    m_plugin->effectiveAppearanceDidChange();
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -171,6 +171,8 @@ public:
 
     bool isPresentingLockedContent() const;
 
+    void effectiveAppearanceDidChange();
+
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);
     virtual ~PluginView();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6451,6 +6451,11 @@ void WebPage::setUseColorAppearance(bool useDarkAppearance, bool useElevatedUser
 
     if (RefPtr inspectorUI = m_inspectorUI)
         inspectorUI->effectiveAppearanceDidChange(useDarkAppearance ? WebCore::InspectorFrontendClient::Appearance::Dark : WebCore::InspectorFrontendClient::Appearance::Light);
+
+#if ENABLE(PDF_PLUGIN)
+    for (Ref pluginView : m_pluginViews)
+        pluginView->effectiveAppearanceDidChange();
+#endif
 }
 
 void WebPage::swipeAnimationDidStart()

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -115,6 +115,7 @@ class Color;
 #endif // PLATFORM(IOS_FAMILY)
 
 - (CALayer *)firstLayerWithName:(NSString *)layerName;
+- (CALayer *)firstLayerWithNameContaining:(NSString *)layerName;
 - (void)forEachCALayer:(IterationStatus(^)(CALayer *))visitor;
 
 @property (nonatomic, readonly) CGImageRef snapshotAfterScreenUpdates;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -800,9 +800,19 @@ static IterationStatus forEachCALayer(CALayer *layer, IterationStatus(^visitor)(
 
 - (CALayer *)firstLayerWithName:(NSString *)layerName
 {
+    return [self _firstLayerWithName:layerName andMatcher:@selector(isEqualToString:)];
+}
+
+- (CALayer *)firstLayerWithNameContaining:(NSString *)layerName
+{
+    return [self _firstLayerWithName:layerName andMatcher:@selector(containsString:)];
+}
+
+- (CALayer *)_firstLayerWithName:(NSString *)layerName andMatcher:(SEL)matcher
+{
     __block RetainPtr<CALayer> result;
     [self forEachCALayer:^(CALayer *layer) {
-        if (![layer.name isEqualToString:layerName])
+        if (![layer.name performSelector:matcher withObject:layerName])
             return IterationStatus::Continue;
 
         result = layer;


### PR DESCRIPTION
#### 42a502b73aebe9c7987907a4162c3a267c4d0ddc
<pre>
PDF background should adapt to system appearance changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=306305">https://bugs.webkit.org/show_bug.cgi?id=306305</a>
<a href="https://rdar.apple.com/168665166">rdar://168665166</a>

Reviewed by Wenson Hsieh.

In 305691@main, we changed the plugin background color from dark grey to
white, citing a better design fit with Liquid Glass. A missing piece to
this change though is our desire to have the plugin background color
adapt to system appearance changes.

In this patch, we introduce PDF plugin hooks that are notified when the
effective appearance changes. In response to this, we update root layer
colors to `-apple-system-background`. Note that we only do this for full
main frame plugins, and not for &lt;iframe&gt;/&lt;embed&gt;/&lt;object&gt; elements. The
intention with embedded PDFs is that they should adopt the behavior
of their surrounding main frame document.

Tests:
  UnifiedPDF.BackgroundAdaptsToColorScheme
  UnifiedPDF.BackgroundDoesNotAdaptToColorSchemeOnEmbeddedDocuments

* Source/WebCore/html/PluginDocument.cpp:
Add a &lt;meta color-scheme=&quot;light dark&quot;&gt; element to (main frame) plugin
documents, opting us into a mode that can adapt to appearance changes.

* Source/WebCore/style/values/color/StyleColorOptions.h:
WEBCORE_EXPORT the TextStream operator. It is helpful during local
debugging from WebKit.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::effectiveAppearanceDidChange):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::pluginBackgroundColor const):
(WebKit::PDFPluginBase::pluginBackgroundColor): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::effectiveAppearanceDidChange):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::effectiveAppearanceDidChange):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setUseColorAppearance):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView firstLayerWithName:]):
(-[WKWebView firstLayerWithNameContaining:]):
  In debug mode, CALayers corresponding to WebCore::GraphicsLayers have
  additional debug information prepended to the name set by the
  GraphicsLayer API clients (such as UnifiedPDFPlugin). As such, we
  introduce a mode where instead of exact layer name searches, we search
  that traversed layers contain our target string.
(-[WKWebView _firstLayerWithName:andMatcher:]):

Canonical link: <a href="https://commits.webkit.org/306364@main">https://commits.webkit.org/306364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feb074881131fa38bc11016ac395a379640d3fe5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94207 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142983 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89286 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10551 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8143 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152075 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13180 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116507 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116850 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12911 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122957 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68353 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21778 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13223 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12962 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76928 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13161 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->