### PR TITLE
Add RuleSet bucket for universal pseudo-elements

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -217,38 +217,52 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
     if (shadowRoot && shadowRoot->mode() == ShadowRootMode::UserAgent)
         collectMatchingUserAgentPartRules(matchRequest);
 
-    bool isHTML = element.isHTMLElement() && element.document().isHTMLDocument();
+    bool isHTMLElement = element.isHTMLElement();
+    bool isCaseInsensitiveForHTML = isHTMLElement && element.document().isHTMLDocument();
+    auto& ruleSet = matchRequest.ruleSet;
 
     // We need to collect the rules for id, class, tag, and everything else into a buffer and
     // then sort the buffer.
     auto& id = element.idForStyleResolution();
     if (!id.isNull())
-        collectMatchingRulesForList(matchRequest.ruleSet.idRules(id), matchRequest);
+        collectMatchingRulesForList(ruleSet.idRules(id), matchRequest);
     if (element.hasClass()) {
         for (auto& className : element.classNames())
-            collectMatchingRulesForList(matchRequest.ruleSet.classRules(className), matchRequest);
+            collectMatchingRulesForList(ruleSet.classRules(className), matchRequest);
     }
-    if (element.hasAttributesWithoutUpdate() && matchRequest.ruleSet.hasAttributeRules()) {
+    if (element.hasAttributesWithoutUpdate() && ruleSet.hasAttributeRules()) {
         Vector<const RuleSet::RuleDataVector*, 4> ruleVectors;
         for (auto& attribute : element.attributes()) {
-            if (auto* rules = matchRequest.ruleSet.attributeRules(attribute.localName(), isHTML))
+            if (auto* rules = ruleSet.attributeRules(attribute.localName(), isCaseInsensitiveForHTML))
                 ruleVectors.append(rules);
         }
         for (auto* rules : ruleVectors)
             collectMatchingRulesForList(rules, matchRequest);
     }
+
     if (m_pseudoElementRequest && m_pseudoElementRequest->nameArgument() != nullAtom())
-        collectMatchingRulesForList(matchRequest.ruleSet.namedPseudoElementRules(m_pseudoElementRequest->nameArgument()), matchRequest);
+        collectMatchingRulesForList(ruleSet.namedPseudoElementRules(m_pseudoElementRequest->nameArgument()), matchRequest);
+
     if (element.isLink())
-        collectMatchingRulesForList(matchRequest.ruleSet.linkPseudoClassRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet.linkPseudoClassRules(), matchRequest);
     if (matchesFocusPseudoClass(element))
-        collectMatchingRulesForList(matchRequest.ruleSet.focusPseudoClassRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet.focusPseudoClassRules(), matchRequest);
     if (matchesFocusVisiblePseudoClass(element))
-        collectMatchingRulesForList(matchRequest.ruleSet.focusVisiblePseudoClassRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet.focusVisiblePseudoClassRules(), matchRequest);
     if (&element == element.document().documentElement())
-        collectMatchingRulesForList(matchRequest.ruleSet.rootElementRules(), matchRequest);
-    collectMatchingRulesForList(matchRequest.ruleSet.tagRules(element.localName(), isHTML), matchRequest);
-    collectMatchingRulesForList(matchRequest.ruleSet.universalRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet.rootElementRules(), matchRequest);
+    collectMatchingRulesForList(ruleSet.tagRules(element.localName(), isCaseInsensitiveForHTML), matchRequest);
+    collectMatchingRulesForList(ruleSet.universalRules(), matchRequest);
+
+    // Shortcut selectors like "::marker" for HTML elements.
+    auto pseudoElementTypes = isHTMLElement ? ruleSet.universalHTMLPseudoElementTypes() : ruleSet.universalPseudoElementTypes();
+    if (m_pseudoElementRequest) {
+        if (pseudoElementTypes.contains(m_pseudoElementRequest->type()))
+            collectMatchingRulesForList(ruleSet.universalPseudoElementRules(), matchRequest);
+    } else {
+        // If pseudo-element is not requested then just mark the bits that tell that this element has these.
+        m_matchedPseudoElements.add(pseudoElementTypes & allPublicPseudoElementTypes);
+    }
 }
 
 
@@ -315,6 +329,9 @@ bool ElementRuleCollector::matchesAnyAuthorRules()
 
     collectMatchingRules(DeclarationOrigin::Author);
 
+    if (m_mode == SelectorChecker::Mode::StyleInvalidation && m_matchedPseudoElements)
+        return true;
+
     return !m_matchedRules.isEmpty();
 }
 
@@ -350,10 +367,8 @@ void ElementRuleCollector::matchHostPseudoClassRules(DeclarationOrigin origin)
         collectMatchingRulesForList(&rules, hostMatchRequest);
     };
 
-    if (shadowRules->hasHostOrScopePseudoClassRulesInUniversalBucket()) {
-        if (auto* universalRules = shadowRules->universalRules())
-            collect(*universalRules);
-    }
+    if (shadowRules->hasHostOrScopePseudoClassRulesInUniversalBucket())
+        collect(shadowRules->universalRules());
 
     collect(shadowRules->hostPseudoClassRules());
 }

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -95,6 +95,7 @@ private:
     void collectMatchingRules(DeclarationOrigin);
     void collectMatchingRules(const MatchRequest&);
     void collectMatchingRulesForList(const RuleSet::RuleDataVector*, const MatchRequest&);
+    void collectMatchingRulesForList(const RuleSet::RuleDataVector&, const MatchRequest&);
     void collectMatchingRulesForListSlow(const RuleSet::RuleDataVector&, const MatchRequest&);
     bool isFirstMatchModeAndHasMatchedAnyRules() const;
     struct ScopingRootWithDistance {
@@ -144,6 +145,13 @@ ALWAYS_INLINE void ElementRuleCollector::collectMatchingRulesForList(const RuleS
     if (!rules || rules->isEmpty())
         return;
     collectMatchingRulesForListSlow(*rules, matchRequest);
+}
+
+ALWAYS_INLINE void ElementRuleCollector::collectMatchingRulesForList(const RuleSet::RuleDataVector& rules, const MatchRequest& matchRequest)
+{
+    if (rules.isEmpty())
+        return;
+    collectMatchingRulesForListSlow(rules, matchRequest);
 }
 
 }

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -101,7 +101,7 @@ public:
     const RuleDataVector* attributeRules(const AtomString& key, bool isHTMLName) const;
     const RuleDataVector* tagRules(const AtomString& key, bool isHTMLName) const;
     const RuleDataVector* userAgentPartRules(const AtomString& key) const { return m_userAgentPartRules.get(key); }
-    const RuleDataVector* linkPseudoClassRules() const { return &m_linkPseudoClassRules; }
+    const RuleDataVector& linkPseudoClassRules() const { return m_linkPseudoClassRules; }
     const RuleDataVector* namedPseudoElementRules(const AtomString& key) const { return m_namedPseudoElementRules.get(key); }
 #if ENABLE(VIDEO)
     const RuleDataVector& cuePseudoRules() const { return m_cuePseudoRules; }
@@ -109,10 +109,16 @@ public:
     const RuleDataVector& hostPseudoClassRules() const { return m_hostPseudoClassRules; }
     const RuleDataVector& slottedPseudoElementRules() const { return m_slottedPseudoElementRules; }
     const RuleDataVector& partPseudoElementRules() const { return m_partPseudoElementRules; }
-    const RuleDataVector* focusPseudoClassRules() const { return &m_focusPseudoClassRules; }
-    const RuleDataVector* focusVisiblePseudoClassRules() const { return &m_focusVisiblePseudoClassRules; }
-    const RuleDataVector* rootElementRules() const { return &m_rootElementRules; }
-    const RuleDataVector* universalRules() const { return &m_universalRules; }
+    const RuleDataVector& focusPseudoClassRules() const { return m_focusPseudoClassRules; }
+    const RuleDataVector& focusVisiblePseudoClassRules() const { return m_focusVisiblePseudoClassRules; }
+    const RuleDataVector& rootElementRules() const { return m_rootElementRules; }
+    const RuleDataVector& universalRules() const { return m_universalRules; }
+    // For pseudo-element rules that apply to all elements or all HTML elements like "::marker".
+    const RuleDataVector& universalPseudoElementRules() const { return m_universalPseudoElementRules; }
+    // Pseudo element types applying to all elements in HTML namespace.
+    EnumSet<PseudoElementType> universalHTMLPseudoElementTypes() const { return m_universalHTMLPseudoElementTypes; }
+    // Pseudo element types applying to all elements.
+    EnumSet<PseudoElementType> universalPseudoElementTypes() const { return m_universalPseudoElementTypes; }
 
     const Vector<StyleRulePage*>& pageRules() const { return m_pageRules; }
 
@@ -218,6 +224,9 @@ private:
     RuleDataVector m_focusVisiblePseudoClassRules;
     RuleDataVector m_rootElementRules;
     RuleDataVector m_universalRules;
+    RuleDataVector m_universalPseudoElementRules;
+    EnumSet<PseudoElementType> m_universalHTMLPseudoElementTypes;
+    EnumSet<PseudoElementType> m_universalPseudoElementTypes;
     Vector<StyleRulePage*> m_pageRules;
     RefPtr<StyleRuleViewTransition> m_viewTransitionRule;
     RuleFeatureSet m_features;


### PR DESCRIPTION
#### 2f1c0a0ae8fd635be93011d4b478aee2f0f06ffa
<pre>
Add RuleSet bucket for universal pseudo-elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=306332">https://bugs.webkit.org/show_bug.cgi?id=306332</a>
<a href="https://rdar.apple.com/169001503">rdar://169001503</a>

Reviewed by Alan Baradlay.

UA sheet has things like ::marker and ::backdrop that get processed like regular selectors. We can shortcut them.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):

If we are in a normal selector matching for a HTML element just mark that we saw these pseudo-elements.
If they are actually requested then process the rules normally.

(WebCore::Style::ElementRuleCollector::matchHostPseudoClassRules):
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForList):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Add a bucket and also an EnumSet to remember what sort of pseudo-elements we saw.

(WebCore::Style::RuleSet::traverseRuleDatas):
(WebCore::Style::RuleSet::shrinkToFit):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::linkPseudoClassRules const):
(WebCore::Style::RuleSet::focusPseudoClassRules const):
(WebCore::Style::RuleSet::focusVisiblePseudoClassRules const):
(WebCore::Style::RuleSet::rootElementRules const):
(WebCore::Style::RuleSet::universalRules const):
(WebCore::Style::RuleSet::universalPseudoElementRules const):
(WebCore::Style::RuleSet::universalHTMLPseudoElementTypes const):
(WebCore::Style::RuleSet::universalPseudoElementTypes const):

Canonical link: <a href="https://commits.webkit.org/306415@main">https://commits.webkit.org/306415@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fad326667812e21082b684bb9cd25bb645bccdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149885 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6608c14d-dd1d-432d-baa2-ee7a4cd6dcd5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108570 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78cca66e-fec4-444d-a2b6-825620f0490d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11121 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53c346bf-ff4f-4844-927b-8dc529072d8f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8305 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152279 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13381 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116668 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117007 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13061 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123121 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68557 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13424 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77130 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13362 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13207 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->