### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from IDL dictionaries (Part 4)

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.h
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.h
@@ -34,18 +34,24 @@ namespace WebCore {
 struct BarcodeDetectorOptions {
     ShapeDetection::BarcodeDetectorOptions convertToBacking() const
     {
+        if (!formats)
+            return { };
+
         return {
-            formats.map([] (auto format) {
+            formats->map([](auto format) {
                 return WebCore::convertToBacking(format);
-            }),
+            })
         };
     }
 
-    Vector<BarcodeFormat> formats;
+    std::optional<Vector<BarcodeFormat>> formats;
 };
 
 inline BarcodeDetectorOptions convertFromBacking(const ShapeDetection::BarcodeDetectorOptions& barcodeDetectorOptions)
 {
+    if (barcodeDetectorOptions.formats.isEmpty())
+        return { std::nullopt };
+
     return {
         barcodeDetectorOptions.formats.map([] (auto format) {
             return WebCore::convertFromBacking(format);

--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.idl
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.idl
@@ -27,7 +27,6 @@
 
 [
     EnabledBySetting=ShapeDetection,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary BarcodeDetectorOptions {
     sequence<BarcodeFormat> formats;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayCouponCodeUpdate.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayCouponCodeUpdate.idl
@@ -25,9 +25,7 @@
 
 [
     Conditional=APPLE_PAY_COUPON_CODE,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayCouponCodeUpdate : ApplePayDetailsUpdateBase {
-    sequence<ApplePayError> errors;
-
-    sequence<ApplePayShippingMethod> newShippingMethods;
+    sequence<ApplePayError> errors = [];
+    sequence<ApplePayShippingMethod> newShippingMethods = [];
 };

--- a/Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.idl
@@ -25,18 +25,13 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayDetailsUpdateBase {
     required ApplePayLineItem newTotal;
-    sequence<ApplePayLineItem> newLineItems;
+    sequence<ApplePayLineItem> newLineItems = [];
 
     [Conditional=APPLE_PAY_RECURRING_PAYMENTS] ApplePayRecurringPaymentRequest newRecurringPaymentRequest;
-
     [Conditional=APPLE_PAY_AUTOMATIC_RELOAD_PAYMENTS] ApplePayAutomaticReloadPaymentRequest newAutomaticReloadPaymentRequest;
-
     [Conditional=APPLE_PAY_MULTI_MERCHANT_PAYMENTS] sequence<ApplePayPaymentTokenContext> newMultiTokenContexts;
-
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] ApplePayDeferredPaymentRequest newDeferredPaymentRequest;
-
     [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementRequest newDisbursementRequest;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayInstallmentConfiguration.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayInstallmentConfiguration.idl
@@ -28,17 +28,16 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayInstallmentConfiguration {
     ApplePaySetupFeatureType featureType = "appleCard";
     DOMString merchandisingImageData;
     DOMString openToBuyThresholdAmount;
     DOMString bindingTotalAmount;
     DOMString currencyCode;
-    boolean isInStorePurchase;
+    boolean isInStorePurchase = false;
     DOMString merchantIdentifier;
     DOMString referrerIdentifier;
-    sequence<ApplePayInstallmentItem> items;
+    sequence<ApplePayInstallmentItem> items = [];
     JSON applicationMetadata;
     ApplePayInstallmentRetailChannel retailChannel = "unknown";
 };

--- a/Source/WebCore/Modules/applepay/ApplePayPayment.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPayment.h
@@ -45,6 +45,13 @@ struct ApplePayPayment {
     String installmentAuthorizationToken;
 };
 
+struct LocalizedApplePayPayment {
+    ApplePayPayment::Token token;
+    std::optional<LocalizedApplePayPaymentContact> billingContact;
+    std::optional<LocalizedApplePayPaymentContact> shippingContact;
+    String installmentAuthorizationToken;
+};
+
 }
 
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizationResult.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizationResult.idl
@@ -25,10 +25,9 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentAuthorizationResult {
     required unsigned short status;
-    sequence<ApplePayError> errors;
+    sequence<ApplePayError> errors = [];
 
     [Conditional=APPLE_PAY_PAYMENT_ORDER_DETAILS] ApplePayPaymentOrderDetails orderDetails;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentContact.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentContact.h
@@ -37,10 +37,8 @@ struct ApplePayPaymentContact {
     String emailAddress;
     String givenName;
     String familyName;
-    String localizedName;
     String phoneticGivenName;
     String phoneticFamilyName;
-    String localizedPhoneticName;
     std::optional<Vector<String>> addressLines;
     String subLocality;
     String locality;
@@ -49,6 +47,11 @@ struct ApplePayPaymentContact {
     String administrativeArea;
     String country;
     String countryCode;
+};
+
+struct LocalizedApplePayPaymentContact : ApplePayPaymentContact {
+    String localizedName;
+    String localizedPhoneticName;
 };
 
 }

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentContact.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentContact.idl
@@ -27,7 +27,6 @@
     Conditional=APPLE_PAY,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentContact {
     DOMString phoneNumber;
     DOMString emailAddress;

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentMethodUpdate.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentMethodUpdate.idl
@@ -25,11 +25,8 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentMethodUpdate : ApplePayDetailsUpdateBase {
-    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayError> errors;
-
-    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayShippingMethod> newShippingMethods;
-
+    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayError> errors = [];
+    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayShippingMethod> newShippingMethods = [];
     [Conditional=APPLE_PAY_INSTALLMENTS] DOMString installmentGroupIdentifier;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.h
@@ -43,13 +43,13 @@ namespace WebCore {
 struct ApplePayPaymentRequest : ApplePayRequestBase {
     using ShippingType = ApplePaySessionPaymentRequest::ShippingType;
 
+    ApplePayLineItem total;
+    std::optional<Vector<ApplePayLineItem>> lineItems;
+
     String currencyCode;
 
     ShippingType shippingType { ShippingType::Shipping };
     std::optional<Vector<ApplePayShippingMethod>> shippingMethods;
-
-    ApplePayLineItem total;
-    std::optional<Vector<ApplePayLineItem>> lineItems;
 
 #if ENABLE(APPLE_PAY_RECURRING_PAYMENTS)
     std::optional<ApplePayRecurringPaymentRequest> recurringPaymentRequest;

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentRequest.idl
@@ -34,7 +34,6 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayPaymentRequest : ApplePayRequestBase {
     required ApplePayLineItem total;
     sequence<ApplePayLineItem> lineItems;
@@ -45,13 +44,8 @@
     sequence<ApplePayShippingMethod> shippingMethods;
 
     [Conditional=APPLE_PAY_RECURRING_PAYMENTS] ApplePayRecurringPaymentRequest recurringPaymentRequest;
-
     [Conditional=APPLE_PAY_AUTOMATIC_RELOAD_PAYMENTS] ApplePayAutomaticReloadPaymentRequest automaticReloadPaymentRequest;
-
     [Conditional=APPLE_PAY_MULTI_MERCHANT_PAYMENTS] sequence<ApplePayPaymentTokenContext> multiTokenContexts;
-
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] ApplePayDeferredPaymentRequest deferredPaymentRequest;
-
     [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementRequest disbursementRequest;
-
 };

--- a/Source/WebCore/Modules/applepay/ApplePayRequestBase.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayRequestBase.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayRequestBase {
     sequence<ApplePayFeature> features;
 
@@ -40,7 +39,7 @@
     ApplePayPaymentContact shippingContact;
 
     DOMString applicationData;
-    sequence<DOMString> supportedCountries;
+    sequence<DOMString> supportedCountries = [];
 
     [Conditional=APPLE_PAY_INSTALLMENTS] ApplePayInstallmentConfiguration installmentConfiguration;
 

--- a/Source/WebCore/Modules/applepay/ApplePaySetupConfiguration.idl
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupConfiguration.idl
@@ -28,10 +28,9 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePaySetupConfiguration {
     DOMString merchantIdentifier;
     DOMString referrerIdentifier;
     DOMString signature;
-    sequence<DOMString> signedFields;
+    sequence<DOMString> signedFields = [];
 };

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ApplePayShippingContactSelectedEvent);
 
 ApplePayShippingContactSelectedEvent::ApplePayShippingContactSelectedEvent(const AtomString& type, unsigned version, const PaymentContact& shippingContact)
     : Event(EventInterfaceType::ApplePayShippingContactSelectedEvent, type, CanBubble::No, IsCancelable::No)
-    , m_shippingContact(shippingContact.toApplePayPaymentContact(version))
+    , m_shippingContact(shippingContact.toLocalizedApplePayPaymentContact(version))
 {
 }
 

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.h
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.h
@@ -49,7 +49,7 @@ public:
 private:
     ApplePayShippingContactSelectedEvent(const AtomString& type, unsigned version, const PaymentContact&);
 
-    const ApplePayPaymentContact m_shippingContact;
+    const LocalizedApplePayPaymentContact m_shippingContact;
 };
 
 }

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactUpdate.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactUpdate.idl
@@ -25,9 +25,7 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayShippingContactUpdate : ApplePayDetailsUpdateBase {
-    sequence<ApplePayError> errors;
-
-    sequence<ApplePayShippingMethod> newShippingMethods;
+    sequence<ApplePayError> errors = [];
+    sequence<ApplePayShippingMethod> newShippingMethods = [];
 };

--- a/Source/WebCore/Modules/applepay/ApplePayShippingMethodUpdate.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingMethodUpdate.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayShippingMethodUpdate : ApplePayDetailsUpdateBase {
-    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayShippingMethod> newShippingMethods;
+    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayShippingMethod> newShippingMethods = [];
 };

--- a/Source/WebCore/Modules/applepay/Payment.h
+++ b/Source/WebCore/Modules/applepay/Payment.h
@@ -34,6 +34,7 @@ OBJC_CLASS PKPayment;
 namespace WebCore {
 
 struct ApplePayPayment;
+struct LocalizedApplePayPayment;
 
 class WEBCORE_EXPORT Payment {
 public:
@@ -42,6 +43,7 @@ public:
     virtual ~Payment();
 
     virtual ApplePayPayment toApplePayPayment(unsigned version) const;
+    virtual LocalizedApplePayPayment toLocalizedApplePayPayment(unsigned version) const;
 
     RetainPtr<PKPayment> pkPayment() const;
 

--- a/Source/WebCore/Modules/applepay/PaymentContact.h
+++ b/Source/WebCore/Modules/applepay/PaymentContact.h
@@ -35,6 +35,7 @@ OBJC_CLASS PKContact;
 namespace WebCore {
 
 struct ApplePayPaymentContact;
+struct LocalizedApplePayPaymentContact;
 
 class WEBCORE_EXPORT PaymentContact {
 public:
@@ -43,7 +44,9 @@ public:
     virtual ~PaymentContact();
 
     static PaymentContact fromApplePayPaymentContact(unsigned version, const ApplePayPaymentContact&);
+
     virtual ApplePayPaymentContact toApplePayPaymentContact(unsigned version) const;
+    virtual LocalizedApplePayPaymentContact toLocalizedApplePayPaymentContact(unsigned version) const;
 
     RetainPtr<PKContact> pkContact() const;
 

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.idl
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.idl
@@ -25,21 +25,14 @@
 
 [
     Conditional=APPLE_PAY&PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayModifier {
     ApplePayPaymentMethodType paymentMethodType;
     ApplePayLineItem total;
-    sequence<ApplePayLineItem> additionalLineItems;
-    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayShippingMethod> additionalShippingMethods;
-
+    sequence<ApplePayLineItem> additionalLineItems = [];
+    [Conditional=APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS] sequence<ApplePayShippingMethod> additionalShippingMethods = [];
     [Conditional=APPLE_PAY_RECURRING_PAYMENTS] ApplePayRecurringPaymentRequest recurringPaymentRequest;
-
     [Conditional=APPLE_PAY_AUTOMATIC_RELOAD_PAYMENTS] ApplePayAutomaticReloadPaymentRequest automaticReloadPaymentRequest;
-
     [Conditional=APPLE_PAY_MULTI_MERCHANT_PAYMENTS] sequence<ApplePayPaymentTokenContext> multiTokenContexts;
-
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] ApplePayDeferredPaymentRequest deferredPaymentRequest;
-
     [Conditional=APPLE_PAY_DISBURSEMENTS] ApplePayDisbursementRequest disbursementRequest;
-
 };

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayRequest.h
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayRequest.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 struct ApplePayRequest : public ApplePayRequestBase {
-    unsigned long version;
+    uint32_t version;
     String merchantIdentifier;
 };
 

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayRequest.idl
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayRequest.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=APPLE_PAY&PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ApplePayRequest : ApplePayRequestBase {
     required unsigned long version;
     required DOMString merchantIdentifier;

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp
@@ -26,26 +26,23 @@
 #include "config.h"
 #include "CookieChangeEvent.h"
 
-#include "CookieChangeEventInit.h"
-#include "CookieListItem.h"
-#include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CookieChangeEvent);
 
-Ref<CookieChangeEvent> CookieChangeEvent::create(const AtomString& type, CookieChangeEventInit&& eventInitDict, IsTrusted isTrusted)
+Ref<CookieChangeEvent> CookieChangeEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new CookieChangeEvent(type, WTF::move(eventInitDict), isTrusted));
+    return adoptRef(*new CookieChangeEvent(type, WTF::move(initializer), isTrusted));
 }
 
-CookieChangeEvent::CookieChangeEvent(const AtomString& type, CookieChangeEventInit&& eventInitDict, IsTrusted isTrusted)
-    : Event(EventInterfaceType::CookieChangeEvent, type, eventInitDict, isTrusted)
-    , m_changed(WTF::move(eventInitDict.changed))
-    , m_deleted(WTF::move(eventInitDict.deleted))
-{ }
+CookieChangeEvent::CookieChangeEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : Event(EventInterfaceType::CookieChangeEvent, type, WTF::move(initializer), isTrusted)
+    , m_changed(WTF::move(initializer.changed).value_or(Vector<CookieListItem> { }))
+    , m_deleted(WTF::move(initializer.deleted).value_or(Vector<CookieListItem> { }))
+{
+}
 
 CookieChangeEvent::~CookieChangeEvent() = default;
 

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEvent.h
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEvent.h
@@ -29,23 +29,22 @@
 #include "Event.h"
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
-
-struct CookieListItem;
 
 class CookieChangeEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(CookieChangeEvent);
 public:
-    static Ref<CookieChangeEvent> create(const AtomString& type, CookieChangeEventInit&&, IsTrusted = IsTrusted::No);
+    using Init = CookieChangeEventInit;
+
+    static Ref<CookieChangeEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
     ~CookieChangeEvent();
 
     const Vector<CookieListItem>& changed() const { return m_changed; }
     const Vector<CookieListItem>& deleted() const { return m_deleted; }
 
 private:
-    CookieChangeEvent(const AtomString& type, CookieChangeEventInit&&, IsTrusted);
+    CookieChangeEvent(const AtomString& type, Init&&, IsTrusted);
 
     Vector<CookieListItem> m_changed;
     Vector<CookieListItem> m_deleted;

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEvent.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEvent.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#cookiechangeevent
-
+// https://cookiestore.spec.whatwg.org/#cookiechangeevent
 [
     EnabledBySetting=CookieStoreAPIEnabled,
     Exposed=Window,

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEventInit.h
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEventInit.h
@@ -27,13 +27,14 @@
 
 #include "CookieListItem.h"
 #include "Event.h"
+#include <optional>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 struct CookieChangeEventInit : EventInit {
-    Vector<CookieListItem> changed;
-    Vector<CookieListItem> deleted;
+    std::optional<Vector<CookieListItem>> changed;
+    std::optional<Vector<CookieListItem>> deleted;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cookie-store/CookieChangeEventInit.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieChangeEventInit.idl
@@ -23,13 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#dictdef-cookiechangeeventinit
-
+// https://cookiestore.spec.whatwg.org/#typedefdef-cookielist
 typedef sequence<CookieListItem> CookieList;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary CookieChangeEventInit : EventInit {
+// https://cookiestore.spec.whatwg.org/#dictdef-cookiechangeeventinit
+dictionary CookieChangeEventInit : EventInit {
     CookieList changed;
     CookieList deleted;
 };

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.h
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.h
@@ -31,15 +31,13 @@
 namespace WebCore {
 
 struct CookieListItem {
-    CookieListItem() = default;
-
-    CookieListItem(Cookie&& cookie)
-        : name(WTF::move(cookie.name))
-        , value(WTF::move(cookie.value))
-    { }
-
     String name;
     String value;
+
+    static CookieListItem fromCookie(Cookie&& cookie)
+    {
+        return { WTF::move(cookie.name), WTF::move(cookie.value) };
+    }
 };
 
-}
+} // namespace WebCore

--- a/Source/WebCore/Modules/cookie-store/CookieListItem.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieListItem.idl
@@ -24,11 +24,9 @@
  */
 
 // https://cookiestore.spec.whatwg.org/#dictdef-cookielistitem
-
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CookieListItem {
     USVString name;
     USVString value;

--- a/Source/WebCore/Modules/cookie-store/CookieSameSite.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieSameSite.idl
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#enumdef-cookiesamesite
+// https://cookiestore.spec.whatwg.org/#enumdef-cookiesamesite
 
 enum CookieSameSite {
     "strict",

--- a/Source/WebCore/Modules/cookie-store/CookieStore.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.idl
@@ -22,11 +22,11 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
-// https://wicg.github.io/cookie-store/#CookieStore
 
+// https://cookiestore.spec.whatwg.org/#typedefdef-cookielist
 typedef sequence<CookieListItem> CookieList;
 
+// https://cookiestore.spec.whatwg.org/#cookiestore
 [
     ActiveDOMObject,
     EnabledBySetting=CookieStoreAPIEnabled,

--- a/Source/WebCore/Modules/cookie-store/CookieStoreDeleteOptions.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreDeleteOptions.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#dictdef-cookiestoredeleteoptions
-
+// https://cookiestore.spec.whatwg.org/#dictdef-cookiestoredeleteoptions
 dictionary CookieStoreDeleteOptions {
     required USVString name;
     USVString? domain = null;

--- a/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#dictdef-cookiestoregetoptions
-
+// https://cookiestore.spec.whatwg.org/#dictdef-cookiestoregetoptions
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,

--- a/Source/WebCore/Modules/cookie-store/CookieStoreManager.idl
+++ b/Source/WebCore/Modules/cookie-store/CookieStoreManager.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#cookiestoremanager
-
+// https://cookiestore.spec.whatwg.org/#cookiestoremanager
 [
     EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled,
     Exposed=(ServiceWorker,Window),

--- a/Source/WebCore/Modules/cookie-store/DOMWindow+CookieStore.idl
+++ b/Source/WebCore/Modules/cookie-store/DOMWindow+CookieStore.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
  
-// https://wicg.github.io/cookie-store/#Window
-
+// https://cookiestore.spec.whatwg.org/#Window
 [
     EnabledBySetting=CookieStoreAPIEnabled,
     SecureContext

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp
@@ -26,26 +26,23 @@
 #include "config.h"
 #include "ExtendableCookieChangeEvent.h"
 
-#include "CookieListItem.h"
-#include "ExtendableCookieChangeEventInit.h"
-#include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ExtendableCookieChangeEvent);
 
-Ref<ExtendableCookieChangeEvent> ExtendableCookieChangeEvent::create(const AtomString& type, ExtendableCookieChangeEventInit&& eventInitDict, IsTrusted isTrusted)
+Ref<ExtendableCookieChangeEvent> ExtendableCookieChangeEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new ExtendableCookieChangeEvent(type, WTF::move(eventInitDict), isTrusted));
+    return adoptRef(*new ExtendableCookieChangeEvent(type, WTF::move(initializer), isTrusted));
 }
 
-ExtendableCookieChangeEvent::ExtendableCookieChangeEvent(const AtomString& type, ExtendableCookieChangeEventInit&& eventInitDict, IsTrusted isTrusted)
-    : ExtendableEvent(EventInterfaceType::ExtendableCookieChangeEvent, type, eventInitDict, isTrusted)
-    , m_changed(WTF::move(eventInitDict.changed))
-    , m_deleted(WTF::move(eventInitDict.deleted))
-{ }
+ExtendableCookieChangeEvent::ExtendableCookieChangeEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : ExtendableEvent(EventInterfaceType::ExtendableCookieChangeEvent, type, WTF::move(initializer), isTrusted)
+    , m_changed(WTF::move(initializer.changed).value_or(Vector<CookieListItem> { }))
+    , m_deleted(WTF::move(initializer.deleted).value_or(Vector<CookieListItem> { }))
+{
+}
 
 ExtendableCookieChangeEvent::~ExtendableCookieChangeEvent() = default;
 

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h
@@ -29,23 +29,22 @@
 #include "ExtendableEvent.h"
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
-
-struct CookieListItem;
 
 class ExtendableCookieChangeEvent final : public ExtendableEvent {
     WTF_MAKE_TZONE_ALLOCATED(ExtendableCookieChangeEvent);
 public:
-    static Ref<ExtendableCookieChangeEvent> create(const AtomString& type, ExtendableCookieChangeEventInit&&, IsTrusted = IsTrusted::No);
+    using Init = ExtendableCookieChangeEventInit;
+
+    static Ref<ExtendableCookieChangeEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
     ~ExtendableCookieChangeEvent();
 
     const Vector<CookieListItem>& changed() const { return m_changed; }
     const Vector<CookieListItem>& deleted() const { return m_deleted; }
 
 private:
-    ExtendableCookieChangeEvent(const AtomString& type, ExtendableCookieChangeEventInit&&, IsTrusted);
+    ExtendableCookieChangeEvent(const AtomString& type, Init&&, IsTrusted);
 
     Vector<CookieListItem> m_changed;
     Vector<CookieListItem> m_deleted;

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.idl
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#extendablecookiechangeevent
-
+// https://cookiestore.spec.whatwg.org/#extendablecookiechangeevent
 [
     EnabledBySetting=CookieStoreAPIEnabled&CookieStoreManagerEnabled,
     Exposed=ServiceWorker

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEventInit.h
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEventInit.h
@@ -27,13 +27,14 @@
 
 #include "CookieListItem.h"
 #include "ExtendableEventInit.h"
+#include <optional>
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
 struct ExtendableCookieChangeEventInit : ExtendableEventInit {
-    Vector<CookieListItem> changed;
-    Vector<CookieListItem> deleted;
+    std::optional<Vector<CookieListItem>> changed;
+    std::optional<Vector<CookieListItem>> deleted;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEventInit.idl
+++ b/Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEventInit.idl
@@ -23,13 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/cookie-store/#dictdef-extendablecookiechangeeventinit
-
+// https://cookiestore.spec.whatwg.org/#typedefdef-cookielist
 typedef sequence<CookieListItem> CookieList;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ExtendableCookieChangeEventInit : ExtendableEventInit {
+// https://cookiestore.spec.whatwg.org/#dictdef-extendablecookiechangeeventinit
+dictionary ExtendableCookieChangeEventInit : ExtendableEventInit {
     CookieList changed;
     CookieList deleted;
 };

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.idl
@@ -26,6 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/encrypted-media/#dom-mediakeysystemconfiguration
 [
     Conditional=ENCRYPTED_MEDIA,
     JSGenerateToJSObject,

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp
@@ -42,11 +42,10 @@ WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent(const AtomString& type, U
 {
 }
 
-
-WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::WebKitMediaKeyMessageEvent, type, initializer, isTrusted)
-    , m_message(initializer.message)
-    , m_destinationURL(initializer.destinationURL)
+WebKitMediaKeyMessageEvent::WebKitMediaKeyMessageEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : Event(EventInterfaceType::WebKitMediaKeyMessageEvent, type, WTF::move(initializer), isTrusted)
+    , m_message(WTF::move(initializer.message))
+    , m_destinationURL(WTF::move(initializer.destinationURL))
 {
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h
@@ -48,9 +48,9 @@ public:
         String destinationURL;
     };
 
-    static Ref<WebKitMediaKeyMessageEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<WebKitMediaKeyMessageEvent> create(const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new WebKitMediaKeyMessageEvent(type, initializer, isTrusted));
+        return adoptRef(*new WebKitMediaKeyMessageEvent(type, WTF::move(initializer), isTrusted));
     }
 
     Uint8Array* message() const { return m_message.get(); }
@@ -58,7 +58,7 @@ public:
 
 private:
     WebKitMediaKeyMessageEvent(const AtomString& type, Uint8Array* message, const String& destinationURL);
-    WebKitMediaKeyMessageEvent(const AtomString& type, const Init&, IsTrusted);
+    WebKitMediaKeyMessageEvent(const AtomString& type, Init&&, IsTrusted);
 
     RefPtr<Uint8Array> m_message;
     String m_destinationURL;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
@@ -34,9 +34,7 @@
     readonly attribute DOMString destinationURL;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary WebKitMediaKeyMessageEventInit : EventInit {
+dictionary WebKitMediaKeyMessageEventInit : EventInit {
     Uint8Array? message = null;
     DOMString destinationURL = "";
 };

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp
@@ -41,9 +41,9 @@ WebKitMediaKeyNeededEvent::WebKitMediaKeyNeededEvent(const AtomString& type, Uin
 {
 }
 
-WebKitMediaKeyNeededEvent::WebKitMediaKeyNeededEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::WebKitMediaKeyNeededEvent, type, initializer, isTrusted)
-    , m_initData(initializer.initData)
+WebKitMediaKeyNeededEvent::WebKitMediaKeyNeededEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : Event(EventInterfaceType::WebKitMediaKeyNeededEvent, type, WTF::move(initializer), isTrusted)
+    , m_initData(WTF::move(initializer.initData))
 {
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h
@@ -46,16 +46,16 @@ public:
         RefPtr<Uint8Array> initData;
     };
 
-    static Ref<WebKitMediaKeyNeededEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<WebKitMediaKeyNeededEvent> create(const AtomString& type, Init&& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new WebKitMediaKeyNeededEvent(type, initializer, isTrusted));
+        return adoptRef(*new WebKitMediaKeyNeededEvent(type, WTF::move(initializer), isTrusted));
     }
 
     Uint8Array* initData() const { return m_initData.get(); }
 
 private:
     WebKitMediaKeyNeededEvent(const AtomString& type, Uint8Array* initData);
-    WebKitMediaKeyNeededEvent(const AtomString& type, const Init&, IsTrusted);
+    WebKitMediaKeyNeededEvent(const AtomString& type, Init&&, IsTrusted);
 
     RefPtr<Uint8Array> m_initData;
 };

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
@@ -33,8 +33,6 @@
     readonly attribute Uint8Array initData;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary WebKitMediaKeyNeededEventInit : EventInit {
+dictionary WebKitMediaKeyNeededEventInit : EventInit {
     Uint8Array? initData = null;
 };

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.h
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.h
@@ -58,7 +58,7 @@ public:
 
     struct DatabaseInfo {
         String name;
-        uint64_t version;
+        std::optional<uint64_t> version;
     };
 
     ExceptionOr<Ref<IDBOpenDBRequest>> open(ScriptExecutionContext&, const String& name, std::optional<uint64_t> version);

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.idl
@@ -23,6 +23,7 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/IndexedDB/#idbfactory
 [
     EnabledBySetting=IndexedDBAPIEnabled,
     SkipVTableValidation,
@@ -36,9 +37,9 @@
     [CallWith=CurrentGlobalObject] short cmp(any first, any second);
 };
 
+// https://w3c.github.io/IndexedDB/#dictdef-idbdatabaseinfo
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary IDBDatabaseInfo {
     DOMString name;
     unsigned long long version;

--- a/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl
@@ -33,9 +33,7 @@
     readonly attribute unsigned long long? newVersion;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary IDBVersionChangeEventInit : EventInit {
+dictionary IDBVersionChangeEventInit : EventInit {
     unsigned long long oldVersion = 0;
     unsigned long long? newVersion = null;
 };

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsContextMenuItem.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsContextMenuItem.idl
@@ -27,11 +27,10 @@
     Conditional=MEDIA_CONTROLS_CONTEXT_MENUS,
     JSGenerateToJSObject,
     EnabledBySetting=MediaControlsContextMenusEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaControlsContextMenuItem {
-    unsigned long long id;
+    unsigned long long id = 0;
     DOMString title;
     DOMString icon;
-    boolean checked;
-    sequence<MediaControlsContextMenuItem> children;
+    boolean checked = false;
+    sequence<MediaControlsContextMenuItem> children = [];
 };

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.cpp
@@ -41,9 +41,9 @@ Ref<BlobEvent> BlobEvent::create(const AtomString& type, Init&& init, IsTrusted 
 }
 
 BlobEvent::BlobEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
-    : Event(EventInterfaceType::BlobEvent, type, init, isTrusted)
-    , m_blob(init.data.releaseNonNull())
-    , m_timecode(init.timecode)
+    : Event(EventInterfaceType::BlobEvent, type, WTF::move(init), isTrusted)
+    , m_blob(WTF::move(init.data))
+    , m_timecode(init.timecode.value_or(0))
 {
 }
 

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.h
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.h
@@ -36,8 +36,8 @@ class BlobEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(BlobEvent);
 public:
     struct Init : EventInit {
-        RefPtr<Blob> data;
-        double timecode;
+        Ref<Blob> data;
+        std::optional<double> timecode;
     };
     
     static Ref<BlobEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);

--- a/Source/WebCore/Modules/mediarecorder/BlobEvent.idl
+++ b/Source/WebCore/Modules/mediarecorder/BlobEvent.idl
@@ -24,21 +24,19 @@
 
 typedef double DOMHighResTimeStamp;
 
+// https://w3c.github.io/mediacapture-record/#blobevent
 [
     Conditional=MEDIA_RECORDER,
     EnabledBySetting=MediaRecorderEnabled,
     Exposed=Window
 ]  interface BlobEvent : Event {
     constructor([AtomString] DOMString type, BlobEventInit eventInitDict);
-
-    // FIXME: Implement these:
     [SameObject] readonly attribute Blob data;
     readonly attribute DOMHighResTimeStamp timecode;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary BlobEventInit : EventInit {
+// https://w3c.github.io/mediacapture-record/#dictdef-blobeventinit
+dictionary BlobEventInit : EventInit {
     required Blob data;
     DOMHighResTimeStamp timecode;
 };

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp
@@ -42,19 +42,18 @@ Ref<MediaRecorderErrorEvent> MediaRecorderErrorEvent::create(const AtomString& t
 
 Ref<MediaRecorderErrorEvent> MediaRecorderErrorEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
-    Ref domError = init.error.releaseNonNull();
-    return adoptRef(*new MediaRecorderErrorEvent(type, WTF::move(init), WTF::move(domError), isTrusted));
+    return adoptRef(*new MediaRecorderErrorEvent(type, WTF::move(init), isTrusted));
 }
 
-MediaRecorderErrorEvent::MediaRecorderErrorEvent(const AtomString& type, Init&& init, Ref<DOMException>&& exception, IsTrusted isTrusted)
+MediaRecorderErrorEvent::MediaRecorderErrorEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
     : Event(EventInterfaceType::MediaRecorderErrorEvent, type, WTF::move(init), isTrusted)
-    , m_domError(WTF::move(exception))
+    , m_error(WTF::move(init.error))
 {
 }
 
 MediaRecorderErrorEvent::MediaRecorderErrorEvent(const AtomString& type, Exception&& exception)
     : Event(EventInterfaceType::MediaRecorderErrorEvent, type, Event::CanBubble::No, Event::IsCancelable::No)
-    , m_domError(DOMException::create(exception))
+    , m_error(DOMException::create(exception))
 {
 }
 

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h
@@ -36,19 +36,19 @@ class MediaRecorderErrorEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(MediaRecorderErrorEvent);
 public:
     struct Init : EventInit {
-        RefPtr<DOMException> error;
+        Ref<DOMException> error;
     };
-    
+
     static Ref<MediaRecorderErrorEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     static Ref<MediaRecorderErrorEvent> create(const AtomString&, Exception&&);
-    
-    DOMException& error() const { return m_domError.get(); }
+
+    DOMException& error() const { return m_error; }
 
 private:
-    MediaRecorderErrorEvent(const AtomString&, Init&&, Ref<DOMException>&&, IsTrusted);
+    MediaRecorderErrorEvent(const AtomString&, Init&&, IsTrusted);
     MediaRecorderErrorEvent(const AtomString&, Exception&&);
 
-    const Ref<DOMException> m_domError;
+    const Ref<DOMException> m_error;
 };
     
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.idl
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.idl
@@ -22,9 +22,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MediaRecorderErrorEventInit : EventInit {
+dictionary MediaRecorderErrorEventInit : EventInit {
     required DOMException error;
 };
 

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
@@ -23,23 +23,24 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    Conditional=MEDIA_SOURCE,
-    EnabledBySetting=ManagedMediaSourceEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary BufferedChangeEventInit : EventInit {
-  TimeRanges addedRanges;
-  TimeRanges removedRanges;
-};
-
+// https://w3c.github.io/media-source/#dom-bufferedchangeevent
 [
     Conditional=MEDIA_SOURCE,
     ConditionalForWorker=MEDIA_SOURCE_IN_WORKERS,
     EnabledBySetting=ManagedMediaSourceEnabled,
     Exposed=(Window,DedicatedWorker)
-]
-interface BufferedChangeEvent : Event {
+] interface BufferedChangeEvent : Event {
   constructor([AtomString] DOMString type, BufferedChangeEventInit eventInitDict);
   [SameObject] readonly attribute TimeRanges? addedRanges;
   [SameObject] readonly attribute TimeRanges? removedRanges;
 };
+
+// https://w3c.github.io/media-source/#dom-bufferedchangeeventinit
+[
+    Conditional=MEDIA_SOURCE,
+    EnabledBySetting=ManagedMediaSourceEnabled,
+] dictionary BufferedChangeEventInit : EventInit {
+  TimeRanges addedRanges;
+  TimeRanges removedRanges;
+};
+

--- a/Source/WebCore/Modules/mediastream/DoubleRange.idl
+++ b/Source/WebCore/Modules/mediastream/DoubleRange.idl
@@ -22,6 +22,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/mediacapture-main/#dom-doublerange
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -56,19 +56,24 @@ enum MediaStreamTrackState { "live", "ended" };
     Promise<undefined> applyConstraints(optional MediaTrackConstraints constraints = {});
 };
 
+// https://w3c.github.io/mediacapture-main/#dom-mediatracksettings
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaTrackSettings {
+    // FIXME: `width` should be of type `unsigned long`.
     long width;
+    // FIXME: `height` should be of type `unsigned long`.
     long height;
     double aspectRatio;
     double frameRate;
     DOMString facingMode;
     double volume;
+    // FIXME: `sampleRate` should be of type `unsigned long`.
     long sampleRate;
+    // FIXME: `sampleSize` should be of type `unsigned long`.
     long sampleSize;
+    // FIXME: `echoCancellation` should be of type `(boolean or DOMString)`.
     boolean echoCancellation;
     // FIXME 169871: add latency
     // FIXME 169871: add channelCount

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp
@@ -51,8 +51,8 @@ MediaStreamTrackEvent::MediaStreamTrackEvent(const AtomString& type, CanBubble c
 }
 
 MediaStreamTrackEvent::MediaStreamTrackEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::MediaStreamTrackEvent, type, initializer, isTrusted)
-    , m_track(initializer.track.releaseNonNull())
+    : Event(EventInterfaceType::MediaStreamTrackEvent, type, WTF::move(initializer), isTrusted)
+    , m_track(WTF::move(initializer.track))
 {
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h
@@ -41,7 +41,7 @@ public:
     static Ref<MediaStreamTrackEvent> create(const AtomString& type, CanBubble, IsCancelable, Ref<MediaStreamTrack>&&);
 
     struct Init : EventInit {
-        RefPtr<MediaStreamTrack> track;
+        Ref<MediaStreamTrack> track;
     };
     static Ref<MediaStreamTrackEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl
@@ -31,8 +31,7 @@
     [SameObject] readonly attribute MediaStreamTrack track;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MediaStreamTrackEventInit : EventInit {
+// https://w3c.github.io/mediacapture-main/#dom-mediastreamtrackeventinit
+dictionary MediaStreamTrackEventInit : EventInit {
     required MediaStreamTrack track;
 };

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -53,7 +53,7 @@ ExceptionOr<Ref<MediaStreamTrackProcessor>> MediaStreamTrackProcessor::create(Sc
     if (init.track->ended())
         return Exception { ExceptionCode::TypeError, "Track is ended"_s };
 
-    return adoptRef(*new MediaStreamTrackProcessor(context, *init.track, init.maxBufferSize));
+    return adoptRef(*new MediaStreamTrackProcessor(context, WTF::move(init.track), init.maxBufferSize.value_or(1)));
 }
 
 MediaStreamTrackProcessor::MediaStreamTrackProcessor(ScriptExecutionContext& context, Ref<MediaStreamTrack>&& track, unsigned short maxVideoFramesCount)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h
@@ -49,8 +49,8 @@ class MediaStreamTrackProcessor
     WTF_MAKE_TZONE_ALLOCATED(MediaStreamTrackProcessor);
 public:
     struct Init {
-        RefPtr<MediaStreamTrack> track;
-        unsigned short maxBufferSize { 1 };
+        Ref<MediaStreamTrack> track;
+        std::optional<unsigned short> maxBufferSize;
     };
 
     static ExceptionOr<Ref<MediaStreamTrackProcessor>> create(ScriptExecutionContext&, Init&&);

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl
@@ -22,6 +22,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/mediacapture-transform/#mediastreamtrackprocessor
 [
     Conditional=MEDIA_STREAM&WEB_CODECS,
     PrivateIdentifier,
@@ -33,10 +34,11 @@
     [CallWith=CurrentGlobalObject] readonly attribute ReadableStream readable;
 };
 
+// https://w3c.github.io/mediacapture-transform/#dictdef-mediastreamtrackprocessorinit
 [
     Conditional=MEDIA_STREAM&WEB_CODECS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaStreamTrackProcessorInit {
+    // FIXME: `track` should be of type `(MediaStreamTrack or MediaStreamTrackHandle)`.
     required MediaStreamTrack track;
     [EnforceRange] unsigned short maxBufferSize;
 };

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
@@ -23,19 +23,22 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
+// https://w3c.github.io/mediacapture-main/#dom-mediatrackcapabilities
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaTrackCapabilities {
+    // FIXME: `width` should be of type `ULongRange`.
     LongRange width;
+    // FIXME: `height` should be of type `ULongRange`.
     LongRange height;
     DoubleRange aspectRatio;
     DoubleRange frameRate;
     sequence<DOMString> facingMode;
     DoubleRange volume;
+    // FIXME: `sampleRate` should be of type `ULongRange`.
     LongRange sampleRate;
+    // FIXME: `sampleSize` should be of type `ULongRange`.
     LongRange sampleSize;
     sequence<boolean> echoCancellation;
     // FIXME 169871: add latency

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
@@ -22,30 +22,35 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraints
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaTrackConstraints : MediaTrackConstraintSet {
     sequence<MediaTrackConstraintSet> advanced;
 };
 
+// https://w3c.github.io/mediacapture-main/#dom-mediatrackconstraintset
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ImplementedAs=MediaTrackConstraintSet,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaTrackConstraintSet {
+    // FIXME: `width` should be of type `ConstrainULong`.
     ConstrainLong width;
+    // FIXME: `height` should be of type `ConstrainULong`.
     ConstrainLong height;
     ConstrainDouble aspectRatio;
     ConstrainDouble frameRate;
     ConstrainDOMString facingMode;
     ConstrainDouble volume;
+    // FIXME: `sampleRate` should be of type `ConstrainULong`.
     ConstrainLong sampleRate;
+    // FIXME: `sampleSize` should be of type `ConstrainULong`.
     ConstrainLong sampleSize;
+    // FIXME: `echoCancellation` should be of type `ConstrainBooleanOrDOMString`.
     ConstrainBoolean echoCancellation;
     // FIXME 169871: add latency
     // FIXME 169871: add channelCount
@@ -83,34 +88,34 @@ typedef (long or ConstrainLongRange) ConstrainLong;
 typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
 typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
 
+// https://w3c.github.io/mediacapture-main/#dom-constrainbooleanparameters
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ImplementedAs=ConstrainBooleanParameters,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ConstrainBooleanParameters {
     boolean exact;
     boolean ideal;
 };
 
+// https://w3c.github.io/mediacapture-main/#dom-constraindomstringparameters
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ImplementedAs=ConstrainDOMStringParameters,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ConstrainDOMStringParameters {
     (DOMString or sequence<DOMString>) exact;
     (DOMString or sequence<DOMString>) ideal;
 };
 
+// https://w3c.github.io/mediacapture-main/#dom-constraindoublerange
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ImplementedAs=ConstrainDoubleRange,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ConstrainDoubleRange : DoubleRange {
     double exact;
     double ideal;
@@ -121,7 +126,6 @@ typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) Const
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ImplementedAs=ConstrainLongRange,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ConstrainLongRange : LongRange {
     long exact;
     long ideal;

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
@@ -28,10 +28,10 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/mediacapture-main/#dom-mediatracksupportedconstraints
 [
     Conditional=MEDIA_STREAM,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaTrackSupportedConstraints {
     boolean width = true;
     boolean height = true;

--- a/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl
@@ -35,8 +35,6 @@
     readonly attribute OverconstrainedError? error;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary OverconstrainedErrorEventInit : EventInit {
+dictionary OverconstrainedErrorEventInit : EventInit {
     OverconstrainedError? error = null;
 };

--- a/Source/WebCore/Modules/mediastream/RTCAnswerOptions.idl
+++ b/Source/WebCore/Modules/mediastream/RTCAnswerOptions.idl
@@ -26,6 +26,5 @@
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCAnswerOptions : RTCOfferAnswerOptions {
 };

--- a/Source/WebCore/Modules/mediastream/RTCCertificate.idl
+++ b/Source/WebCore/Modules/mediastream/RTCCertificate.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCDtlsFingerprint {
     DOMString algorithm;
     DOMString value;

--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.h
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.h
@@ -46,8 +46,8 @@ struct RTCConfiguration {
     RTCIceTransportPolicy iceTransportPolicy;
     RTCBundlePolicy bundlePolicy;
     RTCPMuxPolicy rtcpMuxPolicy;
-    unsigned short iceCandidatePoolSize;
     Vector<Ref<RTCCertificate>> certificates;
+    unsigned short iceCandidatePoolSize;
     enum class TargetLatency { Lowest, None };
     TargetLatency targetLatency { TargetLatency::Lowest };
 };

--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.idl
@@ -59,19 +59,19 @@
   "none"
 };
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcconfiguration
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCConfiguration {
     sequence<RTCIceServer> iceServers = [];
     RTCIceTransportPolicy iceTransportPolicy = "all";
     RTCBundlePolicy bundlePolicy = "balanced";
     RTCPMuxPolicy rtcpMuxPolicy = "require";
     // FIXME 169662: missing peerIdentity
-    sequence<RTCCertificate> certificates;
+    sequence<RTCCertificate> certificates = [];
     [EnforceRange] octet iceCandidatePoolSize = 0;
     RTCConfigurationTargetLatency targetLatency = "lowest";
 };

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp
@@ -40,9 +40,9 @@ Ref<RTCDTMFToneChangeEvent> RTCDTMFToneChangeEvent::create(const String& tone)
     return adoptRef(*new RTCDTMFToneChangeEvent(tone));
 }
 
-Ref<RTCDTMFToneChangeEvent> RTCDTMFToneChangeEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+Ref<RTCDTMFToneChangeEvent> RTCDTMFToneChangeEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new RTCDTMFToneChangeEvent(type, initializer, isTrusted));
+    return adoptRef(*new RTCDTMFToneChangeEvent(type, WTF::move(initializer), isTrusted));
 }
 
 RTCDTMFToneChangeEvent::RTCDTMFToneChangeEvent(const String& tone)
@@ -51,9 +51,9 @@ RTCDTMFToneChangeEvent::RTCDTMFToneChangeEvent(const String& tone)
 {
 }
 
-RTCDTMFToneChangeEvent::RTCDTMFToneChangeEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::RTCDTMFToneChangeEvent, type, initializer, isTrusted)
-    , m_tone(initializer.tone)
+RTCDTMFToneChangeEvent::RTCDTMFToneChangeEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : Event(EventInterfaceType::RTCDTMFToneChangeEvent, type, WTF::move(initializer), isTrusted)
+    , m_tone(WTF::move(initializer.tone))
 {
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h
@@ -43,13 +43,13 @@ public:
         String tone;
     };
 
-    static Ref<RTCDTMFToneChangeEvent> create(const AtomString& type, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<RTCDTMFToneChangeEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
 
     const String& tone() const;
 
 private:
-    explicit RTCDTMFToneChangeEvent(const String& tone);
-    RTCDTMFToneChangeEvent(const AtomString& type, const Init&, IsTrusted);
+    RTCDTMFToneChangeEvent(const String& tone);
+    RTCDTMFToneChangeEvent(const AtomString& type, Init&&, IsTrusted);
 
     String m_tone;
 };

--- a/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.idl
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcdtmftonechangeevent
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -34,10 +35,10 @@
     readonly attribute DOMString tone;
 };
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcdtmftonechangeeventinit
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCDTMFToneChangeEventInit : EventInit {
-    DOMString tone;
+    DOMString tone = "";
 };

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp
@@ -52,8 +52,8 @@ RTCDataChannelEvent::RTCDataChannelEvent(const AtomString& type, CanBubble canBu
 }
 
 RTCDataChannelEvent::RTCDataChannelEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::RTCDataChannelEvent, type, initializer, isTrusted)
-    , m_channel(initializer.channel.releaseNonNull())
+    : Event(EventInterfaceType::RTCDataChannelEvent, type, WTF::move(initializer), isTrusted)
+    , m_channel(WTF::move(initializer.channel))
 {
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h
@@ -37,7 +37,7 @@ class RTCDataChannelEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(RTCDataChannelEvent);
 public:
     struct Init : EventInit {
-        RefPtr<RTCDataChannel> channel;
+        Ref<RTCDataChannel> channel;
     };
 
     static Ref<RTCDataChannelEvent> create(const AtomString& type, CanBubble, IsCancelable, Ref<RTCDataChannel>&&);

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelEvent.idl
@@ -23,6 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcdatachannelevent
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -33,8 +34,7 @@
     readonly attribute RTCDataChannel channel;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCDataChannelEventInit : EventInit {
+// https://w3c.github.io/webrtc-pc/#dom-rtcdatachanneleventinit
+dictionary RTCDataChannelEventInit : EventInit {
     required RTCDataChannel channel;
 };

--- a/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.idl
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.idl
@@ -29,7 +29,6 @@
     Conditional=WEB_RTC,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCEncodedAudioFrameMetadata {
     unsigned long synchronizationSource;
     octet payloadType;
@@ -45,7 +44,6 @@
 
 [
     Conditional=WEB_RTC,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCEncodedAudioFrameOptions {
     RTCEncodedAudioFrameMetadata metadata;
 };

--- a/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl
@@ -27,13 +27,11 @@
 
 enum RTCEncodedVideoFrameType { "empty", "key", "delta" };
 
-// // https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrameMetadata
-
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrameMetadata
 [
     Conditional=WEB_RTC,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCEncodedVideoFrameMetadata {
     long long frameId;
     sequence<long long> dependencies;
@@ -53,15 +51,14 @@ enum RTCEncodedVideoFrameType { "empty", "key", "delta" };
     DOMString mimeType;
 };
 
+// https://w3c.github.io/webrtc-encoded-transform/#dictdef-rtcencodedvideoframeoptions
 [
     Conditional=WEB_RTC,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCEncodedVideoFrameOptions {
     RTCEncodedVideoFrameMetadata metadata;
 };
 
 // https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-interface
-
 [
     Conditional=WEB_RTC,
     EnabledBySetting=WebRTCEncodedTransformEnabled,

--- a/Source/WebCore/Modules/mediastream/RTCError.idl
+++ b/Source/WebCore/Modules/mediastream/RTCError.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcerror
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -39,9 +40,8 @@
     readonly attribute unsigned long? sentAlert;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCErrorInit {
+// https://w3c.github.io/webrtc-pc/#dom-rtcerrorinit
+dictionary RTCErrorInit {
     required RTCErrorDetailType errorDetail;
     long sdpLineNumber;
     long sctpCauseCode;

--- a/Source/WebCore/Modules/mediastream/RTCErrorEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCErrorEvent.cpp
@@ -34,9 +34,19 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RTCErrorEvent);
 
+Ref<RTCErrorEvent> RTCErrorEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
+{
+    return adoptRef(*new RTCErrorEvent(type, WTF::move(init), isTrusted));
+}
+
+Ref<RTCErrorEvent> RTCErrorEvent::create(const AtomString& type, Ref<RTCError>&& error)
+{
+    return create(type, Init { { false, false, false }, WTF::move(error) }, IsTrusted::Yes);
+}
+
 RTCErrorEvent::RTCErrorEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::RTCErrorEvent, type, initializer, isTrusted)
-    , m_error(initializer.error.releaseNonNull())
+    : Event(EventInterfaceType::RTCErrorEvent, type, WTF::move(initializer), isTrusted)
+    , m_error(WTF::move(initializer.error))
 {
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCErrorEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCErrorEvent.h
@@ -36,10 +36,11 @@ class RTCErrorEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(RTCErrorEvent);
 public:
     struct Init : EventInit {
-        RefPtr<RTCError> error;
+        Ref<RTCError> error;
     };
-    static Ref<RTCErrorEvent> create(const AtomString& type, Init&& init, IsTrusted isTrusted = IsTrusted::No) { return adoptRef(*new RTCErrorEvent(type, WTF::move(init), isTrusted)); }
-    static Ref<RTCErrorEvent> create(const AtomString& type, RefPtr<RTCError>&& error) { return create(type, Init { { }, WTF::move(error) }, IsTrusted::Yes); }
+
+    static Ref<RTCErrorEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
+    static Ref<RTCErrorEvent> create(const AtomString& type, Ref<RTCError>&&);
 
     RTCError& error() const { return m_error.get(); }
 

--- a/Source/WebCore/Modules/mediastream/RTCErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCErrorEvent.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcerrorevent
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -32,8 +33,7 @@
     [SameObject] readonly attribute RTCError error;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCErrorEventInit : EventInit {
+// https://w3c.github.io/webrtc-pc/#dom-rtcerroreventinit
+dictionary RTCErrorEventInit : EventInit {
     required RTCError error;
 };

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidateInit.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidateInit.idl
@@ -30,12 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcicecandidateinit
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCIceCandidateInit {
     DOMString candidate = "";
     DOMString? sdpMid = null;

--- a/Source/WebCore/Modules/mediastream/RTCIceServer.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceServer.idl
@@ -24,13 +24,11 @@
  */
 
 // https://w3c.github.io/webrtc-pc/#dom-rtciceserver
-
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCIceServer {
     required (DOMString or sequence<DOMString>) urls;
     DOMString username;

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.idl
@@ -30,7 +30,6 @@ typedef RTCIceGatheringState IceGatheringState;
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCIceCandidatePair {
     RTCIceCandidate local;
     RTCIceCandidate remote;

--- a/Source/WebCore/Modules/mediastream/RTCLocalSessionDescriptionInit.idl
+++ b/Source/WebCore/Modules/mediastream/RTCLocalSessionDescriptionInit.idl
@@ -22,9 +22,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtclocalsessiondescriptioninit
 [
     Conditional=WEB_RTC,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCLocalSessionDescriptionInit {
     RTCSdpType type;
     DOMString sdp = "";

--- a/Source/WebCore/Modules/mediastream/RTCOfferAnswerOptions.idl
+++ b/Source/WebCore/Modules/mediastream/RTCOfferAnswerOptions.idl
@@ -26,8 +26,6 @@
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
-    ImplementedAs=RTCOfferAnswerOptions,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCOfferAnswerOptions {
     boolean voiceActivityDetection = true;
 };

--- a/Source/WebCore/Modules/mediastream/RTCOfferOptions.idl
+++ b/Source/WebCore/Modules/mediastream/RTCOfferOptions.idl
@@ -26,10 +26,9 @@
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCOfferOptions : RTCOfferAnswerOptions {
     boolean iceRestart = false;
 
-    [EnabledBySetting=LegacyWebRTCOfferOptionsEnabled] boolean? offerToReceiveVideo;
-    [EnabledBySetting=LegacyWebRTCOfferOptionsEnabled] boolean? offerToReceiveAudio;
+    [EnabledBySetting=LegacyWebRTCOfferOptionsEnabled, ImplementationDefaultValue=null] boolean? offerToReceiveVideo;
+    [EnabledBySetting=LegacyWebRTCOfferOptionsEnabled, ImplementationDefaultValue=null] boolean? offerToReceiveAudio;
 };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.idl
@@ -53,7 +53,6 @@ typedef RTCRtpTransceiverDirection RtpTransceiverDirection;
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCCertificateParameters {
     DOMString name;
     DOMString hash;
@@ -69,7 +68,6 @@ typedef (object or DOMString) AlgorithmIdentifier;
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     ImplementedAs=RTCRtpTransceiverInit,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpTransceiverInit {
     RtpTransceiverDirection direction = "sendrecv";
     sequence<MediaStream> streams = [];

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.idl
@@ -23,16 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
-    DOMString? address;
-    unsigned short? port;
-    DOMString url;
-    required unsigned short errorCode;
-    USVString errorText;
-};
-
+// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceerrorevent
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -45,4 +36,13 @@
     readonly attribute DOMString url;
     readonly attribute unsigned short errorCode;
     readonly attribute USVString errorText;
+};
+
+// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceerroreventinit
+dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
+    [ImplementationDefaultValue=null] DOMString? address;
+    [ImplementationDefaultValue=null] unsigned short? port;
+    DOMString url;
+    required unsigned short errorCode;
+    USVString errorText;
 };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp
@@ -43,7 +43,7 @@ Ref<RTCPeerConnectionIceEvent> RTCPeerConnectionIceEvent::create(CanBubble canBu
 Ref<RTCPeerConnectionIceEvent> RTCPeerConnectionIceEvent::create(const AtomString& type, Init&& init)
 {
     return adoptRef(*new RTCPeerConnectionIceEvent(type, init.bubbles ? CanBubble::Yes : CanBubble::No,
-        init.cancelable ? IsCancelable::Yes : IsCancelable::No, WTF::move(init.candidate), WTF::move(init.url)));
+        init.cancelable ? IsCancelable::Yes : IsCancelable::No, WTF::move(init.candidate).value_or(RefPtr<RTCIceCandidate> { }), WTF::move(init.url).value_or(String { })));
 }
 
 RTCPeerConnectionIceEvent::RTCPeerConnectionIceEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<RTCIceCandidate>&& candidate, String&& serverURL)

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
@@ -38,8 +38,8 @@ public:
     virtual ~RTCPeerConnectionIceEvent();
 
     struct Init : EventInit {
-        RefPtr<RTCIceCandidate> candidate;
-        String url;
+        std::optional<RefPtr<RTCIceCandidate>> candidate;
+        std::optional<String> url;
     };
 
     static Ref<RTCPeerConnectionIceEvent> create(const AtomString& type, Init&&);

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl
@@ -23,13 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCPeerConnectionIceEventInit : EventInit {
-    RTCIceCandidate? candidate;
-    DOMString? url;
-};
-
+// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceevent
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -40,3 +34,10 @@
     readonly attribute RTCIceCandidate? candidate;
     readonly attribute DOMString? url;
 };
+
+// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnectioniceeventinit
+dictionary RTCPeerConnectionIceEventInit : EventInit {
+    [ImplementationDefaultValue=null] RTCIceCandidate? candidate;
+    [ImplementationDefaultValue=null] DOMString? url;
+};
+

--- a/Source/WebCore/Modules/mediastream/RTCRtcpParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtcpParameters.idl
@@ -23,12 +23,12 @@
 * THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtcpparameters
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtcpParameters {
     DOMString cname;
     boolean reducedSize;

--- a/Source/WebCore/Modules/mediastream/RTCRtpCapabilities.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpCapabilities.idl
@@ -22,20 +22,20 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtpheaderextensioncapability
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpHeaderExtensionCapability {
     DOMString uri;
 };
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtpcapabilities
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpCapabilities {
     required sequence<RTCRtpCodecCapability> codecs;
     required sequence<RTCRtpHeaderExtensionCapability> headerExtensions;

--- a/Source/WebCore/Modules/mediastream/RTCRtpCodecCapability.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpCodecCapability.idl
@@ -22,12 +22,13 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtpcodec
+// FIXME: This should be named `RTCRtpCodec`.
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpCodecCapability {
     required DOMString mimeType;
     required unsigned long clockRate;

--- a/Source/WebCore/Modules/mediastream/RTCRtpCodecParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpCodecParameters.idl
@@ -23,6 +23,8 @@
 * THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtpcodecparameters
+// FIXME: `RTCRtpCodecParameters` should inherit from `RTCRtpCodec`.
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,

--- a/Source/WebCore/Modules/mediastream/RTCRtpCodingParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpCodingParameters.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpCodingParameters {
     DOMString rid;
 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpContributingSource.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpContributingSource.idl
@@ -25,11 +25,11 @@
 
 typedef double DOMHighResTimeStamp;
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtpcontributingsource
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpContributingSource {
     required DOMHighResTimeStamp timestamp;
     required unsigned long rtpTimestamp;

--- a/Source/WebCore/Modules/mediastream/RTCRtpDecodingParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpDecodingParameters.idl
@@ -27,6 +27,5 @@
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpDecodingParameters : RTCRtpCodingParameters {
 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h
@@ -35,7 +35,7 @@ namespace WebCore {
 struct RTCRtpEncodingParameters : RTCRtpCodingParameters {
     unsigned long ssrc { 0 };
 
-    bool active { false};
+    bool active { true };
     std::optional<unsigned long> maxBitrate;
     std::optional<unsigned long> maxFramerate;
     std::optional<double> scaleResolutionDownBy;

--- a/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl
@@ -23,20 +23,21 @@
 * THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpEncodingParameters : RTCRtpCodingParameters {
-    unsigned long ssrc;
+    [ImplementationDefaultValue=0] unsigned long ssrc;
 
     boolean active = true;
     unsigned long maxBitrate;
+    // FIXME: `maxFramerate` should be of type `double`.
     unsigned long maxFramerate;
     double scaleResolutionDownBy;
 
-    RTCPriorityType priority;
+    RTCPriorityType priority = "low";
     RTCPriorityType networkPriority;
 };

--- a/Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.idl
@@ -28,7 +28,6 @@
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpHeaderExtensionParameters {
     required DOMString uri;
     required unsigned short id;

--- a/Source/WebCore/Modules/mediastream/RTCRtpParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpParameters.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpParameters {
     required sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
     required RTCRtcpParameters rtcp;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.idl
@@ -34,9 +34,7 @@ enum RTCRtpSFrameTransformCompatibilityMode {
     "VP8"
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCRtpSFrameTransformOptions {
+dictionary RTCRtpSFrameTransformOptions {
     RTCRtpSFrameTransformRole role = "encrypt";
     unsigned long authenticationSize = 10;
     RTCRtpSFrameTransformCompatibilityMode compatibilityMode = "none";

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl
@@ -32,15 +32,11 @@ enum RTCRtpSFrameTransformErrorEventType {
 };
 
 // https://w3c.github.io/webrtc-encoded-transform/#dictdef-sframetransformerroreventinit
-
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCRtpSFrameTransformErrorEventInit : EventInit {
+dictionary RTCRtpSFrameTransformErrorEventInit : EventInit {
     required RTCRtpSFrameTransformErrorEventType errorType;
 };
 
 // https://w3c.github.io/webrtc-encoded-transform/#sframetransformerrorevent
-
 [
     Conditional=WEB_RTC,
     EnabledBySetting=WebRTCSFrameTransformEnabled,

--- a/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.h
@@ -35,12 +35,6 @@
 namespace WebCore {
 
 struct RTCRtpSendParameters : RTCRtpParameters {
-    RTCRtpSendParameters() = default;
-    explicit RTCRtpSendParameters(RTCRtpParameters&& parameters)
-        : RTCRtpParameters(WTF::move(parameters))
-    {
-    }
-
     String transactionId;
     Vector<RTCRtpEncodingParameters> encodings;
     std::optional<RTCDegradationPreference> degradationPreference;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSendParameters.idl
@@ -28,7 +28,6 @@
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpSendParameters : RTCRtpParameters {
     required DOMString transactionId;
     required sequence<RTCRtpEncodingParameters> encodings;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSynchronizationSource.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSynchronizationSource.idl
@@ -25,11 +25,11 @@
 
 typedef double DOMHighResTimeStamp;
 
+// https://w3c.github.io/webrtc-pc/#dom-rtcrtpsynchronizationsource
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpSynchronizationSource : RTCRtpContributingSource {
     boolean voiceActivityFlag;
 };

--- a/Source/WebCore/Modules/mediastream/RTCSessionDescriptionInit.idl
+++ b/Source/WebCore/Modules/mediastream/RTCSessionDescriptionInit.idl
@@ -29,12 +29,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-pc/#dom-rtclocalsessiondescriptioninit
 [
     Conditional=WEB_RTC,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCSessionDescriptionInit {
+    // FIXME: `type` should not be required.
     required RTCSdpType type;
     DOMString sdp = "";
 };

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp
@@ -62,11 +62,11 @@ RTCTrackEvent::RTCTrackEvent(const AtomString& type, CanBubble canBubble, IsCanc
 }
 
 RTCTrackEvent::RTCTrackEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::RTCTrackEvent, type, initializer, isTrusted)
-    , m_receiver(initializer.receiver.releaseNonNull())
-    , m_track(initializer.track.releaseNonNull())
-    , m_streams(initializer.streams)
-    , m_transceiver(initializer.transceiver.releaseNonNull())
+    : Event(EventInterfaceType::RTCTrackEvent, type, WTF::move(initializer), isTrusted)
+    , m_receiver(WTF::move(initializer.receiver))
+    , m_track(WTF::move(initializer.track))
+    , m_streams(WTF::move(initializer.streams))
+    , m_transceiver(WTF::move(initializer.transceiver))
 {
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.h
@@ -50,10 +50,10 @@ public:
     static Ref<RTCTrackEvent> create(const AtomString& type, CanBubble, IsCancelable, Ref<RTCRtpReceiver>&&, Ref<MediaStreamTrack>&&, MediaStreamArray&&, Ref<RTCRtpTransceiver>&&);
 
     struct Init : EventInit {
-        RefPtr<RTCRtpReceiver> receiver;
-        RefPtr<MediaStreamTrack> track;
+        Ref<RTCRtpReceiver> receiver;
+        Ref<MediaStreamTrack> track;
         MediaStreamArray streams;
-        RefPtr<RTCRtpTransceiver> transceiver;
+        Ref<RTCRtpTransceiver> transceiver;
     };
     static Ref<RTCTrackEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
 

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.idl
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.idl
@@ -44,9 +44,8 @@
     readonly attribute RTCRtpTransceiver? transceiver;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary RTCTrackEventInit : EventInit {
+// https://w3c.github.io/webrtc-pc/#dom-rtctrackeventinit
+dictionary RTCTrackEventInit : EventInit {
     required RTCRtpReceiver receiver;
     required MediaStreamTrack track;
     sequence<MediaStream> streams = [];

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -227,7 +227,7 @@ RTCRtpParameters toRTCRtpParameters(const webrtc::RtpParameters& rtcParameters)
 
 RTCRtpSendParameters toRTCRtpSendParameters(const webrtc::RtpParameters& rtcParameters)
 {
-    RTCRtpSendParameters parameters { toRTCRtpParameters(rtcParameters) };
+    RTCRtpSendParameters parameters { toRTCRtpParameters(rtcParameters), nullString(), { }, { } };
     parameters.rtcp.cname = fromStdString(rtcParameters.rtcp.cname);
 
     parameters.transactionId = fromStdString(rtcParameters.transaction_id);

--- a/Source/WebCore/Modules/model-element/HTMLModelElementCamera.idl
+++ b/Source/WebCore/Modules/model-element/HTMLModelElementCamera.idl
@@ -28,7 +28,6 @@
     EnabledBySetting=ModelElementEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary HTMLModelElementCamera {
     required double pitch;
     required double yaw;

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -123,9 +123,9 @@ ExceptionOr<Ref<Notification>> Notification::createForServiceWorker(ScriptExecut
 Ref<Notification> Notification::create(ScriptExecutionContext& context, NotificationData&& data)
 {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-    Options options { data.direction, WTF::move(data.language), WTF::move(data.body), WTF::move(data.tag), WTF::move(data.iconURL), JSC::jsNull(), nullptr, nullptr, data.silent, data.navigateURL.string() };
+    Options options { data.direction, WTF::move(data.language), WTF::move(data.body), data.navigateURL.string(), WTF::move(data.tag), WTF::move(data.iconURL), data.silent, JSC::jsNull() };
 #else
-    Options options { data.direction, WTF::move(data.language), WTF::move(data.body), WTF::move(data.tag), WTF::move(data.iconURL), JSC::jsNull(), nullptr, nullptr, data.silent };
+    Options options { data.direction, WTF::move(data.language), WTF::move(data.body), WTF::move(data.tag), WTF::move(data.iconURL), data.silent, JSC::jsNull() };
 #endif
     auto notification = adoptRef(*new Notification(context, data.notificationID, WTF::move(data.title), WTF::move(options), SerializedScriptValue::createFromWireBytes(WTF::move(data.data))));
     notification->suspendIfNeeded();
@@ -139,10 +139,9 @@ Ref<Notification> Notification::create(ScriptExecutionContext& context, const UR
     Options options;
     if (payload.options) {
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-        options = { payload.options->dir, payload.options->lang, payload.options->body, payload.options->tag, payload.options->icon, JSC::jsNull(), nullptr, nullptr, payload.options->silent, { } };
-        options.navigate = payload.defaultActionURL.string();
+        options = { payload.options->dir, payload.options->lang, payload.options->body, payload.defaultActionURL.string(), payload.options->tag, payload.options->icon, payload.options->silent, JSC::jsNull() };
 #else
-        options = { payload.options->dir, payload.options->lang, payload.options->body, payload.options->tag, payload.options->icon, JSC::jsNull(), nullptr, nullptr, payload.options->silent };
+        options = { payload.options->dir, payload.options->lang, payload.options->body, payload.options->tag, payload.options->icon, payload.options->silent, JSC::jsNull() };
 #endif
     }
 

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -37,6 +37,7 @@
 #include <WebCore/EventTarget.h>
 #include <WebCore/EventTargetInterfaces.h>
 #include <WebCore/NotificationDirection.h>
+#include <WebCore/NotificationOptions.h>
 #include <WebCore/NotificationPayload.h>
 #include <WebCore/NotificationPermission.h>
 #include <WebCore/NotificationResources.h>
@@ -62,21 +63,8 @@ class Notification final : public RefCounted<Notification>, public ActiveDOMObje
 public:
     using Permission = NotificationPermission;
     using Direction = NotificationDirection;
+    using Options = NotificationOptions;
 
-    struct Options {
-        Direction dir;
-        String lang;
-        String body;
-        String tag;
-        String icon;
-        JSC::JSValue data;
-        RefPtr<SerializedScriptValue> serializedData;
-        RefPtr<JSON::Value> jsonData;
-        std::optional<bool> silent;
-#if ENABLE(DECLARATIVE_WEB_PUSH)
-        String navigate;
-#endif
-    };
     // For JS constructor only.
     static ExceptionOr<Ref<Notification>> create(ScriptExecutionContext&, String&& title, Options&&);
 

--- a/Source/WebCore/Modules/notifications/NotificationEvent.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.cpp
@@ -37,20 +37,23 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(NotificationEvent);
 
 Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Init&& init, IsTrusted isTrusted)
 {
-    Ref notification = init.notification.releaseNonNull();
-    auto action = init.action;
-    return adoptRef(*new NotificationEvent(type, WTF::move(init), WTF::move(notification), action, isTrusted));
+    return adoptRef(*new NotificationEvent(type, WTF::move(init), isTrusted));
 }
 
 Ref<NotificationEvent> NotificationEvent::create(const AtomString& type, Ref<Notification>&& notification, const String& action, IsTrusted isTrusted)
 {
-    return adoptRef(*new NotificationEvent(type, { }, WTF::move(notification), action, isTrusted));
+    auto init = Init {
+        { false, false, false },
+        WTF::move(notification),
+        action
+    };
+    return adoptRef(*new NotificationEvent(type, WTF::move(init), isTrusted));
 }
 
-NotificationEvent::NotificationEvent(const AtomString& type, NotificationEventInit&& eventInit, Ref<Notification>&& notification, const String& action, IsTrusted isTrusted)
-    : ExtendableEvent(EventInterfaceType::NotificationEvent, type, WTF::move(eventInit), isTrusted)
-    , m_notification(WTF::move(notification))
-    , m_action(action)
+NotificationEvent::NotificationEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
+    : ExtendableEvent(EventInterfaceType::NotificationEvent, type, WTF::move(init), isTrusted)
+    , m_notification(WTF::move(init.notification))
+    , m_action(WTF::move(init.action))
 {
 }
 

--- a/Source/WebCore/Modules/notifications/NotificationEvent.h
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.h
@@ -35,7 +35,7 @@
 namespace WebCore {
 
 struct NotificationEventInit : ExtendableEventInit {
-    RefPtr<Notification> notification;
+    Ref<Notification> notification;
     String action;
 };
 
@@ -53,7 +53,7 @@ public:
     const String& action() { return m_action; }
 
 private:
-    NotificationEvent(const AtomString&, NotificationEventInit&&, Ref<Notification>&&, const String& action, IsTrusted = IsTrusted::No);
+    NotificationEvent(const AtomString&, NotificationEventInit&&, IsTrusted = IsTrusted::No);
 
     const Ref<Notification> m_notification;
     String m_action;

--- a/Source/WebCore/Modules/notifications/NotificationEvent.idl
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.idl
@@ -37,7 +37,6 @@ interface NotificationEvent : ExtendableEvent {
 
 [
     Conditional=NOTIFICATION_EVENT,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary NotificationEventInit : ExtendableEventInit {
     required Notification notification;
     DOMString action = "";

--- a/Source/WebCore/Modules/notifications/NotificationOptions.h
+++ b/Source/WebCore/Modules/notifications/NotificationOptions.h
@@ -24,15 +24,28 @@
  */
 #pragma once
 
-#include <WebCore/Notification.h>
-
 #if ENABLE(NOTIFICATIONS)
+
+#include <JavaScriptCore/JSCJSValue.h>
+#include <WebCore/NotificationDirection.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-using NotificationOptions = Notification::Options;
+struct NotificationOptions {
+    NotificationDirection dir;
+    String lang;
+    String body;
+#if ENABLE(DECLARATIVE_WEB_PUSH)
+    String navigate;
+#endif
+    String tag;
+    String icon;
+    std::optional<bool> silent;
+    JSC::JSValue data;
+};
 
-}
+} // namespace WebCore
 
 #endif // ENABLE(NOTIFICATIONS)
 

--- a/Source/WebCore/Modules/notifications/NotificationOptions.idl
+++ b/Source/WebCore/Modules/notifications/NotificationOptions.idl
@@ -23,19 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://notifications.spec.whatwg.org/#dictdef-notificationoptions
 [
     Conditional=NOTIFICATIONS,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary NotificationOptions {
-    [Conditional=DECLARATIVE_WEB_PUSH, EnabledBySetting=DeclarativeWebPush] USVString navigate;
     NotificationDirection dir = "auto";
     DOMString lang = "";
     DOMString body = "";
+    [Conditional=DECLARATIVE_WEB_PUSH, EnabledBySetting=DeclarativeWebPush] USVString navigate;
     DOMString tag = "";
     // USVString image;
     USVString icon;
     // USVString badge;
-    // USVString sound;
     // VibratePattern vibrate;
     // EpochTimeStamp timestamp;
     // boolean renotify = false;

--- a/Source/WebCore/Modules/paymentrequest/AddressErrors.idl
+++ b/Source/WebCore/Modules/paymentrequest/AddressErrors.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AddressErrors {
     DOMString addressLine;
     DOMString city;

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl
@@ -38,7 +38,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MerchantValidationEventInit : EventInit {
     DOMString methodName = "";
     USVString validationURL = "";

--- a/Source/WebCore/Modules/paymentrequest/PayerErrorFields.idl
+++ b/Source/WebCore/Modules/paymentrequest/PayerErrorFields.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PayerErrorFields {
     DOMString email;
     DOMString name;

--- a/Source/WebCore/Modules/paymentrequest/PaymentCurrencyAmount.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentCurrencyAmount.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentCurrencyAmount {
     required DOMString currency;
     required DOMString value;

--- a/Source/WebCore/Modules/paymentrequest/PaymentDetailsBase.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentDetailsBase.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentDetailsBase {
     sequence<PaymentItem> displayItems;
     sequence<PaymentShippingOption> shippingOptions;

--- a/Source/WebCore/Modules/paymentrequest/PaymentDetailsInit.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentDetailsInit.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentDetailsInit : PaymentDetailsBase {
     DOMString id;
     required PaymentItem total;

--- a/Source/WebCore/Modules/paymentrequest/PaymentItem.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentItem.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentItem {
     required DOMString label;
     required PaymentCurrencyAmount amount;

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodData.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodData.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentMethodData {
     required DOMString supportedMethods;
     object data;

--- a/Source/WebCore/Modules/paymentrequest/PaymentOptions.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentOptions.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentOptions {
     boolean requestPayerName = false;
     boolean requestPayerEmail = false;

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEventInit.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEventInit.idl
@@ -25,6 +25,5 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentRequestUpdateEventInit : EventInit {
 };

--- a/Source/WebCore/Modules/paymentrequest/PaymentShippingOption.idl
+++ b/Source/WebCore/Modules/paymentrequest/PaymentShippingOption.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=PAYMENT_REQUEST,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PaymentShippingOption {
     required DOMString id;
     required DOMString label;

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
@@ -121,7 +121,7 @@ void HTMLVideoElementPictureInPicture::requestPictureInPicture(HTMLVideoElement&
 
     Ref videoElementPictureInPicture = HTMLVideoElementPictureInPicture::from(videoElement);
     if (videoElement.document().pictureInPictureElement() == &videoElement) {
-        promise->resolve<IDLInterface<PictureInPictureWindow>>(*(videoElementPictureInPicture->m_pictureInPictureWindow));
+        promise->resolve<IDLInterface<PictureInPictureWindow>>(videoElementPictureInPicture->m_pictureInPictureWindow);
         return;
     }
 
@@ -180,13 +180,14 @@ void HTMLVideoElementPictureInPicture::didEnterPictureInPicture(const IntSize& w
     videoElement->document().setPictureInPictureElement(videoElement.get());
     m_pictureInPictureWindow->setSize(windowSize);
 
-    PictureInPictureEvent::Init initializer;
-    initializer.bubbles = true;
-    initializer.pictureInPictureWindow = m_pictureInPictureWindow;
+    auto initializer = PictureInPictureEvent::Init {
+        { true, false, false },
+        m_pictureInPictureWindow
+    };
     videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().enterpictureinpictureEvent, WTF::move(initializer)));
 
     if (m_enterPictureInPicturePromise) {
-        m_enterPictureInPicturePromise->resolve<IDLInterface<PictureInPictureWindow>>(*m_pictureInPictureWindow);
+        m_enterPictureInPicturePromise->resolve<IDLInterface<PictureInPictureWindow>>(m_pictureInPictureWindow);
         m_enterPictureInPicturePromise = nullptr;
     }
 }
@@ -201,9 +202,10 @@ void HTMLVideoElementPictureInPicture::didExitPictureInPicture()
     m_pictureInPictureWindow->close();
     videoElement->document().setPictureInPictureElement(nullptr);
 
-    PictureInPictureEvent::Init initializer;
-    initializer.bubbles = true;
-    initializer.pictureInPictureWindow = m_pictureInPictureWindow;
+    auto initializer = PictureInPictureEvent::Init {
+        { true, false, false },
+        m_pictureInPictureWindow
+    };
     videoElement->scheduleEvent(PictureInPictureEvent::create(eventNames().leavepictureinpictureEvent, WTF::move(initializer)));
 
     if (m_exitPictureInPicturePromise) {

--- a/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
+++ b/Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h
@@ -86,7 +86,7 @@ private:
     bool m_disablePictureInPicture { false };
 
     WeakRef<HTMLVideoElement> m_videoElement;
-    RefPtr<PictureInPictureWindow> m_pictureInPictureWindow;
+    const Ref<PictureInPictureWindow> m_pictureInPictureWindow;
     RefPtr<DeferredPromise> m_enterPictureInPicturePromise;
     RefPtr<DeferredPromise> m_exitPictureInPicturePromise;
 

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.cpp
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.cpp
@@ -42,8 +42,8 @@ Ref<PictureInPictureEvent> PictureInPictureEvent::create(const AtomString& type,
 }
 
 PictureInPictureEvent::PictureInPictureEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
-    : Event(EventInterfaceType::PictureInPictureEvent, type, init, isTrusted)
-    , m_pictureInPictureWindow(init.pictureInPictureWindow.releaseNonNull())
+    : Event(EventInterfaceType::PictureInPictureEvent, type, WTF::move(init), isTrusted)
+    , m_pictureInPictureWindow(WTF::move(init.pictureInPictureWindow))
 {
 }
 

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h
@@ -38,7 +38,7 @@ class PictureInPictureEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(PictureInPictureEvent);
 public:
     struct Init : EventInit {
-        RefPtr<PictureInPictureWindow> pictureInPictureWindow;
+        Ref<PictureInPictureWindow> pictureInPictureWindow;
     };
 
     static Ref<PictureInPictureEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);

--- a/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.idl
+++ b/Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.idl
@@ -24,14 +24,15 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/picture-in-picture/#dictdef-pictureinpictureeventinit
 [
     Conditional=PICTURE_IN_PICTURE_API,
     EnabledBySetting=PictureInPictureAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PictureInPictureEventInit : EventInit {
     required PictureInPictureWindow pictureInPictureWindow;
 };
 
+// https://w3c.github.io/picture-in-picture/#pictureinpictureevent
 [
     Conditional=PICTURE_IN_PICTURE_API,
     EnabledBySetting=PictureInPictureAPIEnabled,

--- a/Source/WebCore/Modules/push-api/PushEventInit.idl
+++ b/Source/WebCore/Modules/push-api/PushEventInit.idl
@@ -25,8 +25,9 @@
 
 typedef (BufferSource or USVString) PushMessageDataInit;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PushEventInit : ExtendableEventInit {
-    PushMessageDataInit data;
+// https://w3c.github.io/push-api/#dom-pusheventinit
+dictionary PushEventInit : ExtendableEventInit {
+    PushMessageDataInit? data = null;
+    // FIXME: Add support for `notification`.
+    // Notification? notification = null;
 };

--- a/Source/WebCore/Modules/push-api/PushSubscriptionChangeEventInit.idl
+++ b/Source/WebCore/Modules/push-api/PushSubscriptionChangeEventInit.idl
@@ -25,9 +25,8 @@
 
 typedef (BufferSource or USVString) PushMessageDataInit;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PushSubscriptionChangeEventInit : ExtendableEventInit {
-    PushSubscription? newSubscription;
-    PushSubscription? oldSubscription;
+// https://w3c.github.io/push-api/#dom-pushsubscriptionchangeeventinit
+dictionary PushSubscriptionChangeEventInit : ExtendableEventInit {
+    PushSubscription? newSubscription = null;
+    PushSubscription? oldSubscription = null;
 };

--- a/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl
@@ -33,9 +33,7 @@
     readonly attribute DOMString message;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary SpeechRecognitionErrorEventInit : EventInit {
+dictionary SpeechRecognitionErrorEventInit : EventInit {
     required SpeechRecognitionErrorCode error;
     DOMString message = "";
 };

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp
@@ -38,19 +38,19 @@ Ref<SpeechRecognitionEvent> SpeechRecognitionEvent::create(const AtomString& typ
     return adoptRef(*new SpeechRecognitionEvent(type, WTF::move(init), isTrusted));
 }
 
-Ref<SpeechRecognitionEvent> SpeechRecognitionEvent::create(const AtomString& type, uint64_t resultIndex, RefPtr<SpeechRecognitionResultList>&& results)
+Ref<SpeechRecognitionEvent> SpeechRecognitionEvent::create(const AtomString& type, uint32_t resultIndex, RefPtr<SpeechRecognitionResultList>&& results)
 {
     return adoptRef(*new SpeechRecognitionEvent(type, resultIndex, WTF::move(results)));
 }
 
 SpeechRecognitionEvent::SpeechRecognitionEvent(const AtomString& type, Init&& init, IsTrusted isTrusted)
-    : Event(EventInterfaceType::SpeechRecognitionEvent, type, init, isTrusted)
+    : Event(EventInterfaceType::SpeechRecognitionEvent, type, WTF::move(init), isTrusted)
     , m_resultIndex(init.resultIndex)
     , m_results(WTF::move(init.results))
 {
 }
 
-SpeechRecognitionEvent::SpeechRecognitionEvent(const AtomString& type, uint64_t resultIndex, RefPtr<SpeechRecognitionResultList>&& results)
+SpeechRecognitionEvent::SpeechRecognitionEvent(const AtomString& type, uint32_t resultIndex, RefPtr<SpeechRecognitionResultList>&& results)
     : Event(EventInterfaceType::SpeechRecognitionEvent, type, Event::CanBubble::No, Event::IsCancelable::No)
     , m_resultIndex(resultIndex)
     , m_results(WTF::move(results))

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.h
@@ -35,24 +35,24 @@ class SpeechRecognitionEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionEvent);
 public:
     struct Init : EventInit {
-        uint64_t resultIndex;
-        RefPtr<SpeechRecognitionResultList> results;
+        uint32_t resultIndex;
+        Ref<SpeechRecognitionResultList> results;
     };
 
     static Ref<SpeechRecognitionEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
-    static Ref<SpeechRecognitionEvent> create(const AtomString&, uint64_t resultIndex, RefPtr<SpeechRecognitionResultList>&&);
+    static Ref<SpeechRecognitionEvent> create(const AtomString&, uint32_t resultIndex, RefPtr<SpeechRecognitionResultList>&&);
 
     virtual ~SpeechRecognitionEvent();
 
-    uint64_t resultIndex() const { return m_resultIndex; }
-    SpeechRecognitionResultList* results() const { return m_results.get(); }
+    uint32_t resultIndex() const { return m_resultIndex; }
+    const SpeechRecognitionResultList* results() const { return m_results.get(); }
 
 private:
     SpeechRecognitionEvent(const AtomString&, Init&&, IsTrusted);
-    SpeechRecognitionEvent(const AtomString&, uint64_t resultIndex, RefPtr<SpeechRecognitionResultList>&&);
+    SpeechRecognitionEvent(const AtomString&, uint32_t resultIndex, RefPtr<SpeechRecognitionResultList>&&);
 
-    uint64_t m_resultIndex;
-    RefPtr<SpeechRecognitionResultList> m_results;
+    uint32_t m_resultIndex;
+    const RefPtr<SpeechRecognitionResultList> m_results;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl
@@ -35,9 +35,7 @@
     readonly attribute SpeechRecognitionResultList? results;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary SpeechRecognitionEventInit : EventInit {
+dictionary SpeechRecognitionEventInit : EventInit {
     unsigned long resultIndex = 0;
     required SpeechRecognitionResultList results;
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp
@@ -35,13 +35,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechSynthesisErrorEvent);
 
-Ref<SpeechSynthesisErrorEvent> SpeechSynthesisErrorEvent::create(const AtomString& type, SpeechSynthesisErrorEventInit&& initializer)
+Ref<SpeechSynthesisErrorEvent> SpeechSynthesisErrorEvent::create(const AtomString& type, Init&& initializer)
 {
     auto error = initializer.error;
     return adoptRef(*new SpeechSynthesisErrorEvent(type, error, WTF::move(initializer)));
 }
 
-SpeechSynthesisErrorEvent::SpeechSynthesisErrorEvent(const AtomString& type, SpeechSynthesisErrorCode error, SpeechSynthesisErrorEventInit&& initializer)
+SpeechSynthesisErrorEvent::SpeechSynthesisErrorEvent(const AtomString& type, SpeechSynthesisErrorCode error, Init&& initializer)
     : SpeechSynthesisEvent(EventInterfaceType::SpeechSynthesisErrorEvent, type, WTF::move(initializer))
     , m_error(error)
 {

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h
@@ -36,13 +36,14 @@ namespace WebCore {
 class SpeechSynthesisErrorEvent final : public SpeechSynthesisEvent {
     WTF_MAKE_TZONE_ALLOCATED(SpeechSynthesisErrorEvent);
 public:
-    
-    static Ref<SpeechSynthesisErrorEvent> create(const AtomString& type, SpeechSynthesisErrorEventInit&&);
+    using Init = SpeechSynthesisErrorEventInit;
+
+    static Ref<SpeechSynthesisErrorEvent> create(const AtomString& type, Init&&);
 
     SpeechSynthesisErrorCode error() const { return m_error; }
 
 private:
-    SpeechSynthesisErrorEvent(const AtomString& type, SpeechSynthesisErrorCode, SpeechSynthesisErrorEventInit&&);
+    SpeechSynthesisErrorEvent(const AtomString& type, SpeechSynthesisErrorCode, Init&&);
 
     SpeechSynthesisErrorCode m_error;
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.idl
@@ -26,7 +26,6 @@
 [
     EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary SpeechSynthesisErrorEventInit : SpeechSynthesisEventInit {
     required SpeechSynthesisErrorCode error;
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp
@@ -35,18 +35,18 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SpeechSynthesisEvent);
 
-Ref<SpeechSynthesisEvent> SpeechSynthesisEvent::create(const AtomString& type, SpeechSynthesisEventInit&& initializer)
+Ref<SpeechSynthesisEvent> SpeechSynthesisEvent::create(const AtomString& type, Init&& initializer)
 {
     return adoptRef(*new SpeechSynthesisEvent(EventInterfaceType::SpeechSynthesisEvent, type, WTF::move(initializer)));
 }
 
-SpeechSynthesisEvent::SpeechSynthesisEvent(enum EventInterfaceType eventInterface, const AtomString& type, SpeechSynthesisEventInit&& initializer)
+SpeechSynthesisEvent::SpeechSynthesisEvent(enum EventInterfaceType eventInterface, const AtomString& type, Init&& initializer)
     : Event(eventInterface, type, CanBubble::No, IsCancelable::No)
-    , m_utterance(initializer.utterance.releaseNonNull())
+    , m_utterance(WTF::move(initializer.utterance))
     , m_charIndex(initializer.charIndex)
     , m_charLength(initializer.charLength)
     , m_elapsedTime(initializer.elapsedTime)
-    , m_name(initializer.name)
+    , m_name(WTF::move(initializer.name))
 {
 }
     

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEvent.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEvent.h
@@ -36,8 +36,9 @@ namespace WebCore {
 class SpeechSynthesisEvent : public Event {
     WTF_MAKE_TZONE_ALLOCATED(SpeechSynthesisEvent);
 public:
-    
-    static Ref<SpeechSynthesisEvent> create(const AtomString& type, SpeechSynthesisEventInit&&);
+    using Init = SpeechSynthesisEventInit;
+
+    static Ref<SpeechSynthesisEvent> create(const AtomString& type, Init&&);
 
     const SpeechSynthesisUtterance& utterance() const { return m_utterance; }
     unsigned long charIndex() const { return m_charIndex; }
@@ -46,7 +47,7 @@ public:
     const String& name() const { return m_name; }
 
 protected:
-    SpeechSynthesisEvent(enum EventInterfaceType, const AtomString& type, SpeechSynthesisEventInit&&);
+    SpeechSynthesisEvent(enum EventInterfaceType, const AtomString& type, Init&&);
 
 private:
     const Ref<SpeechSynthesisUtterance> m_utterance;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEventInit.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEventInit.h
@@ -33,25 +33,9 @@
 namespace WebCore {
 
 struct SpeechSynthesisEventInit : EventInit {
-
-    // Generated code expects a default constructor
-    SpeechSynthesisEventInit()
-        : EventInit()
-        , utterance(nullptr)
-    { }
-    
-    SpeechSynthesisEventInit(SpeechSynthesisUtterance* utterance, unsigned long charIndex, unsigned long charLength, float elapsedTime, const String& name)
-        : EventInit()
-        , utterance(utterance)
-        , charIndex(charIndex)
-        , charLength(charLength)
-        , elapsedTime(elapsedTime)
-        , name(name)
-    { }
-
-    RefPtr<SpeechSynthesisUtterance> utterance;
-    unsigned long charIndex;
-    unsigned long charLength;
+    Ref<SpeechSynthesisUtterance> utterance;
+    uint32_t charIndex;
+    uint32_t charLength;
     float elapsedTime;
     String name;
 };

--- a/Source/WebCore/Modules/speech/SpeechSynthesisEventInit.idl
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisEventInit.idl
@@ -27,7 +27,6 @@
 [
     EnabledBySetting=SpeechSynthesisAPIEnabled,
     Conditional=SPEECH_SYNTHESIS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary SpeechSynthesisEventInit : EventInit {
     required SpeechSynthesisUtterance utterance;
     unsigned long charIndex = 0;

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -79,7 +79,7 @@ public:
 
     PlatformSpeechSynthesisUtterance& platformUtterance() const { return m_platformUtterance.get(); }
 
-    void eventOccurred(const AtomString& type, unsigned long charIndex, unsigned long charLength, const String& name) final;
+    void eventOccurred(const AtomString& type, uint32_t charIndex, uint32_t charLength, const String& name) final;
     void errorEventOccurred(const AtomString& type, SpeechSynthesisErrorCode);
     void setIsActiveForEventDispatch(bool);
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -674,7 +674,7 @@ void ReadableByteStreamController::clearAlgorithms()
 }
 
 // https://streams.spec.whatwg.org/#readable-byte-stream-controller-pull-into
-void ReadableByteStreamController::pullInto(JSDOMGlobalObject& globalObject, JSC::ArrayBufferView& view, size_t min, Ref<ReadableStreamReadIntoRequest>&& readIntoRequest)
+void ReadableByteStreamController::pullInto(JSDOMGlobalObject& globalObject, JSC::ArrayBufferView& view, uint64_t min, Ref<ReadableStreamReadIntoRequest>&& readIntoRequest)
 {
     Ref stream = m_stream.get();
     size_t elementSize = 1;
@@ -682,7 +682,7 @@ void ReadableByteStreamController::pullInto(JSDOMGlobalObject& globalObject, JSC
     if (viewType != JSC::TypedArrayType::TypeDataView)
         elementSize = JSC::elementSize(view.getType());
 
-    auto minimumFill = min * elementSize;
+    size_t minimumFill = min * elementSize;
     ASSERT(minimumFill <= view.byteLength());
     ASSERT(!(minimumFill % elementSize));
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -69,7 +69,7 @@ public:
     ReadableStream& stream();
     Ref<ReadableStream> protectedStream();
 
-    void pullInto(JSDOMGlobalObject&, JSC::ArrayBufferView&, size_t, Ref<ReadableStreamReadIntoRequest>&&);
+    void pullInto(JSDOMGlobalObject&, JSC::ArrayBufferView&, uint64_t, Ref<ReadableStreamReadIntoRequest>&&);
 
     void runCancelSteps(JSDOMGlobalObject&, JSC::JSValue, Function<void(std::optional<JSC::JSValue>&&)>&&);
     void runPullSteps(JSDOMGlobalObject&, Ref<ReadableStreamReadRequest>&&);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
@@ -156,7 +156,7 @@ void ReadableStreamBYOBReader::initialize(JSDOMGlobalObject& globalObject, Reada
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-byob-reader-read
-void ReadableStreamBYOBReader::read(JSDOMGlobalObject& globalObject, JSC::ArrayBufferView& view, size_t optionMin, Ref<ReadableStreamReadIntoRequest>&& readRequest)
+void ReadableStreamBYOBReader::read(JSDOMGlobalObject& globalObject, JSC::ArrayBufferView& view, uint64_t optionMin, Ref<ReadableStreamReadIntoRequest>&& readRequest)
 {
     ASSERT(m_stream);
     Ref stream = *m_stream;

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -51,7 +51,7 @@ public:
     ~ReadableStreamBYOBReader();
 
     struct ReadOptions {
-        size_t min { 1 };
+        uint64_t min { 1 };
     };
 
     void readForBindings(JSDOMGlobalObject&, JSC::ArrayBufferView&, ReadOptions, Ref<DeferredPromise>&&);
@@ -72,7 +72,7 @@ public:
     using ClosedCallback = Function<void(JSDOMGlobalObject&, JSC::JSValue)>;
     void onClosedPromiseRejection(ClosedCallback&&);
 
-    void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, size_t, Ref<ReadableStreamReadIntoRequest>&&);
+    void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, uint64_t, Ref<ReadableStreamReadIntoRequest>&&);
 
     bool isReachableFromOpaqueRoots() const;
     template<typename Visitor> void visitAdditionalChildren(Visitor&);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl
@@ -25,9 +25,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ReadableStreamBYOBReaderReadOptions {
+dictionary ReadableStreamBYOBReaderReadOptions {
     [EnforceRange] unsigned long long min = 1;
 };
 

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
@@ -61,7 +61,7 @@ static ExceptionOr<void> packAndPostMessage(JSDOMGlobalObject& globalObject, Mes
     if (catchScope.exception()) [[unlikely]]
         return Exception { ExceptionCode::InvalidStateError, "Unable to set value"_s };
 
-    return port.postMessage(globalObject, data, { });
+    return port.postMessage(globalObject, data, StructuredSerializeOptions { });
 }
 
 // https://streams.spec.whatwg.org/#abstract-opdef-crossrealmtransformsenderror

--- a/Source/WebCore/Modules/url-pattern/URLPatternInit.idl
+++ b/Source/WebCore/Modules/url-pattern/URLPatternInit.idl
@@ -28,7 +28,6 @@
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary URLPatternInit {
     USVString protocol;
     USVString username;

--- a/Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.idl
+++ b/Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AllAcceptedCredentialsOptions {
     required DOMString                     rpId;
     required Base64URLString               userId;

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
@@ -48,7 +48,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsPRFInputs {
     AuthenticationExtensionsPRFValues eval;
     record<USVString, AuthenticationExtensionsPRFValues> evalByCredential;
@@ -58,7 +57,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsClientInputs {
     USVString appid;
     // For Google to turn off the legacy AppID support.

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputsJSON.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputsJSON.idl
@@ -25,7 +25,6 @@
  
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsLargeBlobInputsJSON {
     DOMString support;
     boolean read;
@@ -34,7 +33,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsPRFValuesJSON {
     required DOMString first;
     DOMString second;
@@ -42,7 +40,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsPRFInputsJSON {
     AuthenticationExtensionsPRFValuesJSON eval;
     record<USVString, AuthenticationExtensionsPRFValuesJSON> evalByCredential;
@@ -50,7 +47,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsClientInputsJSON {
     DOMString appid;
     boolean credProps;

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsLargeBlobOutputs {
     boolean supported;
     ArrayBuffer blob;
@@ -36,7 +35,6 @@
 [
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsPRFValues {
     required ArrayBuffer first;
     ArrayBuffer second;
@@ -45,7 +43,6 @@
 [
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsPRFOutputs {
     boolean enabled;
     AuthenticationExtensionsPRFValues results;
@@ -54,7 +51,6 @@
 [
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsClientOutputs {
     boolean appid;
     CredentialPropertiesOutput credProps;

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputsJSON.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputsJSON.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsLargeBlobOutputsJSON {
     boolean supported;
     DOMString blob;
@@ -38,7 +37,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsPRFValuesJSON {
     required DOMString first;
     DOMString second;
@@ -48,7 +46,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsPRFOutputsJSON {
     boolean enabled;
     AuthenticationExtensionsPRFValuesJSON results;
@@ -58,7 +55,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationExtensionsClientOutputsJSON {
     boolean appid;
     CredentialPropertiesOutput credProps;

--- a/Source/WebCore/Modules/webauthn/AuthenticationResponseJSON.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticationResponseJSON.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticatorAssertionResponseJSON {
     required Base64URLString clientDataJSON;
     required Base64URLString authenticatorData;
@@ -39,7 +38,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AuthenticationResponseJSON {
     required Base64URLString id;
     required Base64URLString rawId;

--- a/Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.idl
+++ b/Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CurrentUserDetailsOptions {
     required DOMString                     rpId;
     required Base64URLString               userId;

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialEntity.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialEntity.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PublicKeyCredentialEntity {
     required DOMString name;
     USVString icon;

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialParameters.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialParameters.idl
@@ -29,7 +29,6 @@ typedef long COSEAlgorithmIdentifier;
     Conditional=WEB_AUTHN,
     JSGenerateToNativeObject,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PublicKeyCredentialParameters {
     required PublicKeyCredentialType type;
     required COSEAlgorithmIdentifier alg;

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.idl
@@ -25,7 +25,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PublicKeyCredentialRequestOptionsJSON {
     required Base64URLString                                challenge;
     unsigned long                                           timeout;

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialUserEntityJSON.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialUserEntityJSON.idl
@@ -27,7 +27,6 @@ typedef DOMString Base64URLString;
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PublicKeyCredentialUserEntityJSON {
     required Base64URLString id;
     required DOMString              name;

--- a/Source/WebCore/Modules/webauthn/UnknownCredentialOptions.idl
+++ b/Source/WebCore/Modules/webauthn/UnknownCredentialOptions.idl
@@ -27,7 +27,6 @@
     Conditional=WEB_AUTHN,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary UnknownCredentialOptions {
     required DOMString                     rpId;
     required Base64URLString               credentialId;

--- a/Source/WebCore/Modules/webxr/XRProjectionLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayerInit.idl
@@ -29,7 +29,6 @@ typedef unsigned long GLenum;
 [
     Conditional=WEBXR_LAYERS,
     EnabledBySetting=WebXRLayersAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRProjectionLayerInit {
     XRTextureType textureType = "texture";
     GLenum colorFormat = 0x1908; // RGBA

--- a/Source/WebCore/animation/CustomAnimationOptions.idl
+++ b/Source/WebCore/animation/CustomAnimationOptions.idl
@@ -25,9 +25,7 @@
 
 typedef unsigned long FramesPerSecond;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary CustomAnimationOptions : EffectTiming {
+dictionary CustomAnimationOptions : EffectTiming {
     DOMString id = "";
     [EnabledBySetting=WebAnimationsCustomFrameRateEnabled] (FramesPerSecond or AnimationFrameRatePreset) frameRate = "auto";
 };

--- a/Source/WebCore/animation/EffectTiming.h
+++ b/Source/WebCore/animation/EffectTiming.h
@@ -37,14 +37,15 @@ using OptionalDoubleOrString = std::optional<Variant<double, String>>;
 using DoubleOrCSSNumericValueOrString = Variant<double, RefPtr<CSSNumericValue>, String>;
 
 struct EffectTiming {
-    DoubleOrCSSNumericValueOrString duration { autoAtom() };
     double delay { 0 };
     double endDelay { 0 };
+    FillMode fill { FillMode::Auto };
     double iterationStart { 0 };
     double iterations { 1 };
-    String easing { "linear"_s };
-    FillMode fill { FillMode::Auto };
+    DoubleOrCSSNumericValueOrString duration { autoAtom() };
     PlaybackDirection direction { PlaybackDirection::Normal };
+    String easing { "linear"_s };
+
     OptionalDoubleOrString durationAsDoubleOrString() const;
 };
 

--- a/Source/WebCore/animation/EffectTiming.idl
+++ b/Source/WebCore/animation/EffectTiming.idl
@@ -29,7 +29,6 @@
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary EffectTiming {
     double delay = 0;
     double endDelay = 0;

--- a/Source/WebCore/crypto/CryptoKeyPair.idl
+++ b/Source/WebCore/crypto/CryptoKeyPair.idl
@@ -25,7 +25,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CryptoKeyPair {
     CryptoKey publicKey;
     CryptoKey privateKey;

--- a/Source/WebCore/crypto/RsaOtherPrimesInfo.h
+++ b/Source/WebCore/crypto/RsaOtherPrimesInfo.h
@@ -31,17 +31,20 @@
 namespace WebCore {
 
 struct RsaOtherPrimesInfo {
-    RsaOtherPrimesInfo isolatedCopy() && {
-        return {
-            crossThreadCopy(WTF::move(r)),
-            crossThreadCopy(WTF::move(d)),
-            crossThreadCopy(WTF::move(t))
-        };
-    }
-
     String r;
     String d;
     String t;
+
+    RsaOtherPrimesInfo isolatedCopy() &&;
 };
+
+inline RsaOtherPrimesInfo RsaOtherPrimesInfo::isolatedCopy() &&
+{
+    return {
+        crossThreadCopy(WTF::move(r)),
+        crossThreadCopy(WTF::move(d)),
+        crossThreadCopy(WTF::move(t))
+    };
+}
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/RsaOtherPrimesInfo.idl
+++ b/Source/WebCore/crypto/RsaOtherPrimesInfo.idl
@@ -26,7 +26,6 @@
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RsaOtherPrimesInfo {
     // The following fields are defined in Section 6.3.2.7 of JSON Web Algorithms
     required DOMString r;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1246,7 +1246,7 @@ void Element::scrollIntoView(Variant<bool, ScrollIntoViewOptions>&& arg)
         isHorizontal ? alignX : alignY,
         isHorizontal ? alignY : alignX,
         ShouldAllowCrossOriginScrolling::No,
-        options.behavior.value_or(ScrollBehavior::Auto)
+        options.behavior
     };
     LocalFrameView::scrollRectToVisible(absoluteBounds, *renderer, insideFixed, visibleOptions);
 }
@@ -1324,7 +1324,7 @@ void Element::scrollBy(const ScrollToOptions& options)
 
 void Element::scrollBy(double x, double y)
 {
-    scrollBy(ScrollToOptions(x, y));
+    scrollBy(ScrollToOptions { { ScrollBehavior::Auto }, x, y });
 }
 
 void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, ScrollSnapPointSelectionMethod snapPointSelectionMethod, std::optional<FloatSize> originalScrollDelta)
@@ -1394,7 +1394,7 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
         clampToInteger(scrollToOptions.top.value() * renderer->style().usedZoom())
     );
 
-    auto animated = useSmoothScrolling(scrollToOptions.behavior.value_or(ScrollBehavior::Auto), this) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
+    auto animated = useSmoothScrolling(scrollToOptions.behavior, this) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
     if (animated == ScrollIsAnimated::Yes)
         setHasEverHadSmoothScroll(true);
 
@@ -1404,7 +1404,7 @@ void Element::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, 
 
 void Element::scrollTo(double x, double y)
 {
-    scrollTo(ScrollToOptions(x, y));
+    scrollTo(ScrollToOptions { { ScrollBehavior::Auto }, x, y });
 }
 
 static double localZoomForRenderer(const RenderElement& renderer)

--- a/Source/WebCore/dom/ErrorEvent.idl
+++ b/Source/WebCore/dom/ErrorEvent.idl
@@ -44,9 +44,7 @@
 };
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#erroreventinit
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ErrorEventInit : EventInit {
+dictionary ErrorEventInit : EventInit {
     DOMString message = "";
     USVString filename = "";
     unsigned long lineno = 0;

--- a/Source/WebCore/dom/FocusOptions.idl
+++ b/Source/WebCore/dom/FocusOptions.idl
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/interaction.html#focusoptions
 [
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FocusOptions {

--- a/Source/WebCore/dom/FormDataEvent.cpp
+++ b/Source/WebCore/dom/FormDataEvent.cpp
@@ -44,8 +44,8 @@ Ref<FormDataEvent> FormDataEvent::create(const AtomString& eventType, CanBubble 
 }
 
 FormDataEvent::FormDataEvent(const AtomString& eventType, Init&& init)
-    : Event(EventInterfaceType::FormDataEvent, eventType, init, IsTrusted::No)
-    , m_formData(init.formData.releaseNonNull())
+    : Event(EventInterfaceType::FormDataEvent, eventType, WTF::move(init), IsTrusted::No)
+    , m_formData(WTF::move(init.formData))
 {
 }
 

--- a/Source/WebCore/dom/FormDataEvent.h
+++ b/Source/WebCore/dom/FormDataEvent.h
@@ -36,9 +36,9 @@ class FormDataEvent : public Event {
     WTF_MAKE_TZONE_ALLOCATED(FormDataEvent);
 public:
     struct Init : EventInit {
-        RefPtr<DOMFormData> formData;
+        Ref<DOMFormData> formData;
     };
-        
+
     static Ref<FormDataEvent> create(const AtomString&, Init&&);
     static Ref<FormDataEvent> create(const AtomString&, CanBubble, IsCancelable, IsComposed, Ref<DOMFormData>&&);
 

--- a/Source/WebCore/dom/FormDataEvent.idl
+++ b/Source/WebCore/dom/FormDataEvent.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#formdataevent
 [
     Exposed=Window
 ] interface FormDataEvent : Event {
@@ -31,8 +32,7 @@
     readonly attribute DOMFormData formData;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FormDataEventInit : EventInit {
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#formdataeventinit
+dictionary FormDataEventInit : EventInit {
     required DOMFormData formData;
 };

--- a/Source/WebCore/dom/FullscreenOptions.idl
+++ b/Source/WebCore/dom/FullscreenOptions.idl
@@ -41,7 +41,6 @@
 
 [
     Conditional=FULLSCREEN_API,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FullscreenOptions {
     FullscreenNavigationUI navigationUI = "auto";
     [EnabledBySetting=FullScreenKeyboardLock] FullscreenKeyboardLock keyboardLock = "none";

--- a/Source/WebCore/dom/GetHTMLOptions.idl
+++ b/Source/WebCore/dom/GetHTMLOptions.idl
@@ -24,10 +24,7 @@
  */
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#gethtmloptions
-
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary GetHTMLOptions {
+dictionary GetHTMLOptions {
     boolean serializableShadowRoots = false;
     sequence<ShadowRoot> shadowRoots = [];
 };

--- a/Source/WebCore/dom/HashChangeEvent.idl
+++ b/Source/WebCore/dom/HashChangeEvent.idl
@@ -17,8 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-// https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-hashchangeevent-interface
-
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeevent
 [
     Exposed=Window
 ] interface HashChangeEvent : Event {
@@ -28,9 +27,8 @@
     readonly attribute USVString newURL;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary HashChangeEventInit : EventInit {
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#hashchangeeventinit
+dictionary HashChangeEventInit : EventInit {
     USVString oldURL = "";
     USVString newURL = "";
 };

--- a/Source/WebCore/dom/ImportNodeOptions.idl
+++ b/Source/WebCore/dom/ImportNodeOptions.idl
@@ -23,9 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ImportNodeOptions {
+// https://dom.spec.whatwg.org/#dictdef-importnodeoptions
+dictionary ImportNodeOptions {
     boolean selfOnly = false;
     CustomElementRegistry customElementRegistry;
 };

--- a/Source/WebCore/dom/InputEvent.idl
+++ b/Source/WebCore/dom/InputEvent.idl
@@ -39,10 +39,7 @@
 };
 
 // https://w3c.github.io/uievents/#idl-inputeventinit
-
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary InputEventInit : UIEventInit {
+dictionary InputEventInit : UIEventInit {
     DOMString? data = null;
     boolean isComposing = false;
     DOMString inputType = "";

--- a/Source/WebCore/dom/KeyboardEvent.idl
+++ b/Source/WebCore/dom/KeyboardEvent.idl
@@ -57,10 +57,7 @@
 };
 
 // https://w3c.github.io/uievents/#idl-keyboardeventinit
-
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary KeyboardEventInit : EventModifierInit {
+dictionary KeyboardEventInit : EventModifierInit {
     DOMString key = "";
     DOMString code = "";
     unsigned long location = 0;

--- a/Source/WebCore/dom/MessageEvent.idl
+++ b/Source/WebCore/dom/MessageEvent.idl
@@ -26,8 +26,10 @@
  *
  */
 
+// https://html.spec.whatwg.org/multipage/comms.html#messageeventsource
 typedef (WindowProxy or MessagePort or ServiceWorker) MessageEventSource;
 
+// https://html.spec.whatwg.org/multipage/comms.html#messageevent
 [
     Exposed=(Window,Worker,AudioWorklet),
     JSCustomMarkFunction,
@@ -46,9 +48,8 @@ typedef (WindowProxy or MessagePort or ServiceWorker) MessageEventSource;
         optional sequence<MessagePort> messagePorts = []);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MessageEventInit : EventInit {
+// https://html.spec.whatwg.org/multipage/comms.html#messageeventinit
+dictionary MessageEventInit : EventInit {
     any data = null;
     USVString origin = "";
     DOMString lastEventId = "";

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -64,6 +64,7 @@ public:
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
+    ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, Vector<JSC::Strong<JSC::JSObject>>&&);
 
     void start();
     void close();

--- a/Source/WebCore/dom/MutationObserver.idl
+++ b/Source/WebCore/dom/MutationObserver.idl
@@ -28,6 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://dom.spec.whatwg.org/#mutationobserver
 [
     CustomIsReachable,
     LegacyWindowAlias=WebKitMutationObserver,
@@ -41,9 +42,8 @@
     [ResultField=records] sequence<MutationRecord> takeRecords();
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MutationObserverInit {
+// https://dom.spec.whatwg.org/#dictdef-mutationobserverinit
+dictionary MutationObserverInit {
     boolean childList = false;
     boolean attributes;
     boolean characterData;

--- a/Source/WebCore/dom/Node.idl
+++ b/Source/WebCore/dom/Node.idl
@@ -83,8 +83,7 @@
     [CEReactions=Needed] Node removeChild([ReturnValue] Node child);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary GetRootNodeOptions {
+// https://dom.spec.whatwg.org/#dictdef-getrootnodeoptions
+dictionary GetRootNodeOptions {
     boolean composed = false;
 };

--- a/Source/WebCore/dom/ObservableInspector.idl
+++ b/Source/WebCore/dom/ObservableInspector.idl
@@ -22,11 +22,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 // https://github.com/WICG/observable
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ObservableInspector {
+dictionary ObservableInspector {
   SubscriptionObserverCallback next;
   SubscriptionObserverCallback error;
   VoidCallback complete;

--- a/Source/WebCore/dom/PageRevealEvent.idl
+++ b/Source/WebCore/dom/PageRevealEvent.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagerevealevent-interface
-
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#pagerevealevent
 [
     Exposed=Window
 ] interface PageRevealEvent : Event {
@@ -33,8 +32,7 @@
     readonly attribute ViewTransition? viewTransition;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PageRevealEventInit : EventInit {
-  ViewTransition? viewTransition = null;
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#pagerevealeventinit
+dictionary PageRevealEventInit : EventInit {
+    ViewTransition? viewTransition = null;
 };

--- a/Source/WebCore/dom/PageSwapEvent.idl
+++ b/Source/WebCore/dom/PageSwapEvent.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pageswapevent-interface
-
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#pageswapevent
 [
     Exposed=Window
 ] interface PageSwapEvent : Event {
@@ -34,9 +33,8 @@
     readonly attribute ViewTransition? viewTransition;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PageSwapEventInit : EventInit {
-  NavigationActivation? activation = null;
-  ViewTransition? viewTransition = null;
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#pageswapeventinit
+dictionary PageSwapEventInit : EventInit {
+    NavigationActivation? activation = null;
+    ViewTransition? viewTransition = null;
 };

--- a/Source/WebCore/dom/PageTransitionEvent.idl
+++ b/Source/WebCore/dom/PageTransitionEvent.idl
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#pagetransitionevent
 [
     Exposed=Window
 ] interface PageTransitionEvent : Event {
@@ -31,8 +32,7 @@
     readonly attribute boolean persisted;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PageTransitionEventInit : EventInit {
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#pagetransitioneventinit
+dictionary PageTransitionEventInit : EventInit {
     boolean persisted = false;
 };

--- a/Source/WebCore/dom/PointerLockOptions.idl
+++ b/Source/WebCore/dom/PointerLockOptions.idl
@@ -26,7 +26,6 @@
 [
     Conditional=POINTER_LOCK,
     EnabledBySetting=PointerLockEnabled&PointerLockOptionsEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PointerLockOptions {
     boolean unadjustedMovement = false;
 };

--- a/Source/WebCore/dom/PopStateEvent.idl
+++ b/Source/WebCore/dom/PopStateEvent.idl
@@ -34,9 +34,7 @@
     [EnabledBySetting=UAVisualTransitionDetectionEnabled] readonly attribute boolean hasUAVisualTransition;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PopStateEventInit : EventInit {
+dictionary PopStateEventInit : EventInit {
     any state = null;
     [EnabledBySetting=UAVisualTransitionDetectionEnabled] boolean hasUAVisualTransition = false;
 };

--- a/Source/WebCore/dom/ProgressEvent.idl
+++ b/Source/WebCore/dom/ProgressEvent.idl
@@ -33,9 +33,7 @@
     readonly attribute double total;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ProgressEventInit : EventInit {
+dictionary ProgressEventInit : EventInit {
     boolean lengthComputable = false;
     double loaded = 0;
     double total = 0;

--- a/Source/WebCore/dom/PromiseRejectionEvent.cpp
+++ b/Source/WebCore/dom/PromiseRejectionEvent.cpp
@@ -39,7 +39,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PromiseRejectionEvent);
 
 PromiseRejectionEvent::PromiseRejectionEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
     : Event(EventInterfaceType::PromiseRejectionEvent, type, initializer, isTrusted)
-    , m_promise(initializer.promise.releaseNonNull())
+    , m_promise(WTF::move(initializer.promise))
     , m_reason(initializer.reason)
 {
 }

--- a/Source/WebCore/dom/PromiseRejectionEvent.h
+++ b/Source/WebCore/dom/PromiseRejectionEvent.h
@@ -36,7 +36,7 @@ class PromiseRejectionEvent final : public Event {
     WTF_MAKE_TZONE_ALLOCATED(PromiseRejectionEvent);
 public:
     struct Init : EventInit {
-        RefPtr<DOMPromise> promise;
+        Ref<DOMPromise> promise;
         JSC::JSValue reason;
     };
 

--- a/Source/WebCore/dom/PromiseRejectionEvent.idl
+++ b/Source/WebCore/dom/PromiseRejectionEvent.idl
@@ -33,9 +33,7 @@
     readonly attribute any reason;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PromiseRejectionEventInit : EventInit {
+dictionary PromiseRejectionEventInit : EventInit {
     required Promise<any> promise;
     any reason;
 };

--- a/Source/WebCore/dom/SecurityPolicyViolationEvent.cpp
+++ b/Source/WebCore/dom/SecurityPolicyViolationEvent.cpp
@@ -32,21 +32,4 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SecurityPolicyViolationEvent);
 
-SecurityPolicyViolationEventInit::SecurityPolicyViolationEventInit(EventInit&& eventInit, String&& documentURI, String&& referrer, String&& blockedURI, String&& violatedDirective, String&& effectiveDirective, String&& originalPolicy, String&& sourceFile, String&& sample, SecurityPolicyViolationEventDisposition disposition, unsigned short statusCode, unsigned lineNumber, unsigned columnNumber)
-    : EventInit(WTF::move(eventInit))
-    , documentURI(WTF::move(documentURI))
-    , referrer(WTF::move(referrer))
-    , blockedURI(WTF::move(blockedURI))
-    , violatedDirective(WTF::move(violatedDirective))
-    , effectiveDirective(WTF::move(effectiveDirective))
-    , originalPolicy(WTF::move(originalPolicy))
-    , sourceFile(WTF::move(sourceFile))
-    , sample(WTF::move(sample))
-    , disposition(disposition)
-    , statusCode(statusCode)
-    , lineNumber(lineNumber)
-    , columnNumber(columnNumber)
-{
-}
-
 }

--- a/Source/WebCore/dom/SecurityPolicyViolationEvent.h
+++ b/Source/WebCore/dom/SecurityPolicyViolationEvent.h
@@ -31,9 +31,6 @@
 namespace WebCore {
 
 struct SecurityPolicyViolationEventInit : EventInit {
-    SecurityPolicyViolationEventInit() = default;
-    WEBCORE_EXPORT SecurityPolicyViolationEventInit(EventInit&&, String&& documentURI, String&& referrer, String&& blockedURI, String&& violatedDirective, String&& effectiveDirective, String&& originalPolicy, String&& sourceFile, String&& sample, SecurityPolicyViolationEventDisposition, unsigned short statusCode, unsigned lineNumber, unsigned columnNumber);
-
     String documentURI;
     String referrer;
     String blockedURI;
@@ -54,9 +51,9 @@ public:
     using Disposition = SecurityPolicyViolationEventDisposition;
     using Init = SecurityPolicyViolationEventInit;
 
-    static Ref<SecurityPolicyViolationEvent> create(const AtomString& type, const Init& initializer = { }, IsTrusted isTrusted = IsTrusted::No)
+    static Ref<SecurityPolicyViolationEvent> create(const AtomString& type, Init&& initializer = { }, IsTrusted isTrusted = IsTrusted::No)
     {
-        return adoptRef(*new SecurityPolicyViolationEvent(type, initializer, isTrusted));
+        return adoptRef(*new SecurityPolicyViolationEvent(type, WTF::move(initializer), isTrusted));
     }
 
     const String& documentURI() const { return m_documentURI; }
@@ -78,16 +75,16 @@ private:
     {
     }
 
-    SecurityPolicyViolationEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-        : Event(EventInterfaceType::SecurityPolicyViolationEvent, type, initializer, isTrusted)
-        , m_documentURI(initializer.documentURI)
-        , m_referrer(initializer.referrer)
-        , m_blockedURI(initializer.blockedURI)
-        , m_violatedDirective(initializer.violatedDirective)
-        , m_effectiveDirective(initializer.effectiveDirective)
-        , m_originalPolicy(initializer.originalPolicy)
-        , m_sourceFile(initializer.sourceFile)
-        , m_sample(initializer.sample)
+    SecurityPolicyViolationEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+        : Event(EventInterfaceType::SecurityPolicyViolationEvent, type, WTF::move(initializer), isTrusted)
+        , m_documentURI(WTF::move(initializer.documentURI))
+        , m_referrer(WTF::move(initializer.referrer))
+        , m_blockedURI(WTF::move(initializer.blockedURI))
+        , m_violatedDirective(WTF::move(initializer.violatedDirective))
+        , m_effectiveDirective(WTF::move(initializer.effectiveDirective))
+        , m_originalPolicy(WTF::move(initializer.originalPolicy))
+        , m_sourceFile(WTF::move(initializer.sourceFile))
+        , m_sample(WTF::move(initializer.sample))
         , m_disposition(initializer.disposition)
         , m_statusCode(initializer.statusCode)
         , m_lineNumber(initializer.lineNumber)

--- a/Source/WebCore/dom/SecurityPolicyViolationEvent.idl
+++ b/Source/WebCore/dom/SecurityPolicyViolationEvent.idl
@@ -48,10 +48,7 @@
 };
 
 // https://w3c.github.io/webappsec-csp/#dictdef-securitypolicyviolationeventinit
-
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary SecurityPolicyViolationEventInit : EventInit {
+dictionary SecurityPolicyViolationEventInit : EventInit {
     USVString documentURI = "";
     USVString referrer = "";
     USVString blockedURI = "";

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -24,10 +24,7 @@
  */
 
 // https://dom.spec.whatwg.org/#dictdef-shadowrootinit
-
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ShadowRootInit {
+dictionary ShadowRootInit {
     required ShadowRootMode mode;
     boolean delegatesFocus = false;
     boolean clonable = false;

--- a/Source/WebCore/dom/StartViewTransitionOptions.idl
+++ b/Source/WebCore/dom/StartViewTransitionOptions.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary StartViewTransitionOptions {
+dictionary StartViewTransitionOptions {
     ViewTransitionUpdateCallback? update = null;
     sequence<[AtomString] DOMString>? types = null;
 };

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -63,11 +63,9 @@ static bool isDocumentTypeOrAttr(Node& node)
 
 ExceptionOr<Ref<StaticRange>> StaticRange::create(Init&& init)
 {
-    ASSERT(init.startContainer);
-    ASSERT(init.endContainer);
-    if (isDocumentTypeOrAttr(*init.startContainer) || isDocumentTypeOrAttr(*init.endContainer))
+    if (isDocumentTypeOrAttr(init.startContainer) || isDocumentTypeOrAttr(init.endContainer))
         return Exception { ExceptionCode::InvalidNodeTypeError };
-    return create({ { init.startContainer.releaseNonNull(), init.startOffset }, { init.endContainer.releaseNonNull(), init.endOffset } });
+    return create({ { WTF::move(init.startContainer), init.startOffset }, { WTF::move(init.endContainer), init.endOffset } });
 }
 
 void StaticRange::visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const

--- a/Source/WebCore/dom/StaticRange.h
+++ b/Source/WebCore/dom/StaticRange.h
@@ -42,9 +42,9 @@ class StaticRange final : public AbstractRange, public SimpleRange {
     WTF_MAKE_TZONE_ALLOCATED(StaticRange);
 public:
     struct Init {
-        RefPtr<Node> startContainer;
+        Ref<Node> startContainer;
         unsigned startOffset { 0 };
-        RefPtr<Node> endContainer;
+        Ref<Node> endContainer;
         unsigned endOffset { 0 };
     };
 

--- a/Source/WebCore/dom/StaticRange.idl
+++ b/Source/WebCore/dom/StaticRange.idl
@@ -32,9 +32,7 @@
     constructor(StaticRangeInit init);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary StaticRangeInit {
+dictionary StaticRangeInit {
     required Node startContainer;
     required unsigned long startOffset;
     required Node endContainer;

--- a/Source/WebCore/dom/SubscribeOptions.idl
+++ b/Source/WebCore/dom/SubscribeOptions.idl
@@ -24,8 +24,6 @@
  */
 // https://github.com/WICG/observable
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary SubscribeOptions {
+dictionary SubscribeOptions {
   AbortSignal signal;
 };

--- a/Source/WebCore/dom/SubscriptionObserver.idl
+++ b/Source/WebCore/dom/SubscriptionObserver.idl
@@ -24,9 +24,7 @@
  */
 // https://github.com/WICG/observable
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary SubscriptionObserver {
+dictionary SubscriptionObserver {
   SubscriptionObserverCallback next;
   SubscriptionObserverCallback error;
   VoidCallback complete;

--- a/Source/WebCore/dom/TextDecoder.idl
+++ b/Source/WebCore/dom/TextDecoder.idl
@@ -23,16 +23,12 @@
 * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary TextDecoderOptions {
+dictionary TextDecoderOptions {
     boolean fatal = false;
     boolean ignoreBOM = false;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary TextDecodeOptions {
+dictionary TextDecodeOptions {
     boolean stream = false;
 };
 

--- a/Source/WebCore/dom/ToggleEvent.idl
+++ b/Source/WebCore/dom/ToggleEvent.idl
@@ -31,9 +31,7 @@ interface ToggleEvent : Event {
     readonly attribute Element? source;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ToggleEventInit : EventInit {
+dictionary ToggleEventInit : EventInit {
     DOMString oldState = "";
     DOMString newState = "";
     Element? source = null;

--- a/Source/WebCore/dom/TrustedTypePolicyOptions.idl
+++ b/Source/WebCore/dom/TrustedTypePolicyOptions.idl
@@ -23,9 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary TrustedTypePolicyOptions {
+dictionary TrustedTypePolicyOptions {
     CreateHTMLCallback createHTML;
     CreateScriptCallback createScript;
     CreateScriptURLCallback createScriptURL;

--- a/Source/WebCore/dom/ValidityStateFlags.h
+++ b/Source/WebCore/dom/ValidityStateFlags.h
@@ -28,16 +28,16 @@
 namespace WebCore {
 
 struct ValidityStateFlags {
-    bool valueMissing : 1 { false };
-    bool typeMismatch : 1 { false };
-    bool patternMismatch : 1 { false };
-    bool tooLong : 1 { false };
-    bool tooShort : 1 { false };
-    bool rangeUnderflow : 1 { false };
-    bool rangeOverflow : 1 { false };
-    bool stepMismatch : 1 { false };
-    bool badInput : 1 { false };
-    bool customError : 1 { false };
+    bool valueMissing { false };
+    bool typeMismatch { false };
+    bool patternMismatch { false };
+    bool tooLong { false };
+    bool tooShort { false };
+    bool rangeUnderflow { false };
+    bool rangeOverflow { false };
+    bool stepMismatch { false };
+    bool badInput { false };
+    bool customError { false };
 
     bool isValid() const
     {

--- a/Source/WebCore/dom/ValidityStateFlags.idl
+++ b/Source/WebCore/dom/ValidityStateFlags.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ValidityStateFlags {
+dictionary ValidityStateFlags {
     boolean valueMissing = false;
     boolean typeMismatch = false;
     boolean patternMismatch = false;

--- a/Source/WebCore/dom/WheelEvent.idl
+++ b/Source/WebCore/dom/WheelEvent.idl
@@ -45,10 +45,7 @@
 };
 
 // https://w3c.github.io/uievents/#idl-wheeleventinit
-
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary WheelEventInit : MouseEventInit {
+dictionary WheelEventInit : MouseEventInit {
     double deltaX = 0.0;
     double deltaY = 0.0;
     double deltaZ = 0.0;

--- a/Source/WebCore/fileapi/BlobPropertyBag.idl
+++ b/Source/WebCore/fileapi/BlobPropertyBag.idl
@@ -23,9 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary BlobPropertyBag {
+dictionary BlobPropertyBag {
     DOMString type = "";
 
     EndingType endings = "transparent";

--- a/Source/WebCore/fileapi/File.idl
+++ b/Source/WebCore/fileapi/File.idl
@@ -39,8 +39,6 @@ typedef (BufferSource or Blob or USVString) BlobPart;
     [EnabledBySetting=DirectoryUploadEnabled, ImplementedAs=relativePath] readonly attribute USVString webkitRelativePath;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FilePropertyBag : BlobPropertyBag {
+dictionary FilePropertyBag : BlobPropertyBag {
     long long lastModified;
 };

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -19,7 +19,6 @@
  */
 
 // https://html.spec.whatwg.org/multipage/dom.html#htmlelement
-
 [
     CustomToJSObject,
     ExportMacro=WEBCORE_EXPORT,
@@ -72,15 +71,13 @@
     [Conditional=WRITING_SUGGESTIONS, CEReactions=Needed] attribute boolean writingsuggestions;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ShowPopoverOptions {
+// https://html.spec.whatwg.org/multipage/dom.html#showpopoveroptions
+dictionary ShowPopoverOptions {
     HTMLElement source;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary TogglePopoverOptions : ShowPopoverOptions {
+// https://html.spec.whatwg.org/multipage/dom.html#togglepopoveroptions
+dictionary TogglePopoverOptions : ShowPopoverOptions {
     boolean force;
 };
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3456,7 +3456,7 @@ void HTMLMediaElement::mediaPlayerKeyNeeded(const SharedBuffer& initData)
     if (auto initDataBuffer = initData.tryCreateArrayBuffer())
         init.initData = Uint8Array::create(initDataBuffer.releaseNonNull());
 
-    Ref event = WebKitMediaKeyNeededEvent::create(eventNames().webkitneedkeyEvent, init);
+    Ref event = WebKitMediaKeyNeededEvent::create(eventNames().webkitneedkeyEvent, WTF::move(init));
     scheduleEvent(WTF::move(event));
 }
 
@@ -3597,8 +3597,12 @@ void HTMLMediaElement::mediaPlayerInitializationDataEncountered(const String& in
     //    The event interface MediaEncryptedEvent has:
     //      initDataType = initDataType
     //      initData = initData
-    MediaEncryptedEventInit initializer { initDataType, WTF::move(initData) };
-    scheduleEvent(MediaEncryptedEvent::create(eventNames().encryptedEvent, initializer, Event::IsTrusted::Yes));
+    auto initializer = MediaEncryptedEvent::Init {
+        { false, false, false },
+        initDataType,
+        WTF::move(initData)
+    };
+    scheduleEvent(MediaEncryptedEvent::create(eventNames().encryptedEvent, WTF::move(initializer), Event::IsTrusted::Yes));
 }
 
 void HTMLMediaElement::mediaPlayerWaitingForKeyChanged()

--- a/Source/WebCore/html/HTMLSlotElement.idl
+++ b/Source/WebCore/html/HTMLSlotElement.idl
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/scripting.html#htmlslotelement
 [
     JSGenerateToNativeObject,
     Exposed=Window
@@ -33,8 +34,7 @@
     undefined assign((Element or Text)... nodes);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary AssignedNodesOptions {
+// https://html.spec.whatwg.org/multipage/scripting.html#assignednodesoptions
+dictionary AssignedNodesOptions {
     boolean flatten = false;
 };

--- a/Source/WebCore/html/ImageBitmapOptions.idl
+++ b/Source/WebCore/html/ImageBitmapOptions.idl
@@ -28,9 +28,8 @@ enum PremultiplyAlpha { "none", "premultiply", "default" };
 enum ColorSpaceConversion { "none", "default" };
 enum ResizeQuality { "pixelated", "low", "medium", "high" };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ImageBitmapOptions {
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapoptions
+dictionary ImageBitmapOptions {
     [ImplementedAs=orientation] ImageOrientation imageOrientation = "from-image";
     PremultiplyAlpha premultiplyAlpha = "default";
     ColorSpaceConversion colorSpaceConversion = "default";

--- a/Source/WebCore/html/ImageDataSettings.idl
+++ b/Source/WebCore/html/ImageDataSettings.idl
@@ -24,9 +24,7 @@
  */
 
 // https://html.spec.whatwg.org/multipage/canvas.html#imagedatasettings
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ImageDataSettings {
+dictionary ImageDataSettings {
     [EnabledBySetting=CanvasColorSpaceEnabled] PredefinedColorSpace colorSpace;
     [EnabledBySetting=CanvasColorTypeEnabled] ImageDataPixelFormat pixelFormat = "rgba-unorm8";
 };

--- a/Source/WebCore/html/MediaEncryptedEvent.idl
+++ b/Source/WebCore/html/MediaEncryptedEvent.idl
@@ -26,13 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MediaEncryptedEventInit : EventInit {
-    DOMString initDataType = "";
-    ArrayBuffer? initData = null;
-};
-
+// https://w3c.github.io/encrypted-media/#dom-mediaencryptedevent
 [
     Conditional=ENCRYPTED_MEDIA,
     EnabledBySetting=EncryptedMediaAPIEnabled,
@@ -43,4 +37,10 @@
 
     readonly attribute DOMString initDataType;
     readonly attribute ArrayBuffer? initData;
+};
+
+// https://w3c.github.io/encrypted-media/#dom-mediaencryptedeventinit
+dictionary MediaEncryptedEventInit : EventInit {
+    DOMString initDataType = "";
+    ArrayBuffer? initData = null;
 };

--- a/Source/WebCore/html/MediaEncryptedEventInit.h
+++ b/Source/WebCore/html/MediaEncryptedEventInit.h
@@ -36,14 +36,6 @@
 namespace WebCore {
 
 struct MediaEncryptedEventInit : EventInit {
-    MediaEncryptedEventInit() = default;
-
-    MediaEncryptedEventInit(const String& initDataType, RefPtr<JSC::ArrayBuffer>&& initData)
-        : EventInit()
-        , initDataType(initDataType)
-        , initData(WTF::move(initData))
-    { }
-
     String initDataType;
     RefPtr<JSC::ArrayBuffer> initData;
 };

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -32,16 +32,15 @@ typedef (
     ImageBitmapRenderingContext or
     OffscreenCanvasRenderingContext2D) OffscreenRenderingContext;
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ImageEncodeOptions
-{
+// https://html.spec.whatwg.org/multipage/canvas.html#imageencodeoptions
+dictionary ImageEncodeOptions {
    DOMString type = "image/png";
    unrestricted double quality = 1.0;
 };
 
-enum OffscreenRenderingContextType
-{
+// https://html.spec.whatwg.org/multipage/canvas.html#offscreenrenderingcontextid
+// FIXME: This should be named `OffscreenRenderingContextId`.
+enum OffscreenRenderingContextType {
    "2d",
    "webgl",
    "webgl2",
@@ -49,6 +48,7 @@ enum OffscreenRenderingContextType
    "webgpu"
 };
 
+// https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvas
 [
     ActiveDOMObject,
     GenerateIsReachable=Impl,
@@ -70,4 +70,8 @@ enum OffscreenRenderingContextType
     ImageBitmap? transferToImageBitmap();
     Promise<Blob> convertToBlob(optional ImageEncodeOptions options = {});
 
+    // FIXME: Add support for `oncontextlost`.
+    // attribute EventHandler oncontextlost;
+    // FIXME: Add support for `oncontextrestored`.
+    // attribute EventHandler oncontextrestored;
 };

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -202,7 +202,7 @@ void PDFDocument::postMessageToIframe(const String& name, JSC::JSObject* data)
 
     WindowPostMessageOptions options;
     if (data)
-        options = WindowPostMessageOptions { "/"_s, Vector { JSC::Strong<JSC::JSObject> { vm, data } } };
+        options.transfer = Vector { JSC::Strong<JSC::JSObject> { vm, data } };
     auto returnValue = contentWindow->postMessage(*contentWindowGlobalObject, *contentWindow, message, WTF::move(options));
     if (returnValue.hasException())
         returnValue.releaseException();

--- a/Source/WebCore/html/SubmitEvent.idl
+++ b/Source/WebCore/html/SubmitEvent.idl
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submitevent
 [
     Exposed=Window
 ] interface SubmitEvent : Event {
@@ -31,8 +32,7 @@
     readonly attribute HTMLElement? submitter;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary SubmitEventInit : EventInit {
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submiteventinit
+dictionary SubmitEventInit : EventInit {
     HTMLElement? submitter = null;
 };

--- a/Source/WebCore/html/VideoFrameMetadata.idl
+++ b/Source/WebCore/html/VideoFrameMetadata.idl
@@ -25,10 +25,12 @@
 
 typedef double DOMHighResTimeStamp;
 
+// https://w3c.github.io/webcodecs/#dictdef-videoframemetadata
+//   with members defined in
+// https://w3c.github.io/webcodecs/video_frame_metadata_registry.html
 [
     Conditional=VIDEO,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary VideoFrameMetadata {
     required DOMHighResTimeStamp presentationTime;
     required DOMHighResTimeStamp expectedDisplayTime;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl
@@ -38,7 +38,6 @@ enum RenderingMode {
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CanvasRenderingContext2DSettings {
     // FIXME: Add support for 'alpha'.
     // boolean alpha = true;
@@ -46,5 +45,5 @@ enum RenderingMode {
     boolean willReadFrequently = false;
     [EnabledBySetting=CanvasColorSpaceEnabled] PredefinedColorSpace colorSpace = "srgb";
     [EnabledBySetting=CanvasColorTypeEnabled] CanvasColorType colorType = "unorm8";
-    [EnabledBySetting=DOMTestingAPIsEnabled] RenderingMode? renderingModeForTesting;
+    [EnabledBySetting=DOMTestingAPIsEnabled] RenderingMode renderingModeForTesting;
 };

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContextSettings.idl
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContextSettings.idl
@@ -23,8 +23,6 @@
 * THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ImageBitmapRenderingContextSettings {
+dictionary ImageBitmapRenderingContextSettings {
     boolean alpha = true;
 };

--- a/Source/WebCore/html/canvas/WebGLContextAttributes.idl
+++ b/Source/WebCore/html/canvas/WebGLContextAttributes.idl
@@ -44,7 +44,6 @@ enum WebGLPowerPreference {
     Conditional=WEBGL,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary WebGLContextAttributes {
     GLboolean alpha = true;
     GLboolean depth = true;

--- a/Source/WebCore/html/canvas/WebGLContextEvent.idl
+++ b/Source/WebCore/html/canvas/WebGLContextEvent.idl
@@ -33,8 +33,6 @@
     readonly attribute DOMString statusMessage;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary WebGLContextEventInit : EventInit {
+dictionary WebGLContextEventInit : EventInit {
     DOMString statusMessage = "";
 };

--- a/Source/WebCore/html/closewatcher/CloseWatcher.idl
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.idl
@@ -14,8 +14,7 @@
   attribute EventHandler onclose;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary CloseWatcherOptions {
+// https://html.spec.whatwg.org/multipage/interaction.html#closewatcheroptions
+dictionary CloseWatcherOptions {
   AbortSignal signal;
 };

--- a/Source/WebCore/html/track/TrackEvent.idl
+++ b/Source/WebCore/html/track/TrackEvent.idl
@@ -23,8 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
- // https://html.spec.whatwg.org/multipage/media.html#the-trackevent-interface
-
+// https://html.spec.whatwg.org/multipage/media.html#trackevent
 [
     Conditional=VIDEO,
     Exposed=Window
@@ -34,8 +33,7 @@
     readonly attribute (VideoTrack or AudioTrack or TextTrack)? track;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary TrackEventInit : EventInit {
+// https://html.spec.whatwg.org/multipage/media.html#trackeventinit
+dictionary TrackEventInit : EventInit {
     (VideoTrack or AudioTrack or TextTrack)? track = null;
 };

--- a/Source/WebCore/inspector/CommandLineAPIHost.idl
+++ b/Source/WebCore/inspector/CommandLineAPIHost.idl
@@ -47,7 +47,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ListenerEntry {
     required object listener;
     required boolean useCapture;

--- a/Source/WebCore/inspector/RTCLogsCallback.idl
+++ b/Source/WebCore/inspector/RTCLogsCallback.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEB_RTC,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCLogs {
     DOMString type;
     DOMString message;

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -587,7 +587,7 @@ ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& globalObject, Loca
 
 ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& globalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, String&& targetOrigin, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
 {
-    return postMessage(globalObject, incumbentWindow, message, WindowPostMessageOptions { WTF::move(targetOrigin), WTF::move(transfer) });
+    return postMessage(globalObject, incumbentWindow, message, WindowPostMessageOptions { { WTF::move(transfer) }, WTF::move(targetOrigin) });
 }
 
 ExceptionOr<Ref<CSSStyleDeclaration>> DOMWindow::getComputedStyle(Element& element, const String& pseudoElt) const

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -62,7 +62,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EventSource);
 
 const uint64_t EventSource::defaultReconnectDelay = 3000;
 
-inline EventSource::EventSource(ScriptExecutionContext& context, const URL& url, const Init& eventSourceInit)
+inline EventSource::EventSource(ScriptExecutionContext& context, const URL& url, Init&& eventSourceInit)
     : ActiveDOMObject(&context)
     , m_url(url)
     , m_withCredentials(eventSourceInit.withCredentials)
@@ -70,7 +70,7 @@ inline EventSource::EventSource(ScriptExecutionContext& context, const URL& url,
 {
 }
 
-ExceptionOr<Ref<EventSource>> EventSource::create(ScriptExecutionContext& context, const String& url, const Init& eventSourceInit)
+ExceptionOr<Ref<EventSource>> EventSource::create(ScriptExecutionContext& context, const String& url, Init&& eventSourceInit)
 {
     URL fullURL = context.completeURL(url);
     if (!fullURL.isValid())
@@ -82,7 +82,7 @@ ExceptionOr<Ref<EventSource>> EventSource::create(ScriptExecutionContext& contex
         return Exception { ExceptionCode::SecurityError };
     }
 
-    auto source = adoptRef(*new EventSource(context, fullURL, eventSourceInit));
+    auto source = adoptRef(*new EventSource(context, fullURL, WTF::move(eventSourceInit)));
     source->scheduleInitialConnect();
     source->suspendIfNeeded();
     return source;

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -54,7 +54,7 @@ public:
     struct Init {
         bool withCredentials;
     };
-    static ExceptionOr<Ref<EventSource>> create(ScriptExecutionContext&, const String& url, const Init&);
+    static ExceptionOr<Ref<EventSource>> create(ScriptExecutionContext&, const String& url, Init&&);
     virtual ~EventSource();
 
     // EventTarget, ThreadableLoaderClient.
@@ -76,7 +76,7 @@ public:
     void close();
 
 private:
-    EventSource(ScriptExecutionContext&, const URL&, const Init&);
+    EventSource(ScriptExecutionContext&, const URL&, Init&&);
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::EventSource; }
     ScriptExecutionContext* scriptExecutionContext() const final;

--- a/Source/WebCore/page/EventSource.idl
+++ b/Source/WebCore/page/EventSource.idl
@@ -53,8 +53,7 @@
     undefined close();
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary EventSourceInit {
+// https://html.spec.whatwg.org/multipage/server-sent-events.html#eventsourceinit
+dictionary EventSourceInit {
     boolean withCredentials = false;
 };

--- a/Source/WebCore/page/GetComposedRangesOptions.idl
+++ b/Source/WebCore/page/GetComposedRangesOptions.idl
@@ -23,9 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary GetComposedRangesOptions {
+// https://w3c.github.io/selection-api/#dom-getcomposedrangesoptions
+dictionary GetComposedRangesOptions {
     sequence<ShadowRoot> shadowRoots = [];
 };
 

--- a/Source/WebCore/page/IntersectionObserver.idl
+++ b/Source/WebCore/page/IntersectionObserver.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/IntersectionObserver/
-
+// https://w3c.github.io/IntersectionObserver/#intersectionobserver
 [
     Exposed=Window,
     JSCustomMarkFunction,
@@ -32,10 +31,15 @@
 ] interface IntersectionObserver {
     [CallWith=CurrentDocument] constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options = {});
 
+    // FIXME: `root` should have type `(Element or Document)?`.
     readonly attribute Node? root;
     readonly attribute DOMString rootMargin;
     readonly attribute DOMString scrollMargin;
     readonly attribute FrozenArray<double> thresholds;
+    // FIXME: Add support for `delay`.
+    // readonly attribute long delay;
+    // FIXME: Add support for `trackVisibility`.
+    // readonly attribute boolean trackVisibility;
 
     undefined observe(Element target);
     undefined unobserve(Element target);
@@ -43,11 +47,14 @@
     [ResultField=records] sequence<IntersectionObserverEntry> takeRecords();
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary IntersectionObserverInit {
+// https://w3c.github.io/IntersectionObserver/#dictdef-intersectionobserverinit
+dictionary IntersectionObserverInit {
     (Element or Document)? root = null;
     DOMString rootMargin = "0px";
     DOMString scrollMargin = "0px";
     (double or sequence<double>) threshold = 0.0;
+    // FIXME: Add support for `delay`.
+    // long delay = 0;
+    // FIXME: Add support for `trackVisibility`.
+    // boolean trackVisibility = false;
 };

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1780,7 +1780,7 @@ double LocalDOMWindow::devicePixelRatio() const
 
 void LocalDOMWindow::scrollBy(double x, double y) const
 {
-    scrollBy(ScrollToOptions(x, y));
+    scrollBy(ScrollToOptions { { ScrollBehavior::Auto }, x, y });
 }
 
 void LocalDOMWindow::scrollBy(const ScrollToOptions& options) const
@@ -1807,7 +1807,7 @@ void LocalDOMWindow::scrollBy(const ScrollToOptions& options) const
 
 void LocalDOMWindow::scrollTo(double x, double y, ScrollClamping clamping) const
 {
-    scrollTo(ScrollToOptions(x, y), clamping);
+    scrollTo(ScrollToOptions { { ScrollBehavior::Auto }, x, y }, clamping);
 }
 
 void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping clamping, ScrollSnapPointSelectionMethod snapPointSelectionMethod, std::optional<FloatSize> originalScrollDelta) const
@@ -1837,7 +1837,7 @@ void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping cla
 
     // FIXME: Should we use document()->scrollingElement()?
     // See https://bugs.webkit.org/show_bug.cgi?id=205059
-    auto animated = useSmoothScrolling(scrollToOptions.behavior.value_or(ScrollBehavior::Auto), document()->protectedDocumentElement().get()) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
+    auto animated = useSmoothScrolling(scrollToOptions.behavior, document()->protectedDocumentElement().get()) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
     auto scrollPositionChangeOptions = ScrollPositionChangeOptions::createProgrammaticWithOptions(clamping, animated, snapPointSelectionMethod, originalScrollDelta);
     view->setContentsScrollPosition(layoutPos, scrollPositionChangeOptions);
 }

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -45,14 +45,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigateEvent);
 
-NavigateEvent::NavigateEvent(const AtomString& type, NavigateEvent::Init&& init, EventIsTrusted isTrusted, AbortController* abortController)
-    : Event(EventInterfaceType::NavigateEvent, type, init, isTrusted)
+NavigateEvent::NavigateEvent(const AtomString& type, Init&& init, EventIsTrusted isTrusted, AbortController* abortController)
+    : Event(EventInterfaceType::NavigateEvent, type, WTF::move(init), isTrusted)
     , m_navigationType(init.navigationType)
-    , m_destination(init.destination.releaseNonNull())
-    , m_signal(init.signal.releaseNonNull())
-    , m_formData(init.formData)
-    , m_downloadRequest(init.downloadRequest)
-    , m_sourceElement(init.sourceElement)
+    , m_destination(WTF::move(init.destination))
+    , m_signal(WTF::move(init.signal))
+    , m_formData(WTF::move(init.formData))
+    , m_downloadRequest(WTF::move(init.downloadRequest))
+    , m_sourceElement(WTF::move(init.sourceElement))
     , m_canIntercept(init.canIntercept)
     , m_userInitiated(init.userInitiated)
     , m_hashChange(init.hashChange)
@@ -63,14 +63,14 @@ NavigateEvent::NavigateEvent(const AtomString& type, NavigateEvent::Init&& init,
     m_info.setWeakly(init.info);
 }
 
-Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, NavigateEvent::Init&& init, AbortController* abortController)
+Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, Init&& init, AbortController* abortController)
 {
     return adoptRef(*new NavigateEvent(type, WTF::move(init), EventIsTrusted::Yes, abortController));
 }
 
-Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, NavigateEvent::Init&& init)
+Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, Init&& init)
 {
-    // FIXME: AbortController is required but JS bindings need to create it with one.
+    // FIXME: AbortController is required but JS bindings need to create it without one.
     return adoptRef(*new NavigateEvent(type, WTF::move(init), EventIsTrusted::No, nullptr));
 }
 

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -61,16 +61,16 @@ class NavigateEvent final : public Event {
 public:
     struct Init : EventInit {
         NavigationNavigationType navigationType { NavigationNavigationType::Push };
-        RefPtr<NavigationDestination> destination;
-        RefPtr<AbortSignal> signal;
-        RefPtr<DOMFormData> formData;
-        String downloadRequest;
-        JSC::JSValue info;
-        RefPtr<Element> sourceElement;
+        Ref<NavigationDestination> destination;
         bool canIntercept { false };
         bool userInitiated { false };
         bool hashChange { false };
+        Ref<AbortSignal> signal;
+        RefPtr<DOMFormData> formData;
+        String downloadRequest;
+        JSC::JSValue info;
         bool hasUAVisualTransition { false };
+        RefPtr<Element> sourceElement;
     };
 
     enum class NavigationFocusReset : bool {

--- a/Source/WebCore/page/NavigateEvent.idl
+++ b/Source/WebCore/page/NavigateEvent.idl
@@ -49,9 +49,7 @@
   [CallWith=RelevantDocument] undefined scroll();
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary NavigateEventInit : EventInit {
+dictionary NavigateEventInit : EventInit {
   NavigationNavigationType navigationType = "push";
   required NavigationDestination destination;
   boolean canIntercept = false;
@@ -61,13 +59,11 @@
   DOMFormData? formData = null;
   DOMString? downloadRequest = null;
   any info;
-  Element? sourceElement = null;
   [EnabledBySetting=UAVisualTransitionDetectionEnabled] boolean hasUAVisualTransition = false;
+  Element? sourceElement = null;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary NavigationInterceptOptions {
+dictionary NavigationInterceptOptions {
   NavigationInterceptHandler handler;
   NavigationFocusReset focusReset;
   NavigationScrollBehavior scroll;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -555,7 +555,7 @@ ExceptionOr<void> Navigation::updateCurrentEntry(UpdateCurrentEntryOptions&& opt
     auto currentEntryChangeEvent = NavigationCurrentEntryChangeEvent::create(eventNames().currententrychangeEvent, {
         { false, false, false },
         std::nullopt,
-        current
+        current.releaseNonNull()
     });
     dispatchEvent(currentEntryChangeEvent);
 
@@ -756,7 +756,9 @@ void Navigation::updateForNavigation(Ref<HistoryItem>&& item, NavigationNavigati
         notifyCommittedToEntry(ongoingAPIMethodTracker.get(), protectedCurrentEntry().get(), navigationType);
 
     auto currentEntryChangeEvent = NavigationCurrentEntryChangeEvent::create(eventNames().currententrychangeEvent, {
-        { false, false, false }, navigationType, oldCurrentEntry
+        { false, false, false },
+        navigationType,
+        oldCurrentEntry.releaseNonNull()
     });
     dispatchEvent(currentEntryChangeEvent);
 
@@ -1078,16 +1080,16 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     auto init = NavigateEvent::Init {
         { false, canBeCanceled, false },
         navigationType,
-        destination.ptr(),
+        destination,
+        canIntercept,
+        UserGestureIndicator::processingUserGesture(document.get()),
+        hashChange,
         Ref { abortController->signal() },
         formData,
         downloadRequestFilename,
         info,
-        updatedSourceElement.get(),
-        canIntercept,
-        UserGestureIndicator::processingUserGesture(document.get()),
-        hashChange,
         document->page() && document->page()->isInSwipeAnimation(),
+        updatedSourceElement.get(),
     };
 
     // Free up no longer needed info.

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -53,34 +53,25 @@
   attribute EventHandler oncurrententrychange;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary NavigationUpdateCurrentEntryOptions {
+dictionary NavigationUpdateCurrentEntryOptions {
   required any state;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary NavigationOptions {
+dictionary NavigationOptions {
   any info;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary NavigationNavigateOptions : NavigationOptions {
+dictionary NavigationNavigateOptions : NavigationOptions {
   any state;
   NavigationHistoryBehavior history = "auto";
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary NavigationReloadOptions : NavigationOptions {
+dictionary NavigationReloadOptions : NavigationOptions {
   any state;
 };
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary NavigationResult {
   [BypassDocumentFullyActiveCheck] Promise<NavigationHistoryEntry> committed;
   [BypassDocumentFullyActiveCheck] Promise<NavigationHistoryEntry> finished;

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp
@@ -32,14 +32,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationCurrentEntryChangeEvent);
 
-NavigationCurrentEntryChangeEvent::NavigationCurrentEntryChangeEvent(const AtomString& type, NavigationCurrentEntryChangeEvent::Init&& init)
+NavigationCurrentEntryChangeEvent::NavigationCurrentEntryChangeEvent(const AtomString& type, Init&& init)
     : Event(EventInterfaceType::NavigationCurrentEntryChangeEvent, type, CanBubble::No, IsCancelable::No)
     , m_navigationType(init.navigationType)
-    , m_from(init.from.releaseNonNull())
+    , m_from(WTF::move(init.from))
 {
 }
 
-Ref<NavigationCurrentEntryChangeEvent> NavigationCurrentEntryChangeEvent::create(const AtomString& type, NavigationCurrentEntryChangeEvent::Init&& init)
+Ref<NavigationCurrentEntryChangeEvent> NavigationCurrentEntryChangeEvent::create(const AtomString& type, Init&& init)
 {
     return adoptRef(*new NavigationCurrentEntryChangeEvent(type, WTF::move(init)));
 }

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.h
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.h
@@ -37,7 +37,7 @@ class NavigationCurrentEntryChangeEvent final : public Event {
 public:
     struct Init : EventInit {
         std::optional<NavigationNavigationType> navigationType;
-        RefPtr<NavigationHistoryEntry> from;
+        Ref<NavigationHistoryEntry> from;
     };
 
     static Ref<NavigationCurrentEntryChangeEvent> create(const AtomString& type, Init&&);

--- a/Source/WebCore/page/NavigationCurrentEntryChangeEvent.idl
+++ b/Source/WebCore/page/NavigationCurrentEntryChangeEvent.idl
@@ -35,9 +35,7 @@
   readonly attribute NavigationHistoryEntry from;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary NavigationCurrentEntryChangeEventInit : EventInit {
+dictionary NavigationCurrentEntryChangeEventInit : EventInit {
   NavigationNavigationType? navigationType = null;
   required NavigationHistoryEntry from;
 };

--- a/Source/WebCore/page/NavigatorUABrandVersion.h
+++ b/Source/WebCore/page/NavigatorUABrandVersion.h
@@ -24,11 +24,14 @@
  */
 
 #pragma once
+
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
 struct NavigatorUABrandVersion {
     String brand;
     String version;
 };
+
 }

--- a/Source/WebCore/page/NavigatorUABrandVersion.idl
+++ b/Source/WebCore/page/NavigatorUABrandVersion.idl
@@ -23,11 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/ua-client-hints/#idl-index
+// https://wicg.github.io/ua-client-hints/#dictdef-navigatoruabrandversion
 [
     JSGenerateToJSObject,
     EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary NavigatorUABrandVersion {
   DOMString brand;
   DOMString version;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -6015,7 +6015,7 @@ RefPtr<MediaSessionManagerInterface> Page::mediaSessionManager()
         Ref { *m_mediaSessionManager }->setShouldDeactivateAudioSession(true);
 #endif
 
-        MediaEngineConfigurationFactory::setMediaSessionManagerProvider([] (PageIdentifier identifier) {
+        MediaEngineConfigurationFactory::setMediaSessionManagerProvider([](PageIdentifier identifier) {
             return Page::mediaSessionManagerForPageIdentifier(identifier);
         });
     }

--- a/Source/WebCore/page/PerformanceMarkOptions.idl
+++ b/Source/WebCore/page/PerformanceMarkOptions.idl
@@ -26,9 +26,7 @@
 typedef double DOMHighResTimeStamp;
 
 // https://w3c.github.io/user-timing/#ref-for-dom-performancemarkoptions-1
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PerformanceMarkOptions {
+dictionary PerformanceMarkOptions {
     any detail;
     DOMHighResTimeStamp startTime;
 };

--- a/Source/WebCore/page/PerformanceMeasureOptions.idl
+++ b/Source/WebCore/page/PerformanceMeasureOptions.idl
@@ -26,9 +26,7 @@
 typedef double DOMHighResTimeStamp;
 
 // https://w3c.github.io/user-timing/#ref-for-dom-performancemeasureoptions-1
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PerformanceMeasureOptions {
+dictionary PerformanceMeasureOptions {
     any detail;
     (DOMString or DOMHighResTimeStamp) start;
     DOMHighResTimeStamp duration;

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -69,7 +69,7 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
     bool isBuffered = false;
     OptionSet<PerformanceEntry::Type> filter;
     if (init.entryTypes) {
-        if (init.type)
+        if (!init.type.isNull())
             return Exception { ExceptionCode::TypeError, "either entryTypes or type must be provided"_s };
         if (m_registered && m_isTypeObserver)
             return Exception { ExceptionCode::InvalidModificationError, "observer type can't be changed once registered"_s };
@@ -81,19 +81,19 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
             return { };
         m_typeFilter = filter;
     } else {
-        if (!init.type)
+        if (init.type.isNull())
             return Exception { ExceptionCode::TypeError, "no type or entryTypes were provided"_s };
         if (m_registered && !m_isTypeObserver)
             return Exception { ExceptionCode::InvalidModificationError, "observer type can't be changed once registered"_s };
         m_isTypeObserver = true;
-        if (auto type = PerformanceEntry::parseEntryTypeString(*init.type))
+        if (auto type = PerformanceEntry::parseEntryTypeString(init.type))
             filter.add(*type);
         else
             return { };
         if (init.buffered) {
             isBuffered = true;
             auto oldSize = m_entriesToDeliver.size();
-            protectedPerformance()->appendBufferedEntriesByType(*init.type, m_entriesToDeliver, *this);
+            protectedPerformance()->appendBufferedEntriesByType(init.type, m_entriesToDeliver, *this);
             auto entriesToDeliver = m_entriesToDeliver.mutableSpan();
             auto begin = entriesToDeliver.begin();
             auto oldEnd = entriesToDeliver.subspan(oldSize).begin();

--- a/Source/WebCore/page/PerformanceObserver.h
+++ b/Source/WebCore/page/PerformanceObserver.h
@@ -44,7 +44,7 @@ class PerformanceObserver : public RefCounted<PerformanceObserver> {
 public:
     struct Init {
         std::optional<Vector<String>> entryTypes;
-        std::optional<String> type;
+        String type;
         bool buffered;
         std::optional<DOMHighResTimeStamp> durationThreshold;
     };

--- a/Source/WebCore/page/PerformanceObserver.idl
+++ b/Source/WebCore/page/PerformanceObserver.idl
@@ -23,10 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://w3c.github.io/performance-timeline/
-
 typedef double DOMHighResTimeStamp;
 
+// https://w3c.github.io/performance-timeline/#dom-performanceobserver
 [
     CustomIsReachable,
     Exposed=*,
@@ -40,9 +39,8 @@ typedef double DOMHighResTimeStamp;
     [CallWith=CurrentScriptExecutionContext] static readonly attribute FrozenArray<DOMString> supportedEntryTypes;
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary PerformanceObserverInit {
+// https://w3c.github.io/performance-timeline/#dom-performanceobserverinit
+dictionary PerformanceObserverInit {
     sequence<DOMString> entryTypes;
     DOMString type;
     boolean buffered = false;

--- a/Source/WebCore/page/ResizeObserverOptions.idl
+++ b/Source/WebCore/page/ResizeObserverOptions.idl
@@ -24,8 +24,6 @@
  */
 
 // https://drafts.csswg.org/resize-observer/#dictdef-resizeobserveroptions
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ResizeObserverOptions {
+dictionary ResizeObserverOptions {
     ResizeObserverBoxOptions box = "content-box";
 };

--- a/Source/WebCore/page/ScrollIntoViewOptions.h
+++ b/Source/WebCore/page/ScrollIntoViewOptions.h
@@ -25,8 +25,8 @@
 namespace WebCore {
 
 struct ScrollIntoViewOptions : ScrollOptions {
-    std::optional<ScrollLogicalPosition> blockPosition { ScrollLogicalPosition::Start };
-    std::optional<ScrollLogicalPosition> inlinePosition { ScrollLogicalPosition::Nearest };
+    ScrollLogicalPosition blockPosition { ScrollLogicalPosition::Start };
+    ScrollLogicalPosition inlinePosition { ScrollLogicalPosition::Nearest };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/ScrollIntoViewOptions.idl
+++ b/Source/WebCore/page/ScrollIntoViewOptions.idl
@@ -17,9 +17,10 @@
  * Boston, MA 02110-1301, USA.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ScrollIntoViewOptions : ScrollOptions {
+// https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions
+dictionary ScrollIntoViewOptions : ScrollOptions {
     [ImplementedAs=blockPosition] ScrollLogicalPosition block = "start";
     [ImplementedAs=inlinePosition] ScrollLogicalPosition inline = "nearest";
+    // FIXME: Add support for `container`.
+    // ScrollIntoViewContainer container = "all";
 };

--- a/Source/WebCore/page/ScrollOptions.h
+++ b/Source/WebCore/page/ScrollOptions.h
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 struct ScrollOptions {
-    std::optional<ScrollBehavior> behavior { ScrollBehavior::Auto };
+    ScrollBehavior behavior { ScrollBehavior::Auto };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/ScrollOptions.idl
+++ b/Source/WebCore/page/ScrollOptions.idl
@@ -23,8 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ScrollOptions {
+// https://drafts.csswg.org/cssom-view/#dictdef-scrolloptions
+dictionary ScrollOptions {
     ScrollBehavior behavior = "auto";
 };

--- a/Source/WebCore/page/ScrollToOptions.h
+++ b/Source/WebCore/page/ScrollToOptions.h
@@ -36,12 +36,6 @@ namespace WebCore {
 struct ScrollToOptions : ScrollOptions {
     std::optional<double> left;
     std::optional<double> top;
-
-    ScrollToOptions() = default;
-    ScrollToOptions(double x, double y)
-        : left(x)
-        , top(y)
-    { }
 };
 
 inline double normalizeNonFiniteValueOrFallBackTo(std::optional<double> value, double fallbackValue)

--- a/Source/WebCore/page/ScrollToOptions.idl
+++ b/Source/WebCore/page/ScrollToOptions.idl
@@ -26,9 +26,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary ScrollToOptions : ScrollOptions {
+// https://drafts.csswg.org/cssom-view/#dictdef-scrolltooptions
+dictionary ScrollToOptions : ScrollOptions {
     unrestricted double left;
     unrestricted double top;
 };

--- a/Source/WebCore/page/ShareData.idl
+++ b/Source/WebCore/page/ShareData.idl
@@ -23,11 +23,13 @@
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://w3c.github.io/web-share/#sharedata-dictionary
 [
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ShareData {
+    // FIXME: `files` should be a `sequence<File>`.
+    FrozenArray<File> files;
     USVString title;
     USVString text;
     USVString url;
-    FrozenArray<File> files;
 };

--- a/Source/WebCore/page/StructuredSerializeOptions.h
+++ b/Source/WebCore/page/StructuredSerializeOptions.h
@@ -33,11 +33,6 @@
 namespace WebCore {
 
 struct StructuredSerializeOptions {
-    StructuredSerializeOptions() = default;
-    StructuredSerializeOptions(Vector<JSC::Strong<JSC::JSObject>>&& transfer)
-        : transfer(WTF::move(transfer))
-    { }
-
     Vector<JSC::Strong<JSC::JSObject>> transfer;
 };
 

--- a/Source/WebCore/page/StructuredSerializeOptions.idl
+++ b/Source/WebCore/page/StructuredSerializeOptions.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary StructuredSerializeOptions {
+// https://html.spec.whatwg.org/multipage/web-messaging.html#structuredserializeoptions
+dictionary StructuredSerializeOptions {
   sequence<object> transfer = [];
 };

--- a/Source/WebCore/page/UADataValues.idl
+++ b/Source/WebCore/page/UADataValues.idl
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/ua-client-hints/#idl-index
+// https://wicg.github.io/ua-client-hints/#dictdef-uadatavalues
 [
     JSGenerateToJSObject,
     EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled,

--- a/Source/WebCore/page/UALowEntropyJSON.idl
+++ b/Source/WebCore/page/UALowEntropyJSON.idl
@@ -23,7 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://wicg.github.io/ua-client-hints/#idl-index
+// https://wicg.github.io/ua-client-hints/#dictdef-ualowentropyjson
 [
   JSGenerateToJSObject,
   EnabledBySetting=NavigatorUserAgentDataJavaScriptAPIEnabled,

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -42,8 +42,8 @@ class UndoItem : public RefCountedAndCanMakeWeakPtr<UndoItem> {
 public:
     struct Init {
         String label;
-        RefPtr<VoidCallback> undo;
-        RefPtr<VoidCallback> redo;
+        Ref<VoidCallback> undo;
+        Ref<VoidCallback> redo;
     };
 
     static Ref<UndoItem> create(Init&& init)
@@ -67,8 +67,8 @@ public:
 private:
     explicit UndoItem(Init&& init)
         : m_label(WTF::move(init.label))
-        , m_undoHandler(init.undo.releaseNonNull())
-        , m_redoHandler(init.redo.releaseNonNull())
+        , m_undoHandler(WTF::move(init.undo))
+        , m_redoHandler(WTF::move(init.redo))
     {
     }
 

--- a/Source/WebCore/page/UndoItem.idl
+++ b/Source/WebCore/page/UndoItem.idl
@@ -23,9 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://github.com/whsieh/UndoManager/blob/master/README.md
+
 [
     EnabledBySetting=UndoManagerAPIEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary UndoItemInit {
     required DOMString label;
     required VoidCallback undo;

--- a/Source/WebCore/page/WindowPostMessageOptions.h
+++ b/Source/WebCore/page/WindowPostMessageOptions.h
@@ -30,12 +30,6 @@
 namespace WebCore {
 
 struct WindowPostMessageOptions : public StructuredSerializeOptions {
-    WindowPostMessageOptions() = default;
-    WindowPostMessageOptions(String&& targetOrigin, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
-        : StructuredSerializeOptions(WTF::move(transfer))
-        , targetOrigin(WTF::move(targetOrigin))
-    { }
-
     String targetOrigin { "/"_s };
 };
 

--- a/Source/WebCore/page/WindowPostMessageOptions.idl
+++ b/Source/WebCore/page/WindowPostMessageOptions.idl
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary WindowPostMessageOptions : StructuredSerializeOptions {
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowpostmessageoptions
+dictionary WindowPostMessageOptions : StructuredSerializeOptions {
     USVString targetOrigin = "/";
 };

--- a/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
@@ -38,7 +38,7 @@ namespace WebCore {
 class PlatformSpeechSynthesisUtteranceClient : public CanMakeWeakPtr<PlatformSpeechSynthesisUtteranceClient>, public AbstractRefCounted {
 public:
     virtual ~PlatformSpeechSynthesisUtteranceClient() = default;
-    virtual void eventOccurred(const AtomString& type, unsigned long charIndex, unsigned long charLength, const String& name) = 0;
+    virtual void eventOccurred(const AtomString& type, uint32_t charIndex, uint32_t charLength, const String& name) = 0;
 
     virtual bool isSpeechSynthesisUtterance() const { return false; }
 

--- a/Source/WebCore/storage/StorageEvent.cpp
+++ b/Source/WebCore/storage/StorageEvent.cpp
@@ -45,9 +45,9 @@ Ref<StorageEvent> StorageEvent::create(const AtomString& type, const String& key
     return adoptRef(*new StorageEvent(type, key, oldValue, newValue, url, storageArea));
 }
 
-Ref<StorageEvent> StorageEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+Ref<StorageEvent> StorageEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    return adoptRef(*new StorageEvent(type, initializer, isTrusted));
+    return adoptRef(*new StorageEvent(type, WTF::move(initializer), isTrusted));
 }
 
 StorageEvent::StorageEvent()
@@ -65,13 +65,13 @@ StorageEvent::StorageEvent(const AtomString& type, const String& key, const Stri
 {
 }
 
-StorageEvent::StorageEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(EventInterfaceType::StorageEvent, type, initializer, isTrusted)
-    , m_key(initializer.key)
-    , m_oldValue(initializer.oldValue)
-    , m_newValue(initializer.newValue)
-    , m_url(initializer.url)
-    , m_storageArea(initializer.storageArea)
+StorageEvent::StorageEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+    : Event(EventInterfaceType::StorageEvent, type, WTF::move(initializer), isTrusted)
+    , m_key(WTF::move(initializer.key))
+    , m_oldValue(WTF::move(initializer.oldValue))
+    , m_newValue(WTF::move(initializer.newValue))
+    , m_url(WTF::move(initializer.url))
+    , m_storageArea(WTF::move(initializer.storageArea))
 {
 }
 

--- a/Source/WebCore/storage/StorageEvent.h
+++ b/Source/WebCore/storage/StorageEvent.h
@@ -46,7 +46,7 @@ public:
         RefPtr<Storage> storageArea;
     };
 
-    static Ref<StorageEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
+    static Ref<StorageEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     virtual ~StorageEvent();
 
     const String& key() const { return m_key; }
@@ -63,7 +63,7 @@ public:
 private:
     StorageEvent();
     StorageEvent(const AtomString& type, const String& key, const String& oldValue, const String& newValue, const String& url, Storage* storageArea);
-    StorageEvent(const AtomString&, const Init&, IsTrusted);
+    StorageEvent(const AtomString&, Init&&, IsTrusted);
 
     String m_key;
     String m_oldValue;

--- a/Source/WebCore/storage/StorageEvent.idl
+++ b/Source/WebCore/storage/StorageEvent.idl
@@ -23,6 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://html.spec.whatwg.org/multipage/webstorage.html#storageevent
 [
     Exposed=Window
 ] interface StorageEvent : Event {
@@ -47,6 +48,7 @@
     // undefined initStorageEventNS(DOMString namespaceURI, DOMString typeArg, boolean canBubbleArg, boolean cancelableArg, DOMString keyArg, DOMString oldValueArg, DOMString newValueArg, USVString urlArg, Storage? storageAreaArg);
 };
 
+// https://html.spec.whatwg.org/multipage/webstorage.html#storageeventinit
 [
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary StorageEventInit : EventInit {

--- a/Source/WebCore/testing/FakeXRRigidTransformInit.idl
+++ b/Source/WebCore/testing/FakeXRRigidTransformInit.idl
@@ -27,7 +27,6 @@
 [
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRRigidTransformInit {
     // must have three elements
     required sequence<float> position;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1143,20 +1143,20 @@ public:
 
     struct ImageOverlayText {
         String text;
-        RefPtr<DOMPointReadOnly> topLeft;
-        RefPtr<DOMPointReadOnly> topRight;
-        RefPtr<DOMPointReadOnly> bottomRight;
-        RefPtr<DOMPointReadOnly> bottomLeft;
+        Ref<DOMPointReadOnly> topLeft;
+        Ref<DOMPointReadOnly> topRight;
+        Ref<DOMPointReadOnly> bottomRight;
+        Ref<DOMPointReadOnly> bottomLeft;
         bool hasLeadingWhitespace { true };
 
         ~ImageOverlayText();
     };
 
     struct ImageOverlayLine {
-        RefPtr<DOMPointReadOnly> topLeft;
-        RefPtr<DOMPointReadOnly> topRight;
-        RefPtr<DOMPointReadOnly> bottomRight;
-        RefPtr<DOMPointReadOnly> bottomLeft;
+        Ref<DOMPointReadOnly> topLeft;
+        Ref<DOMPointReadOnly> topRight;
+        Ref<DOMPointReadOnly> bottomRight;
+        Ref<DOMPointReadOnly> bottomLeft;
         Vector<ImageOverlayText> children;
         bool hasTrailingNewline { true };
         bool isVertical { false };
@@ -1166,19 +1166,19 @@ public:
 
     struct ImageOverlayBlock {
         String text;
-        RefPtr<DOMPointReadOnly> topLeft;
-        RefPtr<DOMPointReadOnly> topRight;
-        RefPtr<DOMPointReadOnly> bottomRight;
-        RefPtr<DOMPointReadOnly> bottomLeft;
+        Ref<DOMPointReadOnly> topLeft;
+        Ref<DOMPointReadOnly> topRight;
+        Ref<DOMPointReadOnly> bottomRight;
+        Ref<DOMPointReadOnly> bottomLeft;
 
         ~ImageOverlayBlock();
     };
 
     struct ImageOverlayDataDetector {
-        RefPtr<DOMPointReadOnly> topLeft;
-        RefPtr<DOMPointReadOnly> topRight;
-        RefPtr<DOMPointReadOnly> bottomRight;
-        RefPtr<DOMPointReadOnly> bottomLeft;
+        Ref<DOMPointReadOnly> topLeft;
+        Ref<DOMPointReadOnly> topRight;
+        Ref<DOMPointReadOnly> bottomRight;
+        Ref<DOMPointReadOnly> bottomLeft;
 
         ~ImageOverlayDataDetector();
     };
@@ -1204,8 +1204,17 @@ public:
     bool usingAppleInternalSDK() const;
     bool usingGStreamer() const;
 
-    using NowPlayingInfoArtwork = WebCore::NowPlayingInfoArtwork;
-    using NowPlayingMetadata = WebCore::NowPlayingMetadata;
+    struct NowPlayingInfoArtwork {
+        String src;
+        String mimeType;
+    };
+    struct NowPlayingMetadata {
+        String title;
+        String artist;
+        String album;
+        String sourceApplicationIdentifier;
+        std::optional<NowPlayingInfoArtwork> artwork;
+    };
     std::optional<NowPlayingMetadata> nowPlayingMetadata() const;
 
     struct NowPlayingState {
@@ -1346,24 +1355,23 @@ public:
         bool isSameSiteLax { false };
         bool isSameSiteStrict { false };
 
-        CookieData(Cookie cookie)
-            : name(cookie.name)
-            , value(cookie.value)
-            , domain(cookie.domain)
-            , path(cookie.path)
-            , expires(cookie.expires)
-            , isHttpOnly(cookie.httpOnly)
-            , isSecure(cookie.secure)
-            , isSession(cookie.session)
-            , isSameSiteNone(cookie.sameSite == Cookie::SameSitePolicy::None)
-            , isSameSiteLax(cookie.sameSite == Cookie::SameSitePolicy::Lax)
-            , isSameSiteStrict(cookie.sameSite == Cookie::SameSitePolicy::Strict)
+        static CookieData fromCookie(Cookie cookie)
         {
-            ASSERT(!(isSameSiteLax && isSameSiteStrict) && !(isSameSiteLax && isSameSiteNone) && !(isSameSiteStrict && isSameSiteNone));
-        }
-
-        CookieData()
-        {
+            auto cookieData = CookieData {
+                WTF::move(cookie.name),
+                WTF::move(cookie.value),
+                WTF::move(cookie.domain),
+                WTF::move(cookie.path),
+                cookie.expires,
+                cookie.httpOnly,
+                cookie.secure,
+                cookie.session,
+                cookie.sameSite == Cookie::SameSitePolicy::None,
+                cookie.sameSite == Cookie::SameSitePolicy::Lax,
+                cookie.sameSite == Cookie::SameSitePolicy::Strict
+            };
+            ASSERT(!(cookieData.isSameSiteLax && cookieData.isSameSiteStrict) && !(cookieData.isSameSiteLax && cookieData.isSameSiteNone) && !(cookieData.isSameSiteStrict && cookieData.isSameSiteNone));
+            return cookieData;
         }
 
         static Cookie toCookie(CookieData&& cookieData)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -145,22 +145,20 @@ enum AutoplayPolicy {
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     Conditional=VIDEO,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary NowPlayingState {
-    DOMString title;
-    unrestricted double duration;
-    unrestricted double elapsedTime;
-    unsigned long long uniqueIdentifier;
-    boolean hasActiveSession;
-    boolean registeredAsNowPlayingApplication;
-    boolean haveEverRegisteredAsNowPlayingApplication;
+    DOMString title = "";
+    unrestricted double duration = 0;
+    unrestricted double elapsedTime = 0;
+    unsigned long long uniqueIdentifier = 0;
+    boolean hasActiveSession = false;
+    boolean registeredAsNowPlayingApplication = false;
+    boolean haveEverRegisteredAsNowPlayingApplication = false;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     Conditional=VIDEO,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary NowPlayingInfoArtwork {
     DOMString src;
     DOMString mimeType;
@@ -170,20 +168,18 @@ enum AutoplayPolicy {
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     Conditional=VIDEO,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary NowPlayingMetadata {
     DOMString title;
     DOMString artist;
     DOMString album;
     DOMString sourceApplicationIdentifier;
-    NowPlayingInfoArtwork? artwork;
+    NowPlayingInfoArtwork artwork;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     Conditional=VIDEO,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaUsageState {
     DOMString mediaURL;
     boolean isPlaying;
@@ -220,12 +216,11 @@ enum AutoplayPolicy {
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FullscreenInsets {
-    double top;
-    double left;
-    double bottom;
-    double right;
+    float top = 0;
+    float left = 0;
+    float bottom = 0;
+    float right = 0;
 };
 
 enum HEVCParameterCodec {
@@ -239,13 +234,13 @@ enum HEVCParameterCodec {
     JSGenerateToNativeObject,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary HEVCParameterSet {
-    HEVCParameterCodec codec;
-    unsigned short generalProfileSpace;
-    unsigned short generalProfileIDC;
-    unsigned long generalProfileCompatibilityFlags;
-    octet generalTierFlag;
+    HEVCParameterCodec codec = "hvc1";
+    unsigned short generalProfileSpace = 0;
+    unsigned short generalProfileIDC = 0;
+    unsigned long generalProfileCompatibilityFlags = 0;
+    octet generalTierFlag = 0;
     required FrozenArray<octet> generalConstraintIndicatorFlags;
-    unsigned short generalLevelIDC;
+    unsigned short generalLevelIDC = 0;
 };
 
 enum AV1ConfigurationProfile {
@@ -294,63 +289,60 @@ enum AV1ConfigurationRange {
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AV1CodecConfigurationRecord {
     DOMString codecName;
-    AV1ConfigurationProfile profile;
-    AV1ConfigurationLevel level;
-    AV1ConfigurationTier tier;
-    octet bitDepth;
-    octet monochrome;
-    octet chromaSubsampling;
-    octet colorPrimaries;
-    octet transferCharacteristics;
-    octet matrixCoefficients;
-    AV1ConfigurationRange videoFullRangeFlag;
+    AV1ConfigurationProfile profile = "Main";
+    AV1ConfigurationLevel level = "Level_2_0";
+    AV1ConfigurationTier tier = "Main";
+    octet bitDepth = 8;
+    octet monochrome = 0;
+    octet chromaSubsampling = 110;
+    octet colorPrimaries = 1;
+    octet transferCharacteristics = 1;
+    octet matrixCoefficients = 1;
+    AV1ConfigurationRange videoFullRangeFlag = "VideoRange";
+    unsigned long width = 0;
+    unsigned long height = 0;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary DoViParameterSet {
-    DOMString codecName;
-    unsigned short bitstreamProfileID;
-    unsigned short bitstreamLevelID;
+    required DOMString codecName;
+    required unsigned short bitstreamProfileID;
+    required unsigned short bitstreamLevelID;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary VPCodecConfigurationRecord {
     DOMString codecName;
-    octet profile;
-    octet level;
-    octet bitDepth;
-    octet chromaSubsampling;
-    octet videoFullRangeFlag;
-    octet colorPrimaries;
-    octet transferCharacteristics;
-    octet matrixCoefficients;
+    octet profile = 0;
+    octet level = 10;
+    octet bitDepth = 8;
+    octet chromaSubsampling = 1;
+    octet videoFullRangeFlag = 0;
+    octet colorPrimaries = 1;
+    octet transferCharacteristics = 1;
+    octet matrixCoefficients = 1;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary AcceleratedAnimation {
-    DOMString property;
-    double speed;
-    boolean isThreaded;
+    required DOMString property;
+    required double speed;
+    required boolean isThreaded;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary CookieData {
     DOMString name;
     DOMString value;
@@ -391,7 +383,6 @@ enum AV1ConfigurationRange {
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary TextIndicatorOptions {
     boolean useBoundingRectAndPaintAllContentForComplexRanges = false;
     boolean computeEstimatedBackgroundColor = false;
@@ -402,7 +393,6 @@ enum AV1ConfigurationRange {
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary TextIteratorState {
     DOMString text;
     Range range;
@@ -410,7 +400,6 @@ enum AV1ConfigurationRange {
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ImageOverlayText {
     required DOMString text;
     required DOMPointReadOnly topLeft;
@@ -422,20 +411,18 @@ enum AV1ConfigurationRange {
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ImageOverlayLine {
     required DOMPointReadOnly topLeft;
     required DOMPointReadOnly topRight;
     required DOMPointReadOnly bottomRight;
     required DOMPointReadOnly bottomLeft;
-    sequence<ImageOverlayText> children;
+    sequence<ImageOverlayText> children = [];
     boolean hasTrailingNewline = true;
     boolean isVertical = false;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ImageOverlayBlock {
     required DOMString text;
     required DOMPointReadOnly topLeft;
@@ -446,7 +433,6 @@ enum AV1ConfigurationRange {
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ImageOverlayDataDetector {
     required DOMPointReadOnly topLeft;
     required DOMPointReadOnly topRight;
@@ -457,23 +443,21 @@ enum AV1ConfigurationRange {
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary SelectorFilterHashCounts {
-    unsigned long ids;
-    unsigned long classes;
-    unsigned long tags;
-    unsigned long attributes;
+    unsigned long ids = 0;
+    unsigned long classes = 0;
+    unsigned long tags = 0;
+    unsigned long attributes = 0;
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary PDFAnnotationRect {
-    double x;
-    double y;
-    double width;
-    double height; 
+    float x = 0;
+    float y = 0;
+    float width = 0;
+    float height = 0;
 };
 
 typedef (FetchRequest or FetchResponse) FetchObject;
@@ -481,16 +465,15 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ImageBufferResourceLimits {
-    unsigned long long acceleratedImageBufferForCanvasCount;
-    unsigned long long acceleratedImageBufferForCanvasLimit;
-    unsigned long long globalAcceleratedImageBufferCount;
-    unsigned long long globalAcceleratedImageBufferLimit;
-    unsigned long long globalImageBufferForCanvasCount;
-    unsigned long long globalImageBufferForCanvasLimit;
-    unsigned long long imageBufferForCanvasCount;
-    unsigned long long imageBufferForCanvasLimit;
+    unsigned long long acceleratedImageBufferForCanvasCount = 0;
+    unsigned long long acceleratedImageBufferForCanvasLimit = 0;
+    unsigned long long globalAcceleratedImageBufferCount = 0;
+    unsigned long long globalAcceleratedImageBufferLimit = 0;
+    unsigned long long globalImageBufferForCanvasCount = 0;
+    unsigned long long globalImageBufferForCanvasLimit = 0;
+    unsigned long long imageBufferForCanvasCount = 0;
+    unsigned long long imageBufferForCanvasLimit = 0;
 };
 
 enum RenderingMode {
@@ -512,20 +495,18 @@ enum ContentsFormat {
     Conditional=DAMAGE_TRACKING,
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FrameDamage {
-    unsigned long sequenceId;
+    unsigned long sequenceId = 0;
     DOMRectReadOnly bounds;
-    sequence<DOMRectReadOnly> rects;
+    sequence<DOMRectReadOnly> rects = [];
 };
 
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ScrollingNodeID {
-    unsigned long long nodeIdentifier;
-    unsigned long long processIdentifier;
+    required unsigned long long nodeIdentifier;
+    required unsigned long long processIdentifier;
 };
 
 [

--- a/Source/WebCore/testing/MockPayment.h
+++ b/Source/WebCore/testing/MockPayment.h
@@ -34,15 +34,18 @@ namespace WebCore {
 
 class MockPayment final : public Payment {
 public:
-    explicit MockPayment(ApplePayPayment&& applePayPayment)
+    explicit MockPayment(ApplePayPayment&& applePayPayment, LocalizedApplePayPayment&& localizedApplePayPayment)
         : m_applePayPayment { WTF::move(applePayPayment) }
+        , m_localizedApplePayPayment { WTF::move(localizedApplePayPayment) }
     {
     }
 
     ApplePayPayment toApplePayPayment(unsigned) const final { return m_applePayPayment; }
+    LocalizedApplePayPayment toLocalizedApplePayPayment(unsigned) const final { return m_localizedApplePayPayment; }
 
 private:
     ApplePayPayment m_applePayPayment;
+    LocalizedApplePayPayment m_localizedApplePayPayment;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockPaymentAddress.h
+++ b/Source/WebCore/testing/MockPaymentAddress.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-struct MockPaymentAddress : ApplePayPaymentContact {
+struct MockPaymentAddress : LocalizedApplePayPaymentContact {
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockPaymentContact.h
+++ b/Source/WebCore/testing/MockPaymentContact.h
@@ -34,15 +34,16 @@ namespace WebCore {
 
 class MockPaymentContact final : public PaymentContact {
 public:
-    explicit MockPaymentContact(ApplePayPaymentContact&& applePayPaymentContact)
+    explicit MockPaymentContact(LocalizedApplePayPaymentContact&& applePayPaymentContact)
         : m_applePayPaymentContact { WTF::move(applePayPaymentContact) }
     {
     }
 
     ApplePayPaymentContact toApplePayPaymentContact(unsigned) const final { return m_applePayPaymentContact; }
+    LocalizedApplePayPaymentContact toLocalizedApplePayPaymentContact(unsigned) const final { return m_applePayPaymentContact; }
 
 private:
-    ApplePayPaymentContact m_applePayPaymentContact;
+    LocalizedApplePayPaymentContact m_applePayPaymentContact;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -119,7 +119,7 @@ void MockPaymentCoordinator::dispatchIfShowing(Function<void()>&& function)
 bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest& request)
 {
     if (request.shippingContact().pkContact().get())
-        m_shippingAddress = request.shippingContact().toApplePayPaymentContact(request.version());
+        m_shippingAddress = request.shippingContact().toLocalizedApplePayPaymentContact(request.version());
     m_supportedCountries = request.supportedCountries();
     m_shippingMethods = request.shippingMethods();
     m_requiredBillingContactFields = request.requiredBillingContactFields();
@@ -346,8 +346,10 @@ void MockPaymentCoordinator::acceptPayment()
 
     dispatchIfShowing([page = WTF::move(page), shippingAddress = m_shippingAddress]() mutable {
         ApplePayPayment payment;
-        payment.shippingContact = WTF::move(shippingAddress);
-        page->protectedPaymentCoordinator()->didAuthorizePayment(MockPayment { WTF::move(payment) });
+        payment.shippingContact = shippingAddress;
+        LocalizedApplePayPayment localizedPayment;
+        localizedPayment.shippingContact = shippingAddress;
+        page->protectedPaymentCoordinator()->didAuthorizePayment(MockPayment { WTF::move(payment), WTF::move(localizedPayment) });
     });
 }
 

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -159,7 +159,7 @@ private:
     uint64_t m_hideCount { 0 };
     bool m_canMakePayments { true };
     bool m_canMakePaymentsWithActiveCard { true };
-    ApplePayPaymentContact m_shippingAddress;
+    LocalizedApplePayPaymentContact m_shippingAddress;
     ApplePayLineItem m_total;
     Vector<ApplePayLineItem> m_lineItems;
     Vector<MockPaymentError> m_errors;

--- a/Source/WebCore/testing/MockPaymentError.idl
+++ b/Source/WebCore/testing/MockPaymentError.idl
@@ -26,7 +26,6 @@
 [
     Conditional=APPLE_PAY,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockPaymentError {
     required ApplePayErrorCode code;
     required DOMString message;

--- a/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
+++ b/Source/WebCore/testing/MockWebAuthenticationConfiguration.idl
@@ -70,7 +70,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockWebAuthenticationConfiguration {
     boolean silentFailure = false;
     MockLocalConfiguration local;
@@ -81,7 +80,6 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockLocalConfiguration {
     UserVerification userVerification = "no";
     boolean acceptAttestation = false;
@@ -93,11 +91,10 @@
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockHidConfiguration {
-    sequence<DOMString> payloadBase64;
-    sequence<DOMString> expectedCommandsBase64;
-    boolean validateExpectedCommands;
+    sequence<DOMString> payloadBase64 = [];
+    sequence<DOMString> expectedCommandsBase64 = [];
+    boolean validateExpectedCommands = false;
     MockHidStage stage = "info";
     MockHidSubStage subStage = "init";
     MockHidError error = "success";
@@ -109,24 +106,22 @@
     boolean expectCancel = false;
     boolean supportClientPin = false;
     boolean supportInternalUV = false;
-    sequence<octet> pinProtocols;
+    sequence<octet> pinProtocols = [];
     long maxCredentialCountInList = 1;
     long maxCredentialIdLength = 64;
 };
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockNfcConfiguration {
     MockNfcError error = "success";
-    sequence<DOMString> payloadBase64;
+    sequence<DOMString> payloadBase64 = [];
     boolean multipleTags = false;
     boolean multiplePhysicalTags = false;
 };
 
 [
     Conditional=WEB_AUTHN,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockCcidConfiguration {
-    sequence<DOMString> payloadBase64;
+    sequence<DOMString> payloadBase64 = [];
 };

--- a/Source/WebCore/testing/TypeConversions.idl
+++ b/Source/WebCore/testing/TypeConversions.idl
@@ -89,7 +89,6 @@
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary TypeConversionsOtherDictionary {
     long longValue = 0;
     DOMString stringValue = "";
@@ -98,13 +97,12 @@
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary TypeConversionsDictionary {
     long longValue = 0;
     DOMString stringValue = "";
     [LegacyNullToEmptyString] DOMString treatNullAsEmptyStringValue = "";
     sequence<DOMString> sequenceValue = [];
-    (Node or sequence<DOMString> or TypeConversionsOtherDictionary) unionValue = null;
+    (Node or sequence<DOMString> or TypeConversionsOtherDictionary) unionValue = { };
     [Clamp] long clampLongValue = 0;
     [EnforceRange] long enforceRangeLongValue = 0;
 };

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -109,6 +109,11 @@ ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& s
     return { };
 }
 
+ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
+{
+    return postMessage(globalObject, messageValue, StructuredSerializeOptions { WTF::move(transfer) });
+}
+
 Ref<DedicatedWorkerThread> DedicatedWorkerGlobalScope::thread()
 {
     return downcast<DedicatedWorkerThread>(Base::thread());

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -72,6 +72,7 @@ public:
     const String& name() const { return m_name; }
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
+    ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, Vector<JSC::Strong<JSC::JSObject>>&&);
 
     Ref<DedicatedWorkerThread> thread();
 

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -150,10 +150,10 @@ Worker::~Worker()
     m_contextProxy.workerObjectDestroyed();
 }
 
-ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
+ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
     Vector<Ref<MessagePort>> ports;
-    auto message = SerializedScriptValue::create(state, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    auto message = SerializedScriptValue::create(globalObject, messageValue, WTF::move(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (message.hasException())
         return message.releaseException();
 
@@ -164,6 +164,11 @@ ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue m
 
     m_contextProxy.postMessageToWorkerGlobalScope({ message.releaseReturnValue(), channels.releaseReturnValue() });
     return { };
+}
+
+ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
+{
+    return postMessage(globalObject, messageValue, StructuredSerializeOptions { WTF::move(transfer) });
 }
 
 void Worker::terminate()

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -70,6 +70,7 @@ public:
     virtual ~Worker();
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
+    ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, Vector<JSC::Strong<JSC::JSObject>>&&);
 
     void terminate();
     bool wasTerminated() const { return m_wasTerminated; }

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -138,6 +138,11 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
     return { };
 }
 
+ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
+{
+    return postMessage(globalObject, messageValue, StructuredSerializeOptions { WTF::move(transfer) });
+}
+
 enum EventTargetInterfaceType ServiceWorker::eventTargetInterface() const
 {
     return EventTargetInterfaceType::ServiceWorker;

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -67,6 +67,7 @@ public:
     void updateState(State);
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
+    ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, Vector<JSC::Strong<JSC::JSObject>>&&);
 
     ServiceWorkerIdentifier identifier() const { return m_data.identifier; }
     ServiceWorkerRegistrationIdentifier registrationIdentifier() const { return m_data.registrationIdentifier; }

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -100,4 +100,9 @@ ExceptionOr<void> ServiceWorkerClient::postMessage(JSC::JSGlobalObject& globalOb
     return { };
 }
 
+ExceptionOr<void> ServiceWorkerClient::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
+{
+    return postMessage(globalObject, messageValue, StructuredSerializeOptions { WTF::move(transfer) });
+}
+
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerClient.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.h
@@ -67,6 +67,7 @@ public:
     Identifier identifier() const { return m_data.identifier; }
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
+    ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, Vector<JSC::Strong<JSC::JSObject>>&&);
 
     const ServiceWorkerClientData& data() const { return m_data; }
 


### PR DESCRIPTION
#### 9eed59acfad8ba0bf3c85aade97578d3f196ea8a
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from IDL dictionaries (Part 4)
<a href="https://bugs.webkit.org/show_bug.cgi?id=306280">https://bugs.webkit.org/show_bug.cgi?id=306280</a>

Reviewed by Anne van Kesteren and Abrar Rahman Protyasha.

Fourth batch of removing relatively trivial uses of LegacyNativeDictionaryRequiredInterfaceNullability.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.h:
* Source/WebCore/Modules/ShapeDetection/BarcodeDetectorOptions.idl:
* Source/WebCore/Modules/applepay/ApplePayCouponCodeUpdate.idl:
* Source/WebCore/Modules/applepay/ApplePayDetailsUpdateBase.idl:
* Source/WebCore/Modules/applepay/ApplePayInstallmentConfiguration.idl:
* Source/WebCore/Modules/applepay/ApplePayPayment.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizationResult.idl:
* Source/WebCore/Modules/applepay/ApplePayPaymentContact.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentContact.idl:
* Source/WebCore/Modules/applepay/ApplePayPaymentMethodUpdate.idl:
* Source/WebCore/Modules/applepay/ApplePayPaymentRequest.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentRequest.idl:
* Source/WebCore/Modules/applepay/ApplePayRequestBase.idl:
* Source/WebCore/Modules/applepay/ApplePaySetupConfiguration.idl:
* Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.cpp:
* Source/WebCore/Modules/applepay/ApplePayShippingContactSelectedEvent.h:
* Source/WebCore/Modules/applepay/ApplePayShippingContactUpdate.idl:
* Source/WebCore/Modules/applepay/ApplePayShippingMethodUpdate.idl:
* Source/WebCore/Modules/applepay/Payment.h:
* Source/WebCore/Modules/applepay/PaymentContact.h:
* Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm:
* Source/WebCore/Modules/applepay/cocoa/PaymentContactCocoa.mm:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayModifier.idl:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayRequest.h:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayRequest.idl:
* Source/WebCore/Modules/cookie-store/CookieChangeEvent.cpp:
* Source/WebCore/Modules/cookie-store/CookieChangeEvent.h:
* Source/WebCore/Modules/cookie-store/CookieChangeEvent.idl:
* Source/WebCore/Modules/cookie-store/CookieChangeEventInit.h:
* Source/WebCore/Modules/cookie-store/CookieChangeEventInit.idl:
* Source/WebCore/Modules/cookie-store/CookieListItem.h:
* Source/WebCore/Modules/cookie-store/CookieListItem.idl:
* Source/WebCore/Modules/cookie-store/CookieSameSite.idl:
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
* Source/WebCore/Modules/cookie-store/CookieStore.idl:
* Source/WebCore/Modules/cookie-store/CookieStoreDeleteOptions.idl:
* Source/WebCore/Modules/cookie-store/CookieStoreGetOptions.idl:
* Source/WebCore/Modules/cookie-store/CookieStoreManager.idl:
* Source/WebCore/Modules/cookie-store/DOMWindow+CookieStore.idl:
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.cpp:
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.h:
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEvent.idl:
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEventInit.h:
* Source/WebCore/Modules/cookie-store/ExtendableCookieChangeEventInit.idl:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemConfiguration.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.cpp:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.cpp:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.h:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl:
* Source/WebCore/Modules/indexeddb/IDBFactory.h:
* Source/WebCore/Modules/indexeddb/IDBFactory.idl:
* Source/WebCore/Modules/indexeddb/IDBVersionChangeEvent.idl:
* Source/WebCore/Modules/mediacontrols/MediaControlsContextMenuItem.idl:
* Source/WebCore/Modules/mediarecorder/BlobEvent.cpp:
* Source/WebCore/Modules/mediarecorder/BlobEvent.h:
* Source/WebCore/Modules/mediarecorder/BlobEvent.idl:
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.cpp:
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorderErrorEvent.idl:
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl:
* Source/WebCore/Modules/mediastream/DoubleRange.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.cpp:
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrackEvent.idl:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.idl:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl:
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl:
* Source/WebCore/Modules/mediastream/OverconstrainedErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCAnswerOptions.idl:
* Source/WebCore/Modules/mediastream/RTCCertificate.idl:
* Source/WebCore/Modules/mediastream/RTCConfiguration.h:
* Source/WebCore/Modules/mediastream/RTCConfiguration.idl:
* Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.cpp:
* Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.h:
* Source/WebCore/Modules/mediastream/RTCDTMFToneChangeEvent.idl:
* Source/WebCore/Modules/mediastream/RTCDataChannelEvent.cpp:
* Source/WebCore/Modules/mediastream/RTCDataChannelEvent.h:
* Source/WebCore/Modules/mediastream/RTCDataChannelEvent.idl:
* Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.idl:
* Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl:
* Source/WebCore/Modules/mediastream/RTCError.idl:
* Source/WebCore/Modules/mediastream/RTCErrorEvent.cpp:
* Source/WebCore/Modules/mediastream/RTCErrorEvent.h:
* Source/WebCore/Modules/mediastream/RTCErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCIceCandidateInit.idl:
* Source/WebCore/Modules/mediastream/RTCIceServer.idl:
* Source/WebCore/Modules/mediastream/RTCIceTransport.idl:
* Source/WebCore/Modules/mediastream/RTCLocalSessionDescriptionInit.idl:
* Source/WebCore/Modules/mediastream/RTCOfferAnswerOptions.idl:
* Source/WebCore/Modules/mediastream/RTCOfferOptions.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.cpp:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.idl:
* Source/WebCore/Modules/mediastream/RTCRtcpParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpCapabilities.idl:
* Source/WebCore/Modules/mediastream/RTCRtpCodecCapability.idl:
* Source/WebCore/Modules/mediastream/RTCRtpCodecParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpCodingParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpContributingSource.idl:
* Source/WebCore/Modules/mediastream/RTCRtpDecodingParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h:
* Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpHeaderExtensionParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformErrorEvent.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSendParameters.h:
* Source/WebCore/Modules/mediastream/RTCRtpSendParameters.idl:
* Source/WebCore/Modules/mediastream/RTCRtpSynchronizationSource.idl:
* Source/WebCore/Modules/mediastream/RTCSessionDescriptionInit.idl:
* Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp:
* Source/WebCore/Modules/mediastream/RTCTrackEvent.h:
* Source/WebCore/Modules/mediastream/RTCTrackEvent.idl:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp:
* Source/WebCore/Modules/model-element/HTMLModelElementCamera.idl:
* Source/WebCore/Modules/notifications/Notification.cpp:
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/NotificationEvent.cpp:
* Source/WebCore/Modules/notifications/NotificationEvent.h:
* Source/WebCore/Modules/notifications/NotificationEvent.idl:
* Source/WebCore/Modules/notifications/NotificationOptions.h:
* Source/WebCore/Modules/notifications/NotificationOptions.idl:
* Source/WebCore/Modules/paymentrequest/AddressErrors.idl:
* Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.idl:
* Source/WebCore/Modules/paymentrequest/PayerErrorFields.idl:
* Source/WebCore/Modules/paymentrequest/PaymentCurrencyAmount.idl:
* Source/WebCore/Modules/paymentrequest/PaymentDetailsBase.idl:
* Source/WebCore/Modules/paymentrequest/PaymentDetailsInit.idl:
* Source/WebCore/Modules/paymentrequest/PaymentItem.idl:
* Source/WebCore/Modules/paymentrequest/PaymentMethodData.idl:
* Source/WebCore/Modules/paymentrequest/PaymentOptions.idl:
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEventInit.idl:
* Source/WebCore/Modules/paymentrequest/PaymentShippingOption.idl:
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp:
* Source/WebCore/Modules/pictureinpicture/HTMLVideoElementPictureInPicture.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.cpp:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.h:
* Source/WebCore/Modules/pictureinpicture/PictureInPictureEvent.idl:
* Source/WebCore/Modules/push-api/PushEventInit.idl:
* Source/WebCore/Modules/push-api/PushSubscriptionChangeEventInit.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionErrorEvent.idl:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.cpp:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.h:
* Source/WebCore/Modules/speech/SpeechRecognitionEvent.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.cpp:
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEvent.h:
* Source/WebCore/Modules/speech/SpeechSynthesisErrorEventInit.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.cpp:
* Source/WebCore/Modules/speech/SpeechSynthesisEvent.h:
* Source/WebCore/Modules/speech/SpeechSynthesisEventInit.h:
* Source/WebCore/Modules/speech/SpeechSynthesisEventInit.idl:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.cpp:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/streams/ReadableStreamBYOBReader.idl:
* Source/WebCore/Modules/url-pattern/URLPatternInit.idl:
* Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.idl:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputs.idl:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientInputsJSON.idl:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.idl:
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputsJSON.idl:
* Source/WebCore/Modules/webauthn/AuthenticationResponseJSON.idl:
* Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialEntity.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialParameters.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialUserEntityJSON.idl:
* Source/WebCore/Modules/webauthn/UnknownCredentialOptions.idl:
* Source/WebCore/Modules/webxr/XRProjectionLayerInit.idl:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CustomAnimationOptions.idl:
* Source/WebCore/animation/EffectTiming.h:
* Source/WebCore/animation/EffectTiming.idl:
* Source/WebCore/crypto/CryptoKeyPair.idl:
* Source/WebCore/crypto/RsaOtherPrimesInfo.h:
* Source/WebCore/crypto/RsaOtherPrimesInfo.idl:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/ErrorEvent.idl:
* Source/WebCore/dom/FocusOptions.idl:
* Source/WebCore/dom/FormDataEvent.cpp:
* Source/WebCore/dom/FormDataEvent.h:
* Source/WebCore/dom/FormDataEvent.idl:
* Source/WebCore/dom/FullscreenOptions.idl:
* Source/WebCore/dom/GetHTMLOptions.idl:
* Source/WebCore/dom/HashChangeEvent.idl:
* Source/WebCore/dom/ImportNodeOptions.idl:
* Source/WebCore/dom/InputEvent.idl:
* Source/WebCore/dom/KeyboardEvent.idl:
* Source/WebCore/dom/MessageEvent.idl:
* Source/WebCore/dom/MessagePort.cpp:
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/MutationObserver.idl:
* Source/WebCore/dom/Node.idl:
* Source/WebCore/dom/ObservableInspector.idl:
* Source/WebCore/dom/PageRevealEvent.idl:
* Source/WebCore/dom/PageSwapEvent.idl:
* Source/WebCore/dom/PageTransitionEvent.idl:
* Source/WebCore/dom/PointerLockOptions.idl:
* Source/WebCore/dom/PopStateEvent.idl:
* Source/WebCore/dom/ProgressEvent.idl:
* Source/WebCore/dom/PromiseRejectionEvent.cpp:
* Source/WebCore/dom/PromiseRejectionEvent.h:
* Source/WebCore/dom/PromiseRejectionEvent.idl:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
* Source/WebCore/dom/SecurityPolicyViolationEvent.cpp:
* Source/WebCore/dom/SecurityPolicyViolationEvent.h:
* Source/WebCore/dom/SecurityPolicyViolationEvent.idl:
* Source/WebCore/dom/ShadowRootInit.idl:
* Source/WebCore/dom/StartViewTransitionOptions.idl:
* Source/WebCore/dom/StaticRange.cpp:
* Source/WebCore/dom/StaticRange.h:
* Source/WebCore/dom/StaticRange.idl:
* Source/WebCore/dom/SubscribeOptions.idl:
* Source/WebCore/dom/SubscriptionObserver.idl:
* Source/WebCore/dom/TextDecoder.idl:
* Source/WebCore/dom/ToggleEvent.idl:
* Source/WebCore/dom/TrustedTypePolicyOptions.idl:
* Source/WebCore/dom/ValidityStateFlags.h:
* Source/WebCore/dom/ValidityStateFlags.idl:
* Source/WebCore/dom/WheelEvent.idl:
* Source/WebCore/fileapi/BlobPropertyBag.idl:
* Source/WebCore/fileapi/File.idl:
* Source/WebCore/html/HTMLElement.idl:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/html/HTMLSlotElement.idl:
* Source/WebCore/html/ImageBitmapOptions.idl:
* Source/WebCore/html/ImageDataSettings.idl:
* Source/WebCore/html/MediaEncryptedEvent.idl:
* Source/WebCore/html/MediaEncryptedEventInit.h:
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/PDFDocument.cpp:
* Source/WebCore/html/SubmitEvent.idl:
* Source/WebCore/html/VideoFrameMetadata.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext2DSettings.idl:
* Source/WebCore/html/canvas/ImageBitmapRenderingContextSettings.idl:
* Source/WebCore/html/canvas/WebGLContextAttributes.idl:
* Source/WebCore/html/canvas/WebGLContextEvent.idl:
* Source/WebCore/html/closewatcher/CloseWatcher.idl:
* Source/WebCore/html/track/TrackEvent.idl:
* Source/WebCore/inspector/CommandLineAPIHost.idl:
* Source/WebCore/inspector/RTCLogsCallback.idl:
* Source/WebCore/page/DOMWindow.cpp:
* Source/WebCore/page/EventSource.cpp:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/EventSource.idl:
* Source/WebCore/page/GetComposedRangesOptions.idl:
* Source/WebCore/page/IntersectionObserver.idl:
* Source/WebCore/page/LocalDOMWindow.cpp:
* Source/WebCore/page/NavigateEvent.cpp:
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/NavigateEvent.idl:
* Source/WebCore/page/Navigation.cpp:
* Source/WebCore/page/Navigation.idl:
* Source/WebCore/page/NavigationCurrentEntryChangeEvent.cpp:
* Source/WebCore/page/NavigationCurrentEntryChangeEvent.h:
* Source/WebCore/page/NavigationCurrentEntryChangeEvent.idl:
* Source/WebCore/page/NavigatorUABrandVersion.h:
* Source/WebCore/page/NavigatorUABrandVersion.idl:
* Source/WebCore/page/Page.cpp:
* Source/WebCore/page/PerformanceMarkOptions.idl:
* Source/WebCore/page/PerformanceMeasureOptions.idl:
* Source/WebCore/page/PerformanceObserver.cpp:
* Source/WebCore/page/PerformanceObserver.h:
* Source/WebCore/page/PerformanceObserver.idl:
* Source/WebCore/page/ResizeObserverOptions.idl:
* Source/WebCore/page/ScrollIntoViewOptions.h:
* Source/WebCore/page/ScrollIntoViewOptions.idl:
* Source/WebCore/page/ScrollOptions.h:
* Source/WebCore/page/ScrollOptions.idl:
* Source/WebCore/page/ScrollToOptions.h:
* Source/WebCore/page/ScrollToOptions.idl:
* Source/WebCore/page/ShareData.idl:
* Source/WebCore/page/StructuredSerializeOptions.h:
* Source/WebCore/page/StructuredSerializeOptions.idl:
* Source/WebCore/page/UADataValues.idl:
* Source/WebCore/page/UALowEntropyJSON.idl:
* Source/WebCore/page/UndoItem.h:
* Source/WebCore/page/UndoItem.idl:
* Source/WebCore/page/WindowPostMessageOptions.h:
* Source/WebCore/page/WindowPostMessageOptions.idl:
* Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h:
* Source/WebCore/storage/StorageEvent.cpp:
* Source/WebCore/storage/StorageEvent.h:
* Source/WebCore/storage/StorageEvent.idl:
* Source/WebCore/testing/FakeXRRigidTransformInit.idl:
* Source/WebCore/testing/Internals.cpp:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebCore/testing/MockPayment.h:
* Source/WebCore/testing/MockPaymentAddress.h:
* Source/WebCore/testing/MockPaymentContact.h:
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebCore/testing/MockPaymentError.idl:
* Source/WebCore/testing/MockWebAuthenticationConfiguration.idl:
* Source/WebCore/testing/TypeConversions.idl:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.h:
* Source/WebCore/workers/Worker.cpp:
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/service/ServiceWorker.cpp:
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerClient.cpp:
* Source/WebCore/workers/service/ServiceWorkerClient.h:

Canonical link: <a href="https://commits.webkit.org/306518@main">https://commits.webkit.org/306518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bc06f7b0890a1b2718ef9cbedfaca20bcf1a0e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141558 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108776 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144510 "Failed to checkout and rebase branch from PR 57337") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89681 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10879 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8505 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/205 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120158 "Failed to checkout and rebase branch from PR 57337") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152526 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13631 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116876 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117207 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29855 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13245 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123408 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68832 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13674 "Failed to checkout and rebase branch from PR 57337") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2702 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13411 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->