### PR TITLE
Add quirk for consistently applying filtering rules

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1878,6 +1878,20 @@ CompressionStreamEnabled:
     WebCore:
       default: false
 
+ConsistentQueryParameterFilteringQuirkEnabled:
+  type: bool
+  status: internal
+  category: dom
+  humanReadableName: "Consistent Query Parameter Filtering"
+  humanReadableDescription: "Enable consistent query parameter filtering"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 ContactPickerAPIEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -70,6 +70,7 @@
 #include "DocumentLoader.h"
 #include "DocumentMarkerController.h"
 #include "DocumentPage.h"
+#include "DocumentQuirks.h"
 #include "DocumentResourceLoader.h"
 #include "DocumentSyncClient.h"
 #include "DocumentSyncData.h"
@@ -148,6 +149,7 @@
 #include "PointerCaptureController.h"
 #include "PointerLockController.h"
 #include "ProgressTracker.h"
+#include "Quirks.h"
 #include "RTCController.h"
 #include "Range.h"
 #include "RemoteFrame.h"
@@ -5870,6 +5872,11 @@ bool Page::shouldAllowScriptAccess(const URL& url, const SecurityOrigin& topOrig
 
 bool Page::requiresScriptTrackingPrivacyProtections(const URL& scriptURL) const
 {
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
+    if (RefPtr document = localMainFrame ? localMainFrame->document() : nullptr) {
+        if (document->quirks().needsConsistentQueryParameterFilteringQuirk(scriptURL))
+            return true;
+    }
     if (!advancedPrivacyProtections().contains(AdvancedPrivacyProtections::ScriptTrackingPrivacy))
         return false;
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -143,6 +143,7 @@ static inline bool needsDesktopUserAgentInternal(const URL&) { return false; }
 static inline bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(const URL&) { return false; }
 static inline bool shouldNotAutoUpgradeToHTTPSNavigationInternal(const URL&) { return false; }
 static inline bool shouldDisableBlobFileAccessEnforcementInternal() { return false; }
+static inline bool needsConsistentQueryParameterFilteringInternal(const URL&) { return false; }
 #if PLATFORM(COCOA)
 static inline String standardUserAgentWithApplicationNameIncludingCompatOverridesInternal(const String&, const String&, UserAgentType) { return { }; }
 #endif
@@ -1789,6 +1790,22 @@ bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 
     auto url = protectedDocument()->url();
     return url.protocolIs("https"_s) && url.host() == "login.microsoftonline.com"_s && requestURL.protocolIs("https"_s) && requestURL.host() == "www.bing.com"_s;
+}
+
+bool Quirks::needsConsistentQueryParameterFilteringQuirk(const URL& url) const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    URL lowercaseURL { url.string().foldCase() };
+    if (!m_document->settings().consistentQueryParameterFilteringQuirkEnabled())
+        return false;
+
+    if (lowercaseURL.host() == "bundle-file"_s || RegistrableDomain { lowercaseURL } == "consistentqueryparameterfiltering.internal"_s)
+        return true;
+
+    if (needsConsistentQueryParameterFilteringInternal(lowercaseURL))
+        return true;
+    return false;
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -250,6 +250,7 @@ public:
 #endif
 
     bool needsLaxSameSiteCookieQuirk(const URL&) const;
+    WEBCORE_EXPORT bool needsConsistentQueryParameterFilteringQuirk(const URL&) const;
     static String standardUserAgentWithApplicationNameIncludingCompatOverrides(const String&, const String&, UserAgentType);
 
     String scriptToEvaluateBeforeRunningScriptFromURL(const URL&);


### PR DESCRIPTION
#### 49835f37f06e9d64e5cb668b3efd16f1780363af
<pre>
Add quirk for consistently applying filtering rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=306429">https://bugs.webkit.org/show_bug.cgi?id=306429</a>
<a href="https://rdar.apple.com/169100961">rdar://169100961</a>

Reviewed by Wenson Hsieh.

Query parameter filtering and hiding has become a complex web of decisions.
Some websites benefit from having consistent behavior. This PR lays the
groundwork for that quirk where filtering and hiding will be applied without
worrying about exceptions causing web compatibility issues.

Test: Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::requiresScriptTrackingPrivacyProtection):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::requiresScriptTrackingPrivacyProtections const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::needsConsistentQueryParameterFilteringInternal):
(WebCore::Quirks::needsConsistentQueryParameterFilteringQuirk const):
* Source/WebCore/page/Quirks.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::applyLinkDecorationFilteringWithResult):
* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::createWebViewWithAdvancedPrivacyProtections):
(TestWebKitAPI::createWebViewLinkDecorationFiltering):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, RemoveTrackingQueryParametersWhenPrivacyProtectionsAreDisabled)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, ConsistentlyRemoveTrackingQueryParametersWhenPrivacyProtectionsAreDisabled)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, TrackingQueryParametersWith8BitValues)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, ConsistentlyFilterQueryParametersOnSource)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, ConsistentlyFilterQueryParametersOnDestination)):
(TestWebKitAPI::TEST(AdvancedPrivacyProtections, DoNotRemoveTrackingQueryParametersWith8BitValues)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::setUpWebViewForFingerprintingTests):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ConsistentQueryParameters)):

Canonical link: <a href="https://commits.webkit.org/306714@main">https://commits.webkit.org/306714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8a53e477c8d4b59d64c518d83d4cf723a6933b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95198 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3c8f14e-ac00-461d-a869-f18016b140a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109170 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78917 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7142b190-ff62-4820-916d-cd258632fd7f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127145 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90067 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41bc9c95-fb90-4fc9-8297-e09cd8322c6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11244 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8898 "Found 1 new API test failure: TestWebKitAPI.WebKit2.GetUserMediaAfterMuting (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/688 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153005 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2826 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14097 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117564 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13612 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69796 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14146 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3323 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173311 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77862 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44861 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13923 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->