### PR TITLE
Migrate PKPaymentSetupFeature to Wrapped WKKeyedCoder

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -269,6 +269,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSValue.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNull.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKDateComponentsRange.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentToken.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPassKit.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -675,6 +675,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in \
 	Shared/Cocoa/CoreIPCPKDateComponentsRange.serialization.in \
 	Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in \
+	Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in \
 	Shared/Cocoa/CoreIPCPKPaymentToken.serialization.in \
 	Shared/Cocoa/CoreIPCPlist.serialization.in \
 	Shared/Cocoa/CoreIPCPresentationIntent.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h
@@ -104,6 +104,9 @@ enum class NSType : uint8_t {
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)
     SecureCoding,
 #endif
+#if HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
+    Set,
+#endif
     String,
     URL,
     NSValue,

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -380,6 +380,10 @@ NSType typeFromObject(id object)
         return NSType::NSValue;
     if ([object isKindOfClass:[NSString class]])
         return NSType::String;
+#if HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
+    if ([object isKindOfClass:[NSSet class]])
+        return NSType::Set;
+#endif
     if ([object isKindOfClass:[NSURL class]])
         return NSType::URL;
 #if USE(PASSKIT)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -36,6 +36,9 @@
 #if HAVE(WK_SECURE_CODING_PKPAYMENTTOKEN)
 #include "CoreIPCPKPaymentToken.h"
 #endif
+#if HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
+#include "CoreIPCPKPaymentSetupFeature.h"
+#endif
 #endif
 #include <wtf/RetainPtr.h>
 #include <wtf/UniqueRef.h>
@@ -50,7 +53,9 @@ class CoreIPCPKPaymentMethod;
 #if !HAVE(WK_SECURE_CODING_PKPAYMENTMERCHANTSESSION)
 class CoreIPCPKPaymentMerchantSession;
 #endif
+#if !HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
 class CoreIPCPKPaymentSetupFeature;
+#endif
 class CoreIPCPKContact;
 class CoreIPCPKSecureElementPass;
 class CoreIPCPKPayment;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm
@@ -99,6 +99,10 @@ static ObjectValue valueFromID(id object)
         return CoreIPCURL((NSURL *)object);
     case IPC::NSType::CF:
         return CoreIPCCFType((CFTypeRef)object);
+#if HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
+    case IPC::NSType::Set:
+        return nullptr; // Wrapped WKKeyedCoder serialization of PKPaymentSetupFeature
+#endif
     case IPC::NSType::Unknown:
         break;
     }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/OptionSet.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/Vector.h>
+
+OBJC_CLASS PKPaymentSetupFeature;
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
+
+namespace WebKit {
+
+enum class PKPaymentSetupFeatureType : uint8_t {
+    ApplePay = 0,
+    AppleCard = 1,
+    AppleBalance = 2,
+    Transit = 3,
+};
+
+enum class PKPaymentSetupFeatureState : uint8_t {
+    Unsupported = 0,
+    Supported = 1,
+    SupplementarySupported = 2,
+    Completed = 3,
+};
+
+enum class PKPaymentSetupFeatureSupportedOptions : uint8_t {
+    None = 0,
+    Installments = 1 << 0,
+};
+
+enum class PKPaymentSetupFeatureSupportedDevices : uint8_t {
+    None = 0,
+    Phone = 1 << 0,
+    Watch = 1 << 1,
+};
+
+struct CoreIPCPKPaymentSetupFeatureData {
+    std::optional<Vector<RetainPtr<NSString>>> identifiers;
+    RetainPtr<NSString> localizedDisplayName;
+    std::optional<PKPaymentSetupFeatureType> type;
+    std::optional<PKPaymentSetupFeatureState> state;
+    std::optional<OptionSet<PKPaymentSetupFeatureSupportedOptions>> supportedOptions;
+    std::optional<OptionSet<PKPaymentSetupFeatureSupportedDevices>> supportedDevices;
+    RetainPtr<NSString> productIdentifier;
+    RetainPtr<NSString> partnerIdentifier;
+    RetainPtr<NSNumber> featureIdentifier;
+    RetainPtr<NSDate> lastUpdated;
+    RetainPtr<NSDate> expiry;
+    RetainPtr<NSNumber> productType;
+    RetainPtr<NSNumber> productState;
+    RetainPtr<NSString> notificationTitle;
+    RetainPtr<NSString> notificationMessage;
+    RetainPtr<NSString> discoveryCardIdentifier;
+};
+
+class CoreIPCPKPaymentSetupFeature {
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCPKPaymentSetupFeature);
+public:
+    CoreIPCPKPaymentSetupFeature(PKPaymentSetupFeature *);
+    CoreIPCPKPaymentSetupFeature(std::optional<CoreIPCPKPaymentSetupFeatureData>&&);
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCPKPaymentSetupFeature>;
+
+    std::optional<CoreIPCPKPaymentSetupFeatureData> m_data;
+};
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCPKPaymentSetupFeature.h"
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
+
+#import "ArgumentCodersCocoa.h"
+#import "Logging.h"
+#import "WKKeyedCoder.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <pal/cocoa/PassKitSoftLink.h>
+
+
+namespace WebKit {
+
+CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature(PKPaymentSetupFeature *feature)
+{
+    if (!feature)
+        return;
+
+    RetainPtr archiver = adoptNS([WKKeyedCoder new]);
+    [feature encodeWithCoder:archiver.get()];
+    RetainPtr dictionary = [archiver accumulatedDictionary];
+
+    CoreIPCPKPaymentSetupFeatureData data;
+
+    if (RetainPtr identifiersSet = dynamic_objc_cast<NSSet>([dictionary.get() objectForKey:@"identifiers"])) {
+        Vector<RetainPtr<NSString>> identifiersVector;
+        identifiersVector.reserveInitialCapacity([identifiersSet.get() count]);
+        for (NSString *identifier in identifiersSet.get()) {
+            if ([identifier isKindOfClass:NSString.class])
+                identifiersVector.append(identifier);
+        }
+        data.identifiers = WTF::move(identifiersVector);
+    }
+
+    if (RetainPtr localizedDisplayName = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"localizedDisplayName"]))
+        data.localizedDisplayName = WTF::move(localizedDisplayName);
+
+    if (RetainPtr typeNumber = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"type"])) {
+        auto value = [typeNumber unsignedCharValue];
+        if (isValidEnum<PKPaymentSetupFeatureType>(value))
+            data.type = static_cast<PKPaymentSetupFeatureType>(value);
+    }
+
+    if (RetainPtr stateNumber = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"state"])) {
+        auto value = [stateNumber unsignedCharValue];
+        if (isValidEnum<PKPaymentSetupFeatureState>(value))
+            data.state = static_cast<PKPaymentSetupFeatureState>(value);
+    }
+
+    if (RetainPtr optionsNumber = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"supportedOptions"])) {
+        auto rawValue = [optionsNumber unsignedCharValue];
+        auto optionSet = OptionSet<PKPaymentSetupFeatureSupportedOptions>::fromRaw(rawValue);
+        if (isValidOptionSet(optionSet))
+            data.supportedOptions = optionSet;
+    }
+
+    if (RetainPtr devicesNumber = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"supportedDevices"])) {
+        auto rawValue = [devicesNumber unsignedCharValue];
+        auto optionSet = OptionSet<PKPaymentSetupFeatureSupportedDevices>::fromRaw(rawValue);
+        if (isValidOptionSet(optionSet))
+            data.supportedDevices = optionSet;
+    }
+
+    if (RetainPtr productIdentifier = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"productIdentifier"]))
+        data.productIdentifier = WTF::move(productIdentifier);
+
+    if (RetainPtr partnerIdentifier = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"partnerIdentifier"]))
+        data.partnerIdentifier = WTF::move(partnerIdentifier);
+
+    if (RetainPtr featureIdentifier = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"featureIdentifier"]))
+        data.featureIdentifier = WTF::move(featureIdentifier);
+
+    if (RetainPtr lastUpdated = dynamic_objc_cast<NSDate>([dictionary.get() objectForKey:@"lastUpdated"]))
+        data.lastUpdated = WTF::move(lastUpdated);
+
+    if (RetainPtr expiry = dynamic_objc_cast<NSDate>([dictionary.get() objectForKey:@"expiry"]))
+        data.expiry = WTF::move(expiry);
+
+    if (RetainPtr productType = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"productType"]))
+        data.productType = WTF::move(productType);
+
+    if (RetainPtr productState = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"productState"]))
+        data.productState = WTF::move(productState);
+
+    if (RetainPtr notificationTitle = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"notificationTitle"]))
+        data.notificationTitle = WTF::move(notificationTitle);
+
+    if (RetainPtr notificationMessage = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"notificationMessage"]))
+        data.notificationMessage = WTF::move(notificationMessage);
+
+    if (RetainPtr discoveryCardIdentifier = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"discoveryCardIdentifier"]))
+        data.discoveryCardIdentifier = WTF::move(discoveryCardIdentifier);
+
+    m_data = WTF::move(data);
+}
+
+CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature(std::optional<CoreIPCPKPaymentSetupFeatureData>&& data)
+    : m_data { WTF::move(data) }
+{
+}
+
+RetainPtr<id> CoreIPCPKPaymentSetupFeature::toID() const
+{
+    if (!m_data)
+        return { };
+
+    RetainPtr dictionary = [NSMutableDictionary dictionaryWithCapacity:16];
+
+    if (m_data->identifiers) {
+        RetainPtr identifiersSet = adoptNS([[NSMutableSet alloc] initWithCapacity:m_data->identifiers->size()]);
+        for (auto& identifier : *m_data->identifiers)
+            [identifiersSet addObject:identifier.get()];
+        [dictionary setObject:identifiersSet.get() forKey:@"identifiers"];
+    }
+
+    if (m_data->localizedDisplayName)
+        [dictionary setObject:m_data->localizedDisplayName.get() forKey:@"localizedDisplayName"];
+    if (m_data->type)
+        [dictionary setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(*m_data->type)] forKey:@"type"];
+    if (m_data->state)
+        [dictionary setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(*m_data->state)] forKey:@"state"];
+    if (m_data->supportedOptions)
+        [dictionary setObject:[NSNumber numberWithUnsignedChar:m_data->supportedOptions->toRaw()] forKey:@"supportedOptions"];
+    if (m_data->supportedDevices)
+        [dictionary setObject:[NSNumber numberWithUnsignedChar:m_data->supportedDevices->toRaw()] forKey:@"supportedDevices"];
+    if (m_data->productIdentifier)
+        [dictionary setObject:m_data->productIdentifier.get() forKey:@"productIdentifier"];
+    if (m_data->partnerIdentifier)
+        [dictionary setObject:m_data->partnerIdentifier.get() forKey:@"partnerIdentifier"];
+    if (m_data->featureIdentifier)
+        [dictionary setObject:m_data->featureIdentifier.get() forKey:@"featureIdentifier"];
+    if (m_data->lastUpdated)
+        [dictionary setObject:m_data->lastUpdated.get() forKey:@"lastUpdated"];
+    if (m_data->expiry)
+        [dictionary setObject:m_data->expiry.get() forKey:@"expiry"];
+    if (m_data->productType)
+        [dictionary setObject:m_data->productType.get() forKey:@"productType"];
+    if (m_data->productState)
+        [dictionary setObject:m_data->productState.get() forKey:@"productState"];
+    if (m_data->notificationTitle)
+        [dictionary setObject:m_data->notificationTitle.get() forKey:@"notificationTitle"];
+    if (m_data->notificationMessage)
+        [dictionary setObject:m_data->notificationMessage.get() forKey:@"notificationMessage"];
+    if (m_data->discoveryCardIdentifier)
+        [dictionary setObject:m_data->discoveryCardIdentifier.get() forKey:@"discoveryCardIdentifier"];
+
+    RetainPtr unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:dictionary.get()]);
+    RetainPtr feature = adoptNS([[PAL::getPKPaymentSetupFeatureClassSingleton() alloc] initWithCoder:unarchiver.get()]);
+    if (!feature)
+        RELEASE_LOG_ERROR(IPC, "CoreIPCPKPaymentSetupFeature was not able to reconstruct a PKPaymentSetupFeature object");
+    return feature;
+}
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in
@@ -1,0 +1,76 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
+
+header: "CoreIPCPKPaymentSetupFeature.h"
+webkit_platform_headers: "CoreIPCPKPaymentSetupFeature.h"
+
+[CustomHeader, WebKitPlatform] enum class WebKit::PKPaymentSetupFeatureType : uint8_t {
+    ApplePay,
+    AppleCard,
+    AppleBalance,
+    Transit,
+}
+
+[CustomHeader, WebKitPlatform] enum class WebKit::PKPaymentSetupFeatureState : uint8_t {
+    Unsupported,
+    Supported,
+    SupplementarySupported,
+    Completed,
+}
+
+[OptionSet, CustomHeader, WebKitPlatform] enum class WebKit::PKPaymentSetupFeatureSupportedOptions : uint8_t {
+    None,
+    Installments,
+}
+
+[OptionSet, CustomHeader, WebKitPlatform] enum class WebKit::PKPaymentSetupFeatureSupportedDevices : uint8_t {
+    None,
+    Phone,
+    Watch,
+}
+
+[CustomHeader, WebKitPlatform] struct WebKit::CoreIPCPKPaymentSetupFeatureData {
+    std::optional<Vector<RetainPtr<NSString>>> identifiers;
+    RetainPtr<NSString> localizedDisplayName;
+    std::optional<WebKit::PKPaymentSetupFeatureType> type;
+    std::optional<WebKit::PKPaymentSetupFeatureState> state;
+    std::optional<OptionSet<WebKit::PKPaymentSetupFeatureSupportedOptions>> supportedOptions;
+    std::optional<OptionSet<WebKit::PKPaymentSetupFeatureSupportedDevices>> supportedDevices;
+    RetainPtr<NSString> productIdentifier;
+    RetainPtr<NSString> partnerIdentifier;
+    RetainPtr<NSNumber> featureIdentifier;
+    RetainPtr<NSDate> lastUpdated;
+    RetainPtr<NSDate> expiry;
+    RetainPtr<NSNumber> productType;
+    RetainPtr<NSNumber> productState;
+    RetainPtr<NSString> notificationTitle;
+    RetainPtr<NSString> notificationMessage;
+    RetainPtr<NSString> discoveryCardIdentifier;
+}
+
+[WebKitPlatform] class WebKit::CoreIPCPKPaymentSetupFeature {
+    std::optional<WebKit::CoreIPCPKPaymentSetupFeatureData> m_data;
+}
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -116,6 +116,7 @@ additional_forward_declaration: OBJC_CLASS PKSecureElementPass
     usePeerPaymentBalance: Number
 }
 
+#if !HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
 additional_forward_declaration: OBJC_CLASS NSSet
 [WebKitSecureCodingClass=PAL::getPKPaymentSetupFeatureClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentSetupFeature {
     identifiers: Set
@@ -135,5 +136,6 @@ additional_forward_declaration: OBJC_CLASS NSSet
     notificationMessage: String
     discoveryCardIdentifier: String
 }
+#endif
 
 #endif // USE(PASSKIT)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2552,6 +2552,8 @@
 		F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ABDB722B0417AD00C5471A /* CoreIPCLocale.h */; };
 		F4AF72492F22FCC400861236 /* CoreIPCPKPaymentToken.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4AF72472F22CE2B00861236 /* CoreIPCPKPaymentToken.mm */; };
 		F4AF724A2F23025700861236 /* CoreIPCPKPaymentToken.h in Headers */ = {isa = PBXBuildFile; fileRef = F4AF72462F22CE2B00861236 /* CoreIPCPKPaymentToken.h */; };
+		F4AF77882F27CFC800861236 /* CoreIPCPKPaymentSetupFeature.h in Headers */ = {isa = PBXBuildFile; fileRef = F4AF77852F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.h */; };
+		F4AF77892F27CFCF00861236 /* CoreIPCPKPaymentSetupFeature.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4AF77862F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.mm */; };
 		F4B021E72D0BAC2D00D9145E /* CoreIPCSecTrust.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */; };
 		F4B24AA72D5ED4D300725993 /* CoreIPCAVOutputContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B24AA62D5ED3CD00725993 /* CoreIPCAVOutputContext.mm */; };
 		F4B24AA82D5ED4DE00725993 /* CoreIPCAVOutputContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B24AA52D5ED3CD00725993 /* CoreIPCAVOutputContext.h */; };
@@ -8791,6 +8793,9 @@
 		F4AF72462F22CE2B00861236 /* CoreIPCPKPaymentToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPKPaymentToken.h; sourceTree = "<group>"; };
 		F4AF72472F22CE2B00861236 /* CoreIPCPKPaymentToken.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPKPaymentToken.mm; sourceTree = "<group>"; };
 		F4AF72482F22CE2B00861236 /* CoreIPCPKPaymentToken.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPKPaymentToken.serialization.in; sourceTree = "<group>"; };
+		F4AF77852F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPKPaymentSetupFeature.h; sourceTree = "<group>"; };
+		F4AF77862F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPKPaymentSetupFeature.mm; sourceTree = "<group>"; };
+		F4AF77872F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPKPaymentSetupFeature.serialization.in; sourceTree = "<group>"; };
 		F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCSecTrust.mm; sourceTree = "<group>"; };
 		F4B24AA52D5ED3CD00725993 /* CoreIPCAVOutputContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCAVOutputContext.h; sourceTree = "<group>"; };
 		F4B24AA62D5ED3CD00725993 /* CoreIPCAVOutputContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCAVOutputContext.mm; sourceTree = "<group>"; };
@@ -13080,6 +13085,9 @@
 				F4E2D8742F0D88F6007B52E7 /* CoreIPCPKPaymentMerchantSession.h */,
 				F4E2D8752F0D88F6007B52E7 /* CoreIPCPKPaymentMerchantSession.mm */,
 				F4E2D8772F0D91ED007B52E7 /* CoreIPCPKPaymentMerchantSession.serialization.in */,
+				F4AF77852F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.h */,
+				F4AF77862F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.mm */,
+				F4AF77872F27CFBC00861236 /* CoreIPCPKPaymentSetupFeature.serialization.in */,
 				F4AF72462F22CE2B00861236 /* CoreIPCPKPaymentToken.h */,
 				F4AF72472F22CE2B00861236 /* CoreIPCPKPaymentToken.mm */,
 				F4AF72482F22CE2B00861236 /* CoreIPCPKPaymentToken.serialization.in */,
@@ -17871,6 +17879,7 @@
 				5157AE0A2B23E96A00C0E095 /* CoreIPCPassKit.h in Headers */,
 				51AD56912B1C4704001A0ECB /* CoreIPCPersonNameComponents.h in Headers */,
 				F458B8EA2E8F46E900948328 /* CoreIPCPKDateComponentsRange.h in Headers */,
+				F4AF77882F27CFC800861236 /* CoreIPCPKPaymentSetupFeature.h in Headers */,
 				F4AF724A2F23025700861236 /* CoreIPCPKPaymentToken.h in Headers */,
 				564599992B71C3D100BC59E6 /* CoreIPCPresentationIntent.h in Headers */,
 				5C5786922B6EFFFF005D51D5 /* CoreIPCRetainPtr.h in Headers */,
@@ -21492,6 +21501,7 @@
 				51AD56902B1C46FE001A0ECB /* CoreIPCPersonNameComponents.mm in Sources */,
 				F458B8EB2E8F46F000948328 /* CoreIPCPKDateComponentsRange.mm in Sources */,
 				F4E2D8762F0D88FF007B52E7 /* CoreIPCPKPaymentMerchantSession.mm in Sources */,
+				F4AF77892F27CFCF00861236 /* CoreIPCPKPaymentSetupFeature.mm in Sources */,
 				F4AF72492F22FCC400861236 /* CoreIPCPKPaymentToken.mm in Sources */,
 				FAF27D302D2851EB00F1F0BB /* CoreIPCPKSecureElementPass.mm in Sources */,
 				F4F12CB32C48B8C100BC1254 /* CoreIPCPlistArray.mm in Sources */,


### PR DESCRIPTION
#### b001965dd7187d8490c4d3532e94f98259c738ea
<pre>
Migrate PKPaymentSetupFeature to Wrapped WKKeyedCoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=306362">https://bugs.webkit.org/show_bug.cgi?id=306362</a>
<a href="https://rdar.apple.com/137148447">rdar://137148447</a>

Reviewed by Abrar Rahman Protyasha.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.h:
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::typeFromObject):
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.mm:
(WebKit::valueFromID):
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.h: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.mm: Added.
(WebKit::CoreIPCPKPaymentSetupFeature::CoreIPCPKPaymentSetupFeature):
(WebKit::CoreIPCPKPaymentSetupFeature::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, PKPaymentSetupFeature)):

Canonical link: <a href="https://commits.webkit.org/306810@main">https://commits.webkit.org/306810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bca3540989c26ae2659e6d58d61852e0db023d0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14800 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151051 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/685f9aa4-63ad-43ae-bc7f-acbfc083384a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109505 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b12d90f3-bbbd-4929-a631-e3f8ae3fd6d7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12022 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/5235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90410 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe438362-b9f0-4ef3-acf4-8752de6888b2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1070 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/5235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153387 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14479 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117871 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30052 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13918 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/5235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70191 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14528 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14465 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->