### PR TITLE
[Site Isolation] Partition Web process cache entries by main frame site

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -191,13 +191,16 @@ bool WebProcessCache::addProcess(Ref<CachedProcess>&& cachedProcess)
     auto site = *process->site();
     auto isolatedProcessType = process->isolatedProcessType();
 
-    if (auto previousProcess = m_processesPerSite.take({ site, isolatedProcessType }))
+    auto& optionalMainFrameSite = process->mainFrameSite();
+    auto mainFrameSite = optionalMainFrameSite && isolatedProcessType == WebProcessProxy::IsolatedProcessType::SubFrame ? *optionalMainFrameSite : WebCore::Site(URL());
+
+    if (auto previousProcess = m_processesPerSite.take({ site, mainFrameSite }))
         WEBPROCESSCACHE_RELEASE_LOG("addProcess: Evicting process from WebProcess cache because a new process was added for the same domain", previousProcess->process().processID());
 
     evictAtRandomIfNeeded();
 
-    WEBPROCESSCACHE_RELEASE_LOG("addProcess: Added process to WebProcess cache (size=%u, capacity=%u, isolatedProcessType=%d) %" SENSITIVE_LOG_STRING, cachedProcess->process().processID(), size() + 1, capacity(), isolatedProcessType, site.toString().utf8().data());
-    m_processesPerSite.add({ site, isolatedProcessType }, WTF::move(cachedProcess));
+    WEBPROCESSCACHE_RELEASE_LOG("addProcess: Added process to WebProcess cache (size=%u, capacity=%u, isolatedProcessType=%d) %" SENSITIVE_LOG_STRING ", mainFrameSite: %" SENSITIVE_LOG_STRING, cachedProcess->process().processID(), size() + 1, capacity(), isolatedProcessType, site.toString().utf8().data(), mainFrameSite.toString().utf8().data());
+    m_processesPerSite.add({ site, mainFrameSite }, WTF::move(cachedProcess));
 
     return true;
 }
@@ -215,8 +218,8 @@ void WebProcessCache::evictAtRandomIfNeeded()
         if (!m_processesPerSite.isEmpty()) {
             auto it = m_processesPerSite.random();
             auto site = std::get<0>(it->key);
-            auto isolatedProcessType = std::get<1>(it->key);
-            if (RefPtr sharedProcess = m_sharedProcessesPerSite.take(site); sharedProcess && isolatedProcessType == WebProcessProxy::IsolatedProcessType::MainFrame) {
+            auto mainFrameSite = std::get<1>(it->key);
+            if (RefPtr sharedProcess = m_sharedProcessesPerSite.take(mainFrameSite); sharedProcess && mainFrameSite.isEmpty()) {
                 WEBPROCESSCACHE_RELEASE_LOG("addProcess: Evicting shared process from WebProcess cache because capacity was reached", sharedProcess->process().processID());
                 if (size() < capacity())
                     break;
@@ -227,11 +230,13 @@ void WebProcessCache::evictAtRandomIfNeeded()
     }
 }
 
-RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::Site& site, WebProcessProxy::IsolatedProcessType isolatedProcessType, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
+RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::Site& site, WebProcessProxy::IsolatedProcessType isolatedProcessType, const std::optional<WebCore::Site>& optionalMainFrameSite, WebsiteDataStore& dataStore, WebProcessProxy::LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity, const API::PageConfiguration& pageConfiguration)
 {
-    auto it = m_processesPerSite.find({ site, isolatedProcessType });
+    auto mainFrameSite = optionalMainFrameSite && isolatedProcessType == WebProcessProxy::IsolatedProcessType::SubFrame ? *optionalMainFrameSite : WebCore::Site(URL());
+
+    auto it = m_processesPerSite.find({ site, mainFrameSite });
     if (it == m_processesPerSite.end()) {
-        WEBPROCESSCACHE_RELEASE_LOG("takeProcess: did not find %" SENSITIVE_LOG_STRING ", isolatedProcessType=%d", 0, site.toString().utf8().data(), isolatedProcessType);
+        WEBPROCESSCACHE_RELEASE_LOG("takeProcess: did not find %" SENSITIVE_LOG_STRING ", mainFrameSite: %" SENSITIVE_LOG_STRING, 0, site.toString().utf8().data(), mainFrameSite.toString().utf8().data());
         return nullptr;
     }
 
@@ -256,7 +261,7 @@ RefPtr<WebProcessProxy> WebProcessCache::takeProcess(const WebCore::Site& site, 
     }
 
     Ref process = m_processesPerSite.take(it)->takeProcess();
-    WEBPROCESSCACHE_RELEASE_LOG("takeProcess: Taking process from WebProcess cache (size=%u, capacity=%u, processWasTerminated=%d, isolatedProcessType %d) %" SENSITIVE_LOG_STRING, process->processID(), size(), capacity(), process->wasTerminated(), isolatedProcessType, site.toString().utf8().data());
+    WEBPROCESSCACHE_RELEASE_LOG("takeProcess: Taking process from WebProcess cache (size=%u, capacity=%u, processWasTerminated=%d, isolatedProcessType=%d) %" SENSITIVE_LOG_STRING ", mainFrameSite %" SENSITIVE_LOG_STRING, process->processID(), size(), capacity(), process->wasTerminated(), isolatedProcessType, site.toString().utf8().data(), mainFrameSite.toString().utf8().data());
 
     ASSERT(!process->pageCount());
     ASSERT(!process->provisionalPageCount());
@@ -366,7 +371,7 @@ void WebProcessCache::clear()
 
 void WebProcessCache::clearAllProcessesForSession(PAL::SessionID sessionID)
 {
-    Vector<std::tuple<WebCore::Site, WebProcessProxy::IsolatedProcessType>> keysToRemove;
+    Vector<std::tuple<WebCore::Site, WebCore::Site>> keysToRemove;
     for (auto& pair : m_processesPerSite) {
         RefPtr dataStore = pair.value->process().websiteDataStore();
         if (!dataStore || dataStore->sessionID() == sessionID) {
@@ -417,8 +422,8 @@ void WebProcessCache::removeProcess(WebProcessProxy& process, ShouldShutDownProc
     RefPtr<CachedProcess> cachedProcess;
 
     if (auto expectedSite = process.site()) {
-        auto isolatedProcessType = process.isolatedProcessType();
-        auto it = m_processesPerSite.find({ expectedSite.value(), isolatedProcessType });
+        auto& mainFrameSite = process.mainFrameSite();
+        auto it = m_processesPerSite.find({ expectedSite.value(), mainFrameSite && mainFrameSite != expectedSite.value() ? *mainFrameSite : WebCore::Site(URL()) });
         if (it != m_processesPerSite.end() && &it->value->process() == &process) {
             cachedProcess = WTF::move(it->value);
             m_processesPerSite.remove(it);

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -50,7 +50,7 @@ public:
     explicit WebProcessCache(WebProcessPool&);
 
     bool addProcessIfPossible(Ref<WebProcessProxy>&&);
-    RefPtr<WebProcessProxy> takeProcess(const WebCore::Site&, WebProcessProxy::IsolatedProcessType, WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
+    RefPtr<WebProcessProxy> takeProcess(const WebCore::Site&, WebProcessProxy::IsolatedProcessType, const std::optional<WebCore::Site>&, WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
     RefPtr<WebProcessProxy> takeSharedProcess(const WebCore::Site& mainFrameSite, WebsiteDataStore&, WebProcessProxy::LockdownMode, EnhancedSecurity, const API::PageConfiguration&);
 
     void updateCapacity(WebProcessPool&);
@@ -115,7 +115,7 @@ private:
 
     WeakRef<WebProcessPool> m_processPool;
     HashMap<uint64_t, Ref<CachedProcess>> m_pendingAddRequests;
-    HashMap<std::tuple<WebCore::Site, WebProcessProxy::IsolatedProcessType>, Ref<CachedProcess>> m_processesPerSite;
+    HashMap<std::tuple<WebCore::Site, WebCore::Site>, Ref<CachedProcess>> m_processesPerSite;
     HashMap<WebCore::Site, Ref<CachedProcess>> m_sharedProcessesPerSite;
     RunLoop::Timer m_evictionTimer;
     Seconds m_cachedProcessLifetime;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1284,7 +1284,7 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
         }
     } else if (site && !site->isEmpty() && processSwapDisposition != ProcessSwapDisposition::COOP) {
         // We don't reuse cached processess because the process cache is per site, whereas COOP swaps are based on origin.
-        if (RefPtr process = webProcessCache().takeProcess(*site, isolatedProcessType, websiteDataStore, lockdownMode, enhancedSecurity, pageConfiguration)) {
+        if (RefPtr process = webProcessCache().takeProcess(*site, isolatedProcessType, mainFrameSite, websiteDataStore, lockdownMode, enhancedSecurity, pageConfiguration)) {
             WEBPROCESSPOOL_RELEASE_LOG(ProcessSwapping, "processForSite: Using WebProcess from WebProcess cache (process=%p, PID=%i)", process.get(), process->processID());
             ASSERT(m_processes.containsIf([&](auto& item) { return item.ptr() == process; }));
             return process.releaseNonNull();
@@ -1303,7 +1303,7 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
         if (site && !site->isEmpty())
             tryPrewarmWithDomainInformation(*process, site->domain());
         ASSERT(m_processes.containsIf([&](auto& item) { return item.ptr() == process; }));
-        process->setIsolatedProcessType(isolatedProcessType);
+        process->setIsolatedProcessType(isolatedProcessType, mainFrameSite);
         if (processSwapDisposition == ProcessSwapDisposition::COOP)
             process->setIneligbleForWebProcessCache();
         return process.releaseNonNull();
@@ -1328,7 +1328,7 @@ Ref<WebProcessProxy> WebProcessPool::processForSite(WebsiteDataStore& websiteDat
     }
     auto enableWebAssemblyDebugger = protect(pageConfiguration.preferences())->webAssemblyDebuggerEnabled() ? WebProcessProxy::EnableWebAssemblyDebugger::Yes : WebProcessProxy::EnableWebAssemblyDebugger::No;
     Ref process = createNewWebProcess(&websiteDataStore, lockdownMode, enhancedSecurity, enableWebAssemblyDebugger);
-    process->setIsolatedProcessType(isolatedProcessType);
+    process->setIsolatedProcessType(isolatedProcessType, mainFrameSite);
     if (processSwapDisposition == ProcessSwapDisposition::COOP)
         process->setIneligbleForWebProcessCache();
     return process;

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -408,6 +408,19 @@ void WebProcessProxy::addSharedProcessDomain(const RegistrableDomain& domain)
     m_sharedProcessDomains.add(domain);
 }
 
+void WebProcessProxy::setIsolatedProcessType(IsolatedProcessType isolatedProcessType, std::optional<WebCore::Site> mainFrameSite)
+{
+    ASSERT(isolatedProcessType != IsolatedProcessType::Unspecified);
+
+    m_isolatedProcessType = isolatedProcessType;
+
+    if (m_isolatedProcessType == IsolatedProcessType::MainFrame)
+        return;
+
+    ASSERT(mainFrameSite.has_value());
+    m_mainFrameSite = mainFrameSite;
+}
+
 void WebProcessProxy::setIsInProcessCache(bool value, WillShutDown willShutDown)
 {
     WEBPROCESSPROXY_RELEASE_LOG(Process, "setIsInProcessCache(%d)", value);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -239,7 +239,8 @@ public:
     const HashSet<WebCore::RegistrableDomain>& sharedProcessDomains() const { return m_sharedProcessDomains; }
 
     IsolatedProcessType isolatedProcessType() const { return m_isolatedProcessType; }
-    void setIsolatedProcessType(IsolatedProcessType isolatedProcessType) { m_isolatedProcessType = isolatedProcessType; }
+    void setIsolatedProcessType(IsolatedProcessType, std::optional<WebCore::Site> mainFrameSite);
+    const std::optional<WebCore::Site>& mainFrameSite() const { return m_mainFrameSite; }
 
     enum class WillShutDown : bool { No, Yes };
     void setIsInProcessCache(bool, WillShutDown = WillShutDown::No);
@@ -824,6 +825,7 @@ private:
     bool m_isInProcessCache { false };
 
     IsolatedProcessType m_isolatedProcessType { IsolatedProcessType::Unspecified };
+    std::optional<WebCore::Site> m_mainFrameSite;
 
     enum class NoOrMaybe { No, Maybe } m_isResponsive;
     Vector<CompletionHandler<void(bool webProcessIsResponsive)>> m_isResponsiveCallbacks;


### PR DESCRIPTION
#### e42cd9fdf3389b3769cc83e683ff989ff99bf0d5
<pre>
[Site Isolation] Partition Web process cache entries by main frame site
<a href="https://bugs.webkit.org/show_bug.cgi?id=306348">https://bugs.webkit.org/show_bug.cgi?id=306348</a>
<a href="https://rdar.apple.com/169014411">rdar://169014411</a>

Reviewed by Chris Dumez.

When Site Isolation is enabled, we should partition the Web process cache by main frame site,
so that a cached WebContent process previously used in an iframe cannot be reused in a later
load where the main frame site is different.

* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::addProcess):
(WebKit::WebProcessCache::evictAtRandomIfNeeded):
(WebKit::WebProcessCache::takeProcess):
(WebKit::WebProcessCache::clearAllProcessesForSession):
(WebKit::WebProcessCache::removeProcess):
* Source/WebKit/UIProcess/WebProcessCache.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForSite):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/308041@main">https://commits.webkit.org/308041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/295021d4ec5608b5dcb67ad6a3f57c63e7b682cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154993 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99771 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13517f78-348a-482f-b337-6938de6f25c7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112608 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99771 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45f60eff-b5d4-4ba6-aca4-c601433eca77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149289 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14964 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93477 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d657b9d-d841-4d83-9e55-0b4f864d1f7d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14231 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2439 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123800 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157314 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/485 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120637 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120935 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131001 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74610 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7998 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18441 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18170 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->