### PR TITLE
Finalise support of ReadableStream.from

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any-expected.txt
@@ -36,15 +36,15 @@ PASS ReadableStream.from: stream errors when next() returns a non-object
 PASS ReadableStream.from: stream errors when next() fulfills with a non-object
 PASS ReadableStream.from: stream stalls when next() never settles
 PASS ReadableStream.from: calls next() after first read()
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
 PASS ReadableStream.from: return() is not called when iterator completes normally
 PASS ReadableStream.from: cancel() resolves when return() method is missing
-FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: cancel() rejects when return() is not a method
+PASS ReadableStream.from: cancel() rejects when return() rejects
+PASS ReadableStream.from: cancel() rejects when return() throws synchronously
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
 PASS ReadableStream.from: reader.read() inside next()
 PASS ReadableStream.from: reader.cancel() inside next()
-FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from: reader.cancel() inside return()
 PASS ReadableStream.from(array), push() to array while reading
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.serviceworker-expected.txt
@@ -36,15 +36,15 @@ PASS ReadableStream.from: stream errors when next() returns a non-object
 PASS ReadableStream.from: stream errors when next() fulfills with a non-object
 PASS ReadableStream.from: stream stalls when next() never settles
 PASS ReadableStream.from: calls next() after first read()
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
 PASS ReadableStream.from: return() is not called when iterator completes normally
 PASS ReadableStream.from: cancel() resolves when return() method is missing
-FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: cancel() rejects when return() is not a method
+PASS ReadableStream.from: cancel() rejects when return() rejects
+PASS ReadableStream.from: cancel() rejects when return() throws synchronously
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
 PASS ReadableStream.from: reader.read() inside next()
 PASS ReadableStream.from: reader.cancel() inside next()
-FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from: reader.cancel() inside return()
 PASS ReadableStream.from(array), push() to array while reading
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.sharedworker-expected.txt
@@ -36,15 +36,15 @@ PASS ReadableStream.from: stream errors when next() returns a non-object
 PASS ReadableStream.from: stream errors when next() fulfills with a non-object
 PASS ReadableStream.from: stream stalls when next() never settles
 PASS ReadableStream.from: calls next() after first read()
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
 PASS ReadableStream.from: return() is not called when iterator completes normally
 PASS ReadableStream.from: cancel() resolves when return() method is missing
-FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: cancel() rejects when return() is not a method
+PASS ReadableStream.from: cancel() rejects when return() rejects
+PASS ReadableStream.from: cancel() rejects when return() throws synchronously
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
 PASS ReadableStream.from: reader.read() inside next()
 PASS ReadableStream.from: reader.cancel() inside next()
-FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from: reader.cancel() inside return()
 PASS ReadableStream.from(array), push() to array while reading
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/readable-streams/from.any.worker-expected.txt
@@ -36,15 +36,15 @@ PASS ReadableStream.from: stream errors when next() returns a non-object
 PASS ReadableStream.from: stream errors when next() fulfills with a non-object
 PASS ReadableStream.from: stream stalls when next() never settles
 PASS ReadableStream.from: calls next() after first read()
-FAIL ReadableStream.from: cancelling the returned stream calls and awaits return() assert_equals: return() should be called expected 1 but got 0
+PASS ReadableStream.from: cancelling the returned stream calls and awaits return()
 PASS ReadableStream.from: return() is not called when iterator completes normally
 PASS ReadableStream.from: cancel() resolves when return() method is missing
-FAIL ReadableStream.from: cancel() rejects when return() is not a method assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() rejects assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() throws synchronously assert_unreached: Should have rejected: cancel() should reject with error from return() Reached unreachable code
-FAIL ReadableStream.from: cancel() rejects when return() fulfills with a non-object assert_unreached: Should have rejected: cancel() should reject with a TypeError Reached unreachable code
+PASS ReadableStream.from: cancel() rejects when return() is not a method
+PASS ReadableStream.from: cancel() rejects when return() rejects
+PASS ReadableStream.from: cancel() rejects when return() throws synchronously
+PASS ReadableStream.from: cancel() rejects when return() fulfills with a non-object
 PASS ReadableStream.from: reader.read() inside next()
 PASS ReadableStream.from: reader.cancel() inside next()
-FAIL ReadableStream.from: reader.cancel() inside return() assert_equals: return() should be called once expected 1 but got 0
+PASS ReadableStream.from: reader.cancel() inside return()
 PASS ReadableStream.from(array), push() to array while reading
 

--- a/Source/WebCore/Modules/fetch/FetchBodySource.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.cpp
@@ -221,6 +221,10 @@ void FetchBodySource::NonByteSource::doPull()
 
 void FetchBodySource::NonByteSource::doCancel(JSC::JSValue)
 {
+    auto scope = makeScopeExit([&] {
+        cancelFinished();
+    });
+
     m_isCancelling = true;
     RefPtr bodyOwner = m_bodyOwner.get();
     if (!bodyOwner)

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -262,6 +262,10 @@ void MediaStreamTrackProcessor::Source::doPull()
 
 void MediaStreamTrackProcessor::Source::doCancel(JSC::JSValue)
 {
+    auto scope = makeScopeExit([&] {
+        cancelFinished();
+    });
+
     m_isCancelled = true;
     Ref { m_processor.get() }->stopVideoFrameObserver();
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -42,10 +42,10 @@ public:
 
     void start(ReadableStreamDefaultController&&, DOMPromiseDeferred<void>&&);
     void pull(DOMPromiseDeferred<void>&&);
-    void cancel(JSC::JSValue);
+    void cancel(JSC::JSValue, DOMPromiseDeferred<void>&&);
 
-    void error(const Exception&);
     void error(JSC::JSGlobalObject&, JSC::JSValue);
+    void error(const Exception&);
 
     bool isPulling() const { return !!m_promise; }
 
@@ -55,7 +55,8 @@ protected:
 
     void startFinished();
     void pullFinished();
-    void cancelFinished();
+    void cancelFinished(std::optional<Exception>&& = { });
+    void cancelFinishedWithError(JSC::JSValue);
     WEBCORE_EXPORT void clean();
 
     virtual void setActive() = 0;
@@ -63,7 +64,7 @@ protected:
 
     virtual void doStart() = 0;
     virtual void doPull() = 0;
-    virtual void doCancel(JSC::JSValue) = 0;
+    virtual void doCancel(JSC::JSValue) { cancelFinished(); }
 
 private:
     std::unique_ptr<DOMPromiseDeferred<void>> m_promise;

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.idl
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.idl
@@ -32,7 +32,7 @@
 ] interface ReadableStreamSource {
     [Custom, PrivateIdentifier] Promise<undefined> start(ReadableStreamDefaultController controller);
     [Custom, PrivateIdentifier] Promise<undefined> pull(ReadableStreamDefaultController controller);
-    [PrivateIdentifier] undefined cancel(any reason);
+    [PrivateIdentifier] Promise<undefined> cancel(any reason);
 
     // Place holder to keep the controller linked to the source.
     [CachedAttribute, CustomGetter, PrivateIdentifier] readonly attribute any controller;

--- a/Source/WebCore/Modules/webtransport/DatagramSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.cpp
@@ -61,6 +61,7 @@ void DatagramDefaultSource::receiveDatagram(std::span<const uint8_t> datagram, b
 void DatagramDefaultSource::doCancel()
 {
     m_isCancelled = true;
+    cancelFinished();
 }
 
 void DatagramDefaultSource::error(JSC::JSGlobalObject& globalObject, JSC::JSValue value)

--- a/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportBidirectionalStreamSource.cpp
@@ -33,6 +33,7 @@ namespace WebCore {
 void WebTransportBidirectionalStreamSource::doCancel()
 {
     m_isCancelled = true;
+    cancelFinished();
 }
 
 bool WebTransportBidirectionalStreamSource::receiveIncomingStream(JSC::JSGlobalObject& globalObject, Ref<WebTransportBidirectionalStream>& stream)

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
@@ -33,6 +33,7 @@
 #include "WebTransport.h"
 #include "WebTransportError.h"
 #include "WebTransportSession.h"
+#include <wtf/Scope.h>
 
 namespace WebCore {
 
@@ -103,6 +104,10 @@ void WebTransportReceiveStreamSource::receiveError(JSDOMGlobalObject& globalObje
 
 void WebTransportReceiveStreamSource::doCancel(JSC::JSValue value)
 {
+    auto scope = makeScopeExit([&] {
+        cancelFinished();
+    });
+
     if (m_isCancelled)
         return;
     m_isCancelled = true;

--- a/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
+++ b/Source/WebCore/bindings/js/DOMAsyncIterator.cpp
@@ -116,7 +116,7 @@ void DOMAsyncIterator::callReturn(JSC::JSValue reason, Callback&& callback)
     auto returnMethod = m_iterator->object()->getMethod(globalObject, callData, vm->propertyNames->returnKeyword, "return property should be callable"_s);
     if (auto* exception = scope.exception()) {
         scope.clearException();
-        callback(globalObject, false, exception);
+        callback(globalObject, false, exception->value());
         return;
     }
 
@@ -133,14 +133,14 @@ void DOMAsyncIterator::callReturn(JSC::JSValue reason, Callback&& callback)
     auto result = JSC::call(globalObject, returnMethod, callData, m_iterator->guardedObject(), arguments);
     if (auto* exception = scope.exception()) {
         scope.clearException();
-        callback(globalObject, false, exception);
+        callback(globalObject, false, exception->value());
         return;
     }
 
     auto* promise = JSC::JSPromise::resolvedPromise(globalObject, result);
     if (auto* exception = scope.exception()) {
         scope.clearException();
-        callback(globalObject, false, exception);
+        callback(globalObject, false, exception->value());
         return;
     }
 


### PR DESCRIPTION
#### 3e7adccfb5ca42efb7c060a4780d718fda936a21
<pre>
Finalise support of ReadableStream.from
<a href="https://rdar.apple.com/169090451">rdar://169090451</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306424">https://bugs.webkit.org/show_bug.cgi?id=306424</a>

Reviewed by Chris Dumez.

We add support for having the source being cancelled asynchronously by making it return a promise.
We introduce cancelFinished to notify cancel is finished.
We update existing native sources that implement cancel by making sure they call cancelFinished.

We add support for cancelling an AsyncIteratorSource, by using DOMAsyncIterator::callReturn, as per
<a href="https://streams.spec.whatwg.org/#readable-stream-from-iterable">https://streams.spec.whatwg.org/#readable-stream-from-iterable</a>, cancel algorithm steps.

Covered by WPT tests.
WPT readable stream from tests are all passing except one, which needs further study.

Canonical link: <a href="https://commits.webkit.org/306628@main">https://commits.webkit.org/306628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcd6626c6a3befe793e6fb26802c8744df5e47e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150458 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94986 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76811a0f-2a50-4aff-b2b2-96179fdc58dc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109019 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/94986 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b46f520-779f-495c-b154-93db501c0edc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89915 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/693d0994-3678-4c35-89a3-11122c454174) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11113 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8755 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152843 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3565 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117104 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117426 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13472 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69619 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13974 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3028 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13713 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13916 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->