### PR TITLE
REGRESSION (303055@main): Intersection Observer fails with zoomed visual viewport

### DIFF
--- a/LayoutTests/intersection-observer/zoomed-visual-viewport-expected.txt
+++ b/LayoutTests/intersection-observer/zoomed-visual-viewport-expected.txt
@@ -1,0 +1,5 @@
+Text that needs to be here to reproduce the issue.
+
+
+PASS Tests that intersection observer works when the visual viewport is zoomed (e.g from pinched zoom)
+

--- a/LayoutTests/intersection-observer/zoomed-visual-viewport.html
+++ b/LayoutTests/intersection-observer/zoomed-visual-viewport.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+
+<title>Tests that intersection observer works when the visual viewport is zoomed (e.g from pinched zoom)</title>
+<style>
+    .container {
+        border: 1px black solid;
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+    }
+
+    .target {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+
+    .spacer {
+        border: 1px black red;
+        height: 1000px;
+    }
+</style>
+
+<script src="../resources/ui-helper.js"></script>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<body>
+    <p>
+        Text that needs to be here to reproduce the issue.
+    </p>
+
+    <div class="container" id="container">
+        <div class="spacer"></div>
+        <div class="target" id="target"></div>
+    </div>
+
+    <script>
+        var lastObservation = null;
+
+        var observer = new IntersectionObserver((observations) => {
+            lastObservation = observations[observations.length - 1];
+        });
+
+        observer.observe(target);
+
+        function assertRootBounds(actual, expectedX, expectedY, expectedWidth, expectedHeight) {
+            assert_equals(actual.x, expectedX);
+            assert_equals(actual.y, expectedY);
+            assert_equals(actual.width, expectedWidth);
+            assert_equals(actual.height, expectedHeight);
+        }
+
+        promise_test(async t => {
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+            assert_false(lastObservation.isIntersecting, "Target is initially visible");
+            assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
+
+            await UIHelper.zoomToScale(2);
+            window.scrollTo(0, 0);
+
+            container.scrollTop = 1000;
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+            assert_true(lastObservation.isIntersecting, "Scrolled past target, target is no longer visible");
+            assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
+
+            container.scrollTop = 0;
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+            assert_false(lastObservation.isIntersecting, "Scrolled to top of container, target is visible again");
+            assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
+        });
+    </script>
+</body>


### PR DESCRIPTION
#### cb868f1b5b52e1a7bb0087129e471a7145bd10f0
<pre>
REGRESSION (303055@main): Intersection Observer fails with zoomed visual viewport
<a href="https://rdar.apple.com/168143635">rdar://168143635</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306372">https://bugs.webkit.org/show_bug.cgi?id=306372</a>

Reviewed by Simon Fraser.

303055@main removed some calls to RenderView::localToAbsoluteQuad, because those
requires access to the root&apos;s RenderView, which is inaccessible with Site Isolation
enabled. However, this breaks Intersection Observer with pinch-to-zoom. Pinch-to-zoom
applies a scaling transform on the RenderView, and localToAbsoluteQuad accounts for
the transform. This patch temporarily reverts 303055@main while we figure out a
better solution.

Test: intersection-observer/zoomed-visual-viewport.html

* LayoutTests/intersection-observer/zoomed-visual-viewport-expected.txt: Added.
* LayoutTests/intersection-observer/zoomed-visual-viewport.html: Added.
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):

Canonical link: <a href="https://commits.webkit.org/306392@main">https://commits.webkit.org/306392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9dbae1712c3d13513fb1ac84ef9674d1cddcb88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149801 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b3c70372-dc8c-47e6-8b6d-47c48e176cbe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108494 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eec18940-93d3-4bff-8a0a-b1e60c6959d6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11038 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89399 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/921eb09f-97fb-4337-8f16-d8362717cf4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8229 "Passed tests") | [⏳ wpe-libwebrtc ](None "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152195 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13297 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116594 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29759 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12987 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123040 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68471 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13340 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13123 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->