### PR TITLE
Reduce use of protected functions in Source/WebKit/Shared

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -381,7 +381,7 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
 
     GPUProcessConnectionInfo info {
 #if HAVE(AUDIT_TOKEN)
-        .auditToken = gpuProcess.protectedParentProcessConnection()->getAuditToken(),
+        .auditToken = protect(gpuProcess.parentProcessConnection())->getAuditToken(),
 #endif
         .mediaCodecCapabilities = capabilities
     };
@@ -674,7 +674,7 @@ RemoteAudioSessionProxy& GPUConnectionToWebProcess::audioSessionProxy()
     if (!m_audioSessionProxy) {
         Ref audioSessionProxy = RemoteAudioSessionProxy::create(*this);
         m_audioSessionProxy = audioSessionProxy.ptr();
-        auto auditToken = gpuProcess().protectedParentProcessConnection()->getAuditToken();
+        auto auditToken = protect(gpuProcess().parentProcessConnection())->getAuditToken();
         m_gpuProcess->protectedAudioSessionManager()->addProxy(audioSessionProxy, auditToken);
     }
     return *m_audioSessionProxy;
@@ -1204,7 +1204,7 @@ void GPUConnectionToWebProcess::setOrientationForMediaCapture(IntDegrees orienta
 void GPUConnectionToWebProcess::startMonitoringCaptureDeviceRotation(WebCore::PageIdentifier pageIdentifier, const String& persistentId)
 {
 #if PLATFORM(COCOA)
-    gpuProcess().protectedParentProcessConnection()->send(Messages::GPUProcessProxy::StartMonitoringCaptureDeviceRotation(pageIdentifier, persistentId), 0);
+    protect(gpuProcess().parentProcessConnection())->send(Messages::GPUProcessProxy::StartMonitoringCaptureDeviceRotation(pageIdentifier, persistentId), 0);
 #else
     UNUSED_PARAM(pageIdentifier);
     UNUSED_PARAM(persistentId);
@@ -1214,7 +1214,7 @@ void GPUConnectionToWebProcess::startMonitoringCaptureDeviceRotation(WebCore::Pa
 void GPUConnectionToWebProcess::stopMonitoringCaptureDeviceRotation(WebCore::PageIdentifier pageIdentifier, const String& persistentId)
 {
 #if PLATFORM(COCOA)
-    gpuProcess().protectedParentProcessConnection()->send(Messages::GPUProcessProxy::StopMonitoringCaptureDeviceRotation(pageIdentifier, persistentId), 0);
+    protect(gpuProcess().parentProcessConnection())->send(Messages::GPUProcessProxy::StopMonitoringCaptureDeviceRotation(pageIdentifier, persistentId), 0);
 #else
     UNUSED_PARAM(pageIdentifier);
     UNUSED_PARAM(persistentId);
@@ -1333,7 +1333,7 @@ std::optional<audit_token_t> GPUConnectionToWebProcess::presentingApplicationAud
     if (iterator != m_presentingApplicationAuditTokens.end())
         return iterator->value.auditToken();
 
-    if (auto parentAuditToken = m_gpuProcess->protectedParentProcessConnection()->getAuditToken())
+    if (auto parentAuditToken = protect(m_gpuProcess->parentProcessConnection())->getAuditToken())
         return *parentAuditToken;
 
     return std::nullopt;

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -201,7 +201,7 @@ void GPUProcess::tryExitIfUnused()
     m_idleExitTimer.stop();
 
     RELEASE_LOG(Process, "GPUProcess::tryExitIfUnused: GPUProcess is exiting because we are under memory pressure and the process is no longer useful.");
-    protectedParentProcessConnection()->send(Messages::GPUProcessProxy::ProcessIsReadyToExit(), 0);
+    protect(parentProcessConnection())->send(Messages::GPUProcessProxy::ProcessIsReadyToExit(), 0);
 }
 
 void GPUProcess::lowMemoryHandler(Critical critical, Synchronous synchronous)
@@ -436,7 +436,7 @@ void GPUProcess::enableMicrophoneMuteStatusAPI()
 #if PLATFORM(COCOA)
     CoreAudioCaptureUnit::defaultSingleton().setMuteStatusChangedCallback([weakProcess = WeakPtr { *this }] (bool isMuting) {
         if (RefPtr process = weakProcess.get())
-            process->protectedParentProcessConnection()->send(Messages::GPUProcessProxy::MicrophoneMuteStatusChanged(isMuting), 0);
+            protect(process->parentProcessConnection())->send(Messages::GPUProcessProxy::MicrophoneMuteStatusChanged(isMuting), 0);
     });
 #endif
 }
@@ -518,7 +518,7 @@ void GPUProcess::setShouldListenToVoiceActivity(bool shouldListen)
     }
 
     RealtimeMediaSourceCenter::singleton().audioCaptureFactory().enableMutedSpeechActivityEventListener([] {
-        GPUProcess::singleton().protectedParentProcessConnection()->send(Messages::GPUProcessProxy::VoiceActivityDetected { }, 0);
+        protect(GPUProcess::singleton().parentProcessConnection())->send(Messages::GPUProcessProxy::VoiceActivityDetected { }, 0);
     });
 #endif
 }
@@ -631,7 +631,7 @@ void GPUProcess::webProcessConnectionCountForTesting(CompletionHandler<void(uint
 
 void GPUProcess::terminateWebProcess(WebCore::ProcessIdentifier identifier)
 {
-    protectedParentProcessConnection()->send(Messages::GPUProcessProxy::TerminateWebProcess(identifier), 0);
+    protect(parentProcessConnection())->send(Messages::GPUProcessProxy::TerminateWebProcess(identifier), 0);
 }
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -281,7 +281,7 @@ void RemoteAudioSessionProxyManager::updatePresentingProcesses()
             presentingProcesses.append(token.auditToken());
     });
 
-    if (auto token = m_gpuProcess->protectedParentProcessConnection()->getAuditToken(); token && shouldAppendParentProcess)
+    if (auto token = protect(m_gpuProcess->parentProcessConnection())->getAuditToken(); token && shouldAppendParentProcess)
         presentingProcesses.append(*token);
 
     if (!presentingProcesses.isEmpty())

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -455,7 +455,7 @@ void WebResourceLoadStatisticsStore::requestStorageAccess(RegistrableDomain&& su
                     completionHandler({ StorageAccessWasGranted::No, StorageAccessPromptWasShown::Yes, scope, topFrameDomain, subFrameDomain });
             };
 
-            networkSession->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, storageAccessQuirk), WTF::move(requestConfirmationCompletionHandler));
+            protect(networkSession->networkProcess().parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, storageAccessQuirk), WTF::move(requestConfirmationCompletionHandler));
             return;
         }
         case StorageAccessStatus::HasAccess:
@@ -568,7 +568,7 @@ void WebResourceLoadStatisticsStore::requestStorageAccessEphemeral(const Registr
             completionHandler({ StorageAccessWasGranted::No, StorageAccessPromptWasShown::Yes, scope, topFrameDomain, subFrameDomain });
     };
 
-    networkSession->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, WTF::move(storageAccessPromptQuirk)), WTF::move(requestConfirmationCompletionHandler));
+    protect(networkSession->networkProcess().parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestStorageAccessConfirm(webPageProxyID, frameID, subFrameDomain, topFrameDomain, WTF::move(storageAccessPromptQuirk)), WTF::move(requestConfirmationCompletionHandler));
 }
 
 void WebResourceLoadStatisticsStore::requestStorageAccessUnderOpener(RegistrableDomain&& domainInNeedOfStorageAccess, PageIdentifier openerPageID, RegistrableDomain&& openerDomain)
@@ -1421,7 +1421,7 @@ void WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesFor
 
         if (m_domainsWithUserInteractionQuirk != domainsWithUserInteractionQuirk) {
             m_domainsWithUserInteractionQuirk = domainsWithUserInteractionQuirk;
-            networkSession->networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::SetDomainsWithUserInteraction(domainsWithUserInteractionQuirk), 0);
+            protect(networkSession->networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::SetDomainsWithUserInteraction(domainsWithUserInteractionQuirk), 0);
         }
 
         HashMap<TopFrameDomain, Vector<SubResourceDomain>> domainsWithStorageAccessQuirk;
@@ -1435,7 +1435,7 @@ void WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesFor
         if (m_domainsWithCrossPageStorageAccessQuirk != domainsWithStorageAccessQuirk) {
             if (CheckedPtr storageSession = networkSession->networkStorageSession())
                 storageSession->setDomainsWithCrossPageStorageAccess(domainsWithStorageAccessQuirk);
-            networkSession->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::SetDomainsWithCrossPageStorageAccess(domainsWithStorageAccessQuirk), [this, protectedThis = Ref { *this }, domainsWithStorageAccessQuirk] () mutable {
+            protect(networkSession->networkProcess().parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::SetDomainsWithCrossPageStorageAccess(domainsWithStorageAccessQuirk), [this, protectedThis = Ref { *this }, domainsWithStorageAccessQuirk] () mutable {
                 m_domainsWithCrossPageStorageAccessQuirk = domainsWithStorageAccessQuirk;
             });
         }
@@ -1504,7 +1504,7 @@ void WebResourceLoadStatisticsStore::logTestingEvent(const String& event)
 
     CheckedPtr networkSession = m_networkSession.get();
     if (networkSession && networkSession->enableResourceLoadStatisticsLogTestingEvent())
-        networkSession->networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::LogTestingEvent(m_networkSession->sessionID(), event), 0);
+        protect(networkSession->networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::LogTestingEvent(m_networkSession->sessionID(), event), 0);
 }
 
 NetworkSession* WebResourceLoadStatisticsStore::networkSession()

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
@@ -79,7 +79,7 @@ void NetworkContentRuleListManager::contentExtensionsBackend(UserContentControll
     m_pendingCallbacks.ensure(identifier, [] {
         return Vector<BackendCallback> { };
     }).iterator->value.append(WTF::move(callback));
-    protectedNetworkProcess()->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::ContentExtensionRules { identifier }, 0);
+    protect(protectedNetworkProcess()->parentProcessConnection())->send(Messages::NetworkProcessProxy::ContentExtensionRules { identifier }, 0);
 }
 
 void NetworkContentRuleListManager::addContentRuleLists(UserContentControllerIdentifier identifier, Vector<std::pair<WebCompiledContentRuleListData, URL>>&& contentRuleLists)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1370,7 +1370,7 @@ void NetworkProcess::didCommitCrossSiteLoadWithDataTransfer(PAL::SessionID sessi
             networkStorageSession->didCommitCrossSiteLoadWithDataTransferFromPrevalentResource(toDomain, webPageID);
 
         if (navigationDataTransfer.contains(CrossSiteNavigationDataTransfer::Flag::ReferrerLinkDecoration))
-            protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::DidCommitCrossSiteLoadWithDataTransferFromPrevalentResource(webPageProxyID), 0);
+            protect(parentProcessConnection())->send(Messages::NetworkProcessProxy::DidCommitCrossSiteLoadWithDataTransferFromPrevalentResource(webPageProxyID), 0);
     } else
         ASSERT_NOT_REACHED();
 
@@ -2179,7 +2179,7 @@ void NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains(PAL::Sess
             for (auto& domain : domains)
                 callbackAggregator->m_domains.add(domain);
         };
-        protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::DeleteWebsiteDataInUIProcessForRegistrableDomains(sessionID, dataTypesForUIProcess, fetchOptions, domainsToDeleteAllScriptWrittenStorageFor), WTF::move(completionHandler));
+        protect(parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::DeleteWebsiteDataInUIProcessForRegistrableDomains(sessionID, dataTypesForUIProcess, fetchOptions, domainsToDeleteAllScriptWrittenStorageFor), WTF::move(completionHandler));
     }
 }
 
@@ -2409,7 +2409,7 @@ void NetworkProcess::logDiagnosticMessage(WebPageProxyIdentifier webPageProxyID,
     if (!DiagnosticLoggingClient::shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::LogDiagnosticMessage(webPageProxyID, message, description, ShouldSample::No), 0);
+    protect(parentProcessConnection())->send(Messages::NetworkProcessProxy::LogDiagnosticMessage(webPageProxyID, message, description, ShouldSample::No), 0);
 }
 
 void NetworkProcess::logDiagnosticMessageWithResult(WebPageProxyIdentifier webPageProxyID, const String& message, const String& description, DiagnosticLoggingResultType result, ShouldSample shouldSample)
@@ -2417,7 +2417,7 @@ void NetworkProcess::logDiagnosticMessageWithResult(WebPageProxyIdentifier webPa
     if (!DiagnosticLoggingClient::shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::LogDiagnosticMessageWithResult(webPageProxyID, message, description, result, ShouldSample::No), 0);
+    protect(parentProcessConnection())->send(Messages::NetworkProcessProxy::LogDiagnosticMessageWithResult(webPageProxyID, message, description, result, ShouldSample::No), 0);
 }
 
 void NetworkProcess::logDiagnosticMessageWithValue(WebPageProxyIdentifier webPageProxyID, const String& message, const String& description, double value, unsigned significantFigures, ShouldSample shouldSample)
@@ -2425,7 +2425,7 @@ void NetworkProcess::logDiagnosticMessageWithValue(WebPageProxyIdentifier webPag
     if (!DiagnosticLoggingClient::shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::LogDiagnosticMessageWithValue(webPageProxyID, message, description, value, significantFigures, ShouldSample::No), 0);
+    protect(parentProcessConnection())->send(Messages::NetworkProcessProxy::LogDiagnosticMessageWithValue(webPageProxyID, message, description, value, significantFigures, ShouldSample::No), 0);
 }
 
 void NetworkProcess::terminate()
@@ -3278,7 +3278,7 @@ void NetworkProcess::allowFileAccessFromWebProcess(WebCore::ProcessIdentifier pr
 
 void NetworkProcess::requestBackgroundFetchPermission(PAL::SessionID sessionID, const ClientOrigin& origin, CompletionHandler<void(bool)>&& callback)
 {
-    protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestBackgroundFetchPermission(sessionID, origin), WTF::move(callback));
+    protect(parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::RequestBackgroundFetchPermission(sessionID, origin), WTF::move(callback));
 }
 
 #if USE(RUNNINGBOARD)

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -136,7 +136,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(NetworkProcess& ne
 static WebPushD::WebPushDaemonConnectionConfiguration configurationWithHostAuditToken(NetworkProcess& networkProcess, WebPushD::WebPushDaemonConnectionConfiguration configuration)
 {
 #if !USE(EXTENSIONKIT)
-    auto token = networkProcess.protectedParentProcessConnection()->getAuditToken();
+    auto token = protect(networkProcess.parentProcessConnection())->getAuditToken();
     if (token) {
         Vector<uint8_t> auditTokenData(sizeof(*token));
         memcpySpan(auditTokenData.mutableSpan(), asByteSpan(*token));
@@ -703,7 +703,7 @@ String NetworkSession::attributedBundleIdentifierFromPageIdentifier(WebPageProxy
 
 void NetworkSession::reportNetworkIssue(WebPageProxyIdentifier pageIdentifier, const URL& requestURL)
 {
-    m_networkProcess->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::ReportNetworkIssue(pageIdentifier, requestURL), 0);
+    protect(m_networkProcess->parentProcessConnection())->send(Messages::NetworkProcessProxy::ReportNetworkIssue(pageIdentifier, requestURL), 0);
 }
 
 #endif // ENABLE(NETWORK_ISSUE_REPORTING)
@@ -843,7 +843,7 @@ void NetworkSession::softUpdate(ServiceWorkerJobData&& jobData, bool shouldRefre
 void NetworkSession::createContextConnection(const WebCore::Site& site, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(!site.isEmpty());
-    m_networkProcess->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::ServiceWorker, site, requestingProcessIdentifier, serviceWorkerPageIdentifier, m_sessionID }, [completionHandler = WTF::move(completionHandler)] (auto) mutable {
+    protect(m_networkProcess->parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::ServiceWorker, site, requestingProcessIdentifier, serviceWorkerPageIdentifier, m_sessionID }, [completionHandler = WTF::move(completionHandler)] (auto) mutable {
         completionHandler();
     }, 0);
 }
@@ -851,7 +851,7 @@ void NetworkSession::createContextConnection(const WebCore::Site& site, std::opt
 void NetworkSession::appBoundDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    m_networkProcess->protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetAppBoundDomains { m_sessionID }, WTF::move(completionHandler), 0);
+    protect(m_networkProcess->parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::GetAppBoundDomains { m_sessionID }, WTF::move(completionHandler), 0);
 #else
     completionHandler({ });
 #endif

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -559,7 +559,7 @@ void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientO
 
     if (contextConnection) {
         auto& connection = downcast<WebSWServerToContextConnection>(*contextConnection);
-        protectedNetworkProcess()->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
+        protect(protectedNetworkProcess()->parentProcessConnection())->send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
     }
 }
 
@@ -591,7 +591,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
         if (!hasMatchingClient(potentiallyRemovedDomain)) {
             if (RefPtr contextConnection = server->contextConnectionForRegistrableDomain(potentiallyRemovedDomain)) {
                 auto& connection = downcast<WebSWServerToContextConnection>(*contextConnection);
-                protectedNetworkProcess()->protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
+                protect(protectedNetworkProcess()->parentProcessConnection())->send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
             }
         }
     }
@@ -778,7 +778,7 @@ void WebSWServerConnection::contextConnectionCreated(SWServerToContextConnection
     connection.setThrottleState(computeThrottleState(connection.registrableDomain()));
 
     if (hasMatchingClient(connection.registrableDomain()))
-        networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
+        protect(networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
 }
 
 void WebSWServerConnection::terminateWorkerFromClient(ServiceWorkerIdentifier serviceWorkerIdentifier, CompletionHandler<void()>&& callback)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -75,13 +75,13 @@ WebSWServerToContextConnection::~WebSWServerToContextConnection()
 template<typename T>
 void WebSWServerToContextConnection::sendToParentProcess(T&& message)
 {
-    protectedNetworkProcess()->protectedParentProcessConnection()->send(WTF::move(message), 0);
+    protect(protectedNetworkProcess()->parentProcessConnection())->send(WTF::move(message), 0);
 }
 
 template<typename T, typename C>
 void WebSWServerToContextConnection::sendWithAsyncReplyToParentProcess(T&& message, C&& callback)
 {
-    protectedNetworkProcess()->protectedParentProcessConnection()->sendWithAsyncReply(WTF::move(message), WTF::move(callback), 0);
+    protect(protectedNetworkProcess()->parentProcessConnection())->sendWithAsyncReply(WTF::move(message), WTF::move(callback), 0);
 }
 
 void WebSWServerToContextConnection::stop()
@@ -257,7 +257,7 @@ void WebSWServerToContextConnection::fireBackgroundFetchClickEvent(ServiceWorker
 void WebSWServerToContextConnection::terminateWorker(ServiceWorkerIdentifier serviceWorkerIdentifier)
 {
     if (!m_processingFunctionalEventCount++)
-        protectedConnection()->networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        protect(protectedConnection()->networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::StartServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 
     send(Messages::WebSWContextManagerConnection::TerminateWorker(serviceWorkerIdentifier));
 }
@@ -291,7 +291,7 @@ void WebSWServerToContextConnection::workerTerminated(ServiceWorkerIdentifier se
     SWServerToContextConnection::workerTerminated(serviceWorkerIdentifier);
 
     if (--m_processingFunctionalEventCount)
-        protectedConnection()->networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
+        protect(protectedConnection()->networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::EndServiceWorkerBackgroundProcessing { webProcessIdentifier() }, 0);
 }
 
 void WebSWServerToContextConnection::didFinishActivation(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier)

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -158,7 +158,7 @@ void WebSharedWorkerServer::createContextConnection(const WebCore::Site& site, s
     RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::createContextConnection will create a connection");
 
     m_pendingContextConnectionDomains.add(site.domain());
-    m_session->networkProcess().protectedParentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::SharedWorker, site, requestingProcessIdentifier, std::nullopt, m_session->sessionID() }, [weakThis = WeakPtr { *this }, site] (auto remoteProcessIdentifier) {
+    protect(m_session->networkProcess().parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::EstablishRemoteWorkerContextConnectionToNetworkProcess { RemoteWorkerType::SharedWorker, site, requestingProcessIdentifier, std::nullopt, m_session->sessionID() }, [weakThis = WeakPtr { *this }, site] (auto remoteProcessIdentifier) {
         CheckedPtr checkedThis = weakThis.get();
         if (!checkedThis)
             return;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -116,7 +116,7 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
     [NSURLCache setSharedURLCache:urlCache.get()];
 
 #if ENABLE(CONTENT_FILTERING)
-    auto auditToken = protectedParentProcessConnection()->getAuditToken();
+    auto auditToken = protect(parentProcessConnection())->getAuditToken();
     ASSERT(auditToken);
     if (auditToken && [NEFilterSource respondsToSelector:@selector(setDelegation:)])
         [NEFilterSource setDelegation:&auditToken.value()];
@@ -139,10 +139,10 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
 #endif // ENABLE(DNS_SERVER_FOR_TESTING_IN_NETWORKING_PROCESS)
 
 #if ENABLE(INHERITANCE_OF_NETWORK_ACCESS_FROM_UI_PROCESS)
-    if (auto auditToken = protectedParentProcessConnection()->getAuditToken()) {
+    if (auto auditToken = protect(parentProcessConnection())->getAuditToken()) {
         bool isNetworkAccessBlockedInUIProcess = (1 == sandbox_check_by_audit_token(*auditToken, "network-outbound", SANDBOX_FILTER_PATH, "/private/var/run/mDNSResponder"));
 
-        auto xpcConnection = protectedParentProcessConnection()->xpcConnection();
+        auto xpcConnection = protect(parentProcessConnection())->xpcConnection();
         auto [signingIdentifier, isPlatformBinary] = codeSigningIdentifierAndPlatformBinaryStatus(xpcConnection);
         if (!isPlatformBinary && isNetworkAccessBlockedInUIProcess) {
             RELEASE_LOG(Process, "Setting sandbox state flag to block network access");

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1917,14 +1917,14 @@ void NetworkSessionCocoa::dataTaskWithRequest(WebPageProxyIdentifier pageID, Web
 {
     auto identifier = DataTaskIdentifier::generate();
     if (request.url().protocolIsBlob()) {
-        m_blobDataTasksForAPI.add(identifier, BlobDataTaskClient::create(WTF::move(request), topOrigin, *this, networkProcess().protectedParentProcessConnection().get(), identifier));
+        m_blobDataTasksForAPI.add(identifier, BlobDataTaskClient::create(WTF::move(request), topOrigin, *this, protect(networkProcess().parentProcessConnection()).get(), identifier));
         return completionHandler(identifier);
     }
 
     RetainPtr nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
     if (![nsRequest URL]) {
         completionHandler(identifier);
-        networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::DataTaskDidCompleteWithError(identifier, cannotShowURLError(request)), 0);
+        protect(networkProcess().parentProcessConnection())->send(Messages::NetworkProcessProxy::DataTaskDidCompleteWithError(identifier, cannotShowURLError(request)), 0);
         return;
     }
 

--- a/Source/WebKit/NetworkProcess/mac/SecItemShim.mm
+++ b/Source/WebKit/NetworkProcess/mac/SecItemShim.mm
@@ -67,7 +67,7 @@ static WeakPtr<NetworkProcess>& globalNetworkProcess()
 static std::optional<SecItemResponseData> sendSecItemRequest(SecItemRequestData::Type requestType, CFDictionaryRef query, CFDictionaryRef attributesToMatch = 0)
 {
     if (RunLoop::isMain()) {
-        auto sendSync = globalNetworkProcess()->protectedParentProcessConnection()->sendSync(Messages::SecItemShimProxy::SecItemRequestSync(SecItemRequestData(requestType, query, attributesToMatch)), 0);
+        auto sendSync = protect(globalNetworkProcess()->parentProcessConnection())->sendSync(Messages::SecItemShimProxy::SecItemRequestSync(SecItemRequestData(requestType, query, attributesToMatch)), 0);
         auto [response] = sendSync.takeReplyOr(std::nullopt);
         return response;
     }
@@ -83,7 +83,7 @@ static std::optional<SecItemResponseData> sendSecItemRequest(SecItemRequestData:
             return;
         }
 
-        globalNetworkProcess()->protectedParentProcessConnection()->sendWithAsyncReply(Messages::SecItemShimProxy::SecItemRequest(SecItemRequestData(requestType, cfQuery.get(), cfAttributesToMatch.get())), [&](auto reply) {
+        protect(globalNetworkProcess()->parentProcessConnection())->sendWithAsyncReply(Messages::SecItemShimProxy::SecItemRequest(SecItemRequestData(requestType, cfQuery.get(), cfAttributesToMatch.get())), [&](auto reply) {
             if (reply)
                 response = WTF::move(*reply);
 

--- a/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItem.cpp
@@ -150,7 +150,7 @@ WKArrayRef WKContextMenuCopySubmenuItems(WKContextMenuItemRef itemRef)
 WKTypeRef WKContextMenuItemGetUserData(WKContextMenuItemRef itemRef)
 {
 #if ENABLE(CONTEXT_MENUS)
-    return WebKit::toAPI(WebKit::toProtectedImpl(itemRef)->protectedUserData().get());
+    return WebKit::toAPI(protect(WebKit::toProtectedImpl(itemRef)->userData()).get());
 #else
     UNUSED_PARAM(itemRef);
     return 0;

--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
@@ -49,7 +49,6 @@ public:
     PaymentSetupFeatures(RetainPtr<NSArray>&& = nullptr);
 
     NSArray *platformFeatures() const { return m_platformFeatures.get(); }
-    RetainPtr<NSArray> protectedPlatformFeatures() const { return m_platformFeatures; }
     Vector<RetainPtr<PKPaymentSetupFeature>> serializableFeatures() const;
     operator Vector<Ref<WebCore::ApplePaySetupFeature>>() const;
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -508,7 +508,7 @@ void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupCo
 
     auto request = adoptNS([PAL::allocPKPaymentSetupRequestInstance() init]);
     [request setConfiguration:configuration.platformConfiguration().get()];
-    [request setPaymentSetupFeatures:features.protectedPlatformFeatures().get()];
+    [request setPaymentSetupFeatures:protect(features.platformFeatures()).get()];
 
     auto completion = makeBlockPtr([reply = WTF::move(reply)](BOOL success) mutable {
         RunLoop::mainSingleton().dispatch([reply = WTF::move(reply), success]() mutable {

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -239,7 +239,7 @@ void AuxiliaryProcess::platformStopRunLoop()
 
 void AuxiliaryProcess::terminate()
 {
-    protectedParentProcessConnection()->invalidate();
+    protect(parentProcessConnection())->invalidate();
 
     stopRunLoop();
 }

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -100,7 +100,6 @@ public:
     static void applySandboxProfileForDaemon(const String& profilePath, const String& userDirectorySuffix);
 
     IPC::Connection* parentProcessConnection() const { return m_connection.get(); }
-    RefPtr<IPC::Connection> protectedParentProcessConnection() const { return parentProcessConnection(); }
 
     IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }
 

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -145,7 +145,7 @@ void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageNa
 
 bool AuxiliaryProcess::parentProcessHasEntitlement(ASCIILiteral entitlement)
 {
-    return WTF::hasEntitlement(protectedParentProcessConnection()->protectedXPCConnection().get(), entitlement);
+    return WTF::hasEntitlement(protect(parentProcessConnection())->protectedXPCConnection().get(), entitlement);
 }
 
 void AuxiliaryProcess::platformStopRunLoop()

--- a/Source/WebKit/Shared/Cocoa/RevealItem.h
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.h
@@ -60,7 +60,6 @@ public:
     NSRange highlightRange() const;
 
     RVItem *item() const;
-    RetainPtr<RVItem> protectedItem() const;
 
 private:
     String m_text;

--- a/Source/WebKit/Shared/Cocoa/RevealItem.mm
+++ b/Source/WebKit/Shared/Cocoa/RevealItem.mm
@@ -47,7 +47,7 @@ RevealItem::RevealItem(const String& text, RevealItemRange selectedRange)
 
 NSRange RevealItem::highlightRange() const
 {
-    return protectedItem().get().highlightRange;
+    return protect(item()).get().highlightRange;
 }
 
 RVItem *RevealItem::item() const
@@ -55,11 +55,6 @@ RVItem *RevealItem::item() const
     if (!m_item)
         m_item = adoptNS([PAL::allocRVItemInstance() initWithText:m_text.createNSString().get() selectedRange:NSMakeRange(m_selectedRange.location, m_selectedRange.length)]);
     return m_item.get();
-}
-
-RetainPtr<RVItem> RevealItem::protectedItem() const
-{
-    return item();
 }
 
 #endif // ENABLE(REVEAL)

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -62,8 +62,8 @@ IPCStreamTester::~IPCStreamTester() = default;
 
 void IPCStreamTester::initialize()
 {
-    protectedWorkQueue()->dispatch([this] {
-        m_streamConnection->open(*this, protectedWorkQueue());
+    protect(workQueue())->dispatch([this] {
+        m_streamConnection->open(*this, protect(workQueue()));
         m_streamConnection->startReceivingMessages(*this, Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
         m_streamConnection->send(Messages::IPCStreamTesterProxy::WasCreated(workQueue().wakeUpSemaphore(), m_streamConnection->clientWaitSemaphore()), m_identifier);
     });

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -59,7 +59,6 @@ private:
     ~IPCStreamTester();
     void initialize();
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
-    Ref<IPC::StreamConnectionWorkQueue> protectedWorkQueue() const { return m_workQueue; }
 
     // IPC::StreamServerConnection::Client overrides.
     void didReceiveInvalidMessage(IPC::StreamServerConnection&, IPC::MessageName, const Vector<uint32_t>&) final;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h
@@ -89,7 +89,6 @@ public:
     virtual void gpuProcessConnectionWasDestroyed();
 
     RemoteLayerTreeContext& layerTreeContext() const;
-    Ref<RemoteLayerTreeContext> protectedLayerTreeContext() const;
 
 protected:
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm
@@ -68,7 +68,7 @@ void RemoteLayerBackingStoreCollection::deref() const
 
 void RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay(RemoteLayerTreeTransaction& transaction)
 {
-    Ref remoteRenderingBackend = protectedLayerTreeContext()->ensureRemoteRenderingBackendProxy();
+    Ref remoteRenderingBackend = protect(layerTreeContext())->ensureRemoteRenderingBackendProxy();
     remoteRenderingBackend->startPreparingImageBufferSetsForDisplay();
 
     for (CheckedRef backingStore : m_backingStoresNeedingDisplay) {
@@ -447,7 +447,7 @@ bool RemoteLayerBackingStoreCollection::collectAllRemoteRenderingBufferIdentifie
 
 void RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&& identifiers, CompletionHandler<void(bool)>&& completionHandler, bool forcePurge)
 {
-    Ref remoteRenderingBackend = protectedLayerTreeContext()->ensureRemoteRenderingBackendProxy();
+    Ref remoteRenderingBackend = protect(layerTreeContext())->ensureRemoteRenderingBackendProxy();
 
     remoteRenderingBackend->markSurfacesVolatile(WTF::move(identifiers), [completionHandler = WTF::move(completionHandler)](bool markedAllVolatile) mutable {
         LOG_WITH_STREAM(RemoteLayerBuffers, stream << "RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile: marked all volatile " << markedAllVolatile);
@@ -458,11 +458,6 @@ void RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile(Vector<std::pair
 RemoteLayerTreeContext& RemoteLayerBackingStoreCollection::layerTreeContext() const
 {
     return m_layerTreeContext.get();
-}
-
-Ref<RemoteLayerTreeContext> RemoteLayerBackingStoreCollection::protectedLayerTreeContext() const
-{
-    return layerTreeContext();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -50,7 +50,7 @@ RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackin
         return;
     }
 
-    lazyInitialize(m_bufferSet, collection->protectedLayerTreeContext()->ensureProtectedRemoteRenderingBackendProxy()->createImageBufferSet(*CheckedPtr { this }));
+    lazyInitialize(m_bufferSet, protect(collection->layerTreeContext())->ensureProtectedRemoteRenderingBackendProxy()->createImageBufferSet(*CheckedPtr { this }));
 }
 
 RemoteLayerWithRemoteRenderingBackingStore::~RemoteLayerWithRemoteRenderingBackingStore()

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -59,7 +59,7 @@ SharedStringHashStore::SharedStringHashStore(Client& client)
 
 std::optional<SharedMemory::Handle> SharedStringHashStore::createSharedMemoryHandle()
 {
-    return m_table.protectedSharedMemory()->createHandle(SharedMemory::Protection::ReadOnly);
+    return protect(m_table.sharedMemory())->createHandle(SharedMemory::Protection::ReadOnly);
 }
 
 void SharedStringHashStore::scheduleAddition(SharedStringHash sharedStringHash)

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
@@ -96,9 +96,4 @@ SharedStringHash* SharedStringHashTableReadOnly::findSlot(SharedStringHash share
     }
 }
 
-RefPtr<WebCore::SharedMemory> SharedStringHashTableReadOnly::protectedSharedMemory() const
-{
-    return sharedMemory();
-}
-
 } // namespace WebKit

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
@@ -42,7 +42,6 @@ public:
     bool contains(WebCore::SharedStringHash) const;
 
     WebCore::SharedMemory* sharedMemory() const { return m_sharedMemory.get(); }
-    RefPtr<WebCore::SharedMemory> protectedSharedMemory() const;
     void setSharedMemory(RefPtr<WebCore::SharedMemory>&&);
 
 protected:

--- a/Source/WebKit/Shared/UserData.h
+++ b/Source/WebKit/Shared/UserData.h
@@ -44,7 +44,7 @@ public:
     static RefPtr<API::Object> transform(API::Object*, const Transformer&);
 
     API::Object* object() const { return m_object.get(); }
-    RefPtr<API::Object> protectedObject() const { return m_object; }
+    RefPtr<API::Object> objectForSerialization() const { return m_object; }
 
 private:
     RefPtr<API::Object> m_object;

--- a/Source/WebKit/Shared/UserData.serialization.in
+++ b/Source/WebKit/Shared/UserData.serialization.in
@@ -21,5 +21,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class WebKit::UserData {
-    RefPtr<API::Object> protectedObject()
+    RefPtr<API::Object> objectForSerialization()
 }

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -101,15 +101,10 @@ WebBackForwardListItem* WebBackForwardListFrameItem::backForwardListItem() const
     return m_backForwardListItem.get();
 }
 
-RefPtr<WebBackForwardListItem> WebBackForwardListFrameItem::protectedBackForwardListItem() const
-{
-    return m_backForwardListItem.get();
-}
-
 void WebBackForwardListFrameItem::setChild(Ref<FrameState>&& frameState)
 {
     ASSERT(m_backForwardListItem);
-    Ref childItem = WebBackForwardListFrameItem::create(*protectedBackForwardListItem(), this, WTF::move(frameState));
+    Ref childItem = WebBackForwardListFrameItem::create(*protect(backForwardListItem()), this, WTF::move(frameState));
     for (size_t i = 0; i < m_children.size(); i++) {
         if (m_children[i]->frameID() == childItem->m_frameState->frameID) {
             m_children[i] = WTF::move(childItem);
@@ -135,11 +130,6 @@ Ref<WebBackForwardListFrameItem> WebBackForwardListFrameItem::mainFrame()
     return mainFrame;
 }
 
-Ref<WebBackForwardListFrameItem> WebBackForwardListFrameItem::protectedMainFrame()
-{
-    return mainFrame();
-}
-
 void WebBackForwardListFrameItem::setWasRestoredFromSession()
 {
     m_frameState->wasRestoredFromSession = true;
@@ -155,7 +145,7 @@ void WebBackForwardListFrameItem::setFrameState(Ref<FrameState>&& frameState)
 
 Ref<FrameState> WebBackForwardListFrameItem::copyFrameStateWithChildren()
 {
-    Ref frameState = protectedFrameState()->copy();
+    Ref frameState = protect(this->frameState())->copy();
     ASSERT(frameState->children.isEmpty());
     for (auto& child : m_children)
         frameState->children.append(child->copyFrameStateWithChildren());

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -44,7 +44,6 @@ public:
     static WebBackForwardListFrameItem* itemForID(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
 
     FrameState& frameState() const { return m_frameState; }
-    Ref<FrameState> protectedFrameState() const { return m_frameState; }
     void setFrameState(Ref<FrameState>&&);
 
     Ref<FrameState> copyFrameStateWithChildren();
@@ -54,18 +53,15 @@ public:
     const String& url() const;
 
     WebBackForwardListFrameItem* parent() const { return m_parent; }
-    RefPtr<WebBackForwardListFrameItem> protectedParent() const { return m_parent; }
     void setParent(WebBackForwardListFrameItem* parent) { m_parent = parent; }
     bool sharesAncestor(WebBackForwardListFrameItem&) const;
 
     Ref<WebBackForwardListFrameItem> rootFrame();
     Ref<WebBackForwardListFrameItem> mainFrame();
-    Ref<WebBackForwardListFrameItem> protectedMainFrame();
     WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);
     RefPtr<WebBackForwardListFrameItem> protectedChildItemForFrameID(WebCore::FrameIdentifier);
 
     WebBackForwardListItem* backForwardListItem() const;
-    RefPtr<WebBackForwardListItem> protectedBackForwardListItem() const;
 
     void setChild(Ref<FrameState>&&);
     void clearChildren() { m_children.clear(); }

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -147,11 +147,6 @@ void WebBackForwardListItem::removeFromBackForwardCache()
     ASSERT(!m_backForwardCacheEntry);
 }
 
-RefPtr<WebBackForwardCacheEntry> WebBackForwardListItem::protectedBackForwardCacheEntry() const
-{
-    return m_backForwardCacheEntry;
-}
-
 void WebBackForwardListItem::setBackForwardCacheEntry(RefPtr<WebBackForwardCacheEntry>&& backForwardCacheEntry)
 {
     m_backForwardCacheEntry = WTF::move(backForwardCacheEntry);
@@ -164,7 +159,7 @@ SuspendedPageProxy* WebBackForwardListItem::suspendedPage() const
 
 Ref<FrameState> WebBackForwardListItem::navigatedFrameState() const
 {
-    return protectedNavigatedFrameItem()->copyFrameStateWithChildren();
+    return protect(navigatedFrameItem())->copyFrameStateWithChildren();
 }
 
 Ref<FrameState> WebBackForwardListItem::mainFrameState() const
@@ -212,17 +207,7 @@ WebBackForwardListFrameItem& WebBackForwardListItem::navigatedFrameItem() const
     return m_mainFrameItem;
 }
 
-Ref<WebBackForwardListFrameItem> WebBackForwardListItem::protectedNavigatedFrameItem() const
-{
-    return navigatedFrameItem();
-}
-
 WebBackForwardListFrameItem& WebBackForwardListItem::mainFrameItem() const
-{
-    return m_mainFrameItem;
-}
-
-Ref<WebBackForwardListFrameItem> WebBackForwardListItem::protectedMainFrameItem() const
 {
     return m_mainFrameItem;
 }

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -84,17 +84,14 @@ public:
     void wasRemovedFromBackForwardList();
 
     WebBackForwardCacheEntry* backForwardCacheEntry() const { return m_backForwardCacheEntry.get(); }
-    RefPtr<WebBackForwardCacheEntry> protectedBackForwardCacheEntry() const;
 
     SuspendedPageProxy* suspendedPage() const;
 
     std::optional<WebCore::FrameIdentifier> navigatedFrameID() const { return m_navigatedFrameID; }
 
     WebBackForwardListFrameItem& navigatedFrameItem() const;
-    Ref<WebBackForwardListFrameItem> protectedNavigatedFrameItem() const;
 
     WebBackForwardListFrameItem& mainFrameItem() const;
-    Ref<WebBackForwardListFrameItem> protectedMainFrameItem() const;
 
     void setIsRemoteFrameNavigation(bool isRemoteFrameNavigation) { m_isRemoteFrameNavigation = isRemoteFrameNavigation; }
     bool isRemoteFrameNavigation() const { return m_isRemoteFrameNavigation; }

--- a/Source/WebKit/Shared/WebContextMenuItem.h
+++ b/Source/WebKit/Shared/WebContextMenuItem.h
@@ -54,7 +54,6 @@ public:
     Ref<API::Array> submenuItemsAsAPIArray() const;
 
     API::Object* userData() const;
-    RefPtr<API::Object> protectedUserData() const { return userData(); }
     void setUserData(API::Object*);
 
     const WebContextMenuItemData& data() { return m_webContextMenuItemData; }

--- a/Source/WebKit/Shared/WebContextMenuItemData.cpp
+++ b/Source/WebKit/Shared/WebContextMenuItemData.cpp
@@ -86,11 +86,6 @@ API::Object* WebContextMenuItemData::userData() const
     return m_userData.get();
 }
 
-RefPtr<API::Object> WebContextMenuItemData::protectedUserData() const
-{
-    return m_userData;
-}
-
 void WebContextMenuItemData::setUserData(API::Object* userData)
 {
     m_userData = userData;

--- a/Source/WebKit/Shared/WebContextMenuItemData.h
+++ b/Source/WebKit/Shared/WebContextMenuItemData.h
@@ -54,7 +54,6 @@ public:
     WebCore::ContextMenuItem core() const;
     
     API::Object* userData() const;
-    RefPtr<API::Object> protectedUserData() const;
     void setUserData(API::Object*);
 
 private:

--- a/Source/WebKit/Shared/mac/SecItemRequestData.h
+++ b/Source/WebKit/Shared/mac/SecItemRequestData.h
@@ -53,9 +53,7 @@ public:
     Type type() const { return m_type; }
 
     CFDictionaryRef query() const { return m_queryDictionary.get(); }
-    RetainPtr<CFDictionaryRef> protectedQuery() const { return m_queryDictionary; }
     CFDictionaryRef attributesToMatch() const { return m_attributesToMatch.get(); }
-    RetainPtr<CFDictionaryRef> protectedAttributesToMatch() const { return m_attributesToMatch; }
 
 private:
     friend struct IPC::ArgumentCoder<WebKit::SecItemRequestData>;

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1092,7 +1092,7 @@ void WebAutomationSessionProxy::deleteCookie(WebCore::PageIdentifier pageID, std
 #if ENABLE(WEBDRIVER_BIDI)
 void WebAutomationSessionProxy::addMessageToConsole(const JSC::MessageSource& source, const JSC::MessageLevel& level, const String& messageText, const JSC::MessageType& type, const WallTime& timestamp)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebAutomationSession::LogEntryAdded(source, level, messageText, type, timestamp), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebAutomationSession::LogEntryAdded(source, level, messageText, type, timestamp), 0);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp
@@ -91,13 +91,13 @@ void WebGeolocationManager::registerWebPage(WebPage& page, const String& authori
     m_pageToRegistrableDomain.add(page, registrableDomain);
 
     if (!wasUpdating) {
-        WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebGeolocationManagerProxy::StartUpdating(registrableDomain, page.webPageProxyIdentifier(), authorizationToken, needsHighAccuracy), 0);
+        protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebGeolocationManagerProxy::StartUpdating(registrableDomain, page.webPageProxyIdentifier(), authorizationToken, needsHighAccuracy), 0);
         return;
     }
 
     bool highAccuracyShouldBeEnabled = isHighAccuracyEnabled(pageSets);
     if (highAccuracyWasEnabled != highAccuracyShouldBeEnabled)
-        WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
+        protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
 }
 
 void WebGeolocationManager::unregisterWebPage(WebPage& page)
@@ -117,11 +117,11 @@ void WebGeolocationManager::unregisterWebPage(WebPage& page)
     pageSets.highAccuracyPageSet.remove(page);
 
     if (!isUpdating(pageSets))
-        WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebGeolocationManagerProxy::StopUpdating(registrableDomain), 0);
+        protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebGeolocationManagerProxy::StopUpdating(registrableDomain), 0);
     else {
         bool highAccuracyShouldBeEnabled = isHighAccuracyEnabled(pageSets);
         if (highAccuracyWasEnabled != highAccuracyShouldBeEnabled)
-            WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
+            protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
     }
 
     if (pageSets.pageSet.isEmptyIgnoringNullReferences() && pageSets.highAccuracyPageSet.isEmptyIgnoringNullReferences())
@@ -149,7 +149,7 @@ void WebGeolocationManager::setEnableHighAccuracyForPage(WebPage& page, bool ena
 
     bool highAccuracyShouldBeEnabled = isHighAccuracyEnabled(pageSets);
     if (highAccuracyWasEnabled != isHighAccuracyEnabled(pageSets))
-        WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
+        protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebGeolocationManagerProxy::SetEnableHighAccuracy(registrableDomain, highAccuracyShouldBeEnabled), 0);
 }
 
 void WebGeolocationManager::didChangePosition(const WebCore::RegistrableDomain& registrableDomain, const GeolocationPositionData& position)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -124,16 +124,16 @@ void InjectedBundle::setServiceWorkerProxyCreationCallback(void (*callback)(uint
 void InjectedBundle::postMessage(const String& messageName, API::Object* messageBody)
 {
     auto& webProcess = WebProcess::singleton();
-    webProcess.protectedParentProcessConnection()->send(Messages::WebProcessPool::HandleMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), 0);
+    protect(webProcess.parentProcessConnection())->send(Messages::WebProcessPool::HandleMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), 0);
 }
 
 void InjectedBundle::postSynchronousMessage(const String& messageName, API::Object* messageBody, RefPtr<API::Object>& returnData)
 {
     auto& webProcess = WebProcess::singleton();
-    auto sendResult = webProcess.protectedParentProcessConnection()->sendSync(Messages::WebProcessPool::HandleSynchronousMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), 0);
+    auto sendResult = protect(webProcess.parentProcessConnection())->sendSync(Messages::WebProcessPool::HandleSynchronousMessage(messageName, UserData(webProcess.transformObjectsToHandles(messageBody))), 0);
     if (sendResult.succeeded()) {
         auto [returnUserData] = sendResult.takeReply();
-        returnData = webProcess.transformHandlesToObjects(returnUserData.protectedObject().get());
+        returnData = webProcess.transformHandlesToObjects(protect(returnUserData.object()).get());
     } else
         returnData = nullptr;
 }

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -90,7 +90,7 @@ void RemoteWebInspectorUI::sendMessageToFrontend(const String& message)
 
 void RemoteWebInspectorUI::sendMessageToBackend(const String& message)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SendMessageToBackend(message), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::SendMessageToBackend(message), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::windowObjectCleared()
@@ -108,7 +108,7 @@ void RemoteWebInspectorUI::frontendLoaded()
 
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setIsVisible"_s, { JSON::Value::create(true) });
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::FrontendLoaded(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::FrontendLoaded(), m_page->identifier());
 
     bringToFront();
 }
@@ -125,17 +125,17 @@ void RemoteWebInspectorUI::pageUnpaused()
 
 void RemoteWebInspectorUI::changeSheetRect(const FloatRect& rect)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetSheetRect(rect), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::SetSheetRect(rect), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::setForcedAppearance(WebCore::InspectorFrontendClient::Appearance appearance)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetForcedAppearance(appearance), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::SetForcedAppearance(appearance), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::startWindowDrag()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::StartWindowDrag(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::StartWindowDrag(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::moveWindowBy(float x, float y)
@@ -168,7 +168,7 @@ bool RemoteWebInspectorUI::supportsDockSide(DockSide dockSide)
 
 void RemoteWebInspectorUI::bringToFront()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::BringToFront(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::BringToFront(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::closeWindow()
@@ -179,17 +179,17 @@ void RemoteWebInspectorUI::closeWindow()
     m_extensionController = nullptr;
 #endif
     
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::FrontendDidClose(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::FrontendDidClose(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::reopen()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::Reopen(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::Reopen(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::resetState()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::ResetState(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::ResetState(), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::showConsole()
@@ -204,27 +204,27 @@ void RemoteWebInspectorUI::showResources()
 
 void RemoteWebInspectorUI::openURLExternally(const String& url)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::OpenURLExternally(url), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::OpenURLExternally(url), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::revealFileExternally(const String& path)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::RevealFileExternally(path), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::RevealFileExternally(path), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::save(Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::Save(WTF::move(saveDatas), forceSaveAs), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::Save(WTF::move(saveDatas), forceSaveAs), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::load(const String& path, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::Load(path), WTF::move(completionHandler), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::Load(path), WTF::move(completionHandler), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::pickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&& completionHandler)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::PickColorFromScreen(), WTF::move(completionHandler), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::RemoteWebInspectorUIProxy::PickColorFromScreen(), WTF::move(completionHandler), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::inspectedURLChanged(const String& urlString)
@@ -234,18 +234,18 @@ void RemoteWebInspectorUI::inspectedURLChanged(const String& urlString)
 
 void RemoteWebInspectorUI::showCertificate(const CertificateInfo& certificateInfo)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::ShowCertificate(certificateInfo), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::ShowCertificate(certificateInfo), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::setInspectorPageDeveloperExtrasEnabled(bool enabled)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetInspectorPageDeveloperExtrasEnabled(enabled), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::SetInspectorPageDeveloperExtrasEnabled(enabled), m_page->identifier());
 }
 
 void RemoteWebInspectorUI::setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFactor)
 {
     m_pageZoomFactor = pageZoomFactor;
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::RemoteWebInspectorUIProxy::SetPageAndTextZoomFactors(pageZoomFactor, textZoomFactor), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::SetPageAndTextZoomFactors(pageZoomFactor, textZoomFactor), m_page->identifier());
 }
 
 double RemoteWebInspectorUI::pageZoomFactor() const

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -78,7 +78,7 @@ WebPage* WebInspectorBackend::page() const
 
 void WebInspectorBackend::openLocalInspectorFrontend()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::RequestOpenLocalInspectorFrontend(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::RequestOpenLocalInspectorFrontend(), m_page->identifier());
 }
 
 void WebInspectorBackend::setFrontendConnection(IPC::Connection::Handle&& connectionHandle)
@@ -102,7 +102,7 @@ void WebInspectorBackend::setFrontendConnection(IPC::Connection::Handle&& connec
 
 void WebInspectorBackend::closeFrontendConnection()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::DidClose(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::DidClose(), m_page->identifier());
 
     // If we tried to close the frontend before it was created, then no connection exists yet.
     if (RefPtr frontendConnection = m_frontendConnection) {
@@ -118,7 +118,7 @@ void WebInspectorBackend::closeFrontendConnection()
 
 void WebInspectorBackend::bringToFront()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::BringToFront(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::BringToFront(), m_page->identifier());
 }
 
 void WebInspectorBackend::whenFrontendConnectionEstablished(Function<void(IPC::Connection&)>&& callback)
@@ -239,24 +239,24 @@ void WebInspectorBackend::stopElementSelection()
 
 void WebInspectorBackend::elementSelectionChanged(bool active)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::ElementSelectionChanged(active), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::ElementSelectionChanged(active), m_page->identifier());
 }
 
 void WebInspectorBackend::timelineRecordingChanged(bool active)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::TimelineRecordingChanged(active), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::TimelineRecordingChanged(active), m_page->identifier());
 }
 
 void WebInspectorBackend::setDeveloperPreferenceOverride(InspectorBackendClient::DeveloperPreference developerPreference, std::optional<bool> overrideValue)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::SetDeveloperPreferenceOverride(developerPreference, overrideValue), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::SetDeveloperPreferenceOverride(developerPreference, overrideValue), m_page->identifier());
 }
 
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
 void WebInspectorBackend::setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::SetEmulatedConditions(WTF::move(bytesPerSecondLimit)), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::SetEmulatedConditions(WTF::move(bytesPerSecondLimit)), m_page->identifier());
 }
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
@@ -297,7 +297,7 @@ void WebInspectorBackend::updateDockingAvailability()
 
     m_previousCanAttach = canAttachWindow;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorBackendProxy::AttachAvailabilityChanged(canAttachWindow), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::AttachAvailabilityChanged(canAttachWindow), m_page->identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -192,13 +192,13 @@ private:
     template<typename T>
     IPC::Error sendToParentProcess(T&& message)
     {
-        return WebProcess::singleton().protectedParentProcessConnection()->send(std::forward<T>(message), m_inspectedPageIdentifier ? m_inspectedPageIdentifier->toUInt64() : 0);
+        return protect(WebProcess::singleton().parentProcessConnection())->send(std::forward<T>(message), m_inspectedPageIdentifier ? m_inspectedPageIdentifier->toUInt64() : 0);
     }
 
     template<typename T, typename C>
     std::optional<IPC::AsyncReplyID> sendToParentProcessWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), m_inspectedPageIdentifier ? m_inspectedPageIdentifier->toUInt64() : 0);
+        return protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), m_inspectedPageIdentifier ? m_inspectedPageIdentifier->toUInt64() : 0);
     }
 
     WeakRef<WebPage> m_page;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp
@@ -476,22 +476,22 @@ void WebInspectorUIExtensionController::evaluateScriptInExtensionTab(const Inspe
 
 void WebInspectorUIExtensionController::didShowExtensionTab(const Inspector::ExtensionID& extensionID, const Inspector::ExtensionTabID& extensionTabID, WebCore::FrameIdentifier frameID)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorUIExtensionControllerProxy::DidShowExtensionTab { extensionID, extensionTabID, frameID }, m_inspectorPageIdentifier);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorUIExtensionControllerProxy::DidShowExtensionTab { extensionID, extensionTabID, frameID }, m_inspectorPageIdentifier);
 }
 
 void WebInspectorUIExtensionController::didHideExtensionTab(const Inspector::ExtensionID& extensionID, const Inspector::ExtensionTabID& extensionTabID)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorUIExtensionControllerProxy::DidHideExtensionTab { extensionID, extensionTabID }, m_inspectorPageIdentifier);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorUIExtensionControllerProxy::DidHideExtensionTab { extensionID, extensionTabID }, m_inspectorPageIdentifier);
 }
 
 void WebInspectorUIExtensionController::didNavigateExtensionTab(const Inspector::ExtensionID& extensionID, const Inspector::ExtensionTabID& extensionTabID, const URL& newURL)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorUIExtensionControllerProxy::DidNavigateExtensionTab { extensionID, extensionTabID, newURL }, m_inspectorPageIdentifier);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorUIExtensionControllerProxy::DidNavigateExtensionTab { extensionID, extensionTabID, newURL }, m_inspectorPageIdentifier);
 }
 
 void WebInspectorUIExtensionController::inspectedPageDidNavigate(const URL& newURL)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebInspectorUIExtensionControllerProxy::InspectedPageDidNavigate { newURL }, m_inspectorPageIdentifier);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorUIExtensionControllerProxy::InspectedPageDidNavigate { newURL }, m_inspectorPageIdentifier);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp
@@ -337,7 +337,7 @@ void WebSWClientConnection::getNotifications(const URL& registrationURL, const S
     }
 #endif
 
-    WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(Messages::WebProcessProxy::GetNotifications { registrationURL, tag }, WTF::move(callback));
+    protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::WebProcessProxy::GetNotifications { registrationURL, tag }, WTF::move(callback));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -313,7 +313,7 @@ private:
         if (!message)
             return;
 
-        WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(Messages::WebProcessProxy::DidPostMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), webFrame->info(), m_identifier, *message), [completionHandler = WTF::move(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
+        protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::WebProcessProxy::DidPostMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), webFrame->info(), m_identifier, *message), [completionHandler = WTF::move(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
             if (!result)
                 return completionHandler(JSC::jsUndefined(), result.error());
             completionHandler(toJS(toJS(context.get()), result->toJS(context.get()).get()), { });
@@ -339,7 +339,7 @@ private:
         if (!message)
             return JSC::jsUndefined();
 
-        auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebProcessProxy::DidPostLegacySynchronousMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), webFrame->info(), m_identifier, *message), 0);
+        auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebProcessProxy::DidPostLegacySynchronousMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), webFrame->info(), m_identifier, *message), 0);
         auto [result] = sendResult.takeReplyOr(makeUnexpected(String()));
         if (!result)
             return JSC::jsUndefined();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp
@@ -39,13 +39,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebCaptionPreferencesDelegate);
 
 void WebCaptionPreferencesDelegate::setDisplayMode(WebCore::CaptionUserPreferences::CaptionDisplayMode displayMode)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::SetCaptionDisplayMode(displayMode), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::SetCaptionDisplayMode(displayMode), 0);
     WebCore::CaptionUserPreferencesMediaAF::setCachedCaptionDisplayMode(displayMode);
 }
 
 void WebCaptionPreferencesDelegate::setPreferredLanguage(const String& language)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::SetCaptionLanguage(language), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::SetCaptionLanguage(language), 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -243,7 +243,7 @@ FloatRect WebChromeClient::windowRect() const
         return page->windowFrameInUnflippedScreenCoordinates();
 #endif
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPageProxy::GetWindowFrame(), page->identifier());
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPageProxy::GetWindowFrame(), page->identifier());
     auto [newWindowFrame] = sendResult.takeReplyOr(FloatRect { });
     return newWindowFrame;
 #endif
@@ -333,7 +333,7 @@ void WebChromeClient::focusedElementChanged(Element* element, LocalFrame* frame,
     RefPtr webFrame = coreFrame ? WebFrame::fromCoreFrame(*coreFrame) : nullptr;
     RefPtr page = m_page.get();
     if (page && broadcast == BroadcastFocusedElement::Yes)
-        WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::FocusedElementChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt, options), page->identifier());
+        protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::FocusedElementChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt, options), page->identifier());
 
     RefPtr inputElement = dynamicDowncast<HTMLInputElement>(element);
     if (!inputElement || !inputElement->isText())
@@ -350,7 +350,7 @@ void WebChromeClient::focusedFrameChanged(Frame* frame)
         return;
 
     RefPtr webFrame = frame ? WebFrame::fromCoreFrame(*frame) : nullptr;
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::FocusedFrameChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::FocusedFrameChanged(webFrame ? std::make_optional(webFrame->frameID()) : std::nullopt), m_page->identifier());
 }
 
 RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& openedMainFrameName, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction)
@@ -416,7 +416,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         navigationAction.requester(), /* requester */
     };
 
-    auto sendResult = webProcess.protectedParentProcessConnection()->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page->identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });
+    auto sendResult = protect(webProcess.parentProcessConnection())->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page->identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });
     if (!sendResult.succeeded())
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp
@@ -46,7 +46,7 @@ WebColorChooser::WebColorChooser(WebPage* page, ColorChooserClient* client, cons
     page->setActiveColorChooser(this);
     auto supportsAlpha = client->supportsAlpha() ? ColorControlSupportsAlpha::Yes : ColorControlSupportsAlpha::No;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::ShowColorPicker(initialColor, client->elementRectRelativeToRootView(), supportsAlpha, client->suggestedColors(), client->rootFrameID()), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowColorPicker(initialColor, client->elementRectRelativeToRootView(), supportsAlpha, client->suggestedColors(), client->rootFrameID()), page->identifier());
 }
 
 WebColorChooser::~WebColorChooser()
@@ -79,7 +79,7 @@ void WebColorChooser::reattachColorChooser(const Color& color)
 
     Ref colorChooserClient = *m_colorChooserClient;
     auto supportsAlpha = colorChooserClient->supportsAlpha() ? ColorControlSupportsAlpha::Yes : ColorControlSupportsAlpha::No;
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::ShowColorPicker(color, colorChooserClient->elementRectRelativeToRootView(), supportsAlpha, colorChooserClient->suggestedColors(), colorChooserClient->rootFrameID()), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowColorPicker(color, colorChooserClient->elementRectRelativeToRootView(), supportsAlpha, colorChooserClient->suggestedColors(), colorChooserClient->rootFrameID()), page->identifier());
 }
 
 void WebColorChooser::setSelectedColor(const Color& color)
@@ -91,7 +91,7 @@ void WebColorChooser::setSelectedColor(const Color& color)
     if (page->activeColorChooser() != this)
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::SetColorPickerColor(color), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::SetColorPickerColor(color), page->identifier());
 }
 
 void WebColorChooser::endChooser()
@@ -99,7 +99,7 @@ void WebColorChooser::endChooser()
     if (!m_page)
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::EndColorPicker(), m_page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::EndColorPicker(), m_page->identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
@@ -53,7 +53,7 @@ void WebDataListSuggestionPicker::handleKeydownWithIdentifier(const String& key)
     if (!page)
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::HandleKeydownInDataList(key), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::HandleKeydownInDataList(key), page->identifier());
 }
 
 void WebDataListSuggestionPicker::didSelectOption(const String& selectedOption)
@@ -74,7 +74,7 @@ void WebDataListSuggestionPicker::close()
     if (!page)
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::EndDataListSuggestions(), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::EndDataListSuggestions(), page->identifier());
 }
 
 void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSuggestionActivationType type)
@@ -103,7 +103,7 @@ void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSug
     page->setActiveDataListSuggestionPicker(*this);
 
     WebCore::DataListSuggestionInformation info { type, WTF::move(suggestions), WTF::move(elementRectInRootViewCoordinates) };
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::ShowDataListSuggestions(info), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowDataListSuggestions(info), page->identifier());
 }
 
 void WebDataListSuggestionPicker::detach()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp
@@ -58,7 +58,7 @@ void WebDateTimeChooser::endChooser()
     if (!page)
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::EndDateTimePicker(), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::EndDateTimePicker(), page->identifier());
 }
 
 void WebDateTimeChooser::showChooser(const WebCore::DateTimeChooserParameters& params)
@@ -68,7 +68,7 @@ void WebDateTimeChooser::showChooser(const WebCore::DateTimeChooserParameters& p
         return;
 
     page->setActiveDateTimeChooser(*this);
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::ShowDateTimePicker(params), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowDateTimePicker(params), page->identifier());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -140,7 +140,7 @@ void WebPlatformStrategies::getTypes(Vector<String>& types, const String& pasteb
     if (!types.isEmpty())
         return;
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardTypes(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardTypes(pasteboardName, pageIdentifier(context)), 0);
     if (sendResult.succeeded())
         std::tie(types) = sendResult.takeReply();
 }
@@ -153,7 +153,7 @@ RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::bufferForType(const String&
         return SharedBuffer::create(WTF::move(overrideBuffer));
 
     // Fallback to messaging the UI process for native pasteboard content.
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardBufferForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardBufferForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
     auto [pasteboardBuffer] = sendResult.takeReplyOr(WebCore::PasteboardBuffer { });
 
     return Pasteboard::bufferConvertedToPasteboardType(pasteboardBuffer, pasteboardType);
@@ -162,7 +162,7 @@ RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::bufferForType(const String&
 void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
     Vector<SandboxExtension::Handle> sandboxExtensionsHandleArray;
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardPathnamesForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardPathnamesForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
     if (sendResult.succeeded())
         std::tie(pathnames, sandboxExtensionsHandleArray) = sendResult.takeReply();
     ASSERT(pathnames.size() == sandboxExtensionsHandleArray.size());
@@ -171,14 +171,14 @@ void WebPlatformStrategies::getPathnamesForType(Vector<String>& pathnames, const
 
 String WebPlatformStrategies::stringForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardStringForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardStringForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
     auto [value] = sendResult.takeReplyOr(String { });
     return value;
 }
 
 Vector<String> WebPlatformStrategies::allStringsForType(const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardStringsForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardStringsForType(pasteboardName, pasteboardType, pageIdentifier(context)), 0);
     auto [values] = sendResult.takeReplyOr(Vector<String> { });
     return values;
 }
@@ -186,35 +186,35 @@ Vector<String> WebPlatformStrategies::allStringsForType(const String& pasteboard
 int64_t WebPlatformStrategies::changeCount(const String& pasteboardName, const PasteboardContext* context)
 {
     WebProcess::singleton().waitForPendingPasteboardWritesToFinish(pasteboardName);
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardChangeCount(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardChangeCount(pasteboardName, pageIdentifier(context)), 0);
     auto [changeCount] = sendResult.takeReplyOr(0);
     return changeCount;
 }
 
 Color WebPlatformStrategies::color(const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardColor(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardColor(pasteboardName, pageIdentifier(context)), 0);
     auto [color] = sendResult.takeReplyOr(Color { });
     return color;
 }
 
 URL WebPlatformStrategies::url(const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardURL(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardURL(pasteboardName, pageIdentifier(context)), 0);
     auto [urlString] = sendResult.takeReplyOr(String { });
     return URL({ }, urlString);
 }
 
 int64_t WebPlatformStrategies::addTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::AddPasteboardTypes(pasteboardName, pasteboardTypes, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::AddPasteboardTypes(pasteboardName, pasteboardTypes, pageIdentifier(context)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
 
 int64_t WebPlatformStrategies::setTypes(const Vector<String>& pasteboardTypes, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardTypes(pasteboardName, pasteboardTypes, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::SetPasteboardTypes(pasteboardName, pasteboardTypes, pageIdentifier(context)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
@@ -223,28 +223,28 @@ int64_t WebPlatformStrategies::setBufferForType(SharedBuffer* buffer, const Stri
 {
     // FIXME: Null check prevents crashing, but it is not great that we will have empty pasteboard content for this type,
     // because we've already set the types.
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardBufferForType(pasteboardName, pasteboardType, buffer ? RefPtr { buffer } : SharedBuffer::create(), pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::SetPasteboardBufferForType(pasteboardName, pasteboardType, buffer ? RefPtr { buffer } : SharedBuffer::create(), pageIdentifier(context)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
 
 int64_t WebPlatformStrategies::setURL(const PasteboardURL& pasteboardURL, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardURL(pasteboardURL, pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::SetPasteboardURL(pasteboardURL, pasteboardName, pageIdentifier(context)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
 
 int64_t WebPlatformStrategies::setColor(const Color& color, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardColor(pasteboardName, color, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::SetPasteboardColor(pasteboardName, color, pageIdentifier(context)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
 
 int64_t WebPlatformStrategies::setStringForType(const String& string, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::SetPasteboardStringForType(pasteboardName, pasteboardType, string, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::SetPasteboardStringForType(pasteboardName, pasteboardType, string, pageIdentifier(context)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
@@ -293,21 +293,21 @@ int64_t WebPlatformStrategies::writeWebArchive(WebCore::LegacyWebArchive& webArc
     for (auto identifier : webArchive.subframeIdentifiers())
         collectFrameWebArchives(identifier, localFrameWebArchives, remoteFrameIdentifiers);
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::WriteWebArchiveToPasteBoard(pasteboardName, *frameIdentifier, WTF::move(localFrameWebArchives), WTF::move(remoteFrameIdentifiers)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::WriteWebArchiveToPasteBoard(pasteboardName, *frameIdentifier, WTF::move(localFrameWebArchives), WTF::move(remoteFrameIdentifiers)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
 
 int WebPlatformStrategies::getNumberOfFiles(const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetNumberOfFiles(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetNumberOfFiles(pasteboardName, pageIdentifier(context)), 0);
     auto [numberOfFiles] = sendResult.takeReplyOr(0);
     return numberOfFiles;
 }
 
 bool WebPlatformStrategies::containsURLStringSuitableForLoading(const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ContainsURLStringSuitableForLoading(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ContainsURLStringSuitableForLoading(pasteboardName, pageIdentifier(context)), 0);
     auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
@@ -315,7 +315,7 @@ bool WebPlatformStrategies::containsURLStringSuitableForLoading(const String& pa
 String WebPlatformStrategies::urlStringSuitableForLoading(const String& pasteboardName, String& title, const PasteboardContext* context)
 {
     String url;
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::URLStringSuitableForLoading(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::URLStringSuitableForLoading(pasteboardName, pageIdentifier(context)), 0);
     if (sendResult.succeeded())
         std::tie(url, title) = sendResult.takeReply();
     return url;
@@ -326,7 +326,7 @@ String WebPlatformStrategies::urlStringSuitableForLoading(const String& pasteboa
 void WebPlatformStrategies::writeToPasteboard(const PasteboardURL& url, const String& pasteboardName, const PasteboardContext* context)
 {
     WebProcess::singleton().willWriteToPasteboardAsynchronously(pasteboardName);
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPasteboardProxy::WriteURLToPasteboard(url, pasteboardName, pageIdentifier(context)), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::WriteURLToPasteboard(url, pasteboardName, pageIdentifier(context)), 0);
 }
 
 static std::optional<WebCore::PasteboardWebContent> updateContentForWebArchive(const WebCore::PasteboardWebContent& content)
@@ -359,7 +359,7 @@ void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardWebConten
 {
     WebProcess::singleton().willWriteToPasteboardAsynchronously(pasteboardName);
     if (auto updatedContent = updateContentForWebArchive(content)) {
-        WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(*updatedContent, pasteboardName, pageIdentifier(context)), 0);
+        protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(*updatedContent, pasteboardName, pageIdentifier(context)), 0);
         return;
     }
     WebProcess::singleton().parentProcessConnection()->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(content, pasteboardName, pageIdentifier(context)), 0);
@@ -368,18 +368,18 @@ void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardWebConten
 void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardImage& image, const String& pasteboardName, const PasteboardContext* context)
 {
     WebProcess::singleton().willWriteToPasteboardAsynchronously(pasteboardName);
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPasteboardProxy::WriteImageToPasteboard(image, pasteboardName, pageIdentifier(context)), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::WriteImageToPasteboard(image, pasteboardName, pageIdentifier(context)), 0);
 }
 
 void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, const String& text, const String& pasteboardName, const PasteboardContext* context)
 {
     WebProcess::singleton().willWriteToPasteboardAsynchronously(pasteboardName);
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPasteboardProxy::WriteStringToPasteboard(pasteboardType, text, pasteboardName, pageIdentifier(context)), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::WriteStringToPasteboard(pasteboardType, text, pasteboardName, pageIdentifier(context)), 0);
 }
 
 void WebPlatformStrategies::updateSupportedTypeIdentifiers(const Vector<String>& identifiers, const String& pasteboardName, const PasteboardContext* context)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPasteboardProxy::UpdateSupportedTypeIdentifiers(identifiers, pasteboardName, pageIdentifier(context)), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::UpdateSupportedTypeIdentifiers(identifiers, pasteboardName, pageIdentifier(context)), 0);
 }
 #endif // PLATFORM(IOS_FAMILY)
 
@@ -390,28 +390,28 @@ void WebPlatformStrategies::updateSupportedTypeIdentifiers(const Vector<String>&
 
 Vector<String> WebPlatformStrategies::types(const String& pasteboardName)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetTypes(pasteboardName), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetTypes(pasteboardName), 0);
     auto [result] = sendResult.takeReplyOr(Vector<String> { });
     return result;
 }
 
 String WebPlatformStrategies::readTextFromClipboard(const String& pasteboardName, const String& pasteboardType)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadText(pasteboardName, pasteboardType), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ReadText(pasteboardName, pasteboardType), 0);
     auto [result] = sendResult.takeReplyOr(String { });
     return result;
 }
 
 Vector<String> WebPlatformStrategies::readFilePathsFromClipboard(const String& pasteboardName)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadFilePaths(pasteboardName), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ReadFilePaths(pasteboardName), 0);
     auto [result] = sendResult.takeReplyOr(Vector<String> { });
     return result;
 }
 
 RefPtr<SharedBuffer> WebPlatformStrategies::readBufferFromClipboard(const String& pasteboardName, const String& pasteboardType)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadBuffer(pasteboardName, pasteboardType), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ReadBuffer(pasteboardName, pasteboardType), 0);
     auto [buffer] = sendResult.takeReplyOr(nullptr);
     return buffer;
 }
@@ -428,7 +428,7 @@ void WebPlatformStrategies::clearClipboard(const String& pasteboardName)
 
 int64_t WebPlatformStrategies::changeCount(const String& pasteboardName)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardChangeCount(pasteboardName), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardChangeCount(pasteboardName), 0);
     auto [changeCount] = sendResult.takeReplyOr(0);
     return changeCount;
 }
@@ -438,14 +438,14 @@ int64_t WebPlatformStrategies::changeCount(const String& pasteboardName)
 
 void WebPlatformStrategies::getTypes(Vector<String>& types)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardTypes(), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardTypes(), 0);
     if (sendResult.succeeded())
         std::tie(types) = sendResult.takeReply();
 }
 
 void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardWebContent& content)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(content), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(content), 0);
 }
 
 void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, const String& text)
@@ -457,21 +457,21 @@ void WebPlatformStrategies::writeToPasteboard(const String& pasteboardType, cons
 
 Vector<String> WebPlatformStrategies::typesSafeForDOMToReadAndWrite(const String& pasteboardName, const String& origin, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::TypesSafeForDOMToReadAndWrite(pasteboardName, origin, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::TypesSafeForDOMToReadAndWrite(pasteboardName, origin, pageIdentifier(context)), 0);
     auto [types] = sendResult.takeReplyOr(Vector<String> { });
     return types;
 }
 
 int64_t WebPlatformStrategies::writeCustomData(const Vector<PasteboardCustomData>& data, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::WriteCustomData(data, pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::WriteCustomData(data, pasteboardName, pageIdentifier(context)), 0);
     auto [newChangeCount] = sendResult.takeReplyOr(0);
     return newChangeCount;
 }
 
 bool WebPlatformStrategies::containsStringSafeForDOMToReadForType(const String& type, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ContainsStringSafeForDOMToReadForType(type, pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ContainsStringSafeForDOMToReadForType(type, pasteboardName, pageIdentifier(context)), 0);
     auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
@@ -483,7 +483,7 @@ int WebPlatformStrategies::getPasteboardItemsCount(const String& pasteboardName,
         return 1;
     }
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::GetPasteboardItemsCount(pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::GetPasteboardItemsCount(pasteboardName, pageIdentifier(context)), 0);
     auto [itemsCount] = sendResult.takeReplyOr(0);
     return itemsCount;
 }
@@ -493,7 +493,7 @@ std::optional<Vector<PasteboardItemInfo>> WebPlatformStrategies::allPasteboardIt
     if (auto info = WebPasteboardOverrides::sharedPasteboardOverrides().overriddenInfo(pasteboardName))
         return { { WTF::move(*info) } };
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::AllPasteboardItemInfo(pasteboardName, changeCount, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::AllPasteboardItemInfo(pasteboardName, changeCount, pageIdentifier(context)), 0);
     auto [allInfo] = sendResult.takeReplyOr(std::nullopt);
     return allInfo;
 }
@@ -503,7 +503,7 @@ std::optional<PasteboardItemInfo> WebPlatformStrategies::informationForItemAtInd
     if (auto info = WebPasteboardOverrides::sharedPasteboardOverrides().overriddenInfo(pasteboardName))
         return info;
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::InformationForItemAtIndex(index, pasteboardName, changeCount, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::InformationForItemAtIndex(index, pasteboardName, changeCount, pageIdentifier(context)), 0);
     auto [info] = sendResult.takeReplyOr(std::nullopt);
     return info;
 }
@@ -514,7 +514,7 @@ RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::readBufferFromPasteboard(st
     if (WebPasteboardOverrides::sharedPasteboardOverrides().getDataForOverride(pasteboardName, pasteboardType, overrideBuffer))
         return SharedBuffer::create(WTF::move(overrideBuffer));
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadBufferFromPasteboard(index, pasteboardType, pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ReadBufferFromPasteboard(index, pasteboardType, pasteboardName, pageIdentifier(context)), 0);
     auto [buffer] = sendResult.takeReplyOr(nullptr);
     return buffer;
 }
@@ -522,7 +522,7 @@ RefPtr<WebCore::SharedBuffer> WebPlatformStrategies::readBufferFromPasteboard(st
 URL WebPlatformStrategies::readURLFromPasteboard(size_t index, const String& pasteboardName, String& title, const PasteboardContext* context)
 {
     String urlString;
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadURLFromPasteboard(index, pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ReadURLFromPasteboard(index, pasteboardName, pageIdentifier(context)), 0);
     if (sendResult.succeeded())
         std::tie(urlString, title) = sendResult.takeReply();
     return URL({ }, urlString);
@@ -530,7 +530,7 @@ URL WebPlatformStrategies::readURLFromPasteboard(size_t index, const String& pas
 
 String WebPlatformStrategies::readStringFromPasteboard(size_t index, const String& pasteboardType, const String& pasteboardName, const PasteboardContext* context)
 {
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPasteboardProxy::ReadStringFromPasteboard(index, pasteboardType, pasteboardName, pageIdentifier(context)), 0);
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPasteboardProxy::ReadStringFromPasteboard(index, pasteboardType, pasteboardName, pageIdentifier(context)), 0);
     auto [value] = sendResult.takeReplyOr(String { });
     return value;
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
@@ -109,7 +109,7 @@ void WebPopupMenu::show(const IntRect& rect, LocalFrameView& view, int selectedI
     PlatformPopupMenuData platformData;
     setUpPlatformData(pageCoordinates, platformData);
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::ShowPopupMenuFromFrame(view.frame().frameID(), pageCoordinates, static_cast<uint64_t>(popupClient->menuStyle().textDirection()), items, selectedIndex, platformData), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowPopupMenuFromFrame(view.frame().frameID(), pageCoordinates, static_cast<uint64_t>(popupClient->menuStyle().textDirection()), items, selectedIndex, platformData), page->identifier());
 }
 
 void WebPopupMenu::hide()
@@ -119,7 +119,7 @@ void WebPopupMenu::hide()
     if (!page || !popupClient)
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::HidePopupMenu(), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::HidePopupMenu(), page->identifier());
     page->setActivePopupMenu(nullptr);
     popupClient->popupDidHide();
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
@@ -60,7 +60,7 @@ void WebSearchPopupMenu::saveRecentSearches(const AtomString& name, const Vector
     if (!page)
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::SaveRecentSearches(name, searchItems), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::SaveRecentSearches(name, searchItems), page->identifier());
 }
 
 void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<RecentSearch>& resultItems)
@@ -72,7 +72,7 @@ void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<Recen
     if (!page)
         return;
 
-    auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPageProxy::LoadRecentSearches(name), page->identifier());
+    auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPageProxy::LoadRecentSearches(name), page->identifier());
     if (sendResult.succeeded())
         std::tie(resultItems) = sendResult.takeReply();
 }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -337,7 +337,7 @@ void EventDispatcher::dispatchGestureEvent(FrameIdentifier frameID, PageIdentifi
 
 void EventDispatcher::sendDidReceiveEvent(PageIdentifier pageID, WebEventType eventType, bool didHandleEvent)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebPageProxy::DidReceiveEventIPC(eventType, didHandleEvent, std::nullopt), pageID);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::DidReceiveEventIPC(eventType, didHandleEvent, std::nullopt), pageID);
 }
 
 void EventDispatcher::notifyScrollingTreesDisplayDidRefresh(PlatformDisplayID displayID)
@@ -394,12 +394,12 @@ void EventDispatcher::handleSyntheticWheelEvent(WebCore::PageIdentifier pageIden
 
 void EventDispatcher::startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID displayID)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID, WebCore::FullSpeedFramesPerSecond), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID, WebCore::FullSpeedFramesPerSecond), 0);
 }
 
 void EventDispatcher::stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID displayID)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID), 0);
 }
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)

--- a/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp
@@ -80,7 +80,7 @@ void VisitedLinkTableController::addVisitedLink(Page& page, SharedStringHash lin
     if (m_visitedLinkTable.contains(linkHash))
         return;
 
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::VisitedLinkStore::AddVisitedLinkHashFromPage(WebPage::fromCorePage(page)->webPageProxyIdentifier(), linkHash), m_identifier);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::VisitedLinkStore::AddVisitedLinkHashFromPage(WebPage::fromCorePage(page)->webPageProxyIdentifier(), linkHash), m_identifier);
 }
 
 void VisitedLinkTableController::setVisitedLinkTable(SharedMemory::Handle&& handle)

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -142,7 +142,7 @@ const WebBackForwardListCounts& WebBackForwardListProxy::cacheListCountsIfNecess
     if (!m_cachedBackForwardListCounts) {
         WebBackForwardListCounts backForwardListCounts;
         if (m_page) {
-            auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebBackForwardList::BackForwardListCounts(), m_page->identifier());
+            auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebBackForwardList::BackForwardListCounts(), m_page->identifier());
             if (sendResult.succeeded())
                 std::tie(backForwardListCounts) = sendResult.takeReply();
         }

--- a/Source/WebKit/WebProcess/WebPage/WebDisplayRefreshMonitor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebDisplayRefreshMonitor.cpp
@@ -81,7 +81,7 @@ bool WebDisplayRefreshMonitor::startNotificationMechanism()
         return true;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] WebDisplayRefreshMonitor::requestRefreshCallback for display " << displayID() << " - starting");
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID(), maxClientPreferredFramesPerSecond().value_or(FullSpeedFramesPerSecond)), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID(), maxClientPreferredFramesPerSecond().value_or(FullSpeedFramesPerSecond)), 0);
 
 #if PLATFORM(MAC)
     if (!m_runLoopObserver) {
@@ -106,7 +106,7 @@ void WebDisplayRefreshMonitor::stopNotificationMechanism()
         return;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] WebDisplayRefreshMonitor::requestRefreshCallback - stopping");
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID()), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID()), 0);
 #if PLATFORM(MAC)
     m_runLoopObserver->invalidate();
 #endif
@@ -116,7 +116,7 @@ void WebDisplayRefreshMonitor::stopNotificationMechanism()
 void WebDisplayRefreshMonitor::adjustPreferredFramesPerSecond(FramesPerSecond preferredFramesPerSecond)
 {
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] WebDisplayRefreshMonitor::adjustPreferredFramesPerSecond for display link on display " << displayID() << " to " << preferredFramesPerSecond);
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::SetDisplayLinkPreferredFramesPerSecond(m_observerID, displayID(), preferredFramesPerSecond), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::SetDisplayLinkPreferredFramesPerSecond(m_observerID, displayID(), preferredFramesPerSecond), 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -295,7 +295,7 @@ bool WebPage::executeKeypressCommandsInternal(const Vector<WebCore::KeypressComm
                     eventWasHandled |= performedNonEditingBehavior;
                 }
             } else {
-                auto sendResult = WebProcess::singleton().protectedParentProcessConnection()->sendSync(Messages::WebPageProxy::ExecuteSavedCommandBySelector(commands[i].commandName), m_identifier);
+                auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebPageProxy::ExecuteSavedCommandBySelector(commands[i].commandName), m_identifier);
                 auto [commandWasHandledByUIProcess] = sendResult.takeReplyOr(false);
                 eventWasHandled |= commandWasHandledByUIProcess;
             }

--- a/Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp
+++ b/Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp
@@ -36,7 +36,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSystemSoundDelegate);
 
 void WebSystemSoundDelegate::systemBeep()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::WebProcessProxy::SystemBeep(), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebProcessProxy::SystemBeep(), 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -66,12 +66,12 @@ void AudioSessionRoutingArbitrator::deref() const
 
 void AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)
 {
-    WebProcess::singleton().protectedParentProcessConnection()->sendWithAsyncReply(Messages::AudioSessionRoutingArbitratorProxy::BeginRoutingArbitrationWithCategory(category), WTF::move(callback), AudioSessionRoutingArbitratorProxy::destinationId());
+    protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::AudioSessionRoutingArbitratorProxy::BeginRoutingArbitrationWithCategory(category), WTF::move(callback), AudioSessionRoutingArbitratorProxy::destinationId());
 }
 
 void AudioSessionRoutingArbitrator::leaveRoutingArbitration()
 {
-    WebProcess::singleton().protectedParentProcessConnection()->send(Messages::AudioSessionRoutingArbitratorProxy::EndRoutingArbitration(), AudioSessionRoutingArbitratorProxy::destinationId());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::AudioSessionRoutingArbitratorProxy::EndRoutingArbitration(), AudioSessionRoutingArbitratorProxy::destinationId());
 }
 
 bool AudioSessionRoutingArbitrator::canLog() const

--- a/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp
@@ -71,7 +71,7 @@ void RemoteCaptureSampleManager::deref() const
 void RemoteCaptureSampleManager::stopListeningForIPC()
 {
     if (m_isRegisteredToParentProcessConnection)
-        WebProcess::singleton().protectedParentProcessConnection()->removeWorkQueueMessageReceiver(Messages::RemoteCaptureSampleManager::messageReceiverName());
+        protect(WebProcess::singleton().parentProcessConnection())->removeWorkQueueMessageReceiver(Messages::RemoteCaptureSampleManager::messageReceiverName());
     setConnection(nullptr);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry-BadReplyBlock.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry-BadReplyBlock.html
@@ -46,7 +46,7 @@
         CoreIPC.UI.RemoteObjectRegistry.CallReplyBlock(uiProcessWebPageID, {
             replyID: firstReplyID,
             blockInvocation: {
-                protectedObject:
+                objectForSerialization:
                 new API_Dictionary([
                     {
                         key: "$objectStream",
@@ -68,7 +68,7 @@
         CoreIPC.UI.RemoteObjectRegistry.CallReplyBlock(uiProcessWebPageID, {
             replyID: secondReplyID,
             blockInvocation: {
-                protectedObject:
+                objectForSerialization:
                     new API_Dictionary([
                     {
                         key: "$objectStream",


### PR DESCRIPTION
#### 214730ad42992cc04dced2e36f7efb41f94a2e15
<pre>
Reduce use of protected functions in Source/WebKit/Shared
<a href="https://bugs.webkit.org/show_bug.cgi?id=306325">https://bugs.webkit.org/show_bug.cgi?id=306325</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_sharedPreferencesForWebProcess):
(WebKit::GPUConnectionToWebProcess::audioSessionProxy):
(WebKit::GPUConnectionToWebProcess::startMonitoringCaptureDeviceRotation):
(WebKit::GPUConnectionToWebProcess::stopMonitoringCaptureDeviceRotation):
(WebKit::GPUConnectionToWebProcess::presentingApplicationAuditToken const):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::tryExitIfUnused):
(WebKit::GPUProcess::enableMicrophoneMuteStatusAPI):
(WebKit::GPUProcess::setShouldListenToVoiceActivity):
(WebKit::GPUProcess::terminateWebProcess):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updatePresentingProcesses):
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccess):
(WebKit::WebResourceLoadStatisticsStore::requestStorageAccessEphemeral):
(WebKit::WebResourceLoadStatisticsStore::callUpdatePrevalentDomainsToBlockCookiesForHandler):
(WebKit::WebResourceLoadStatisticsStore::logTestingEvent):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::m_ipcTester):
(WebKit::NetworkConnectionToWebProcess::hasUploadStateChanged):
(WebKit::NetworkConnectionToWebProcess::didReceiveInvalidMessage):
(WebKit::NetworkConnectionToWebProcess::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
(WebKit::NetworkConnectionToWebProcess::sharedWorkerServerToContextConnectionIsNoLongerNeeded):
(WebKit::NetworkConnectionToWebProcess::serviceWorkerServerToContextConnectionNoLongerNeeded):
(WebKit::NetworkConnectionToWebProcess::terminateSWContextConnectionDueToUnresponsiveness):
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp:
(WebKit::NetworkContentRuleListManager::contentExtensionsBackend):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::didCommitCrossSiteLoadWithDataTransfer):
(WebKit::NetworkProcess::deleteAndRestrictWebsiteDataForRegistrableDomains):
(WebKit::NetworkProcess::logDiagnosticMessage):
(WebKit::NetworkProcess::logDiagnosticMessageWithResult):
(WebKit::NetworkProcess::logDiagnosticMessageWithValue):
(WebKit::NetworkProcess::requestBackgroundFetchPermission):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startNetworkLoad):
(WebKit::NetworkResourceLoader::processClearSiteDataHeader):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::sendDidReceiveResponsePotentiallyInNewBrowsingContextGroup):
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::didFailLoading):
(WebKit::NetworkResourceLoader::didReceiveChallenge):
(WebKit::NetworkResourceLoader::continueWillSendRequest):
(WebKit::NetworkResourceLoader::sendResultForCacheEntry):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::configurationWithHostAuditToken):
(WebKit::NetworkSession::reportNetworkIssue):
(WebKit::NetworkSession::createContextConnection):
(WebKit::NetworkSession::appBoundDomains):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::sendToParentProcess):
(WebKit::WebSWServerToContextConnection::sendWithAsyncReplyToParentProcess):
(WebKit::WebSWServerToContextConnection::terminateWorker):
(WebKit::WebSWServerToContextConnection::workerTerminated):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::createContextConnection):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcessCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::dataTaskWithRequest):
* Source/WebKit/NetworkProcess/mac/SecItemShim.mm:
(WebKit::sendSecItemRequest):
* Source/WebKit/Shared/API/c/WKContextMenuItem.cpp:
(WKContextMenuItemGetUserData):
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h:
(WebKit::PaymentSetupFeatures::platformFeatures const):
(WebKit::PaymentSetupFeatures::protectedPlatformFeatures const): Deleted.
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformBeginApplePaySetup):
* Source/WebKit/Shared/AuxiliaryProcess.cpp:
(WebKit::AuxiliaryProcess::terminate):
* Source/WebKit/Shared/AuxiliaryProcess.h:
(WebKit::AuxiliaryProcess::parentProcessConnection const):
(WebKit::AuxiliaryProcess::protectedParentProcessConnection const): Deleted.
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::parentProcessHasEntitlement):
* Source/WebKit/Shared/Cocoa/RevealItem.h:
* Source/WebKit/Shared/Cocoa/RevealItem.mm:
(WebKit::RevealItem::highlightRange const):
(WebKit::RevealItem::protectedItem const): Deleted.
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::initialize):
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStoreCollection.mm:
(WebKit::RemoteLayerBackingStoreCollection::prepareBackingStoresForDisplay):
(WebKit::RemoteLayerBackingStoreCollection::sendMarkBuffersVolatile):
(WebKit::RemoteLayerBackingStoreCollection::protectedLayerTreeContext const): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackingStore):
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::SharedStringHashStore::createSharedMemoryHandle):
* Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp:
(WebKit::SharedStringHashTableReadOnly::protectedSharedMemory const): Deleted.
* Source/WebKit/Shared/SharedStringHashTableReadOnly.h:
(WebKit::SharedStringHashTableReadOnly::sharedMemory const):
* Source/WebKit/Shared/UserData.h:
(WebKit::UserData::objectForSerialization const):
(WebKit::UserData::protectedObject const): Deleted.
* Source/WebKit/Shared/UserData.serialization.in:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::setChild):
(WebKit::WebBackForwardListFrameItem::copyFrameStateWithChildren):
(WebKit::WebBackForwardListFrameItem::protectedBackForwardListItem const): Deleted.
(WebKit::WebBackForwardListFrameItem::protectedMainFrame): Deleted.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(WebKit::WebBackForwardListFrameItem::frameState const):
(WebKit::WebBackForwardListFrameItem::parent const):
(WebKit::WebBackForwardListFrameItem::protectedFrameState const): Deleted.
(WebKit::WebBackForwardListFrameItem::protectedParent const): Deleted.
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::navigatedFrameState const):
(WebKit::WebBackForwardListItem::protectedBackForwardCacheEntry const): Deleted.
(WebKit::WebBackForwardListItem::protectedNavigatedFrameItem const): Deleted.
(WebKit::WebBackForwardListItem::protectedMainFrameItem const): Deleted.
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::backForwardCacheEntry const):
* Source/WebKit/Shared/WebContextMenuItem.h:
(WebKit::WebContextMenuItem::protectedUserData const): Deleted.
* Source/WebKit/Shared/WebContextMenuItemData.cpp:
(WebKit::WebContextMenuItemData::protectedUserData const): Deleted.
* Source/WebKit/Shared/WebContextMenuItemData.h:
* Source/WebKit/Shared/mac/SecItemRequestData.h:
(WebKit::SecItemRequestData::query const):
(WebKit::SecItemRequestData::attributesToMatch const):
(WebKit::SecItemRequestData::protectedQuery const): Deleted.
(WebKit::SecItemRequestData::protectedAttributesToMatch const): Deleted.
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::addMessageToConsole):
* Source/WebKit/WebProcess/Geolocation/WebGeolocationManager.cpp:
(WebKit::WebGeolocationManager::registerWebPage):
(WebKit::WebGeolocationManager::unregisterWebPage):
(WebKit::WebGeolocationManager::setEnableHighAccuracyForPage):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::postMessage):
(WebKit::InjectedBundle::postSynchronousMessage):
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::sendMessageToBackend):
(WebKit::RemoteWebInspectorUI::frontendLoaded):
(WebKit::RemoteWebInspectorUI::changeSheetRect):
(WebKit::RemoteWebInspectorUI::setForcedAppearance):
(WebKit::RemoteWebInspectorUI::startWindowDrag):
(WebKit::RemoteWebInspectorUI::bringToFront):
(WebKit::RemoteWebInspectorUI::closeWindow):
(WebKit::RemoteWebInspectorUI::reopen):
(WebKit::RemoteWebInspectorUI::resetState):
(WebKit::RemoteWebInspectorUI::openURLExternally):
(WebKit::RemoteWebInspectorUI::revealFileExternally):
(WebKit::RemoteWebInspectorUI::save):
(WebKit::RemoteWebInspectorUI::load):
(WebKit::RemoteWebInspectorUI::pickColorFromScreen):
(WebKit::RemoteWebInspectorUI::showCertificate):
(WebKit::RemoteWebInspectorUI::setInspectorPageDeveloperExtrasEnabled):
(WebKit::RemoteWebInspectorUI::setPageAndTextZoomFactors):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::openLocalInspectorFrontend):
(WebKit::WebInspectorBackend::closeFrontendConnection):
(WebKit::WebInspectorBackend::bringToFront):
(WebKit::WebInspectorBackend::elementSelectionChanged):
(WebKit::WebInspectorBackend::timelineRecordingChanged):
(WebKit::WebInspectorBackend::setDeveloperPreferenceOverride):
(WebKit::WebInspectorBackend::setEmulatedConditions):
(WebKit::WebInspectorBackend::updateDockingAvailability):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.cpp:
(WebKit::WebInspectorUIExtensionController::didShowExtensionTab):
(WebKit::WebInspectorUIExtensionController::didHideExtensionTab):
(WebKit::WebInspectorUIExtensionController::didNavigateExtensionTab):
(WebKit::WebInspectorUIExtensionController::inspectedPageDidNavigate):
* Source/WebKit/WebProcess/Storage/WebSWClientConnection.cpp:
(WebKit::WebSWClientConnection::getNotifications):
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebCaptionPreferencesDelegate.cpp:
(WebKit::WebCaptionPreferencesDelegate::setDisplayMode):
(WebKit::WebCaptionPreferencesDelegate::setPreferredLanguage):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::windowRect const):
(WebKit::WebChromeClient::focusedElementChanged):
(WebKit::WebChromeClient::focusedFrameChanged):
(WebKit::WebChromeClient::createWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.cpp:
(WebKit::WebColorChooser::WebColorChooser):
(WebKit::WebColorChooser::reattachColorChooser):
(WebKit::WebColorChooser::setSelectedColor):
(WebKit::WebColorChooser::endChooser):
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp:
(WebKit::WebDataListSuggestionPicker::handleKeydownWithIdentifier):
(WebKit::WebDataListSuggestionPicker::close):
(WebKit::WebDataListSuggestionPicker::displayWithActivationType):
* Source/WebKit/WebProcess/WebCoreSupport/WebDateTimeChooser.cpp:
(WebKit::WebDateTimeChooser::endChooser):
(WebKit::WebDateTimeChooser::showChooser):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::getTypes):
(WebKit::WebPlatformStrategies::bufferForType):
(WebKit::WebPlatformStrategies::getPathnamesForType):
(WebKit::WebPlatformStrategies::stringForType):
(WebKit::WebPlatformStrategies::allStringsForType):
(WebKit::WebPlatformStrategies::changeCount):
(WebKit::WebPlatformStrategies::color):
(WebKit::WebPlatformStrategies::url):
(WebKit::WebPlatformStrategies::addTypes):
(WebKit::WebPlatformStrategies::setTypes):
(WebKit::WebPlatformStrategies::setBufferForType):
(WebKit::WebPlatformStrategies::setURL):
(WebKit::WebPlatformStrategies::setColor):
(WebKit::WebPlatformStrategies::setStringForType):
(WebKit::WebPlatformStrategies::writeWebArchive):
(WebKit::WebPlatformStrategies::getNumberOfFiles):
(WebKit::WebPlatformStrategies::containsURLStringSuitableForLoading):
(WebKit::WebPlatformStrategies::urlStringSuitableForLoading):
(WebKit::WebPlatformStrategies::writeToPasteboard):
(WebKit::WebPlatformStrategies::updateSupportedTypeIdentifiers):
(WebKit::WebPlatformStrategies::types):
(WebKit::WebPlatformStrategies::readTextFromClipboard):
(WebKit::WebPlatformStrategies::readFilePathsFromClipboard):
(WebKit::WebPlatformStrategies::readBufferFromClipboard):
(WebKit::WebPlatformStrategies::typesSafeForDOMToReadAndWrite):
(WebKit::WebPlatformStrategies::writeCustomData):
(WebKit::WebPlatformStrategies::containsStringSafeForDOMToReadForType):
(WebKit::WebPlatformStrategies::getPasteboardItemsCount):
(WebKit::WebPlatformStrategies::allPasteboardItemInfo):
(WebKit::WebPlatformStrategies::informationForItemAtIndex):
(WebKit::WebPlatformStrategies::readBufferFromPasteboard):
(WebKit::WebPlatformStrategies::readURLFromPasteboard):
(WebKit::WebPlatformStrategies::readStringFromPasteboard):
* Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp:
(WebKit::WebPopupMenu::show):
(WebKit::WebPopupMenu::hide):
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::saveRecentSearches):
(WebKit::WebSearchPopupMenu::loadRecentSearches):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::sendDidReceiveEvent):
(WebKit::EventDispatcher::startDisplayDidRefreshCallbacks):
(WebKit::EventDispatcher::stopDisplayDidRefreshCallbacks):
* Source/WebKit/WebProcess/WebPage/VisitedLinkTableController.cpp:
(WebKit::VisitedLinkTableController::addVisitedLink):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::cacheListCountsIfNecessary const):
* Source/WebKit/WebProcess/WebPage/WebDisplayRefreshMonitor.cpp:
(WebKit::WebDisplayRefreshMonitor::startNotificationMechanism):
(WebKit::WebDisplayRefreshMonitor::stopNotificationMechanism):
(WebKit::WebDisplayRefreshMonitor::adjustPreferredFramesPerSecond):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::SendStopResponsivenessTimer::~SendStopResponsivenessTimer):
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::loadDataImpl):
(WebKit::WebPage::postInjectedBundleMessage):
(WebKit::WebPage::preferencesDidChange):
(WebKit::WebPage::updatePreferences):
(WebKit::WebPage::postSynchronousMessageForTesting):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::executeKeypressCommandsInternal):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
(WebKit::WebProcess::shouldTerminate):
(WebKit::WebProcess::userGestureTokenDestroyed):
(WebKit::WebProcess::backgroundResponsivenessPing):
(WebKit::WebProcess::handleInjectedBundleMessage):
(WebKit::WebProcess::ensureGPUProcessConnection):
(WebKit::WebProcess::gpuProcessConnectionDidBecomeUnresponsive):
(WebKit::WebProcess::sendPrewarmInformation):
(WebKit::WebProcess::setAppBadge):
* Source/WebKit/WebProcess/WebSystemSoundDelegate.cpp:
(WebKit::WebSystemSoundDelegate::systemBeep):
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
(WebKit::AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory):
(WebKit::AudioSessionRoutingArbitrator::leaveRoutingArbitration):
* Source/WebKit/WebProcess/cocoa/RemoteCaptureSampleManager.cpp:
(WebKit::RemoteCaptureSampleManager::stopListeningForIPC):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteObjectRegistry-BadReplyBlock.html:

Canonical link: <a href="https://commits.webkit.org/306322@main">https://commits.webkit.org/306322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65aa7110d448d3dcc5ab89a4a2d5074733717318

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149542 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13583 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143998 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89199 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152011 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/13117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116456 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116800 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/12860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21760 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13160 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/76862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->