### PR TITLE
Deleting highlight from registry does not clear highlight ranges.

### DIFF
--- a/LayoutTests/fast/repaint/highlight-removed-when-deleted-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-removed-when-deleted-expected.txt
@@ -1,0 +1,6 @@
+Highlight this first and then delete highlight.
+(repaint rects
+  (rect 8 8 568 37)
+  (rect 8 8 568 37)
+)
+When run, the first "this" should be highlighted, and then the highlight should be removed.

--- a/LayoutTests/fast/repaint/highlight-removed-when-deleted.html
+++ b/LayoutTests/fast/repaint/highlight-removed-when-deleted.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html {
+    font-size: 24pt;
+}
+
+::highlight(yellowHighlight) {
+    background-color: yellow;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <div id="highlight_area">Highlight this first and then delete highlight.</div>
+    <pre id="result"></pre>
+    <p>When run, the first "this" should be highlighted, and then the highlight should be removed.</p>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    let highlightRange = new Range();
+    let highlightOne = new Highlight(highlightRange);
+    CSS.highlights.set("yellowHighlight", highlightOne);
+    let highlightNode = highlight_area;
+
+    highlightRange.setStart(highlightNode.firstChild, 10);
+    highlightRange.setEnd(highlightNode.firstChild, 14);
+
+    await UIHelper.renderingUpdate();
+
+    CSS.highlights.delete("yellowHighlight");
+    if (window.internals) {
+        let repaintRects = internals.repaintRectsAsText();
+        internals.stopTrackingRepaints();
+        result.textContent = repaintRects;
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</html>

--- a/LayoutTests/platform/glib/fast/repaint/highlight-removed-when-deleted-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/highlight-removed-when-deleted-expected.txt
@@ -1,0 +1,6 @@
+Highlight this first and then delete highlight.
+(repaint rects
+  (rect 8 8 570 37)
+  (rect 8 8 570 37)
+)
+When run, the first "this" should be highlighted, and then the highlight should be removed.

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -57,8 +57,13 @@ void HighlightRegistry::clear()
 
 bool HighlightRegistry::remove(const AtomString& key)
 {
+    auto highlight = m_map.take(key);
+    if (!highlight)
+        return false;
+
     m_highlightNames.removeFirst(key);
-    return m_map.remove(key);
+    highlight->repaint();
+    return true;
 }
 
 #if ENABLE(APP_HIGHLIGHTS)


### PR DESCRIPTION
#### 15176166d70f4095b6c4d7b8d97e25f7810d6753
<pre>
Deleting highlight from registry does not clear highlight ranges.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306396">https://bugs.webkit.org/show_bug.cgi?id=306396</a>
<a href="https://rdar.apple.com/168765380">rdar://168765380</a>

Reviewed by Aditya Keerthi.

When deleting a highlight from the registry, we did not repaint
the ranges of that highlight, which resulted in the page
looking like the highlights were still present. We simply need
to repaint the ranges when we delete the highlight.

Test: fast/repaint/highlight-removed-when-deleted.html

* LayoutTests/fast/repaint/highlight-removed-when-deleted-expected.txt: Added.
* LayoutTests/fast/repaint/highlight-removed-when-deleted.html: Added.
* LayoutTests/platform/glib/fast/repaint/highlight-removed-when-deleted-expected.txt: Added.
* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::remove):

Canonical link: <a href="https://commits.webkit.org/306433@main">https://commits.webkit.org/306433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/869268253ac149b9ead1669145deec743269bcf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2903 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94307 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc5b5e41-9aed-4833-882e-fa4abed2cc9f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108476 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78542 "1 flakes 14 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61eda69d-b5ea-43fa-81db-973d7d362764) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67ad624d-5626-4d26-97db-83d798626087) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8216 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119865 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152179 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13280 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2792 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116583 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116924 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29794 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12969 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68454 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13323 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->