### PR TITLE
Reduce use of protected functions in Source/WebKit/WebProcess

### DIFF
--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1061,7 +1061,7 @@ void WebAutomationSessionProxy::getCookiesForFrame(WebCore::PageIdentifier pageI
     // This returns the same list of cookies as when evaluating `document.cookies` in JavaScript.
     Vector<WebCore::Cookie> foundCookies;
     if (!document->cookieURL().isEmpty())
-        page->protectedCorePage()->protectedCookieJar()->getRawCookies(*document, document->cookieURL(), foundCookies);
+        protect(page->corePage())->protectedCookieJar()->getRawCookies(*document, document->cookieURL(), foundCookies);
 
     completionHandler(std::nullopt, foundCookies);
 }
@@ -1084,7 +1084,7 @@ void WebAutomationSessionProxy::deleteCookie(WebCore::PageIdentifier pageID, std
         return;
     }
 
-    page->protectedCorePage()->protectedCookieJar()->deleteCookie(*document, document->cookieURL(), cookieName, [completionHandler = WTF::move(completionHandler)] () mutable {
+    protect(page->corePage())->protectedCookieJar()->deleteCookie(*document, document->cookieURL(), cookieName, [completionHandler = WTF::move(completionHandler)] () mutable {
         completionHandler(std::nullopt);
     });
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -1051,7 +1051,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
         documentIdentifier.value(),
     };
 
-    Ref port = WebExtensionAPIPort::create(*this, frame.protectedPage()->webPageProxyIdentifier(), WebExtensionContentWorldType::ContentScript, resolvedName);
+    Ref port = WebExtensionAPIPort::create(*this, protect(frame.page())->webPageProxyIdentifier(), WebExtensionContentWorldType::ContentScript, resolvedName);
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::TabsConnect(tabIdentifer.value(), port->channelIdentifier(), resolvedName, targetParameters, senderParameters), [=, this, protectedThis = Ref { *this }, globalContext = JSRetainPtr { JSContextGetGlobalContext(context) }](Expected<void, WebExtensionError>&& result) {
         if (result)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -151,7 +151,7 @@ void WebFullScreenManager::videoControlsManagerDidChange()
         return;
     }
 
-    RefPtr currentPlaybackControlsElement = dynamicDowncast<WebCore::HTMLVideoElement>(m_page->protectedPlaybackSessionManager()->currentPlaybackControlsElement());
+    RefPtr currentPlaybackControlsElement = dynamicDowncast<WebCore::HTMLVideoElement>(protect(m_page->playbackSessionManager())->currentPlaybackControlsElement());
     if (!currentPlaybackControlsElement) {
         setPIPStandbyElement(nullptr);
         return;
@@ -184,7 +184,7 @@ void WebFullScreenManager::setPIPStandbyElement(WebCore::HTMLVideoElement* pipSt
 
 bool WebFullScreenManager::supportsFullScreenForElement(const WebCore::Element& element, bool withKeyboard)
 {
-    if (!m_page->protectedCorePage()->isDocumentFullscreenEnabled())
+    if (!protect(m_page->corePage())->isDocumentFullscreenEnabled())
         return false;
 
     if (m_inWindowFullScreenMode && &element != m_element)
@@ -296,7 +296,7 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
         return;
     }
 
-    if (RefPtr currentPlaybackControlsElement = m_page->protectedPlaybackSessionManager()->currentPlaybackControlsElement())
+    if (RefPtr currentPlaybackControlsElement = protect(m_page->playbackSessionManager())->currentPlaybackControlsElement())
         currentPlaybackControlsElement->prepareForVideoFullscreenStandby();
 #endif
 
@@ -449,7 +449,7 @@ void WebFullScreenManager::didEnterFullScreen(CompletionHandler<bool(bool)>&& co
     }
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
-    RefPtr currentPlaybackControlsElement = m_page->protectedPlaybackSessionManager()->currentPlaybackControlsElement();
+    RefPtr currentPlaybackControlsElement = protect(m_page->playbackSessionManager())->currentPlaybackControlsElement();
     setPIPStandbyElement(dynamicDowncast<WebCore::HTMLVideoElement>(currentPlaybackControlsElement.get()));
 #endif
 
@@ -579,7 +579,7 @@ void WebFullScreenManager::didExitFullScreen(CompletionHandler<void()>&& complet
 
     clearElement();
 
-    if (RefPtr localMainFrame = m_page->protectedCorePage()->localMainFrame()) {
+    if (RefPtr localMainFrame = protect(m_page->corePage())->localMainFrame()) {
         // Make sure overflow: hidden is unapplied from the root element before restoring.
         RefPtr view = localMainFrame->view();
         view->forceLayout();
@@ -646,12 +646,12 @@ void WebFullScreenManager::close()
 
 void WebFullScreenManager::setFullscreenInsets(const WebCore::FloatBoxExtent& insets)
 {
-    m_page->protectedCorePage()->setFullscreenInsets(insets);
+    protect(m_page->corePage())->setFullscreenInsets(insets);
 }
 
 void WebFullScreenManager::setFullscreenAutoHideDuration(Seconds duration)
 {
-    m_page->protectedCorePage()->setFullscreenAutoHideDuration(duration);
+    protect(m_page->corePage())->setFullscreenAutoHideDuration(duration);
 }
 
 void WebFullScreenManager::handleEvent(WebCore::ScriptExecutionContext& context, WebCore::Event& event)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -201,11 +201,6 @@ SampleBufferDisplayLayerManager& GPUProcessConnection::sampleBufferDisplayLayerM
     return *m_sampleBufferDisplayLayerManager;
 }
 
-Ref<SampleBufferDisplayLayerManager> GPUProcessConnection::protectedSampleBufferDisplayLayerManager()
-{
-    return sampleBufferDisplayLayerManager();
-}
-
 void GPUProcessConnection::resetAudioMediaStreamTrackRendererInternalUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
 {
     WebProcess::singleton().audioMediaStreamTrackRendererInternalUnitManager().reset(identifier);
@@ -220,19 +215,9 @@ RemoteVideoFrameObjectHeapProxy& GPUProcessConnection::videoFrameObjectHeapProxy
     return *m_videoFrameObjectHeapProxy;
 }
 
-Ref<RemoteVideoFrameObjectHeapProxy> GPUProcessConnection::protectedVideoFrameObjectHeapProxy()
-{
-    return videoFrameObjectHeapProxy();
-}
-
 RemoteMediaPlayerManager& GPUProcessConnection::mediaPlayerManager()
 {
     return WebProcess::singleton().remoteMediaPlayerManager();
-}
-
-Ref<RemoteMediaPlayerManager> GPUProcessConnection::protectedMediaPlayerManager()
-{
-    return mediaPlayerManager();
 }
 #endif
 
@@ -243,18 +228,13 @@ RemoteAudioSourceProviderManager& GPUProcessConnection::audioSourceProviderManag
         m_audioSourceProviderManager = RemoteAudioSourceProviderManager::create();
     return *m_audioSourceProviderManager;
 }
-
-Ref<RemoteAudioSourceProviderManager> GPUProcessConnection::protectedAudioSourceProviderManager()
-{
-    return audioSourceProviderManager();
-}
 #endif
 
 bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
 #if ENABLE(VIDEO)
     if (decoder.messageReceiverName() == Messages::MediaPlayerPrivateRemote::messageReceiverName()) {
-        WebProcess::singleton().protectedRemoteMediaPlayerManager()->didReceivePlayerMessage(connection, decoder);
+        protect(WebProcess::singleton().remoteMediaPlayerManager())->didReceivePlayerMessage(connection, decoder);
         return true;
     }
 
@@ -273,14 +253,14 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
     }
 
     if (decoder.messageReceiverName() == Messages::SampleBufferDisplayLayer::messageReceiverName()) {
-        protectedSampleBufferDisplayLayerManager()->didReceiveLayerMessage(connection, decoder);
+        protect(sampleBufferDisplayLayerManager())->didReceiveLayerMessage(connection, decoder);
         return true;
     }
 #endif // PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 
 #if ENABLE(ENCRYPTED_MEDIA)
     if (decoder.messageReceiverName() == Messages::RemoteCDMInstanceSession::messageReceiverName()) {
-        WebProcess::singleton().protectedCDMFactory()->didReceiveSessionMessage(connection, decoder);
+        protect(WebProcess::singleton().cdmFactory())->didReceiveSessionMessage(connection, decoder);
         return true;
     }
 #endif
@@ -341,7 +321,7 @@ void GPUProcessConnection::didInitialize(std::optional<GPUProcessConnectionInfo>
 #endif
 #if ENABLE(AV1)
     WebCore::setAV1HardwareDecoderAvailable(info->mediaCodecCapabilities.hasAV1HardwareDecoder);
-    WebProcess::singleton().protectedLibWebRTCCodecs()->setHasAV1HardwareDecoder(info->mediaCodecCapabilities.hasAV1HardwareDecoder);
+    protect(WebProcess::singleton().libWebRTCCodecs())->setHasAV1HardwareDecoder(info->mediaCodecCapabilities.hasAV1HardwareDecoder);
 #endif
 #endif
 #if ENABLE(VP9)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -91,19 +91,15 @@ public:
     Ref<RemoteSharedResourceCacheProxy> sharedResourceCache();
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     SampleBufferDisplayLayerManager& sampleBufferDisplayLayerManager();
-    Ref<SampleBufferDisplayLayerManager> protectedSampleBufferDisplayLayerManager();
     void resetAudioMediaStreamTrackRendererInternalUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier);
 #endif
 #if ENABLE(VIDEO)
     RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy();
-    Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy();
     RemoteMediaPlayerManager& mediaPlayerManager();
-    Ref<RemoteMediaPlayerManager> protectedMediaPlayerManager();
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(WEB_AUDIO)
     RemoteAudioSourceProviderManager& audioSourceProviderManager();
-    Ref<RemoteAudioSourceProviderManager> protectedAudioSourceProviderManager();
 #endif
 
     void updateMediaConfiguration(bool forceUpdate);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -214,7 +214,7 @@ RefPtr<WebCore::VideoFrame> RemoteGraphicsContextGLProxy::surfaceBufferToVideoFr
     auto [result] = sendResult.takeReply();
     if (!result)
         return nullptr;
-    return RemoteVideoFrameProxy::create(WebProcess::singleton().ensureGPUProcessConnection().connection(), WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy(), WTF::move(*result));
+    return RemoteVideoFrameProxy::create(WebProcess::singleton().ensureGPUProcessConnection().connection(), protect(WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy()), WTF::move(*result));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -280,7 +280,7 @@ RefPtr<VideoFrame> AudioVideoRendererRemote::currentVideoFrame() const
         auto [result] = sendResult.takeReply();
         if (!result)
             return;
-        videoFrame = RemoteVideoFrameProxy::create(gpuProcessConnection->connection(), gpuProcessConnection->protectedVideoFrameObjectHeapProxy(), WTF::move(*result));
+        videoFrame = RemoteVideoFrameProxy::create(gpuProcessConnection->connection(), protect(gpuProcessConnection->videoFrameObjectHeapProxy()), WTF::move(*result));
     });
     return videoFrame;
 }
@@ -303,7 +303,7 @@ RefPtr<NativeImage> AudioVideoRendererRemote::currentNativeImage() const
         return nullptr;
     ASSERT(gpuProcessConnection);
 
-    return gpuProcessConnection->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
+    return protect(gpuProcessConnection->videoFrameObjectHeapProxy())->getNativeImage(*videoFrame);
 #else
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1418,7 +1418,7 @@ void MediaPlayerPrivateRemote::setCDM(LegacyCDM* cdm)
     if (!cdm)
         return;
 
-    if (RefPtr remoteCDM = WebProcess::singleton().protectedLegacyCDMFactory()->findCDM(cdm->protectedCDMPrivate().get()))
+    if (RefPtr remoteCDM = protect(WebProcess::singleton().legacyCDMFactory())->findCDM(cdm->protectedCDMPrivate().get()))
         remoteCDM->setPlayerId(m_id);
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
@@ -45,7 +45,7 @@ using namespace WebCore;
 Ref<RemoteAudioSourceProvider> RemoteAudioSourceProvider::create(WebCore::MediaPlayerIdentifier identifier, WTF::LoggerHelper& helper)
 {
     auto provider = adoptRef(*new RemoteAudioSourceProvider(identifier, helper));
-    provider->m_gpuProcessConnection.get()->protectedAudioSourceProviderManager()->addProvider(provider.copyRef());
+    protect(provider->m_gpuProcessConnection.get()->audioSourceProviderManager())->addProvider(provider.copyRef());
     return provider;
 }
 
@@ -72,7 +72,7 @@ void RemoteAudioSourceProvider::close()
 {
     ASSERT(isMainRunLoop());
     if (RefPtr gpuProcessConnection = m_gpuProcessConnection.get())
-        gpuProcessConnection->protectedAudioSourceProviderManager()->removeProvider(m_identifier);
+        protect(gpuProcessConnection->audioSourceProviderManager())->removeProvider(m_identifier);
 }
 
 void RemoteAudioSourceProvider::hasNewClient(AudioSourceProviderClient* client)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp
@@ -118,7 +118,7 @@ std::unique_ptr<CDMPrivateInterface> RemoteLegacyCDMFactory::createCDM(WebCore::
     std::optional<MediaPlayerIdentifier> playerId;
     Ref gpuProcessConnection = this->gpuProcessConnection();
     if (auto player = cdm.mediaPlayer())
-        playerId = gpuProcessConnection->protectedMediaPlayerManager()->findRemotePlayerId(player->protectedPlayerPrivate().get());
+        playerId = protect(gpuProcessConnection->mediaPlayerManager())->findRemotePlayerId(player->protectedPlayerPrivate().get());
 
     auto sendResult = gpuProcessConnection->connection().sendSync(Messages::RemoteLegacyCDMFactoryProxy::CreateCDM(cdm.keySystem(), WTF::move(playerId)), { });
     auto [identifier] = sendResult.takeReplyOr(std::nullopt);

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -145,7 +145,7 @@ void WebMediaStrategy::enableMockMediaSource()
 void WebMediaStrategy::nativeImageFromVideoFrame(const WebCore::VideoFrame& frame, CompletionHandler<void(std::optional<RefPtr<WebCore::NativeImage>>&&)>&& completionHandler)
 {
     // FIXME: Move out of sync IPC.
-    completionHandler(WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(frame));
+    completionHandler(protect(WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy())->getNativeImage(frame));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -67,7 +67,7 @@ RefPtr<NativeImage> MediaPlayerPrivateRemote::nativeImageForCurrentTime()
     if (!videoFrame)
         return nullptr;
 
-    return WebProcess::singleton().ensureProtectedGPUProcessConnection()->protectedVideoFrameObjectHeapProxy()->getNativeImage(*videoFrame);
+    return protect(WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy())->getNativeImage(*videoFrame);
 }
 
 WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -146,39 +146,39 @@ std::optional<WebCore::VideoCodecType> LibWebRTCCodecs::videoEncoderTypeFromWebC
 
 static int32_t releaseVideoDecoder(webrtc::WebKitVideoDecoder::Value decoder)
 {
-    return WebProcess::singleton().protectedLibWebRTCCodecs()->releaseDecoder(*static_cast<LibWebRTCCodecs::Decoder*>(decoder));
+    return protect(WebProcess::singleton().libWebRTCCodecs())->releaseDecoder(*static_cast<LibWebRTCCodecs::Decoder*>(decoder));
 }
 
 static int32_t decodeVideoFrame(webrtc::WebKitVideoDecoder::Value decoder, uint32_t timeStamp, const uint8_t* data, size_t size, uint16_t width,  uint16_t height)
 {
-    return WebProcess::singleton().protectedLibWebRTCCodecs()->decodeWebRTCFrame(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), timeStamp, unsafeMakeSpan(data, size), width, height);
+    return protect(WebProcess::singleton().libWebRTCCodecs())->decodeWebRTCFrame(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), timeStamp, unsafeMakeSpan(data, size), width, height);
 }
 
 static int32_t registerDecodeCompleteCallback(webrtc::WebKitVideoDecoder::Value decoder, void* decodedImageCallback)
 {
-    WebProcess::singleton().protectedLibWebRTCCodecs()->registerDecodeFrameCallback(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), decodedImageCallback);
+    protect(WebProcess::singleton().libWebRTCCodecs())->registerDecodeFrameCallback(*static_cast<LibWebRTCCodecs::Decoder*>(decoder), decodedImageCallback);
     return 0;
 }
 
 static webrtc::WebKitVideoEncoder createVideoEncoder(const webrtc::SdpVideoFormat& format)
 {
     if (format.name == "H264" || format.name == "h264")
-        return WebProcess::singleton().protectedLibWebRTCCodecs()->createEncoder(WebCore::VideoCodecType::H264, format.parameters);
+        return protect(WebProcess::singleton().libWebRTCCodecs())->createEncoder(WebCore::VideoCodecType::H264, format.parameters);
 
     if (format.name == "H265" || format.name == "h265")
-        return WebProcess::singleton().protectedLibWebRTCCodecs()->createEncoder(WebCore::VideoCodecType::H265, format.parameters);
+        return protect(WebProcess::singleton().libWebRTCCodecs())->createEncoder(WebCore::VideoCodecType::H265, format.parameters);
 
     return nullptr;
 }
 
 static int32_t releaseVideoEncoder(webrtc::WebKitVideoEncoder encoder)
 {
-    return WebProcess::singleton().protectedLibWebRTCCodecs()->releaseEncoder(*static_cast<LibWebRTCCodecs::Encoder*>(encoder));
+    return protect(WebProcess::singleton().libWebRTCCodecs())->releaseEncoder(*static_cast<LibWebRTCCodecs::Encoder*>(encoder));
 }
 
 static int32_t initializeVideoEncoder(webrtc::WebKitVideoEncoder encoder, const webrtc::VideoCodec& codec)
 {
-    return WebProcess::singleton().protectedLibWebRTCCodecs()->initializeEncoder(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), codec.width, codec.height, codec.startBitrate, codec.maxBitrate, codec.minBitrate, codec.maxFramerate);
+    return protect(WebProcess::singleton().libWebRTCCodecs())->initializeEncoder(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), codec.width, codec.height, codec.startBitrate, codec.maxBitrate, codec.minBitrate, codec.maxFramerate);
 }
 
 static inline VideoFrame::Rotation toVideoRotation(webrtc::VideoRotation rotation)
@@ -204,12 +204,12 @@ static void createRemoteDecoder(LibWebRTCCodecs::Decoder& decoder, IPC::Connecti
 
 static int32_t encodeVideoFrame(webrtc::WebKitVideoEncoder encoder, const webrtc::VideoFrame& frame, bool shouldEncodeAsKeyFrame)
 {
-    return WebProcess::singleton().protectedLibWebRTCCodecs()->encodeFrame(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), frame, shouldEncodeAsKeyFrame);
+    return protect(WebProcess::singleton().libWebRTCCodecs())->encodeFrame(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), frame, shouldEncodeAsKeyFrame);
 }
 
 static int32_t registerEncodeCompleteCallback(webrtc::WebKitVideoEncoder encoder, void* encodedImageCallback)
 {
-    WebProcess::singleton().protectedLibWebRTCCodecs()->registerEncodeFrameCallback(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), encodedImageCallback);
+    protect(WebProcess::singleton().libWebRTCCodecs())->registerEncodeFrameCallback(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), encodedImageCallback);
     return 0;
 }
 
@@ -217,7 +217,7 @@ static void setEncodeRatesCallback(webrtc::WebKitVideoEncoder encoder, const web
 {
     uint32_t bitRateInKbps = parameters.bitrate.get_sum_kbps();
     uint32_t frameRate = static_cast<uint32_t>(parameters.framerate_fps + 0.5);
-    WebProcess::singleton().protectedLibWebRTCCodecs()->setEncodeRates(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), bitRateInKbps, frameRate);
+    protect(WebProcess::singleton().libWebRTCCodecs())->setEncodeRates(*static_cast<LibWebRTCCodecs::Encoder*>(encoder), bitRateInKbps, frameRate);
 }
 
 Ref<LibWebRTCCodecs> LibWebRTCCodecs::create()

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -211,12 +211,12 @@ static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<Web
 
 - (NSArray *)appleTouchIconURLs
 {
-    return collectIcons(protectedFrame(self)->protectedCoreLocalFrame().get(), { WebCore::LinkIconType::TouchIcon, WebCore::LinkIconType::TouchPrecomposedIcon }).autorelease();
+    return collectIcons(protect(protectedFrame(self)->coreLocalFrame()).get(), { WebCore::LinkIconType::TouchIcon, WebCore::LinkIconType::TouchPrecomposedIcon }).autorelease();
 }
 
 - (NSArray *)faviconURLs
 {
-    return collectIcons(protectedFrame(self)->protectedCoreLocalFrame().get(), WebCore::LinkIconType::Favicon).autorelease();
+    return collectIcons(protect(protectedFrame(self)->coreLocalFrame()).get(), WebCore::LinkIconType::Favicon).autorelease();
 }
 
 - (WKWebProcessPlugInFrame *)_parentFrame
@@ -230,7 +230,7 @@ static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<Web
     if (!frame->isMainFrame())
         return false;
 
-    return frame->protectedPage()->mainFrameHasCustomContentProvider();
+    return protect(frame->page())->mainFrameHasCustomContentProvider();
 }
 
 - (NSArray *)_certificateChain

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -140,7 +140,7 @@ unsigned WKBundleFrameGetPendingUnloadCount(WKBundleFrameRef frameRef)
 
 WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 {
-    return toAPI(WebKit::toProtectedImpl(frameRef)->protectedPage().get());
+    return toAPI(protect(WebKit::toProtectedImpl(frameRef)->page()).get());
 }
 
 void WKBundleFrameStopLoading(WKBundleFrameRef frameRef)
@@ -288,7 +288,7 @@ void WKBundleFrameFocus(WKBundleFrameRef frameRef)
     if (!coreFrame)
         return;
 
-    coreFrame->protectedPage()->focusController().setFocusedFrame(coreFrame.get());
+    protect(coreFrame->page())->focusController().setFocusedFrame(coreFrame.get());
 }
 
 void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef message, WKStringRef group)
@@ -338,6 +338,6 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
     CheckedPtr cache = getAXObjectCache();
-    RefPtr root = cache ? cache->rootObjectForFrame(*WebKit::toProtectedImpl(frameRef)->protectedCoreLocalFrame()) : nullptr;
+    RefPtr root = cache ? cache->rootObjectForFrame(*protect(WebKit::toProtectedImpl(frameRef)->coreLocalFrame())) : nullptr;
     return root ? root->wrapper() : nullptr;
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -135,7 +135,7 @@ WKFrameHandleRef WKBundleFrameCreateFrameHandle(WKBundleFrameRef bundleFrameRef)
 void WKBundlePageClickMenuItem(WKBundlePageRef pageRef, WKContextMenuItemRef item)
 {
 #if ENABLE(CONTEXT_MENUS)
-    WebKit::toProtectedImpl(pageRef)->protectedContextMenu()->itemSelected(WebKit::toImpl(item)->data());
+    protect(WebKit::toProtectedImpl(pageRef)->contextMenu())->itemSelected(WebKit::toImpl(item)->data());
 #else
     UNUSED_PARAM(pageRef);
     UNUSED_PARAM(item);
@@ -379,7 +379,7 @@ void WKBundlePageSetFooterBanner(WKBundlePageRef pageRef, WKBundlePageBannerRef 
 
 bool WKBundlePageHasLocalDataForURL(WKBundlePageRef pageRef, WKURLRef urlRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->protectedCorePage()->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
+    return protect(WebKit::toProtectedImpl(pageRef)->corePage())->hasLocalDataForURL(URL { WebKit::toWTFString(urlRef) });
 }
 
 bool WKBundlePageCanHandleRequest(WKURLRequestRef requestRef)
@@ -442,12 +442,12 @@ void WKBundlePageListenForLayoutMilestones(WKBundlePageRef pageRef, WKLayoutMile
 
 void WKBundlePageCloseInspectorForTest(WKBundlePageRef page)
 {
-    WebKit::toProtectedImpl(page)->protectedInspector()->close();
+    protect(WebKit::toProtectedImpl(page)->inspector())->close();
 }
 
 void WKBundlePageEvaluateScriptInInspectorForTest(WKBundlePageRef page, WKStringRef script)
 {
-    WebKit::toProtectedImpl(page)->protectedInspector()->evaluateScriptForTest(WebKit::toWTFString(script));
+    protect(WebKit::toProtectedImpl(page)->inspector())->evaluateScriptForTest(WebKit::toWTFString(script));
 }
 
 void WKBundlePageForceRepaint(WKBundlePageRef page)
@@ -710,7 +710,7 @@ WKStringRef WKBundlePageCopyGroupIdentifier(WKBundlePageRef pageRef)
 void WKBundlePageSetCaptionDisplayMode(WKBundlePageRef page, WKStringRef mode)
 {
 #if ENABLE(VIDEO)
-    Ref captionPreferences = WebKit::toProtectedImpl(page)->protectedCorePage()->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(WebKit::toProtectedImpl(page)->corePage())->checkedGroup()->ensureCaptionPreferences();
     auto displayMode = WTF::EnumTraits<WebCore::CaptionUserPreferences::CaptionDisplayMode>::fromString(WebKit::toWTFString(mode));
     if (displayMode.has_value())
         captionPreferences->setCaptionDisplayMode(displayMode.value());
@@ -723,7 +723,7 @@ void WKBundlePageSetCaptionDisplayMode(WKBundlePageRef page, WKStringRef mode)
 WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPreferencesTestingModeToken(WKBundlePageRef page)
 {
 #if ENABLE(VIDEO)
-    Ref captionPreferences = WebKit::toProtectedImpl(page)->protectedCorePage()->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(WebKit::toProtectedImpl(page)->corePage())->checkedGroup()->ensureCaptionPreferences();
     return WebKit::toAPILeakingRef(API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()));
 #else
     UNUSED_PARAM(page);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -274,7 +274,7 @@ void InjectedBundle::setUserStyleSheetLocation(const String& location)
 void InjectedBundle::removeAllWebNotificationPermissions(WebPage* page)
 {
 #if ENABLE(NOTIFICATIONS)
-    page->protectedNotificationPermissionRequestManager()->removeAllPermissionsForTesting();
+    protect(page->notificationPermissionRequestManager())->removeAllPermissionsForTesting();
 #else
     UNUSED_PARAM(page);
 #endif

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -59,7 +59,7 @@ InjectedBundleDOMWindowExtension* InjectedBundleDOMWindowExtension::get(DOMWindo
 }
 
 InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension(WebFrame* frame, InjectedBundleScriptWorld* world)
-    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? frame->protectedCoreLocalFrame()->protectedWindow().get() : nullptr, world->protectedCoreWorld().get()))
+    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? protect(frame->coreLocalFrame())->protectedWindow().get() : nullptr, world->protectedCoreWorld().get()))
 {
     allExtensions().add(m_coreExtension.get(), *this);
 }

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -57,7 +57,7 @@ Ref<RemoteWebInspectorUI> RemoteWebInspectorUI::create(WebPage& page)
 
 RemoteWebInspectorUI::RemoteWebInspectorUI(WebPage& page)
     : m_page(page)
-    , m_frontendAPIDispatcher(InspectorFrontendAPIDispatcher::create(*page.protectedCorePage()))
+    , m_frontendAPIDispatcher(InspectorFrontendAPIDispatcher::create(*protect(page.corePage())))
 {
 }
 
@@ -72,7 +72,7 @@ void RemoteWebInspectorUI::initialize(DebuggableInfoData&& debuggableInfo, const
     m_debuggableInfo = WTF::move(debuggableInfo);
     m_backendCommandsURL = backendCommandsURL;
 
-    protectedWebPage()->protectedCorePage()->inspectorController().setInspectorFrontendClient(this);
+    protect(protectedWebPage()->corePage())->inspectorController().setInspectorFrontendClient(this);
 
     m_frontendAPIDispatcher->reset();
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setDockingUnavailable"_s, { JSON::Value::create(true) });
@@ -98,7 +98,7 @@ void RemoteWebInspectorUI::windowObjectCleared()
     if (RefPtr frontendHost = m_frontendHost)
         frontendHost->disconnectClient();
 
-    m_frontendHost = InspectorFrontendHost::create(this, protectedWebPage()->protectedCorePage().get());
+    m_frontendHost = InspectorFrontendHost::create(this, protect(protectedWebPage()->corePage()).get());
     RefPtr { m_frontendHost }->addSelfToGlobalObjectInWorld(mainThreadNormalWorldSingleton());
 }
 
@@ -173,7 +173,7 @@ void RemoteWebInspectorUI::bringToFront()
 
 void RemoteWebInspectorUI::closeWindow()
 {
-    protectedWebPage()->protectedCorePage()->inspectorController().setInspectorFrontendClient(nullptr);
+    protect(protectedWebPage()->corePage())->inspectorController().setInspectorFrontendClient(nullptr);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = nullptr;
@@ -286,7 +286,7 @@ bool RemoteWebInspectorUI::supportsDiagnosticLogging()
 
 void RemoteWebInspectorUI::logDiagnosticEvent(const String& eventName,  const DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
-    protectedWebPage()->protectedCorePage()->checkedDiagnosticLoggingClient()->logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+    protect(protectedWebPage()->corePage())->checkedDiagnosticLoggingClient()->logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
 }
 
 void RemoteWebInspectorUI::setDiagnosticLoggingAvailable(bool available)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -190,7 +190,7 @@ void WebInspectorBackend::showMainResourceForFrame(WebCore::FrameIdentifier fram
     if (!m_page->corePage())
         return;
 
-    String inspectorFrameIdentifier = CheckedRef { m_page->corePage()->inspectorController().ensurePageAgent() }->frameId(frame->protectedCoreLocalFrame().get());
+    String inspectorFrameIdentifier = CheckedRef { m_page->corePage()->inspectorController().ensurePageAgent() }->frameId(protect(frame->coreLocalFrame()).get());
 
     whenFrontendConnectionEstablished([inspectorFrameIdentifier](auto& frontendConnection) {
         frontendConnection.send(Messages::WebInspectorUI::ShowMainResourceForFrame(inspectorFrameIdentifier), 0);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -105,7 +105,7 @@ void WebInspectorBackendClient::frontendCountChanged(unsigned count)
 Inspector::FrontendChannel* WebInspectorBackendClient::openLocalFrontend(PageInspectorController* controller)
 {
     if (RefPtr page = m_page.get())
-        page->protectedInspector()->openLocalInspectorFrontend();
+        protect(page->inspector())->openLocalInspectorFrontend();
     return nullptr;
 }
 
@@ -205,7 +205,7 @@ void WebInspectorBackendClient::showPaintRect(const FloatRect& rect)
     if (!m_paintIndicatorLayerClient)
         m_paintIndicatorLayerClient = makeUnique<RepaintIndicatorLayerClient>(*this);
 
-    Ref paintLayer = GraphicsLayer::create(page->protectedDrawingArea()->graphicsLayerFactory(), *m_paintIndicatorLayerClient);
+    Ref paintLayer = GraphicsLayer::create(protect(page->drawingArea())->graphicsLayerFactory(), *m_paintIndicatorLayerClient);
 
     paintLayer->setName(MAKE_STATIC_STRING_IMPL("paint rect"));
     paintLayer->setAnchorPoint(FloatPoint3D());

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -55,7 +55,7 @@ Ref<WebInspectorUI> WebInspectorUI::create(WebPage& page)
 
 WebInspectorUI::WebInspectorUI(WebPage& page)
     : m_page(page)
-    , m_frontendAPIDispatcher(InspectorFrontendAPIDispatcher::create(*page.protectedCorePage()))
+    , m_frontendAPIDispatcher(InspectorFrontendAPIDispatcher::create(*protect(page.corePage())))
     , m_debuggableInfo(DebuggableInfoData::empty())
 {
 }
@@ -107,7 +107,7 @@ void WebInspectorUI::windowObjectCleared()
     if (frontendHost)
         frontendHost->disconnectClient();
 
-    frontendHost = InspectorFrontendHost::create(this, RefPtr { m_page.get() }->protectedCorePage().get());
+    frontendHost = InspectorFrontendHost::create(this, protect(RefPtr { m_page.get() }->corePage()).get());
     m_frontendHost = frontendHost.copyRef();
     frontendHost->addSelfToGlobalObjectInWorld(mainThreadNormalWorldSingleton());
 }
@@ -343,7 +343,7 @@ bool WebInspectorUI::supportsDiagnosticLogging()
 
 void WebInspectorUI::logDiagnosticEvent(const String& eventName, const DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
-    RefPtr { m_page.get() }->protectedCorePage()->checkedDiagnosticLoggingClient()->logDiagnosticMessageWithValueDictionary(eventName, "Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+    protect(RefPtr { m_page.get() }->corePage())->checkedDiagnosticLoggingClient()->logDiagnosticMessageWithValueDictionary(eventName, "Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
 }
 
 void WebInspectorUI::setDiagnosticLoggingAvailable(bool available)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -95,7 +95,7 @@ NetworkProcessConnection::NetworkProcessConnection(IPC::Connection::Identifier&&
 
 #if USE(LIBWEBRTC)
     if (WebRTCProvider::webRTCAvailable())
-        WebProcess::singleton().protectedLibWebRTCNetwork()->setConnection(m_connection.copyRef());
+        protect(WebProcess::singleton().libWebRTCNetwork())->setConnection(m_connection.copyRef());
 #endif
 }
 
@@ -107,7 +107,7 @@ NetworkProcessConnection::~NetworkProcessConnection()
 bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)
 {
     if (decoder.messageReceiverName() == Messages::WebResourceLoader::messageReceiverName()) {
-        if (RefPtr webResourceLoader = WebProcess::singleton().protectedWebLoaderStrategy()->webResourceLoaderForIdentifier(AtomicObjectIdentifier<WebCore::ResourceLoaderIdentifierType>(decoder.destinationID())))
+        if (RefPtr webResourceLoader = protect(WebProcess::singleton().webLoaderStrategy())->webResourceLoaderForIdentifier(AtomicObjectIdentifier<WebCore::ResourceLoaderIdentifierType>(decoder.destinationID())))
             webResourceLoader->didReceiveMessage(connection, decoder);
         return true;
     }
@@ -130,7 +130,7 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
         return true;
     }
     if (decoder.messageReceiverName() == Messages::WebFileSystemStorageConnection::messageReceiverName()) {
-        WebProcess::singleton().protectedFileSystemStorageConnection()->didReceiveMessage(connection, decoder);
+        protect(WebProcess::singleton().fileSystemStorageConnection())->didReceiveMessage(connection, decoder);
         return true;
     }
     if (decoder.messageReceiverName() == Messages::WebTransportSession::messageReceiverName() && WebProcess::singleton().isWebTransportEnabled()) {
@@ -143,7 +143,7 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
     if (decoder.messageReceiverName() == Messages::WebRTCMonitor::messageReceiverName()) {
         Ref network = WebProcess::singleton().libWebRTCNetwork();
         if (network->isActive())
-            network->protectedMonitor()->didReceiveMessage(connection, decoder);
+            protect(network->monitor())->didReceiveMessage(connection, decoder);
         else
             RELEASE_LOG_ERROR(WebRTC, "Received WebRTCMonitor message while libWebRTCNetwork is not active");
         return true;
@@ -241,17 +241,17 @@ void NetworkProcessConnection::writeBlobsToTemporaryFilesForIndexedDB(const Vect
 
 void NetworkProcessConnection::didFinishPingLoad(WebCore::ResourceLoaderIdentifier pingLoadIdentifier, ResourceError&& error, ResourceResponse&& response)
 {
-    WebProcess::singleton().protectedWebLoaderStrategy()->didFinishPingLoad(pingLoadIdentifier, WTF::move(error), WTF::move(response));
+    protect(WebProcess::singleton().webLoaderStrategy())->didFinishPingLoad(pingLoadIdentifier, WTF::move(error), WTF::move(response));
 }
 
 void NetworkProcessConnection::didFinishPreconnection(WebCore::ResourceLoaderIdentifier preconnectionIdentifier, ResourceError&& error)
 {
-    WebProcess::singleton().protectedWebLoaderStrategy()->didFinishPreconnection(preconnectionIdentifier, WTF::move(error));
+    protect(WebProcess::singleton().webLoaderStrategy())->didFinishPreconnection(preconnectionIdentifier, WTF::move(error));
 }
 
 void NetworkProcessConnection::setOnLineState(bool isOnLine)
 {
-    WebProcess::singleton().protectedWebLoaderStrategy()->setOnLineState(isOnLine);
+    protect(WebProcess::singleton().webLoaderStrategy())->setOnLineState(isOnLine);
 }
 
 bool NetworkProcessConnection::cookiesEnabled() const

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -860,7 +860,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     loadParameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Default;
     loadParameters.storedCredentialsPolicy = options.credentials == FetchOptions::Credentials::Omit ? StoredCredentialsPolicy::DoNotUse : StoredCredentialsPolicy::Use;
     loadParameters.clientCredentialPolicy = clientCredentialPolicy;
-    loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect(webFrame ? webFrame->protectedCoreLocalFrame().get() : nullptr);
+    loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect(webFrame ? protect(webFrame->coreLocalFrame()).get() : nullptr);
     loadParameters.shouldRestrictHTTPResponseAccess = shouldPerformSecurityChecks();
 
     loadParameters.options = options;
@@ -875,7 +875,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     if (webFrame)
         loadParameters.isNavigatingToAppBoundDomain = webFrame->isTopFrameNavigatingToAppBoundDomain();
 #endif
-    addParametersShared(webFrame->protectedCoreLocalFrame().get(), loadParameters);
+    addParametersShared(protect(webFrame->coreLocalFrame()).get(), loadParameters);
 
     data.shrink(0);
 
@@ -906,7 +906,7 @@ void WebLoaderStrategy::browsingContextRemoved(LocalFrame& frame)
     if (!networkProcessConnection)
         return;
 
-    Ref page = *WebPage::fromCorePage(*frame.protectedPage());
+    Ref page = *WebPage::fromCorePage(*protect(frame.page()));
     networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::BrowsingContextRemoved(page->webPageProxyIdentifier(), page->identifier(), WebFrame::fromCoreFrame(frame)->frameID()), 0);
 }
 
@@ -1031,7 +1031,7 @@ void WebLoaderStrategy::preconnectTo(WebCore::ResourceRequest&& request, WebPage
 #if ENABLE(APP_BOUND_DOMAINS)
     parameters.isNavigatingToAppBoundDomain = webFrame.isTopFrameNavigatingToAppBoundDomain();
 #endif
-    if (RefPtr loader = policySourceDocumentLoaderForFrame(*webFrame.protectedCoreLocalFrame()))
+    if (RefPtr loader = policySourceDocumentLoaderForFrame(*protect(webFrame.coreLocalFrame())))
         parameters.advancedPrivacyProtections = loader->advancedPrivacyProtections();
 
     std::optional<WebCore::ResourceLoaderIdentifier> preconnectionIdentifier;

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
@@ -62,7 +62,7 @@ void LibWebRTCNetwork::networkProcessCrashed()
 {
     setConnection(nullptr);
 
-    protectedMonitor()->networkProcessCrashed();
+    protect(monitor())->networkProcessCrashed();
 }
 
 void LibWebRTCNetwork::setConnection(RefPtr<IPC::Connection>&& connection)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h
@@ -54,7 +54,6 @@ public:
     void setAsActive() final;
 
     WebRTCMonitor& monitor() { return m_webNetworkMonitor; }
-    Ref<WebRTCMonitor> protectedMonitor() { return m_webNetworkMonitor; }
     LibWebRTCSocketFactory& socketFactory() { return m_socketFactory; }
     CheckedRef<LibWebRTCSocketFactory> checkedSocketFactory() { return m_socketFactory; }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp
@@ -86,7 +86,7 @@ webrtc::scoped_refptr<webrtc::PeerConnectionInterface> LibWebRTCProvider::create
 
 void LibWebRTCProvider::disableNonLocalhostConnections()
 {
-    WebProcess::singleton().protectedLibWebRTCNetwork()->disableNonLocalhostConnections();
+    protect(WebProcess::singleton().libWebRTCNetwork())->disableNonLocalhostConnections();
 }
 
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
@@ -173,7 +173,7 @@ void RTCSocketFactory::resume()
 
 void LibWebRTCProvider::startedNetworkThread()
 {
-    WebProcess::singleton().protectedLibWebRTCNetwork()->setAsActive();
+    protect(WebProcess::singleton().libWebRTCNetwork())->setAsActive();
 }
 
 std::unique_ptr<LibWebRTCProvider::SuspendableSocketFactory> LibWebRTCProvider::createSocketFactory(String&& userAgent, ScriptExecutionContextIdentifier identifier, bool isFirstParty, RegistrableDomain&& domain, bool enableServiceClass)
@@ -200,7 +200,7 @@ void LibWebRTCProvider::setLoggingLevel(WTFLogLevel level)
 {
     WebCore::LibWebRTCProvider::setLoggingLevel(level);
 #if PLATFORM(COCOA)
-    WebProcess::singleton().protectedLibWebRTCCodecs()->setLoggingLevel(level);
+    protect(WebProcess::singleton().libWebRTCCodecs())->setLoggingLevel(level);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.h
@@ -51,7 +51,6 @@ public:
     bool isActive() const { return m_isActive; }
 
     WebMDNSRegister& mdnsRegister() { return m_mdnsRegister; }
-    Ref<WebMDNSRegister> protectedMDNSRegister() { return m_mdnsRegister; }
 
 private:
     const CheckedRef<WebProcess> m_webProcess;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -556,7 +556,7 @@ PDFPlugin::PDFPlugin(HTMLPlugInElement& element)
     [m_containerLayer addSublayer:m_contentLayer.get()];
     [m_containerLayer addSublayer:m_scrollCornerLayer.get()];
     if ([m_pdfLayerController respondsToSelector:@selector(setDeviceColorSpace:)])
-        [m_pdfLayerController setDeviceColorSpace:screenColorSpace(frame->protectedCoreLocalFrame()->view()).platformColorSpace()];
+        [m_pdfLayerController setDeviceColorSpace:screenColorSpace(protect(frame->coreLocalFrame())->view()).platformColorSpace()];
     
     if ([getPDFLayerControllerClassSingleton() respondsToSelector:@selector(setUseIOSurfaceForTiles:)])
         [getPDFLayerControllerClassSingleton() setUseIOSurfaceForTiles:false];
@@ -569,13 +569,13 @@ void PDFPlugin::updateScrollbars()
     PDFPluginBase::updateScrollbars();
 
     if (m_verticalScrollbarLayer) {
-        m_verticalScrollbarLayer.get().frame = protectedVerticalScrollbar()->frameRect();
+        m_verticalScrollbarLayer.get().frame = protect(verticalScrollbar())->frameRect();
         [m_verticalScrollbarLayer setContents:nil];
         [m_verticalScrollbarLayer setNeedsDisplay];
     }
     
     if (m_horizontalScrollbarLayer) {
-        m_horizontalScrollbarLayer.get().frame = protectedHorizontalScrollbar()->frameRect();
+        m_horizontalScrollbarLayer.get().frame = protect(horizontalScrollbar())->frameRect();
         [m_horizontalScrollbarLayer setContents:nil];
         [m_horizontalScrollbarLayer setNeedsDisplay];
     }
@@ -742,7 +742,7 @@ void PDFPlugin::teardown()
     m_pdfLayerController.get().delegate = nil;
 
     RefPtr frame = m_frame.get();
-    if (RefPtr frameView = frame && frame->coreLocalFrame() ? frame->protectedCoreLocalFrame()->view() : nullptr)
+    if (RefPtr frameView = frame && frame->coreLocalFrame() ? protect(frame->coreLocalFrame())->view() : nullptr)
         frameView->removeScrollableArea(this);
 
     m_activeAnnotation = nullptr;
@@ -1102,7 +1102,7 @@ bool PDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
     RefPtr webPage = frame->page();
     if (!webPage)
         return false;
-    RefPtr frameView = frame->protectedCoreLocalFrame()->view();
+    RefPtr frameView = protect(frame->coreLocalFrame())->view();
     if (!frameView)
         return false;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -138,7 +138,6 @@ public:
     virtual WebCore::PluginLayerHostingStrategy layerHostingStrategy() const = 0;
     virtual PlatformLayer* platformLayer() const { return nullptr; }
     virtual WebCore::GraphicsLayer* graphicsLayer() const { return nullptr; }
-    RefPtr<WebCore::GraphicsLayer> protectedGraphicsLayer() const;
 
     virtual void setView(PluginView&);
 
@@ -250,8 +249,6 @@ public:
     WebCore::ScrollPosition scrollPositionForTesting() const { return scrollPosition(); }
     WebCore::Scrollbar* horizontalScrollbar() const override { return m_horizontalScrollbar.get(); }
     WebCore::Scrollbar* verticalScrollbar() const override { return m_verticalScrollbar.get(); }
-    RefPtr<WebCore::Scrollbar> protectedHorizontalScrollbar() const { return horizontalScrollbar(); }
-    RefPtr<WebCore::Scrollbar> protectedVerticalScrollbar() const { return verticalScrollbar(); }
     void setScrollOffset(const WebCore::ScrollOffset&) final;
 
     virtual void willAttachScrollingNode() { }
@@ -273,7 +270,6 @@ public:
 
 #if PLATFORM(MAC)
     PDFPluginAnnotation* activeAnnotation() const { return m_activeAnnotation.get(); }
-    RefPtr<PDFPluginAnnotation> protectedActiveAnnotation() const;
 #endif
 
     enum class IsInPluginCleanup : bool { No, Yes };

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -202,7 +202,7 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
     [m_accessibilityDocumentObject setPDFPlugin:this];
     RefPtr frame = m_frame.get();
     if (isFullMainFramePlugin())
-        [m_accessibilityDocumentObject setParent:frame->protectedPage()->protectedAccessibilityRemoteObject().get()];
+        [m_accessibilityDocumentObject setParent:protect(protect(frame->page())->accessibilityRemoteObject()).get()];
 
     if (protectedPresentationController()->wantsWheelEvents())
         wantsWheelEventsChanged();
@@ -701,8 +701,8 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
 {
     ensureLayers();
 
-    // The protectedGraphicsLayer()'s position is set in RenderLayerBacking::updateAfterWidgetResize().
-    protectedGraphicsLayer()->setSize(size());
+    // The protect(graphicsLayer())'s position is set in RenderLayerBacking::updateAfterWidgetResize().
+    protect(graphicsLayer())->setSize(size());
     protectedOverflowControlsContainer()->setSize(size());
 
     auto scrollContainerRect = availableContentsRect();
@@ -1322,7 +1322,7 @@ void UnifiedPDFPlugin::deviceOrPageScaleFactorChanged(CheckForMagnificationGestu
     bool gestureAllowsScaleUpdate = checkForMagnificationGesture == CheckForMagnificationGesture::No || !m_inMagnificationGesture;
 
     if (!handlesPageScaleFactor() || gestureAllowsScaleUpdate)
-        protectedGraphicsLayer()->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
+        protect(graphicsLayer())->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
 
     if (gestureAllowsScaleUpdate)
         protectedPresentationController()->deviceOrPageScaleFactorChanged();
@@ -2098,7 +2098,7 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
                     if (RefPtr webPage = frame->page(); webPage && webPage->hasActiveContextMenuInteraction())
                         return false;
 #endif
-                    auto immediateActionStage = frame->protectedCoreLocalFrame()->eventHandler().immediateActionStage();
+                    auto immediateActionStage = protect(frame->coreLocalFrame())->eventHandler().immediateActionStage();
                     return !immediateActionBeganOrWasCompleted(immediateActionStage);
                 }();
 
@@ -3401,10 +3401,10 @@ void UnifiedPDFPlugin::collectFindMatchRects(const String& target, WebCore::Find
 void UnifiedPDFPlugin::updateFindOverlay(HideFindIndicator hideFindIndicator)
 {
     Ref frame = *m_frame;
-    frame->protectedPage()->findController().didInvalidateFindRects();
+    protect(frame->page())->findController().didInvalidateFindRects();
 
     if (hideFindIndicator == HideFindIndicator::Yes)
-        frame->protectedPage()->findController().hideFindIndicator();
+        protect(frame->page())->findController().hideFindIndicator();
 }
 
 Vector<FloatRect> UnifiedPDFPlugin::rectsForTextMatchesInRect(const IntRect& clipRect) const
@@ -3562,7 +3562,7 @@ std::optional<TextIndicatorData> UnifiedPDFPlugin::textIndicatorDataForPageRect(
         RefPtr frame = m_frame.get();
         if (!frame || !frame->page())
             return 1.0;
-        return frame->protectedPage()->pageScaleFactor();
+        return protect(frame->page())->pageScaleFactor();
     }();
     float deviceScaleFactor = this->deviceScaleFactor();
 
@@ -3896,11 +3896,11 @@ auto UnifiedPDFPlugin::updatePageNumberIndicatorVisibility() -> IndicatorVisible
         return IndicatorVisible::No;
 
     if (shouldShowPageNumberIndicator()) {
-        m_frame->protectedPage()->createPDFPageNumberIndicator(*this, frameForPageNumberIndicatorInRootViewCoordinates(), m_documentLayout.pageCount());
+        protect(m_frame->page())->createPDFPageNumberIndicator(*this, frameForPageNumberIndicatorInRootViewCoordinates(), m_documentLayout.pageCount());
         return IndicatorVisible::Yes;
     }
 
-    m_frame->protectedPage()->removePDFPageNumberIndicator(*this);
+    protect(m_frame->page())->removePDFPageNumberIndicator(*this);
     return IndicatorVisible::No;
 }
 
@@ -3909,7 +3909,7 @@ void UnifiedPDFPlugin::updatePageNumberIndicatorLocation()
     if (!m_frame || !m_frame->page())
         return;
 
-    m_frame->protectedPage()->updatePDFPageNumberIndicatorLocation(*this, frameForPageNumberIndicatorInRootViewCoordinates());
+    protect(m_frame->page())->updatePDFPageNumberIndicatorLocation(*this, frameForPageNumberIndicatorInRootViewCoordinates());
 }
 
 void UnifiedPDFPlugin::updatePageNumberIndicatorCurrentPage(const std::optional<IntRect>& maybeUnobscuredContentRectInRootView)
@@ -3932,7 +3932,7 @@ void UnifiedPDFPlugin::updatePageNumberIndicatorCurrentPage(const std::optional<
     auto scrollPositionInPluginSpace = convertFromRootViewToPlugin(FloatPoint { unobscuredContentRectInRootView->center() });
     auto scrollPositionInDocumentLayoutSpace = convertDown(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, scrollPositionInPluginSpace);
     auto currentPageIndex = m_presentationController->nearestPageIndexForDocumentPoint(scrollPositionInDocumentLayoutSpace);
-    m_frame->protectedPage()->updatePDFPageNumberIndicatorCurrentPage(*this, currentPageIndex + 1);
+    protect(m_frame->page())->updatePDFPageNumberIndicatorCurrentPage(*this, currentPageIndex + 1);
 }
 
 
@@ -4079,7 +4079,7 @@ void UnifiedPDFPlugin::setActiveAnnotation(SetActiveAnnotationParams&& setActive
             RefPtr newActiveAnnotation = PDFPluginAnnotation::create(annotation.get(), this);
             newActiveAnnotation->attach(m_annotationContainer.get());
             m_activeAnnotation = WTF::move(newActiveAnnotation);
-            revealAnnotation(protectedActiveAnnotation()->protectedAnnotation().get());
+            revealAnnotation(protect(activeAnnotation())->protectedAnnotation().get());
         } else
             m_activeAnnotation = nullptr;
     });

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -145,7 +145,7 @@ void PluginView::Stream::start()
     RefPtr frame = m_pluginView->frame();
     ASSERT(frame);
 
-    WebProcess::singleton().protectedWebLoaderStrategy()->schedulePluginStreamLoad(*frame, *this, ResourceRequest { m_request }, [this, protectedThis = Ref { *this }](RefPtr<NetscapePlugInStreamLoader>&& loader) {
+    protect(WebProcess::singleton().webLoaderStrategy())->schedulePluginStreamLoad(*frame, *this, ResourceRequest { m_request }, [this, protectedThis = Ref { *this }](RefPtr<NetscapePlugInStreamLoader>&& loader) {
         m_loader = WTF::move(loader);
     });
 }
@@ -270,11 +270,6 @@ RefPtr<WebPage> PluginView::protectedWebPage() const
 LocalFrame* PluginView::frame() const
 {
     return m_pluginElement->document().frame();
-}
-
-RefPtr<LocalFrame> PluginView::protectedFrame() const
-{
-    return frame();
 }
 
 void PluginView::manualLoadDidReceiveResponse(const ResourceResponse& response)
@@ -444,7 +439,7 @@ void PluginView::initializePlugin()
         if (RefPtr frameView = frame->view())
             frameView->setNeedsLayoutAfterViewConfigurationChange();
         if (frame->isMainFrame() && plugin->isFullFramePlugin())
-            WebFrame::fromCoreFrame(*frame)->protectedPage()->send(Messages::WebPageProxy::MainFramePluginHandlesPageScaleGestureDidChange(plugin->handlesPageScaleFactor(), plugin->minScaleFactor(), plugin->maxScaleFactor()));
+            protect(WebFrame::fromCoreFrame(*frame)->page())->send(Messages::WebPageProxy::MainFramePluginHandlesPageScaleGestureDidChange(plugin->handlesPageScaleFactor(), plugin->minScaleFactor(), plugin->maxScaleFactor()));
     }
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -72,7 +72,6 @@ public:
     static RefPtr<PluginView> create(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader);
 
     WebCore::LocalFrame* frame() const;
-    RefPtr<WebCore::LocalFrame> protectedFrame() const;
 
     bool isBeingDestroyed() const;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -553,7 +553,7 @@ void WebChromeClient::closeWindow()
     if (!page)
         return;
 
-    page->protectedCorePage()->setGroupName(String());
+    protect(page->corePage())->setGroupName(String());
 
     Ref frame = page->mainWebFrame();
     if (RefPtr coreFrame = frame->coreLocalFrame())
@@ -750,7 +750,7 @@ void WebChromeClient::invalidateContentsAndRootView(const IntRect& rect)
             return;
     }
 
-    page->protectedDrawingArea()->setNeedsDisplayInRect(rect);
+    protect(page->drawingArea())->setNeedsDisplayInRect(rect);
 }
 
 void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
@@ -769,7 +769,7 @@ void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& rect)
     }
 
     page->pageDidScroll();
-    page->protectedDrawingArea()->setNeedsDisplayInRect(rect);
+    protect(page->drawingArea())->setNeedsDisplayInRect(rect);
 }
 
 void WebChromeClient::scroll(const IntSize& scrollDelta, const IntRect& scrollRect, const IntRect& clipRect)
@@ -779,7 +779,7 @@ void WebChromeClient::scroll(const IntSize& scrollDelta, const IntRect& scrollRe
         return;
 
     page->pageDidScroll();
-    page->protectedDrawingArea()->scroll(intersection(scrollRect, clipRect), scrollDelta);
+    protect(page->drawingArea())->scroll(intersection(scrollRect, clipRect), scrollDelta);
 }
 
 IntPoint WebChromeClient::screenToRootView(const IntPoint& point) const
@@ -857,7 +857,7 @@ void WebChromeClient::contentsSizeChanged(LocalFrame& frame, const IntSize& size
 
     page->send(Messages::WebPageProxy::DidChangeContentSize(size));
 
-    page->protectedDrawingArea()->mainFrameContentSizeChanged(frame.frameID(), size);
+    protect(page->drawingArea())->mainFrameContentSizeChanged(frame.frameID(), size);
 
     if (frameView && !frameView->delegatesScrollingToNativeView())  {
         bool hasHorizontalScrollbar = frameView->horizontalScrollbar();
@@ -1131,7 +1131,7 @@ std::unique_ptr<WebCore::WorkerClient> WebChromeClient::createWorkerClient(Seria
     RefPtr page = m_page.get();
     if (!page)
         return nullptr;
-    return WebWorkerClient::create(*page->protectedCorePage(), dispatcher).moveToUniquePtr();
+    return WebWorkerClient::create(*protect(page->corePage()), dispatcher).moveToUniquePtr();
 }
 
 #if ENABLE(WEBGL)
@@ -1348,7 +1348,7 @@ RefPtr<WebCore::ScrollingCoordinator> WebChromeClient::createScrollingCoordinato
 
     ASSERT_UNUSED(corePage, page->corePage() == &corePage);
 #if ENABLE(TILED_CA_DRAWING_AREA)
-    switch (page->protectedDrawingArea()->type()) {
+    switch (protect(page->drawingArea())->type()) {
     case DrawingAreaType::TiledCoreAnimation:
         return TiledCoreAnimationScrollingCoordinator::create(page.get());
     case DrawingAreaType::RemoteLayerTree:
@@ -1379,7 +1379,7 @@ void WebChromeClient::ensureScrollbarsController(Page& corePage, ScrollableArea&
     }
 
 #if ENABLE(TILED_CA_DRAWING_AREA)
-    switch (page->protectedDrawingArea()->type()) {
+    switch (protect(page->drawingArea())->type()) {
     case DrawingAreaType::RemoteLayerTree: {
         if (!area.usesCompositedScrolling() && (!currentScrollbarsController || is<RemoteScrollbarsController>(currentScrollbarsController)))
             area.setScrollbarsController(ScrollbarsController::create(area));
@@ -1414,19 +1414,19 @@ void WebChromeClient::prepareForVideoFullscreen()
 bool WebChromeClient::canEnterVideoFullscreen(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode) const
 {
     RefPtr page = m_page.get();
-    return page && page->protectedVideoPresentationManager()->canEnterVideoFullscreen(videoElement, mode);
+    return page && protect(page->videoPresentationManager())->canEnterVideoFullscreen(videoElement, mode);
 }
 
 bool WebChromeClient::supportsVideoFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     RefPtr page = m_page.get();
-    return page && page->protectedVideoPresentationManager()->supportsVideoFullscreen(mode);
+    return page && protect(page->videoPresentationManager())->supportsVideoFullscreen(mode);
 }
 
 bool WebChromeClient::supportsVideoFullscreenStandby()
 {
     RefPtr page = m_page.get();
-    return page && page->protectedVideoPresentationManager()->supportsVideoFullscreenStandby();
+    return page && protect(page->videoPresentationManager())->supportsVideoFullscreenStandby();
 }
 
 void WebChromeClient::setMockVideoPresentationModeEnabled(bool enabled)
@@ -1443,37 +1443,37 @@ void WebChromeClient::enterVideoFullscreenForVideoElement(HTMLVideoElement& vide
     ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 #endif
     if (RefPtr page = m_page.get())
-        page->protectedVideoPresentationManager()->enterVideoFullscreenForVideoElement(videoElement, mode, standby);
+        protect(page->videoPresentationManager())->enterVideoFullscreenForVideoElement(videoElement, mode, standby);
 }
 
 void WebChromeClient::setPlayerIdentifierForVideoElement(HTMLVideoElement& videoElement)
 {
     if (RefPtr page = m_page.get())
-        page->protectedVideoPresentationManager()->setPlayerIdentifierForVideoElement(videoElement);
+        protect(page->videoPresentationManager())->setPlayerIdentifierForVideoElement(videoElement);
 }
 
 void WebChromeClient::exitVideoFullscreenForVideoElement(HTMLVideoElement& videoElement, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (RefPtr page = m_page.get())
-        page->protectedVideoPresentationManager()->exitVideoFullscreenForVideoElement(videoElement, WTF::move(completionHandler));
+        protect(page->videoPresentationManager())->exitVideoFullscreenForVideoElement(videoElement, WTF::move(completionHandler));
 }
 
 void WebChromeClient::setUpPlaybackControlsManager(HTMLMediaElement& mediaElement)
 {
     if (RefPtr page = m_page.get())
-        page->protectedPlaybackSessionManager()->setUpPlaybackControlsManager(mediaElement);
+        protect(page->playbackSessionManager())->setUpPlaybackControlsManager(mediaElement);
 }
 
 void WebChromeClient::clearPlaybackControlsManager()
 {
     if (RefPtr page = m_page.get())
-        page->protectedPlaybackSessionManager()->clearPlaybackControlsManager();
+        protect(page->playbackSessionManager())->clearPlaybackControlsManager();
 }
 
 void WebChromeClient::mediaEngineChanged(WebCore::HTMLMediaElement& mediaElement)
 {
     if (RefPtr page = m_page.get())
-        page->protectedPlaybackSessionManager()->mediaEngineChanged(mediaElement);
+        protect(page->playbackSessionManager())->mediaEngineChanged(mediaElement);
 }
 
 #endif
@@ -1503,19 +1503,19 @@ void WebChromeClient::removeMediaUsageManagerSession(MediaSessionIdentifier iden
 void WebChromeClient::exitVideoFullscreenToModeWithoutAnimation(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode targetMode)
 {
     if (RefPtr page = m_page.get())
-        page->protectedVideoPresentationManager()->exitVideoFullscreenToModeWithoutAnimation(videoElement, targetMode);
+        protect(page->videoPresentationManager())->exitVideoFullscreenToModeWithoutAnimation(videoElement, targetMode);
 }
 
 void WebChromeClient::setVideoFullscreenMode(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     if (RefPtr page = m_page.get())
-        page->protectedVideoPresentationManager()->setVideoFullscreenMode(videoElement, mode);
+        protect(page->videoPresentationManager())->setVideoFullscreenMode(videoElement, mode);
 }
 
 void WebChromeClient::clearVideoFullscreenMode(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     if (RefPtr page = m_page.get())
-        page->protectedVideoPresentationManager()->clearVideoFullscreenMode(videoElement, mode);
+        protect(page->videoPresentationManager())->clearVideoFullscreenMode(videoElement, mode);
 }
 
 #endif
@@ -1525,14 +1525,14 @@ void WebChromeClient::clearVideoFullscreenMode(HTMLVideoElement& videoElement, H
 bool WebChromeClient::supportsFullScreenForElement(const Element& element, bool withKeyboard)
 {
     RefPtr page = m_page.get();
-    return page && page->protectedFullscreenManager()->supportsFullScreenForElement(element, withKeyboard);
+    return page && protect(page->fullScreenManager())->supportsFullScreenForElement(element, withKeyboard);
 }
 
 void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode, CompletionHandler<void(ExceptionOr<void>)>&& willEnterFullscreen, CompletionHandler<bool(bool)>&& didEnterFullscreen)
 {
     RefPtr page = m_page.get();
     ASSERT(page);
-    page->protectedFullscreenManager()->enterFullScreenForElement(element, mode, WTF::move(willEnterFullscreen), WTF::move(didEnterFullscreen));
+    protect(page->fullScreenManager())->enterFullScreenForElement(element, mode, WTF::move(willEnterFullscreen), WTF::move(didEnterFullscreen));
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(element); videoElement && mode == HTMLMediaElementEnums::VideoFullscreenModeInWindow)
         setVideoFullscreenMode(*videoElement, mode);
@@ -1557,7 +1557,7 @@ void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandl
     }
 #endif
     if (RefPtr page = m_page.get())
-        page->protectedFullscreenManager()->exitFullScreenForElement(element, WTF::move(completionHandler));
+        protect(page->fullScreenManager())->exitFullScreenForElement(element, WTF::move(completionHandler));
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (exitingInWindowFullscreen)
         clearVideoFullscreenMode(*dynamicDowncast<HTMLVideoElement>(*element), HTMLMediaElementEnums::VideoFullscreenModeInWindow);
@@ -1747,7 +1747,7 @@ void WebChromeClient::didAddFooterLayer(GraphicsLayer& footerParent)
 bool WebChromeClient::shouldUseTiledBackingForFrameView(const LocalFrameView& frameView) const
 {
     RefPtr page = m_page.get();
-    return page && page->protectedDrawingArea()->shouldUseTiledBackingForFrameView(frameView);
+    return page && protect(page->drawingArea())->shouldUseTiledBackingForFrameView(frameView);
 }
 
 void WebChromeClient::frameViewLayoutOrVisualViewportChanged(const LocalFrameView& frameView)
@@ -2237,7 +2237,7 @@ bool WebChromeClient::isUsingUISideCompositing() const
 {
 #if ENABLE(TILED_CA_DRAWING_AREA)
     RefPtr page = m_page.get();
-    return page && page->protectedDrawingArea()->type() == DrawingAreaType::RemoteLayerTree;
+    return page && protect(page->drawingArea())->type() == DrawingAreaType::RemoteLayerTree;
 #elif PLATFORM(COCOA)
     return true;
 #else

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -97,7 +97,7 @@ void WebContextMenuClient::stopSpeaking()
 
 void WebContextMenuClient::showContextMenu()
 {
-    protectedPage()->protectedContextMenu()->show();
+    protect(protectedPage()->contextMenu())->show();
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1456,7 +1456,7 @@ void WebLocalFrameLoaderClient::restoreViewState()
     // FIXME: This should not be necessary. WebCore should be correctly invalidating
     // the view on restores from the back/forward cache.
     if (page && m_frame.ptr() == &page->mainWebFrame())
-        page->protectedDrawingArea()->setNeedsDisplay();
+        protect(page->drawingArea())->setNeedsDisplay();
 #endif
 }
 
@@ -1483,7 +1483,7 @@ void WebLocalFrameLoaderClient::prepareForDataSourceReplacement()
 
 Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, ResourceRequest&& originalRequest)
 {
-    return m_frame->protectedPage()->createDocumentLoader(protectedLocalFrame(), WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
+    return protect(m_frame->page())->createDocumentLoader(protectedLocalFrame(), WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
@@ -1493,7 +1493,7 @@ Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequ
 
 void WebLocalFrameLoaderClient::updateCachedDocumentLoader(WebCore::DocumentLoader& loader)
 {
-    m_frame->protectedPage()->updateCachedDocumentLoader(loader, protectedLocalFrame());
+    protect(m_frame->page())->updateCachedDocumentLoader(loader, protectedLocalFrame());
 }
 
 void WebLocalFrameLoaderClient::setTitle(const StringWithDirection& title, const URL& url)
@@ -1538,7 +1538,7 @@ void WebLocalFrameLoaderClient::savePlatformDataToCachedFrame(CachedFrame*)
 void WebLocalFrameLoaderClient::transitionToCommittedFromCachedFrame(CachedFrame*)
 {
     const ResourceResponse& response = m_localFrame->loader().documentLoader()->response();
-    m_frameHasCustomContentProvider = m_frame->isMainFrame() && m_frame->protectedPage()->shouldUseCustomContentProviderForResponse(response);
+    m_frameHasCustomContentProvider = m_frame->isMainFrame() && protect(m_frame->page())->shouldUseCustomContentProviderForResponse(response);
     m_frameCameFromBackForwardCache = true;
 }
 
@@ -1615,7 +1615,7 @@ void WebLocalFrameLoaderClient::transitionToCommittedForNewPage(InitializingIfra
     if (isMainFrame)
         view->setDelegatedScrollingMode(drawingArea->delegatedScrollingMode());
 
-    webPage->protectedCorePage()->setDelegatesScaling(drawingArea->usesDelegatedPageScaling());
+    protect(webPage->corePage())->setDelegatesScaling(drawingArea->usesDelegatedPageScaling());
 #endif
 
     if (webPage->scrollPinningBehavior() != ScrollPinningBehavior::DoNotPin)
@@ -1707,7 +1707,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
         if (mimeType.isEmpty()) {
             // Check if there's a plug-in around that can handle the extension.
             if (RefPtr webPage = m_frame->page()) {
-                if (pluginSupportsExtension(webPage->protectedCorePage()->protectedPluginData(), extension))
+                if (pluginSupportsExtension(protect(webPage->corePage())->protectedPluginData(), extension))
                     return ObjectContentType::PlugIn;
             }
             return ObjectContentType::Frame;
@@ -1724,7 +1724,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
 
     if (RefPtr webPage = m_frame->page()) {
         auto allowedPluginTypes = PluginData::OnlyApplicationPlugins;
-        if (webPage->protectedCorePage()->protectedPluginData()->supportsMimeType(mimeType, allowedPluginTypes))
+        if (protect(webPage->corePage())->protectedPluginData()->supportsMimeType(mimeType, allowedPluginTypes))
             return ObjectContentType::PlugIn;
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp
@@ -115,7 +115,7 @@ void WebNotificationClient::requestPermission(ScriptExecutionContext& context, P
     }
 #endif
 
-    Ref { *m_page }->protectedNotificationPermissionRequestManager()->startRequest(securityOrigin->data(), WTF::move(permissionHandler));
+    protect(Ref { *m_page }->notificationPermissionRequestManager())->startRequest(securityOrigin->data(), WTF::move(permissionHandler));
 }
 
 NotificationClient::Permission WebNotificationClient::checkPermission(ScriptExecutionContext* context)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -265,7 +265,7 @@ void WebPage::performDictionaryLookupAtLocation(const FloatPoint& floatPoint)
     }
 #endif
     
-    RefPtr localMainFrame = protectedCorePage()->localMainFrame();
+    RefPtr localMainFrame = protect(corePage())->localMainFrame();
     if (!localMainFrame)
         return;
     // Find the frame the point is over.
@@ -543,7 +543,7 @@ void WebPage::resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier fra
     if (!webFrame)
         return completionHandler("NULL"_s);
 #if PLATFORM(MAC)
-    if (RetainPtr coreObject = [m_mockAccessibilityElement accessibilityRootObjectWrapper:webFrame->protectedCoreLocalFrame().get()]) {
+    if (RetainPtr coreObject = [m_mockAccessibilityElement accessibilityRootObjectWrapper:protect(webFrame->coreLocalFrame()).get()]) {
         if (RetainPtr hitTestResult = [coreObject accessibilityHitTest:point]) {
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             completionHandler([hitTestResult accessibilityAttributeValue:@"AXInfoStringForTesting"]);
@@ -569,7 +569,7 @@ void WebPage::getAccessibilityWebProcessDebugInfo(CompletionHandler<void(WebCore
     isAXThreadInitialized = WebCore::AXObjectCache::isAXThreadInitialized();
 #endif
 
-    if (std::optional treeData = protectedCorePage()->accessibilityTreeData(IncludeDOMInfo::No)) {
+    if (std::optional treeData = protect(corePage())->accessibilityTreeData(IncludeDOMInfo::No)) {
         completionHandler({ WebCore::AXObjectCache::accessibilityEnabled(), isAXThreadInitialized, WTF::move(treeData->liveTree), WTF::move(treeData->isolatedTree), WTF::move(treeData->warnings), [m_mockAccessibilityElement remoteTokenHash], [accessibilityRemoteTokenData() hash] });
         return;
     }
@@ -597,7 +597,7 @@ WebPaymentCoordinator* WebPage::paymentCoordinator()
 
 void WebPage::getContentsAsAttributedString(CompletionHandler<void(const WebCore::AttributedString&)>&& completionHandler)
 {
-    RefPtr localFrame = protectedCorePage()->localMainFrame();
+    RefPtr localFrame = protect(corePage())->localMainFrame();
     completionHandler(localFrame ? attributedString(makeRangeSelectingNodeContents(*localFrame->protectedDocument()), IgnoreUserSelectNone::No) : AttributedString { });
 }
 
@@ -792,7 +792,7 @@ void WebPage::getPDFFirstPageSize(WebCore::FrameIdentifier frameID, CompletionHa
         return completionHandler({ });
 
 #if ENABLE(PDF_PLUGIN)
-    if (RefPtr pluginView = pluginViewForFrame(webFrame->protectedCoreLocalFrame().get()))
+    if (RefPtr pluginView = pluginViewForFrame(protect(webFrame->coreLocalFrame()).get()))
         return completionHandler(pluginView->pdfDocumentSizeForPrinting());
 #endif
 
@@ -1041,45 +1041,45 @@ void WebPage::setMediaEnvironment(const String& mediaEnvironment)
 #if ENABLE(WRITING_TOOLS)
 void WebPage::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    protectedCorePage()->willBeginWritingToolsSession(session, WTF::move(completionHandler));
+    protect(corePage())->willBeginWritingToolsSession(session, WTF::move(completionHandler));
 }
 
 void WebPage::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)
 {
-    protectedCorePage()->didBeginWritingToolsSession(session, contexts);
+    protect(corePage())->didBeginWritingToolsSession(session, contexts);
 }
 
 void WebPage::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::CharacterRange& processedRange, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
-    protectedCorePage()->proofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished);
+    protect(corePage())->proofreadingSessionDidReceiveSuggestions(session, suggestions, processedRange, context, finished);
     completionHandler();
 }
 
 void WebPage::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& suggestion, const WebCore::WritingTools::Context& context)
 {
-    protectedCorePage()->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
+    protect(corePage())->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
 }
 
 void WebPage::willEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted, CompletionHandler<void()>&& completionHandler)
 {
-    protectedCorePage()->willEndWritingToolsSession(session, accepted);
+    protect(corePage())->willEndWritingToolsSession(session, accepted);
     completionHandler();
 }
 
 void WebPage::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
 {
-    protectedCorePage()->didEndWritingToolsSession(session, accepted);
+    protect(corePage())->didEndWritingToolsSession(session, accepted);
 }
 
 void WebPage::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished, CompletionHandler<void()>&& completionHandler)
 {
-    protectedCorePage()->compositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
+    protect(corePage())->compositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
     completionHandler();
 }
 
 void WebPage::writingToolsSessionDidReceiveAction(const WritingTools::Session& session, WebCore::WritingTools::Action action)
 {
-    protectedCorePage()->writingToolsSessionDidReceiveAction(session, action);
+    protect(corePage())->writingToolsSessionDidReceiveAction(session, action);
 }
 
 void WebPage::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect rect)
@@ -1147,37 +1147,37 @@ void WebPage::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID& 
 
 void WebPage::proofreadingSessionSuggestionTextRectsInRootViewCoordinates(const WebCore::CharacterRange& enclosingRangeRelativeToSessionRange, CompletionHandler<void(Vector<FloatRect>&&)>&& completionHandler) const
 {
-    auto rects = protectedCorePage()->proofreadingSessionSuggestionTextRectsInRootViewCoordinates(enclosingRangeRelativeToSessionRange);
+    auto rects = protect(corePage())->proofreadingSessionSuggestionTextRectsInRootViewCoordinates(enclosingRangeRelativeToSessionRange);
     completionHandler(WTF::move(rects));
 }
 
 void WebPage::updateTextVisibilityForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, bool visible, const WTF::UUID& identifier, CompletionHandler<void()>&& completionHandler)
 {
-    protectedCorePage()->updateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible, identifier);
+    protect(corePage())->updateTextVisibilityForActiveWritingToolsSession(rangeRelativeToSessionRange, visible, identifier);
     completionHandler();
 }
 
 void WebPage::textPreviewDataForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&& completionHandler)
 {
-    RefPtr textIndicator = protectedCorePage()->textPreviewDataForActiveWritingToolsSession(rangeRelativeToSessionRange);
+    RefPtr textIndicator = protect(corePage())->textPreviewDataForActiveWritingToolsSession(rangeRelativeToSessionRange);
     completionHandler(WTF::move(textIndicator));
 }
 
 void WebPage::decorateTextReplacementsForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(void)>&& completionHandler)
 {
-    protectedCorePage()->decorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange);
+    protect(corePage())->decorateTextReplacementsForActiveWritingToolsSession(rangeRelativeToSessionRange);
     completionHandler();
 }
 
 void WebPage::setSelectionForActiveWritingToolsSession(const WebCore::CharacterRange& rangeRelativeToSessionRange, CompletionHandler<void(void)>&& completionHandler)
 {
-    protectedCorePage()->setSelectionForActiveWritingToolsSession(rangeRelativeToSessionRange);
+    protect(corePage())->setSelectionForActiveWritingToolsSession(rangeRelativeToSessionRange);
     completionHandler();
 }
 
 void WebPage::intelligenceTextAnimationsDidComplete()
 {
-    protectedCorePage()->intelligenceTextAnimationsDidComplete();
+    protect(corePage())->intelligenceTextAnimationsDidComplete();
 }
 
 void WebPage::didEndPartialIntelligenceTextAnimation()
@@ -1510,11 +1510,6 @@ bool WebPage::shouldFallbackToWebContentAXObjectForMainFramePlugin() const
 WKAccessibilityWebPageObject* WebPage::accessibilityRemoteObject()
 {
     return m_mockAccessibilityElement.get();
-}
-
-RetainPtr<WKAccessibilityWebPageObject> WebPage::protectedAccessibilityRemoteObject()
-{
-    return accessibilityRemoteObject();
 }
 
 RetainPtr<PDFDocument> WebPage::pdfDocumentForPrintingFrame(LocalFrame* coreFrame)
@@ -1979,7 +1974,7 @@ void WebPage::removeTextPlaceholder(const ElementContext& placeholder, Completio
 
 void WebPage::setObscuredContentInsetsFenced(const FloatBoxExtent& obscuredContentInsets, const WTF::MachSendRight& machSendRight)
 {
-    protectedDrawingArea()->addFence(machSendRight);
+    protect(drawingArea())->addFence(machSendRight);
     setObscuredContentInsets(obscuredContentInsets);
 }
 
@@ -2090,13 +2085,6 @@ bool WebPage::isSpeaking() const
     auto [result] = sendResult.takeReplyOr(false);
     return result;
 }
-
-#if ENABLE(WK_WEB_EXTENSIONS)
-RefPtr<WebExtensionControllerProxy> WebPage::protectedWebExtensionControllerProxy() const
-{
-    return webExtensionControllerProxy();
-}
-#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -140,7 +140,7 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
         videoElement.naturalSize()
     };
 
-    protectedWebPage()->protectedVideoPresentationManager()->setupRemoteLayerHosting(videoElement);
+    protect(protectedWebPage()->videoPresentationManager())->setupRemoteLayerHosting(videoElement);
     m_videoLayers.add(layerID, videoElement.identifier());
 
     m_createdLayers.add(layerID, WTF::move(creationProperties));
@@ -170,7 +170,7 @@ void RemoteLayerTreeContext::layerWillLeaveContext(PlatformCALayerRemote& layer)
 #if HAVE(AVKIT)
     auto videoLayerIter = m_videoLayers.find(layerID);
     if (videoLayerIter != m_videoLayers.end()) {
-        protectedWebPage()->protectedVideoPresentationManager()->willRemoveLayerForID(videoLayerIter->value);
+        protect(protectedWebPage()->videoPresentationManager())->willRemoveLayerForID(videoLayerIter->value);
         m_videoLayers.remove(videoLayerIter);
     }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -248,7 +248,7 @@ void RemoteLayerTreeDrawingArea::updateRenderingWithForcedRepaint()
     if (m_isRenderingSuspended)
         return;
 
-    protectedWebPage()->protectedCorePage()->forceRepaintAllFrames();
+    protect(protectedWebPage()->corePage())->forceRepaintAllFrames();
     updateRendering();
 }
 
@@ -385,7 +385,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         RemoteScrollingCoordinatorTransaction scrollingTransaction;
 #if ENABLE(ASYNC_SCROLLING)
         if (webPage->scrollingCoordinator())
-            scrollingTransaction = downcast<RemoteScrollingCoordinator>(*webPage->protectedScrollingCoordinator()).buildTransaction(rootLayer.frameID);
+            scrollingTransaction = downcast<RemoteScrollingCoordinator>(*protect(webPage->scrollingCoordinator())).buildTransaction(rootLayer.frameID);
         scrollingTransaction.setFrameIdentifier(rootLayer.frameID);
 #endif
 
@@ -395,7 +395,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
     for (auto& transaction : transactions)
         backingStoreCollection->willCommitLayerTree(CheckedRef { transaction.first });
 
-    RemoteLayerTreeCommitBundle bundle { WTF::move(transactions), { WTF::move(m_pendingCallbackIDs), webPage->protectedCorePage()->renderTreeSize() }, std::nullopt, transactionID };
+    RemoteLayerTreeCommitBundle bundle { WTF::move(transactions), { WTF::move(m_pendingCallbackIDs), protect(webPage->corePage())->renderTreeSize() }, std::nullopt, transactionID };
 
     if (webPage->localMainFrame()) {
         bundle.mainFrameData = MainFrameData { };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -73,7 +73,7 @@ RemoteScrollingCoordinator::~RemoteScrollingCoordinator()
 void RemoteScrollingCoordinator::scheduleTreeStateCommit()
 {
     if (RefPtr webPage = m_webPage.get())
-        webPage->protectedDrawingArea()->triggerRenderingUpdate();
+        protect(webPage->drawingArea())->triggerRenderingUpdate();
 }
 
 bool RemoteScrollingCoordinator::coordinatesScrollingForFrameView(const LocalFrameView& frameView) const

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp
@@ -73,7 +73,7 @@ String WebCookieCache::cookiesForDOM(const URL& firstParty, const SameSiteInfo& 
         auto host = url.host().toString();
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
         if (!hasCacheForHost)
-            WebProcess::singleton().protectedCookieJar()->addChangeListenerWithAccess(url, firstParty, frameID, pageID, webPageProxyID, *this);
+            protect(WebProcess::singleton().cookieJar())->addChangeListenerWithAccess(url, firstParty, frameID, pageID, webPageProxyID, *this);
 #endif
         auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::DomCookiesForHost(url), 0);
         if (!sendResult.succeeded())
@@ -140,7 +140,7 @@ void WebCookieCache::clear()
 {
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
     for (auto& host : m_hostsWithInMemoryStorage)
-        WebProcess::singleton().protectedCookieJar()->removeChangeListener(host, *this);
+        protect(WebProcess::singleton().cookieJar())->removeChangeListener(host, *this);
 #endif
     m_hostsWithInMemoryStorage.clear();
     m_inMemoryStorageSession = nullptr;
@@ -154,7 +154,7 @@ void WebCookieCache::clearForHost(const String& host)
 
     checkedInMemoryStorageSession()->deleteCookiesForHostnames(Vector<String> { removedHost }, [] { });
 #if HAVE(COOKIE_CHANGE_LISTENER_API)
-    WebProcess::singleton().protectedCookieJar()->removeChangeListener(removedHost, *this);
+    protect(WebProcess::singleton().cookieJar())->removeChangeListener(removedHost, *this);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -119,7 +119,7 @@ static inline Vector<WebFoundTextRange::PDFData> findPDFMatchesInFrame(Frame* fr
 
 void WebFoundTextRangeController::findTextRangesForStringMatches(const String& string, OptionSet<FindOptions> options, uint32_t maxMatchCount, CompletionHandler<void(HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>>&&)>&& completionHandler)
 {
-    auto matchingRanges = protectedWebPage()->protectedCorePage()->findTextMatches(string, core(options), maxMatchCount, false);
+    auto matchingRanges = protect(protectedWebPage()->corePage())->findTextMatches(string, core(options), maxMatchCount, false);
     Vector<WebCore::SimpleRange> findMatches = WTF::move(matchingRanges.ranges);
 
     if (findMatches.size() > 0)
@@ -283,7 +283,7 @@ void WebFoundTextRangeController::clearAllDecoratedFoundText()
     clearCachedRanges();
     m_decoratedRanges.clear();
     m_unhighlightedFoundRanges.clear();
-    protectedWebPage()->protectedCorePage()->unmarkAllTextMatches();
+    protect(protectedWebPage()->corePage())->unmarkAllTextMatches();
 
     m_highlightedRange = { };
     m_textIndicator = nullptr;
@@ -558,12 +558,12 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
 
 WebCore::LocalFrame* WebFoundTextRangeController::frameForFoundTextRange(const WebFoundTextRange& range) const
 {
-    Ref mainFrame = protectedWebPage()->protectedCorePage()->mainFrame();
+    Ref mainFrame = protect(protectedWebPage()->corePage())->mainFrame();
 
     if (range.pathToFrame.isEmpty())
         return dynamicDowncast<WebCore::LocalFrame>(mainFrame.ptr());
 
-    RefPtr foundFrame = mainFrame->protectedPage()->findFrameByPath(range.pathToFrame);
+    RefPtr foundFrame = protect(mainFrame->page())->findFrameByPath(range.pathToFrame);
     return dynamicDowncast<WebCore::LocalFrame>(foundFrame.get());
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -127,15 +127,12 @@ public:
     ScopeExit<Function<void()>> makeInvalidator();
 
     WebPage* page() const;
-    RefPtr<WebPage> protectedPage() const;
 
     static WebFrame* webFrame(std::optional<WebCore::FrameIdentifier>);
     static RefPtr<WebFrame> fromCoreFrame(const WebCore::Frame&);
     WebCore::LocalFrame* coreLocalFrame() const;
-    RefPtr<WebCore::LocalFrame> protectedCoreLocalFrame() const;
     WebCore::RemoteFrame* coreRemoteFrame() const;
     WebCore::Frame* coreFrame() const;
-    RefPtr<WebCore::Frame> protectedCoreFrame() const;
 
     void createProvisionalFrame(ProvisionalFrameCreationParameters&&);
     void commitProvisionalFrame();
@@ -244,7 +241,6 @@ public:
 #endif
 
     WebLocalFrameLoaderClient* localFrameLoaderClient() const;
-    RefPtr<WebLocalFrameLoaderClient> protectedLocalFrameLoaderClient() const;
 
     WebRemoteFrameClient* remoteFrameClient() const;
     WebFrameLoaderClient* frameLoaderClient() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -599,7 +599,6 @@ public:
     static WebPage* fromCorePage(WebCore::Page&);
 
     WebCore::Page* corePage() const { return m_page.get(); }
-    RefPtr<WebCore::Page> protectedCorePage() const;
     WebCore::PageIdentifier identifier() const { return m_identifier; }
     inline StorageNamespaceIdentifier sessionStorageNamespaceIdentifier() const;
     PAL::SessionID sessionID() const;
@@ -610,11 +609,9 @@ public:
     inline WebCore::IntRect bounds() const;
 
     DrawingArea* drawingArea() const { return m_drawingArea.get(); }
-    RefPtr<DrawingArea> protectedDrawingArea() const;
 
 #if ENABLE(ASYNC_SCROLLING)
     WebCore::ScrollingCoordinator* scrollingCoordinator() const;
-    RefPtr<WebCore::ScrollingCoordinator> protectedScrollingCoordinator() const;
 #endif
 
 #if HAVE(NSVIEW_CORNER_CONFIGURATION)
@@ -675,7 +672,6 @@ public:
     enum class LazyCreationPolicy { UseExistingOnly, CreateIfNeeded };
 
     WebInspectorBackend* inspector(LazyCreationPolicy = LazyCreationPolicy::CreateIfNeeded);
-    RefPtr<WebInspectorBackend> protectedInspector();
     WebInspectorUI* inspectorUI();
     RemoteWebInspectorUI* remoteInspectorUI();
     bool isInspectorPage() { return !!m_inspectorUI || !!m_remoteInspectorUI; }
@@ -684,13 +680,11 @@ public:
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
     PlaybackSessionManager& playbackSessionManager();
-    Ref<PlaybackSessionManager> protectedPlaybackSessionManager();
     void videoControlsManagerDidChange();
 #endif
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     VideoPresentationManager& videoPresentationManager();
-    Ref<VideoPresentationManager> protectedVideoPresentationManager();
 
     void startPlayingPredominantVideo(CompletionHandler<void(bool)>&&);
 #endif
@@ -704,7 +698,6 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManager& fullScreenManager();
-    Ref<WebFullScreenManager> protectedFullscreenManager();
 
     enum class IsInFullscreenMode : bool { No, Yes };
     void isInFullscreenChanged(IsInFullscreenMode);
@@ -1209,13 +1202,11 @@ public:
     void swipeAnimationDidEnd();
 
     NotificationPermissionRequestManager* notificationPermissionRequestManager();
-    RefPtr<NotificationPermissionRequestManager> protectedNotificationPermissionRequestManager();
 
     void pageDidScroll();
 
 #if ENABLE(CONTEXT_MENUS)
     WebContextMenu& contextMenu();
-    Ref<WebContextMenu> protectedContextMenu();
     RefPtr<WebContextMenu> contextMenuAtPointInWindow(WebCore::FrameIdentifier, const WebCore::DoublePoint&);
 #endif
 
@@ -1272,7 +1263,6 @@ public:
     void registerUIProcessAccessibilityTokens(WebCore::AccessibilityRemoteToken elementToken, WebCore::AccessibilityRemoteToken windowToken);
     void registerRemoteFrameAccessibilityTokens(pid_t, WebCore::AccessibilityRemoteToken, WebCore::FrameIdentifier);
     WKAccessibilityWebPageObject* accessibilityRemoteObject();
-    RetainPtr<WKAccessibilityWebPageObject> protectedAccessibilityRemoteObject();
     WebCore::IntPoint accessibilityRemoteFrameOffset();
     void createMockAccessibilityElement(pid_t);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -1765,7 +1755,6 @@ public:
 
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
     WebExtensionControllerProxy* webExtensionControllerProxy() const { return m_webExtensionController.get(); }
-    RefPtr<WebExtensionControllerProxy> protectedWebExtensionControllerProxy() const;
 #endif
 
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() const { return m_userInterfaceLayoutDirection; }

--- a/Source/WebKit/WebProcess/WebPage/WebPageInlines.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageInlines.h
@@ -48,7 +48,7 @@ inline StorageNamespaceIdentifier WebPage::sessionStorageNamespaceIdentifier() c
 
 inline void WebPage::setHiddenPageDOMTimerThrottlingIncreaseLimit(Seconds limit)
 {
-    protectedCorePage()->setDOMTimerAlignmentIntervalIncreaseLimit(limit);
+    protect(corePage())->setDOMTimerAlignmentIntervalIncreaseLimit(limit);
 }
 
 inline bool WebPage::isVisible() const

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -178,7 +178,7 @@ void WebPageTesting::displayAndTrackRepaints(CompletionHandler<void()>&& complet
     if (!corePage)
         return completionHandler();
 
-    page->protectedDrawingArea()->updateRenderingWithForcedRepaint();
+    protect(page->drawingArea())->updateRenderingWithForcedRepaint();
     for (auto& rootFrame : corePage->rootFrames()) {
         if (RefPtr view = rootFrame->view()) {
             view->setTracksRepaints(true);

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
@@ -59,7 +59,7 @@ void WebURLSchemeHandlerProxy::startNewTask(ResourceLoader& loader, WebFrame& we
     auto result = m_tasks.add(*loader.identifier(), task);
     ASSERT_UNUSED(result, result.isNewEntry);
 
-    WebProcess::singleton().protectedWebLoaderStrategy()->addURLSchemeTaskProxy(task);
+    protect(WebProcess::singleton().webLoaderStrategy())->addURLSchemeTaskProxy(task);
     task->startLoading();
 }
 
@@ -120,7 +120,7 @@ RefPtr<WebURLSchemeTaskProxy> WebURLSchemeHandlerProxy::removeTask(WebCore::Reso
     if (!task)
         return nullptr;
 
-    WebProcess::singleton().protectedWebLoaderStrategy()->removeURLSchemeTaskProxy(*task);
+    protect(WebProcess::singleton().webLoaderStrategy())->removeURLSchemeTaskProxy(*task);
 
     return task;
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -6192,7 +6192,7 @@ void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementCo
     // because we only want to do so if the caret can be placed.
     UserGestureIndicator gestureIndicator { IsProcessingUserGesture::Yes, &target->document() };
     SetForScope userIsInteractingChange { m_userIsInteracting, true };
-    protectedCorePage()->focusController().setFocusedElement(target.get(), targetFrame.ptr());
+    protect(corePage())->focusController().setFocusedElement(target.get(), targetFrame.ptr());
 
     // Setting the focused element could tear down the element's renderer. Check that we still have one.
     if (m_focusedElement != target || !target->renderer()) {

--- a/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
@@ -58,10 +58,10 @@ void PageBanner::addToPage(Type type, WebPage* webPage)
 
     switch (type) {
     case Header:
-        webPage->protectedCorePage()->setHeaderHeight(m_height);
+        protect(webPage->corePage())->setHeaderHeight(m_height);
         break;
     case Footer:
-        webPage->protectedCorePage()->setFooterHeight(m_height);
+        protect(webPage->corePage())->setFooterHeight(m_height);
         break;
     case NotSet:
         ASSERT_NOT_REACHED();
@@ -100,9 +100,9 @@ void PageBanner::hide()
 {
     // We can hide the banner by removing the parent layer that hosts it.
     if (m_type == Header)
-        protectedWebPage()->protectedCorePage()->setHeaderHeight(0);
+        protect(protectedWebPage()->corePage())->setHeaderHeight(0);
     else if (m_type == Footer)
-        protectedWebPage()->protectedCorePage()->setFooterHeight(0);
+        protect(protectedWebPage()->corePage())->setFooterHeight(0);
 
     m_isHidden = true;
 }

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -143,12 +143,12 @@ void TiledCoreAnimationDrawingArea::sendEnterAcceleratedCompositingModeIfNeeded(
 
 void TiledCoreAnimationDrawingArea::registerScrollingTree()
 {
-    WebProcess::singleton().protectedEventDispatcher()->addScrollingTreeForPage(Ref { m_webPage.get() });
+    protect(WebProcess::singleton().eventDispatcher())->addScrollingTreeForPage(Ref { m_webPage.get() });
 }
 
 void TiledCoreAnimationDrawingArea::unregisterScrollingTree()
 {
-    WebProcess::singleton().protectedEventDispatcher()->removeScrollingTreeForPage(Ref { m_webPage.get() });
+    protect(WebProcess::singleton().eventDispatcher())->removeScrollingTreeForPage(Ref { m_webPage.get() });
 }
 
 void TiledCoreAnimationDrawingArea::setNeedsDisplay()
@@ -177,7 +177,7 @@ void TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaint()
     if (m_layerTreeStateIsFrozen)
         return;
 
-    Ref { m_webPage.get() }->protectedCorePage()->forceRepaintAllFrames();
+    protect(Ref { m_webPage.get() }->corePage())->forceRepaintAllFrames();
     updateRendering();
     [CATransaction flush];
     [CATransaction synchronize];
@@ -195,7 +195,7 @@ void TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaintAsync(WebPag
         if (!protectedThis)
             return completionHandler();
         Ref protectedPage = protectedThis->m_webPage.get();
-        protectedPage->protectedDrawingArea()->updateRenderingWithForcedRepaint();
+        protect(protectedPage->drawingArea())->updateRenderingWithForcedRepaint();
         completionHandler();
     });
 }
@@ -240,7 +240,7 @@ void TiledCoreAnimationDrawingArea::updatePreferences(const WebPreferencesStore&
     // in order to be scrolled by the ScrollingCoordinator.
     settings->setAcceleratedCompositingForFixedPositionEnabled(true);
 
-    DebugPageOverlays::settingsChanged(*webPage->protectedCorePage());
+    DebugPageOverlays::settingsChanged(*protect(webPage->corePage()));
 
     bool showTiledScrollingIndicator = settings->showTiledScrollingIndicator();
     if (showTiledScrollingIndicator == !!m_debugInfoLayer)
@@ -283,7 +283,7 @@ void TiledCoreAnimationDrawingArea::dispatchAfterEnsuringUpdatedScrollPosition(W
         return;
     }
 
-    corePage->protectedScrollingCoordinator()->commitTreeStateIfNeeded();
+    protect(corePage->scrollingCoordinator())->commitTreeStateIfNeeded();
 
     if (!m_layerTreeStateIsFrozen) {
         invalidateRenderingUpdateRunLoopObserver();

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -140,7 +140,7 @@ void WebPage::platformInitializeAccessibility(ShouldInitializeNSAccessibility sh
     // Get the pid for the starting process.
     pid_t pid = legacyPresentingApplicationPID();
     createMockAccessibilityElement(pid);
-    if (protectedCorePage()->localMainFrame())
+    if (protect(corePage())->localMainFrame())
         accessibilityTransferRemoteToken(accessibilityRemoteTokenData());
 
     // Close Mach connection to Launch Services.
@@ -435,7 +435,7 @@ bool WebPage::performNonEditingBehaviorForSelector(const String& selector, Keybo
 
 void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
 {
-    [protectedAccessibilityRemoteObject() setRemoteFrameOffset:offset];
+    [protect(accessibilityRemoteObject()) setRemoteFrameOffset:offset];
 }
 
 void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, WebCore::AccessibilityRemoteToken elementToken, WebCore::FrameIdentifier frameID)
@@ -629,7 +629,7 @@ void WebPage::setUseFormSemanticContext(bool useFormSemanticContext)
 void WebPage::semanticContextDidChange(bool useFormSemanticContext)
 {
     setUseFormSemanticContext(useFormSemanticContext);
-    protectedCorePage()->scheduleRenderingUpdate({ });
+    protect(corePage())->scheduleRenderingUpdate({ });
 }
 
 void WebPage::updateHeaderAndFooterLayersForDeviceScaleChange(float scaleFactor)
@@ -874,13 +874,13 @@ std::optional<WebCore::SimpleRange> WebPage::lookupTextAtLocation(FrameIdentifie
 
 void WebPage::immediateActionDidUpdate()
 {
-    if (RefPtr localMainFrame = protectedCorePage()->localMainFrame())
+    if (RefPtr localMainFrame = protect(corePage())->localMainFrame())
         localMainFrame->eventHandler().setImmediateActionStage(ImmediateActionStage::ActionUpdated);
 }
 
 void WebPage::immediateActionDidCancel()
 {
-    RefPtr localMainFrame = protectedCorePage()->localMainFrame();
+    RefPtr localMainFrame = protect(corePage())->localMainFrame();
     if (!localMainFrame)
         return;
     ImmediateActionStage lastStage = localMainFrame->eventHandler().immediateActionStage();
@@ -892,7 +892,7 @@ void WebPage::immediateActionDidCancel()
 
 void WebPage::immediateActionDidComplete()
 {
-    if (RefPtr localMainFrame = protectedCorePage()->localMainFrame())
+    if (RefPtr localMainFrame = protect(corePage())->localMainFrame())
         localMainFrame->eventHandler().setImmediateActionStage(ImmediateActionStage::ActionCompleted);
 }
 
@@ -942,22 +942,22 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo&, Mon
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
 void WebPage::playbackTargetSelected(PlaybackTargetClientContextIdentifier contextId, MediaPlaybackTargetContextSerialized&& targetContext) const
 {
-    protectedCorePage()->setPlaybackTarget(contextId, MediaPlaybackTargetSerialized::create(WTF::move(targetContext)));
+    protect(corePage())->setPlaybackTarget(contextId, MediaPlaybackTargetSerialized::create(WTF::move(targetContext)));
 }
 
 void WebPage::playbackTargetAvailabilityDidChange(PlaybackTargetClientContextIdentifier contextId, bool changed)
 {
-    protectedCorePage()->playbackTargetAvailabilityDidChange(contextId, changed);
+    protect(corePage())->playbackTargetAvailabilityDidChange(contextId, changed);
 }
 
 void WebPage::setShouldPlayToPlaybackTarget(PlaybackTargetClientContextIdentifier contextId, bool shouldPlay)
 {
-    protectedCorePage()->setShouldPlayToPlaybackTarget(contextId, shouldPlay);
+    protect(corePage())->setShouldPlayToPlaybackTarget(contextId, shouldPlay);
 }
 
 void WebPage::playbackTargetPickerWasDismissed(PlaybackTargetClientContextIdentifier contextId)
 {
-    protectedCorePage()->playbackTargetPickerWasDismissed(contextId);
+    protect(corePage())->playbackTargetPickerWasDismissed(contextId);
 }
 #endif
 
@@ -972,7 +972,7 @@ void WebPage::didBeginMagnificationGesture()
 void WebPage::didEndMagnificationGesture()
 {
 #if ENABLE(MAC_GESTURE_EVENTS)
-    if (RefPtr localMainFrame = protectedCorePage()->localMainFrame())
+    if (RefPtr localMainFrame = protect(corePage())->localMainFrame())
         localMainFrame->eventHandler().didEndMagnificationGesture();
 #endif
 #if ENABLE(PDF_PLUGIN)
@@ -1013,7 +1013,7 @@ void WebPage::setAccentColor(WebCore::Color color)
 #if PLATFORM(MAC)
 void WebPage::setAppUsesCustomAccentColor(bool appUsesCustomAccentColor)
 {
-    protectedCorePage()->setAppUsesCustomAccentColor(appUsesCustomAccentColor);
+    protect(corePage())->setAppUsesCustomAccentColor(appUsesCustomAccentColor);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -441,7 +441,7 @@ void WebProcess::initializeConnection(IPC::Connection* connection)
     connection->setShouldExitOnSyncMessageSendFailure(true);
 #endif
 
-    protectedEventDispatcher()->initializeConnection(*connection);
+    protect(eventDispatcher())->initializeConnection(*connection);
 #if PLATFORM(IOS_FAMILY)
     Ref { m_viewUpdateDispatcher }->initializeConnection(*connection);
 #endif // PLATFORM(IOS_FAMILY)
@@ -592,7 +592,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
     for (auto& supplement : m_supplements.values())
         supplement->initialize(parameters);
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
-    protectedRemoteMediaPlayerManager()->initialize(parameters);
+    protect(remoteMediaPlayerManager())->initialize(parameters);
 #endif
 
     setCacheModel(parameters.cacheModel);
@@ -836,13 +836,6 @@ void WebProcess::setHasSuspendedPageProxy(bool hasSuspendedPageProxy)
     ASSERT(m_hasSuspendedPageProxy != hasSuspendedPageProxy);
     m_hasSuspendedPageProxy = hasSuspendedPageProxy;
 }
-
-#if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
-Ref<RemoteImageDecoderAVFManager> WebProcess::protectedRemoteImageDecoderAVFManager()
-{
-    return m_remoteImageDecoderAVFManager;
-}
-#endif
 
 void WebProcess::setIsInProcessCache(bool isInProcessCache, CompletionHandler<void()>&& completionHandler)
 {
@@ -1513,19 +1506,9 @@ WebFileSystemStorageConnection& WebProcess::fileSystemStorageConnection()
     return *m_fileSystemStorageConnection;
 }
 
-Ref<WebFileSystemStorageConnection> WebProcess::protectedFileSystemStorageConnection()
-{
-    return fileSystemStorageConnection();
-}
-
 WebLoaderStrategy& WebProcess::webLoaderStrategy()
 {
     return m_webLoaderStrategy;
-}
-
-Ref<WebLoaderStrategy> WebProcess::protectedWebLoaderStrategy()
-{
-    return m_webLoaderStrategy.get();
 }
 
 #if ENABLE(GPU_PROCESS)
@@ -1590,11 +1573,6 @@ LibWebRTCCodecs& WebProcess::libWebRTCCodecs()
     if (!m_libWebRTCCodecs)
         m_libWebRTCCodecs = LibWebRTCCodecs::create();
     return *m_libWebRTCCodecs;
-}
-
-Ref<LibWebRTCCodecs> WebProcess::protectedLibWebRTCCodecs()
-{
-    return libWebRTCCodecs();
 }
 #endif
 
@@ -2230,11 +2208,6 @@ LibWebRTCNetwork& WebProcess::libWebRTCNetwork()
         lazyInitialize(m_libWebRTCNetwork, makeUniqueWithoutRefCountedCheck<LibWebRTCNetwork>(*this));
     return *m_libWebRTCNetwork;
 }
-
-Ref<LibWebRTCNetwork> WebProcess::protectedLibWebRTCNetwork()
-{
-    return libWebRTCNetwork();
-}
 #endif
 
 void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType workerType, PageGroupIdentifier pageGroupID, WebPageProxyIdentifier webPageProxyID, PageIdentifier pageID, const WebPreferencesStore& store, Site&& site, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, RemoteWorkerInitializationData&& initializationData, CompletionHandler<void()>&& completionHandler)
@@ -2407,7 +2380,7 @@ void WebProcess::setAppBadge(WebCore::Frame* frame, const WebCore::SecurityOrigi
 void WebProcess::displayDidRefresh(uint32_t displayID, const DisplayUpdate& displayUpdate)
 {
     ASSERT(RunLoop::isMain());
-    protectedEventDispatcher()->notifyScrollingTreesDisplayDidRefresh(displayID);
+    protect(eventDispatcher())->notifyScrollingTreesDisplayDidRefresh(displayID);
     DisplayRefreshMonitorManager::sharedManager().displayDidRefresh(displayID, displayUpdate);
 }
 #endif
@@ -2490,7 +2463,7 @@ void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)
     auto& cdmFactories = CDMFactory::registeredFactories();
     cdmFactories.clear();
     if (useGPUProcessForMedia)
-        protectedCDMFactory()->registerFactory(cdmFactories);
+        protect(cdmFactory())->registerFactory(cdmFactories);
     else
         CDMFactory::platformRegisterFactories(cdmFactories);
 #endif
@@ -2511,7 +2484,7 @@ void WebProcess::setUseGPUProcessForMedia(bool useGPUProcessForMedia)
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     if (useGPUProcessForMedia)
-        protectedLegacyCDMFactory()->registerFactory();
+        protect(legacyCDMFactory())->registerFactory();
     else
         LegacyCDM::resetFactories();
 #endif
@@ -2610,22 +2583,12 @@ RemoteLegacyCDMFactory& WebProcess::legacyCDMFactory()
 {
     return *supplement<RemoteLegacyCDMFactory>();
 }
-
-Ref<RemoteLegacyCDMFactory> WebProcess::protectedLegacyCDMFactory()
-{
-    return legacyCDMFactory();
-}
 #endif
 
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 RemoteCDMFactory& WebProcess::cdmFactory()
 {
     return *supplement<RemoteCDMFactory>();
-}
-
-Ref<RemoteCDMFactory> WebProcess::protectedCDMFactory()
-{
-    return cdmFactory();
 }
 #endif
 
@@ -2711,18 +2674,6 @@ void WebProcess::enableMediaPlayback()
 #if ENABLE(ROUTING_ARBITRATION)
     lazyInitialize(m_routingArbitrator, makeUniqueWithoutRefCountedCheck<AudioSessionRoutingArbitrator>(*this));
 #endif
-}
-
-#if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
-Ref<RemoteMediaPlayerManager> WebProcess::protectedRemoteMediaPlayerManager()
-{
-    return m_remoteMediaPlayerManager;
-}
-#endif
-
-Ref<WebCookieJar> WebProcess::protectedCookieJar()
-{
-    return m_cookieJar;
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -284,7 +284,6 @@ public:
     void setTextCheckerState(OptionSet<TextCheckerState>);
 
     EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
-    Ref<EventDispatcher> protectedEventDispatcher() { return m_eventDispatcher; }
     Ref<WebInspectorInterruptDispatcher> protectedWebInspectorInterruptDispatcher() { return m_webInspectorInterruptDispatcher; }
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     Ref<WasmDebuggerDispatcher> protectedWasmDebuggerDispatcher() { return m_wasmDebuggerDispatcher; }
@@ -297,9 +296,7 @@ public:
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
     RefPtr<NetworkProcessConnection> protectedNetworkProcessConnection();
     WebLoaderStrategy& webLoaderStrategy();
-    Ref<WebLoaderStrategy> protectedWebLoaderStrategy();
     WebFileSystemStorageConnection& fileSystemStorageConnection();
-    Ref<WebFileSystemStorageConnection> protectedFileSystemStorageConnection();
 
     RefPtr<WebTransportSession> webTransportSession(WebTransportSessionIdentifier);
     void addWebTransportSession(WebTransportSessionIdentifier, WebTransportSession&);
@@ -326,18 +323,15 @@ public:
 
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
     LibWebRTCCodecs& libWebRTCCodecs();
-    Ref<LibWebRTCCodecs> protectedLibWebRTCCodecs();
 #endif
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
     AudioMediaStreamTrackRendererInternalUnitManager& audioMediaStreamTrackRendererInternalUnitManager();
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RemoteLegacyCDMFactory& legacyCDMFactory();
-    Ref<RemoteLegacyCDMFactory> protectedLegacyCDMFactory();
 #endif
 #if ENABLE(ENCRYPTED_MEDIA)
     RemoteCDMFactory& cdmFactory();
-    Ref<RemoteCDMFactory> protectedCDMFactory();
 #endif
     RemoteMediaEngineConfigurationFactory& mediaEngineConfigurationFactory();
 #endif // ENABLE(GPU_PROCESS)
@@ -350,7 +344,6 @@ public:
 
 #if USE(LIBWEBRTC)
     LibWebRTCNetwork& libWebRTCNetwork();
-    Ref<LibWebRTCNetwork> protectedLibWebRTCNetwork();
 #endif
 
     void setCacheModel(CacheModel);
@@ -418,15 +411,12 @@ public:
     WebBadgeClient& badgeClient() { return m_badgeClient.get(); }
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
     RemoteMediaPlayerManager& remoteMediaPlayerManager() { return m_remoteMediaPlayerManager.get(); }
-    Ref<RemoteMediaPlayerManager> protectedRemoteMediaPlayerManager();
 #endif
 #if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
     RemoteImageDecoderAVFManager& remoteImageDecoderAVFManager() { return m_remoteImageDecoderAVFManager.get(); }
-    Ref<RemoteImageDecoderAVFManager> protectedRemoteImageDecoderAVFManager();
 #endif
     WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
     WebCookieJar& cookieJar() { return m_cookieJar.get(); }
-    Ref<WebCookieJar> protectedCookieJar();
     WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
 
     Ref<WebNotificationManager> protectedNotificationManager();

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -301,7 +301,7 @@ void PlaybackSessionManager::setUpPlaybackControlsManager(WebCore::HTMLMediaElem
             RefPtr previousElement = dynamicDowncast<HTMLVideoElement>(mediaElementWithContextId(*previousContextId));
             if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(mediaElement); videoElement && previousElement
                 && previousElement->fullscreenMode() != HTMLMediaElement::VideoFullscreenModeNone) {
-                page->protectedVideoPresentationManager()->swapFullscreenModes(*videoElement, *previousElement);
+                protect(page->videoPresentationManager())->swapFullscreenModes(*videoElement, *previousElement);
 
                 page->send(Messages::PlaybackSessionManagerProxy::SwapFullscreenModes(processQualify(contextId), processQualify(*previousContextId)));
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
@@ -40,7 +40,7 @@ Ref<RealtimeMediaSource> RemoteRealtimeAudioSource::create(const CaptureDevice& 
 {
     auto source = adoptRef(*new RemoteRealtimeAudioSource(RealtimeMediaSourceIdentifier::generate(), device, constraints, WTF::move(hashSalts), manager, shouldCaptureInGPUProcess, pageIdentifier));
     manager.addSource(source.copyRef());
-    manager.protectedRemoteCaptureSampleManager()->addSource(source.copyRef());
+    protect(manager.remoteCaptureSampleManager())->addSource(source.copyRef());
     source->createRemoteMediaSource();
     return source;
 }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -116,7 +116,7 @@ void RemoteRealtimeMediaSource::applyConstraintsSucceeded(WebCore::RealtimeMedia
 void RemoteRealtimeMediaSource::stopProducingData()
 {
     if (isAudio())
-        m_manager->protectedRemoteCaptureSampleManager()->audioSourceWillBeStopped(identifier());
+        protect(m_manager->remoteCaptureSampleManager())->audioSourceWillBeStopped(identifier());
     m_proxy.stopProducingData();
 }
 
@@ -127,7 +127,7 @@ void RemoteRealtimeMediaSource::didEnd()
 
     m_proxy.end();
     m_manager->removeSource(identifier());
-    m_manager->protectedRemoteCaptureSampleManager()->removeSource(identifier());
+    protect(m_manager->remoteCaptureSampleManager())->removeSource(identifier());
 }
 
 void RemoteRealtimeMediaSource::captureStopped(bool didFail)
@@ -153,7 +153,7 @@ void RemoteRealtimeMediaSource::gpuProcessConnectionDidClose(GPUProcessConnectio
         return;
 
     m_proxy.updateConnection();
-    m_manager->protectedRemoteCaptureSampleManager()->didUpdateSourceConnection(Ref { m_proxy.connection() });
+    protect(m_manager->remoteCaptureSampleManager())->didUpdateSourceConnection(Ref { m_proxy.connection() });
     m_proxy.resetReady();
     createRemoteMediaSource();
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -94,7 +94,6 @@ public:
 
 private:
     struct PromiseConverter;
-    Ref<IPC::Connection> protectedConnection() const;
 
     WebCore::RealtimeMediaSourceIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -39,7 +39,7 @@ Ref<RealtimeMediaSource> RemoteRealtimeVideoSource::create(const CaptureDevice& 
 {
     auto source = adoptRef(*new RemoteRealtimeVideoSource(RealtimeMediaSourceIdentifier::generate(), device, constraints, WTF::move(hashSalts), manager, shouldCaptureInGPUProcess, pageIdentifier));
     manager.addSource(source.copyRef());
-    manager.protectedRemoteCaptureSampleManager()->addSource(source.copyRef());
+    protect(manager.remoteCaptureSampleManager())->addSource(source.copyRef());
     source->createRemoteMediaSource();
     return source;
 }
@@ -81,7 +81,7 @@ Ref<RealtimeMediaSource> RemoteRealtimeVideoSource::clone()
         clone->setMuted(muted());
 
         manager().addSource(*clone);
-        manager().protectedRemoteCaptureSampleManager()->addSource(*clone);
+        protect(manager().remoteCaptureSampleManager())->addSource(*clone);
         proxy().createRemoteCloneSource(clone->identifier(), *pageIdentifier());
 
         bool isNewClonedSource = true;

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp
@@ -64,7 +64,7 @@ UserMediaCaptureManager::~UserMediaCaptureManager()
     RealtimeMediaSourceCenter::singleton().unsetDisplayCaptureFactory(m_displayFactory);
     RealtimeMediaSourceCenter::singleton().unsetVideoCaptureFactory(m_videoFactory);
     m_process->removeMessageReceiver(Messages::UserMediaCaptureManager::messageReceiverName());
-    protectedRemoteCaptureSampleManager()->stopListeningForIPC();
+    protect(remoteCaptureSampleManager())->stopListeningForIPC();
 }
 
 void UserMediaCaptureManager::ref() const
@@ -236,7 +236,7 @@ CaptureSourceOrError UserMediaCaptureManager::VideoFactory::createVideoCaptureSo
         return CaptureSourceOrError { "Video capture in GPUProcess is not implemented"_s };
 #endif
     if (m_shouldCaptureInGPUProcess)
-        m_manager->protectedRemoteCaptureSampleManager()->setVideoFrameObjectHeapProxy(&WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy());
+        protect(m_manager->remoteCaptureSampleManager())->setVideoFrameObjectHeapProxy(&WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy());
 
     return RemoteRealtimeVideoSource::create(device, constraints, WTF::move(hashSalts), m_manager, m_shouldCaptureInGPUProcess, pageIdentifier);
 }
@@ -249,7 +249,7 @@ CaptureSourceOrError UserMediaCaptureManager::DisplayFactory::createDisplayCaptu
 #endif
     if (m_shouldCaptureInGPUProcess) {
         Ref videoFrameObjectHeapProxy = WebProcess::singleton().ensureProtectedGPUProcessConnection()->videoFrameObjectHeapProxy();
-        m_manager->protectedRemoteCaptureSampleManager()->setVideoFrameObjectHeapProxy(WTF::move(videoFrameObjectHeapProxy));
+        protect(m_manager->remoteCaptureSampleManager())->setVideoFrameObjectHeapProxy(WTF::move(videoFrameObjectHeapProxy));
     }
 
     return RemoteRealtimeVideoSource::create(device, constraints, WTF::move(hashSalts), m_manager, m_shouldCaptureInGPUProcess, pageIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -78,7 +78,6 @@ public:
     void addSource(Ref<RemoteRealtimeVideoSource>&&);
     void removeSource(WebCore::RealtimeMediaSourceIdentifier);
 
-    Ref<RemoteCaptureSampleManager> protectedRemoteCaptureSampleManager() { return m_remoteCaptureSampleManager; }
     RemoteCaptureSampleManager& remoteCaptureSampleManager() { return m_remoteCaptureSampleManager; }
     bool shouldUseGPUProcessRemoteFrames() const { return m_shouldUseGPUProcessRemoteFrames; }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -238,7 +238,7 @@ id WebProcess::accessibilityFocusedUIElement()
             RefPtr page = WebProcess::singleton().focusedWebPage();
             if (!page || !page->accessibilityRemoteObject())
                 return nil;
-            return [page->protectedAccessibilityRemoteObject() accessibilityFocusedUIElement];
+            return [protect(page->accessibilityRemoteObject()) accessibilityFocusedUIElement];
         });
     };
 


### PR DESCRIPTION
#### 499d23e470fa049fa0675e8801276ea907da1be1
<pre>
Reduce use of protected functions in Source/WebKit/WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=306401">https://bugs.webkit.org/show_bug.cgi?id=306401</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getCookiesForFrame):
(WebKit::WebAutomationSessionProxy::deleteCookie):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIWebPageRuntime::sendMessage):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
(WebKit::matches):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeConnectEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::connect):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::videoControlsManagerDidChange):
(WebKit::WebFullScreenManager::supportsFullScreenForElement):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::didEnterFullScreen):
(WebKit::WebFullScreenManager::didExitFullScreen):
(WebKit::WebFullScreenManager::setFullscreenInsets):
(WebKit::WebFullScreenManager::setFullscreenAutoHideDuration):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::mediaPlayerManager):
(WebKit::GPUProcessConnection::audioSourceProviderManager):
(WebKit::GPUProcessConnection::dispatchMessage):
(WebKit::GPUProcessConnection::didInitialize):
(WebKit::GPUProcessConnection::protectedSampleBufferDisplayLayerManager): Deleted.
(WebKit::GPUProcessConnection::protectedVideoFrameObjectHeapProxy): Deleted.
(WebKit::GPUProcessConnection::protectedMediaPlayerManager): Deleted.
(WebKit::GPUProcessConnection::protectedAudioSourceProviderManager): Deleted.
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::surfaceBufferToVideoFrame):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::currentVideoFrame const):
(WebKit::AudioVideoRendererRemote::currentNativeImage const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp:
(WebKit::RemoteAudioSourceProvider::create):
(WebKit::RemoteAudioSourceProvider::close):
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.cpp:
(WebKit::RemoteLegacyCDMFactory::createCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteVideoCodecFactory.cpp:
(WebKit::RemoteVideoCodecFactory::createDecoder):
(WebKit::RemoteVideoCodecFactory::createEncoder):
(WebKit::RemoteVideoDecoder::RemoteVideoDecoder):
(WebKit::RemoteVideoDecoder::~RemoteVideoDecoder):
(WebKit::RemoteVideoDecoder::flush):
(WebKit::RemoteVideoEncoder::~RemoteVideoEncoder):
(WebKit::RemoteVideoEncoder::setRates):
(WebKit::RemoteVideoEncoder::flush):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::nativeImageFromVideoFrame):
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::nativeImageForCurrentTime):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::releaseVideoDecoder):
(WebKit::decodeVideoFrame):
(WebKit::registerDecodeCompleteCallback):
(WebKit::createVideoEncoder):
(WebKit::releaseVideoEncoder):
(WebKit::initializeVideoEncoder):
(WebKit::encodeVideoFrame):
(WebKit::registerEncodeCompleteCallback):
(WebKit::setEncodeRatesCallback):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame appleTouchIconURLs]):
(-[WKWebProcessPlugInFrame faviconURLs]):
(-[WKWebProcessPlugInFrame _hasCustomContentProvider]):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameGetPage):
(WKBundleFrameFocus):
(_WKAccessibilityRootObjectForTesting):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageClickMenuItem):
(WKBundlePageHasLocalDataForURL):
(WKBundlePageCloseInspectorForTest):
(WKBundlePageEvaluateScriptInInspectorForTest):
(WKBundlePageSetCaptionDisplayMode):
(WKBundlePageCreateCaptionUserPreferencesTestingModeToken):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::removeAllWebNotificationPermissions):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension):
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::RemoteWebInspectorUI):
(WebKit::RemoteWebInspectorUI::initialize):
(WebKit::RemoteWebInspectorUI::windowObjectCleared):
(WebKit::RemoteWebInspectorUI::closeWindow):
(WebKit::RemoteWebInspectorUI::logDiagnosticEvent):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::showMainResourceForFrame):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
(WebKit::WebInspectorBackendClient::openLocalFrontend):
(WebKit::WebInspectorBackendClient::showPaintRect):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::WebInspectorUI):
(WebKit::WebInspectorUI::windowObjectCleared):
(WebKit::WebInspectorUI::logDiagnosticEvent):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::NetworkProcessConnection):
(WebKit::NetworkProcessConnection::dispatchMessage):
(WebKit::NetworkProcessConnection::didFinishPingLoad):
(WebKit::NetworkProcessConnection::didFinishPreconnection):
(WebKit::NetworkProcessConnection::setOnLineState):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
(WebKit::WebLoaderStrategy::browsingContextRemoved):
(WebKit::WebLoaderStrategy::preconnectTo):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.cpp:
(WebKit::LibWebRTCNetwork::networkProcessCrashed):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.h:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::getOrCreate):
(WebKit::LibWebRTCNetworkManager::close):
(WebKit::LibWebRTCNetworkManager::unregisterMDNSNames):
(WebKit::LibWebRTCNetworkManager::StopUpdating):
(WebKit::LibWebRTCNetworkManager::CreateNameForAddress):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.cpp:
(WebKit::LibWebRTCProvider::disableNonLocalhostConnections):
(WebKit::LibWebRTCProvider::startedNetworkThread):
(WebKit::LibWebRTCProvider::setLoggingLevel):
* Source/WebKit/WebProcess/Network/webrtc/WebRTCNetworkBase.h:
(WebKit::WebRTCNetworkBase::mdnsRegister):
(WebKit::WebRTCNetworkBase::protectedMDNSRegister): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::PDFPlugin):
(WebKit::PDFPlugin::updateScrollbars):
(WebKit::PDFPlugin::teardown):
(WebKit::PDFPlugin::handleContextMenuEvent):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::graphicsLayer const):
(WebKit::PDFPluginBase::activeAnnotation const):
(WebKit::PDFPluginBase::protectedHorizontalScrollbar const): Deleted.
(WebKit::PDFPluginBase::protectedVerticalScrollbar const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::notifySelectionChanged):
(WebKit::PDFPluginBase::startByteRangeRequest):
(WebKit::PDFPluginBase::addArchiveResource):
(WebKit::PDFPluginBase::print):
(WebKit::PDFPluginBase::updateHUDLocation):
(WebKit::PDFPluginBase::protectedGraphicsLayer const): Deleted.
(WebKit::PDFPluginBase::protectedActiveAnnotation const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::deviceOrPageScaleFactorChanged):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::updateFindOverlay):
(WebKit::UnifiedPDFPlugin::textIndicatorDataForPageRect):
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorVisibility):
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorLocation):
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorCurrentPage):
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::Stream::start):
(WebKit::PluginView::initializePlugin):
(WebKit::PluginView::protectedFrame const): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::closeWindow):
(WebKit::WebChromeClient::invalidateContentsAndRootView):
(WebKit::WebChromeClient::invalidateContentsForSlowScroll):
(WebKit::WebChromeClient::scroll):
(WebKit::WebChromeClient::contentsSizeChanged const):
(WebKit::WebChromeClient::createWorkerClient):
(WebKit::WebChromeClient::createScrollingCoordinator const):
(WebKit::WebChromeClient::ensureScrollbarsController const):
(WebKit::WebChromeClient::canEnterVideoFullscreen const):
(WebKit::WebChromeClient::supportsVideoFullscreen):
(WebKit::WebChromeClient::supportsVideoFullscreenStandby):
(WebKit::WebChromeClient::enterVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::setPlayerIdentifierForVideoElement):
(WebKit::WebChromeClient::exitVideoFullscreenForVideoElement):
(WebKit::WebChromeClient::setUpPlaybackControlsManager):
(WebKit::WebChromeClient::clearPlaybackControlsManager):
(WebKit::WebChromeClient::mediaEngineChanged):
(WebKit::WebChromeClient::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::WebChromeClient::setVideoFullscreenMode):
(WebKit::WebChromeClient::clearVideoFullscreenMode):
(WebKit::WebChromeClient::supportsFullScreenForElement):
(WebKit::WebChromeClient::enterFullScreenForElement):
(WebKit::WebChromeClient::exitFullScreenForElement):
(WebKit::WebChromeClient::shouldUseTiledBackingForFrameView const):
(WebKit::WebChromeClient::isUsingUISideCompositing const):
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
(WebKit::WebContextMenuClient::showContextMenu):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::restoreViewState):
(WebKit::WebLocalFrameLoaderClient::createDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::updateCachedDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedFromCachedFrame):
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedForNewPage):
(WebKit::WebLocalFrameLoaderClient::objectContentType):
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::requestPermission):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::performDictionaryLookupAtLocation):
(WebKit::WebPage::resolveAccessibilityHitTestForTesting):
(WebKit::WebPage::getAccessibilityWebProcessDebugInfo):
(WebKit::WebPage::getContentsAsAttributedString):
(WebKit::WebPage::getPDFFirstPageSize):
(WebKit::WebPage::willBeginWritingToolsSession):
(WebKit::WebPage::didBeginWritingToolsSession):
(WebKit::WebPage::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPage::proofreadingSessionDidUpdateStateForSuggestion):
(WebKit::WebPage::willEndWritingToolsSession):
(WebKit::WebPage::didEndWritingToolsSession):
(WebKit::WebPage::compositionSessionDidReceiveTextWithReplacementRange):
(WebKit::WebPage::writingToolsSessionDidReceiveAction):
(WebKit::WebPage::proofreadingSessionSuggestionTextRectsInRootViewCoordinates const):
(WebKit::WebPage::updateTextVisibilityForActiveWritingToolsSession):
(WebKit::WebPage::textPreviewDataForActiveWritingToolsSession):
(WebKit::WebPage::decorateTextReplacementsForActiveWritingToolsSession):
(WebKit::WebPage::setSelectionForActiveWritingToolsSession):
(WebKit::WebPage::intelligenceTextAnimationsDidComplete):
(WebKit::WebPage::setObscuredContentInsetsFenced):
(WebKit::WebPage::protectedAccessibilityRemoteObject): Deleted.
(WebKit::WebPage::protectedWebExtensionControllerProxy const): Deleted.
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::countStringMatches):
(WebKit::FindController::replaceMatches):
(WebKit::FindController::updateFindUIAfterPageScroll):
(WebKit::FindController::findStringIncludingImages):
(WebKit::FindController::findString):
(WebKit::FindController::findStringMatches):
(WebKit::FindController::indicateFindMatch):
(WebKit::FindController::hideFindUI):
(WebKit::FindController::updateFindIndicator):
(WebKit::FindController::didFindString):
(WebKit::FindController::rectsForTextMatchesInRect):
(WebKit::FindController::drawRect):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::layerDidEnterContext):
(WebKit::RemoteLayerTreeContext::layerWillLeaveContext):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRenderingWithForcedRepaint):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::scheduleTreeStateCommit):
* Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp:
(WebKit::WebCookieCache::cookiesForDOM):
(WebKit::WebCookieCache::clear):
(WebKit::WebCookieCache::clearForHost):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
(WebKit::WebFoundTextRangeController::clearAllDecoratedFoundText):
(WebKit::WebFoundTextRangeController::frameForFoundTextRange const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::didReceivePolicyDecision):
(WebKit::WebFrame::jsContextForServiceWorkerWorld):
(WebKit::WebFrame::createSelectionSnapshot const):
(WebKit::WebFrame::handleContextMenuEvent):
(WebKit::WebFrame::protectedLocalFrameLoaderClient const): Deleted.
(WebKit::WebFrame::protectedPage const): Deleted.
(WebKit::WebFrame::protectedCoreLocalFrame const): Deleted.
(WebKit::WebFrame::protectedCoreFrame const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updateAfterDrawingAreaCreation):
(WebKit::WebPage::gpuProcessConnectionWasDestroyed):
(WebKit::WebPage::pauseAllMediaPlayback):
(WebKit::WebPage::suspendAllMediaPlayback):
(WebKit::WebPage::resumeAllMediaPlayback):
(WebKit::WebPage::suspendAllMediaBuffering):
(WebKit::WebPage::resumeAllMediaBuffering):
(WebKit::WebPage::shouldDispatchSyntheticMouseEventsWhenModifyingSelection const):
(WebKit::WebPage::renderTreeExternalRepresentation const):
(WebKit::WebPage::renderTreeExternalRepresentationForPrinting const):
(WebKit::WebPage::setEditable):
(WebKit::WebPage::enterAcceleratedCompositingMode):
(WebKit::WebPage::exitAcceleratedCompositingMode):
(WebKit::WebPage::close):
(WebKit::WebPage::suspendForProcessSwap):
(WebKit::WebPage::goToBackForwardItem):
(WebKit::WebPage::setSize):
(WebKit::WebPage::accessibilitySettingsDidChange):
(WebKit::WebPage::screenPropertiesDidChange):
(WebKit::WebPage::setSuppressScrollbarAnimations):
(WebKit::WebPage::setEnableVerticalRubberBanding):
(WebKit::WebPage::setEnableHorizontalRubberBanding):
(WebKit::WebPage::setUnderPageBackgroundColorOverride):
(WebKit::WebPage::setShouldSuppressHDR):
(WebKit::WebPage::setHeaderBannerHeight):
(WebKit::WebPage::setFooterBannerHeight):
(WebKit::WebPage::takeSnapshot):
(WebKit::snapshotColorSpace):
(WebKit::WebPage::pageDidScroll):
(WebKit::WebPage::contextMenuForKeyEvent):
(WebKit::WebPage::startDeferringResizeEvents):
(WebKit::WebPage::flushDeferredResizeEvents):
(WebKit::WebPage::startDeferringScrollEvents):
(WebKit::WebPage::flushDeferredScrollEvents):
(WebKit::WebPage::startDeferringIntersectionObservations):
(WebKit::WebPage::flushDeferredIntersectionObservations):
(WebKit::WebPage::handleKeyEventByRelinquishingFocusToChrome):
(WebKit::WebPage::updateIsInWindow):
(WebKit::WebPage::setActivityState):
(WebKit::WebPage::suspendActiveDOMObjectsAndAnimations):
(WebKit::WebPage::resumeActiveDOMObjectsAndAnimations):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::getResourceDataFromFrame):
(WebKit::WebPage::getAccessibilityTreeData):
(WebKit::WebPage::updateRenderingWithForcedRepaintWithoutCallback):
(WebKit::WebPage::updateRenderingWithForcedRepaint):
(WebKit::WebPage::updatePreferences):
(WebKit::WebPage::detectDataInAllFrames):
(WebKit::WebPage::layoutIfNeeded):
(WebKit::WebPage::updateRendering):
(WebKit::WebPage::didUpdateRendering):
(WebKit::WebPage::finalizeRenderingUpdate):
(WebKit::WebPage::willStartRenderingUpdateDisplay):
(WebKit::WebPage::didCompleteRenderingUpdateDisplay):
(WebKit::WebPage::didCompleteRenderingFrame):
(WebKit::WebPage::videoPresentationManager):
(WebKit::WebPage::videoControlsManagerDidChange):
(WebKit::WebPage::sendReportToEndpoints):
(WebKit::WebPage::voiceActivityDetected):
(WebKit::WebPage::mainFrameDidLayout):
(WebKit::WebPage::setMainFrameIsScrollable):
(WebKit::WebPage::dispatchMessage):
(WebKit::WebPage::scrollingCoordinator const):
(WebKit::WebPage::setUseColorAppearance):
(WebKit::WebPage::beginPrinting):
(WebKit::WebPage::endPrintingImmediately):
(WebKit::WebPage::setMediaVolume):
(WebKit::WebPage::setMuted):
(WebKit::WebPage::stopMediaCapture):
(WebKit::WebPage::didChangeSelection):
(WebKit::WebPage::setAlwaysShowsHorizontalScroller):
(WebKit::WebPage::setAlwaysShowsVerticalScroller):
(WebKit::WebPage::canShowResponse const):
(WebKit::WebPage::canShowMIMEType const):
(WebKit::WebPage::willReplaceMultipartContent):
(WebKit::WebPage::didReplaceMultipartContent):
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::scheduleFullEditorStateUpdate):
(WebKit::WebPage::flushPendingThemeColorChange):
(WebKit::WebPage::flushPendingPageExtendedBackgroundColorChange):
(WebKit::WebPage::flushPendingSampledPageTopColorChange):
(WebKit::WebPage::setUserInterfaceLayoutDirection):
(WebKit::WebPage::speakingErrorOccurred):
(WebKit::WebPage::boundaryEventOccurred):
(WebKit::WebPage::voicesDidChange):
(WebKit::WebPage::textAutoSizingAdjustmentTimerFired):
(WebKit::WebPage::setOverriddenMediaType):
(WebKit::WebPage::requestTextRecognition):
(WebKit::WebPage::startVisualTranslation):
(WebKit::WebPage::createTextFragmentDirectiveFromSelection):
(WebKit::WebPage::createMediaSessionCoordinator):
(WebKit::WebPage::updateImageAnimationEnabled):
(WebKit::WebPage::pauseAllAnimations):
(WebKit::WebPage::playAllAnimations):
(WebKit::WebPage::elementWasFocusedInAnotherProcess):
(WebKit::WebPage::frameWasFocusedInAnotherProcess):
(WebKit::WebPage::remotePostMessage):
(WebKit::WebPage::isAlwaysOnLoggingAllowed const):
(WebKit::WebPage::showCaptionDisplaySettingsPreview):
(WebKit::WebPage::hideCaptionDisplaySettingsPreview):
(WebKit::WebPage::protectedCorePage const): Deleted.
(WebKit::WebPage::protectedContextMenu): Deleted.
(WebKit::WebPage::protectedInspector): Deleted.
(WebKit::WebPage::protectedPlaybackSessionManager): Deleted.
(WebKit::WebPage::protectedVideoPresentationManager): Deleted.
(WebKit::WebPage::protectedFullscreenManager): Deleted.
(WebKit::WebPage::protectedNotificationPermissionRequestManager): Deleted.
(WebKit::WebPage::protectedScrollingCoordinator const): Deleted.
(WebKit::WebPage::protectedDrawingArea const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPageInlines.h:
(WebKit::WebPage::setHiddenPageDOMTimerThrottlingIncreaseLimit):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::displayAndTrackRepaints):
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp:
(WebKit::WebURLSchemeHandlerProxy::startNewTask):
(WebKit::WebURLSchemeHandlerProxy::removeTask):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):
* Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm:
(WebKit::PageBanner::addToPage):
(WebKit::PageBanner::hide):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::registerScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::unregisterScrollingTree):
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaint):
(WebKit::TiledCoreAnimationDrawingArea::updateRenderingWithForcedRepaintAsync):
(WebKit::TiledCoreAnimationDrawingArea::updatePreferences):
(WebKit::TiledCoreAnimationDrawingArea::dispatchAfterEnsuringUpdatedScrollPosition):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::platformInitializeAccessibility):
(WebKit::WebPage::updateRemotePageAccessibilityOffset):
(WebKit::WebPage::semanticContextDidChange):
(WebKit::WebPage::immediateActionDidUpdate):
(WebKit::WebPage::immediateActionDidCancel):
(WebKit::WebPage::immediateActionDidComplete):
(WebKit::WebPage::playbackTargetSelected const):
(WebKit::WebPage::playbackTargetAvailabilityDidChange):
(WebKit::WebPage::setShouldPlayToPlaybackTarget):
(WebKit::WebPage::playbackTargetPickerWasDismissed):
(WebKit::WebPage::didEndMagnificationGesture):
(WebKit::WebPage::setAppUsesCustomAccentColor):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeConnection):
(WebKit::WebProcess::initializeWebProcess):
(WebKit::WebProcess::libWebRTCCodecs):
(WebKit::WebProcess::libWebRTCNetwork):
(WebKit::WebProcess::displayDidRefresh):
(WebKit::WebProcess::setUseGPUProcessForMedia):
(WebKit::WebProcess::legacyCDMFactory):
(WebKit::WebProcess::cdmFactory):
(WebKit::WebProcess::protectedRemoteImageDecoderAVFManager): Deleted.
(WebKit::WebProcess::protectedFileSystemStorageConnection): Deleted.
(WebKit::WebProcess::protectedWebLoaderStrategy): Deleted.
(WebKit::WebProcess::protectedLibWebRTCCodecs): Deleted.
(WebKit::WebProcess::protectedLibWebRTCNetwork): Deleted.
(WebKit::WebProcess::protectedLegacyCDMFactory): Deleted.
(WebKit::WebProcess::protectedCDMFactory): Deleted.
(WebKit::WebProcess::protectedRemoteMediaPlayerManager): Deleted.
(WebKit::WebProcess::protectedCookieJar): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::setUpPlaybackControlsManager):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeAudioSource.cpp:
(WebKit::RemoteRealtimeAudioSource::create):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::stopProducingData):
(WebKit::RemoteRealtimeMediaSource::didEnd):
(WebKit::RemoteRealtimeMediaSource::gpuProcessConnectionDidClose):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::startProducingData):
(WebKit::RemoteRealtimeMediaSourceProxy::stopProducingData):
(WebKit::RemoteRealtimeMediaSourceProxy::endProducingData):
(WebKit::RemoteRealtimeMediaSourceProxy::createRemoteMediaSource):
(WebKit::RemoteRealtimeMediaSourceProxy::createRemoteCloneSource):
(WebKit::RemoteRealtimeMediaSourceProxy::applyConstraints):
(WebKit::RemoteRealtimeMediaSourceProxy::takePhoto):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoCapabilities):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoSettings):
(WebKit::RemoteRealtimeMediaSourceProxy::end):
(WebKit::RemoteRealtimeMediaSourceProxy::isPowerEfficient const):
(WebKit::RemoteRealtimeMediaSourceProxy::protectedConnection const): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp:
(WebKit::RemoteRealtimeVideoSource::create):
(WebKit::RemoteRealtimeVideoSource::clone):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.cpp:
(WebKit::UserMediaCaptureManager::~UserMediaCaptureManager):
(WebKit::UserMediaCaptureManager::VideoFactory::createVideoCaptureSource):
(WebKit::UserMediaCaptureManager::DisplayFactory::createDisplayCaptureSource):
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):

Canonical link: <a href="https://commits.webkit.org/306376@main">https://commits.webkit.org/306376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c06c2aeb1999bf9fb6c13be38315a3df4a58dea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94174 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108325 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78494 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89232 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10521 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8112 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119775 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152041 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13147 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116475 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12880 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68320 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13190 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76894 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13128 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12973 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->