### PR TITLE
Control Center shows YouTube video after navigating away from YouTube

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -422,6 +422,9 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 {
     assertIsMainThread();
 
+    if (m_isActiveNowPlayingProcess)
+        clearNowPlayingInfo();
+
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
     if (m_routingArbitrator)
         m_routingArbitrator->processDidTerminate();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
@@ -240,4 +240,25 @@ TEST(NowPlayingSession, NavigateSubframeAfterHasSessionInSubframe)
     [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
+TEST(NowPlayingSession, KillWebContentProcessAfterHasSession)
+{
+    RetainPtr webView = createWebView();
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    RetainPtr observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView synchronouslyLoadTestPageNamed:@"now-playing-session-test"];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView evaluateJavaScript:@"playInMainFrame()" completionHandler:nil];
+    [observer waitForHasActiveNowPlayingSessionChanged];
+    EXPECT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView _killWebContentProcessAndResetState];
+    EXPECT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
+}
+
 @end


### PR DESCRIPTION
#### 995043a1cea994b964c1a8e670ba9ed2d3274325
<pre>
Control Center shows YouTube video after navigating away from YouTube
<a href="https://bugs.webkit.org/show_bug.cgi?id=306376">https://bugs.webkit.org/show_bug.cgi?id=306376</a>
<a href="https://rdar.apple.com/155225435">rdar://155225435</a>

Reviewed by Brady Eidson.

Currently, the GPU process relies on an explicit message from
the web content process to clear the now playing info. However,
there are a variety of ways a web process can exit, and not
all of them require being cleanly torn down, in which case
NowPlayingManager::clearNowPlayingInfo() might not be
called.

In this particular case, when a tab playing a video on youtube.com
is closed, youtube&apos;s service worker prevents us from cleanly tearing
down the web process, and clearNowPlayingInfo() is not called.

This fix makes it so when the GPU process knows that the web process is
about to close, it clears the now playing info on its own. This hardens it
against all ways the web process might close.

Added API test NowPlayingSession.KillWebContentProcessAfterHasSession

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm:
(TEST(NowPlayingSession, KillWebContentProcessAfterHasSession)):

Canonical link: <a href="https://commits.webkit.org/306351@main">https://commits.webkit.org/306351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb90ec3528506b29ad68c9a2528ef92d5e402986

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149682 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13673 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144088 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/10987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89318 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8163 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152102 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13207 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13223 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116871 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/12930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/122981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21770 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13250 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76955 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->