### PR TITLE
Implement SetUpCrossRealmTransformReadable

### DIFF
--- a/LayoutTests/streams/transfer-internal-expected.txt
+++ b/LayoutTests/streams/transfer-internal-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Validate default behavior
+PASS Validate invalid type
+PASS Validate invalid object messages
+

--- a/LayoutTests/streams/transfer-internal.html
+++ b/LayoutTests/streams/transfer-internal.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<script src='../resources/testharness.js'></script>
+<script src='../resources/testharnessreport.js'></script>
+<script>
+function createReadableStreamAndPort()
+{
+    const channel = new MessageChannel();
+    channel.port1.start();
+    channel.port2.start();
+
+    const stream = internals.readableStreamFromMessagePort(channel.port2);
+    return { stream, port: channel.port1 };
+}
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const { stream, port } = createReadableStreamAndPort();
+    const reader = stream.getReader();
+
+    port.postMessage({ type:"chunk", value:"test" });
+
+    const chunk = await reader.read();
+    assert_equals(chunk.value, "test");
+
+    port.postMessage({ type:"close" });
+    await reader.closed;
+}, 'Validate default behavior');
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const { stream, port } = createReadableStreamAndPort();
+    const reader = stream.getReader();
+
+    port.postMessage({ type:"ee" });
+    await promise_rejects_js(t, TypeError, reader.closed);
+}, 'Validate invalid type');
+
+function createReadableStreamReaderFromMessage(message)
+{
+    const { stream, port } = createReadableStreamAndPort();
+    port.postMessage(message);
+    return stream.getReader();
+}
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    let reader = createReadableStreamReaderFromMessage({ });
+    await promise_rejects_dom(t, "DataCloneError", reader.closed);
+
+    reader = createReadableStreamReaderFromMessage(1);
+    await promise_rejects_dom(t, "DataCloneError", reader.closed);
+
+    reader = createReadableStreamReaderFromMessage(undefined);
+    await promise_rejects_dom(t, "DataCloneError", reader.closed);
+
+    reader = createReadableStreamReaderFromMessage(null);
+    await promise_rejects_dom(t, "DataCloneError", reader.closed);
+
+}, 'Validate invalid object messages');
+</script>

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "config.h"
+#include "StreamTransferUtilities.h"
+
+#include "JSDOMException.h"
+#include "MessagePort.h"
+#include "ReadableStream.h"
+#include "ReadableStreamSource.h"
+#include "StructuredSerializeOptions.h"
+#include <JavaScriptCore/ObjectConstructor.h>
+
+namespace WebCore {
+
+// https://streams.spec.whatwg.org/#abstract-opdef-packandpostmessage
+static ExceptionOr<void> packAndPostMessage(JSDOMGlobalObject& globalObject, MessagePort& port, const String& type, JSC::JSValue value)
+{
+    Ref vm = globalObject.vm();
+    Locker locker(vm->apiLock());
+    auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+    auto* data = JSC::constructEmptyObject(&globalObject);
+    if (catchScope.exception()) [[unlikely]]
+        return Exception { ExceptionCode::InvalidStateError, "Unable to post message"_s };
+    JSC::Strong<JSC::JSObject> strongData(vm, data);
+
+    auto* jsType = JSC::jsNontrivialString(vm.get(), type);
+    if (catchScope.exception()) [[unlikely]]
+        return Exception { ExceptionCode::InvalidStateError, "Unable to post message"_s };
+    JSC::Strong<JSC::JSString> strongType(vm.get(), jsType);
+
+    data->putDirect(vm.get(), vm->propertyNames->type, jsType);
+    if (catchScope.exception()) [[unlikely]]
+        return Exception { ExceptionCode::InvalidStateError, "Unable to set value"_s };
+
+    data->putDirect(vm.get(), vm->propertyNames->value, value);
+    if (catchScope.exception()) [[unlikely]]
+        return Exception { ExceptionCode::InvalidStateError, "Unable to set value"_s };
+
+    return port.postMessage(globalObject, data, { });
+}
+
+// https://streams.spec.whatwg.org/#abstract-opdef-crossrealmtransformsenderror
+static void crossRealmTransformSendError(JSDOMGlobalObject& globalObject, MessagePort& port, JSC::JSValue error)
+{
+    packAndPostMessage(globalObject, port, "error"_s, error);
+}
+
+static ExceptionOr<void> packAndPostMessageHandlingError(JSDOMGlobalObject& globalObject, MessagePort& port, const String& type, JSC::JSValue value)
+{
+    auto result = packAndPostMessage(globalObject, port, type, value);
+    if (result.hasException())
+        crossRealmTransformSendError(globalObject, port, toJS(&globalObject, &globalObject, DOMException::create(result.exception()).get()));
+    return result;
+}
+
+class CrossRealmReadableStreamSource final : public ReadableStreamSource, public RefCountedAndCanMakeWeakPtr<CrossRealmReadableStreamSource> {
+public:
+    static Ref<CrossRealmReadableStreamSource> create(Ref<MessagePort>&& port)
+    {
+        Ref source = adoptRef(*new CrossRealmReadableStreamSource(WTF::move(port)));
+        source->m_port->setMessageHandler([weakSource = WeakPtr { source }](auto& globalObject, auto& value) {
+            RefPtr protectedSource = weakSource.get();
+            if (!protectedSource)
+                return;
+
+            auto& vm = globalObject.vm();
+            Locker locker(vm.apiLock());
+            auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+            bool didFail = false;
+            auto deserialized = value.deserialize(globalObject, &globalObject, { }, SerializationErrorMode::NonThrowing, &didFail);
+            bool isSuccess = [&] {
+                if (catchScope.exception() || didFail) [[unlikely]]
+                    return false;
+
+                auto* object = deserialized.getObject();
+                if (!object)
+                    return false;
+
+                JSC::Strong<JSC::JSObject> strongObject(vm, object);
+                return protectedSource->handleMessage(globalObject, *object);
+            }();
+
+            if (!isSuccess)
+                protectedSource->handleMessageError(globalObject);
+        });
+        return source;
+    }
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    explicit CrossRealmReadableStreamSource(Ref<MessagePort>&& port)
+        : m_port(WTF::move(port))
+    {
+    }
+
+    bool handleMessage(JSDOMGlobalObject& globalObject, JSC::JSObject& object)
+    {
+        Ref vm = globalObject.vm();
+        auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+        auto typeValue = object.get(&globalObject, vm->propertyNames->type);
+        if (catchScope.exception()) [[unlikely]]
+            return false;
+        auto value = object.get(&globalObject, vm->propertyNames->value);
+        if (catchScope.exception()) [[unlikely]]
+            return false;
+
+        if (!typeValue.isString())
+            return false;
+
+        String type = JSC::asString(typeValue)->tryGetValue();
+        if (type == "chunk"_s) {
+            if (controller().enqueue(value))
+                pullFinished();
+            return true;
+        }
+        if (type == "close"_s) {
+            controller().close();
+            return true;
+        }
+        if (type == "error"_s) {
+            errorStream(globalObject, value);
+            return true;
+        }
+
+        errorStream(globalObject, createDOMException(&globalObject, ExceptionCode::TypeError, "Unexpected value"_s));
+        return true;
+    }
+
+    void handleMessageError(JSDOMGlobalObject& globalObject)
+    {
+        errorStream(globalObject, createDOMException(&globalObject, ExceptionCode::DataCloneError, "Failed to deserialize value"_s));
+    }
+
+    void errorStream(JSDOMGlobalObject& globalObject, JSC::JSValue error)
+    {
+        Ref vm = globalObject.vm();
+        JSC::Strong<JSC::Unknown> strongError(vm.get(), error);
+        crossRealmTransformSendError(globalObject, m_port, error);
+        this->error(globalObject, error);
+        m_port->close();
+    }
+
+    // ReadableStreamSource
+    void setActive() final { };
+    void setInactive() final { };
+
+    void doStart() final { startFinished(); }
+    void doPull() final
+    {
+        RefPtr context = m_port->scriptExecutionContext();
+        auto* globalObject = context ? context->globalObject() : nullptr;
+        if (!globalObject)
+            return;
+
+        packAndPostMessage(*JSC::jsCast<JSDOMGlobalObject*>(globalObject), m_port.get(), "pull"_s, JSC::jsUndefined());
+    }
+    void doCancel(JSC::JSValue reason) final
+    {
+        // FIXME: Reject cancel promise in case of error.
+        RefPtr context = m_port->scriptExecutionContext();
+        auto* globalObject = context ? context->globalObject() : nullptr;
+        if (!globalObject)
+            return;
+
+        packAndPostMessageHandlingError(*JSC::jsCast<JSDOMGlobalObject*>(globalObject), m_port.get(), "error"_s, reason);
+        m_port->close();
+    }
+
+    const Ref<MessagePort> m_port;
+};
+
+ExceptionOr<Ref<ReadableStream>> setupCrossRealmTransformReadable(JSDOMGlobalObject& globalObject, MessagePort& port)
+{
+    return ReadableStream::create(globalObject, CrossRealmReadableStreamSource::create(port));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.h
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ExceptionOr.h"
+
+namespace WebCore {
+
+class JSDOMGlobalObject;
+class MessagePort;
+class ReadableStream;
+class WritableStream;
+
+// https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
+WEBCORE_EXPORT ExceptionOr<Ref<ReadableStream>> setupCrossRealmTransformReadable(JSDOMGlobalObject&, MessagePort&);
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -37,6 +37,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
 
 namespace JSC {
@@ -47,6 +48,7 @@ class ArrayBufferView;
 namespace WebCore {
 
 class Blob;
+class SecurityOrigin;
 class ThreadableWebSocketChannel;
 template<typename> class ExceptionOr;
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -386,6 +386,7 @@ Modules/streams/ReadableStreamToSharedBufferSink.cpp
 Modules/streams/ReadableStreamSource.cpp
 Modules/streams/StreamPipeToUtilities.cpp @no-unify
 Modules/streams/StreamTeeUtilities.cpp
+Modules/streams/StreamTransferUtilities.cpp
 Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
 Modules/url-pattern/URLPattern.cpp

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -42,7 +42,9 @@ class JSValue;
 
 namespace WebCore {
 
+class JSDOMGlobalObject;
 class LocalFrame;
+class SerializedScriptValue;
 class WebCoreOpaqueRoot;
 
 struct StructuredSerializeOptions;
@@ -66,6 +68,9 @@ public:
     void start();
     void close();
     void entangle();
+
+    using MessageHandler = Function<void(JSDOMGlobalObject&, SerializedScriptValue&)>;
+    void setMessageHandler(MessageHandler&&);
 
     // Returns nullptr if the passed-in vector is empty.
     static ExceptionOr<Vector<TransferredMessagePort>> disentanglePorts(Vector<Ref<MessagePort>>&&);
@@ -121,6 +126,8 @@ private:
 
     MessagePortIdentifier m_identifier;
     MessagePortIdentifier m_remoteIdentifier;
+
+    MessageHandler m_messageHandler;
 };
 
 WebCoreOpaqueRoot root(MessagePort*);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -243,6 +243,7 @@
 #include "StaticNodeList.h"
 #include "StorageNamespace.h"
 #include "StorageNamespaceProvider.h"
+#include "StreamTransferUtilities.h"
 #include "StringCallback.h"
 #include "StyleGridPosition.h"
 #include "StyleResolver.h"
@@ -8346,6 +8347,11 @@ void Internals::testAsyncIterator(JSDOMGlobalObject& globalObject, JSC::JSValue 
     Vector<JSC::Strong<JSC::Unknown>> results;
     Ref domIterator = domIteratorOrException.releaseReturnValue();
     storeNextResults(domIterator.get(), WTF::move(results), WTF::move(promise));
+}
+
+ExceptionOr<Ref<ReadableStream>> Internals::readableStreamFromMessagePort(JSDOMGlobalObject& globalObject, MessagePort& port)
+{
+    return setupCrossRealmTransformReadable(globalObject, port);
 }
 
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1672,6 +1672,8 @@ public:
     ExceptionOr<Vector<FrameDamage>> getFrameDamageHistory() const;
 #endif // ENABLE(DAMAGE_TRACKING)
 
+    ExceptionOr<Ref<ReadableStream>> readableStreamFromMessagePort(JSDOMGlobalObject&, MessagePort&);
+
 #if ENABLE(MODEL_ELEMENT)
     void disableModelLoadDelaysForTesting();
     String modelElementState(HTMLModelElement&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1524,6 +1524,8 @@ enum ContentsFormat {
     attribute boolean shouldSkipResourceMonitorThrottling;
 #endif
 
+    [CallWith=CurrentGlobalObject] ReadableStream readableStreamFromMessagePort(MessagePort port);
+
     [Conditional=MODEL_ELEMENT] undefined disableModelLoadDelaysForTesting();
     [Conditional=MODEL_ELEMENT] DOMString modelElementState(HTMLModelElement element);
     [Conditional=MODEL_ELEMENT] boolean isModelElementIntersectingViewport(HTMLModelElement element);


### PR DESCRIPTION
#### 378d33fcfd7109660e72d4215bce53b9e64c5082
<pre>
Implement SetUpCrossRealmTransformReadable
<a href="https://rdar.apple.com/169089453">rdar://169089453</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306421">https://bugs.webkit.org/show_bug.cgi?id=306421</a>

Reviewed by Chris Dumez.

Follow the spec by introducing <a href="https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable">https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable</a> and related methods.
This will be useful to implement transferring of readable and writable streams.

Covered by added API test, using new internal API.

Canonical link: <a href="https://commits.webkit.org/306488@main">https://commits.webkit.org/306488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af02b1c37664ff7fe20ea33baa537d6c3ebd5e01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94589 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4684067b-d7c8-493a-b7ea-98e0f81b6e2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc6d63be-92a1-4680-b8cb-20029478acf4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89621 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/007b705b-9a4c-4247-a30d-0232361bf801) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10818 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8444 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/140 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152461 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13566 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116819 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117150 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13188 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68763 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13609 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2601 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->