### PR TITLE
Add basic ReadableStream.from support

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream interface object name
 PASS ReadableStream interface: existence and properties of interface prototype object
 PASS ReadableStream interface: existence and properties of interface prototype object's "constructor" property
 PASS ReadableStream interface: existence and properties of interface prototype object's @@unscopables property
-FAIL ReadableStream interface: operation from(any) assert_own_property: interface object missing static operation expected property "from" missing
+PASS ReadableStream interface: operation from(any)
 PASS ReadableStream interface: attribute locked
 PASS ReadableStream interface: operation cancel(optional any)
 PASS ReadableStream interface: operation getReader(optional ReadableStreamGetReaderOptions)
@@ -20,7 +20,7 @@ PASS ReadableStream interface: async iterable<any>
 PASS ReadableStream must be primary interface of new ReadableStream()
 PASS Stringification of new ReadableStream()
 PASS ReadableStream interface: new ReadableStream() must inherit property "from(any)" with the proper type
-FAIL ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError assert_own_property: interface object must have static operation as own property expected property "from" missing
+PASS ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError
 PASS ReadableStream interface: new ReadableStream() must inherit property "locked" with the proper type
 PASS ReadableStream interface: new ReadableStream() must inherit property "cancel(optional any)" with the proper type
 PASS ReadableStream interface: calling cancel(optional any) on new ReadableStream() with too few arguments must throw TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.serviceworker-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream interface object name
 PASS ReadableStream interface: existence and properties of interface prototype object
 PASS ReadableStream interface: existence and properties of interface prototype object's "constructor" property
 PASS ReadableStream interface: existence and properties of interface prototype object's @@unscopables property
-FAIL ReadableStream interface: operation from(any) assert_own_property: interface object missing static operation expected property "from" missing
+PASS ReadableStream interface: operation from(any)
 PASS ReadableStream interface: attribute locked
 PASS ReadableStream interface: operation cancel(optional any)
 PASS ReadableStream interface: operation getReader(optional ReadableStreamGetReaderOptions)
@@ -20,7 +20,7 @@ PASS ReadableStream interface: async iterable<any>
 PASS ReadableStream must be primary interface of new ReadableStream()
 PASS Stringification of new ReadableStream()
 PASS ReadableStream interface: new ReadableStream() must inherit property "from(any)" with the proper type
-FAIL ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError assert_own_property: interface object must have static operation as own property expected property "from" missing
+PASS ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError
 PASS ReadableStream interface: new ReadableStream() must inherit property "locked" with the proper type
 PASS ReadableStream interface: new ReadableStream() must inherit property "cancel(optional any)" with the proper type
 PASS ReadableStream interface: calling cancel(optional any) on new ReadableStream() with too few arguments must throw TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.sharedworker-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream interface object name
 PASS ReadableStream interface: existence and properties of interface prototype object
 PASS ReadableStream interface: existence and properties of interface prototype object's "constructor" property
 PASS ReadableStream interface: existence and properties of interface prototype object's @@unscopables property
-FAIL ReadableStream interface: operation from(any) assert_own_property: interface object missing static operation expected property "from" missing
+PASS ReadableStream interface: operation from(any)
 PASS ReadableStream interface: attribute locked
 PASS ReadableStream interface: operation cancel(optional any)
 PASS ReadableStream interface: operation getReader(optional ReadableStreamGetReaderOptions)
@@ -20,7 +20,7 @@ PASS ReadableStream interface: async iterable<any>
 PASS ReadableStream must be primary interface of new ReadableStream()
 PASS Stringification of new ReadableStream()
 PASS ReadableStream interface: new ReadableStream() must inherit property "from(any)" with the proper type
-FAIL ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError assert_own_property: interface object must have static operation as own property expected property "from" missing
+PASS ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError
 PASS ReadableStream interface: new ReadableStream() must inherit property "locked" with the proper type
 PASS ReadableStream interface: new ReadableStream() must inherit property "cancel(optional any)" with the proper type
 PASS ReadableStream interface: calling cancel(optional any) on new ReadableStream() with too few arguments must throw TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/idlharness.any.worker-expected.txt
@@ -9,7 +9,7 @@ PASS ReadableStream interface object name
 PASS ReadableStream interface: existence and properties of interface prototype object
 PASS ReadableStream interface: existence and properties of interface prototype object's "constructor" property
 PASS ReadableStream interface: existence and properties of interface prototype object's @@unscopables property
-FAIL ReadableStream interface: operation from(any) assert_own_property: interface object missing static operation expected property "from" missing
+PASS ReadableStream interface: operation from(any)
 PASS ReadableStream interface: attribute locked
 PASS ReadableStream interface: operation cancel(optional any)
 PASS ReadableStream interface: operation getReader(optional ReadableStreamGetReaderOptions)
@@ -20,7 +20,7 @@ PASS ReadableStream interface: async iterable<any>
 PASS ReadableStream must be primary interface of new ReadableStream()
 PASS Stringification of new ReadableStream()
 PASS ReadableStream interface: new ReadableStream() must inherit property "from(any)" with the proper type
-FAIL ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError assert_own_property: interface object must have static operation as own property expected property "from" missing
+PASS ReadableStream interface: calling from(any) on new ReadableStream() with too few arguments must throw TypeError
 PASS ReadableStream interface: new ReadableStream() must inherit property "locked" with the proper type
 PASS ReadableStream interface: new ReadableStream() must inherit property "cancel(optional any)" with the proper type
 PASS ReadableStream interface: calling cancel(optional any) on new ReadableStream() with too few arguments must throw TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL ReadableStream.from accepts an array of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: iterable should be an object"
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+PASS ReadableStream.from accepts a ReadableStream
+PASS ReadableStream.from accepts a ReadableStream async iterator
 PASS ReadableStream.from throws on invalid iterables; specifically null
 PASS ReadableStream.from throws on invalid iterables; specifically undefined
 PASS ReadableStream.from throws on invalid iterables; specifically 0
@@ -25,26 +25,26 @@ PASS ReadableStream.from throws on invalid iterables; specifically an object wit
 PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@iterator method returning a non-object
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@asyncIterator method returning a non-object
-FAIL ReadableStream.from re-throws errors from calling the @@iterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from re-throws errors from calling the @@asyncIterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores @@iterator if @@asyncIterator exists assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores a null @@asyncIterator assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from accepts an empty iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() returns a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream stalls when next() never settles promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: calls next() after first read() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: return() is not called when iterator completes normally promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() resolves when return() method is missing promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() is not a method promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.read() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from(array), push() to array while reading promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(array)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from ignores a null @@asyncIterator
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream errors when next() throws synchronously
+PASS ReadableStream.from: stream errors when next() returns a non-object
+PASS ReadableStream.from: stream errors when next() fulfills with a non-object
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() resolves when return() method is missing
+FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from(array), push() to array while reading
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL ReadableStream.from accepts an array of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: iterable should be an object"
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+PASS ReadableStream.from accepts a ReadableStream
+PASS ReadableStream.from accepts a ReadableStream async iterator
 PASS ReadableStream.from throws on invalid iterables; specifically null
 PASS ReadableStream.from throws on invalid iterables; specifically undefined
 PASS ReadableStream.from throws on invalid iterables; specifically 0
@@ -25,26 +25,26 @@ PASS ReadableStream.from throws on invalid iterables; specifically an object wit
 PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@iterator method returning a non-object
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@asyncIterator method returning a non-object
-FAIL ReadableStream.from re-throws errors from calling the @@iterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from re-throws errors from calling the @@asyncIterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores @@iterator if @@asyncIterator exists assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores a null @@asyncIterator assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from accepts an empty iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() returns a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream stalls when next() never settles promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: calls next() after first read() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: return() is not called when iterator completes normally promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() resolves when return() method is missing promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() is not a method promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.read() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from(array), push() to array while reading promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(array)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from ignores a null @@asyncIterator
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream errors when next() throws synchronously
+PASS ReadableStream.from: stream errors when next() returns a non-object
+PASS ReadableStream.from: stream errors when next() fulfills with a non-object
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() resolves when return() method is missing
+FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from(array), push() to array while reading
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL ReadableStream.from accepts an array of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: iterable should be an object"
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+PASS ReadableStream.from accepts a ReadableStream
+PASS ReadableStream.from accepts a ReadableStream async iterator
 PASS ReadableStream.from throws on invalid iterables; specifically null
 PASS ReadableStream.from throws on invalid iterables; specifically undefined
 PASS ReadableStream.from throws on invalid iterables; specifically 0
@@ -25,26 +25,26 @@ PASS ReadableStream.from throws on invalid iterables; specifically an object wit
 PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@iterator method returning a non-object
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@asyncIterator method returning a non-object
-FAIL ReadableStream.from re-throws errors from calling the @@iterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from re-throws errors from calling the @@asyncIterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores @@iterator if @@asyncIterator exists assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores a null @@asyncIterator assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from accepts an empty iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() returns a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream stalls when next() never settles promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: calls next() after first read() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: return() is not called when iterator completes normally promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() resolves when return() method is missing promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() is not a method promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.read() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from(array), push() to array while reading promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(array)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from ignores a null @@asyncIterator
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream errors when next() throws synchronously
+PASS ReadableStream.from: stream errors when next() returns a non-object
+PASS ReadableStream.from: stream errors when next() fulfills with a non-object
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() resolves when return() method is missing
+FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from(array), push() to array while reading
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker-expected.txt
@@ -1,17 +1,17 @@
 
-FAIL ReadableStream.from accepts an array of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an array iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a Set iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async generator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of values promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a sync iterable of promises promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts an async iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from accepts a ReadableStream async iterator promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from accepts an array of values
+PASS ReadableStream.from accepts an array of promises
+PASS ReadableStream.from accepts an array iterator
+FAIL ReadableStream.from accepts a string promise_test: Unhandled rejection with value: object "TypeError: iterable should be an object"
+PASS ReadableStream.from accepts a Set
+PASS ReadableStream.from accepts a Set iterator
+PASS ReadableStream.from accepts a sync generator
+PASS ReadableStream.from accepts an async generator
+PASS ReadableStream.from accepts a sync iterable of values
+PASS ReadableStream.from accepts a sync iterable of promises
+PASS ReadableStream.from accepts an async iterable
+PASS ReadableStream.from accepts a ReadableStream
+PASS ReadableStream.from accepts a ReadableStream async iterator
 PASS ReadableStream.from throws on invalid iterables; specifically null
 PASS ReadableStream.from throws on invalid iterables; specifically undefined
 PASS ReadableStream.from throws on invalid iterables; specifically 0
@@ -25,26 +25,26 @@ PASS ReadableStream.from throws on invalid iterables; specifically an object wit
 PASS ReadableStream.from throws on invalid iterables; specifically an object with a non-callable @@asyncIterator method
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@iterator method returning a non-object
 PASS ReadableStream.from throws on invalid iterables; specifically an object with an @@asyncIterator method returning a non-object
-FAIL ReadableStream.from re-throws errors from calling the @@iterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from re-throws errors from calling the @@asyncIterator method assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores @@iterator if @@asyncIterator exists assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from ignores a null @@asyncIterator assert_throws_exactly: from() should re-throw the error function "() => ReadableStream.from(iterable)" threw object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)" but we expected it to throw object "Error: a unique string"
-FAIL ReadableStream.from accepts an empty iterable promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() returns a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream errors when next() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: stream stalls when next() never settles promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: calls next() after first read() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: return() is not called when iterator completes normally promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() resolves when return() method is missing promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() is not a method promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() rejects promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.read() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside next() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from: reader.cancel() inside return() promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(iterable)', 'ReadableStream.from' is undefined)"
-FAIL ReadableStream.from(array), push() to array while reading promise_test: Unhandled rejection with value: object "TypeError: ReadableStream.from is not a function. (In 'ReadableStream.from(array)', 'ReadableStream.from' is undefined)"
+PASS ReadableStream.from re-throws errors from calling the @@iterator method
+PASS ReadableStream.from re-throws errors from calling the @@asyncIterator method
+PASS ReadableStream.from ignores @@iterator if @@asyncIterator exists
+PASS ReadableStream.from ignores a null @@asyncIterator
+PASS ReadableStream.from accepts an empty iterable
+PASS ReadableStream.from: stream errors when next() rejects
+PASS ReadableStream.from: stream errors when next() throws synchronously
+PASS ReadableStream.from: stream errors when next() returns a non-object
+PASS ReadableStream.from: stream errors when next() fulfills with a non-object
+PASS ReadableStream.from: stream stalls when next() never settles
+PASS ReadableStream.from: calls next() after first read()
+FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: return() is not called when iterator completes normally
+PASS ReadableStream.from: cancel() resolves when return() method is missing
+FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
+FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: reader.read() inside next()
+PASS ReadableStream.from: reader.cancel() inside next()
+FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from(array), push() to array while reading
 

--- a/Source/JavaScriptCore/runtime/IteratorOperations.cpp
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.cpp
@@ -98,13 +98,23 @@ JSValue iteratorValue(JSGlobalObject* globalObject, JSValue iterResult)
     return iterResult.get(globalObject, globalObject->vm().propertyNames->value);
 }
 
-bool iteratorComplete(JSGlobalObject* globalObject, JSValue iterResult)
+static bool iteratorCompleteImpl(JSGlobalObject* globalObject, JSValue iterResult)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue done = iterResult.get(globalObject, globalObject->vm().propertyNames->done);
     RETURN_IF_EXCEPTION(scope, true);
     RELEASE_AND_RETURN(scope, done.toBoolean(globalObject));
+}
+
+bool iteratorComplete(JSGlobalObject* globalObject, JSValue iterResult)
+{
+    return iteratorCompleteImpl(globalObject, iterResult);
+}
+
+bool iteratorCompleteExported(JSGlobalObject* globalObject, JSValue iterResult)
+{
+    return iteratorCompleteImpl(globalObject, iterResult);
 }
 
 JSValue iteratorStep(JSGlobalObject* globalObject, IterationRecord iterationRecord)

--- a/Source/JavaScriptCore/runtime/IteratorOperations.h
+++ b/Source/JavaScriptCore/runtime/IteratorOperations.h
@@ -52,6 +52,7 @@ JS_EXPORT_PRIVATE JSValue iteratorNextExported(JSGlobalObject*, IterationRecord,
 JSValue iteratorNextWithCachedCall(JSGlobalObject*, IterationRecord, CachedCall*, JSValue argument = JSValue());
 JS_EXPORT_PRIVATE JSValue iteratorValue(JSGlobalObject*, JSValue iterResult);
 bool iteratorComplete(JSGlobalObject*, JSValue iterResult);
+JS_EXPORT_PRIVATE bool iteratorCompleteExported(JSGlobalObject*, JSValue iterResult);
 JS_EXPORT_PRIVATE JSValue iteratorStep(JSGlobalObject*, IterationRecord);
 JS_EXPORT_PRIVATE JSValue iteratorStepWithCachedCall(JSGlobalObject*, IterationRecord, CachedCall*);
 JS_EXPORT_PRIVATE void iteratorClose(JSGlobalObject*, JSValue iterator);

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6392,6 +6392,20 @@ ReadableByteStreamFetchSourceEnabled:
     WebKit:
       default: true
 
+ReadableStreamFromEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "ReadableStream.from"
+  humanReadableDescription: "Enable ReadableStream.from"
+  defaultValue:
+    WebCore:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+
 ReadableStreamIterableEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -76,6 +76,8 @@ public:
     static ExceptionOr<Ref<ReadableStream>> createFromByteUnderlyingSource(JSDOMGlobalObject&, JSC::JSValue underlyingSource, UnderlyingSource&&, double highWaterMark);
     static Ref<ReadableStream> create(Ref<InternalReadableStream>&&);
 
+    static ExceptionOr<Ref<ReadableStream>> from(JSDOMGlobalObject&, JSC::JSValue);
+
     virtual ~ReadableStream();
 
     // ContextDestructionObserver.

--- a/Source/WebCore/Modules/streams/ReadableStream.idl
+++ b/Source/WebCore/Modules/streams/ReadableStream.idl
@@ -54,6 +54,7 @@ typedef (ReadableStreamDefaultReader or ReadableStreamBYOBReader) ReadableStream
     PublicIdentifier
 ] interface ReadableStream {
     [CallWith=CurrentGlobalObject] constructor(optional object underlyingSource, optional object options);
+    [EnabledBySetting=ReadableStreamFromEnabled, CallWith=CurrentGlobalObject] static ReadableStream from(any asyncIterable);
 
     [ImplementedAs=isLocked] readonly attribute boolean locked;
 

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
@@ -77,6 +77,12 @@ void ReadableStreamSource::cancel(JSC::JSValue value)
     doCancel(value);
 }
 
+void ReadableStreamSource::error(const Exception& exception)
+{
+    if (m_controller)
+        m_controller->error(exception);
+}
+
 void ReadableStreamSource::error(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
 {
     if (m_controller)

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -43,6 +43,8 @@ public:
     void start(ReadableStreamDefaultController&&, DOMPromiseDeferred<void>&&);
     void pull(DOMPromiseDeferred<void>&&);
     void cancel(JSC::JSValue);
+
+    void error(const Exception&);
     void error(JSC::JSGlobalObject&, JSC::JSValue);
 
     bool isPulling() const { return !!m_promise; }

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
@@ -80,14 +80,14 @@ void DOMAsyncIterator::callNext(Callback&& callback)
     auto result = JSC::iteratorNextExported(globalObject, { m_iterator->guardedObject(), guardedObject() }, { });
     if (auto* exception = scope.exception()) {
         scope.clearException();
-        callback(globalObject, false, exception);
+        callback(globalObject, false, exception->value());
         return;
     }
 
     auto* promise = JSC::JSPromise::resolvedPromise(globalObject, result);
     if (auto* exception = scope.exception()) {
         scope.clearException();
-        callback(globalObject, false, exception);
+        callback(globalObject, false, exception->value());
         return;
     }
 


### PR DESCRIPTION
#### 2202493e7f18159a4d6283ee81a55b64f3a3ae74
<pre>
Add basic ReadableStream.from support
<a href="https://rdar.apple.com/169090253">rdar://169090253</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306423">https://bugs.webkit.org/show_bug.cgi?id=306423</a>

Reviewed by Yusuke Suzuki.

We implement <a href="https://streams.spec.whatwg.org/#readable-stream-from-iterable">https://streams.spec.whatwg.org/#readable-stream-from-iterable</a> and expose ReadableStream.from behind a feature flag.
This patch implements support using DOMAsyncIterator, but does not yet implement cancel support, which will be done in a follow-up PR.

Covered by rebased WPT tests.

Canonical link: <a href="https://commits.webkit.org/306599@main">https://commits.webkit.org/306599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d839f59d6323d7091894f067de487d2539d724c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150077 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94598 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be219a0b-621e-41e1-84c0-78be053ee4cc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108726 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78676 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf6021b1-ddfd-4ac6-85d4-7e74c45818ca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89631 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fda0d67-cf4c-49f1-8de3-25c57267fe42) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10831 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8456 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/149 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133485 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2614 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152470 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2305 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13575 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117160 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29903 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13199 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123290 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68772 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13618 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2608 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172794 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13355 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77332 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44760 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13554 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13402 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->