### PR TITLE
Add Screen Wake Lock API Tests in Site Isolation

### DIFF
--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -261,6 +261,7 @@ Tests/WebKitCocoa/SafeBrowsing.mm @nonARC
 Tests/WebKitCocoa/SampledPageTopColor.mm @nonARC
 Tests/WebKitCocoa/SchemeRegistry.mm @nonARC
 Tests/WebKitCocoa/ScreenTime.mm @nonARC
+Tests/WebKitCocoa/ScreenWakeLock.mm @nonARC
 Tests/WebKitCocoa/SerializedNode.mm @nonARC
 Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm @nonARC
 Tests/WebKitCocoa/ServiceWorkerBasic.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -4136,6 +4136,8 @@
 		D3BE5E341E4CE85E00FD563A /* WKWebViewGetContents.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewGetContents.mm; sourceTree = "<group>"; };
 		D606F87F2EBC1C93002783D7 /* FindInPageUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FindInPageUtilities.h; sourceTree = "<group>"; };
 		D606F8872EBC201D002783D7 /* FindInPageUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FindInPageUtilities.mm; sourceTree = "<group>"; };
+		D621F9312F2AB42900ABB100 /* ScreenWakeLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScreenWakeLock.h; sourceTree = "<group>"; };
+		D621F9322F2AC47400ABB100 /* ScreenWakeLock.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScreenWakeLock.mm; sourceTree = "<group>"; };
 		D69D9E2F2E9041E800689F1D /* SiteIsolationUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SiteIsolationUtilities.h; sourceTree = "<group>"; };
 		D69D9E372E9041F400689F1D /* SiteIsolationUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SiteIsolationUtilities.mm; sourceTree = "<group>"; };
 		D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStyleChange.cpp; sourceTree = "<group>"; };
@@ -5103,6 +5105,8 @@
 				5CC8B16226A2527C00909603 /* SchemeChangingPlugIn.mm */,
 				CE0947362063223B003C9BA0 /* SchemeRegistry.mm */,
 				6DE8CFD32D10ED7300C6FDBE /* ScreenTime.mm */,
+				D621F9312F2AB42900ABB100 /* ScreenWakeLock.h */,
+				D621F9322F2AC47400ABB100 /* ScreenWakeLock.mm */,
 				F4AF63B32C990A47001D782B /* ScriptTrackingPrivacyTests.mm */,
 				FAD420BF2E4AB7AA00069B2E /* SerializedNode.mm */,
 				51EB12931FDF050500A5A1BD /* ServiceWorkerBasic.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenWakeLock.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenWakeLock.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#if PLATFORM (IOS_FAMILY)
+@class SetShouldKeepScreenAwakeDelegate;
+#endif // PLATFORM (IOS_FAMILY)
+
+@class TestNavigationDelegate;
+@class TestWKWebView;
+@protocol WKUIDelegatePrivate;
+
+struct ScreenWakeLockTestsConfig {
+    enum class CrossSite : bool { No, Yes };
+    CrossSite crossSite;
+};
+
+class ScreenWakeLockTests : public testing::TestWithParam<ScreenWakeLockTestsConfig> {
+public:
+    void SetUp() final;
+    void requestLock();
+    void releaseLock();
+    void killWebPage();
+    void closeWebPage();
+    void closeTab();
+    void lockShouldBeReleased();
+    void lockShouldNotBeReleased();
+
+private:
+    void setUpCrossSite();
+    void setUpSameSite();
+    WKFrameInfo* frameOfConcern();
+
+    RetainPtr<TestWKWebView> m_webView;
+    RetainPtr<TestNavigationDelegate> m_navigationDelegate;
+#if PLATFORM (IOS_FAMILY)
+    RetainPtr<SetShouldKeepScreenAwakeDelegate> m_uiDelegate;
+#endif // PLATFORM (IOS_FAMILY)
+};
+

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenWakeLock.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenWakeLock.mm
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ScreenWakeLock.h"
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
+#import "TestWKWebView.h"
+#import "Utilities.h"
+#import "WKWebViewConfigurationExtras.h"
+
+#if PLATFORM(IOS_FAMILY)
+static bool gShouldKeepScreenAwake = false;
+
+@interface SetShouldKeepScreenAwakeDelegate : NSObject <WKUIDelegatePrivate>
+@end
+
+@implementation SetShouldKeepScreenAwakeDelegate
+
+- (void)_webView:(WKWebView *)webView setShouldKeepScreenAwake:(BOOL)shouldKeepScreenAwake
+{
+    EXPECT_NE(gShouldKeepScreenAwake, shouldKeepScreenAwake);
+    gShouldKeepScreenAwake = shouldKeepScreenAwake;
+}
+
+@end
+#endif // PLATFORM(IOS_FAMILY)
+
+TEST_P(ScreenWakeLockTests, SetShouldKeepScreenAwake)
+{
+    requestLock();
+    releaseLock();
+    lockShouldBeReleased();
+}
+
+TEST_P(ScreenWakeLockTests, SetShouldKeepScreenAwakeTabIsClosed)
+{
+    requestLock();
+    closeTab();
+    lockShouldBeReleased();
+}
+
+TEST_P(ScreenWakeLockTests, SetShouldKeepScreenAwakeLastPageIsClosed)
+{
+    requestLock();
+    requestLock();
+    closeWebPage();
+    lockShouldBeReleased();
+}
+
+TEST_P(ScreenWakeLockTests, SetShouldKeepScreenAwakeWebProcessCrash)
+{
+    requestLock();
+    requestLock();
+    killWebPage();
+    lockShouldBeReleased();
+}
+
+void ScreenWakeLockTests::SetUp()
+{
+    if (GetParam().crossSite == ScreenWakeLockTestsConfig::CrossSite::Yes)
+        setUpCrossSite();
+    else
+        setUpSameSite();
+
+#if PLATFORM(IOS_FAMILY)
+    m_uiDelegate = adoptNS([SetShouldKeepScreenAwakeDelegate new]);
+    [m_webView setUIDelegate:m_uiDelegate.get()];
+#endif
+}
+
+void ScreenWakeLockTests::requestLock()
+{
+    __block bool done = false;
+    [m_webView callAsyncJavaScript:@"lock = await navigator.wakeLock.request('screen');" arguments:nil inFrame:frameOfConcern() inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *err) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    lockShouldNotBeReleased();
+}
+
+void ScreenWakeLockTests::releaseLock()
+{
+    __block bool done = false;
+    [m_webView callAsyncJavaScript:@"return await lock.release()" arguments:nil inFrame:frameOfConcern() inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *err) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+void ScreenWakeLockTests::killWebPage()
+{
+    kill([m_webView _webProcessIdentifier], SIGKILL);
+    m_webView = nil;
+}
+
+void ScreenWakeLockTests::closeWebPage()
+{
+    [m_webView _close];
+    m_webView = nil;
+}
+
+void ScreenWakeLockTests::closeTab()
+{
+    [m_webView removeFromSuperview];
+    [m_webView waitUntilActivityStateUpdateDone];
+}
+
+void ScreenWakeLockTests::lockShouldBeReleased()
+{
+#if PLATFORM(IOS_FAMILY)
+    while (gShouldKeepScreenAwake)
+        TestWebKitAPI::Util::spinRunLoop(10);
+#endif // PLATFORM(IOS_FAMILY)
+
+    if (m_webView)
+        EXPECT_TRUE([[m_webView objectByEvaluatingJavaScript:@"window.lock.released" inFrame:frameOfConcern()] boolValue]);
+}
+
+void ScreenWakeLockTests::lockShouldNotBeReleased()
+{
+#if PLATFORM(IOS_FAMILY)
+    EXPECT_TRUE(gShouldKeepScreenAwake);
+#endif // PLATFORM(IOS_FAMILY)
+
+    ASSERT_TRUE(m_webView);
+    EXPECT_FALSE([[m_webView objectByEvaluatingJavaScript:@"window.lock.released" inFrame:frameOfConcern()] boolValue]);
+}
+
+void ScreenWakeLockTests::setUpCrossSite()
+{
+    ASCIILiteral mainFrameHTML = "<iframe src='https://examplesubframe.com/subframe' allow='screen-wake-lock' id='subFrame'></iframe>";
+    ASCIILiteral subFrameHTML = "<script> alert('frame loaded'); </script>";
+    TestWebKitAPI::HTTPServer server({
+        { "/mainframe"_s, { mainFrameHTML } },
+        { "/subframe"_s, { subFrameHTML } } },
+        TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    auto configuration = server.httpsProxyConfiguration();
+    m_navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [m_navigationDelegate allowAnyTLSCertificate];
+    m_webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration addToWindow:YES]);
+    [m_webView setNavigationDelegate:m_navigationDelegate.get()];
+    [m_webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://examplemainframe.com/mainframe"]]];
+    EXPECT_WK_STREQ([m_webView _test_waitForAlert], "frame loaded");
+}
+
+void ScreenWakeLockTests::setUpSameSite()
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    m_webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
+    [m_webView synchronouslyLoadHTMLString:@"<body></body>"];
+}
+
+WKFrameInfo *ScreenWakeLockTests::frameOfConcern()
+{
+    return GetParam().crossSite == ScreenWakeLockTestsConfig::CrossSite::Yes ? [m_webView firstChildFrame] : nil;
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #import "IOSMouseEventTestHarness.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
+#import "ScreenWakeLock.h"
 #import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
@@ -688,79 +689,9 @@ TEST(WebKit, LockdownModeAskAgainFirstUseMessage)
 
 #endif // (PLATFORM(IOS) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) || PLATFORM(VISION)
 
-#if PLATFORM(IOS_FAMILY)
-
-static bool gShouldKeepScreenAwake = false;
-
-@interface SetShouldKeepScreenAwakeDelegate : NSObject <WKUIDelegatePrivate>
-@end
-
-@implementation SetShouldKeepScreenAwakeDelegate
-
-- (void)_webView:(WKWebView *)webView setShouldKeepScreenAwake:(BOOL)shouldKeepScreenAwake
-{
-    EXPECT_NE(gShouldKeepScreenAwake, shouldKeepScreenAwake);
-    gShouldKeepScreenAwake = shouldKeepScreenAwake;
-}
-
-@end
-
-TEST(WebKit, SetShouldKeepScreenAwake)
-{
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([SetShouldKeepScreenAwakeDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-    [webView synchronouslyLoadHTMLString:@"<body></body>"];
-    [webView evaluateJavaScript:@"navigator.wakeLock.request('screen').then((wakeLock) => { window.lock = wakeLock; }); true;" completionHandler:nil];
-    TestWebKitAPI::Util::run(&gShouldKeepScreenAwake);
-    [webView evaluateJavaScript:@"window.lock.release(); true;" completionHandler:nil];
-    while (gShouldKeepScreenAwake)
-        TestWebKitAPI::Util::spinRunLoop(10);
-}
-
-TEST(WebKit, SetShouldKeepScreenAwakeLastPageIsClosed)
-{
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([SetShouldKeepScreenAwakeDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-    [webView synchronouslyLoadHTMLString:@"<body></body>"];
-    [webView evaluateJavaScript:@"navigator.wakeLock.request('screen').then((wakeLock) => { window.lock = wakeLock; }); true;" completionHandler:nil];
-    TestWebKitAPI::Util::run(&gShouldKeepScreenAwake);
-
-    [webView evaluateJavaScript:@"navigator.wakeLock.request('screen').then((wakeLock) => { window.lock = wakeLock; }); true;" completionHandler:nil];
-    TestWebKitAPI::Util::run(&gShouldKeepScreenAwake);
-
-    // Close the last page while holding the lock.
-    [webView _close];
-    webView = nil;
-
-    while (gShouldKeepScreenAwake)
-        TestWebKitAPI::Util::spinRunLoop(10);
-}
-
-TEST(WebKit, SetShouldKeepScreenAwakeWebProcessCrash)
-{
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get() addToWindow:YES]);
-    auto delegate = adoptNS([SetShouldKeepScreenAwakeDelegate new]);
-    [webView setUIDelegate:delegate.get()];
-    [webView synchronouslyLoadHTMLString:@"<body></body>"];
-    [webView evaluateJavaScript:@"navigator.wakeLock.request('screen').then((wakeLock) => { window.lock = wakeLock; }); true;" completionHandler:nil];
-    TestWebKitAPI::Util::run(&gShouldKeepScreenAwake);
-
-    [webView evaluateJavaScript:@"navigator.wakeLock.request('screen').then((wakeLock) => { window.lock = wakeLock; }); true;" completionHandler:nil];
-    TestWebKitAPI::Util::run(&gShouldKeepScreenAwake);
-
-    // Kill the WebProcess while holding the screen lock.
-    kill([webView _webProcessIdentifier], 9);
-
-    while (gShouldKeepScreenAwake)
-        TestWebKitAPI::Util::spinRunLoop(10);
-}
-
-#endif // PLATFORM(IOS_FAMILY)
+INSTANTIATE_TEST_SUITE_P(WebKit, ScreenWakeLockTests, testing::Values(
+    ScreenWakeLockTestsConfig::CrossSite::No,
+    ScreenWakeLockTestsConfig::CrossSite::Yes));
 
 #if PLATFORM(MAC)
 


### PR DESCRIPTION
#### 0dba82be37720810c1136086f614ce8bfa59df1f
<pre>
Add Screen Wake Lock API Tests in Site Isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=305988">https://bugs.webkit.org/show_bug.cgi?id=305988</a>
<a href="https://rdar.apple.com/163809691">rdar://163809691</a>

Reviewed by Sihui Liu.

I have added new site isolation API tests for the Screen Wake Lock
API. I have also added new screen wake lock tests for the UIDelegate.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenWakeLock.h: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenWakeLock.mm: Added.
(-[SetShouldKeepScreenAwakeDelegate _webView:setShouldKeepScreenAwake:]):
(TEST_P):
(ScreenWakeLockTests::SetUp):
(ScreenWakeLockTests::requestLock):
(ScreenWakeLockTests::releaseLock):
(ScreenWakeLockTests::killWebPage):
(ScreenWakeLockTests::closeWebPage):
(ScreenWakeLockTests::closeTab):
(ScreenWakeLockTests::lockShouldBeReleased):
(ScreenWakeLockTests::lockShouldNotBeReleased):
(ScreenWakeLockTests::setUpCrossSite):
(ScreenWakeLockTests::setUpSameSite):
(ScreenWakeLockTests::frameOfConcern):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(-[SetShouldKeepScreenAwakeDelegate _webView:setShouldKeepScreenAwake:]): Deleted.
((WebKit, SetShouldKeepScreenAwake)): Deleted.
((WebKit, SetShouldKeepScreenAwakeLastPageIsClosed)): Deleted.
((WebKit, SetShouldKeepScreenAwakeWebProcessCrash)): Deleted.

Canonical link: <a href="https://commits.webkit.org/306455@main">https://commits.webkit.org/306455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09ac1a968acf627a009d4ff6a3028b2eb515f654

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149931 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94452 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5f4e868-da65-4786-b720-fb9a3ec02f6f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108603 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25db5c18-77bf-42d1-b20c-5aeaa22bdedc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89508 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/944f9689-f8ca-4e84-9d03-d6d9fa21e253) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10725 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8346 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/3 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119991 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152323 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2919 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116710 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117042 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29805 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13092 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68626 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13470 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13407 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13253 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->