### PR TITLE
[GStreamer] Switch to GStreamer 1.28 compile-time checks

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -631,7 +631,7 @@ void webkitGstWebRTCIceAgentClosed(WebKitGstIceAgent* agent)
     agent->priv->closePromise.clear();
 }
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
 static void webkitGstWebRTCIceAgentClose(GstWebRTCICE* ice, GstPromise* promise)
 {
     auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(ice);
@@ -741,7 +741,7 @@ static void webkit_gst_webrtc_ice_backend_class_init(WebKitGstIceAgentClass* kla
     iceClass->set_http_proxy = webkitGstWebRTCIceAgentSetHttpProxy;
     iceClass->get_http_proxy = webkitGstWebRTCIceAgentGetHttpProxy;
     iceClass->get_selected_pair = webkitGstWebRTCIceAgentGetSelectedPair;
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     iceClass->close = webkitGstWebRTCIceAgentClose;
 #endif
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp
@@ -216,7 +216,7 @@ static void populateCandidateStats(const RiceCandidate* candidate, GstWebRTCICEC
     }
     gstStats->prio = candidate->priority;
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     GST_WEBRTC_ICE_CANDIDATE_STATS_FOUNDATION(gstStats) = g_strdup(candidate->foundation);
     if (candidate->related_address) {
         auto relatedAddress = riceAddressToString(candidate->related_address, false);
@@ -246,7 +246,7 @@ static void populateCandidateStats(const RiceCandidate* candidate, GstWebRTCICEC
 #endif
 }
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
 static void fillCredentials(const GRefPtr<RiceStream>& stream, bool isLocal, GstWebRTCICECandidateStats* stats)
 {
     GUniquePtr<RiceCredentials> credentials(isLocal ? rice_stream_get_local_credentials(stream.get()) : rice_stream_get_remote_credentials(stream.get()));
@@ -278,14 +278,14 @@ bool webkitGstWebRTCIceTransportGetSelectedPair(WebKitGstIceTransport* transport
 
     *localStats = g_new0(GstWebRTCICECandidateStats, 1);
     populateCandidateStats(localCandidate.get(), *localStats);
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     fillCredentials(riceStream, true, *localStats);
 #endif
     (*localStats)->stream_id = streamId;
 
     *remoteStats = g_new0(GstWebRTCICECandidateStats, 1);
     populateCandidateStats(remoteCandidate.get(), *remoteStats);
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     fillCredentials(riceStream, false, *remoteStats);
 #endif
     (*remoteStats)->stream_id = streamId;
@@ -293,7 +293,7 @@ bool webkitGstWebRTCIceTransportGetSelectedPair(WebKitGstIceTransport* transport
     return true;
 }
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
 static GstWebRTCICECandidate* riceCandidateToGst(const RiceCandidate* candidate, const GRefPtr<RiceStream>& stream, bool isLocal)
 {
     RELEASE_ASSERT(candidate);
@@ -335,7 +335,7 @@ static void webkit_gst_webrtc_ice_transport_class_init(WebKitGstIceTransportClas
     auto gobjectClass = G_OBJECT_CLASS(klass);
     gobjectClass->constructed = webkitGstWebRTCIceTransportConstructed;
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     auto transportClass = GST_WEBRTC_ICE_TRANSPORT_CLASS(klass);
     transportClass->get_selected_candidate_pair = webkitGstWebRTCIceTransportGetSelectedCandidatePair;
 #endif

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
@@ -152,7 +152,7 @@ void GStreamerIceTransportBackend::gatheringStateChanged() const
     });
 }
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
 static Ref<RTCIceCandidate> candidateFromGstWebRTC(const GstWebRTCICECandidate* candidate)
 {
     RTCIceCandidate::Fields fields;
@@ -202,7 +202,7 @@ static Ref<RTCIceCandidate> candidateFromGstWebRTC(const GstWebRTCICECandidate* 
 void GStreamerIceTransportBackend::selectedCandidatePairChanged()
 {
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/8484
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     GUniquePtr<GstWebRTCICECandidatePair> selectedPair(gst_webrtc_ice_transport_get_selected_candidate_pair(m_iceTransport.get()));
     if (!selectedPair)
         return;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -2182,7 +2182,7 @@ void GStreamerMediaEndpoint::close()
     GST_DEBUG_OBJECT(m_pipeline.get(), "Closing");
 
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9379
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     g_signal_emit_by_name(m_webrtcBin.get(), "close", gst_promise_new_with_change_func([](GstPromise* rawPromise, gpointer userData) {
         auto promise = adoptGRef(rawPromise);
         auto result = gst_promise_wait(promise.get());

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -213,7 +213,7 @@ RTCStatsReport::TransportStats::TransportStats(const GstStructure* structure)
     }
 
     // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/9e38ee7526ecbb12320d1aef29a0c74b815eb4ef
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     if (gst_structure_has_field_typed(structure, "dtls-role", GST_TYPE_WEBRTC_DTLS_ROLE)) {
         GstWebRTCDTLSRole role;
         gst_structure_get(structure, "dtls-role", GST_TYPE_WEBRTC_DTLS_ROLE, &role, nullptr);
@@ -255,7 +255,7 @@ RTCStatsReport::IceCandidateStats::IceCandidateStats(GstWebRTCStatsType statsTyp
     port = gstStructureGet<unsigned>(structure, "port"_s);
     priority = gstStructureGet<unsigned>(structure, "priority"_s);
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     GstWebRTCICETcpCandidateType gstTcpType;
     if (gst_structure_get(structure, "tcp-type", &gstTcpType, nullptr)) {
         switch (gstTcpType) {

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1294,7 +1294,7 @@ static ASCIILiteral webrtcDtlsTransportStateName(int value)
     return nullptr;
 }
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
 static ASCIILiteral webrtcIceTcpCandidateTypeName(int value)
 {
     switch (value) {
@@ -1546,7 +1546,7 @@ static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* 
         if (!name.isEmpty()) [[likely]]
             return JSON::Value::create(makeString(name))->asValue();
     }
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
     if (valueType == GST_TYPE_WEBRTC_ICE_TCP_CANDIDATE_TYPE) {
         auto name = webrtcIceTcpCandidateTypeName(g_value_get_enum(value));
         if (!name.isEmpty()) [[likely]]
@@ -2261,7 +2261,7 @@ GstBuffer* gst_buffer_new_memdup(gconstpointer data, gsize size)
 }
 #endif
 
-#if !GST_CHECK_VERSION(1, 27, 3)
+#if !GST_CHECK_VERSION(1, 28, 0)
 void gst_pad_probe_info_set_buffer(GstPadProbeInfo* info, GstBuffer* buffer)
 {
     g_return_if_fail(info->type & GST_PAD_PROBE_TYPE_BUFFER);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -491,7 +491,7 @@ private:
 GstBuffer* gst_buffer_new_memdup(gconstpointer data, gsize size);
 #endif
 
-#if !GST_CHECK_VERSION(1, 27, 3)
+#if !GST_CHECK_VERSION(1, 28, 0)
 void gst_pad_probe_info_set_buffer(GstPadProbeInfo*, GstBuffer*);
 void gst_pad_probe_info_set_event(GstPadProbeInfo*, GstEvent*);
 #endif

--- a/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h
@@ -55,10 +55,10 @@ WTF_DEFINE_GPTR_DELETER(GstWebRTCSessionDescription, gst_webrtc_session_descript
 WTF_DEFINE_GPTR_DELETER(GstSDPMessage, gst_sdp_message_free)
 WTF_DEFINE_GPTR_DELETER(GstSDPMedia, gst_sdp_media_free)
 
-#if GST_CHECK_VERSION(1, 27, 0)
+#if GST_CHECK_VERSION(1, 28, 0)
 WTF_DEFINE_GPTR_DELETER(GstWebRTCICECandidate, gst_webrtc_ice_candidate_free)
 WTF_DEFINE_GPTR_DELETER(GstWebRTCICECandidatePair, gst_webrtc_ice_candidate_pair_free)
-#endif // GST_CHECK_VERSION(1, 27, 0)
+#endif // GST_CHECK_VERSION(1, 28, 0)
 #endif
 }
 


### PR DESCRIPTION
#### d3c1df774f3becbecb418b47e77861963204eb2e
<pre>
[GStreamer] Switch to GStreamer 1.28 compile-time checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=306361">https://bugs.webkit.org/show_bug.cgi?id=306361</a>

Reviewed by Xabier Rodriguez-Calvar.

GStreamer 1.28.0 has been released, so migrate 1.27.x checks to 1.28.0.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(webkit_gst_webrtc_ice_backend_class_init):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransport.cpp:
(populateCandidateStats):
(webkitGstWebRTCIceTransportGetSelectedPair):
(webkit_gst_webrtc_ice_transport_class_init):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp:
(WebCore::GStreamerIceTransportBackend::selectedCandidatePairChanged):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::close):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::TransportStats::TransportStats):
(WebCore::RTCStatsReport::IceCandidateStats::IceCandidateStats):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureValueToJSON):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/GUniquePtrGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/306336@main">https://commits.webkit.org/306336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f80c80242628567db39e3a0afa66a5a445503a5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108183 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78447 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89087 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8030 "Passed tests") | [✅ 🛠 wpe-cairo-libwebrtc](https://ews-build.webkit.org/#/builders/166/builds/9392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119696 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151922 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13028 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116391 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116731 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29709 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12796 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68189 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13071 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76772 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->