### PR TITLE
Border collapse problem with rowspan/colspan cells

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color-expected.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<style>
+  table {
+    border-collapse: collapse;
+  }
+
+  td {
+    width: 100px;
+    height: 50px;
+    border: 1px solid black;
+  }
+
+  /* Row borders */
+  #ref tr:nth-child(1) {
+    border-bottom: 5px solid blue;
+  }
+
+  #ref tr:nth-child(2) {
+    border-bottom: 5px solid green;
+  }
+
+  #ref tr:nth-child(3) {
+    border-bottom: 5px solid red;
+  }
+
+  /* The rowspan cell should have red bottom border */
+  #ref .rowspan-cell {
+    border-bottom: 5px solid red;
+  }
+</style>
+<p>The cell with rowspan=3 should have a red bottom border (from row 3), not blue (from row 1).</p>
+<table id="ref">
+  <tr>
+    <td class="rowspan-cell" rowspan="3">Rowspan 3</td>
+    <td>Cell B</td>
+  </tr>
+  <tr>
+    <td>Cell C</td>
+  </tr>
+  <tr>
+    <td>Cell D</td>
+  </tr>
+</table>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color-ref.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<style>
+  table {
+    border-collapse: collapse;
+  }
+
+  td {
+    width: 100px;
+    height: 50px;
+    border: 1px solid black;
+  }
+
+  /* Row borders */
+  #ref tr:nth-child(1) {
+    border-bottom: 5px solid blue;
+  }
+
+  #ref tr:nth-child(2) {
+    border-bottom: 5px solid green;
+  }
+
+  #ref tr:nth-child(3) {
+    border-bottom: 5px solid red;
+  }
+
+  /* The rowspan cell should have red bottom border */
+  #ref .rowspan-cell {
+    border-bottom: 5px solid red;
+  }
+</style>
+<p>The cell with rowspan=3 should have a red bottom border (from row 3), not blue (from row 1).</p>
+<table id="ref">
+  <tr>
+    <td class="rowspan-cell" rowspan="3">Rowspan 3</td>
+    <td>Cell B</td>
+  </tr>
+  <tr>
+    <td>Cell C</td>
+  </tr>
+  <tr>
+    <td>Cell D</td>
+  </tr>
+</table>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<link rel="help" href="https://www.w3.org/TR/CSS2/tables.html#border-conflict-resolution">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=5515">
+<link rel="match" href="rowspan-cell-border-after-color-ref.html">
+<meta name="assert" content="A cell with rowspan should use the last row's border for its after (bottom) border, not the first row's border">
+<style>
+  table {
+    border-collapse: collapse;
+  }
+
+  td {
+    width: 100px;
+    height: 50px;
+    border: 1px solid black;
+  }
+
+  /* Different border colors for each row */
+  #test tr:nth-child(1) {
+    border-bottom: 5px solid blue;
+  }
+
+  #test tr:nth-child(2) {
+    border-bottom: 5px solid green;
+  }
+
+  #test tr:nth-child(3) {
+    border-bottom: 5px solid red;
+  }
+</style>
+<p>The cell with rowspan=3 should have a red bottom border (from row 3), not blue (from row 1).</p>
+<table id="test">
+  <tr>
+    <td rowspan="3">Rowspan 3</td>
+    <td>Cell B</td>
+  </tr>
+  <tr>
+    <td>Cell C</td>
+  </tr>
+  <tr>
+    <td>Cell D</td>
+  </tr>
+</table>
+</html>


### PR DESCRIPTION
#### c9af451c45ddb76c864a157c7494cf4256d2e655
<pre>
Border collapse problem with rowspan/colspan cells
<a href="https://bugs.webkit.org/show_bug.cgi?id=5515">https://bugs.webkit.org/show_bug.cgi?id=5515</a>
<a href="https://rdar.apple.com/94163960">rdar://94163960</a>

Reviewed by Alan Baradlay.

Currently for a table of 2 columns and 4 rows.
* the first column has a rowspan = 3
  (so 2 cells with one covering the first 3 rows)
* the second column has 4 cells on 4 rows
When specifiying a different bottom border color for each first 3 rows,
WebKit is adopting the color of the first cell defined in the second
colum for the bottom color of the rowspanned cell instead of the color
of the third row like Gecko and Blink do.

This patch is fixing and only this. It doesn&apos;t fix the more general
issue for vertical border shared in between the rowspanned cell and the
second column cells.
This will need to be fixed in <a href="https://webkit.org/b/20260">https://webkit.org/b/20260</a> as it requires
a larger architectural change on border segmenting.

This didn&apos;t have WPT tests before, this is adding one covering this
behavior.

Tests: imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color-ref.html
       imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/rowspan-cell-border-after-color.html: Added.
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::computeCollapsedAfterBorder const):

Canonical link: <a href="https://commits.webkit.org/306471@main">https://commits.webkit.org/306471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef1a9cdda22fbfece5f6e0c262330fc481d96e78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150046 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12c361af-7ea3-4683-b936-589c249d1af2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108696 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e59387dd-0928-4106-a1f5-9d5176c5ed40) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89602 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98a27b9d-8d68-4968-98f8-91f94f22b3a5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8426 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/118 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152439 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116799 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117129 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13169 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123250 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21825 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13587 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13323 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->