### PR TITLE
NEW TEST:(305922@main) [macOS iOS] TestWebKitAPI.FocusWebView.MultipleFrames is timing out

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
@@ -187,7 +187,7 @@ TEST(FocusWebView, AdvanceFocusRelinquishToChrome)
     EXPECT_FALSE(textField.get().didSeeKeyDownEvent);
 }
 
-TEST(FocusWebView, DISABLED_MultipleFrames)
+TEST(FocusWebView, MultipleFrames)
 {
     auto exampleHTML = "<body>"
         "<input id='input'>"
@@ -197,7 +197,7 @@ TEST(FocusWebView, DISABLED_MultipleFrames)
 
     auto iframeHTML = "<script>"
         "onload = () => {"
-        "    document.getElementById('iframeInput').addEventListener('focus', () => {"
+        "    document.getElementById('iframeInput').addEventListener('focusin', (e) => {"
         "        alert(window.origin + ' focused');"
         "    });"
         "};"
@@ -212,14 +212,14 @@ TEST(FocusWebView, DISABLED_MultipleFrames)
     }, HTTPServer::Protocol::HttpsProxy);
 
     RetainPtr configuration = server.httpsProxyConfiguration();
-    [[configuration preferences] _setSiteIsolationEnabled:YES];
+    // FIXME: Enable site isolation here and make the test behave the same.
     auto [webView, navigationDelegate, uiDelegate] = makeWebViewAndDelegates(WTF::move(configuration));
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
     [webView evaluateJavaScript:@""
         "let i = document.getElementById('input');"
-        "i.addEventListener('focus', () => {"
+        "i.addEventListener('focusin', (e) => {"
         "    alert('main frame focused');"
         "});"
         "i.focus()" completionHandler:nil];
@@ -228,13 +228,7 @@ TEST(FocusWebView, DISABLED_MultipleFrames)
     [webView typeCharacter:'\t'];
     EXPECT_WK_STREQ([uiDelegate waitForAlert], "https://webkit.org focused");
     [webView typeCharacter:'\t'];
-#if PLATFORM(MAC)
-    EXPECT_WK_STREQ([uiDelegate waitForAlert], "main frame focused"); // FIXME: This should be webkit.org like it is with site isolation off.
-#else
-    EXPECT_WK_STREQ([uiDelegate waitForAlert], "https://webkit.org focused"); // FIXME: This should be the same as it is on macOS.
-#endif
-    [webView typeCharacter:'\t'];
-    EXPECT_WK_STREQ([uiDelegate waitForAlert], "main frame focused"); // FIXME: This should be apple.com like it is with site isolation off
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "https://apple.com focused");
 }
 
 TEST(FocusWebView, DoNotFocusWebViewWhenUnparented)


### PR DESCRIPTION
#### 25cc3686bf4b8ef032c88c46d01985b49ffbb081
<pre>
NEW TEST:(305922@main) [macOS iOS] TestWebKitAPI.FocusWebView.MultipleFrames is timing out
<a href="https://rdar.apple.com/168688750">rdar://168688750</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306048">https://bugs.webkit.org/show_bug.cgi?id=306048</a>

Unreviewed.

The focus event happens more than once each time the tab key is hit.
To make the test more deterministic and test what I intended to test,
use the focusin event instead.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm:
(TestWebKitAPI::MultipleFrames)):
(TestWebKitAPI::DISABLED_MultipleFrames)): Deleted.

Canonical link: <a href="https://commits.webkit.org/306323@main">https://commits.webkit.org/306323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49347229a200d9ef2689ce6ff600a39677f173bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149518 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108271 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89181 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10493 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/151997 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2499 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116449 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116793 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12843 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122886 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21761 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13146 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13084 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->