### PR TITLE
http/tests/media/hls/hls-audio-description-track-kind.html times out on macOS arm64 wk2 bots

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-audio-description-track-kind.html
+++ b/LayoutTests/http/tests/media/hls/hls-audio-description-track-kind.html
@@ -52,6 +52,12 @@
 
         waitForEvent('addtrack', addTrack, false, false, video.audioTracks);
         video.src = '../resources/hls/audio-description/main.m3u8';
+
+        // DEBUGGING
+        [
+            'loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough', 'durationchange',
+            'error', 'abort', 'suspend', 'stalled', 'waiting', 'emptied'
+        ].forEach(event => { waitForEvent(event) } );
     }
     </script>
 </head>

--- a/LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html
+++ b/LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html
@@ -12,6 +12,11 @@
                 video = document.getElementById('video');
                 waitForEvent('canplaythrough', canplaythrough);
                 video.src = "../resources/hls/audio-tracks.m3u8";
+                // DEBUGGING
+                [
+                    'loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough', 'durationchange',
+                    'error', 'abort', 'suspend', 'stalled', 'waiting', 'emptied'
+                ].forEach(event => { waitForEvent(event) });
             }
 
             function canplaythrough() {

--- a/LayoutTests/http/tests/media/hls/hls-webvtt-default.html
+++ b/LayoutTests/http/tests/media/hls/hls-webvtt-default.html
@@ -8,6 +8,10 @@
             
             video = document.getElementById('video');
             video.src = "../resources/hls/test-webvtt-default.m3u8";
+            [
+                'loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough', 'durationchange',
+                'error', 'abort', 'suspend', 'stalled', 'waiting', 'emptied'
+            ].forEach(event => { waitForEvent(event) });
             video.play();
             await waitFor(video.textTracks, 'addtrack');
 

--- a/LayoutTests/http/tests/media/hls/hls-webvtt-style.html
+++ b/LayoutTests/http/tests/media/hls/hls-webvtt-style.html
@@ -6,6 +6,11 @@
         window.addEventListener('load', async event => {
             video = document.getElementById('video');
             video.src = "../resources/hls/test-webvtt-style.m3u8";
+            video.src = "../resources/hls/test-webvtt-default.m3u8";
+            [
+                'loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough', 'durationchange',
+                'error', 'abort', 'suspend', 'stalled', 'waiting', 'emptied'
+            ].forEach(event => { waitForEvent(event) });
             video.play();
             await waitFor(video.textTracks, 'addtrack');
 

--- a/LayoutTests/http/tests/media/hls/range-request-cross-origin.html
+++ b/LayoutTests/http/tests/media/hls/range-request-cross-origin.html
@@ -49,6 +49,10 @@ async function start() {
     video.autoplay = true
     waitForEventOnce("playing", playing);
     video.src = "../resources/hls/range-request-playlist-cross-origin.m3u8";
+    [
+        'loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough', 'durationchange',
+        'error', 'abort', 'suspend', 'stalled', 'waiting', 'emptied'
+    ].forEach(event => { waitForEvent(event) });
 }
         </script>
     </head>

--- a/LayoutTests/http/tests/media/hls/track-in-band-multiple-cues.html
+++ b/LayoutTests/http/tests/media/hls/track-in-band-multiple-cues.html
@@ -13,6 +13,10 @@
 
                 waitForAndFail(video, 'error')
                 video.src = "http://127.0.0.1:8000/media/resources/hls/multiple-cues-per-sample/master.m3u8";
+                [
+                    'loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough', 'durationchange',
+                    'error', 'abort', 'suspend', 'stalled', 'waiting', 'emptied'
+                ].forEach(event => { waitForEvent(event) });
 
                 await waitFor(video.textTracks, 'addtrack')
                 track = video.textTracks[0];

--- a/LayoutTests/http/tests/media/hls/track-webvtt-multitracks.html
+++ b/LayoutTests/http/tests/media/hls/track-webvtt-multitracks.html
@@ -7,6 +7,10 @@
             video = document.getElementById('video');
             waitForAndFail(video, 'error');
             video.src = "../resources/hls/test-webvtt-multitracks.m3u8";
+            [
+                'loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'canplaythrough', 'durationchange',
+                'error', 'abort', 'suspend', 'stalled', 'waiting', 'emptied'
+            ].forEach(event => { waitForEvent(event) });
             await Promise.all([
                 video.play(),
                 waitFor(video.textTracks, 'addtrack', true),

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2403,13 +2403,6 @@ webkit.org/b/305086 [ arm64 ] imported/w3c/web-platform-tests/media-source/media
 webkit.org/b/305403 [ Sequoia ] http/tests/performance/performance-resource-timing-redirection-cross-origin-media.html [ Failure ]
 
 # webkit.org/b/296008 [macOS Debug] http/tests/media/hls and platform/mac/media/encrypted-media tests are timing out on some EWS bots
-[ Sequoia+ arm64 ] http/tests/media/hls/hls-audio-description-track-kind.html [ Timeout ]
-[ Sequoia+ arm64 ] http/tests/media/hls/hls-audio-tracks-language.html [ Timeout ]
-[ Sequoia+ arm64 ] http/tests/media/hls/hls-webvtt-default.html [ Timeout ]
-[ Sequoia+ arm64 ] http/tests/media/hls/hls-webvtt-style.html [ Timeout ]
-[ Sequoia+ arm64 ] http/tests/media/hls/range-request-cross-origin.html [ Timeout ]
-[ Sequoia+ arm64 ] http/tests/media/hls/track-in-band-multiple-cues.html [ Timeout ]
-[ Sequoia+ arm64 ] http/tests/media/hls/track-webvtt-multitracks.html [ Timeout ]
 [ Sequoia+ arm64 ] platform/mac/media/encrypted-media/fps-generateRequest.html [ Timeout ]
 
 webkit.org/b/305508 http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html [ Pass Failure ]

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1285,11 +1285,13 @@ void HTMLMediaElement::mediaPlayerActiveSourceBuffersChanged()
 
 void HTMLMediaElement::scheduleEvent(const AtomString& eventName)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "[HTMLMediaElement::scheduleEvent] - scheduling event: " << eventName);
     scheduleEvent(Event::create(eventName, Event::CanBubble::No, Event::IsCancelable::Yes));
 }
 
 void HTMLMediaElement::scheduleEvent(Ref<Event>&& event)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "[HTMLMediaElement::scheduleEvent] - scheduling event (from Ref<Event>): " << event->type());
     queueCancellableTaskToDispatchEvent(*this, TaskSource::MediaElement, m_asyncEventsCancellationGroup, WTF::move(event));
 }
 

--- a/Source/WebCore/html/track/AudioTrackList.cpp
+++ b/Source/WebCore/html/track/AudioTrackList.cpp
@@ -43,6 +43,8 @@ AudioTrackList::~AudioTrackList() = default;
 
 void AudioTrackList::append(Ref<AudioTrack>&& track)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "[AudioTrackList::append] - Adding track: id='" << track->id() << "', label='" << track->label() << "', kind='" << track->kind() << "'");
+
     // Insert tracks in the media file order.
     size_t index = track->inbandTrackIndex();
     size_t insertionIndex;
@@ -56,6 +58,7 @@ void AudioTrackList::append(Ref<AudioTrack>&& track)
     if (!track->trackList())
         track->setTrackList(*this);
 
+    ALWAYS_LOG_WITH_STREAM(stream << "[AudioTrackList::append] - Calling scheduleAddTrackEvent, total tracks now=" << m_inbandTracks.size());
     scheduleAddTrackEvent(WTF::move(track));
 }
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -139,7 +139,19 @@ void TrackListBase::scheduleAddTrackEvent(Ref<TrackBase>&& track)
     // bubble and is not cancelable, and that uses the TrackEvent interface, with
     // the track attribute initialized to the text track's TextTrack object, at
     // the media element's textTracks attribute's TextTrackList object.
+
+    const char* trackType = "Unknown";
+    switch (track->type()) {
+        case TrackBase::AudioTrack: trackType = "AudioTrack"; break;
+        case TrackBase::VideoTrack: trackType = "VideoTrack"; break;
+        case TrackBase::TextTrack: trackType = "TextTrack"; break;
+        default: break;
+    }
+    ALWAYS_LOG_WITH_STREAM(stream << "[TrackListBase::scheduleAddTrackEvent] - Queueing 'addtrack' event for " << trackType);
+
     scheduleTrackEvent(eventNames().addtrackEvent, WTF::move(track));
+
+    ALWAYS_LOG_WITH_STREAM(stream << "[TrackListBase::scheduleAddTrackEvent] - Event queued via queueTaskToDispatchEvent");
 }
 
 void TrackListBase::scheduleRemoveTrackEvent(Ref<TrackBase>&& track)

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(VIDEO)
 
+#import "Logging.h"
 #import <AVFoundation/AVAsset.h>
 #import <AVFoundation/AVPlayerItem.h>
 #import <objc/runtime.h>
@@ -138,16 +139,24 @@ void MediaSelectionGroupAVFObjC::updateOptions(const Vector<String>& characteris
 {
     assertIsMainThread();
 
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - starting updateOptions with " << characteristics.size() << " characteristics");
+    for (size_t i = 0; i < characteristics.size(); ++i)
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - characteristic[" << i << "]: " << characteristics[i]);
+
     RetainPtr<NSSet> newAVOptions = adoptNS([[NSSet alloc] initWithArray:[PAL::getAVMediaSelectionGroupClassSingleton() playableMediaSelectionOptionsFromArray:[m_mediaSelectionGroup options]]]);
     RetainPtr<NSMutableSet> oldAVOptions = adoptNS([[NSMutableSet alloc] initWithCapacity:m_options.size()]);
     for (auto& avOption : m_options.keys())
         [oldAVOptions addObject:(__bridge AVMediaSelectionOption *)avOption];
+
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - newAVOptions count: " << [newAVOptions count] << ", oldAVOptions count: " << [oldAVOptions count]);
 
     RetainPtr<NSMutableSet> addedAVOptions = adoptNS([newAVOptions mutableCopy]);
     [addedAVOptions minusSet:oldAVOptions.get()];
 
     RetainPtr<NSMutableSet> removedAVOptions = adoptNS([oldAVOptions mutableCopy]);
     [removedAVOptions minusSet:newAVOptions.get()];
+
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - addedAVOptions count: " << [addedAVOptions count] << ", removedAVOptions count: " << [removedAVOptions count]);
 
     for (AVMediaSelectionOption* removedAVOption in removedAVOptions.get()) {
         if (RefPtr protectedSelectedOption = selectedOption(); protectedSelectedOption && removedAVOption == protectedSelectedOption->avMediaSelectionOption())
@@ -158,12 +167,18 @@ void MediaSelectionGroupAVFObjC::updateOptions(const Vector<String>& characteris
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RetainPtr<AVMediaSelectionOption> selectedOption = [m_playerItem selectedMediaOptionInMediaSelectionGroup:m_mediaSelectionGroup.get()];
 ALLOW_DEPRECATED_DECLARATIONS_END
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - currently selected AVMediaSelectionOption: " << (selectedOption ? "exists" : "nil"));
+
     for (AVMediaSelectionOption* addedAVOption in addedAVOptions.get()) {
         Ref addedOption = MediaSelectionOptionAVFObjC::create(*this, addedAVOption);
-        if (addedAVOption == selectedOption)
+        if (addedAVOption == selectedOption) {
             m_selectedOption = addedOption.get();
+            ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - added option matches selected option");
+        }
         m_options.set((__bridge CFTypeRef)addedAVOption, WTF::move(addedOption));
     }
+
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - m_shouldSelectOptionAutomatically: " << m_shouldSelectOptionAutomatically);
 
     if (!m_shouldSelectOptionAutomatically)
         return;
@@ -171,28 +186,39 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr filteredOptions = [PAL::getAVMediaSelectionGroupClassSingleton() mediaSelectionOptionsFromArray:[m_mediaSelectionGroup options]
         filteredAndSortedAccordingToPreferredLanguages:createNSArray(userPreferredLanguages(ShouldMinimizeLanguages::No)).get()];
 
-    if (![filteredOptions count] && characteristics.isEmpty())
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - filteredOptions count after language filtering: " << [filteredOptions count]);
+
+    if (![filteredOptions count] && characteristics.isEmpty()) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - no filtered options and no characteristics, returning early");
         return;
+    }
 
     // If no options match our language selection, search for matching characteristics across all the group's options
     if (![filteredOptions count])
         filteredOptions = [m_mediaSelectionGroup options];
 
     RetainPtr optionsWithCharacteristics = [PAL::getAVMediaSelectionGroupClassSingleton() mediaSelectionOptionsFromArray:filteredOptions.get() withMediaCharacteristics:createNSArray(characteristics).get()];
-    if (optionsWithCharacteristics && [optionsWithCharacteristics count])
+    if (optionsWithCharacteristics && [optionsWithCharacteristics count]) {
         filteredOptions = optionsWithCharacteristics;
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - found " << [optionsWithCharacteristics count] << " options with requested characteristics");
+    }
 
-    if (![filteredOptions count])
+    if (![filteredOptions count]) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - no filtered options after all filtering, returning early");
         return;
+    }
 
     RetainPtr preferredOption = [filteredOptions objectAtIndex:0];
-    if (RefPtr protectedSelectedOption = this->selectedOption(); protectedSelectedOption && protectedSelectedOption->avMediaSelectionOption() == preferredOption)
+    if (RefPtr protectedSelectedOption = this->selectedOption(); protectedSelectedOption && protectedSelectedOption->avMediaSelectionOption() == preferredOption) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - preferred option is already selected, returning early");
         return;
+    }
 
     ASSERT(m_options.contains((__bridge CFTypeRef)preferredOption.get()));
     RefPtr selectedOptionAVFObjC = m_options.get((__bridge CFTypeRef)preferredOption.get());
     m_selectedOption = selectedOptionAVFObjC;
     m_selectionTimer.startOneShot(0_s);
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaSelectionGroupAVFObjC::updateOptions] - set new selected option and started selection timer");
 }
 
 void MediaSelectionGroupAVFObjC::setSelectedOption(MediaSelectionOptionAVFObjC* option)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1198,6 +1198,11 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem()
         [m_avPlayerItem addObserver:m_objcObserver.get() forKeyPath:keyName options:options context:(void *)MediaPlayerAVFoundationObservationContextPlayerItem];
     }
 
+    // Log the initial tracks state to check if tracks are already populated before KVO fires
+    NSArray *initialTracks = [m_avPlayerItem tracks];
+    // Note: hasEnabledAudio/hasEnabledVideo are KVO properties, not public methods. Use valueForKey to access them.
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem] - After KVO setup, initial tracks count=" << (initialTracks ? [initialTracks count] : 0) << ", hasEnabledAudio=" << [[m_avPlayerItem valueForKey:@"hasEnabledAudio"] boolValue] << ", hasEnabledVideo=" << [[m_avPlayerItem valueForKey:@"hasEnabledVideo"] boolValue]);
+
     [m_avPlayerItem setAudioTimePitchAlgorithm:MediaSessionManagerCocoa::audioTimePitchAlgorithmForMediaPlayerPitchCorrectionAlgorithm(player->pitchCorrectionAlgorithm(), player->preservesPitch(), m_requestedRate).createNSString().get()];
 
 #if HAVE(AVFOUNDATION_INTERSTITIAL_EVENTS)
@@ -1997,6 +2002,7 @@ MediaPlayerPrivateAVFoundation::AssetStatus MediaPlayerPrivateAVFoundationObjC::
     if (*m_cachedAssetIsPlayable && *m_cachedTracksArePlayable)
         return MediaPlayerAVAssetStatusPlayable;
 
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::assetStatus] - Asset loaded but not fully playable");
     return MediaPlayerAVAssetStatusLoaded;
 }
 
@@ -2352,6 +2358,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 void MediaPlayerPrivateAVFoundationObjC::tracksChanged()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::tracksChanged] - m_avPlayerItem=" << (m_avPlayerItem ? "EXISTS" : "NULL"));
+
     String primaryAudioTrackLanguage = m_languageOfPrimaryAudioTrack;
     m_languageOfPrimaryAudioTrack = String();
 
@@ -2365,6 +2373,7 @@ void MediaPlayerPrivateAVFoundationObjC::tracksChanged()
     // This is called whenever the tracks collection changes so cache hasVideo and hasAudio since we are
     // asked about those fairly fequently.
     if (!m_avPlayerItem) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::tracksChanged] - Taking ASSET-BASED path (m_avPlayerItem is NULL, updateAudioTracks will NOT be called)");
         // We don't have a player item yet, so check with the asset because some assets support inspection
         // prior to becoming ready to play.
         RetainPtr firstEnabledVideoTrack = firstEnabledVisibleTrack();
@@ -2379,6 +2388,7 @@ void MediaPlayerPrivateAVFoundationObjC::tracksChanged()
             size.setHeight(-size.height());
         presentationSizeDidChange(size);
     } else {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::tracksChanged] - Taking PLAYER-ITEM-BASED path (m_avPlayerItem exists, will call updateAudioTracks)");
         bool hasVideo = false;
         bool hasAudio = false;
         bool hasMetaData = false;
@@ -2523,6 +2533,8 @@ void determineChangedTracksFromNewTracksAndOldItems(NSArray* tracks, NSString* t
 template <typename RefT, typename PassRefT>
 void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* group, Vector<RefT>& oldItems, const Vector<String>& characteristics, RefT (*itemFactory)(MediaSelectionOptionAVFObjC&), RefPtr<MediaPlayer>& player, void (MediaPlayer::*removedFunction)(PassRefT), void (MediaPlayer::*addedFunction)(PassRefT))
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "[determineChangedTracksFromNewTracksAndOldItems] - called with MediaSelectionGroupAVFObjC, oldItems count: " << oldItems.size());
+
     group->updateOptions(characteristics);
 
     ListHashSet<Ref<MediaSelectionOptionAVFObjC>> newSelectionOptions;
@@ -2532,6 +2544,8 @@ void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* 
             continue;
         newSelectionOptions.add(option);
     }
+
+    ALWAYS_LOG_WITH_STREAM(stream << "[determineChangedTracksFromNewTracksAndOldItems] - found " << newSelectionOptions.size() << " new selection options");
 
     ListHashSet<Ref<MediaSelectionOptionAVFObjC>> oldSelectionOptions;
     for (auto& oldItem : oldItems) {
@@ -2551,6 +2565,8 @@ void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* 
         if (!oldSelectionOptions.contains(newOption.ptr()))
             addedSelectionOptions.add(newOption);
     }
+
+    ALWAYS_LOG_WITH_STREAM(stream << "[determineChangedTracksFromNewTracksAndOldItems] - removed options: " << removedSelectionOptions.size() << ", added options: " << addedSelectionOptions.size());
 
     typedef Vector<RefT> ItemVector;
     ItemVector replacementItems;
@@ -2572,37 +2588,61 @@ void determineChangedTracksFromNewTracksAndOldItems(MediaSelectionGroupAVFObjC* 
     oldItems.swap(replacementItems);
 
     if (player) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[determineChangedTracksFromNewTracksAndOldItems] - notifying player of " << removedItems.size() << " removed and " << addedItems.size() << " added tracks");
+
         for (auto& removedItem : removedItems)
             (player.get()->*removedFunction)(removedItem.get());
 
         for (auto& addedItem : addedItems)
             (player.get()->*addedFunction)(addedItem.get());
     }
+
+    ALWAYS_LOG_WITH_STREAM(stream << "[determineChangedTracksFromNewTracksAndOldItems] - finished, final oldItems count: " << oldItems.size());
 }
 
 void MediaPlayerPrivateAVFoundationObjC::updateAudioTracks()
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - starting updateAudioTracks");
+
     auto player = this->player();
-    if (!player)
+    if (!player) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - no player, returning early");
         return;
-
-    size_t count = m_audioTracks.size();
-
-    Vector<String> characteristics = player->preferredAudioCharacteristics();
-    if (!m_audibleGroup) {
-        if (RetainPtr<AVMediaSelectionGroup> group = safeMediaSelectionGroupForAudibleMedia())
-            m_audibleGroup = MediaSelectionGroupAVFObjC::create(m_avPlayerItem.get(), group.get(), characteristics);
     }
 
-    if (m_audibleGroup)
+    size_t count = m_audioTracks.size();
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - current track count: " << count);
+
+    Vector<String> characteristics = player->preferredAudioCharacteristics();
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - preferred audio characteristics count: " << characteristics.size());
+    for (size_t i = 0; i < characteristics.size(); ++i)
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - characteristic[" << i << "]: " << characteristics[i]);
+
+    if (!m_audibleGroup) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - m_audibleGroup is null, attempting to create");
+        if (RetainPtr<AVMediaSelectionGroup> group = safeMediaSelectionGroupForAudibleMedia()) {
+            ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - creating MediaSelectionGroupAVFObjC");
+            m_audibleGroup = MediaSelectionGroupAVFObjC::create(m_avPlayerItem.get(), group.get(), characteristics);
+        } else {
+            ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - safeMediaSelectionGroupForAudibleMedia returned null");
+        }
+    } else {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - m_audibleGroup already exists");
+    }
+
+    if (m_audibleGroup) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - using m_audibleGroup for track determination");
         determineChangedTracksFromNewTracksAndOldItems(m_audibleGroup.get(), m_audioTracks, characteristics, &AudioTrackPrivateAVFObjC::create, player, &MediaPlayer::removeAudioTrack, &MediaPlayer::addAudioTrack);
-    else
+    } else {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - using m_cachedTracks for track determination");
         determineChangedTracksFromNewTracksAndOldItems(m_cachedTracks.get(), AVMediaTypeAudio, m_audioTracks, &AudioTrackPrivateAVFObjC::create, player, &MediaPlayer::removeAudioTrack, &MediaPlayer::addAudioTrack);
+    }
 
     for (auto& track : m_audioTracks)
         track->resetPropertiesFromTrack();
 
     ALWAYS_LOG(LOGIDENTIFIER, "track count was ", count, ", is ", m_audioTracks.size());
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::updateAudioTracks] - finished updateAudioTracks, final track count: " << m_audioTracks.size());
 }
 
 void MediaPlayerPrivateAVFoundationObjC::updateVideoTracks()
@@ -3113,12 +3153,18 @@ AVAssetTrack* MediaPlayerPrivateAVFoundationObjC::firstEnabledVisibleTrack() con
 
 bool MediaPlayerPrivateAVFoundationObjC::hasLoadedMediaSelectionGroups()
 {
-    if (!m_avAsset)
+    if (!m_avAsset) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::hasLoadedMediaSelectionGroups] - m_avAsset is null, returning false");
         return false;
+    }
 
-    if ([m_avAsset statusOfValueForKey:@"availableMediaCharacteristicsWithMediaSelectionOptions" error:NULL] != AVKeyValueStatusLoaded)
+    auto status = [m_avAsset statusOfValueForKey:@"availableMediaCharacteristicsWithMediaSelectionOptions" error:NULL];
+    if (status != AVKeyValueStatusLoaded) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::hasLoadedMediaSelectionGroups] - availableMediaCharacteristicsWithMediaSelectionOptions status: " << (int)status << " (not loaded), returning false");
         return false;
+    }
 
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::hasLoadedMediaSelectionGroups] - media selection groups loaded, returning true");
     return true;
 }
 
@@ -3133,12 +3179,23 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 AVMediaSelectionGroup* MediaPlayerPrivateAVFoundationObjC::safeMediaSelectionGroupForAudibleMedia()
 {
-    if (!hasLoadedMediaSelectionGroups())
+    if (!hasLoadedMediaSelectionGroups()) {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::safeMediaSelectionGroupForAudibleMedia] - media selection groups not loaded, returning nil");
         return nil;
+    }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [m_avAsset mediaSelectionGroupForMediaCharacteristic:AVMediaCharacteristicAudible];
+    auto* group = [m_avAsset mediaSelectionGroupForMediaCharacteristic:AVMediaCharacteristicAudible];
 ALLOW_DEPRECATED_DECLARATIONS_END
+
+    if (group) {
+        auto optionsCount = [[group options] count];
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::safeMediaSelectionGroupForAudibleMedia] - found audible media selection group with " << optionsCount << " options");
+    } else {
+        ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::safeMediaSelectionGroupForAudibleMedia] - no audible media selection group found, returning nil");
+    }
+
+    return group;
 }
 
 AVMediaSelectionGroup* MediaPlayerPrivateAVFoundationObjC::safeMediaSelectionGroupForVisualMedia()
@@ -3828,6 +3885,7 @@ void MediaPlayerPrivateAVFoundationObjC::metadataDidArrive(const RetainPtr<NSArr
 
 void MediaPlayerPrivateAVFoundationObjC::tracksDidChange(const RetainPtr<NSArray>& tracks)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::tracksDidChange] - ENTERED, tracks count=" << (tracks ? [tracks count] : 0));
     for (AVPlayerItemTrack *track in m_cachedTracks.get())
         [track removeObserver:m_objcObserver.get() forKeyPath:@"enabled"];
 
@@ -3867,6 +3925,7 @@ void MediaPlayerPrivateAVFoundationObjC::tracksDidChange(const RetainPtr<NSArray
 void MediaPlayerPrivateAVFoundationObjC::hasEnabledAudioDidChange(bool hasEnabledAudio)
 {
     ALWAYS_LOG(LOGIDENTIFIER, hasEnabledAudio);
+    ALWAYS_LOG_WITH_STREAM(stream << "[MediaPlayerPrivateAVFoundationObjC::hasEnabledAudioDidChange] - hasEnabledAudio=" << hasEnabledAudio << ", will call tracksChanged()");
     m_cachedHasEnabledAudio = hasEnabledAudio;
 
     tracksChanged();
@@ -4451,6 +4510,9 @@ NSArray* playerKVOProperties()
         }
 
         if (context == MediaPlayerAVFoundationObservationContextPlayerItem && !willChange) {
+            // Log ALL PlayerItem KVO callbacks to diagnose ARM64 vs Intel differences
+            ALWAYS_LOG_WITH_STREAM(stream << "[KVO PlayerItem] - keyPath=" << [keyPath.get() UTF8String]);
+
             // A value changed for an AVPlayerItem
             if ([keyPath isEqualToString:@"status"])
                 player.playerItemStatusDidChange([newValue intValue]);


### PR DESCRIPTION
#### 81047c18eb668f6df5217a069dbb624c91dd91d2
<pre>
http/tests/media/hls/hls-audio-description-track-kind.html times out on macOS arm64 wk2 bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=306317">https://bugs.webkit.org/show_bug.cgi?id=306317</a>
<a href="https://rdar.apple.com/168981061">rdar://168981061</a>

Reviewed by NOBODY (OOPS!).

Debug logging for investigating EWS hls test failures

* LayoutTests/http/tests/media/hls/hls-audio-description-track-kind.html:
* LayoutTests/http/tests/media/hls/hls-audio-tracks-language.html:
* LayoutTests/http/tests/media/hls/hls-webvtt-default.html:
* LayoutTests/http/tests/media/hls/hls-webvtt-style.html:
* LayoutTests/http/tests/media/hls/range-request-cross-origin.html:
* LayoutTests/http/tests/media/hls/track-in-band-multiple-cues.html:
* LayoutTests/http/tests/media/hls/track-webvtt-multitracks.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::scheduleEvent):
* Source/WebCore/html/track/AudioTrackList.cpp:
(WebCore::AudioTrackList::append):
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::scheduleAddTrackEvent):
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm:
(WebCore::MediaSelectionGroupAVFObjC::updateOptions):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::assetStatus const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::tracksChanged):
(WebCore::determineChangedTracksFromNewTracksAndOldItems):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateAudioTracks):
(WebCore::MediaPlayerPrivateAVFoundationObjC::hasLoadedMediaSelectionGroups):
(WebCore::MediaPlayerPrivateAVFoundationObjC::safeMediaSelectionGroupForAudibleMedia):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81047c18eb668f6df5217a069dbb624c91dd91d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145235 "53 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98871 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111675 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80049 "2 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92575 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d52bf6a-dda8-406a-8fba-ef3382c5943c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13394 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11158 "Found 27 new API test failures: TestWebKitAPI.RequiresUserActionForPlaybackTest.DeprecatedRequiresUserActionForAudioButNotVideoPlayback, TestWebKitAPI.AVFoundationPref.PrefTest, TestWebKitAPI.WKWebViewSuspendAllMediaPlayback.PauseWhenResume, TestWebKitAPI.SiteIsolation.PlayAudioInMultipleFrames, TestWebKitAPI.ProcessSwap.SuspendAllMediaPlayback, TestWebKitAPI.RequiresUserActionForPlaybackTest.DeprecatedRequiresUserActionForAudioAndVideoPlayback, TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureVideoCase, TestWebKitAPI.WebpagePreferences.WebsitePoliciesPlayingWithUserGesture, TestWebKitAPI.WKWebViewSuspendAllMediaPlayback.BeforeLoading, TestWebKitAPI.GPUProcess.CrashWhilePlayingVideo ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1352 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122919 "Found 15 new API test failures: TestWebKitAPI.RequiresUserActionForPlaybackTest.DeprecatedRequiresUserActionForAudioButNotVideoPlayback, TestWebKitAPI.Fullscreen.AllowsInlinePlaybackInDesktopContentMode, TestWebKitAPI.WebKit.NoPauseWhenSwitchingTabs, TestWebKitAPI.GPUProcess.CrashWhilePlayingAudioViaCreateMediaElementSource, TestWebKitAPI.SiteIsolation.PlayAudioInMultipleFrames, TestWebKitAPI.RequiresUserActionForPlaybackTest.RequiresUserActionForAudioButNotVideoPlayback, TestWebKitAPI.WebpagePreferences.WebsitePoliciesUserInterferenceWithPlaying, TestWebKitAPI.WebpagePreferences.WebsitePoliciesPlayingWithUserGesture, TestWebKitAPI.WebpagePreferences.WebsitePoliciesAutoplayEnabled, TestWebKitAPI.RequiresUserActionForPlaybackTest.DoesNotRequireUserActionForMediaPlayback ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156219 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17767 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8298 "Found 7 new test failures: http/tests/media/hls/hls-audio-description-track-kind.html http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119686 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17813 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14826 "Found 7 new test failures: http/tests/media/hls/hls-audio-description-track-kind.html http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120020 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15793 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128468 "Exiting early after 10 failures. 10 tests run. 5 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73452 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17388 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6727 "Found 7 new test failures: http/tests/media/hls/hls-audio-description-track-kind.html http/tests/media/hls/hls-audio-tracks-language.html http/tests/media/hls/hls-webvtt-default.html http/tests/media/hls/hls-webvtt-style.html http/tests/media/hls/range-request-cross-origin.html http/tests/media/hls/track-in-band-multiple-cues.html http/tests/media/hls/track-webvtt-multitracks.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17188 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->