### PR TITLE
Cull simple canvas text drawing outside of the clip

### DIFF
--- a/LayoutTests/fast/canvas/fillText-edge-clip-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip-expected.html
@@ -1,0 +1,26 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+ctx.clearRect(width, 0, clip, canvas.height);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-clip-shadow-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip-shadow-expected.html
@@ -1,0 +1,31 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillStyle = "black";
+  ctx.fillText("Hi", x + shadowOffsetX, y);
+  if (x < width) {
+    ctx.fillStyle = "blue";
+    ctx.fillText("Hi", x, y);
+  }
+}
+
+ctx.clearRect(width, 0, clip, canvas.height);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-clip-shadow.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip-shadow.html
@@ -1,0 +1,32 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+let region = new Path2D();
+region.rect(0, 0, width, canvas.height);
+ctx.clip(region);
+
+ctx.shadowColor = "black";
+ctx.shadowOffsetX = shadowOffsetX;
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-clip.html
+++ b/LayoutTests/fast/canvas/fillText-edge-clip.html
@@ -1,0 +1,28 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const clip = 20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width - clip;
+const ctx = canvas.getContext('2d');
+
+let region = new Path2D();
+region.rect(0, 0, width, canvas.height);
+ctx.clip(region);
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-expected.html
@@ -1,0 +1,25 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  if (x < width) {
+    ctx.fillText("Hi", x, y);
+  }
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-shadow-expected.html
+++ b/LayoutTests/fast/canvas/fillText-edge-shadow-expected.html
@@ -1,0 +1,28 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillStyle = "black";
+  ctx.fillText("Hi", x + shadowOffsetX, y);
+  if (x < width) {
+    ctx.fillStyle = "blue";
+    ctx.fillText("Hi", x, y);
+  }
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge-shadow.html
+++ b/LayoutTests/fast/canvas/fillText-edge-shadow.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const shadowOffsetX = -20;
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.shadowColor = "black";
+ctx.shadowOffsetX = shadowOffsetX;
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-edge.html
+++ b/LayoutTests/fast/canvas/fillText-edge.html
@@ -1,0 +1,23 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-empty-clip-expected.html
+++ b/LayoutTests/fast/canvas/fillText-empty-clip-expected.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+</body>
+</html>

--- a/LayoutTests/fast/canvas/fillText-empty-clip.html
+++ b/LayoutTests/fast/canvas/fillText-empty-clip.html
@@ -1,0 +1,27 @@
+<html>
+<body>
+<canvas width="100" height="100" style="border: solid 1px gray"></canvas>
+<script>
+const iterations = 10;
+const increment = 4;
+
+const canvas = document.getElementsByTagName('canvas')[0];
+const width = canvas.width;
+const ctx = canvas.getContext('2d');
+
+let region = new Path2D();
+region.rect(width - 1, 0, 0, canvas.height);
+ctx.clip(region);
+
+ctx.font = "10px monospace";
+ctx.fillStyle = "blue";
+
+for (let i = 0; i < iterations; ++i) {
+  const x = width + (i - iterations / 2) * increment;
+  const y = i * 10;
+  ctx.fillText("Hi", x, y);
+}
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -4506,6 +4506,9 @@ fast/css/highlight-text-repaint.html [ Skip ] # Failure
 fast/css/text-underline-offset-repaint.html [ Skip ] # Failure
 fast/flexbox/missing-repaint-when-flext-item-never-had-layout.html [ Skip ] # Failure
 
+fast/canvas/fillText-edge-clip-shadow.html [ ImageOnlyFailure ]
+fast/canvas/fillText-edge-shadow.html [ ImageOnlyFailure ]
+
 webkit.org/b/286284 fast/canvas/canvas-image-shadow.html [ Failure ]
 webkit.org/b/286284 webgl/2.0.y/conformance/canvas/to-data-url-test.html [ Failure ]
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2964,8 +2964,12 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
         clearCanvas();
         fontProxy.drawBidiText(*c, textRun, location, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
         repaintEntireCanvas = true;
-    } else
+    } else {
+        auto clipBounds = c->clipBounds();
+        if ((clipBounds.isEmpty() || !clipBounds.intersects(enclosingIntRect(textRect))) && !shouldDrawShadows())
+            return;
         fontProxy.drawBidiText(*c, textRun, location, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+    }
 
     didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : textRect);
 }


### PR DESCRIPTION
#### a0ea903bb9afa692396f45e6960c8ab5ef4fc364
<pre>
Cull simple canvas text drawing outside of the clip
<a href="https://bugs.webkit.org/show_bug.cgi?id=306394">https://bugs.webkit.org/show_bug.cgi?id=306394</a>
<a href="https://rdar.apple.com/168526176">rdar://168526176</a>

Reviewed by Matt Woodrow.

In simple cases where no-frills text would be drawn on top of a canvas,
it&apos;s easy and fast to check if the text does NOT intersect with the
current clip, in which case the whole operation can safely be skipped.

Tech detail: Even though the first thing `IntRect::intersects()` does is
check for `this-&gt;empty()`, doing it explicitly first can avoid having to
compute `enclosingIntRect(FloatRect)`.

Tests: fast/canvas/fillText-edge-clip-shadow.html
       fast/canvas/fillText-edge-clip.html
       fast/canvas/fillText-edge-shadow.html
       fast/canvas/fillText-edge.html
       fast/canvas/fillText-empty-clip.html
* LayoutTests/fast/canvas/fillText-edge-clip-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-clip-shadow-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-clip-shadow.html: Added.
* LayoutTests/fast/canvas/fillText-edge-clip.html: Added.
* LayoutTests/fast/canvas/fillText-edge-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-shadow-expected.html: Added.
* LayoutTests/fast/canvas/fillText-edge-shadow.html: Added.
* LayoutTests/fast/canvas/fillText-edge.html: Added.
* LayoutTests/fast/canvas/fillText-empty-clip-expected.html: Added.
* LayoutTests/fast/canvas/fillText-empty-clip.html: Added.
* LayoutTests/platform/win/TestExpectations: Slight shadow color diffs, filed <a href="https://bugs.webkit.org/show_bug.cgi?id=306588">https://bugs.webkit.org/show_bug.cgi?id=306588</a>
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):

Canonical link: <a href="https://commits.webkit.org/306465@main">https://commits.webkit.org/306465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fbd6fa7d249a30af7765dd0413d1d3b193a8f26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13843 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/3184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150032 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbff8903-9e95-41a5-b4d1-6b5a8687904a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14000 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11227 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89588 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/503d1606-85a4-4538-8e35-42c5598d6203) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8414 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/104 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133440 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13530 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/3009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/13545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29811 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/123239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13573 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/13309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13508 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/13356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->