### PR TITLE
[JSC] Optimize `String#endsWith` in DFG/FTL

### DIFF
--- a/JSTests/microbenchmarks/string-prototype-endswith-constant-folding.js
+++ b/JSTests/microbenchmarks/string-prototype-endswith-constant-folding.js
@@ -1,0 +1,34 @@
+// Benchmark for String.prototype.endsWith constant folding
+
+function testConstantFound() {
+    return "Hello World".endsWith("World");
+}
+noInline(testConstantFound);
+
+function testConstantNotFound() {
+    return "Hello World".endsWith("Hello");
+}
+noInline(testConstantNotFound);
+
+function testConstantWithEndPosition() {
+    return "Hello World".endsWith("Hello", 5);
+}
+noInline(testConstantWithEndPosition);
+
+function testConstantOneChar() {
+    return "Hello World".endsWith("d");
+}
+noInline(testConstantOneChar);
+
+function testConstantOneCharWithEndPosition() {
+    return "Hello World".endsWith("o", 5);
+}
+noInline(testConstantOneCharWithEndPosition);
+
+for (var i = 0; i < 1e6; ++i) {
+    testConstantFound();
+    testConstantNotFound();
+    testConstantWithEndPosition();
+    testConstantOneChar();
+    testConstantOneCharWithEndPosition();
+}

--- a/JSTests/microbenchmarks/string-prototype-endswith-with-index.js
+++ b/JSTests/microbenchmarks/string-prototype-endswith-with-index.js
@@ -1,0 +1,23 @@
+// Benchmark for String.prototype.endsWith with endPosition argument
+
+function test(string, search, endPosition) {
+    return string.endsWith(search, endPosition);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("................................okokHellookok.............................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okok");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1, string.length);
+    test(string, search1, 41);
+    test(string, search1, 40);
+    test(string, search2, string.length);
+    test(string, search2, 45);
+}

--- a/JSTests/microbenchmarks/string-prototype-endswith-with-one-char.js
+++ b/JSTests/microbenchmarks/string-prototype-endswith-with-one-char.js
@@ -1,0 +1,22 @@
+// Benchmark for String.prototype.endsWith (single-char search, no endPosition)
+
+function test(string, search) {
+    return string.endsWith(search);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("................................okokHellookok.............................................");
+var search1 = makeString(".");
+var search2 = makeString("o");
+var search3 = makeString("X");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1);
+    test(string, search2);
+    test(string, search3);
+}

--- a/JSTests/microbenchmarks/string-prototype-endswith.js
+++ b/JSTests/microbenchmarks/string-prototype-endswith.js
@@ -1,0 +1,23 @@
+// Benchmark for String.prototype.endsWith (multi-char search, no endPosition)
+
+function test(string, search) {
+    return string.endsWith(search);
+}
+noInline(test);
+
+// Create strings dynamically to avoid constant folding
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("................................okokHellookok.............................................");
+var search1 = makeString(".....");
+var search2 = makeString("Hello");
+var search3 = makeString("NotFound");
+
+for (var i = 0; i < 1e6; ++i) {
+    test(string, search1);
+    test(string, search2);
+    test(string, search3);
+}

--- a/JSTests/stress/string-prototype-endswith-coerced-position.js
+++ b/JSTests/stress/string-prototype-endswith-coerced-position.js
@@ -1,0 +1,71 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search, endPosition) {
+    return string.endsWith(search, endPosition);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("HelloWorld");
+var search = makeString("Hello");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // NaN should be treated as 0 (NaN converts to 0 in ToIntegerOrInfinity)
+    shouldBe(test(string, makeString(""), NaN), true);
+    shouldBe(test(string, search, NaN), false);
+    shouldBe(test(string, makeString("H"), NaN), false);
+
+    // Infinity should be clamped to string length
+    shouldBe(test(string, makeString("World"), Infinity), true);
+    shouldBe(test(string, search, Infinity), false);
+    shouldBe(test(string, makeString("HelloWorld"), Infinity), true);
+
+    // -Infinity should be treated as 0
+    shouldBe(test(string, makeString(""), -Infinity), true);
+    shouldBe(test(string, search, -Infinity), false);
+
+    // Floating point numbers should be truncated
+    shouldBe(test(string, search, 5.0), true);
+    shouldBe(test(string, search, 5.9), true);
+    shouldBe(test(string, search, 5.1), true);
+    shouldBe(test(string, search, 4.9), false);
+    shouldBe(test(string, makeString("ello"), 5.0), true);
+    shouldBe(test(string, makeString("ello"), 4.0), false);
+
+    // Negative floating point
+    shouldBe(test(string, makeString(""), -0.5), true);
+    shouldBe(test(string, search, -0.5), false);
+
+    // undefined should be treated as string.length
+    shouldBe(test(string, makeString("World"), undefined), true);
+    shouldBe(test(string, search, undefined), false);
+
+    // null should be treated as 0
+    shouldBe(test(string, makeString(""), null), true);
+    shouldBe(test(string, search, null), false);
+
+    // Boolean coercion
+    shouldBe(test(string, makeString(""), false), true);
+    shouldBe(test(string, makeString("H"), true), true);
+    shouldBe(test(string, search, true), false);
+
+    // String coercion
+    shouldBe(test(string, makeString(""), "0"), true);
+    shouldBe(test(string, search, "5"), true);
+    shouldBe(test(string, search, "5.9"), true);
+    shouldBe(test(string, makeString("World"), "notanumber"), false); // "notanumber" -> NaN -> 0
+
+    // Object with valueOf
+    shouldBe(test(string, search, { valueOf: function() { return 5; } }), true);
+    shouldBe(test(string, search, { valueOf: function() { return 4; } }), false);
+
+    // Object with toString
+    shouldBe(test(string, search, { toString: function() { return "5"; } }), true);
+}

--- a/JSTests/stress/string-prototype-endswith-constant-folding.js
+++ b/JSTests/stress/string-prototype-endswith-constant-folding.js
@@ -1,0 +1,67 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function testConstantFound() {
+    return "Hello World".endsWith("World");
+}
+noInline(testConstantFound);
+
+function testConstantNotFound() {
+    return "Hello World".endsWith("Hello");
+}
+noInline(testConstantNotFound);
+
+function testConstantWithEndPosition() {
+    return "Hello World".endsWith("Hello", 5);
+}
+noInline(testConstantWithEndPosition);
+
+function testConstantWithEndPositionNotFound() {
+    return "Hello World".endsWith("Hello", 4);
+}
+noInline(testConstantWithEndPositionNotFound);
+
+function testConstantOneChar() {
+    return "Hello World".endsWith("d");
+}
+noInline(testConstantOneChar);
+
+function testConstantOneCharNotFound() {
+    return "Hello World".endsWith("o");
+}
+noInline(testConstantOneCharNotFound);
+
+function testConstantOneCharWithEndPosition() {
+    return "Hello World".endsWith("o", 5);
+}
+noInline(testConstantOneCharWithEndPosition);
+
+function testConstantOneCharWithEndPositionNotFound() {
+    return "Hello World".endsWith("o", 4);
+}
+noInline(testConstantOneCharWithEndPositionNotFound);
+
+function testEmptySearch() {
+    return "Hello World".endsWith("");
+}
+noInline(testEmptySearch);
+
+function testEmptySearchWithEndPosition() {
+    return "Hello World".endsWith("", 5);
+}
+noInline(testEmptySearchWithEndPosition);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(testConstantFound(), true);
+    shouldBe(testConstantNotFound(), false);
+    shouldBe(testConstantWithEndPosition(), true);
+    shouldBe(testConstantWithEndPositionNotFound(), false);
+    shouldBe(testConstantOneChar(), true);
+    shouldBe(testConstantOneCharNotFound(), false);
+    shouldBe(testConstantOneCharWithEndPosition(), true);
+    shouldBe(testConstantOneCharWithEndPositionNotFound(), false);
+    shouldBe(testEmptySearch(), true);
+    shouldBe(testEmptySearchWithEndPosition(), true);
+}

--- a/JSTests/stress/string-prototype-endswith-rope.js
+++ b/JSTests/stress/string-prototype-endswith-rope.js
@@ -1,0 +1,80 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.endsWith(search);
+}
+noInline(test);
+
+function testWithEndPosition(string, search, endPosition) {
+    return string.endsWith(search, endPosition);
+}
+noInline(testWithEndPosition);
+
+// Create rope strings by concatenation
+function makeRope(a, b) {
+    return a + b;
+}
+noInline(makeRope);
+
+function makeRope3(a, b, c) {
+    return a + b + c;
+}
+noInline(makeRope3);
+
+var part1 = "Hello";
+var part2 = "World";
+var part3 = "JavaScript";
+
+// Basic rope strings
+var rope1 = makeRope(part1, part2);
+var rope2 = makeRope3(part1, part2, part3);
+
+// Longer rope strings
+var longPart1 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+var longPart2 = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+var longPart3 = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+var longRope = makeRope3(longPart1, longPart2, longPart3);
+
+// Search strings as ropes
+var searchRope1 = makeRope("Wor", "ld");
+var searchRope2 = makeRope("Hello", "World");
+var searchRope3 = makeRope("CC", "CC");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Basic rope tests
+    shouldBe(test(rope1, "World"), true);
+    shouldBe(test(rope1, "HelloWorld"), true);
+    shouldBe(test(rope1, "Hello"), false);
+    shouldBe(test(rope1, "HelloWorldExtra"), false);
+
+    // Rope with rope search
+    shouldBe(test(rope1, searchRope1), true);
+    shouldBe(test(rope1, searchRope2), true);
+
+    // Longer rope tests
+    shouldBe(test(rope2, "JavaScript"), true);
+    shouldBe(test(rope2, "WorldJavaScript"), true);
+    shouldBe(test(rope2, "HelloWorldJavaScript"), true);
+    shouldBe(test(rope2, "World"), false);
+
+    // Long rope string tests
+    shouldBe(test(longRope, longPart3), true);
+    shouldBe(test(longRope, makeRope(longPart2, longPart3)), true);
+    shouldBe(test(longRope, longPart2), false);
+    shouldBe(test(longRope, searchRope3), true);
+
+    // Rope with endPosition
+    shouldBe(testWithEndPosition(rope1, "Hello", 5), true);
+    shouldBe(testWithEndPosition(rope1, "Hello", 10), false);
+    shouldBe(testWithEndPosition(rope2, "HelloWorld", 10), true);
+    shouldBe(testWithEndPosition(longRope, longPart1, 40), true);
+    shouldBe(testWithEndPosition(longRope, longPart2, 80), true);
+
+    // Cross-boundary searches (search spans multiple rope segments)
+    shouldBe(test(rope1, "oWor"), false);
+    shouldBe(testWithEndPosition(rope1, "Worl", 9), true);  // "HelloWorl".endsWith("Worl") = true
+    shouldBe(testWithEndPosition(longRope, makeRope("A", "B"), 41), true); // ends with "AB" at position 41
+}

--- a/JSTests/stress/string-prototype-endswith-search-coercion.js
+++ b/JSTests/stress/string-prototype-endswith-search-coercion.js
@@ -1,0 +1,99 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function shouldThrow(func, expectedError) {
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error('Expected error: ' + expectedError);
+    if (!(error instanceof expectedError))
+        throw new Error('Wrong error type: ' + error.constructor.name + ' expected: ' + expectedError.name);
+}
+
+function test(string, search) {
+    return string.endsWith(search);
+}
+noInline(test);
+
+function testWithEndPosition(string, search, endPosition) {
+    return string.endsWith(search, endPosition);
+}
+noInline(testWithEndPosition);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("null[object Object]true123HelloWorld");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Number coercion to string
+    shouldBe(test(makeString("Hello123"), 123), true);
+    shouldBe(test(makeString("Hello124"), 124), true);
+    shouldBe(test(string, 123), false);
+    shouldBe(testWithEndPosition(string, 123, 26), true);
+
+    // Boolean coercion to string
+    shouldBe(test(makeString("Hellotrue"), true), true);
+    shouldBe(test(makeString("Hellofalse"), false), true);
+    shouldBe(test(makeString("Hellotrue"), false), false);
+    shouldBe(testWithEndPosition(string, true, 23), true);
+
+    // null coercion to string
+    shouldBe(test(makeString("Hellonull"), null), true);
+    shouldBe(test(string, null), false);
+    shouldBe(testWithEndPosition(string, null, 4), true);
+
+    // undefined coercion to string
+    shouldBe(test(makeString("Helloundefined"), undefined), true);
+    shouldBe(test(string, undefined), false);
+
+    // Object coercion via toString
+    var objWithToString = { toString: function() { return "World"; } };
+    shouldBe(test(string, objWithToString), true);
+    shouldBe(test(makeString("Hello"), objWithToString), false);
+
+    // Object coercion via valueOf (toString takes precedence for string conversion)
+    var objWithValueOf = { valueOf: function() { return "World"; }, toString: function() { return "Hello"; } };
+    shouldBe(test(string, objWithValueOf), false);
+    shouldBe(test(makeString("WorldHello"), objWithValueOf), true);
+
+    // Plain object "[object Object]"
+    var plainObj = {};
+    shouldBe(test(string, plainObj), false);
+    shouldBe(testWithEndPosition(string, plainObj, 19), true);
+
+    // Array coercion
+    shouldBe(test(makeString("Hello"), ["Hello"]), true);
+    shouldBe(test(makeString("Hello1,2,3"), [1, 2, 3]), true);
+    shouldBe(test(makeString("Hello"), [1, 2, 3]), false);
+
+    // Empty array
+    shouldBe(test(makeString("Hello"), []), true);
+
+    // Symbol should throw TypeError
+    shouldThrow(function() {
+        test(string, Symbol("test"));
+    }, TypeError);
+
+    shouldThrow(function() {
+        testWithEndPosition(string, Symbol.iterator, 0);
+    }, TypeError);
+
+    // RegExp should throw TypeError (per spec)
+    shouldThrow(function() {
+        test(string, /World/);
+    }, TypeError);
+
+    // RegExp with Symbol.match set to falsy should work
+    var regexLike = /World/;
+    regexLike[Symbol.match] = false;
+    shouldBe(test(makeString("Hello/World/"), regexLike), true);
+}

--- a/JSTests/stress/string-prototype-endswith-unicode.js
+++ b/JSTests/stress/string-prototype-endswith-unicode.js
@@ -1,0 +1,66 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.endsWith(search);
+}
+noInline(test);
+
+function testWithEndPosition(string, search, endPosition) {
+    return string.endsWith(search, endPosition);
+}
+noInline(testWithEndPosition);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+// Basic Unicode characters
+var unicodeString = makeString("こんにちは世界");
+var unicodeSearch1 = makeString("世界");
+var unicodeSearch2 = makeString("こんにちは");
+var unicodeSearch3 = makeString("界");
+
+// Surrogate pairs (emoji)
+var emojiString = makeString("Hello😀🎉World🌍");
+var emojiSearch1 = makeString("🌍");
+var emojiSearch2 = makeString("World🌍");
+var emojiSearch3 = makeString("😀");
+var emojiSearch4 = makeString("🎉World🌍");
+
+// Mixed ASCII and Unicode
+var mixedString = makeString("Hello世界こんにちは");
+var mixedSearch1 = makeString("こんにちは");
+var mixedSearch2 = makeString("世界こんにちは");
+var mixedSearch3 = makeString("世界");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Basic Unicode tests
+    shouldBe(test(unicodeString, unicodeSearch1), true);
+    shouldBe(test(unicodeString, unicodeSearch2), false);
+    shouldBe(test(unicodeString, unicodeSearch3), true);
+    shouldBe(test(unicodeString, makeString("")), true);
+
+    // Surrogate pair tests
+    shouldBe(test(emojiString, emojiSearch1), true);
+    shouldBe(test(emojiString, emojiSearch2), true);
+    shouldBe(test(emojiString, emojiSearch3), false);
+    shouldBe(test(emojiString, emojiSearch4), true);
+
+    // Mixed ASCII and Unicode tests
+    shouldBe(test(mixedString, mixedSearch1), true);
+    shouldBe(test(mixedString, mixedSearch2), true);
+    shouldBe(test(mixedString, mixedSearch3), false);
+
+    // Unicode with endPosition
+    shouldBe(testWithEndPosition(unicodeString, makeString("こんにちは"), 5), true);
+    shouldBe(testWithEndPosition(unicodeString, makeString("こんにちは"), 6), false);
+
+    // Emoji with endPosition (note: emoji are 2 UTF-16 code units each)
+    shouldBe(testWithEndPosition(emojiString, makeString("😀"), 7), true);
+    shouldBe(testWithEndPosition(emojiString, makeString("🎉"), 9), true);
+    shouldBe(testWithEndPosition(emojiString, makeString("Hello"), 5), true);
+}

--- a/JSTests/stress/string-prototype-endswith-with-index.js
+++ b/JSTests/stress/string-prototype-endswith-with-index.js
@@ -1,0 +1,48 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search, endPosition) {
+    return string.endsWith(search, endPosition);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("................................okokHellookok.............................................");
+var search1 = makeString("Hello");
+var search2 = makeString("okok");
+var search3 = makeString("NotFound");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Basic tests with endPosition
+    shouldBe(test(string, search1, string.length), false);
+    shouldBe(test(string, search1, 41), true);
+    shouldBe(test(string, search1, 40), false);
+    shouldBe(test(string, search1, 0), false);
+
+    shouldBe(test(string, search2, string.length), false);
+    shouldBe(test(string, search2, 36), true);
+    shouldBe(test(string, search2, 35), false);
+    shouldBe(test(string, search2, 45), true);
+
+    shouldBe(test(string, search3, string.length), false);
+    shouldBe(test(string, search3, 20), false);
+
+    // Negative endPosition should be treated as 0
+    shouldBe(test(string, makeString(""), -10), true);
+    shouldBe(test(string, makeString(""), -1), true);
+    shouldBe(test(string, makeString("."), -1), false);
+    shouldBe(test(string, search1, -1), false);
+
+    // Edge cases
+    shouldBe(test(makeString("Hello"), makeString("Hell"), 4), true);
+    shouldBe(test(makeString("Hello"), makeString("Hell"), 5), false);
+    shouldBe(test(makeString("Hello"), makeString("lo"), 5), true);
+    shouldBe(test(makeString("Hello"), makeString("lo"), 3), false);
+    shouldBe(test(makeString("Hello"), makeString(""), 3), true);
+}

--- a/JSTests/stress/string-prototype-endswith.js
+++ b/JSTests/stress/string-prototype-endswith.js
@@ -1,0 +1,33 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+function test(string, search) {
+    return string.endsWith(search);
+}
+noInline(test);
+
+function makeString(base) {
+    return base + "";
+}
+noInline(makeString);
+
+var string = makeString("................................okokHellookok.............................................");
+var search1 = makeString(".....");
+var search2 = makeString("okok");
+var search3 = makeString("NotFound");
+var search4 = makeString("");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    shouldBe(test(string, search1), true);
+    shouldBe(test(string, search2), false);
+    shouldBe(test(string, search3), false);
+    shouldBe(test(string, search4), true);
+
+    shouldBe(test(string, makeString("")), true);
+    shouldBe(test(makeString(""), search1), false);
+    shouldBe(test(makeString("Hello"), makeString("Hello")), true);
+    shouldBe(test(makeString("Hello"), makeString("ello")), true);
+    shouldBe(test(makeString("Hello"), makeString("Hell")), false);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2608,6 +2608,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
 
     case StringStartsWith:
+    case StringEndsWith:
         setNonCellTypeForNode(node, SpecBoolean);
         break;
 

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -358,7 +358,8 @@ private:
             break;
         }
 
-        case StringStartsWith: {
+        case StringStartsWith:
+        case StringEndsWith: {
             node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
             node->child2()->mergeFlags(NodeBytecodeUsesAsValue);
             if (node->child3())

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3081,22 +3081,25 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
-        case StringPrototypeStartsWithIntrinsic: {
+        case StringPrototypeStartsWithIntrinsic:
+        case StringPrototypeEndsWithIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;
 
             if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, Uncountable) || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
                 return CallOptimizationResult::DidNothing;
 
+            NodeType nodeType = intrinsic == StringPrototypeStartsWithIntrinsic ? StringStartsWith : StringEndsWith;
+
             insertChecks();
             Node* thisValue = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
             Node* search = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
             Node* result = nullptr;
             if (argumentCountIncludingThis == 2)
-                result = addToGraph(StringStartsWith, thisValue, search);
+                result = addToGraph(nodeType, thisValue, search);
             else {
-                Node* index = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
-                result = addToGraph(StringStartsWith, thisValue, search, index);
+                Node* position = get(virtualRegisterForArgumentIncludingThis(2, registerOffset));
+                result = addToGraph(nodeType, thisValue, search, position);
             }
 
             setResult(result);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -237,6 +237,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case StringCodePointAt:
     case StringIndexOf:
     case StringStartsWith:
+    case StringEndsWith:
     case CompareStrictEq:
     case SameValue:
     case IsEmpty:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -339,6 +339,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringFromCharCode, Common) \
     CLONE_STATUS(StringIndexOf, Common) \
     CLONE_STATUS(StringStartsWith, Common) \
+    CLONE_STATUS(StringEndsWith, Common) \
     CLONE_STATUS(StringLocaleCompare, Common) \
     CLONE_STATUS(StringReplace, Common) \
     CLONE_STATUS(StringReplaceString, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -482,6 +482,7 @@ bool doesGC(Graph& graph, Node* node)
     case DateSetTime:
     case StringIndexOf:
     case StringStartsWith:
+    case StringEndsWith:
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1109,7 +1109,8 @@ private:
             break;
         }
 
-        case StringStartsWith: {
+        case StringStartsWith:
+        case StringEndsWith: {
             fixEdge<StringUse>(node->child1());
             fixEdge<StringUse>(node->child2());
             if (node->child3())

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -361,6 +361,7 @@ namespace JSC { namespace DFG {
     macro(StringReplaceString, NodeResultJS | NodeMustGenerate) \
     macro(StringIndexOf, NodeResultInt32) \
     macro(StringStartsWith, NodeResultBoolean) \
+    macro(StringEndsWith, NodeResultBoolean) \
     \
     /* Optimizations for string access */ \
     macro(StringAt, NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3409,6 +3409,47 @@ JSC_DEFINE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObje
     OPERATION_RETURN(scope, baseView->hasInfixStartingAt(prefixView, start));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationStringEndsWith, bool, (JSGlobalObject* globalObject, JSString* base, JSString* suffix))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto baseView = base->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    auto suffixView = suffix->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    OPERATION_RETURN(scope, baseView->endsWith(suffixView));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringEndsWithWithEndPosition, bool, (JSGlobalObject* globalObject, JSString* base, JSString* suffix, int32_t endPosition))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto baseView = base->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    auto suffixView = suffix->view(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, false);
+
+    int32_t length = baseView->length();
+    unsigned end = length;
+    if (endPosition >= 0)
+        end = std::min<uint32_t>(endPosition, length);
+    else
+        end = 0;
+
+    OPERATION_RETURN(scope, baseView->hasInfixEndingAt(suffixView, end));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject* globalObject, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -295,6 +295,8 @@ JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithIndex, UCPUStrictInt32, (JSG
 JSC_DECLARE_JIT_OPERATION(operationStringIndexOfWithIndexWithOneChar, UCPUStrictInt32, (JSGlobalObject*, JSString*, int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObject*, JSString*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringEndsWith, bool, (JSGlobalObject*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationStringEndsWithWithEndPosition, bool, (JSGlobalObject*, JSString*, JSString*, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceAllGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1187,7 +1187,8 @@ private:
             break;
         }
 
-        case StringStartsWith: {
+        case StringStartsWith:
+        case StringEndsWith: {
             setPrediction(SpecBoolean);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -346,6 +346,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NumberIsSafeInteger:
     case StringIndexOf:
     case StringStartsWith:
+    case StringEndsWith:
         return true;
 
     case GlobalIsFinite:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1787,7 +1787,7 @@ public:
     void compileStringCodePointAt(Node*);
     void compileStringLocaleCompare(Node*);
     void compileStringIndexOf(Node*);
-    void compileStringStartsWith(Node*);
+    void compileStringStartsOrEndsWith(Node*);
     void compileDateGet(Node*);
     void compileDateSet(Node*);
     void compileGlobalIsNaN(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3152,8 +3152,9 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case StringStartsWith: {
-        compileStringStartsWith(node);
+    case StringStartsWith:
+    case StringEndsWith: {
+        compileStringStartsOrEndsWith(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3782,8 +3782,9 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case StringStartsWith: {
-        compileStringStartsWith(node);
+    case StringStartsWith:
+    case StringEndsWith: {
+        compileStringStartsOrEndsWith(node);
         break;
     }
 

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -175,6 +175,7 @@ inline CapabilityLevel canCompile(Node* node)
     case StringFromCharCode:
     case StringIndexOf:
     case StringStartsWith:
+    case StringEndsWith:
     case AllocatePropertyStorage:
     case ReallocatePropertyStorage:
     case NukeStructureAndSetButterfly:

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -122,6 +122,7 @@ namespace JSC {
     macro(StringPrototypeIndexOfIntrinsic) \
     macro(StringPrototypeIncludesIntrinsic) \
     macro(StringPrototypeStartsWithIntrinsic) \
+    macro(StringPrototypeEndsWithIntrinsic) \
     macro(StringPrototypeLocaleCompareIntrinsic) \
     macro(StringPrototypeValueOfIntrinsic) \
     macro(StringPrototypeReplaceIntrinsic) \

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -167,7 +167,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toLocaleUpperCase"_s, stringProtoFuncToLocaleUpperCase, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("trim"_s, stringProtoFuncTrim, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("startsWith"_s, stringProtoFuncStartsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeStartsWithIntrinsic);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("endsWith"_s, stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("endsWith"_s, stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeEndsWithIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("includes"_s, stringProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeIncludesIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("normalize"_s, stringProtoFuncNormalize, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().charCodeAtPrivateName(), stringProtoFuncCharCodeAt, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, CharCodeAtIntrinsic);
@@ -183,7 +183,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->iteratorSymbol, iteratorFunction, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().substrPrivateName(), stringProtoFuncSubstr, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().endsWithPrivateName(), stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().endsWithPrivateName(), stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, StringPrototypeEndsWithIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isWellFormed, stringProtoFuncIsWellFormed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toWellFormed, stringProtoFuncToWellFormed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
 


### PR DESCRIPTION
#### 901865149859cae66bd836c2f2e4f0524cd9adf7
<pre>
[JSC] Optimize `String#endsWith` in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=306410">https://bugs.webkit.org/show_bug.cgi?id=306410</a>

Reviewed by Yusuke Suzuki.

This patch changes to optimize `String#endsWith` in DFG/FTL.

                                                  TipOfTree                  Patched

string-prototype-endswith-constant-folding
                                               56.8176+-21.9201    ^      5.3935+-0.4238        ^ definitely 10.5345x faster
string-prototype-endswith-with-index           45.2050+-13.0423          40.9865+-10.1781         might be 1.1029x faster
string-prototype-endswith-with-one-char        27.4311+-12.0414          17.6594+-5.6997          might be 1.5533x faster
string-prototype-endswith                      25.0453+-1.0958     ^     17.3048+-1.2104        ^ definitely 1.4473x faster

Tests: JSTests/microbenchmarks/string-prototype-endswith-constant-folding.js
       JSTests/microbenchmarks/string-prototype-endswith-with-index.js
       JSTests/microbenchmarks/string-prototype-endswith-with-one-char.js
       JSTests/microbenchmarks/string-prototype-endswith.js
       JSTests/stress/string-prototype-endswith-coerced-position.js
       JSTests/stress/string-prototype-endswith-constant-folding.js
       JSTests/stress/string-prototype-endswith-rope.js
       JSTests/stress/string-prototype-endswith-search-coercion.js
       JSTests/stress/string-prototype-endswith-unicode.js
       JSTests/stress/string-prototype-endswith-with-index.js
       JSTests/stress/string-prototype-endswith.js

* JSTests/microbenchmarks/string-prototype-endswith-constant-folding.js: Added.
(testConstantFound):
(testConstantNotFound):
(testConstantWithEndPosition):
(testConstantOneChar):
(testConstantOneCharWithEndPosition):
* JSTests/microbenchmarks/string-prototype-endswith-with-index.js: Added.
(test):
(makeString):
* JSTests/microbenchmarks/string-prototype-endswith-with-one-char.js: Added.
(test):
(makeString):
* JSTests/microbenchmarks/string-prototype-endswith.js: Added.
(test):
(makeString):
* JSTests/stress/string-prototype-endswith-coerced-position.js: Added.
(shouldBe):
(test):
(makeString):
(i.valueOf):
(i.toString):
* JSTests/stress/string-prototype-endswith-constant-folding.js: Added.
(shouldBe):
(testConstantFound):
(testConstantNotFound):
(testConstantWithEndPosition):
(testConstantWithEndPositionNotFound):
(testConstantOneChar):
(testConstantOneCharNotFound):
(testConstantOneCharWithEndPosition):
(testConstantOneCharWithEndPositionNotFound):
(testEmptySearch):
(testEmptySearchWithEndPosition):
* JSTests/stress/string-prototype-endswith-rope.js: Added.
(shouldBe):
(test):
(testWithEndPosition):
(makeRope):
(makeRope3):
* JSTests/stress/string-prototype-endswith-search-coercion.js: Added.
(shouldBe):
(shouldThrow):
(test):
(testWithEndPosition):
(makeString):
(i.objWithToString.toString):
(i.objWithValueOf.valueOf):
(i.objWithValueOf.toString):
(i.shouldThrow):
* JSTests/stress/string-prototype-endswith-unicode.js: Added.
(shouldBe):
(test):
(testWithEndPosition):
(makeString):
* JSTests/stress/string-prototype-endswith-with-index.js: Added.
(shouldBe):
(test):
(makeString):
* JSTests/stress/string-prototype-endswith.js: Added.
(shouldBe):
(test):
(makeString):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileStringEndsWith):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/306937@main">https://commits.webkit.org/306937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee6d79fa875b93dceab4d89bb4ee4ff0c548c8b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94181 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14178 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108357 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78500 "1 flakes 7 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10525 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8119 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133064 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152049 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/1885 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116487 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116830 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30210 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12885 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122932 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68327 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13197 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2371 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172377 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76901 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44683 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->