### PR TITLE
Add stallCompilerThread to $vm for compiler testing

### DIFF
--- a/JSTests/stress/compiler-thread-stall.js
+++ b/JSTests/stress/compiler-thread-stall.js
@@ -1,0 +1,63 @@
+//@ requireOptions('--useConcurrentJIT=true')
+//@ skip if !$jitTests || $architecture != "arm64e" || $platform == "tvos" || $platform == "watchos"
+
+// Test that we can stall a compiler thread and get its stack bounds.
+// This is useful for testing memory access to compiler thread stacks.
+
+function dummyFunction() {
+    // This function exists just to provide a CodeBlock for the stall plan.
+    let x = 0;
+    for (let i = 0; i < 100; i++) {
+        x += i;
+    }
+    return x;
+}
+
+function doubleToUint(d) {
+    let buffer = new ArrayBuffer(8);
+    let uintView = new BigUint64Array(buffer);
+    return uintView[0];
+}
+
+// Call it once to ensure it gets a baseline CodeBlock
+dummyFunction();
+
+let handle = $vm.stallCompilerThread(dummyFunction);
+
+if (typeof handle.stackBase !== 'number')
+    throw new Error("stackBase should be a number");
+
+if (typeof handle.stackBound !== 'number')
+    throw new Error("stackBound should be a number");
+
+// The values are double-encoded pointers. To get the actual address,
+// we will need to reinterpret the double bits as a 64-bit integer.
+let base = handle.stackBase;
+let bound = handle.stackBound;
+
+if (base === 0 || bound === 0)
+    throw new Error("Neither stack bound should be zero");
+
+if (base === bound)
+    throw new Error("Stack base and bound should be different");
+
+if (base < bound)
+    throw new Error("Stack base should be a higher address than its bound");
+
+
+// Helper to convert double-encoded pointer to hex string for display
+function doubleToHex(d) {
+    let buffer = new ArrayBuffer(8);
+    let floatView = new Float64Array(buffer);
+    let uintView = new BigUint64Array(buffer);
+    floatView[0] = d;
+    return "0x" + uintView[0].toString(16);
+}
+
+print("Compiler thread stack base: " + doubleToHex(base));
+print("Compiler thread stack bound: " + doubleToHex(bound));
+
+// Release the stalled thread
+$vm.releaseStallHandle(handle);
+
+print("PASSED")

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -44,6 +44,8 @@
 #include "HeapSnapshotBuilder.h"
 #include "InterpreterInlines.h"
 #include "JITSizeStatistics.h"
+#include "JITPlan.h"
+#include "JITWorklist.h"
 #include "JSArray.h"
 #include "JSCInlines.h"
 #include "JSGlobalProxyInlines.h"
@@ -224,6 +226,122 @@ private:
 };
 
 const ClassInfo JSDollarVMCallFrame::s_info = { "CallFrame"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDollarVMCallFrame) };
+
+#if ENABLE(JIT)
+// CompilerThreadStallHandle - holds synchronization state for stalling a compiler thread
+struct CompilerThreadStallHandle : public ThreadSafeRefCounted<CompilerThreadStallHandle> {
+    std::atomic<bool> stallRequested { true };
+    std::atomic<bool> stalled { false };
+    StackBounds stackBounds { StackBounds::emptyBounds() };
+    Lock lock;
+    Condition condition;
+};
+
+// StallPlan - a JITPlan that stalls instead of compiling, for testing purposes
+class StallPlan final : public JITPlan {
+public:
+    StallPlan(CodeBlock* codeBlock, Ref<CompilerThreadStallHandle>&& handle)
+        : JITPlan(JITCompilationMode::Baseline, codeBlock)
+        , m_handle(WTF::move(handle))
+    {
+        DollarVMAssertScope assertScope;
+    }
+
+    CompilationPath compileInThreadImpl() final
+    {
+        DollarVMAssertScope assertScope;
+
+        // Capture our stack bounds
+        m_handle->stackBounds = Thread::currentSingleton().stack();
+
+        // Signal that we're stalled
+        {
+            Locker locker { m_handle->lock };
+            m_handle->stalled = true;
+            m_handle->condition.notifyAll();
+        }
+
+        // Wait until released
+        {
+            Locker locker { m_handle->lock };
+            while (m_handle->stallRequested)
+                m_handle->condition.wait(m_handle->lock);
+        }
+
+        return BaselinePath;
+    }
+
+    size_t codeSize() const final { return 0; }
+
+    CompilationResult finalize() final
+    {
+        DollarVMAssertScope assertScope;
+        // Don't actually install any code
+        return CompilationResult::CompilationSuccessful;
+    }
+
+    bool isKnownToBeLiveAfterGC() final { return m_stage != JITPlanStage::Canceled; }
+    bool isKnownToBeLiveDuringGC(AbstractSlotVisitor&) final { return m_stage != JITPlanStage::Canceled; }
+
+private:
+    Ref<CompilerThreadStallHandle> m_handle;
+};
+
+// JSCompilerThreadStallHandle - JS wrapper exposing the stall handle
+class JSCompilerThreadStallHandle : public JSDestructibleObject {
+    using Base = JSDestructibleObject;
+public:
+    template<typename CellType, SubspaceAccess>
+    static CompleteSubspace* subspaceFor(VM& vm)
+    {
+        return &vm.destructibleObjectSpace();
+    }
+
+    static JSCompilerThreadStallHandle* create(VM& vm, Structure* structure, Ref<CompilerThreadStallHandle>&& handle)
+    {
+        DollarVMAssertScope assertScope;
+        JSCompilerThreadStallHandle* result = new (NotNull, allocateCell<JSCompilerThreadStallHandle>(vm)) JSCompilerThreadStallHandle(vm, structure, WTF::move(handle));
+        result->finishCreation(vm);
+        return result;
+    }
+
+    static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+    {
+        DollarVMAssertScope assertScope;
+        return Structure::create(vm, globalObject, prototype, TypeInfo(ObjectType, StructureFlags), info());
+    }
+
+    DECLARE_INFO;
+
+    CompilerThreadStallHandle& handle() { return m_handle.get(); }
+
+    void release()
+    {
+        DollarVMAssertScope assertScope;
+        Locker locker { m_handle->lock };
+        m_handle->stallRequested = false;
+        m_handle->condition.notifyAll();
+    }
+
+private:
+    JSCompilerThreadStallHandle(VM& vm, Structure* structure, Ref<CompilerThreadStallHandle>&& handle)
+        : Base(vm, structure)
+        , m_handle(WTF::move(handle))
+    {
+        DollarVMAssertScope assertScope;
+    }
+
+    void finishCreation(VM& vm)
+    {
+        DollarVMAssertScope assertScope;
+        Base::finishCreation(vm);
+    }
+
+    Ref<CompilerThreadStallHandle> m_handle;
+};
+
+const ClassInfo JSCompilerThreadStallHandle::s_info = { "CompilerThreadStallHandle"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSCompilerThreadStallHandle) };
+#endif // ENABLE(JIT)
 
 class ElementHandleOwner;
 class Root;
@@ -2260,6 +2378,8 @@ static JSC_DECLARE_HOST_FUNCTION(functionHeapExtraMemorySize);
 static JSC_DECLARE_HOST_FUNCTION(functionJITSizeStatistics);
 static JSC_DECLARE_HOST_FUNCTION(functionDumpJITSizeStatistics);
 static JSC_DECLARE_HOST_FUNCTION(functionResetJITSizeStatistics);
+static JSC_DECLARE_HOST_FUNCTION(functionStallCompilerThread);
+static JSC_DECLARE_HOST_FUNCTION(functionReleaseStallHandle);
 #endif
 
 static JSC_DECLARE_HOST_FUNCTION(functionAllowDoubleShape);
@@ -4198,6 +4318,69 @@ JSC_DEFINE_HOST_FUNCTION(functionResetJITSizeStatistics, (JSGlobalObject* global
     vm.jitSizeStatistics->reset();
     return JSValue::encode(jsUndefined());
 }
+
+// Usage: var handle = $vm.stallCompilerThread(function() {})
+// The function argument is used to get a CodeBlock for the plan.
+// Returns an object with stackBase, stackBound properties and a release() method.
+JSC_DEFINE_HOST_FUNCTION(functionStallCompilerThread, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue functionValue = callFrame->argument(0);
+    FunctionExecutable* executable = getExecutableForFunction(functionValue);
+    if (!executable)
+        return throwVMError(globalObject, scope, "Could not get FunctionExecutable from function"_s);
+
+    CodeBlock* codeBlock = executable->baselineCodeBlockFor(CodeSpecializationKind::CodeForCall);
+    JITWorklist* worklist = JITWorklist::existingGlobalWorklistOrNull();
+    if (!worklist)
+        worklist = &JITWorklist::ensureGlobalWorklist();
+
+    auto handle = adoptRef(*new CompilerThreadStallHandle());
+    Ref<JITPlan> plan = adoptRef(*new StallPlan(codeBlock, handle.copyRef()));
+
+    // Enqueue the stall plan and wait for the compiler thread to
+    // get into the loop
+    worklist->enqueue(WTF::move(plan));
+    {
+        Locker locker { handle->lock };
+        while (!handle->stalled)
+            handle->condition.wait(handle->lock);
+    }
+
+    Structure* structure = JSCompilerThreadStallHandle::createStructure(vm, globalObject, jsNull());
+    JSCompilerThreadStallHandle* jsHandle = JSCompilerThreadStallHandle::create(vm, structure, handle.copyRef());
+#if CPU(ADDRESS64)
+    using targetType = double;
+#else
+    using targetType = float;
+#endif
+    jsHandle->putDirect(vm, Identifier::fromString(vm, "stackBase"_s), jsNumber(std::bit_cast<targetType>(reinterpret_cast<uintptr_t>(handle->stackBounds.origin()))));
+    jsHandle->putDirect(vm, Identifier::fromString(vm, "stackBound"_s), jsNumber(std::bit_cast<targetType>(reinterpret_cast<uintptr_t>(handle->stackBounds.end()))));
+
+    return JSValue::encode(jsHandle);
+}
+
+// Releases a stalled compiler thread.
+// Usage: $vm.releaseStallHandle(handle)
+JSC_DEFINE_HOST_FUNCTION(functionReleaseStallHandle, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue handleValue = callFrame->argument(0);
+    JSCompilerThreadStallHandle* jsHandle = jsDynamicCast<JSCompilerThreadStallHandle*>(handleValue);
+    if (!jsHandle)
+        return throwVMError(globalObject, scope, "Argument is not a CompilerThreadStallHandle"_s);
+
+    jsHandle->release();
+    return JSValue::encode(jsUndefined());
+}
 #endif
 
 // Checks if DoubleShape is allowed.
@@ -4529,6 +4712,8 @@ void JSDollarVM::finishCreation(VM& vm)
     addFunction(vm, "jitSizeStatistics"_s, functionJITSizeStatistics, 0);
     addFunction(vm, "dumpJITSizeStatistics"_s, functionDumpJITSizeStatistics, 0);
     addFunction(vm, "resetJITSizeStatistics"_s, functionResetJITSizeStatistics, 0);
+    addFunction(vm, "stallCompilerThread"_s, functionStallCompilerThread, 1);
+    addFunction(vm, "releaseStallHandle"_s, functionReleaseStallHandle, 1);
 #endif
 
     addFunction(vm, "allowDoubleShape"_s, functionAllowDoubleShape, 0);


### PR DESCRIPTION
#### 017062fb071aa9369b91a458eb525df14b2aa30e
<pre>
Add stallCompilerThread to $vm for compiler testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=306306">https://bugs.webkit.org/show_bug.cgi?id=306306</a>
<a href="https://rdar.apple.com/168956986">rdar://168956986</a>

Reviewed by NOBODY (OOPS!).

This will enable us to prod at compiler memory in jsc stress tests
without exposing those same code-paths for normal execution.

Explanation of why this fixes the bug (OOPS!).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/017062fb071aa9369b91a458eb525df14b2aa30e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140930 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94018 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108146 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78437 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89046 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6da77b82-4fc6-4853-89b9-99f0ce51bb95) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10439 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8005 "Passed tests") | [⏳ wpe-libwebrtc ](None "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132908 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151894 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1729 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13000 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116369 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116708 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12775 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122817 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68161 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13043 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2224 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172222 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12782 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76744 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44659 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12826 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->