### PR TITLE
[webkitpy][run-webkit-tests] Wrong exit code and report when a test is repeated (via --repeat-each=X) and there is a mix of unexpected and expected results

### DIFF
--- a/Tools/Scripts/webkitpy/common/host_mock.py
+++ b/Tools/Scripts/webkitpy/common/host_mock.py
@@ -40,9 +40,10 @@ from webkitpy.port.test import add_unit_tests_to_mock_filesystem, add_checkout_i
 
 
 class MockHost(MockSystemHost):
-    def __init__(self, log_executive=False, executive_throws_when_run=None, initialize_scm_by_default=True, web=None, create_stub_repository_files=False, **kwargs):
+    def __init__(self, log_executive=False, executive_throws_when_run=None, initialize_scm_by_default=True, web=None, create_stub_repository_files=False, add_unit_tests=True, **kwargs):
         MockSystemHost.__init__(self, log_executive, executive_throws_when_run, **kwargs)
-        add_unit_tests_to_mock_filesystem(self.filesystem)
+        if add_unit_tests:
+            add_unit_tests_to_mock_filesystem(self.filesystem)
         if create_stub_repository_files:
             add_checkout_information_json_to_mock_filesystem(self.filesystem)
         self.web = web or MockWeb()

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
@@ -50,6 +50,8 @@ def get_result(test_name, result_type=test_expectations.PASS, run_time=0):
         failures = [test_failures.FailureCrash()]
     elif result_type == test_expectations.LEAK:
         failures = [test_failures.FailureDocumentLeak(['http://localhost:8000/failures/expected/leak.html'])]
+    elif result_type == test_expectations.TEXT:
+        failures = [test_failures.FailureTextMismatch()]
     return test_results.TestResult(test_name, failures=failures, test_run_time=run_time)
 
 
@@ -195,3 +197,166 @@ class SummarizedResultsTest(unittest.TestCase):
                 summary['baseline_search_path'],
                 ['platform/test-mac-leopard', 'platform/test-mac-snowleopard'],
             )
+
+
+def summarized_results_repeat_tests(port, test_name, actual_results_str):
+    expectations = test_expectations.TestExpectations(port, [test_name])
+    expectations.parse_all_expectations()
+    initial_results = test_run_results.TestRunResults(expectations, 1)
+
+    expected_results = expectations.filtered_expectations_for_test(test_name, False, False)
+    for actual_result in actual_results_str.split():
+        actual_result = getattr(test_expectations, actual_result)
+        is_expected = expectations.matches_an_expected_result(test_name, actual_result, expected_results)
+        initial_results.add(get_result(test_name, actual_result), is_expected)
+    return test_run_results.summarize_results(port, {None: initial_results.expectations}, initial_results, None, enabled_pixel_tests_in_retry=False)
+
+
+class SummarizedResultsRepeatResultsFlakiesTest(unittest.TestCase):
+    def setUp(self):
+        host = MockHost(initialize_scm_by_default=False, create_stub_repository_files=False, add_unit_tests=False)
+        LAYOUT_TEST_DIR = '/test.checkout/LayoutTests'
+        host.filesystem.maybe_make_directory(LAYOUT_TEST_DIR)
+        host.filesystem.write_text_file(LAYOUT_TEST_DIR + '/TestExpectations', """
+Bug(test) failures/text.html [ Failure ]
+Bug(test) failures/crash.html [ Crash ]
+Bug(test) failures/timeout.html [ Timeout ]
+Bug(test) flakies/crash-timeout.html [ Crash Timeout ]
+Bug(test) flakies/pass-crash-timeout.html [ Pass Crash Timeout ]
+Bug(test) flakies/fail-timeout.html [ Failure Timeout ]
+""")
+        for test_dir in ['failures', 'flakies', 'pass']:
+            host.filesystem.maybe_make_directory(LAYOUT_TEST_DIR + f'/{test_dir}')
+            test_preffixes = ['text', 'crash', 'timeout'] if test_dir == 'failures' else ['crash-timeout', 'pass-crash-timeout', 'fail-timeout']
+            test_preffixes = ['passing'] if test_dir == 'pass' else test_preffixes
+            for test_preffix in test_preffixes:
+                host.filesystem.write_text_file(LAYOUT_TEST_DIR + f'/{test_dir}/{test_preffix}.html', 'test lorem ipsum')
+                host.filesystem.write_text_file(LAYOUT_TEST_DIR + f'/{test_dir}/{test_preffix}-expected.txt', 'expect lorem ipsum')
+        self.port = host.port_factory.get(port_name='test', options=MockOptions(http=True, pixel_tests=False, world_leaks=False))
+
+    def run_test_case_expected_regression_or_flaky(self, test_path, test_expectation, actual_results, expected_summary_result):
+        self.assertIn(expected_summary_result, ['report_is_flaky', 'report_is_regression', 'no_report_and_pass', 'no_report_and_expected_failure'])
+        num_flaky = 0
+        num_regressions = 0
+        num_passes = 0
+        with mocks.local.Git(path='/'), OutputCapture():
+            self.port._options.builder_name = 'dummy builder'
+            summary = summarized_results_repeat_tests(self.port, test_path, actual_results)
+            test_dir, test_filename = test_path.split('/')
+            # Check that the expected and actual results on the generated summary dict matches what we passed.
+            self.assertEqual(set(summary['tests'][test_dir][test_filename]['expected'].replace('FAIL', 'TEXT').split()), set(test_expectation.split()))
+            self.assertEqual(set(summary['tests'][test_dir][test_filename]['actual'].split()), set(actual_results.split()))
+            # Check the report field and the num_xxx values
+            if expected_summary_result.startswith('no_report'):
+                self.assertNotIn('report', summary['tests'][test_dir][test_filename])
+                if expected_summary_result == 'no_report_and_pass':
+                    num_passes += 1
+                self.assertEqual(summary['num_passes'], num_passes)
+            else:
+                if expected_summary_result == 'report_is_regression':
+                    num_regressions += 1
+                    report_expected = 'REGRESSION'
+                else:
+                    num_flaky += 1
+                    report_expected = 'FLAKY'
+                self.assertIn('report', summary['tests'][test_dir][test_filename])
+                self.assertEqual(summary['tests'][test_dir][test_filename]['report'], report_expected)
+            self.assertEqual(summary['num_flaky'], num_flaky)
+            self.assertEqual(summary['num_regressions'], num_regressions)
+
+    def test_repeat_results_failures_text(self):
+        test_name = 'failures/text.html'
+        test_expectations = 'TEXT'
+        # Should be marked flaky and not regression if any of the values on the run or the retries matches the expectation or is a pass
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS', 'no_report_and_pass')
+
+    def test_repeat_results_failures_crash(self):
+        test_name = 'failures/crash.html'
+        test_expectations = 'CRASH'
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT TEXT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT TIMEOUT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS', 'no_report_and_pass')
+
+    def test_repeat_results_failures_timeout(self):
+        test_name = 'failures/timeout.html'
+        test_expectations = 'TIMEOUT'
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT TEXT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS', 'no_report_and_pass')
+
+    def test_repeat_results_flakies_crash_timeout(self):
+        test_name = 'flakies/crash-timeout.html'
+        test_expectations = 'CRASH TIMEOUT'
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS CRASH', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS', 'no_report_and_pass')
+
+    def test_repeat_results_flakies_pass_crash_timeout(self):
+        test_name = 'flakies/pass-crash-timeout.html'
+        test_expectations = 'PASS CRASH TIMEOUT'
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS CRASH', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS', 'no_report_and_pass')
+
+    def test_repeat_results_flakies_fail_timeout(self):
+        test_name = 'flakies/fail-timeout.html'
+        test_expectations = 'TEXT TIMEOUT'
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT', 'no_report_and_expected_failure')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'PASS', 'no_report_and_pass')
+
+    def test_repeat_results_pass(self):
+        test_name = 'pass/passing.html'
+        test_expectations = 'PASS'
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT TIMEOUT PASS', 'report_is_flaky')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT TIMEOUT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TIMEOUT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH TEXT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'CRASH', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TIMEOUT', 'report_is_regression')
+        self.run_test_case_expected_regression_or_flaky(test_name, test_expectations, 'TEXT', 'report_is_regression')


### PR DESCRIPTION
#### 96d2789262f79ea36dad789e9a3dae5a334b3ff1
<pre>
[webkitpy][run-webkit-tests] Wrong exit code and report when a test is repeated (via --repeat-each=X) and there is a mix of unexpected and expected results
<a href="https://bugs.webkit.org/show_bug.cgi?id=306336">https://bugs.webkit.org/show_bug.cgi?id=306336</a>

Reviewed by Nikolas Zimmermann.

When a test is run multiple times (via --repeat-each=X) then it should only
be considered a regression if _all_ of the results it generated where
unexpected. Otherwise, if there is only one PASS or only one expected failure
it should be considered flaky instead.

And run-webkit-tests should not exit with non-zero error in case of flaky test.
Only the tests results marked as regression should increment the exit code.

This has been causing issues on the WPE WK2 EWS when on the retry step with
patch (layout-tests-repeat-failures) there are flaky tests but not regressions
and the return code of the step is non-zero. That confuses the EWS logic that
expects a list of failed tests when the result is non-zero to guard against
a patch that breaks the runner itself, and since there isn&apos;t such list it
ends trigerring an insfrastructure error.

This patch changes the code to count the number of regressions and number
of flakies after the loop processing all the test results is finished.
That avoids counting as regression a case that later will be reclassified
as flaky when the retry-results for the tests are processed.

This also fixes a logic error when the retry results are examined to determine
if a test should be marked as flaky that was introduced in 243493@main:
The test should be marked flaky if there are more than one result and any of
those results match the expectation or PASS.

Also several unit tests are added to ensure to test better this logic.

* Tools/Scripts/webkitpy/common/host_mock.py:
(MockHost.__init__):
* Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py:
(count_tests_with_report_result):
(summarize_results):
* Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py:
(get_result):
(SummarizedResultsTest.test_summarized_run_metadata):
(summarized_results_repeat_tests):
(SummarizedResultsRepeatResultsFlakiesTest):
(SummarizedResultsRepeatResultsFlakiesTest.setUp):

Canonical link: <a href="https://commits.webkit.org/306367@main">https://commits.webkit.org/306367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cc3610d02e1c217d241f6b39a478c253a6b237d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/93999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108126 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78427 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126129 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89027 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/140256 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10416 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/7989 "Passed tests") | [⏳ wpe-libwebrtc ](None "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151874 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/12981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116355 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/12996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116694 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12763 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68142 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21780 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13024 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2213 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/12962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->