### PR TITLE
AX: Propagate visibility/render hidden state between local frames

### DIFF
--- a/LayoutTests/accessibility/iframe-display-none-expected.txt
+++ b/LayoutTests/accessibility/iframe-display-none-expected.txt
@@ -1,0 +1,20 @@
+This test ensures that iframe content is ignored when the iframe is display:none.
+
+PASS: root.childAtIndex(0).isIgnored === false
+PASS: iframeButton1.isIgnored === false
+PASS: iframeButton2.isIgnored === false
+
+document.getElementById('iframe1').style.display = 'none';
+PASS: !root.childAtIndex(0) === true
+PASS: !iframeButton1 === true
+PASS: !iframeButton2 === true
+
+document.getElementById('iframe1').style.display = '';
+PASS: root.childAtIndex(0).isIgnored === false
+PASS: iframeButton1.isIgnored === false
+PASS: iframeButton2.isIgnored === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/iframe-display-none.html
+++ b/LayoutTests/accessibility/iframe-display-none.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<iframe id="iframe1" onload="runTest()" srcdoc="<body>
+    <button id='frame-button-1'>Click me</button>
+    <iframe id='iframe2' src='resources/iframe-button.html'></iframe>
+</body>"></iframe>
+
+<script>
+window.jsTestIsAsync = true;
+
+var output = "This test ensures that iframe content is ignored when the iframe is display:none.\n\n";
+var iframeButton1, iframeButton2, root;
+
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    root = accessibilityController.rootElement.childAtIndex(0);
+    iframeButton1 = accessibilityController.accessibleElementById("frame-button-1");
+
+    setTimeout(async function() {
+        await waitFor(() => {
+            iframeButton2 = accessibilityController.accessibleElementById("frame-button-2");
+            return !!iframeButton2;
+        });
+
+        output += expect("root.childAtIndex(0).isIgnored", "false");
+        output += expect("iframeButton1.isIgnored", "false");
+        output += expect("iframeButton2.isIgnored", "false");
+
+        output += `\n${evalAndReturn("document.getElementById('iframe1').style.display = 'none';")}`;
+
+        await waitFor(() => {
+            iframeButton1 = accessibilityController.accessibleElementById("frame-button-1");
+            iframeButton2 = accessibilityController.accessibleElementById("frame-button-2");
+            return !iframeButton1 && !iframeButton2;
+        });
+        output += await expectAsync("!root.childAtIndex(0)", "true");
+        output += await expectAsync("!iframeButton1", "true");
+        output += await expectAsync("!iframeButton2", "true");
+
+        output += `\n${evalAndReturn("document.getElementById('iframe1').style.display = '';")}`;
+
+        await waitFor(() => {
+            iframeButton1 = accessibilityController.accessibleElementById("frame-button-1");
+            iframeButton2 = accessibilityController.accessibleElementById("frame-button-2");
+            return iframeButton1 && iframeButton2;
+        });
+
+        output += await expectAsync("root.childAtIndex(0).isIgnored", "false");
+        output += await expectAsync("iframeButton1.isIgnored", "false");
+        output += await expectAsync("iframeButton2.isIgnored", "false");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4025,7 +4025,7 @@ bool AccessibilityObject::isWithinHiddenWebArea() const
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
     if (RefPtr parentScrollView = dynamicDowncast<AccessibilityScrollView>(webArea->parentObject())) {
-        if (parentScrollView->isHostingFrameInert()) {
+        if (parentScrollView->isHostingFrameInert() || parentScrollView->isHostingFrameRenderHidden()) {
             // The frame that hosts this web area is inert, so this entire frame should be inert as well.
             return true;
         }

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -336,7 +336,7 @@ void AccessibilityScrollView::addLocalFrameChild()
 
         // Set the initial hosting node state on the child frame's root scroll view.
         if (RefPtr childScrollView = dynamicDowncast<AccessibilityScrollView>(frameRoot.get()))
-            childScrollView->setInheritedFrameState({ isHostingFrameHidden(), isHostingFrameInert() });
+            childScrollView->setInheritedFrameState({ isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() });
 
         m_localFrame = downcast<AXLocalFrame>(cache->create(AccessibilityRole::LocalFrame));
         m_localFrame->setLocalFrameView(localFrameView.get());
@@ -579,6 +579,18 @@ bool AccessibilityScrollView::isHostingFrameInert() const
     return false;
 }
 
+bool AccessibilityScrollView::isHostingFrameRenderHidden() const
+{
+    if (isRoot())
+        return m_inheritedFrameState.isRenderHidden;
+
+    RefPtr frameOwner = frameOwnerElement();
+    if (CheckedPtr renderer = frameOwner ? frameOwner->renderer() : nullptr)
+        return WebCore::isRenderHidden(renderer->style());
+
+    return false;
+}
+
 void AccessibilityScrollView::updateHostedFrameInheritedState()
 {
     if (!m_localFrame)
@@ -601,7 +613,7 @@ void AccessibilityScrollView::updateHostedFrameInheritedState()
     if (!hostedFrameScrollView)
         return;
 
-    hostedFrameScrollView->setInheritedFrameState({ isHostingFrameHidden(), isHostingFrameInert() });
+    hostedFrameScrollView->setInheritedFrameState({ isHostingFrameHidden(), isHostingFrameInert(), isHostingFrameRenderHidden() });
 
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     hostedFrameScrollView->recomputeIsIgnoredForDescendants(/* includeSelf */ true);

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -43,16 +43,18 @@ struct InheritedFrameState {
     InheritedFrameState()
         : isAXHidden(false)
         , isInert(false)
+        , isRenderHidden(false)
     { }
 
-    InheritedFrameState(bool isAXHidden, bool isInert)
+    InheritedFrameState(bool isAXHidden, bool isInert, bool isRenderHidden)
         : isAXHidden(isAXHidden)
         , isInert(isInert)
+        , isRenderHidden(isRenderHidden)
     { }
 
-    bool isAXHidden;
-    bool isInert;
-    // FIXME: include visibility state.
+    bool isAXHidden { false };
+    bool isInert { false };
+    bool isRenderHidden { false };
 };
 #endif
 
@@ -86,8 +88,8 @@ public:
     // We can't use isIgnored() because FrameHost scroll views are always ignored (see computeIsIgnored).
     bool isHostingFrameHidden() const { return isAXHidden(); }
     bool isHostingFrameInert() const;
-    bool isIgnoredFromHostingFrame() const { return isHostingFrameHidden() || isHostingFrameInert(); }
-    // FIXME: This should also consider visibility state for full site isolation support.
+    bool isHostingFrameRenderHidden() const;
+    bool isIgnoredFromHostingFrame() const { return isHostingFrameHidden() || isHostingFrameInert() || isHostingFrameRenderHidden(); }
 #endif // ENABLE(ACCESSIBLITY_LOCAL_FRAME)
 
 private:


### PR DESCRIPTION
#### e2602ace35698fc96e3b5184c079a6adf45ccae3
<pre>
AX: Propagate visibility/render hidden state between local frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=306368">https://bugs.webkit.org/show_bug.cgi?id=306368</a>
<a href="https://rdar.apple.com/169033129">rdar://169033129</a>

Reviewed by Tyler Wilcock.

Similar to what we have done with aria-hidden and inert, frames should send their render
hidden state to other subframes so that things have the right ignored state.

Test: accessibility/iframe-display-none.html

* LayoutTests/accessibility/iframe-display-none-expected.txt: Added.
* LayoutTests/accessibility/iframe-display-none.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::isWithinHiddenWebArea const):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::addLocalFrameChild):
(WebCore::AccessibilityScrollView::isHostingFrameRenderHidden const):
(WebCore::AccessibilityScrollView::updateHostedFrameInheritedState):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
(WebCore::InheritedFrameState::InheritedFrameState):

Canonical link: <a href="https://commits.webkit.org/306417@main">https://commits.webkit.org/306417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63b6d8a7ea647c427e3b6b97cda37594e290f8c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149794 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94317 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1adee6cd-7d76-479d-8459-4d1e12356c2d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108488 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78547 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf48f773-9278-4ece-8c88-bcd1c4860039) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89394 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9adb160b-a39a-4548-b467-8fc6adac3998) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10629 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8224 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152187 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13290 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116589 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12980 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68464 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13333 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->