### PR TITLE
[threaded-animations] WPT test `css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html` fails with "Threaded Time-based Animations" enabled

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/content-visibility-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/content-visibility-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setting 'content-visiblity' to 'auto' prevents an 'opacity' animation from being accelerated.
+PASS Setting 'content-visiblity' to 'auto' interrupts a running accelerated 'opacity' animation.
+

--- a/LayoutTests/webanimations/threaded-animations/content-visibility.html
+++ b/LayoutTests/webanimations/threaded-animations/content-visibility.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="threaded-animations-utils.js"></script>
+<style>
+
+div {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+<script>
+
+const createContainerAndTarget = test => {
+    const container = document.createElement("div");
+    const target = document.createElement("div");
+    target.style.backgroundColor = "red";
+
+    test.add_cleanup(() => {
+        container.remove();
+        target.remove();
+    });
+
+    container.appendChild(target);
+    document.body.appendChild(container);
+
+    return [container, target];
+}
+
+const duration = 1000 * 1000; // 1000s.
+
+promise_test(async test => {
+    const [container, target] = createContainerAndTarget(test);
+
+    container.style.contentVisibility = "hidden";
+    const animation = target.animate({ opacity: 0.5 }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Setting 'content-visiblity' to 'auto' prevents an 'opacity' animation from being accelerated.");
+
+promise_test(async test => {
+    const [container, target] = createContainerAndTarget(test);
+
+    const animation = target.animate({ opacity: 0.5 }, duration);
+    await animationAcceleration(animation);
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+
+    container.style.contentVisibility = "hidden";
+    await threadedAnimationsCommit();
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 0);
+}, "Setting 'content-visiblity' to 'auto' interrupts a running accelerated 'opacity' animation.");
+
+</script>
+
+<div id="container"><div id="target"></div></div>
+
+</body>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1927,7 +1927,7 @@ const TimingFunction* KeyframeEffect::timingFunctionForKeyframeAtIndex(size_t in
 
 bool KeyframeEffect::canBeAccelerated() const
 {
-    if (!animation() || !animation()->timeline())
+    if (!animation() || !animation()->timeline() || animation()->isSkippedContentAnimation())
         return false;
 
     if (m_acceleratedPropertiesState == AcceleratedProperties::None)


### PR DESCRIPTION
#### 2d110664327e6b1c94dd13f891029078b60bc885
<pre>
[threaded-animations] WPT test `css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html` fails with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306427">https://bugs.webkit.org/show_bug.cgi?id=306427</a>
<a href="https://rdar.apple.com/169096874">rdar://169096874</a>

Reviewed by Anne van Kesteren.

The first subtest of the WPT test `css/css-contain/content-visibility/content-visibility-animation-in-auto-subtree.html` checks
that an element within a skipped subtree does not update its computed style due to a running animation.

This test regressed with threaded animations because we neglected to check whether the scenario described above occurred. We now
account for it in `KeyframeEffect::canBeAccelerated()`. Additionally, to check this type of case is more explicitly tested, we
add a new test.

Note that there is no test expectation change for the WPT test in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using `--experimental-feature ThreadedTimeBasedAnimationsEnabled=true`.

Test: webanimations/threaded-animations/content-visibility.html

* LayoutTests/webanimations/threaded-animations/content-visibility-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/content-visibility.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canBeAccelerated const):

Canonical link: <a href="https://commits.webkit.org/306355@main">https://commits.webkit.org/306355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b88128c2c2eb4acd7a28e5fb595519f06fb02f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149671 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143003 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/10984 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89310 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10567 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8160 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152095 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13200 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116524 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116867 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12927 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/122973 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68373 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21771 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13243 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/12982 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76948 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->