### PR TITLE
Reduce use of protected functions in Source/WebKit/NetworkProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -148,7 +148,7 @@ void BackgroundFetchLoad::didReceiveChallenge(AuthenticationChallenge&& challeng
 {
     BGLOAD_RELEASE_LOG("didReceiveChallenge");
     if (challenge.protectionSpace().authenticationScheme() == ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested) {
-        Ref { m_networkLoadChecker }->protectedNetworkProcess()->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_sessionID, { }, nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
+        protect(protect(Ref { m_networkLoadChecker }->networkProcess())->authenticationManager())->didReceiveAuthenticationChallenge(m_sessionID, { }, nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
         return;
     }
     WeakPtr weakThis { *this };

--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -130,7 +130,7 @@ void Download::didReceiveChallenge(const WebCore::AuthenticationChallenge& chall
         return;
     }
 
-    m_client->protectedDownloadsAuthenticationManager()->didReceiveAuthenticationChallenge(*this, challenge, WTF::move(completionHandler));
+    protect(m_client->downloadsAuthenticationManager())->didReceiveAuthenticationChallenge(*this, challenge, WTF::move(completionHandler));
 }
 
 void Download::didCreateDestination(const String& path)

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp
@@ -68,7 +68,7 @@ void DownloadManager::startDownload(PAL::SessionID sessionID, DownloadID downloa
     }
     parameters.storedCredentialsPolicy = sessionID.isEphemeral() ? StoredCredentialsPolicy::DoNotUse : StoredCredentialsPolicy::Use;
 
-    m_pendingDownloads.add(downloadID, PendingDownload::create(m_client->protectedParentProcessConnectionForDownloads().get(), WTF::move(parameters), downloadID, *networkSession, suggestedName, fromDownloadAttribute, webProcessID));
+    m_pendingDownloads.add(downloadID, PendingDownload::create(protect(m_client->parentProcessConnectionForDownloads()).get(), WTF::move(parameters), downloadID, *networkSession, suggestedName, fromDownloadAttribute, webProcessID));
 }
 
 void DownloadManager::dataTaskBecameDownloadTask(DownloadID downloadID, Ref<Download>&& download)
@@ -87,7 +87,7 @@ void DownloadManager::dataTaskBecameDownloadTask(DownloadID downloadID, Ref<Down
 void DownloadManager::convertNetworkLoadToDownload(DownloadID downloadID, Ref<NetworkLoad>&& networkLoad, ResponseCompletionHandler&& completionHandler, Vector<Ref<WebCore::BlobDataFileReference>>&& blobFileReferences, const ResourceRequest& request, const ResourceResponse& response)
 {
     ASSERT(!m_pendingDownloads.contains(downloadID));
-    m_pendingDownloads.add(downloadID, PendingDownload::create(m_client->protectedParentProcessConnectionForDownloads().get(), WTF::move(networkLoad), WTF::move(completionHandler), downloadID, request, response));
+    m_pendingDownloads.add(downloadID, PendingDownload::create(protect(m_client->parentProcessConnectionForDownloads()).get(), WTF::move(networkLoad), WTF::move(completionHandler), downloadID, request, response));
 }
 
 void DownloadManager::downloadDestinationDecided(DownloadID downloadID, Ref<NetworkDataTask>&& networkDataTask)
@@ -182,16 +182,6 @@ IPC::Connection* DownloadManager::downloadProxyConnection()
 AuthenticationManager& DownloadManager::downloadsAuthenticationManager()
 {
     return m_client->downloadsAuthenticationManager();
-}
-
-RefPtr<IPC::Connection> DownloadManager::Client::protectedParentProcessConnectionForDownloads()
-{
-    return parentProcessConnectionForDownloads();
-}
-
-Ref<AuthenticationManager> WebKit::DownloadManager::Client::protectedDownloadsAuthenticationManager()
-{
-    return downloadsAuthenticationManager();
 }
 
 void DownloadManager::applicationDidEnterBackground()

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -80,9 +80,7 @@ public:
         virtual void didDestroyDownload() = 0;
         virtual IPC::Connection* downloadProxyConnection() = 0;
         virtual IPC::Connection* parentProcessConnectionForDownloads() = 0;
-        RefPtr<IPC::Connection> protectedParentProcessConnectionForDownloads();
         virtual AuthenticationManager& downloadsAuthenticationManager() = 0;
-        Ref<AuthenticationManager> protectedDownloadsAuthenticationManager();
         virtual NetworkSession* networkSession(PAL::SessionID) const = 0;
     };
 

--- a/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp
@@ -130,7 +130,7 @@ void EarlyHintsResourceLoader::startPreconnectTask(const URL& baseURL, const Lin
     if (!contentSecurityPolicy.allowConnectToSource(url, ContentSecurityPolicy::RedirectResponseReceived::No, originalRequest.url()))
         return;
 
-    CheckedPtr networkSession = loader->protectedConnectionToWebProcess()->networkSession();
+    CheckedPtr networkSession = protect(loader->connectionToWebProcess())->networkSession();
     if (!networkSession)
         return;
 

--- a/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp
@@ -118,7 +118,7 @@ void NetworkCORSPreflightChecker::didReceiveChallenge(WebCore::AuthenticationCha
         return;
     }
 
-    m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_parameters.sessionID, m_parameters.webPageProxyID, &m_parameters.topOrigin->data(), challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
+    protect(m_networkProcess->authenticationManager())->didReceiveAuthenticationChallenge(m_parameters.sessionID, m_parameters.webPageProxyID, &m_parameters.topOrigin->data(), challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
 }
 
 void NetworkCORSPreflightChecker::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1281,7 +1281,7 @@ void NetworkConnectionToWebProcess::setCaptureExtraNetworkLoadMetricsEnabled(boo
 void NetworkConnectionToWebProcess::clearPageSpecificData(PageIdentifier pageID)
 {
     if (CheckedPtr session = networkSession())
-        session->protectedNetworkLoadScheduler()->clearPageData(pageID);
+        protect(session->networkLoadScheduler())->clearPageData(pageID);
 
     if (CheckedPtr storageSession = m_networkProcess->storageSession(m_sessionID))
         storageSession->clearPageSpecificDataForResourceLoadStatistics(pageID);
@@ -1713,7 +1713,7 @@ void NetworkConnectionToWebProcess::setResourceLoadSchedulingMode(WebCore::PageI
     if (!session)
         return;
 
-    session->protectedNetworkLoadScheduler()->setResourceLoadSchedulingMode(pageIdentifier, mode);
+    protect(session->networkLoadScheduler())->setResourceLoadSchedulingMode(pageIdentifier, mode);
 }
 
 void NetworkConnectionToWebProcess::prioritizeResourceLoads(const Vector<WebCore::ResourceLoaderIdentifier>& loadIdentifiers)
@@ -1732,7 +1732,7 @@ void NetworkConnectionToWebProcess::prioritizeResourceLoads(const Vector<WebCore
             loads.append(networkLoad.releaseNonNull());
     }
 
-    session->protectedNetworkLoadScheduler()->prioritizeLoads(loads);
+    protect(session->networkLoadScheduler())->prioritizeLoads(loads);
 }
 
 RefPtr<NetworkResourceLoader> NetworkConnectionToWebProcess::takeNetworkResourceLoader(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier)
@@ -1879,7 +1879,7 @@ void NetworkConnectionToWebProcess::shouldOffloadIFrameForHost(const String& hos
 {
     CONNECTION_RELEASE_LOG(ResourceMonitoring, "shouldOffloadIFrameForHost: (host=%" SENSITIVE_LOG_STRING ")", host.utf8().data());
     if (CheckedPtr session = networkSession())
-        session->protectedResourceMonitorThrottler()->tryAccess(host, ContinuousApproximateTime::now(), WTF::move(completionHandler));
+        protect(session->resourceMonitorThrottler())->tryAccess(host, ContinuousApproximateTime::now(), WTF::move(completionHandler));
     else
         completionHandler(false);
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -115,7 +115,6 @@ public:
     virtual State state() const = 0;
 
     NetworkDataTaskClient* client() const { return m_client.get(); }
-    RefPtr<NetworkDataTaskClient> protectedClient() const { return client(); }
     void clearClient() { m_client = nullptr; }
 
     std::optional<DownloadID> pendingDownloadID() const { return m_pendingDownloadID.asOptional(); }

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -175,7 +175,7 @@ bool NetworkDataTaskBlob::didReceiveData(std::span<const uint8_t> data)
             return false;
     } else {
         ASSERT(m_client);
-        protectedClient()->didReceiveData(SharedBuffer::create(data));
+        protect(client())->didReceiveData(SharedBuffer::create(data));
     }
     return true;
 }
@@ -302,7 +302,7 @@ void NetworkDataTaskBlob::didFail(Error errorCode)
 
     clearStream();
     ASSERT(m_client);
-    protectedClient()->didCompleteWithError(ResourceError(webKitBlobResourceDomain, static_cast<int>(errorCode), m_firstRequest.url(), String()));
+    protect(client())->didCompleteWithError(ResourceError(webKitBlobResourceDomain, static_cast<int>(errorCode), m_firstRequest.url(), String()));
 }
 
 void NetworkDataTaskBlob::didFinish()
@@ -318,7 +318,7 @@ void NetworkDataTaskBlob::didFinish()
 
     clearStream();
     ASSERT(m_client);
-    protectedClient()->didCompleteWithError({ });
+    protect(client())->didCompleteWithError({ });
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -243,9 +243,9 @@ void NetworkLoad::didReceiveChallenge(AuthenticationChallenge&& challenge, Negot
     }
     
     if (RefPtr pendingDownload = m_task->pendingDownload())
-        m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(*pendingDownload, challenge, WTF::move(completionHandler));
+        protect(m_networkProcess->authenticationManager())->didReceiveAuthenticationChallenge(*pendingDownload, challenge, WTF::move(completionHandler));
     else
-        m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_task->sessionID(), m_parameters.webPageProxyID, m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
+        protect(m_networkProcess->authenticationManager())->didReceiveAuthenticationChallenge(m_task->sessionID(), m_parameters.webPageProxyID, m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
 }
 
 void NetworkLoad::didReceiveInformationalResponse(ResourceResponse&& response)
@@ -264,7 +264,7 @@ void NetworkLoad::didReceiveResponse(ResourceResponse&& response, NegotiatedLega
     }
 
     if (negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes)
-        m_networkProcess->protectedAuthenticationManager()->negotiatedLegacyTLS(*m_parameters.webPageProxyID);
+        protect(m_networkProcess->authenticationManager())->negotiatedLegacyTLS(*m_parameters.webPageProxyID);
     
     notifyDidReceiveResponse(WTF::move(response), negotiatedLegacyTLS, privateRelayed, WTF::move(completionHandler));
 }

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -560,7 +560,7 @@ void NetworkLoadChecker::processContentRuleListsForLoad(ResourceRequest&& reques
         return;
     }
 
-    m_networkProcess->protectedNetworkContentRuleListManager()->contentExtensionsBackend(*m_userContentControllerIdentifier, [weakThis = WeakPtr { *this }, request = WTF::move(request), callback = WTF::move(callback)](auto& backend) mutable {
+    protect(m_networkProcess->networkContentRuleListManager())->contentExtensionsBackend(*m_userContentControllerIdentifier, [weakThis = WeakPtr { *this }, request = WTF::move(request), callback = WTF::move(callback)](auto& backend) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             callback(makeUnexpected(ResourceError { ResourceError::Type::Cancellation }));
@@ -579,11 +579,6 @@ void NetworkLoadChecker::storeRedirectionIfNeeded(const ResourceRequest& request
     if (!m_shouldCaptureExtraNetworkLoadMetrics)
         return;
     m_loadInformation.transactions.append(NetworkTransactionInformation { NetworkTransactionInformation::Type::Redirection, ResourceRequest { request }, ResourceResponse { response }, { } });
-}
-
-Ref<NetworkProcess> NetworkLoadChecker::protectedNetworkProcess()
-{
-    return m_networkProcess;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -106,7 +106,6 @@ public:
 #endif
 
     NetworkProcess& networkProcess() { return m_networkProcess; }
-    Ref<NetworkProcess> protectedNetworkProcess();
 
     const URL& url() const { return m_url; }
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const { return m_storedCredentialsPolicy; }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -216,11 +216,6 @@ AuthenticationManager& NetworkProcess::authenticationManager()
     return *supplement<AuthenticationManager>();
 }
 
-Ref<AuthenticationManager> NetworkProcess::protectedAuthenticationManager()
-{
-    return authenticationManager();
-}
-
 DownloadManager& NetworkProcess::downloadManager()
 {
     return m_downloadManager;
@@ -251,7 +246,7 @@ bool NetworkProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder& 
 {
 #if ENABLE(CONTENT_EXTENSIONS)
     if (decoder.messageReceiverName() == Messages::NetworkContentRuleListManager::messageReceiverName()) {
-        protectedNetworkContentRuleListManager()->didReceiveMessage(connection, decoder);
+        protect(networkContentRuleListManager())->didReceiveMessage(connection, decoder);
         return true;
     }
 #endif
@@ -1624,11 +1619,11 @@ void NetworkProcess::preconnectTo(PAL::SessionID sessionID, WebPageProxyIdentifi
 
     NetworkLoadParameters parametersForAdditionalPreconnect = parameters;
 
-    session->protectedNetworkLoadScheduler()->startedPreconnectForMainResource(url, userAgent);
+    protect(session->networkLoadScheduler())->startedPreconnectForMainResource(url, userAgent);
     Ref task = PreconnectTask::create(*session, WTF::move(parameters));
     task->start([weakSession = WeakPtr { *session }, url, userAgent, parametersForAdditionalPreconnect = WTF::move(parametersForAdditionalPreconnect)](const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics& metrics) mutable {
         if (CheckedPtr session = weakSession.get()) {
-            session->protectedNetworkLoadScheduler()->finishedPreconnectForMainResource(url, userAgent, error);
+            protect(session->networkLoadScheduler())->finishedPreconnectForMainResource(url, userAgent, error);
 #if ENABLE(ADDITIONAL_PRECONNECT_ON_HTTP_1X)
             if (equalLettersIgnoringASCIICase(metrics.protocol, "http/1.1"_s)) {
                 auto parameters = parametersForAdditionalPreconnect;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -201,7 +201,6 @@ public:
     void removeNetworkConnectionToWebProcess(NetworkConnectionToWebProcess&);
 
     AuthenticationManager& authenticationManager();
-    Ref<AuthenticationManager> protectedAuthenticationManager();
     DownloadManager& downloadManager();
     CheckedRef<DownloadManager> checkedDownloadManager();
 
@@ -350,7 +349,6 @@ public:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     NetworkContentRuleListManager& networkContentRuleListManager() { return m_networkContentRuleListManager; }
-    Ref<NetworkContentRuleListManager> protectedNetworkContentRuleListManager() { return m_networkContentRuleListManager; }
 #endif
 
     void syncLocalStorage(CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -118,7 +118,6 @@ public:
     const WebCore::ResourceResponse& response() const { return m_response; }
 
     NetworkConnectionToWebProcess& connectionToWebProcess() const { return m_connection; }
-    Ref<NetworkConnectionToWebProcess> protectedConnectionToWebProcess() const;
     PAL::SessionID sessionID() const { return m_connection->sessionID(); }
     WebCore::ResourceLoaderIdentifier coreIdentifier() const { return *m_parameters.identifier; }
     WebCore::FrameIdentifier frameID() const { return m_parameters.webFrameID; }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -638,7 +638,7 @@ RefPtr<NetworkResourceLoader> NetworkSession::CachedNetworkResourceLoader::takeL
 void NetworkSession::CachedNetworkResourceLoader::expirationTimerFired()
 {
     RefPtr loader = m_loader;
-    CheckedPtr session = loader->protectedConnectionToWebProcess()->networkSession();
+    CheckedPtr session = protect(loader->connectionToWebProcess())->networkSession();
     ASSERT(session);
     if (!session)
         return;
@@ -687,11 +687,6 @@ NetworkLoadScheduler& NetworkSession::networkLoadScheduler()
     if (!m_networkLoadScheduler)
         lazyInitialize(m_networkLoadScheduler, NetworkLoadScheduler::create());
     return *m_networkLoadScheduler;
-}
-
-Ref<NetworkLoadScheduler> NetworkSession::protectedNetworkLoadScheduler()
-{
-    return networkLoadScheduler();
 }
 
 String NetworkSession::attributedBundleIdentifierFromPageIdentifier(WebPageProxyIdentifier identifier) const
@@ -962,14 +957,9 @@ WebCore::ResourceMonitorThrottlerHolder& NetworkSession::resourceMonitorThrottle
     return *m_resourceMonitorThrottler;
 }
 
-Ref<WebCore::ResourceMonitorThrottlerHolder> NetworkSession::protectedResourceMonitorThrottler()
-{
-    return resourceMonitorThrottler();
-}
-
 void NetworkSession::clearResourceMonitorThrottlerData(CompletionHandler<void()>&& completionHandler)
 {
-    protectedResourceMonitorThrottler()->clearAllData(WTF::move(completionHandler));
+    protect(resourceMonitorThrottler())->clearAllData(WTF::move(completionHandler));
 }
 
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -244,7 +244,6 @@ public:
     void clearCacheEngine();
 
     NetworkLoadScheduler& networkLoadScheduler();
-    Ref<NetworkLoadScheduler> protectedNetworkLoadScheduler();
 
     PCM::ManagerInterface& privateClickMeasurement() { return m_privateClickMeasurement.get(); }
     void setPrivateClickMeasurementDebugMode(bool);
@@ -302,7 +301,6 @@ public:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WebCore::ResourceMonitorThrottlerHolder& resourceMonitorThrottler();
-    Ref<WebCore::ResourceMonitorThrottlerHolder> protectedResourceMonitorThrottler();
 
     void clearResourceMonitorThrottlerData(CompletionHandler<void()>&&);
 #endif

--- a/Source/WebKit/NetworkProcess/PingLoad.cpp
+++ b/Source/WebKit/NetworkProcess/PingLoad.cpp
@@ -153,7 +153,7 @@ void PingLoad::didReceiveChallenge(AuthenticationChallenge&& challenge, Negotiat
 {
     PING_RELEASE_LOG("didReceiveChallenge");
     if (challenge.protectionSpace().authenticationScheme() == ProtectionSpace::AuthenticationScheme::ServerTrustEvaluationRequested) {
-        m_networkLoadChecker->protectedNetworkProcess()->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_sessionID, m_parameters.webPageProxyID,  m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
+        protect(protect(m_networkLoadChecker->networkProcess())->authenticationManager())->didReceiveAuthenticationChallenge(m_sessionID, m_parameters.webPageProxyID,  m_parameters.topOrigin ? &m_parameters.topOrigin->data() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
         return;
     }
     WeakPtr weakThis { *this };

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -72,7 +72,7 @@ ServiceWorkerDownloadTask::~ServiceWorkerDownloadTask()
 
 void ServiceWorkerDownloadTask::startListeningForIPC()
 {
-    RefPtr { m_serviceWorkerConnection.get() }->protectedIPCConnection()->addMessageReceiver(*this, *this, Messages::ServiceWorkerDownloadTask::messageReceiverName(), fetchIdentifier().toUInt64());
+    protect(RefPtr { m_serviceWorkerConnection.get() }->ipcConnection())->addMessageReceiver(*this, *this, Messages::ServiceWorkerDownloadTask::messageReceiverName(), fetchIdentifier().toUInt64());
 }
 
 void ServiceWorkerDownloadTask::close()
@@ -80,7 +80,7 @@ void ServiceWorkerDownloadTask::close()
     ASSERT(isMainRunLoop());
 
     if (RefPtr serviceWorkerConnection = m_serviceWorkerConnection.get()) {
-        serviceWorkerConnection->protectedIPCConnection()->removeMessageReceiver(Messages::ServiceWorkerDownloadTask::messageReceiverName(), fetchIdentifier().toUInt64());
+        protect(serviceWorkerConnection->ipcConnection())->removeMessageReceiver(Messages::ServiceWorkerDownloadTask::messageReceiverName(), fetchIdentifier().toUInt64());
         serviceWorkerConnection->unregisterDownload(*this);
         m_serviceWorkerConnection = nullptr;
     }
@@ -92,7 +92,7 @@ template<typename Message> bool ServiceWorkerDownloadTask::sendToServiceWorker(M
     if (!serviceWorkerConnection)
         return false;
 
-    return serviceWorkerConnection->protectedIPCConnection()->send(std::forward<Message>(message), 0) == IPC::Error::NoError;
+    return protect(serviceWorkerConnection->ipcConnection())->send(std::forward<Message>(message), 0) == IPC::Error::NoError;
 }
 
 void ServiceWorkerDownloadTask::dispatch(Function<void()>&& function)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -172,7 +172,7 @@ RefPtr<IPC::Connection> ServiceWorkerFetchTask::serviceWorkerConnection()
 template<typename Message> bool ServiceWorkerFetchTask::sendToClient(Message&& message)
 {
     Ref loader = *m_loader;
-    return loader->protectedConnectionToWebProcess()->connection().send(std::forward<Message>(message), loader->coreIdentifier()) == IPC::Error::NoError;
+    return protect(loader->connectionToWebProcess())->connection().send(std::forward<Message>(message), loader->coreIdentifier()) == IPC::Error::NoError;
 }
 
 void ServiceWorkerFetchTask::start(WebSWServerToContextConnection& serviceWorkerConnection)
@@ -500,7 +500,7 @@ void ServiceWorkerFetchTask::softUpdateIfNeeded()
     if (!m_shouldSoftUpdate)
         return;
     Ref loader = *m_loader;
-    RefPtr swConnection = loader->protectedConnectionToWebProcess()->swConnection();
+    RefPtr swConnection = protect(loader->connectionToWebProcess())->swConnection();
     if (!swConnection)
         return;
     RefPtr server = swConnection->server();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -108,11 +108,6 @@ NetworkProcess& WebSWServerConnection::networkProcess()
     return m_networkConnectionToWebProcess->networkProcess();
 }
 
-Ref<NetworkProcess> WebSWServerConnection::protectedNetworkProcess()
-{
-    return networkProcess();
-}
-
 std::optional<SharedPreferencesForWebProcess> WebSWServerConnection::sharedPreferencesForWebProcess() const
 {
     if (!m_networkConnectionToWebProcess)
@@ -559,7 +554,7 @@ void WebSWServerConnection::registerServiceWorkerClientInternal(WebCore::ClientO
 
     if (contextConnection) {
         auto& connection = downcast<WebSWServerToContextConnection>(*contextConnection);
-        protect(protectedNetworkProcess()->parentProcessConnection())->send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
+        protect(protect(networkProcess())->parentProcessConnection())->send(Messages::NetworkProcessProxy::RegisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
     }
 }
 
@@ -591,7 +586,7 @@ void WebSWServerConnection::unregisterServiceWorkerClient(const ScriptExecutionC
         if (!hasMatchingClient(potentiallyRemovedDomain)) {
             if (RefPtr contextConnection = server->contextConnectionForRegistrableDomain(potentiallyRemovedDomain)) {
                 auto& connection = downcast<WebSWServerToContextConnection>(*contextConnection);
-                protect(protectedNetworkProcess()->parentProcessConnection())->send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
+                protect(protect(networkProcess())->parentProcessConnection())->send(Messages::NetworkProcessProxy::UnregisterRemoteWorkerClientProcess { RemoteWorkerType::ServiceWorker, identifier(), connection.webProcessIdentifier() }, 0);
             }
         }
     }
@@ -807,7 +802,7 @@ PAL::SessionID WebSWServerConnection::sessionID() const
 
 NetworkSession* WebSWServerConnection::session()
 {
-    return protectedNetworkProcess()->networkSession(sessionID());
+    return protect(networkProcess())->networkSession(sessionID());
 }
 
 CheckedPtr<NetworkSession> WebSWServerConnection::checkedSession()

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -186,7 +186,6 @@ private:
     
     template<typename U> static void sendToContextProcess(WebCore::SWServerToContextConnection&, U&& message);
     NetworkProcess& networkProcess();
-    Ref<NetworkProcess> protectedNetworkProcess();
 
     bool isWebSWServerConnection() const final { return true; }
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -75,13 +75,13 @@ WebSWServerToContextConnection::~WebSWServerToContextConnection()
 template<typename T>
 void WebSWServerToContextConnection::sendToParentProcess(T&& message)
 {
-    protect(protectedNetworkProcess()->parentProcessConnection())->send(WTF::move(message), 0);
+    protect(protect(networkProcess())->parentProcessConnection())->send(WTF::move(message), 0);
 }
 
 template<typename T, typename C>
 void WebSWServerToContextConnection::sendWithAsyncReplyToParentProcess(T&& message, C&& callback)
 {
-    protect(protectedNetworkProcess()->parentProcessConnection())->sendWithAsyncReply(WTF::move(message), WTF::move(callback), 0);
+    protect(protect(networkProcess())->parentProcessConnection())->sendWithAsyncReply(WTF::move(message), WTF::move(callback), 0);
 }
 
 void WebSWServerToContextConnection::stop()
@@ -116,16 +116,6 @@ RefPtr<NetworkConnectionToWebProcess> WebSWServerToContextConnection::protectedC
 NetworkProcess* WebSWServerToContextConnection::networkProcess()
 {
     return m_connection ? &m_connection->networkProcess() : nullptr;
-}
-
-RefPtr<NetworkProcess> WebSWServerToContextConnection::protectedNetworkProcess()
-{
-    return networkProcess();
-}
-
-RefPtr<IPC::Connection> WebSWServerToContextConnection::protectedIPCConnection() const
-{
-    return ipcConnection();
 }
 
 IPC::Connection* WebSWServerToContextConnection::ipcConnection() const

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -71,7 +71,6 @@ public:
 
     void stop();
 
-    RefPtr<IPC::Connection> protectedIPCConnection() const;
     IPC::Connection* ipcConnection() const;
 
     // IPC::MessageReceiver
@@ -92,7 +91,6 @@ public:
 
     WebCore::ProcessIdentifier webProcessIdentifier() const final { return m_webProcessIdentifier; }
     NetworkProcess* networkProcess();
-    RefPtr<NetworkProcess> protectedNetworkProcess();
 
     void didFinishInstall(const std::optional<WebCore::ServiceWorkerJobDataIdentifier>&, WebCore::ServiceWorkerIdentifier, bool wasSuccessful);
     void didFinishActivation(WebCore::ServiceWorkerIdentifier);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -185,7 +185,7 @@ HashSet<String> NetworkProcess::hostNamesWithHSTSCache(PAL::SessionID sessionID)
 {
     HashSet<String> hostNames;
     if (CheckedPtr networkSession = downcast<NetworkSessionCocoa>(this->networkSession(sessionID))) {
-        for (NSString *host in networkSession->protectedHSTSStorage().get().nonPreloadedHosts)
+        for (NSString *host in protect(networkSession->hstsStorage()).get().nonPreloadedHosts)
             hostNames.add(host);
     }
     return hostNames;
@@ -195,7 +195,7 @@ void NetworkProcess::deleteHSTSCacheForHostNames(PAL::SessionID sessionID, const
 {
     if (CheckedPtr networkSession = downcast<NetworkSessionCocoa>(this->networkSession(sessionID))) {
         for (auto& hostName : hostNames)
-            [networkSession->protectedHSTSStorage() resetHSTSForHost:hostName.createNSString().get()];
+            [protect(networkSession->hstsStorage()).get() resetHSTSForHost:hostName.createNSString().get()];
     }
 }
 
@@ -204,7 +204,7 @@ void NetworkProcess::clearHSTSCache(PAL::SessionID sessionID, WallTime modifiedS
     NSTimeInterval timeInterval = modifiedSince.secondsSinceEpoch().seconds();
     RetainPtr date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
     if (CheckedPtr networkSession = downcast<NetworkSessionCocoa>(this->networkSession(sessionID)))
-        [networkSession->protectedHSTSStorage() resetHSTSHostsSinceDate:date.get()];
+        [protect(networkSession->hstsStorage()).get() resetHSTSHostsSinceDate:date.get()];
 }
 
 void NetworkProcess::clearDiskCache(WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -157,9 +157,8 @@ public:
 
     SessionWrapper& sessionWrapperForTask(std::optional<WebPageProxyIdentifier>, const WebCore::ResourceRequest&, WebCore::StoredCredentialsPolicy, std::optional<NavigatingToAppBoundDomain>);
     bool preventsSystemHTTPProxyAuthentication() const { return m_preventsSystemHTTPProxyAuthentication; }
-    
+
     _NSHSTSStorage *hstsStorage() const;
-    RetainPtr<_NSHSTSStorage> protectedHSTSStorage() const;
 
     NSURLCredentialStorage *nsCredentialStorage() const;
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1045,11 +1045,6 @@ _NSHSTSStorage *NetworkSessionCocoa::hstsStorage() const
     return m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration._hstsStorage;
 }
 
-RetainPtr<_NSHSTSStorage> NetworkSessionCocoa::protectedHSTSStorage() const
-{
-    return hstsStorage();
-}
-
 NSURLCredentialStorage *NetworkSessionCocoa::nsCredentialStorage() const
 {
     return m_defaultSessionSet->sessionWithCredentialStorage->session.get().configuration.URLCredentialStorage;
@@ -1635,7 +1630,7 @@ void NetworkSessionCocoa::continueDidReceiveChallenge(SessionWrapper& sessionWra
     if (!networkDataTask) {
         if (RefPtr webSocketTask = sessionWrapper.webSocketDataTaskMap.get(taskIdentifier).get()) {
             auto challengeCompletionHandler = createChallengeCompletionHandler(networkProcess(), sessionID(), challenge, webSocketTask->partition(), 0, WTF::move(completionHandler));
-            networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(sessionID(), webSocketTask->webPageProxyID(), !webSocketTask->topOrigin().isNull() ? &webSocketTask->topOrigin() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(challengeCompletionHandler));
+            protect(networkProcess().authenticationManager())->didReceiveAuthenticationChallenge(sessionID(), webSocketTask->webPageProxyID(), !webSocketTask->topOrigin().isNull() ? &webSocketTask->topOrigin() : nullptr, challenge, negotiatedLegacyTLS, WTF::move(challengeCompletionHandler));
             return;
         }
         if (auto downloadID = sessionWrapper.downloadMap.getOptional(taskIdentifier)) {
@@ -1866,7 +1861,7 @@ void NetworkSessionCocoa::loadImageForDecoding(WebCore::ResourceRequest&& reques
         void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler) final { completionHandler(WTF::move(request)); }
         void didReceiveChallenge(WebCore::AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler) final
         {
-            m_networkProcess->protectedAuthenticationManager()->didReceiveAuthenticationChallenge(m_sessionID, m_pageID, nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
+            protect(m_networkProcess->authenticationManager())->didReceiveAuthenticationChallenge(m_sessionID, m_pageID, nullptr, challenge, negotiatedLegacyTLS, WTF::move(completionHandler));
         }
         void didReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&& completionHandler) final
         {

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -73,7 +73,7 @@ RefPtr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdenti
 
 void NetworkSessionCurl::didReceiveChallenge(WebSocketTask& webSocketTask, WebCore::AuthenticationChallenge&& challenge, CompletionHandler<void(WebKit::AuthenticationChallengeDisposition, const WebCore::Credential&)>&& challengeCompletionHandler)
 {
-    networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(sessionID(), webSocketTask.webPageProxyID(), !webSocketTask.topOrigin().isNull() ? &webSocketTask.topOrigin() : nullptr, challenge, NegotiatedLegacyTLS::No, WTF::move(challengeCompletionHandler));
+    protect(networkProcess().authenticationManager())->didReceiveAuthenticationChallenge(sessionID(), webSocketTask.webPageProxyID(), !webSocketTask.topOrigin().isNull() ? &webSocketTask.topOrigin() : nullptr, challenge, NegotiatedLegacyTLS::No, WTF::move(challengeCompletionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -681,11 +681,6 @@ OriginQuotaManager& OriginStorageManager::quotaManager()
     return m_quotaManager.get();
 }
 
-Ref<OriginQuotaManager> OriginStorageManager::protectedQuotaManager()
-{
-    return m_quotaManager.get();
-}
-
 FileSystemStorageManager& OriginStorageManager::fileSystemStorageManager(FileSystemStorageHandleRegistry& registry)
 {
     return defaultBucket().fileSystemStorageManager(registry, [quotaManager = ThreadSafeWeakPtr { this->quotaManager() }](uint64_t spaceRequested, CompletionHandler<void(bool)>&& completionHandler) mutable {

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -70,7 +70,6 @@ public:
     WebCore::StorageEstimate estimate();
     const String& path() const { return m_path; }
     OriginQuotaManager& quotaManager();
-    Ref<OriginQuotaManager> protectedQuotaManager();
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&);
     FileSystemStorageManager* existingFileSystemStorageManager();
     LocalStorageManager& localStorageManager(StorageAreaRegistry&);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -271,7 +271,7 @@ void NetworkRTCMonitor::stopUpdating()
 void NetworkRTCMonitor::onNetworksChanged(const Vector<RTCNetwork>& networkList, const RTCNetwork::IPAddress& ipv4, const RTCNetwork::IPAddress& ipv6)
 {
     RTC_RELEASE_LOG("onNetworksChanged sent");
-    m_rtcProvider->protectedConnection()->send(Messages::WebRTCMonitor::NetworksChanged(networkList, ipv4, ipv6), 0);
+    protect(m_rtcProvider->connection())->send(Messages::WebRTCMonitor::NetworksChanged(networkList, ipv4, ipv6), 0);
 }
 
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -84,7 +84,7 @@ NetworkRTCProvider::NetworkRTCProvider(NetworkConnectionToWebProcess& connection
 
 void NetworkRTCProvider::startListeningForIPC()
 {
-    protectedConnection()->addMessageReceiver(*this, *this, Messages::NetworkRTCProvider::messageReceiverName());
+    protect(connection())->addMessageReceiver(*this, *this, Messages::NetworkRTCProvider::messageReceiverName());
 }
 
 NetworkRTCProvider::~NetworkRTCProvider()
@@ -98,7 +98,7 @@ void NetworkRTCProvider::close()
 {
     RTC_RELEASE_LOG("close");
 
-    protectedConnection()->removeMessageReceiver(Messages::NetworkRTCProvider::messageReceiverName());
+    protect(connection())->removeMessageReceiver(Messages::NetworkRTCProvider::messageReceiverName());
     m_connection = nullptr;
     protectedRTCMonitor()->stopUpdating();
 
@@ -192,7 +192,7 @@ void NetworkRTCProvider::createResolver(LibWebRTCResolverIdentifier identifier, 
             ipAddresses.append(rtcMonitor->ipv4());
         if (!rtcMonitor->ipv6().isUnspecified())
             ipAddresses.append(rtcMonitor->ipv6());
-        protectedConnection()->send(Messages::WebRTCResolver::SetResolvedAddress(ipAddresses), identifier);
+        protect(this->connection())->send(Messages::WebRTCResolver::SetResolvedAddress(ipAddresses), identifier);
         return;
     }
 
@@ -386,7 +386,7 @@ void NetworkRTCProvider::assertIsRTCNetworkThread()
 
 void NetworkRTCProvider::signalSocketIsClosed(LibWebRTCSocketIdentifier identifier)
 {
-    protectedConnection()->send(Messages::LibWebRTCNetwork::SignalClose(identifier, 1), 0);
+    protect(connection())->send(Messages::LibWebRTCNetwork::SignalClose(identifier, 1), 0);
 }
 
 Ref<NetworkRTCMonitor> NetworkRTCProvider::protectedRTCMonitor()

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -116,7 +116,6 @@ public:
     void callOnRTCNetworkThread(Function<void()>&&);
 
     IPC::Connection& connection() { return m_ipcConnection.get(); }
-    Ref<IPC::Connection> protectedConnection() { return m_ipcConnection.get(); }
 
     void closeSocket(WebCore::LibWebRTCSocketIdentifier);
 

--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -174,7 +174,7 @@ static void didReceiveServerTrustChallenge(NetworkConnectionToWebProcess& connec
                 return;
             }
 
-            connectionToWebProcess->networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(connectionToWebProcess->sessionID(), pageID, &clientOrigin.topOrigin, challenge, NegotiatedLegacyTLS::No, WTF::move(challengeCompletionHandler));
+            protect(connectionToWebProcess->networkProcess().authenticationManager())->didReceiveAuthenticationChallenge(connectionToWebProcess->sessionID(), pageID, &clientOrigin.topOrigin, challenge, NegotiatedLegacyTLS::No, WTF::move(challengeCompletionHandler));
         });
 
 
@@ -182,7 +182,7 @@ static void didReceiveServerTrustChallenge(NetworkConnectionToWebProcess& connec
         return;
     }
 
-    connectionToWebProcess.networkProcess().protectedAuthenticationManager()->didReceiveAuthenticationChallenge(connectionToWebProcess.sessionID(), pageID, &clientOrigin.topOrigin, challenge.get(), NegotiatedLegacyTLS::No, WTF::move(challengeCompletionHandler));
+    protect(connectionToWebProcess.networkProcess().authenticationManager())->didReceiveAuthenticationChallenge(connectionToWebProcess.sessionID(), pageID, &clientOrigin.topOrigin, challenge.get(), NegotiatedLegacyTLS::No, WTF::move(challengeCompletionHandler));
 }
 
 static String joinProtocolStrings(const Vector<String>& protocols)


### PR DESCRIPTION
#### 8cc5d073e70ecb73fc5d907571c0052a419806f5
<pre>
Reduce use of protected functions in Source/WebKit/NetworkProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=306412">https://bugs.webkit.org/show_bug.cgi?id=306412</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
(WebKit::BackgroundFetchLoad::didReceiveChallenge):
* Source/WebKit/NetworkProcess/Downloads/Download.cpp:
(WebKit::Download::didReceiveChallenge):
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.cpp:
(WebKit::DownloadManager::startDownload):
(WebKit::DownloadManager::convertNetworkLoadToDownload):
(WebKit::DownloadManager::Client::protectedParentProcessConnectionForDownloads): Deleted.
(WebKit::WebKit::DownloadManager::Client::protectedDownloadsAuthenticationManager): Deleted.
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/EarlyHintsResourceLoader.cpp:
(WebKit::EarlyHintsResourceLoader::startPreconnectTask):
* Source/WebKit/NetworkProcess/NetworkCORSPreflightChecker.cpp:
(WebKit::NetworkCORSPreflightChecker::didReceiveChallenge):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::clearPageSpecificData):
(WebKit::NetworkConnectionToWebProcess::setResourceLoadSchedulingMode):
(WebKit::NetworkConnectionToWebProcess::prioritizeResourceLoads):
(WebKit::NetworkConnectionToWebProcess::shouldOffloadIFrameForHost):
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::client const):
(WebKit::NetworkDataTask::protectedClient const): Deleted.
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::didReceiveData):
(WebKit::NetworkDataTaskBlob::didFail):
(WebKit::NetworkDataTaskBlob::didFinish):
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::didReceiveChallenge):
(WebKit::NetworkLoad::didReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::processContentRuleListsForLoad):
(WebKit::NetworkLoadChecker::protectedNetworkProcess): Deleted.
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
(WebKit::NetworkLoadChecker::networkProcess):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::dispatchMessage):
(WebKit::NetworkProcess::preconnectTo):
(WebKit::NetworkProcess::protectedAuthenticationManager): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startRequest):
(WebKit::NetworkResourceLoader::startContentFiltering):
(WebKit::NetworkResourceLoader::retrieveCacheEntry):
(WebKit::NetworkResourceLoader::startNetworkLoad):
(WebKit::NetworkResourceLoader::convertToDownload):
(WebKit::NetworkResourceLoader::abort):
(WebKit::NetworkResourceLoader::processClearSiteDataHeader):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::didReceiveChallenge):
(WebKit::NetworkResourceLoader::validateCacheEntryForMaxAgeCapValidation):
(WebKit::NetworkResourceLoader::continueWillSendRedirectedRequest):
(WebKit::NetworkResourceLoader::didFinishWithRedirectResponse):
(WebKit::NetworkResourceLoader::continueWillSendRequest):
(WebKit::NetworkResourceLoader::tryStoreAsCacheEntry):
(WebKit::NetworkResourceLoader::sendResultForCacheEntry):
(WebKit::NetworkResourceLoader::logCookieInformation const):
(WebKit::NetworkResourceLoader::startWithServiceWorker):
(WebKit::NetworkResourceLoader::handleProvisionalLoadFailureFromContentFilter):
(WebKit::NetworkResourceLoader::webContentRestrictionsConfigurationPath const):
(WebKit::NetworkResourceLoader::protectedConnectionToWebProcess const): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::CachedNetworkResourceLoader::expirationTimerFired):
(WebKit::NetworkSession::clearResourceMonitorThrottlerData):
(WebKit::NetworkSession::protectedNetworkLoadScheduler): Deleted.
(WebKit::NetworkSession::protectedResourceMonitorThrottler): Deleted.
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/PingLoad.cpp:
(WebKit::PingLoad::didReceiveChallenge):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::startListeningForIPC):
(WebKit::ServiceWorkerDownloadTask::close):
(WebKit::ServiceWorkerDownloadTask::sendToServiceWorker):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::sendToClient):
(WebKit::ServiceWorkerFetchTask::softUpdateIfNeeded):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::resolveUnregistrationJobInClient):
(WebKit::WebSWServerConnection::protectedNetworkProcess): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::sendToParentProcess):
(WebKit::WebSWServerToContextConnection::sendWithAsyncReplyToParentProcess):
(WebKit::WebSWServerToContextConnection::protectedNetworkProcess): Deleted.
(WebKit::WebSWServerToContextConnection::protectedIPCConnection const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::hostNamesWithHSTSCache const):
(WebKit::NetworkProcess::deleteHSTSCacheForHostNames):
(WebKit::NetworkProcess::clearHSTSCache):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::continueDidReceiveChallenge):
(WebKit::NetworkSessionCocoa::loadImageForDecoding):
(WebKit::NetworkSessionCocoa::protectedHSTSStorage const): Deleted.
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp:
(WebKit::NetworkSessionCurl::didReceiveChallenge):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::donePrepareForEviction):
(WebKit::NetworkStorageManager::didIncreaseQuota):
(WebKit::NetworkStorageManager::requestSpace):
(WebKit::NetworkStorageManager::resetQuotaForTesting):
(WebKit::NetworkStorageManager::resetQuotaUpdatedBasedOnUsageForTesting):
(WebKit::NetworkStorageManager::setOriginQuotaRatioEnabledForTesting):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::protectedQuotaManager): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::NetworkRTCMonitor::onNetworksChanged):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::startListeningForIPC):
(WebKit::NetworkRTCProvider::close):
(WebKit::NetworkRTCProvider::createResolver):
(WebKit::NetworkRTCProvider::signalSocketIsClosed):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
(WebKit::NetworkRTCProvider::connection):
(WebKit::NetworkRTCProvider::protectedConnection): Deleted.
* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::didReceiveServerTrustChallenge):

Canonical link: <a href="https://commits.webkit.org/306377@main">https://commits.webkit.org/306377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1bafaa6f2094441f094dbbd1674996593cc59c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94187 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108346 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78498 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89253 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8125 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119793 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152055 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13160 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116489 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13176 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11500 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116832 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29737 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12895 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122941 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68333 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13203 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76908 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13141 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/12986 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->