### PR TITLE
Fix ContentRuleList HTTPS upgrade behaviour with Enhanced Security

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1571,7 +1571,7 @@ void DocumentLoader::setNavigationID(NavigationIdentifier navigationID)
 void DocumentLoader::clearMainResourceLoader()
 {
     m_loadingMainResource = false;
-    m_isContinuingLoadAfterProvisionalLoadStarted = false;
+    m_isContinuingLoad = ShouldTreatAsContinuingLoad::No;
 
     RefPtr frameLoader = this->frameLoader();
 
@@ -2402,7 +2402,7 @@ void DocumentLoader::clearMainResource()
 #endif
 
     m_mainResource = nullptr;
-    m_isContinuingLoadAfterProvisionalLoadStarted = false;
+    m_isContinuingLoad = ShouldTreatAsContinuingLoad::No;
 
     unregisterReservedServiceWorkerClient();
 }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -105,6 +105,7 @@ struct IntegrityPolicy;
 enum class ClearSiteDataValue : uint8_t;
 enum class LoadWillContinueInAnotherProcess : bool;
 enum class ShouldContinue;
+enum class ShouldTreatAsContinuingLoad : uint8_t;
 
 using ResourceLoaderMap = HashSet<RefPtr<ResourceLoader>>;
 
@@ -519,8 +520,9 @@ public:
     std::unique_ptr<IntegrityPolicy> integrityPolicy();
     std::unique_ptr<IntegrityPolicy> integrityPolicyReportOnly();
 
-    bool isContinuingLoadAfterProvisionalLoadStarted() const { return m_isContinuingLoadAfterProvisionalLoadStarted; }
-    void setIsContinuingLoadAfterProvisionalLoadStarted(bool isContinuingLoadAfterProvisionalLoadStarted) { m_isContinuingLoadAfterProvisionalLoadStarted = isContinuingLoadAfterProvisionalLoadStarted; }
+    bool isContinuingLoadAfterProvisionalLoadStarted() const { return m_isContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted; }
+    bool isContinuingLoadAfterNavigationPolicyDecision() const { return m_isContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision; }
+    void setIsContinuingLoad(ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad) { m_isContinuingLoad = shouldTreatAsContinuingLoad; }
 
     bool isRequestFromClientOrUserInput() const { return m_isRequestFromClientOrUserInput; }
     void setIsRequestFromClientOrUserInput(bool isRequestFromClientOrUserInput) { m_isRequestFromClientOrUserInput = isRequestFromClientOrUserInput; }
@@ -780,6 +782,7 @@ private:
     ShouldOpenExternalURLsPolicy m_shouldOpenExternalURLsPolicy { ShouldOpenExternalURLsPolicy::ShouldNotAllow };
     PushAndNotificationsEnabledPolicy m_pushAndNotificationsEnabledPolicy { PushAndNotificationsEnabledPolicy::UseGlobalPolicy };
     InlineMediaPlaybackPolicy m_inlineMediaPlaybackPolicy { InlineMediaPlaybackPolicy::Default };
+    ShouldTreatAsContinuingLoad m_isContinuingLoad { ShouldTreatAsContinuingLoad::No };
     WebpagePreferences m_preferences;
     // The triggering action's requester should take precedence. This is used for site-isolation situations that require a cross-site requester.
     std::optional<NavigationRequester> m_crossSiteRequester;
@@ -803,7 +806,6 @@ private:
     bool m_isContentRuleListRedirect { false };
     bool m_isClientRedirect { false };
     bool m_isLoadingMultipartContent { false };
-    bool m_isContinuingLoadAfterProvisionalLoadStarted { false };
     bool m_isInFinishedLoadingOfEmptyDocument { false };
     bool m_isInitialAboutBlank { false };
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1749,7 +1749,7 @@ void FrameLoader::load(FrameLoadRequest&& request, std::optional<NavigationReque
     Ref loader = m_client->createDocumentLoader(request.takeResourceRequest(), request.takeSubstituteData(), request.takeOriginalResourceRequest());
     loader->setIsContentRuleListRedirect(request.isContentRuleListRedirect());
     loader->setIsRequestFromClientOrUserInput(request.isRequestFromClientOrUserInput());
-    loader->setIsContinuingLoadAfterProvisionalLoadStarted(request.shouldTreatAsContinuingLoad() == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
+    loader->setIsContinuingLoad(request.shouldTreatAsContinuingLoad());
     if (crossSiteRequester)
         loader->setCrossSiteRequester(WTF::move(*crossSiteRequester));
 
@@ -1791,7 +1791,7 @@ void FrameLoader::loadWithNavigationAction(ResourceRequest&& request, Navigation
     auto&& substituteData = defaultSubstituteDataForURL(request.url());
     Ref loader = m_client->createDocumentLoader(WTF::move(request), WTF::move(substituteData));
     applyShouldOpenExternalURLsPolicyToNewDocumentLoader(protect(m_frame), loader, action.initiatedByMainFrame(), action.shouldOpenExternalURLsPolicy());
-    loader->setIsContinuingLoadAfterProvisionalLoadStarted(shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted);
+    loader->setIsContinuingLoad(shouldTreatAsContinuingLoad);
     loader->setIsRequestFromClientOrUserInput(action.isRequestFromClientOrUserInput());
 
     if (action.lockHistory() == LockHistory::Yes) {

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1142,7 +1142,8 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         RefPtr userContentProvider = frame->userContentProvider();
         if (request.options().shouldEnableContentExtensionsCheck == ShouldEnableContentExtensionsCheck::Yes && userContentProvider) {
             RegistrableDomain originalDomain { resourceRequest.url() };
-            auto results = userContentProvider->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader);
+            const URL& redirectFromURL = (documentLoader->isContinuingLoadAfterNavigationPolicyDecision() && documentLoader->originalRequest().url() != resourceRequest.url()) ? documentLoader->originalRequest().url() : URL { };
+            auto results = userContentProvider->processContentRuleListsForLoad(page, resourceRequest.url(), ContentExtensions::toResourceType(type, request.resourceRequest().requester(), frame->isMainFrame()), *documentLoader, redirectFromURL);
             madeHTTPS = results.summary.madeHTTPS;
             request.applyResults(WTF::move(results), page.ptr());
             if (results.shouldBlock()) {


### PR DESCRIPTION
#### ea7d159a45e544d013234dec9c56760129dcc8c0
<pre>
Fix ContentRuleList HTTPS upgrade behaviour with Enhanced Security
<a href="https://bugs.webkit.org/show_bug.cgi?id=305379">https://bugs.webkit.org/show_bug.cgi?id=305379</a>
<a href="https://rdar.apple.com/168058731">rdar://168058731</a>

Reviewed by Matthew Finkel.

When the Enhanced Security heuristics flag is enabled by default, a test
failure occurred in:

  * WebKit.RedirectToPlaintextHTTPSUpgrade

This test ensures that a HTTPS site performing a same-site redirect to
plaintext HTTP does not get upgraded by the ContentRuleList rules, as this
is an explicit HTTP redirect.

When the Enhanced Security heuristics flag is enabled, the redirect to the
HTTP site causes us to process swap and load this in an Enhanced Security
process. In doing so, we change the load code path taken and lost information
that this explicit redirect had occurred.

To address this, this change explicitly checks for us having continued the
load due to a navigation policy change, and uses the original request URL,
if different, when processing the ContentRuleList for this load.

We also now have an explicit test that checks this case.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::clearMainResourceLoader):
(WebCore::DocumentLoader::clearMainResource):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::isContinuingLoadAfterProvisionalLoadStarted const):
(WebCore::DocumentLoader::isContinuingLoadAfterNavigationPolicyDecision const):
(WebCore::DocumentLoader::setIsContinuingLoad):
(WebCore::DocumentLoader::setIsContinuingLoadAfterProvisionalLoadStarted): Deleted.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithNavigationAction):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(runHttpsToSameSiteHttpExplicitRedirect):

Canonical link: <a href="https://commits.webkit.org/306844@main">https://commits.webkit.org/306844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bfa9a6a142c7a13c884c0e7ecbc1dab2184855d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95623 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109536 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79058 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/207962f2-5096-4b48-b64e-d8dc035a7ff4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90441 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9acfed3-51fc-4f86-9fc7-b88cf88e2a44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11557 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9214 "Found 1 new API test failure: TestWebKitAPI.WebKit2.GetUserMediaAfterMuting (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1102 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153419 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14511 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117566 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117896 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30081 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13943 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124769 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70223 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14560 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3731 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14292 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78276 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->