### PR TITLE
AX: Local frames should propagate their inert state

### DIFF
--- a/LayoutTests/accessibility/iframe-content-inert-expected.txt
+++ b/LayoutTests/accessibility/iframe-content-inert-expected.txt
@@ -9,6 +9,10 @@ PASS: !body.childAtIndex(0) === true
 PASS: !accessibilityController.accessibleElementById('frame-button-1') === true
 PASS: !accessibilityController.accessibleElementById('frame-button-2') === true
 
+document.getElementById('iframe1').removeAttribute('inert');
+PASS: iframeButton1.isIgnored === false
+PASS: iframeButton2.isIgnored === false
+
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/iframe-content-inert.html
+++ b/LayoutTests/accessibility/iframe-content-inert.html
@@ -42,6 +42,16 @@ function runTest() {
         output += await expectAsync("!body.childAtIndex(0)", "true");
         output += await expectAsync("!accessibilityController.accessibleElementById('frame-button-1')", "true");
         output += await expectAsync("!accessibilityController.accessibleElementById('frame-button-2')", "true");
+        
+        // Add the inert tag back again, verify the buttons become available again.
+        output += `\n${evalAndReturn("document.getElementById('iframe1').removeAttribute('inert');")}`;
+        
+        await waitFor(() => {
+            iframeButton2 = accessibilityController.accessibleElementById("frame-button-2");
+            return !!iframeButton2;
+        });
+        output += await expectAsync("iframeButton1.isIgnored", "false");
+        output += await expectAsync("iframeButton2.isIgnored", "false");
 
         debug(output);
         finishJSTest();

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -622,6 +622,7 @@ public:
     bool isScrollbar() const { return role() == AccessibilityRole::ScrollBar; }
     bool isRemoteFrame() const { return role() == AccessibilityRole::RemoteFrame; }
     bool isLocalFrame() const { return role() == AccessibilityRole::LocalFrame; }
+    bool isFrame() const;
 #if PLATFORM(COCOA)
     virtual RetainPtr<id> remoteFramePlatformElement() const = 0;
 #endif
@@ -1497,6 +1498,12 @@ inline void AXCoreObject::detachWrapper(AccessibilityDetachmentType detachmentTy
 inline Vector<AXID> AXCoreObject::childrenIDs(bool updateChildrenIfNeeded)
 {
     return axIDs(children(updateChildrenIfNeeded));
+}
+
+inline bool AXCoreObject::isFrame() const
+{
+    auto role = this->role();
+    return role == AccessibilityRole::LocalFrame || role == AccessibilityRole::RemoteFrame;
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/accessibility/AXLocalFrame.cpp
+++ b/Source/WebCore/accessibility/AXLocalFrame.cpp
@@ -53,7 +53,7 @@ bool AXLocalFrame::computeIsIgnored() const
 {
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     if (RefPtr hostingScrollView = dynamicDowncast<AccessibilityScrollView>(parentObject()))
-        return hostingScrollView->isHostingFrameHidden();
+        return hostingScrollView->isIgnoredFromHostingFrame();
 #endif
     return false;
 }

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -6024,8 +6024,10 @@ void AXObjectCache::objectBecameIgnored(const AccessibilityObject& object)
         tree->objectBecameIgnored(object);
 #endif
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    if (RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(object); scrollView && scrollView->role() == AccessibilityRole::FrameHost)
-        const_cast<AccessibilityScrollView*>(scrollView.get())->updateHostedFrameInheritedState();
+    if (object.isFrame()) {
+        if (RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(object.parentObject()); scrollView && scrollView->role() == AccessibilityRole::FrameHost)
+            scrollView->updateHostedFrameInheritedState();
+    }
 #endif
 #if !ENABLE(ACCESSIBILITY_ISOLATED_TREE) && !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     UNUSED_PARAM(object);
@@ -6039,8 +6041,10 @@ void AXObjectCache::objectBecameUnignored(const AccessibilityObject& object)
         tree->objectBecameUnignored(object);
 #endif
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    if (RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(object); scrollView && scrollView->role() == AccessibilityRole::FrameHost)
-        const_cast<AccessibilityScrollView*>(scrollView.get())->updateHostedFrameInheritedState();
+    if (object.isFrame()) {
+        if (RefPtr scrollView = dynamicDowncast<AccessibilityScrollView>(object.parentObject()); scrollView && scrollView->role() == AccessibilityRole::FrameHost)
+            scrollView->updateHostedFrameInheritedState();
+    }
 #endif
 #if !ENABLE(ACCESSIBILITY_ISOLATED_TREE) && !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     UNUSED_PARAM(object);

--- a/Source/WebCore/accessibility/AXRemoteFrame.cpp
+++ b/Source/WebCore/accessibility/AXRemoteFrame.cpp
@@ -45,7 +45,7 @@ bool AXRemoteFrame::computeIsIgnored() const
 {
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     if (RefPtr hostingScrollView = dynamicDowncast<AccessibilityScrollView>(parentObject()))
-        return hostingScrollView->isHostingFrameHidden();
+        return hostingScrollView->isIgnoredFromHostingFrame();
 #endif
     return false;
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4020,6 +4020,19 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
 bool AccessibilityObject::isWithinHiddenWebArea() const
 {
     RefPtr webArea = this->containingWebArea();
+    if (!webArea)
+        return false;
+
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+    if (RefPtr parentScrollView = dynamicDowncast<AccessibilityScrollView>(webArea->parentObject())) {
+        if (parentScrollView->isHostingFrameInert()) {
+            // The frame that hosts this web area is inert, so this entire frame should be inert as well.
+            return true;
+        }
+    }
+#endif
+
+    // Fallback for same-process visibility/inert check.
     CheckedPtr renderView = webArea ? dynamicDowncast<RenderView>(webArea->renderer()) : nullptr;
     CheckedPtr frameRenderer = renderView ? renderView->frameView().frame().ownerRenderer() : nullptr;
     while (frameRenderer) {

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -336,7 +336,7 @@ void AccessibilityScrollView::addLocalFrameChild()
 
         // Set the initial hosting node state on the child frame's root scroll view.
         if (RefPtr childScrollView = dynamicDowncast<AccessibilityScrollView>(frameRoot.get()))
-            childScrollView->setInheritedFrameState({ isAXHidden() });
+            childScrollView->setInheritedFrameState({ isHostingFrameHidden(), isHostingFrameInert() });
 
         m_localFrame = downcast<AXLocalFrame>(cache->create(AccessibilityRole::LocalFrame));
         m_localFrame->setLocalFrameView(localFrameView.get());
@@ -567,6 +567,18 @@ bool AccessibilityScrollView::isARIAHidden() const
     return AccessibilityObject::isARIAHidden();
 }
 
+bool AccessibilityScrollView::isHostingFrameInert() const
+{
+    if (isRoot())
+        return m_inheritedFrameState.isInert;
+
+    RefPtr frameOwner = frameOwnerElement();
+    if (CheckedPtr renderer = frameOwner ? frameOwner->renderer() : nullptr)
+        return renderer->style().effectiveInert();
+
+    return false;
+}
+
 void AccessibilityScrollView::updateHostedFrameInheritedState()
 {
     if (!m_localFrame)
@@ -589,7 +601,7 @@ void AccessibilityScrollView::updateHostedFrameInheritedState()
     if (!hostedFrameScrollView)
         return;
 
-    hostedFrameScrollView->setInheritedFrameState({ isAXHidden() });
+    hostedFrameScrollView->setInheritedFrameState({ isHostingFrameHidden(), isHostingFrameInert() });
 
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     hostedFrameScrollView->recomputeIsIgnoredForDescendants(/* includeSelf */ true);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -42,14 +42,17 @@ class ScrollView;
 struct InheritedFrameState {
     InheritedFrameState()
         : isAXHidden(false)
+        , isInert(false)
     { }
 
-    InheritedFrameState(bool isAXHidden)
+    InheritedFrameState(bool isAXHidden, bool isInert)
         : isAXHidden(isAXHidden)
+        , isInert(isInert)
     { }
 
     bool isAXHidden;
-    // FIXME: include inert and visibility state.
+    bool isInert;
+    // FIXME: include visibility state.
 };
 #endif
 
@@ -74,15 +77,18 @@ public:
     AccessibilityObject* crossFrameChildObject() const final;
 
     void setInheritedFrameState(InheritedFrameState state) { m_inheritedFrameState = state; }
+    const InheritedFrameState& inheritedFrameState() const { return m_inheritedFrameState; }
     bool isAXHidden() const final;
     bool isARIAHidden() const final;
     void updateHostedFrameInheritedState();
 
     // Returns true if the iframe element (or ancestors) cause the content to be hidden.
     // We can't use isIgnored() because FrameHost scroll views are always ignored (see computeIsIgnored).
-    // FIXME: This should also consider inert and visibility.
     bool isHostingFrameHidden() const { return isAXHidden(); }
-#endif
+    bool isHostingFrameInert() const;
+    bool isIgnoredFromHostingFrame() const { return isHostingFrameHidden() || isHostingFrameInert(); }
+    // FIXME: This should also consider visibility state for full site isolation support.
+#endif // ENABLE(ACCESSIBLITY_LOCAL_FRAME)
 
 private:
     explicit AccessibilityScrollView(AXID, ScrollView&, AXObjectCache&);
@@ -120,6 +126,7 @@ private:
     AccessibilityObject* parentObject() const final;
     RefPtr<AccessibilityObject> protectedHorizontalScrollbar() const { return m_horizontalScrollbar; }
     RefPtr<AccessibilityObject> protectedVerticalScrollbar() const { return m_verticalScrollbar; }
+    HTMLFrameOwnerElement* frameOwnerElement() const { return m_frameOwnerElement; }
     RefPtr<HTMLFrameOwnerElement> protectedFrameOwnerElement() const { return m_frameOwnerElement; }
 
     AccessibilityObject* firstChild() const final { return webAreaObject(); }


### PR DESCRIPTION
#### 4db39d5577ab95c6ef0252b5763022bb179306dd
<pre>
AX: Local frames should propagate their inert state
<a href="https://bugs.webkit.org/show_bug.cgi?id=306315">https://bugs.webkit.org/show_bug.cgi?id=306315</a>
<a href="https://rdar.apple.com/168972760">rdar://168972760</a>

Reviewed by Tyler Wilcock.

This PR, like the previous 306210@main, provides the infrastructure for passing the inert-ness
from a hosting frame in one cache to the hosted frame in another. This data is used in an
existing method, isWithinHiddenWebArea, which is used in the ignored calculation.

Extending the tests here helped expose a critical flaw in the original design. We used to
call updateHostedFrameInheritedState() only when an AccessibilityScrollView changed its
ignored state. However, this never actually got called, since FrameHosts are *always* ignored.
Instead, this needs to be called whenever the LocalFrame or RemoteFrame changes its ignored
status. We pass the previous aria-hidden and inert tests now, and the test modification provides
coverage of this behavior.

* LayoutTests/accessibility/iframe-content-inert-expected.txt:
* LayoutTests/accessibility/iframe-content-inert.html:
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isFrame const):
* Source/WebCore/accessibility/AXLocalFrame.cpp:
(WebCore::AXLocalFrame::computeIsIgnored const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::objectBecameIgnored):
(WebCore::AXObjectCache::objectBecameUnignored):
* Source/WebCore/accessibility/AXRemoteFrame.cpp:
(WebCore::AXRemoteFrame::computeIsIgnored const):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isWithinHiddenWebArea const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::addLocalFrameChild):
(WebCore::AccessibilityScrollView::isHostingFrameInert const):
(WebCore::AccessibilityScrollView::updateHostedFrameInheritedState):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
(WebCore::InheritedFrameState::InheritedFrameState):

Canonical link: <a href="https://commits.webkit.org/306298@main">https://commits.webkit.org/306298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/518fae8036bcdf001b19ef4210eee9105671af37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149356 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93994 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108140 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78424 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89040 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10410 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7983 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9340 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151869 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12976 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2370 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116356 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116695 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29683 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12756 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68137 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13019 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12758 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76720 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12957 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12802 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->