### PR TITLE
[MSE] Fix sample DTS to prevent deletion of preexisting samples when PTS doesn't conflict

### DIFF
--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt
@@ -1,0 +1,124 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+Test 1: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+Test 1: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({50/10 = 5.000000}), flags(1), generation(1)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 2: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp, and a last sync sample.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+Test 2: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '6') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({50/10 = 5.000000}), flags(1), generation(1)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 3: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+Test 3: Segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend
+beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a
+sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that.
+Same duration samples.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({10/10 = 1.000000}), flags(1), generation(1)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 4: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp, and a last sync sample.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+Test 4: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend
+beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a
+sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that.
+Same duration samples.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '6') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({3000100/1000000 = 3.000100}), duration({10/10 = 1.000000}), flags(1), generation(1)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+Test 5: First segment has normal, monotonically increasing samples with decode timestamp equal
+to presentation timestamp, and a last sync sample.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '5') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({20/10 = 2.000000}), DTS({20/10 = 2.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({30/10 = 3.000000}), DTS({30/10 = 3.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+Test 5: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't
+cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend
+beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a
+sample appended in the future (DTS 29/10). This isn't met, so the whole correction algorithm bails out.
+and all the conflicting samples are deleted (old behaviour). Same duration samples.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/10 = 0.000000}), DTS({0/10 = 0.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+{PTS({10/10 = 1.000000}), DTS({10/10 = 1.000000}), duration({10/10 = 1.000000}), flags(0), generation(0)}
+{PTS({40/10 = 4.000000}), DTS({19/10 = 1.900000}), duration({10/10 = 1.000000}), flags(1), generation(1)}
+{PTS({100/10 = 10.000000}), DTS({100/10 = 10.000000}), duration({10/10 = 1.000000}), flags(1), generation(0)}
+RUN(sourceBuffer.remove(0, Infinity))
+EVENT(updateend)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-samples-out-of-order-erase-last-previous-frames</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var mediaSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+
+        // Test 1.
+
+        consoleWrite("Test 1: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            // Syntax: makeASample(presentationTime, decodeTime, duration, timeScale, trackID, flags, generation)
+            makeASample( 0,  0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample(10, 10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(20, 20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(30, 30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 1: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 9, 50, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 2.
+
+        consoleWrite("Test 2: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp, and a last sync sample.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(  0,   0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample( 10,  10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 20,  20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 30,  30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(100, 100, 10, 10, 0, SAMPLE_FLAG.SYNC, 0)
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 2: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 9, 50, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 6);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 3.
+
+        consoleWrite("Test 3: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample( 0,  0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample(10, 10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(20, 20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(30, 30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 3: Segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend ");
+        consoleWrite("beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a ");
+        consoleWrite("sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that. ");
+        consoleWrite("Same duration samples.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 29, 10, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 4.
+
+        consoleWrite("Test 4: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp, and a last sync sample.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(  0,   0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample( 10,  10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 20,  20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 30,  30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(100, 100, 10, 10, 0, SAMPLE_FLAG.SYNC, 0)
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 4: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend ");
+        consoleWrite("beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a ");
+        consoleWrite("sample appended in the future (DTS 39/10), so some samples will be deleted to prevent that. ");
+        consoleWrite("Same duration samples.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 29, 10, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 6);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Test 5.
+
+        consoleWrite("Test 5: First segment has normal, monotonically increasing samples with decode timestamp equal ");
+        consoleWrite("to presentation timestamp, and a last sync sample.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(  0,   0, 10, 10, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample( 10,  10, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 20,  20, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample( 30,  30, 10, 10, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(100, 100, 10, 10, 0, SAMPLE_FLAG.SYNC, 0)
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 5);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite("Test 5: Second, segment with overlap in decoding order but no overlap in presentation order shouldn't ");
+        consoleWrite("cause any deletion if decoding order is corrected to avoid conflicts. This correction can't extend ");
+        consoleWrite("beyond the duration of the sample, to avoid conflicts with the hypothetical decode timestamp of a ");
+        consoleWrite("sample appended in the future (DTS 29/10). This isn't met, so the whole correction algorithm bails out. ");
+        consoleWrite("and all the conflicting samples are deleted (old behaviour). Same duration samples.");
+
+        mediaSegment = concatenateSamples([
+            makeAInit(1, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(40, 19, 10, 10, 0, SAMPLE_FLAG.SYNC, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        run('sourceBuffer.remove(0, Infinity)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>


### PR DESCRIPTION
#### 13a26d1f906516826613902bd3813f867553644b
<pre>
[MSE] Fix sample DTS to prevent deletion of preexisting samples when PTS doesn&apos;t conflict
<a href="https://bugs.webkit.org/show_bug.cgi?id=305208">https://bugs.webkit.org/show_bug.cgi?id=305208</a>

Reviewed by Alicia Boya Garcia.

Let&apos;s consider a preexisting samples A, B, C, and a new sample N with the
following timestamps:

       Decoding time  Presentation time
       -------------  -----------------
Sample A: 827.826164000  827.826164000
Sample B: 827.826164100  827.826164100
Sample C: 827.826164200  827.826164200
Sample N: 827.826125000  827.909542000

These disparities in DTS vs. PTS offsets between samples A and B exist
because both samples come from completely different videos (eg: because
of ad insertion).

In a timeline:

DTS ···NABC·······
PTS ····ABC···N···

Judging by PTS, the samples A, B, C should remain and theoretically don&apos;t
need to be erased. However, considering DTS, the samples A, B, C have to
be erased, because the sample N would reach the video decoder earlier (by
decoding ordering) and change the state of the decoder, making it
unsuitable for samples A, B, C.

This commit tries to fix the situation by changing sample N (the new
sample) DTS to a value slightly higher than sample C DTS (that is, DTS plus
epsilon, a small value), like this:

       Decoding time  Presentation time
       -------------  -----------------
Sample A:  827.826164000  827.826164000
Sample B:  827.826164100  827.826164100
Sample C:  827.826164200  827.826164200
Sample N: *827.826164201* 827.909542000

DTS ····ABCN······
PTS ····ABC···N···

This fix avoids the deletion of samples A, B, C and the potential
problems associated with that.

A layout test has been added to show the problem and prove that the fix
solves it.

* LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames-expected.txt: Added.
* LayoutTests/media/media-source/media-source-samples-out-of-order-erase-last-previous-frames.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample): If a new sync sample is being added and there are next samples in decode order with PTS lower than the one of the new sample, fix the DTS of the new sample by assigning it to have a safeDecodeTime (the DTS of the highest (by DTS order) preexisting sample, plus epsilon), but only if that DTS wouldn&apos;t be higher than the DTS of the next sample that should come after the new sample being added (estimated as sample.decodeTime() + 2*duration, and keeping a safety margin).

Canonical link: <a href="https://commits.webkit.org/307359@main">https://commits.webkit.org/307359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8ec24e9bdb706a4f081110b2a8fa5c0513d4ec5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97233 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110725 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79596 "Exiting early after 60 failures. 15479 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13149 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129387 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts, TestWebKitAPI.MediaLoading.LockdownModeHLS (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12616 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10347 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/110 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154976 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16525 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16561 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30557 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14998 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16147 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5691 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79926 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16092 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->