### PR TITLE
[WebXR][HitTest] Incorrect hit test poses when not using fixed reference spaces

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -399,7 +399,7 @@ ExceptionOr<Vector<Ref<WebXRHitTestResult>>> WebXRFrame::getHitTestResults(const
     if (platformResults == platformResultsHash.end())
         return Exception { ExceptionCode::InvalidStateError, "Unable to obtain hit test results for specified hit test source."_s };
 
-    return platformResults->value.map([&](auto& platformResult) { return WebXRHitTestResult::create(*this, platformResult); });
+    return platformResults->value.map([&](auto& platformResult) { return WebXRHitTestResult::create(*this, source.space(), platformResult); });
 }
 
 // https://immersive-web.github.io/hit-test/#dom-xrframe-gethittestresultsfortransientinput
@@ -420,7 +420,7 @@ ExceptionOr<Vector<Ref<WebXRTransientInputHitTestResult>>> WebXRFrame::getHitTes
         RefPtr inputSource = m_session->inputSources().itemByHandle(platformResult.inputSource);
         if (!inputSource)
             continue;
-        Vector<Ref<WebXRHitTestResult>> hitTestResults = platformResult.results.map([&](auto& platformHitTestResult) { return WebXRHitTestResult::create(*this, platformHitTestResult); });
+        Vector<Ref<WebXRHitTestResult>> hitTestResults = platformResult.results.map([&](auto& platformHitTestResult) { return WebXRHitTestResult::create(*this, inputSource->targetRaySpace(), platformHitTestResult); });
         results.append(WebXRTransientInputHitTestResult::create(inputSource.releaseNonNull(), WTF::move(hitTestResults)));
     }
     return results;

--- a/Source/WebCore/Modules/webxr/WebXRHitTestResult.h
+++ b/Source/WebCore/Modules/webxr/WebXRHitTestResult.h
@@ -30,8 +30,11 @@
 #include "ExceptionOr.h"
 #include "PlatformXR.h"
 #include <wtf/Forward.h>
+#include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -43,14 +46,15 @@ class WebXRSpace;
 class WebXRHitTestResult : public RefCounted<WebXRHitTestResult> {
     WTF_MAKE_TZONE_ALLOCATED(WebXRHitTestResult);
 public:
-    static Ref<WebXRHitTestResult> create(WebXRFrame&, const PlatformXR::FrameData::HitTestResult&);
+    static Ref<WebXRHitTestResult> create(WebXRFrame&, WebXRSpace&, const PlatformXR::FrameData::HitTestResult&);
     ~WebXRHitTestResult();
     ExceptionOr<RefPtr<WebXRPose>> getPose(Document&, const WebXRSpace& baseSpace);
 
 private:
-    WebXRHitTestResult(WebXRFrame&, const PlatformXR::FrameData::HitTestResult&);
+    WebXRHitTestResult(WebXRFrame&, WebXRSpace&, const PlatformXR::FrameData::HitTestResult&);
 
     const Ref<WebXRFrame> m_frame;
+    Ref<WebXRSpace> m_space;
     PlatformXR::FrameData::HitTestResult m_result;
 };
 

--- a/Source/WebCore/Modules/webxr/WebXRHitTestSource.h
+++ b/Source/WebCore/Modules/webxr/WebXRHitTestSource.h
@@ -28,28 +28,35 @@
 #if ENABLE(WEBXR_HIT_TEST)
 
 #include "PlatformXR.h"
-#include <wtf/RefCounted.h>
+#include <wtf/Ref.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class WebXRSession;
+class WebXRSpace;
+template<typename> class ExceptionOr;
 
-class WebXRHitTestSource : public RefCounted<WebXRHitTestSource> {
+class WebXRHitTestSource : public RefCountedAndCanMakeWeakPtr<WebXRHitTestSource> {
     WTF_MAKE_TZONE_ALLOCATED(WebXRHitTestSource);
 public:
-    static Ref<WebXRHitTestSource> create(WebXRSession&, PlatformXR::HitTestSource&&);
+    static Ref<WebXRHitTestSource> create(WebXRSession&, PlatformXR::HitTestSource&&, WebXRSpace&);
     ~WebXRHitTestSource();
     ExceptionOr<void> cancel();
 
     std::optional<PlatformXR::HitTestSource> handle() const { return m_source; }
 
+    WebXRSpace& space() const;
+
 private:
-    WebXRHitTestSource(WebXRSession&, PlatformXR::HitTestSource&&);
+    WebXRHitTestSource(WebXRSession&, PlatformXR::HitTestSource&&, WebXRSpace&);
 
     WeakPtr<WebXRSession> m_session;
     std::optional<PlatformXR::HitTestSource> m_source;
+    Ref<WebXRSpace> m_space;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.h
@@ -65,7 +65,7 @@ public:
     PlatformXR::InputSourceHandle handle() const { return m_source.handle; }
     XRHandedness handedness() const { return m_source.handedness; }
     XRTargetRayMode targetRayMode() const { return m_source.targetRayMode; };
-    const WebXRSpace& targetRaySpace() const {return m_targetRaySpace.get(); };
+    WebXRSpace& targetRaySpace() const { return m_targetRaySpace.get(); };
     WebXRSpace* gripSpace() const { return m_gripSpace.get(); }
     const Vector<String>& profiles() const { return m_source.profiles; };
     double connectTime() const { return m_connectTime; }

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -42,11 +42,13 @@
 #include "XRSessionMode.h"
 #include "XRVisibilityState.h"
 #include <numbers>
+#include <wtf/HashMap.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -126,6 +128,8 @@ public:
     void requestHitTestSource(const XRHitTestOptionsInit&, RequestHitTestSourcePromise&&);
     using RequestHitTestSourceForTransientInputPromise = DOMPromiseDeferred<IDLInterface<WebXRTransientInputHitTestSource>>;
     void requestHitTestSourceForTransientInput(const XRTransientInputHitTestOptionsInit&, RequestHitTestSourceForTransientInputPromise&&);
+    ExceptionOr<void> cancelHitTestSource(PlatformXR::HitTestSource);
+    ExceptionOr<void> cancelTransientInputHitTestSource(PlatformXR::TransientInputHitTestSource);
 #endif
 
     void initializeTrackingAndRendering(std::optional<XRCanvasConfiguration>&&);
@@ -161,6 +165,10 @@ private:
     void applyPendingRenderState();
     void minimalUpdateRendering();
 
+#if ENABLE(WEBXR_HIT_TEST)
+    void cleanupInactiveHitTestSources();
+#endif
+
     XRInteractionMode m_interactionMode { XRInteractionMode::WorldSpace };
     XRVisibilityState m_visibilityState { XRVisibilityState::Visible };
     const UniqueRef<WebXRInputSourceArray> m_inputSources;
@@ -194,6 +202,11 @@ private:
 
     // https://immersive-web.github.io/webxr/#xrsession-promise-resolved
     bool m_inputInitialized { false };
+
+#if ENABLE(WEBXR_HIT_TEST)
+    HashMap<PlatformXR::HitTestSource, WeakPtr<WebXRHitTestSource>> m_activeHitTestSources;
+    HashMap<PlatformXR::HitTestSource, WeakPtr<WebXRTransientInputHitTestSource>> m_activeTransientInputHitTestSources;
+#endif
 };
 
 WebCoreOpaqueRoot root(WebXRSession*);

--- a/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp
@@ -55,10 +55,7 @@ ExceptionOr<void> WebXRTransientInputHitTestSource::cancel()
     RefPtr session = m_session.get();
     if (!session)
         return Exception { ExceptionCode::InvalidStateError };
-    RefPtr device = session->device();
-    if (!device)
-        return Exception { ExceptionCode::InvalidStateError };
-    device->deleteTransientInputHitTestSource(*m_source);
+    session->cancelTransientInputHitTestSource(*m_source);
     m_source = std::nullopt;
     return { };
 }

--- a/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.h
+++ b/Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.h
@@ -30,14 +30,14 @@
 #include "ExceptionOr.h"
 #include "PlatformXR.h"
 #include <wtf/Forward.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
 
 class WebXRSession;
 
-class WebXRTransientInputHitTestSource : public RefCounted<WebXRTransientInputHitTestSource> {
+class WebXRTransientInputHitTestSource : public WTF::RefCountedAndCanMakeWeakPtr<WebXRTransientInputHitTestSource> {
     WTF_MAKE_TZONE_ALLOCATED(WebXRTransientInputHitTestSource);
 public:
     static Ref<WebXRTransientInputHitTestSource> create(WebXRSession&, PlatformXR::TransientInputHitTestSource&&);

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
@@ -67,6 +67,8 @@ OpenXRHitTestManager::OpenXRHitTestManager(XrInstance instance, XrSystemId syste
             break;
         }
     }
+#else
+    UNUSED_VARIABLE(m_session);
 #endif
 }
 


### PR DESCRIPTION
#### 75e1aa48969bfa3da5cbc154c4fec970ab804803
<pre>
[WebXR][HitTest] Incorrect hit test poses when not using fixed reference spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=306418">https://bugs.webkit.org/show_bug.cgi?id=306418</a>

Reviewed by Fujii Hironori.

The hit test poses were always computed using a generated
WebXRHitTestResultSpace whose native origin was the pose of the hit
test. That&apos;s wrong because the hit tests are reported against the
reference space used to create the hit test source (or the space of the
input for transient input hit test sources).

That&apos;s why we need to pass the reference space of the source (or the
input source) to resolve the poses.

Apart from that we know keep the lists of active hit test sources in the
session as mandated by the spec. Those lists must be updated whenever
hit test sources are created and canceled. We also cleanup the hit test
sources that are no longer referenced by the application as suggested by
the specs.

The FakeXRDevice had to be adjusted to support this. It was also
assuming that the reference space was always the same. There are also
some subtleties there, the WPT tests for hit testing were developed by
Chromium folks so they are tailored for the data structures and
assumptions used in Chromium. For example the poses inside the JS code
are all specified based on the mojo (device) pose. That forces us to do
some extra conversions in the testing code to get the right results when
using different reference spaces.

* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
(WebCore::WebXRFrame::getHitTestResults):
(WebCore::WebXRFrame::getHitTestResultsForTransientInput):
* Source/WebCore/Modules/webxr/WebXRHitTestResult.cpp:
(WebCore::WebXRHitTestResult::create):
(WebCore::WebXRHitTestResult::WebXRHitTestResult):
(WebCore::WebXRHitTestResult::getPose):
(WebCore::WebXRHitTestResultSpace::WebXRHitTestResultSpace): Deleted.
(): Deleted.
* Source/WebCore/Modules/webxr/WebXRHitTestResult.h:
* Source/WebCore/Modules/webxr/WebXRHitTestSource.cpp:
(WebCore::WebXRHitTestSource::create):
(WebCore::WebXRHitTestSource::WebXRHitTestSource):
(WebCore::WebXRHitTestSource::cancel):
(WebCore::WebXRHitTestSource::space const):
* Source/WebCore/Modules/webxr/WebXRHitTestSource.h:
* Source/WebCore/Modules/webxr/WebXRInputSource.h:
(WebCore::WebXRInputSource::targetRaySpace const):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::cleanupInactiveHitTestSources):
(WebCore::WebXRSession::onFrame):
(WebCore::WebXRSession::requestHitTestSource):
(WebCore::WebXRSession::requestHitTestSourceForTransientInput):
(WebCore::WebXRSession::cancelHitTestSource):
(WebCore::WebXRSession::cancelTransientInputHitTestSource):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.cpp:
(WebCore::WebXRTransientInputHitTestSource::cancel):
* Source/WebCore/Modules/webxr/WebXRTransientInputHitTestSource.h:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::rigidTransformToPose):
(WebCore::SimulatedXRDevice::frameTimerFired):
(WebCore::SimulatedXRDevice::hitTestWorld):
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp:
(WebKit::OpenXRHitTestManager::OpenXRHitTestManager):

Canonical link: <a href="https://commits.webkit.org/306939@main">https://commits.webkit.org/306939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52b973708f660f6b442f4e8560e6154bbd29d837

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151529 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90768 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9500 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1528 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153842 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14953 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117875 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14990 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14201 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125140 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70650 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14996 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4059 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78705 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->