### PR TITLE
[threaded-animations] test `webanimations/accelerated-animations-and-motion-path.html` fails with "Threaded Time-based Animations" enabled

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-motion-path-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-motion-path-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Setting 'offset' on the underlying style should not prevent a 'transform' animation from being accelerated.
+PASS Toggling 'offset' dynamically on the underlying style should not affect the ability for a 'transform' animation to be accelerated.
+PASS Animating both 'offset' and 'transform' on the same animation should not prevent acceleration.
+PASS Animating both 'offset' and 'transform' on different animations should not prevent acceleration.
+PASS Setting keyframes on an animation to include 'offset' on top of 'transform' should not prevent acceleration.
+

--- a/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-motion-path.html
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-motion-path.html
@@ -1,7 +1,8 @@
-<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ] -->
 <body>
-<script src="../resources/testharness.js"></script>
-<script src="../resources/testharnessreport.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="threaded-animations-utils.js"></script>
 <style>
 
 div {
@@ -22,13 +23,6 @@ const createDiv = test => {
     return document.body.appendChild(div);
 }
 
-const animationReadyToAnimateAccelerated = async animation => {
-    await animation.ready;
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
-}
-
 const duration = 1000 * 1000; // 1000s.
 
 promise_test(async test => {
@@ -42,9 +36,9 @@ promise_test(async test => {
         { transform: "translateX(100px)" },
         { duration }
     );
-    await animationReadyToAnimateAccelerated(animation);
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
-}, "Setting 'offset' on the underlying style prevents a 'transform' animation from being accelerated.");
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+}, "Setting 'offset' on the underlying style should not prevent a 'transform' animation from being accelerated.");
 
 promise_test(async test => {
     const target = createDiv(test);
@@ -54,19 +48,19 @@ promise_test(async test => {
         { transform: "translateX(100px)" },
         { duration }
     );
-    await animationReadyToAnimateAccelerated(animation);
+    await animationAcceleration(animation);
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
 
     // Set offset on the underlying style.
     target.style.offset = "path('M10,10 H10')";
-    await animationReadyToAnimateAccelerated(animation);
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
 
     // Remove offset on the underlying style.
     target.style.removeProperty("offset");
-    await animationReadyToAnimateAccelerated(animation);
+    await animationAcceleration(animation);
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
-}, "Toggling 'offset' dynamically on the underlying style toggles the ability for a 'transform' animation to be accelerated.");
+}, "Toggling 'offset' dynamically on the underlying style should not affect the ability for a 'transform' animation to be accelerated.");
 
 promise_test(async test => {
     const target = createDiv(test);
@@ -75,9 +69,9 @@ promise_test(async test => {
         { transform: "translateX(100px)", cssOffset: ["path('M10,10 H10')", "path('M10,10 H20')"] },
         { duration }
     );
-    await animationReadyToAnimateAccelerated(animation);
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
-}, "Animating both 'offset' and 'transform' on the same animation prevents acceleration.");
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 6);
+}, "Animating both 'offset' and 'transform' on the same animation should not prevent acceleration.");
 
 promise_test(async test => {
     const target = createDiv(test);
@@ -88,22 +82,22 @@ promise_test(async test => {
         { transform: "translateX(100px)" },
         { duration }
     ));
-    await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
+    await Promise.all(animations.map(animation => animationAcceleration(animation)));
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
 
-    // Then, add an offset animation that prevents the whole stack from being accelerated.
+    // Then, add an offset animation.
     animations.push(target.animate(
         { cssOffset: ["path('M10,10 H10')", "path('M10,10 H20')"] },
         { duration }
     ));
-    await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+    await Promise.all(animations.map(animation => animationAcceleration(animation)));
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 6);
 
-    // Canceling the offset animation will no longer prevent the stack from being accelerated. 
+    // Canceling the offset animation. 
     animations.at(-1).cancel();
-    await Promise.all(animations.map(animation => animationReadyToAnimateAccelerated(animation)));
+    await threadedAnimationsCommit();
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
-}, "Animating both 'offset' and 'transform' on different animations prevents acceleration.");
+}, "Animating both 'offset' and 'transform' on different animations should not prevent acceleration.");
 
 promise_test(async test => {
     const target = createDiv(test);
@@ -112,15 +106,15 @@ promise_test(async test => {
         { transform: "translateX(100px)" },
         { duration }
     );
-    await animationReadyToAnimateAccelerated(animation);
+    await animationAcceleration(animation);
     assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
 
     animation.effect.setKeyframes(
         { transform: "translateX(100px)", cssOffset: ["path('M10,10 H10')", "path('M10,10 H20')"] }
     );
-    await animationReadyToAnimateAccelerated(animation);
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
-}, "Setting keyframes on an animation to include 'offset' on top of 'transform' prevents acceleration.");
+    await threadedAnimationsCommit();
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 6);
+}, "Setting keyframes on an animation to include 'offset' on top of 'transform' should not prevent acceleration.");
 
 </script>
 </body>


### PR DESCRIPTION
#### 5268de03dd9d47a9a4b62e968d68661fd4044edc
<pre>
[threaded-animations] test `webanimations/accelerated-animations-and-motion-path.html` fails with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306349">https://bugs.webkit.org/show_bug.cgi?id=306349</a>
<a href="https://rdar.apple.com/169014715">rdar://169014715</a>

Reviewed by Anne van Kesteren.

The test `webanimations/accelerated-animations-and-motion-path.html` fails with &quot;Threaded
Time-based Animations&quot; enabled because it makes the assumption that we cannot accelerate
CSS Motion Path properties. We update this test to force &quot;Threaded Time-based Animations&quot;
to be disabled and duplicate it with the new expected behavior with &quot;Threaded Time-based
Animations&quot; enabled.

* LayoutTests/webanimations/accelerated-animations-and-motion-path.html:
* LayoutTests/webanimations/threaded-animations/accelerated-animations-and-motion-path-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/accelerated-animations-and-motion-path.html: Added.

Canonical link: <a href="https://commits.webkit.org/306338@main">https://commits.webkit.org/306338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61bbd0f248150b3f2afb6b037a5ab31ab90c2686

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149591 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108326 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126255 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89233 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152045 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13151 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116478 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11488 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116821 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12881 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122929 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21764 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13194 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12933 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->