### PR TITLE
I420 BT709 VideoFrame is drawn incorrectly to 2D context

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6666,6 +6666,8 @@ imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-mo
 
 webkit.org/b/258192 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.worker.html?h264_avc [ Pass Failure ]
 
+webkit.org/b/306751 http/wpt/webcodecs/encoder-decoder-vp9-I420.html [ Failure ]
+
 # These tests are timing out since their import.
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?indexed [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/the-window-object/window-open-noopener.html?_self [ Skip ]

--- a/LayoutTests/http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709-expected.txt
@@ -1,0 +1,12 @@
+
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: true color:255,0,0,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: true color:0,255,0,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: true color:0,255,255,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: true color:30,30,230,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: true color:3,3,77,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: false color:255,0,0,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: false color:0,255,0,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: false color:0,255,255,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: false color:30,30,230,255
+PASS VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: false color:3,3,77,255
+

--- a/LayoutTests/http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709.html
+++ b/LayoutTests/http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/videoframe-utilities.js"></script>
+<style>
+body { margin: 0 }
+canvas { image-rendering: pixelated }
+</style>
+<canvas style="display: none" id="referenceCanvas"></canvas>
+<canvas style="display: none" id="resultCanvas"></canvas>
+<script>
+// Tests that VideoFrame constructed from I420, BT709 data is has correct RGBA pixel values
+// when drawn to 2D canvas.
+// 1. Create sRGB RGBA test pattern.
+// 2. Convert that to I420 BT709 data with a reference JS implementation.
+// 3. Create VideoFrame of this I420 BT709 data and draw it to result canvas.
+// Expect that the drawn image is correct.
+// To verify that the image is correct:
+// V1. Convert the I420 BT709 to sRGB RGBA data with a reference JS implementation.
+// V2. Create VideoFrame out of that and draw it to reference canvas.
+// V3. Expect that reference and result match.
+let colors = [[255, 0, 0, 255], [0, 255, 0,  255], [0, 255, 255, 255], [30, 30, 230, 255], [3, 3, 77, 255]];
+let subtests = [];
+for (let fullRange of [true, false]) {
+  for (let color of colors)
+    subtests.push({fullRange, color});
+}
+
+for (let subtest of subtests) {
+  test(() => {
+    runTest(subtest.color, subtest.fullRange);
+  }, `VideoFrame from I420, BT709 data has correct RGBA pixel values. fullRange: ${subtest.fullRange} color:${subtest.color}`);
+}
+
+function runTest(color, fullRange) {
+    const pattern = createTestImageData(referenceCanvas.width, referenceCanvas.height, color);
+    const i420Data = sRGBImageDataToI420BT709(pattern, fullRange);
+    const videoFrame = new VideoFrame(i420Data.data, {
+        format: i420Data.format,
+        colorSpace: i420Data.colorSpace,
+        codedWidth: i420Data.width,
+        codedHeight: i420Data.height,
+        layout: i420Data.layout,
+        timestamp: 0
+    });
+    // This is being tested.
+    resultCanvas.getContext('2d').drawImage(videoFrame, 0, 0);
+    videoFrame.close();
+
+    // For clarity, convert the data also with JS-based reference implementation and
+    // compare that against the above native implementation.
+    const referenceSRGBData = I420BT709ToSRGB(i420Data, fullRange);
+    const referenceVideoFrame = new VideoFrame(referenceSRGBData.data, {
+        format: referenceSRGBData.format,
+        colorSpace: referenceSRGBData.colorSpace,
+        codedWidth: referenceSRGBData.width,
+        codedHeight: referenceSRGBData.height,
+        layout: referenceSRGBData.layout,
+        timestamp: 0
+    });
+    referenceCanvas.getContext("2d").drawImage(referenceVideoFrame, 0, 0);
+    referenceVideoFrame.close();
+
+    let referenceColor = referenceCanvas.getContext("2d").getImageData(0, 0, 1, 1).data;
+    let resultColor = resultCanvas.getContext("2d").getImageData(0, 0, 1, 1).data;
+    assert_array_approx_equals(resultColor, referenceColor, 20);
+    assert_array_approx_equals(resultColor, color, 20);
+}
+</script>

--- a/LayoutTests/http/wpt/webcodecs/encoder-decoder-vp9-I420-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/encoder-decoder-vp9-I420-expected.txt
@@ -1,0 +1,12 @@
+
+PASS VP9 encoding preserves pixel values fullRange: true color:255,0,0,255
+PASS VP9 encoding preserves pixel values fullRange: true color:0,255,0,255
+PASS VP9 encoding preserves pixel values fullRange: true color:0,255,255,255
+PASS VP9 encoding preserves pixel values fullRange: true color:30,30,230,255
+PASS VP9 encoding preserves pixel values fullRange: true color:3,3,77,255
+PASS VP9 encoding preserves pixel values fullRange: false color:255,0,0,255
+PASS VP9 encoding preserves pixel values fullRange: false color:0,255,0,255
+PASS VP9 encoding preserves pixel values fullRange: false color:0,255,255,255
+PASS VP9 encoding preserves pixel values fullRange: false color:30,30,230,255
+PASS VP9 encoding preserves pixel values fullRange: false color:3,3,77,255
+

--- a/LayoutTests/http/wpt/webcodecs/encoder-decoder-vp9-I420.html
+++ b/LayoutTests/http/wpt/webcodecs/encoder-decoder-vp9-I420.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/videoframe-utilities.js"></script>
+<style>
+body { margin: 0 }
+canvas { image-rendering: pixelated }
+</style>
+<canvas style="display: none" id="referenceCanvas"></canvas>
+<canvas style="display: none" id="resultCanvas"></canvas>
+<script>
+// Tests that VP9 encoding preserves pixel values.
+// 1. Create sRGB RGBA test pattern.
+// 2. Convert that to I420 BT709 data with a reference JS implementation.
+// 3. Encode the I420 video frame to VP9 and decode it back to VideoFrame
+// Check that the video frame has correct contents by drawing it and inspecting pixels.
+// To verify that the image is correct:
+// V1. Convert the I420 BT709 to sRGB RGBA data with a reference JS implementation.
+// V2. Create VideoFrame out of that and draw it to reference canvas.
+// V3. Expect that reference and result match.
+
+let colors = [[255, 0, 0, 255], [0, 255, 0,  255], [0, 255, 255, 255], [30, 30, 230, 255], [3, 3, 77, 255]];
+let subtests = [];
+for (let fullRange of [true, false]) {
+  for (let color of colors)
+    subtests.push({fullRange, color});
+}
+
+for (let subtest of subtests) {
+  promise_test(async () => {
+    await runTest(subtest.color, subtest.fullRange);
+  }, `VP9 encoding preserves pixel values fullRange: ${subtest.fullRange} color:${subtest.color}`);
+}
+
+async function runTest(color, fullRange) {
+    const pattern = createTestImageData(referenceCanvas.width, referenceCanvas.height, color);
+    const i420Data = sRGBImageDataToI420BT709(pattern, fullRange);
+    const videoFrame = new VideoFrame(i420Data.data, {
+        format: i420Data.format,
+        codedWidth: i420Data.width,
+        codedHeight: i420Data.height,
+        layout: i420Data.layout,
+        timestamp: 0
+    });
+    // This is being tested.
+    let testedVideoFrame = await encodeDecodeVideoFrame(videoFrame, "vp09.00.10.08");
+    resultCanvas.getContext('2d').drawImage(testedVideoFrame, 0, 0);
+    testedVideoFrame.close();
+    referenceCanvas.getContext("2d").drawImage(videoFrame, 0, 0);
+    videoFrame.close();
+
+    let referenceColor = referenceCanvas.getContext("2d").getImageData(0, 0, 1, 1).data;
+    let resultColor = resultCanvas.getContext("2d").getImageData(0, 0, 1, 1).data;
+    assert_array_approx_equals(resultColor, referenceColor, 20);
+    assert_array_approx_equals(resultColor, color, 20);
+}
+</script>

--- a/LayoutTests/http/wpt/webcodecs/resources/videoframe-utilities.js
+++ b/LayoutTests/http/wpt/webcodecs/resources/videoframe-utilities.js
@@ -1,0 +1,192 @@
+function sRGBToBT709Gamma(value) {
+    // sRGB -> linear. https://en.wikipedia.org/wiki/SRGB#Transfer_function_(%22gamma%22)
+    const normalized = value / 255.0;
+    const linear = normalized <= 0.04045 ? normalized / 12.92 : Math.pow((normalized + 0.055) / 1.055, 2.4);
+    // linear -> BT709. https://en.wikipedia.org/wiki/Rec._709#Non-linear_encoding
+    if (linear < 0.018)
+        return 4.5 * linear * 255.0;
+    return (1.099 * Math.pow(linear, 0.45) - 0.099) * 255.0;
+}
+
+// Converts source sRGB ImageData to I420 BT709 data.
+// sRGB and BT709 have the same primaries but different transfer functions.
+function sRGBImageDataToI420BT709(imageData, fullRange) {
+    const width = imageData.width;
+    const height = imageData.height;
+    const rgba = imageData.data;
+
+    const chromaWidth = Math.ceil(width / 2);
+    const chromaHeight = Math.ceil(height / 2);
+
+    const ySize = width * height;
+    const uvSize = chromaWidth * chromaHeight;
+    const totalSize = ySize + 2 * uvSize;
+
+    const data = new Uint8Array(totalSize);
+    const yPlane = new Uint8ClampedArray(data.buffer, 0, ySize);
+    const uPlane = new Uint8ClampedArray(data.buffer, ySize, uvSize);
+    const vPlane = new Uint8ClampedArray(data.buffer, ySize + uvSize, uvSize);
+
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            const i = (y * width + x) * 4;
+            const r = sRGBToBT709Gamma(rgba[i + 0]);
+            const g = sRGBToBT709Gamma(rgba[i + 1]);
+            const b = sRGBToBT709Gamma(rgba[i + 2]);
+            // https://en.wikipedia.org/wiki/Rec._709#The_Y'C'BC'R_color_space
+            const yIndex =  y * width + x;
+            let Y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+            if (!fullRange)
+                Y = 16 + 219 * Y / 255;
+            yPlane[yIndex] = Math.round(Y);
+            if (y % 2 === 0 && x % 2 === 0) {
+                const uvIndex = (y / 2) * chromaWidth + (x / 2);
+                let U = -0.114572 * r - 0.385428 * g + 0.5 * b + 128;
+                let V = 0.5 * r - 0.454153 * g - 0.045847 * b + 128;
+                if (!fullRange) {
+                    U = 224 * (U - 128) / 255 + 128;
+                    V = 224 * (V - 128) / 255 + 128;
+                }
+                uPlane[uvIndex] = Math.round(U);
+                vPlane[uvIndex] = Math.round(V);
+            }
+        }
+    }
+    return {
+        data,
+        width,
+        height,
+        chromaWidth,
+        chromaHeight,
+        format: "I420",
+        colorSpace: {
+            primaries: "bt709",
+            transfer: "bt709",
+            matrix: "bt709",
+            fullRange
+        },
+        layout: [
+            { offset: 0, stride: width },
+            { offset: ySize, stride: chromaWidth },
+            { offset: ySize + uvSize, stride: chromaWidth }
+        ]
+    };
+}
+
+function BT709ToSRGBGamma(value) {
+    // BT.709 -> linear. https://en.wikipedia.org/wiki/Rec._709#Non-linear_decoding
+    const normalized = value / 255.0;
+    const linear = normalized < 0.081 ? normalized / 4.5 : Math.pow((normalized + 0.099) / 1.099, 1 / 0.45);
+
+    // linear -> sRGB. https://en.wikipedia.org/wiki/SRGB#Transfer_function_(%22gamma%22)
+    if (linear <= 0.0031308)
+        return 12.92 * linear * 255.0;
+    return (1.055 * Math.pow(linear, 1 / 2.4) - 0.055) * 255.0;
+}
+
+// Converts I420 BT.709 YUV data to sRGB RGBA format.
+function I420BT709ToSRGB(i420Data, fullRange) {
+    const width = i420Data.width;
+    const height = i420Data.height;
+    const chromaWidth = i420Data.chromaWidth;
+    const chromaHeight = i420Data.chromaHeight;
+
+    const ySize = width * height;
+    const uvSize = chromaWidth * chromaHeight;
+
+    const yPlane = new Uint8Array(i420Data.data.buffer, 0, ySize);
+    const uPlane = new Uint8Array(i420Data.data.buffer, ySize, uvSize);
+    const vPlane = new Uint8Array(i420Data.data.buffer, ySize + uvSize, uvSize);
+
+    const data = new Uint8ClampedArray(width * height * 4);
+
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            // https://en.wikipedia.org/wiki/Rec._709#The_Y'C'BC'R_color_space.
+            // Solve for r, g, b to get the values based on Y, Cb, Cr.
+            const yIndex = y * width + x;
+            let Y = yPlane[yIndex];
+            const uvIndex = Math.floor(y / 2) * chromaWidth + Math.floor(x / 2);
+            let Cb = uPlane[uvIndex] - 128;
+            let Cr = vPlane[uvIndex] - 128;
+            if (!fullRange) {
+                Y = (Y - 16) * 255 / 219;
+                Cb = Cb * 255 / 224;
+                Cr = Cr * 255 / 224;
+            }
+            const r = Y + 1.5748 * Cr;
+            const g = Y - 0.1873 * Cb - 0.4681 * Cr;
+            const b = Y + 1.8556 * Cb;
+
+            const i = (y * width + x) * 4;
+            data[i + 0] = BT709ToSRGBGamma(r);
+            data[i + 1] = BT709ToSRGBGamma(g);
+            data[i + 2] = BT709ToSRGBGamma(b);
+            data[i + 3] = 255;
+        }
+    }
+    return {
+        data,
+        width,
+        height,
+        format: "RGBA",
+        colorSpace: {
+            primaries: "bt709",
+            transfer: "iec61966-2-1",
+            matrix: "rgb",
+            fullRange: true
+        },
+
+        layout: [{ offset: 0, stride: width * 4 }]
+    };
+}
+
+function createTestImageData(width, height, color) {
+    const data = new Uint8Array(width * height * 4);
+    for (let y = 0; y < height; ++y) {
+        for (let x = 0; x < width; ++x) {
+            const o = (y * width + x) * 4;
+            for (let i = 0; i < 4; ++i)
+                data[o + i] = color[i];
+        }
+    }
+    return { width, height, data };
+}
+
+// Recreates the video frame through a video codec.
+async function encodeDecodeVideoFrame(videoFrame, codec) {
+    codec = codec || "vp09.00.10.08";
+    let newFrame;
+    let decoder = new VideoDecoder({
+        output: (frame) => {
+            newFrame = frame;
+        },
+        error: (e) => {
+            throw e;
+        }
+    });
+    decoder.configure({
+        codec: codec,
+    });
+    encoder = new VideoEncoder({
+        output: (chunk) => {
+            decoder.decode(chunk);
+        },
+        error: (e) => {
+            throw e;
+        }
+    });
+    encoder.configure({
+        codec: codec,
+        width: videoFrame.codedWidth,
+        height: videoFrame.codedHeight,
+        bitrate: 10e6,
+        framerate: 30
+    });
+    encoder.encode(videoFrame, {
+        keyFrame: true
+    });
+    await encoder.flush();
+    await decoder.flush();
+    return newFrame;
+}

--- a/LayoutTests/ipc/videoEncode.html
+++ b/LayoutTests/ipc/videoEncode.html
@@ -22,7 +22,7 @@ if (window.IPC) {
             id, width, height, startBitrate:62, maxBitrate:91, minBitrate:5, maxFramerate:720916
         });
         CoreIPC.GPU.LibWebRTCCodecsProxy.EncodeFrame(0, {
-            id, buffer:{ time: { timeValue:43, timeScale:79, timeFlags:145 }, mirrored:false, rotation:0, buffer:{ alias: { variantType:'WebCore::IntSize', variant : { width, height } } } }, timeStamp:61, duration:{}, shouldEncodeAsKeyFrame:true
+            id, buffer:{ time: { timeValue:43, timeScale:79, timeFlags:145 }, mirrored:false, rotation:0, colorSpace: {primaries: {optionalValue: 0}, transfer: {optionalValue: 0}, matrix:{optionalValue: 1}, fullRange: {optionalValue: false}}, buffer:{ alias: { variantType:'WebCore::IntSize', variant : { width, height } } }}, timeStamp:61, duration:{}, shouldEncodeAsKeyFrame:true
         });
         CoreIPC.GPU.LibWebRTCCodecsProxy.ReleaseEncoder(0, {
             id

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1848,6 +1848,9 @@ imported/w3c/web-platform-tests/webcodecs/videoFrame-drawImage.any.worker.html [
 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.html?mp3 [ Failure ]
 [ x86_64 ] imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp3 [ Failure ]
 
+webkit.org/b/306751 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.html [ Failure ]
+webkit.org/b/306751 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.https.any.worker.html [ Failure ]
+
 webkit.org/b/230327 imported/w3c/web-platform-tests/css/css-transforms/crashtests/transform-marquee-resize-div-image-001.html [ Pass Failure ]
 
 webkit.org/b/170629  memory/memory-pressure-simulation.html [ Pass Failure Crash ]

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2599,6 +2599,7 @@ platform/graphics/PixelBufferFormat.cpp
 platform/graphics/PixelFormat.cpp
 platform/graphics/PlatformDynamicRangeLimit.cpp
 platform/graphics/PlatformTimeRanges.cpp
+platform/graphics/PlatformVideoColorSpace.cpp
 platform/graphics/Region.cpp
 platform/graphics/RenderingMode.cpp
 platform/graphics/RotationDirection.cpp

--- a/Source/WebCore/platform/graphics/PlatformVideoColorPrimaries.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoColorPrimaries.h
@@ -47,4 +47,6 @@ enum class PlatformVideoColorPrimaries : uint8_t {
     Smpte432 = SmpteEg432,
 };
 
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformVideoColorPrimaries);
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PlatformVideoColorSpace.cpp
+++ b/Source/WebCore/platform/graphics/PlatformVideoColorSpace.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformVideoColorSpace.h"
+
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PlatformVideoMatrixCoefficients coefficients)
+{
+    switch (coefficients) {
+    case PlatformVideoMatrixCoefficients::Rgb:
+        ts << "rgb"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Bt709:
+        ts << "bt709"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Bt470bg:
+        ts << "bt470bg"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Smpte170m:
+        ts << "smpte170m"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Smpte240m:
+        ts << "smpte240m"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Fcc:
+        ts << "fcc"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::YCgCo:
+        ts << "y-cg-co"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Bt2020NonconstantLuminance:
+        ts << "bt2020-nonconstant-luminance"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Bt2020ConstantLuminance:
+        ts << "bt2020-constant-luminance"_s;
+        break;
+    case PlatformVideoMatrixCoefficients::Unspecified:
+        ts << "unspecified"_s;
+        break;
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PlatformVideoColorPrimaries primaries)
+{
+    switch (primaries) {
+    case PlatformVideoColorPrimaries::Bt709:
+        ts << "bt709"_s;
+        break;
+    case PlatformVideoColorPrimaries::Bt470bg:
+        ts << "bt470bg"_s;
+        break;
+    case PlatformVideoColorPrimaries::Smpte170m:
+        ts << "smpte170m"_s;
+        break;
+    case PlatformVideoColorPrimaries::Bt470m:
+        ts << "bt470m"_s;
+        break;
+    case PlatformVideoColorPrimaries::Smpte240m:
+        ts << "smpte240m"_s;
+        break;
+    case PlatformVideoColorPrimaries::Film:
+        ts << "film"_s;
+        break;
+    case PlatformVideoColorPrimaries::Bt2020:
+        ts << "bt2020"_s;
+        break;
+    case PlatformVideoColorPrimaries::SmpteSt4281:
+        ts << "smpte-st4281"_s;
+        break;
+    case PlatformVideoColorPrimaries::SmpteRp431:
+        ts << "smpte-rp431"_s;
+        break;
+    case PlatformVideoColorPrimaries::SmpteEg432:
+        ts << "smpte-eg432"_s;
+        break;
+    case PlatformVideoColorPrimaries::JedecP22Phosphors:
+        ts << "jedec-p22-phosphors"_s;
+        break;
+    case PlatformVideoColorPrimaries::Unspecified:
+        ts << "unspecified"_s;
+        break;
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PlatformVideoTransferCharacteristics characteristics)
+{
+    switch (characteristics) {
+    case PlatformVideoTransferCharacteristics::Bt709:
+        ts << "bt709"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Smpte170m:
+        ts << "smpte170m"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Iec6196621:
+        ts << "iec6196621"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Gamma22curve:
+        ts << "gamma22curve"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Gamma28curve:
+        ts << "gamma28curve"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Smpte240m:
+        ts << "smpte240m"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Linear:
+        ts << "linear"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Log:
+        ts << "log"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::LogSqrt:
+        ts << "log-sqrt"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Iec6196624:
+        ts << "iec6196624"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Bt1361ExtendedColourGamut:
+        ts << "bt1361-extended-colour-gamut"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Bt2020_10bit:
+        ts << "bt2020_10bit"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Bt2020_12bit:
+        ts << "bt2020_12bit"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::SmpteSt2084:
+        ts << "smpte-st2084"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::SmpteSt4281:
+        ts << "smpte-st4281"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::AribStdB67Hlg:
+        ts << "arib-std-b67-hlg"_s;
+        break;
+    case PlatformVideoTransferCharacteristics::Unspecified:
+        ts << "unspecified"_s;
+        break;
+    }
+    return ts;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream& ts, PlatformVideoColorSpace colorSpace)
+{
+    ts.dumpProperty("primaries"_s, colorSpace.primaries);
+    ts.dumpProperty("transfer"_s, colorSpace.transfer);
+    ts.dumpProperty("matrix"_s, colorSpace.matrix);
+    if (colorSpace.fullRange)
+        ts.dumpProperty("full-range"_s, *colorSpace.fullRange);
+    return ts;
+}
+
+}

--- a/Source/WebCore/platform/graphics/PlatformVideoColorSpace.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoColorSpace.h
@@ -43,4 +43,6 @@ struct PlatformVideoColorSpace {
     friend bool operator==(const PlatformVideoColorSpace&, const PlatformVideoColorSpace&) = default;
 };
 
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformVideoColorSpace);
+
 }

--- a/Source/WebCore/platform/graphics/PlatformVideoMatrixCoefficients.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoMatrixCoefficients.h
@@ -46,4 +46,6 @@ enum class PlatformVideoMatrixCoefficients : uint8_t {
     Bt2020Cl = Bt2020ConstantLuminance,
 };
 
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformVideoMatrixCoefficients);
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/PlatformVideoTransferCharacteristics.h
+++ b/Source/WebCore/platform/graphics/PlatformVideoTransferCharacteristics.h
@@ -53,4 +53,6 @@ enum class PlatformVideoTransferCharacteristics : uint8_t {
     HLG = AribStdB67Hlg,
 };
 
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformVideoTransferCharacteristics);
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -65,6 +65,8 @@ WEBCORE_EXPORT UniqueRef<MediaSamplesBlock> samplesBlockFromCMSampleBuffer(CMSam
 
 WEBCORE_EXPORT void attachColorSpaceToPixelBuffer(const PlatformVideoColorSpace&, CVPixelBufferRef);
 
+PlatformVideoColorSpace computeVideoFrameColorSpace(CVPixelBufferRef);
+
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
 WEBCORE_EXPORT Vector<Ref<SharedBuffer>> getKeyIDs(CMFormatDescriptionRef);
 #endif

--- a/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.mm
+++ b/Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.mm
@@ -162,7 +162,7 @@ RefPtr<VideoFrame> ImageRotationSessionVT::applyRotation(VideoFrame& videoFrame,
     if (!pixelBuffer)
         return nullptr;
 
-    return VideoFrameCV::create(videoFrame.presentationTime(), false, VideoFrameRotation::None, WTF::move(pixelBuffer), videoFrame.colorSpace());
+    return VideoFrameCV::create(videoFrame.presentationTime(), false, VideoFrameRotation::None, WTF::move(pixelBuffer), PlatformVideoColorSpace { videoFrame.colorSpace() });
 }
 
 }

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.h
@@ -40,7 +40,12 @@ class PixelBuffer;
 
 class VideoFrameCV : public VideoFrame {
 public:
-    WEBCORE_EXPORT static Ref<VideoFrameCV> create(MediaTime presentationTime, bool isMirrored, Rotation, RetainPtr<CVPixelBufferRef>&&, std::optional<PlatformVideoColorSpace>&& = { });
+    // Create a VideoFrameCV in specific color space with data from CVPixelBuffer. Intended for constructing VideoFrameCV from new pixel data.
+    WEBCORE_EXPORT static Ref<VideoFrameCV> create(MediaTime presentationTime, bool isMirrored, Rotation, RetainPtr<CVPixelBufferRef>&&, PlatformVideoColorSpace&&);
+    // Create a VideoFrameCV in with data data and color space from CVPixelBuffer. Intended for constructing VideoFrameCV from a buffer created by
+    // a component that already set the color space properties to the buffer.
+    WEBCORE_EXPORT static Ref<VideoFrameCV> create(MediaTime presentationTime, bool isMirrored, Rotation, RetainPtr<CVPixelBufferRef>&&);
+    // Create a VideoFrameCV in with data data and color space from CMSampleBufferRef.
     WEBCORE_EXPORT static Ref<VideoFrameCV> create(CMSampleBufferRef, bool isMirrored, Rotation);
     WEBCORE_EXPORT ~VideoFrameCV();
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -696,7 +696,7 @@ template<typename Frame> RefPtr<LibWebRTCCodecs::FramePromise> LibWebRTCCodecs::
     if (!buffer)
         return nullptr;
 
-    SharedVideoFrame sharedVideoFrame { mediaTime, false, rotation, WTF::move(*buffer) };
+    SharedVideoFrame sharedVideoFrame { mediaTime, false, rotation, { }, WTF::move(*buffer) };
     auto promise = Ref { *encoder.connection }->sendWithPromisedReply(Messages::LibWebRTCCodecsProxy::EncodeFrame { encoder.identifier, WTF::move(sharedVideoFrame), timestamp, duration, shouldEncodeAsKeyFrame });
     return promise->whenSettled(workQueue(), [] (auto&& result) mutable {
         if (!result)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -124,7 +124,7 @@ void SampleBufferDisplayLayer::enqueueBlackFrameFrom(const VideoFrame& videoFram
 {
     auto size = videoFrame.presentationSize();
     WebCore::IntSize blackFrameSize { static_cast<int>(size.width()), static_cast<int>(size.height()) };
-    SharedVideoFrame sharedVideoFrame { videoFrame.presentationTime(), false, videoFrame.rotation(), blackFrameSize };
+    SharedVideoFrame sharedVideoFrame { videoFrame.presentationTime(), false, videoFrame.rotation(), { }, blackFrameSize };
     m_connection->send(Messages::RemoteSampleBufferDisplayLayer::EnqueueVideoFrame { WTF::move(sharedVideoFrame) }, identifier());
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -113,7 +113,7 @@ std::optional<SharedVideoFrame> SharedVideoFrameWriter::write(const VideoFrame& 
     auto buffer = writeBuffer(frame, newSemaphoreCallback, newMemoryCallback);
     if (!buffer)
         return { };
-    return SharedVideoFrame { frame.presentationTime(), frame.isMirrored(), frame.rotation(), WTF::move(*buffer) };
+    return SharedVideoFrame { frame.presentationTime(), frame.isMirrored(), frame.rotation(), frame.colorSpace(), WTF::move(*buffer) };
 }
 
 std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(const VideoFrame& frame, NOESCAPE const Function<void(IPC::Semaphore&)>& newSemaphoreCallback, NOESCAPE const Function<void(SharedMemory::Handle&&)>& newMemoryCallback)
@@ -297,7 +297,7 @@ RefPtr<VideoFrame> SharedVideoFrameReader::read(SharedVideoFrame&& sharedVideoFr
     if (!pixelBuffer)
         return nullptr;
 
-    return VideoFrameCV::create(sharedVideoFrame.time, sharedVideoFrame.mirrored, sharedVideoFrame.rotation, WTF::move(pixelBuffer));
+    return VideoFrameCV::create(sharedVideoFrame.time, sharedVideoFrame.mirrored, sharedVideoFrame.rotation, WTF::move(pixelBuffer), WTF::move(sharedVideoFrame.colorSpace));
 }
 
 CVPixelBufferPoolRef SharedVideoFrameReader::pixelBufferPool(const SharedVideoFrameInfo& info)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -31,6 +31,7 @@
 #include "RemoteVideoFrameIdentifier.h"
 #include <WebCore/IntSize.h>
 #include <WebCore/PixelBufferConformerCV.h>
+#include <WebCore/PlatformVideoColorSpace.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/SharedMemory.h>
 #include <wtf/MediaTime.h>
@@ -61,6 +62,7 @@ struct SharedVideoFrame {
     MediaTime time;
     bool mirrored { false };
     WebCore::VideoFrameRotation rotation { };
+    WebCore::PlatformVideoColorSpace colorSpace;
     using Buffer = Variant<std::nullptr_t, RemoteVideoFrameReadReference, MachSendRight, WebCore::IntSize>;
     Buffer buffer;
 };

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.serialization.in
@@ -28,6 +28,7 @@ using WebKit::SharedVideoFrame::Buffer = Variant<std::nullptr_t, WebKit::RemoteV
     MediaTime time;
     bool mirrored;
     WebCore::VideoFrameRotation rotation;
+    WebCore::PlatformVideoColorSpace colorSpace;
     WebKit::SharedVideoFrame::Buffer buffer;
 };
 


### PR DESCRIPTION
#### d473ec91f732b22aa3f952dfc329ef6317252cdf
<pre>
I420 BT709 VideoFrame is drawn incorrectly to 2D context
<a href="https://bugs.webkit.org/show_bug.cgi?id=305048">https://bugs.webkit.org/show_bug.cgi?id=305048</a>
<a href="https://rdar.apple.com/167688407">rdar://167688407</a>

Reviewed by Youenn Fablet.

Consider case:
const v = new VideoFrame(i420Data, { format: &quot;I420&quot;, ... });
ctx.drawImage(v, 0, 0);

On Cocoa, the data is put to CVPixelBufferRef. Upon the draw, the I420
data is converted to RGB with VTPixelTransferSession (currently through
the VTPixelBufferConformer API).

VTPixelTransferSession expects the CVPixelBufferRef to be configured
with the color space properties. However, VideoFrameCV did not do this.
Thus the conversion is done in wrong color space and results in
incorrect pixel values, likely values for BT.601.

Fix by always ensuring that the WebKit -created CVPixelBuffers for
VideoFrames set the color space properties.

Test:

http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709.html
Tests the bug above.

http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709.html
FIXME:
Tests a bug that might be need to be fixed in this patch:
Create sRGB RGB image with a component that has 255 in it (say RGB 255, 255, 40). 2. Create BT709 VideoFrame out of that.
 3. Encode the VideoFrame to VP9 via VideoEncoder.
 4. Decode the VP9 to VideoFrame via VideoDecoder.
 5. The new VideoFrame is in BT709.
 6. Draw the VideoFrame and  check the components.
 7. The component comes out as 239. Expected is to get that 255+-4 back.
Other browsers pass the test.
Either the encode or the decode does not use the correct colorspace at some point. BT.601 is likely used, as that can&apos;t represent RGB 255. BT709 can.

* LayoutTests/http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/2d-drawImage-videoFrame-I420-BT709.html: Added.
* LayoutTests/http/wpt/webcodecs/encoder-decoder-vp9-I420.html: Added.
* LayoutTests/http/wpt/webcodecs/resources/videoframe-utilities.js: Added.
(sRGBToBT709Gamma):
(sRGBImageDataToI420BT709):
(BT709ToSRGBGamma):
(I420BT709ToSRGB):
(createTestPattern):
(diffCanvas):
(async encodeDecodeVideoFrame):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformVideoColorPrimaries.h:
* Source/WebCore/platform/graphics/PlatformVideoColorSpace.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PlatformVideoColorSpace.h:
* Source/WebCore/platform/graphics/PlatformVideoMatrixCoefficients.h:
* Source/WebCore/platform/graphics/PlatformVideoTransferCharacteristics.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::computeVideoFrameColorSpace):
* Source/WebCore/platform/graphics/cv/ImageRotationSessionVT.mm:
(WebCore::ImageRotationSessionVT::applyRotation):
* Source/WebCore/platform/graphics/cv/VideoFrameCV.h:
(WebCore::VideoFrameCV::create): Deleted.
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrameCV::create):
(WebCore::computeVideoFrameColorSpace): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::encodeFrameInternal):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::enqueueBlackFrameFrom):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameWriter::write):
(WebKit::SharedVideoFrameReader::read):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.serialization.in:

Canonical link: <a href="https://commits.webkit.org/307179@main">https://commits.webkit.org/307179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cf3253cf653593820ac115c148907822db98d81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152013 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/410549f9-f4ee-425f-88ef-23422b050473) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91151 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f01c9f2c-d446-4466-86bd-1d96289a0311) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12169 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9887 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2011 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154324 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15856 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118259 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13375 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118600 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14537 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71251 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15481 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5157 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15426 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->