### PR TITLE
layerX/layerY return incorrect values with CSS transforms

### DIFF
--- a/LayoutTests/fast/events/mouse-relative-position-expected.txt
+++ b/LayoutTests/fast/events/mouse-relative-position-expected.txt
@@ -1,6 +1,9 @@
 span
 
 PASS simulateElementClick(testElement, [100, 100, 200, 200]); is '100, 100, 200, 200'
-PASS simulateElementClick(spanElement, [16, 10, 16, 10]); is '16, 10, 16, 10'
-PASS simulateElementClick(inputElement, [40, 10, 40, 10]); is '40, 10, 40, 10'
+PASS simulateElementClick(spanElement, [16, 10, 112, 110]); is '16, 10, 112, 110'
+PASS simulateElementClick(inputElement, [39, 9, 95, 10]); is '39, 9, 95, 10'
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/events/mouse-relative-position.html
+++ b/LayoutTests/fast/events/mouse-relative-position.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 <style>
     html, body {
         margin: 0;
@@ -97,7 +97,7 @@
     var inputElement = testElement2.getElementsByTagName('input')[0];
 
     shouldBe("simulateElementClick(testElement, [100, 100, 200, 200]);", "'100, 100, 200, 200'");
-    shouldBe("simulateElementClick(spanElement, [16, 10, 16, 10]);", "'16, 10, 16, 10'");
-    shouldBe("simulateElementClick(inputElement, [40, 10, 40, 10]);", "'40, 10, 40, 10'");
+    shouldBe("simulateElementClick(spanElement, [16, 10, 112, 110]);", "'16, 10, 112, 110'");
+    shouldBe("simulateElementClick(inputElement, [39, 9, 95, 10]);", "'39, 9, 95, 10'");
 </script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/layer-coords-transform-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/layer-coords-transform-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL layer-coords-transform assert_equals: layerX expected 200 but got 210
+PASS layer-coords-transform
 PASS layer-coords-transform 1
 


### PR DESCRIPTION
#### 63d6cf248df1e0ed4f2fd51fe72a4ee061714ad9
<pre>
layerX/layerY return incorrect values with CSS transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=306314">https://bugs.webkit.org/show_bug.cgi?id=306314</a>
<a href="https://rdar.apple.com/168968832">rdar://168968832</a>

Reviewed by Lily Spiniolas and Abrar Rahman Protyasha.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The layerX and layerY properties were computed by walking up the layer
tree and subtracting each layer&apos;s location(). This approach fails with
CSS transforms because layer locations are in local coordinate space
and don&apos;t account for transforms applied to parent layers.

It doesn&apos;t make sense not to include transforms when subtracting the
layer offset, because before this subtraction the mouse position value
already includes transforms (via absoluteLocation which applies the
documentToAbsoluteScaleFactor).

Fix by computing the layer&apos;s position in absolute coordinates using
localToAbsolute() with UseTransforms, matching Chromium&apos;s approach.
This ensures both the mouse position and layer position are in the
same coordinate system before computing their relative offset.

See: <a href="https://github.com/w3c/uievents/issues/398">https://github.com/w3c/uievents/issues/398</a>

* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::computeRelativePosition):
* LayoutTests/imported/w3c/web-platform-tests/uievents/mouse/layer-coords-transform-expected.txt: Progression
* LayoutTests/fast/events/mouse-relative-position-expected.txt:
* LayoutTests/fast/events/mouse-relative-position.html:

Canonical link: <a href="https://commits.webkit.org/306300@main">https://commits.webkit.org/306300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abbf924202c76ec7e8732bea34e43e1832565ea6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149394 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13483 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10838 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89075 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9381 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151911 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13017 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116384 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116724 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29682 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12787 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122828 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13060 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12799 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76761 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12843 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->