### PR TITLE
Address more unsafe cast warnings in Source/WebCore/svg/properties

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -3,5 +3,3 @@
 [ iOS ] platform/ios/VideoPresentationInterfaceIOS.mm
 [ iOS ] platform/ios/wak/WAKView.mm
 [ iOS ] platform/ios/wak/WAKWindow.mm
-svg/properties/SVGAnimatedPropertyAccessorImpl.h
-svg/properties/SVGAnimatedPropertyPairAccessorImpl.h

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h
@@ -60,7 +60,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedBooleanAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedBooleanAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -82,7 +82,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedEnumerationAnimator<EnumType>&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedEnumerationAnimator<EnumType>>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -104,7 +104,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedIntegerAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedIntegerAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -129,7 +129,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedLengthAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedLengthAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -151,7 +151,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedLengthListAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedLengthListAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -173,7 +173,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedNumberAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedNumberAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -195,7 +195,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedNumberListAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedNumberListAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -217,7 +217,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedPathSegListAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedPathSegListAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -239,7 +239,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedPointListAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedPointListAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
     
@@ -271,7 +271,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedPreserveAspectRatioAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedPreserveAspectRatioAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -293,7 +293,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedRectAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedRectAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -315,7 +315,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedStringAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedStringAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 
@@ -337,7 +337,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedTransformListAnimator&>(animator).appendAnimatedInstance(property(owner));
+        downcast<SVGAnimatedTransformListAnimator>(animator).appendAnimatedInstance(property(owner));
     }
 };
 

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h
@@ -31,6 +31,7 @@
 #include "SVGAnimationAdditiveListFunctionImpl.h"
 #include "SVGAnimationAdditiveValueFunctionImpl.h"
 #include "SVGAnimationDiscreteFunctionImpl.h"
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -55,6 +56,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Angle; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal().value());
@@ -74,6 +77,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Boolean; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         bool& animated = m_animated->animVal();
@@ -96,6 +101,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Enumeration; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         EnumType animated;
@@ -121,6 +128,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Integer; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal());
@@ -143,6 +152,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Length; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal().value());
@@ -165,6 +176,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::LengthList; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal());
@@ -185,6 +198,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Number; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal());
@@ -201,8 +216,10 @@ public:
     {
         return adoptRef(*new SVGAnimatedNumberListAnimator(attributeName, animated, animationMode, calcMode, isAccumulated, isAdditive));
     }
-    
+
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::NumberList; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal());
@@ -221,6 +238,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::PathSegList; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_animated->animVal().pathByteStreamWillChange();
@@ -238,8 +257,10 @@ public:
     {
         return adoptRef(*new SVGAnimatedPointListAnimator(attributeName, animated, animationMode, calcMode, isAccumulated, isAdditive));
     }
-    
+
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::PointList; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal());
@@ -260,6 +281,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::OrientType; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         SVGMarkerOrientType animated;
@@ -280,6 +303,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::PreserveAspectRatio; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         SVGPreserveAspectRatioValue& animated = m_animated->animVal().value();
@@ -300,6 +325,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Rect; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal().value());
@@ -318,6 +345,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::String; }
+
     bool isAnimatedStyleClassAnimator() const
     {
         return m_attributeName.matches(HTMLNames::classAttr);
@@ -359,6 +388,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::TransformList; }
+
     void animate(SVGElement& targetElement, float progress, unsigned repeatCount) final
     {
         m_function.animate(targetElement, progress, repeatCount, m_animated->animVal());
@@ -366,3 +397,68 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedAngleAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::Angle; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedBooleanAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::Boolean; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+// Type trait for template class SVGAnimatedEnumerationAnimator
+namespace WTF {
+template<typename EnumType, typename ArgType>
+class TypeCastTraits<const WebCore::SVGAnimatedEnumerationAnimator<EnumType>, ArgType, false> {
+public:
+    static bool isOfType(ArgType& source) { return source.animatorType() == WebCore::SVGAnimatorType::Enumeration; }
+};
+}
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedIntegerAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::Integer; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedLengthAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::Length; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedLengthListAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::LengthList; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedNumberAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::Number; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedNumberListAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::NumberList; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedPathSegListAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::PathSegList; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedPointListAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::PointList; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedOrientTypeAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::OrientType; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedPreserveAspectRatioAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::PreserveAspectRatio; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedRectAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::Rect; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedStringAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::String; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedTransformListAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::TransformList; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
@@ -80,7 +80,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedAngleOrientAnimator&>(animator).appendAnimatedInstance(property1(owner), property2(owner));
+        downcast<SVGAnimatedAngleOrientAnimator>(animator).appendAnimatedInstance(property1(owner), property2(owner));
     }
 };
 
@@ -115,7 +115,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedIntegerPairAnimator&>(animator).appendAnimatedInstance(property1(owner), property2(owner));
+        downcast<SVGAnimatedIntegerPairAnimator>(animator).appendAnimatedInstance(property1(owner), property2(owner));
     }
 };
 
@@ -150,7 +150,7 @@ private:
 
     void appendAnimatedInstance(OwnerType& owner, SVGAttributeAnimator& animator) const final
     {
-        static_cast<SVGAnimatedNumberPairAnimator&>(animator).appendAnimatedInstance(property1(owner), property2(owner));
+        downcast<SVGAnimatedNumberPairAnimator>(animator).appendAnimatedInstance(property1(owner), property2(owner));
     }
 };
 

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
@@ -28,6 +28,7 @@
 #include "SVGAnimatedPropertyImpl.h"
 #include "SVGAnimatedPropertyPairAnimator.h"
 #include "SVGMarkerTypes.h"
+#include <wtf/TypeCasts.h>
 
 namespace WebCore {
 
@@ -45,6 +46,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::AngleOrient; }
+
     void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
     {
         auto pairFrom = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(targetElement, from);
@@ -119,6 +122,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::IntegerPair; }
+
     void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
     {
         auto pairFrom = SVGPropertyTraits<std::pair<int, int>>::fromString(targetElement, from);
@@ -163,6 +168,8 @@ public:
     }
 
 private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::NumberPair; }
+
     void setFromAndToValues(SVGElement& targetElement, const String& from, const String& to) final
     {
         auto pairFrom = SVGPropertyTraits<std::pair<float, float>>::fromString(targetElement, from);
@@ -196,3 +203,15 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedAngleOrientAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::AngleOrient; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedIntegerPairAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::IntegerPair; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::SVGAnimatedNumberPairAnimator)
+    static bool isType(const WebCore::SVGAttributeAnimator& animator) { return animator.animatorType() == WebCore::SVGAnimatorType::NumberPair; }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/svg/properties/SVGAttributeAnimator.h
+++ b/Source/WebCore/svg/properties/SVGAttributeAnimator.h
@@ -53,6 +53,32 @@ enum class CalcMode : uint8_t {
     Spline
 };
 
+enum class SVGAnimatorType : uint8_t {
+    Angle,
+    AngleOrient,
+    Boolean,
+    Color,
+    CSSLength,
+    CSSLengthList,
+    CSSNumber,
+    CSSString,
+    Enumeration,
+    Integer,
+    IntegerPair,
+    Length,
+    LengthList,
+    Number,
+    NumberList,
+    NumberPair,
+    OrientType,
+    PathSegList,
+    PointList,
+    PreserveAspectRatio,
+    Rect,
+    String,
+    TransformList
+};
+
 class SVGAttributeAnimator : public RefCountedAndCanMakeWeakPtr<SVGAttributeAnimator> {
     WTF_MAKE_TZONE_ALLOCATED(SVGAttributeAnimator);
 public:
@@ -62,6 +88,8 @@ public:
     }
 
     virtual ~SVGAttributeAnimator() = default;
+
+    virtual SVGAnimatorType animatorType() const = 0;
 
     virtual bool isDiscrete() const { return false; }
 

--- a/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGPrimitivePropertyAnimatorImpl.h
@@ -30,8 +30,40 @@
 
 namespace WebCore {
 
-using SVGColorAnimator = SVGPrimitivePropertyAnimator<Color, SVGAnimationColorFunction>;
-using SVGNumberAnimator = SVGPrimitivePropertyAnimator<float, SVGAnimationNumberFunction>;
-using SVGStringAnimator = SVGPrimitivePropertyAnimator<String, SVGAnimationStringFunction>;
+class SVGColorAnimator final : public SVGPrimitivePropertyAnimator<Color, SVGAnimationColorFunction> {
+    using Base = SVGPrimitivePropertyAnimator<Color, SVGAnimationColorFunction>;
+public:
+    using Base::Base;
+    static auto create(const QualifiedName& attributeName, Ref<SVGProperty>&& property, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive)
+    {
+        return adoptRef(*new SVGColorAnimator(attributeName, WTF::move(property), animationMode, calcMode, isAccumulated, isAdditive));
+    }
+private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::Color; }
+};
+
+class SVGNumberAnimator final : public SVGPrimitivePropertyAnimator<float, SVGAnimationNumberFunction> {
+    using Base = SVGPrimitivePropertyAnimator<float, SVGAnimationNumberFunction>;
+public:
+    using Base::Base;
+    static auto create(const QualifiedName& attributeName, Ref<SVGProperty>&& property, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive)
+    {
+        return adoptRef(*new SVGNumberAnimator(attributeName, WTF::move(property), animationMode, calcMode, isAccumulated, isAdditive));
+    }
+private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::CSSNumber; }
+};
+
+class SVGStringAnimator final : public SVGPrimitivePropertyAnimator<String, SVGAnimationStringFunction> {
+    using Base = SVGPrimitivePropertyAnimator<String, SVGAnimationStringFunction>;
+public:
+    using Base::Base;
+    static auto create(const QualifiedName& attributeName, Ref<SVGProperty>&& property, AnimationMode animationMode, CalcMode calcMode, bool isAccumulated, bool isAdditive)
+    {
+        return adoptRef(*new SVGStringAnimator(attributeName, WTF::move(property), animationMode, calcMode, isAccumulated, isAdditive));
+    }
+private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::CSSString; }
+};
 
 }

--- a/Source/WebCore/svg/properties/SVGValuePropertyAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyAnimatorImpl.h
@@ -43,6 +43,9 @@ public:
         return adoptRef(*new SVGLengthAnimator(attributeName, WTF::move(property), animationMode, calcMode, isAccumulated, isAdditive, SVGLengthMode::Other));
     }
 
+private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::CSSLength; }
+
     void start(SVGElement& targetElement) override
     {
         String baseValue = computeCSSPropertyValue(targetElement, cssPropertyID(m_attributeName.localName()));

--- a/Source/WebCore/svg/properties/SVGValuePropertyListAnimatorImpl.h
+++ b/Source/WebCore/svg/properties/SVGValuePropertyListAnimatorImpl.h
@@ -42,6 +42,9 @@ public:
         return adoptRef(*new SVGLengthListAnimator(attributeName, WTF::move(property), animationMode, calcMode, isAccumulated, isAdditive, SVGLengthMode::Other));
     }
 
+private:
+    SVGAnimatorType animatorType() const final { return SVGAnimatorType::CSSLengthList; }
+
     void start(SVGElement& targetElement) final
     {
         String baseValue = computeCSSPropertyValue(targetElement, cssPropertyID(m_attributeName.localName()));


### PR DESCRIPTION
#### 543ddf9c7ddd92417b2a863af0a0ec00fe48e145
<pre>
Address more unsafe cast warnings in Source/WebCore/svg/properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=306399">https://bugs.webkit.org/show_bug.cgi?id=306399</a>

Reviewed by Darin Adler.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/svg/properties/SVGAnimatedPropertyAccessorImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyAnimatorImpl.h:
(isType):
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessorImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h:
(isType):
* Source/WebCore/svg/properties/SVGAttributeAnimator.h:
* Source/WebCore/svg/properties/SVGPrimitivePropertyAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGValuePropertyAnimatorImpl.h:
* Source/WebCore/svg/properties/SVGValuePropertyListAnimatorImpl.h:

Canonical link: <a href="https://commits.webkit.org/306541@main">https://commits.webkit.org/306541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f4e9cbb252cf514fd9848282d4efcc80896eb21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94188 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b543360e-d682-4480-a1e5-4607f2917fed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142964 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13627 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78499 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/672d971b-f32d-45cf-b16d-bb81f726f50b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89273 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/205f78e8-7e6e-40e8-be60-694aff4e472f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10535 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8126 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152056 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13161 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116492 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11501 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116835 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29875 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12891 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13204 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2378 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12943 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12987 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->