### PR TITLE
CheckedPtr crash in NetworkResourceLoader::contentFilterDidBlock() when ContentFilter is deleted during delayed async callback

### DIFF
--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,7 +34,7 @@
 #include <functional>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RefCounted.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/WorkQueue.h>
 
@@ -47,14 +47,13 @@ class ResourceRequest;
 class ResourceResponse;
 class SubstituteData;
 
-class ContentFilter : public CanMakeWeakPtr<ContentFilter>, public CanMakeCheckedPtr<ContentFilter> {
+class ContentFilter : public RefCounted<ContentFilter> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ContentFilter, Loader);
     WTF_MAKE_NONCOPYABLE(ContentFilter);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ContentFilter);
 public:
     template <typename T> static void addType() { types().append(type<T>()); }
 
-    WEBCORE_EXPORT static std::unique_ptr<ContentFilter> create(ContentFilterClient&);
+    WEBCORE_EXPORT static RefPtr<ContentFilter> create(ContentFilterClient&);
     WEBCORE_EXPORT ~ContentFilter();
 
     static constexpr ASCIILiteral urlScheme() { return "x-apple-content-filter"_s; }
@@ -104,7 +103,7 @@ private:
     private:
         ContentFilterCallbackAggregator(ContentFilter&, const ResourceRequest&, CompletionHandler<void(ResourceRequest&&)>&&);
 
-        CheckedPtr<ContentFilter> m_contentFilter;
+        RefPtr<ContentFilter> m_contentFilter;
         ResourceRequest m_request;
         CompletionHandler<void(ResourceRequest&&)> m_callback;
         unsigned m_numberOfFiltersAllowed { 0 };
@@ -118,7 +117,6 @@ private:
     WEBCORE_EXPORT static Vector<Type>& types();
 
     using Container = Vector<Ref<PlatformContentFilter>>;
-    friend std::unique_ptr<ContentFilter> std::make_unique<ContentFilter>(Container&&, ContentFilterClient&);
     ContentFilter(Container&&, ContentFilterClient&);
 
     template <typename Function> void forEachContentFilterUntilBlocked(Function&&);
@@ -129,7 +127,7 @@ private:
     URL url();
 
     Container m_contentFilters;
-    WeakRef<ContentFilterClient> m_client;
+    WeakPtr<ContentFilterClient> m_client;
     URL m_mainResourceURL;
     struct ResourceDataItem {
         RefPtr<const SharedBuffer> buffer;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -440,7 +440,7 @@ void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadM
 {
     ASSERT(isMainThread());
 #if ENABLE(CONTENT_FILTERING)
-    if (CheckedPtr contentFilter = m_contentFilter.get(); contentFilter && !contentFilter->continueAfterNotifyFinished(resource))
+    if (RefPtr contentFilter = m_contentFilter; contentFilter && !contentFilter->continueAfterNotifyFinished(resource))
         return;
 #endif
 
@@ -760,7 +760,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
     }
 
 #if ENABLE(CONTENT_FILTERING)
-    if (CheckedPtr contentFilter = m_contentFilter.get(); contentFilter && !contentFilter->continueAfterWillSendRequest(newRequest, redirectResponse))
+    if (RefPtr contentFilter = m_contentFilter; contentFilter && !contentFilter->continueAfterWillSendRequest(newRequest, redirectResponse))
         return completionHandler(WTF::move(newRequest));
 #endif
 
@@ -944,7 +944,7 @@ void DocumentLoader::responseReceived(ResourceResponse&& response, CompletionHan
     CompletionHandlerCallingScope completionHandlerCaller(WTF::move(completionHandler));
 
 #if ENABLE(CONTENT_FILTERING)
-    if (CheckedPtr contentFilter = m_contentFilter.get(); contentFilter && !contentFilter->continueAfterResponseReceived(response))
+    if (RefPtr contentFilter = m_contentFilter; contentFilter && !contentFilter->continueAfterResponseReceived(response))
         return;
 #endif
 
@@ -1400,7 +1400,7 @@ void DocumentLoader::dataReceived(CachedResource& resource, const SharedBuffer& 
 void DocumentLoader::dataReceived(const SharedBuffer& buffer)
 {
 #if ENABLE(CONTENT_FILTERING)
-    if (CheckedPtr contentFilter = m_contentFilter.get(); contentFilter && !contentFilter->continueAfterDataReceived(buffer, ContentFilter::FromDocumentLoader::Yes))
+    if (RefPtr contentFilter = m_contentFilter; contentFilter && !contentFilter->continueAfterDataReceived(buffer, ContentFilter::FromDocumentLoader::Yes))
         return;
 #endif
 
@@ -1541,7 +1541,7 @@ void DocumentLoader::detachFromFrame(LoadWillContinueInAnotherProcess loadWillCo
     if (m_mainResource && m_mainResource->hasClient(*this))
         m_mainResource->removeClient(*this);
 #if ENABLE(CONTENT_FILTERING)
-    if (CheckedPtr contentFilter = m_contentFilter.get())
+    if (RefPtr contentFilter = m_contentFilter)
         contentFilter->stopFilteringMainResource();
 #endif
 
@@ -2397,7 +2397,7 @@ void DocumentLoader::clearMainResource()
     if (m_mainResource && m_mainResource->hasClient(*this))
         m_mainResource->removeClient(*this);
 #if ENABLE(CONTENT_FILTERING)
-    if (CheckedPtr contentFilter = m_contentFilter.get())
+    if (RefPtr contentFilter = m_contentFilter)
         contentFilter->stopFilteringMainResource();
 #endif
 
@@ -2548,7 +2548,7 @@ bool DocumentLoader::navigationCanTriggerCrossDocumentViewTransition(Document& o
 void DocumentLoader::becomeMainResourceClient()
 {
 #if ENABLE(CONTENT_FILTERING)
-    if (CheckedPtr contentFilter = m_contentFilter.get())
+    if (RefPtr contentFilter = m_contentFilter)
         contentFilter->startFilteringMainResource(*m_mainResource);
 #endif
     m_mainResource->addClient(*this);
@@ -2665,7 +2665,7 @@ ResourceError DocumentLoader::handleContentFilterDidBlock(ContentFilterUnblockHa
 
 bool DocumentLoader::contentFilterWillHandleProvisionalLoadFailure(const ResourceError& error)
 {
-    if (CheckedPtr contentFilter = m_contentFilter.get(); contentFilter && contentFilter->willHandleProvisionalLoadFailure(error))
+    if (RefPtr contentFilter = m_contentFilter; contentFilter && contentFilter->willHandleProvisionalLoadFailure(error))
         return true;
     if (contentFilterInDocumentLoader())
         return false;
@@ -2674,7 +2674,7 @@ bool DocumentLoader::contentFilterWillHandleProvisionalLoadFailure(const Resourc
 
 void DocumentLoader::contentFilterHandleProvisionalLoadFailure(const ResourceError& error)
 {
-    if (CheckedPtr contentFilter = m_contentFilter.get())
+    if (RefPtr contentFilter = m_contentFilter)
         contentFilter->handleProvisionalLoadFailure(error);
     if (contentFilterInDocumentLoader())
         return;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -734,7 +734,7 @@ private:
     std::unique_ptr<IntegrityPolicy> m_integrityPolicyReportOnly;
 
 #if ENABLE(CONTENT_FILTERING)
-    std::unique_ptr<ContentFilter> m_contentFilter;
+    RefPtr<ContentFilter> m_contentFilter;
     ResourceError m_blockedError;
     URL m_blockedPageURL;
     SubstituteData m_substituteDataFromContentFilter;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -206,7 +206,6 @@ private:
     WebCore::ResourceError contentFilterDidBlock(WebCore::ContentFilterUnblockHandler&&, String&& unblockRequestDeniedScript) final;
     void cancelMainResourceLoadForContentFilter(const WebCore::ResourceError&) final;
     void handleProvisionalLoadFailureFromContentFilter(const URL& blockedPageURL, WebCore::SubstituteData&&) final;
-    CheckedPtr<WebCore::ContentFilter> checkedContentFilter();
 #if HAVE(WEBCONTENTRESTRICTIONS)
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     String webContentRestrictionsConfigurationPath() const final;
@@ -353,7 +352,7 @@ private:
     std::optional<WebCore::CrossOriginOpenerPolicyEnforcementResult> m_currentCoopEnforcementResult;
 
 #if ENABLE(CONTENT_FILTERING)
-    std::unique_ptr<WebCore::ContentFilter> m_contentFilter;
+    RefPtr<WebCore::ContentFilter> m_contentFilter;
     WebCore::ContentFilterUnblockHandler m_unblockHandler;
     String m_unblockRequestDeniedScript;
 #endif


### PR DESCRIPTION
#### 4c8d209dd76f8c8770505341180c5a78680f88cb
<pre>
CheckedPtr crash in NetworkResourceLoader::contentFilterDidBlock() when ContentFilter is deleted during delayed async callback
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306402">https://bugs.webkit.org/show_bug.cgi?id=306402</a>&gt;
&lt;<a href="https://rdar.apple.com/165364915">rdar://165364915</a>&gt;

Reviewed by Per Arne Vollan and Chris Dumez.

Fix the crash by converting WebCore::ContentFilter from
CheckedPtr/WeakPtr to RefPtr so that the lifetime of the object can be
kept through callbacks.

Change WeakRef&lt;ContentFilterClient&gt; to WeakPtr&lt;ContentFilterClient&gt; as
well.

An attempt to construct a test was made, but it required changes to
shipping code to make it reproduce a similar crash.

* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::create):
(WebCore::ContentFilter::ContentFilterCallbackAggregator::~ContentFilterCallbackAggregator):
(WebCore::ContentFilter::ContentFilterCallbackAggregator::didReceivePlatformContentFilterDecision):
(WebCore::ContentFilter::continueAfterSubstituteDataRequest):
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::notifyFinished):
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::dataReceived):
(WebCore::DocumentLoader::detachFromFrame):
(WebCore::DocumentLoader::clearMainResource):
(WebCore::DocumentLoader::becomeMainResourceClient):
(WebCore::DocumentLoader::contentFilterWillHandleProvisionalLoadFailure):
(WebCore::DocumentLoader::contentFilterHandleProvisionalLoadFailure):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startContentFiltering):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):
(WebKit::NetworkResourceLoader::bufferingTimerFired):
(WebKit::NetworkResourceLoader::sendBuffer):
(WebKit::NetworkResourceLoader::didRetrieveCacheEntry):
(WebKit::NetworkResourceLoader::sendResultForCacheEntry):
(WebKit::NetworkResourceLoader::continueAfterServiceWorkerReceivedData):
(WebKit::NetworkResourceLoader::continueAfterServiceWorkerReceivedResponse):
(WebKit::NetworkResourceLoader::serviceWorkerDidFinish):
(WebKit::NetworkResourceLoader::contentFilterDidBlock):
(WebKit::NetworkResourceLoader::checkedContentFilter): Delete.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/306652@main">https://commits.webkit.org/306652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af07bac22f54847ec99d63c9c1a7855ba354db2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95108 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/109da9f2-3cea-43ad-bf1b-c4a7660c283c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109089 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ab05eaf-7410-4ffe-bd40-6c73b726d46f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144882 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89986 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa964298-80d0-4b48-a966-f61caa0282ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11177 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8823 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/593 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152915 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14008 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3877 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117169 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117489 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13540 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69702 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21904 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14046 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3194 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13785 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->