### PR TITLE
[GTK3] Fix the build once again

### DIFF
--- a/Source/WebCore/dom/ImportNodeOptions.h
+++ b/Source/WebCore/dom/ImportNodeOptions.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
+#include "CustomElementRegistry.h"
+
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
-
-class CustomElementRegistry;
 
 struct ImportNodeOptions {
     bool selfOnly { false };

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp
@@ -56,9 +56,9 @@ void GObjectEventListener::gobjectDestroyed()
     // Protect 'this' class in case the 'm_coreTarget' holds the last reference,
     // which may cause, inside removeEventListener(), free of this object
     // and later use-after-free with the m_handler = 0; assignment.
-    RefPtr<GObjectEventListener> protectedThis(this);
+    RefPtr protectedThis { this };
 
-    m_coreTarget->removeEventListener(m_eventType, *this, m_capture);
+    m_coreTarget->removeEventListener(m_eventType, *this, { .capture = m_capture });
     m_coreTarget = nullptr;
     m_handler = nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h
@@ -42,7 +42,7 @@ public:
     static bool removeEventListener(GObject* target, WebCore::EventTarget* coreTarget, const char* domEventName, GClosure* handler, bool useCapture)
     {
         GObjectEventListener key(target, coreTarget, domEventName, handler, useCapture);
-        return coreTarget->removeEventListener(key.m_eventType, key, useCapture);
+        return coreTarget->removeEventListener(key.m_eventType, key, { .capture = useCapture });
     }
 
     static void gobjectDestroyedCallback(GObjectEventListener* listener, GObject*)


### PR DESCRIPTION
#### 5453a701e02cf9241ed74468a8b3dca69c0e4e35
<pre>
[GTK3] Fix the build once again
<a href="https://bugs.webkit.org/show_bug.cgi?id=306333">https://bugs.webkit.org/show_bug.cgi?id=306333</a>

Unreviewed build fix.

* Source/WebCore/dom/ImportNodeOptions.h:
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.cpp:
(WebKit::GObjectEventListener::gobjectDestroyed):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/GObjectEventListener.h:
(WebKit::GObjectEventListener::removeEventListener):

Canonical link: <a href="https://commits.webkit.org/306276@main">https://commits.webkit.org/306276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6272307e4f43e5dbed7159ae7776fb2270fbb362

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13276 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/2515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149316 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/13986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13428 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143843 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10803 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/2515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89011 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/7975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9326 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/2515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12962 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/2515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12977 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116681 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/12736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/2515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21737 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13005 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/2515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76706 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->