### PR TITLE
Revert incorrect stretch alignment test in aspect-ratio dependency check

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/aspect-ratio-stretch-item-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/aspect-ratio-stretch-item-001-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/aspect-ratio-stretch-item-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/aspect-ratio-stretch-item-001.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>Automatic Sizing and aspect-ratio with fr tracks, percent width, and explicit stretch alignment</title>
+<link rel=help href="https://www.w3.org/TR/css-sizing-4/#aspect-ratio">
+<link rel=help href="https://www.w3.org/TR/css-grid-2/#fr-unit">
+<link rel=match href="../../reference/ref-filled-green-100px-square-only.html">
+<style>
+.container {
+	width: 100px;
+}
+.grid {
+	display: grid;
+	gap: 2px;
+	grid-template: repeat(2, minmax(0,1fr)) / repeat(2, minmax(0,1fr));
+}
+.figure {
+	background: green;
+	aspect-ratio: 1;
+	width: 100%;
+	grid-row: span 2;
+	grid-column: span 2;
+	place-self: stretch;
+}
+</style>
+
+<p>Test passes if there is a filled green square.</p>
+
+<div class=container>
+	<div class=grid>
+		<div class=figure></div>
+	</div>
+</div>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -4944,7 +4944,7 @@ bool RenderBox::shouldComputeLogicalHeightFromAspectRatio() const
         return false;
 
     auto h = style().logicalHeight();
-    return (h.isAuto() && !hasStretchedLogicalHeight(StretchingMode::Explicit)) || h.isIntrinsic() || (!isOutOfFlowPositioned() && h.isPercentOrCalculated() && !percentageLogicalHeightIsResolvable());
+    return (h.isAuto()) || h.isIntrinsic() || (!isOutOfFlowPositioned() && h.isPercentOrCalculated() && !percentageLogicalHeightIsResolvable());
 }
 
 bool RenderBox::shouldComputeLogicalWidthFromAspectRatio() const


### PR DESCRIPTION
#### c2519b57af750bd6bb0f2daf9f3c294fd143d68d
<pre>
Revert incorrect stretch alignment test in aspect-ratio dependency check
<a href="https://bugs.webkit.org/show_bug.cgi?id=306319">https://bugs.webkit.org/show_bug.cgi?id=306319</a>
<a href="https://rdar.apple.com/168880191">rdar://168880191</a>

Reviewed by Sammy Gill.

305260@main tried to fix an aspect ratio check that wasn&apos;t broken, which
resulted in us failing to compute automatic heights correctly when combining
aspect-ratio and stretch alignment on auto-sized grid items in the block axis.
This patch reverts the extra conditional.

Test: imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/aspect-ratio-stretch-item-001.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/aspect-ratio-stretch-item-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/aspect-ratio-stretch-item-001.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::shouldComputeLogicalHeightFromAspectRatio const):

Canonical link: <a href="https://commits.webkit.org/306282@main">https://commits.webkit.org/306282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c876dcf6c37af05459fb8e2bb393904842b19a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93934 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108060 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78394 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/88962 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10370 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7939 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9280 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151809 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12916 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116307 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12677 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68057 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/12959 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76659 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->