### PR TITLE
Custom scrollbar pseudo-element styles not updating on class change

### DIFF
--- a/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-change-expected.html
+++ b/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-change-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroll {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            overflow: auto;
+            border: 1px solid black;
+        }
+
+        .scroll::-webkit-scrollbar {
+            width: 16px;
+        }
+
+        .scroll::-webkit-scrollbar-track {
+            background-color: silver;
+        }
+
+        .scroll::-webkit-scrollbar-thumb {
+            background-color: gray;
+        }
+
+        /* Class that changes only the scrollbar-thumb style */
+        .scroll.highlight::-webkit-scrollbar-thumb {
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <p>Test: Adding a class should update ::-webkit-scrollbar-thumb style with overflow: auto</p>
+    <div id="test" class="scroll highlight">
+        <div style="width: 400px; height: 400px;"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-change.html
+++ b/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-change.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroll {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            overflow: auto;
+            border: 1px solid black;
+        }
+
+        .scroll::-webkit-scrollbar {
+            width: 16px;
+        }
+
+        .scroll::-webkit-scrollbar-track {
+            background-color: silver;
+        }
+
+        .scroll::-webkit-scrollbar-thumb {
+            background-color: gray;
+        }
+
+        /* Class that changes only the scrollbar-thumb style */
+        .scroll.highlight::-webkit-scrollbar-thumb {
+            background-color: blue;
+        }
+    </style>
+    <script>
+        window.onload = () => {
+            document.getElementById('test').classList.add('highlight');
+        }
+    </script>
+</head>
+<body>
+    <p>Test: Adding a class should update ::-webkit-scrollbar-thumb style with overflow: auto</p>
+    <div id="test" class="scroll">
+        <div style="width: 400px; height: 400px;"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-remove-expected.html
+++ b/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-remove-expected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroll {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            overflow: auto;
+            border: 1px solid black;
+        }
+
+        .scroll::-webkit-scrollbar {
+            width: 16px;
+        }
+
+        .scroll::-webkit-scrollbar-track {
+            background-color: silver;
+        }
+
+        .scroll::-webkit-scrollbar-thumb {
+            background-color: gray;
+        }
+
+        /* Class that changes only the scrollbar-thumb style */
+        .scroll.highlight::-webkit-scrollbar-thumb {
+            background-color: blue;
+        }
+    </style>
+</head>
+<body>
+    <p>Test: Removing a class should update ::-webkit-scrollbar-thumb style</p>
+    <div id="test" class="scroll">
+        <div style="width: 400px; height: 400px;"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-remove.html
+++ b/LayoutTests/fast/css/scrollbar-thumb-dynamic-class-remove.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroll {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            overflow: auto;
+            border: 1px solid black;
+        }
+
+        .scroll::-webkit-scrollbar {
+            width: 16px;
+        }
+
+        .scroll::-webkit-scrollbar-track {
+            background-color: silver;
+        }
+
+        .scroll::-webkit-scrollbar-thumb {
+            background-color: gray;
+        }
+
+        /* Class that changes only the scrollbar-thumb style */
+        .scroll.highlight::-webkit-scrollbar-thumb {
+            background-color: blue;
+        }
+    </style>
+    <script>
+        window.onload = () => {
+            document.getElementById('test').classList.remove('highlight');
+        }
+    </script>
+</head>
+<body>
+    <p>Test: Removing a class should update ::-webkit-scrollbar-thumb style</p>
+    <div id="test" class="scroll highlight">
+        <div style="width: 400px; height: 400px;"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -390,10 +390,35 @@ void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::El
         element.didAttachRenderers();
 }
 
+// Scrollbar sub-element styles depend on runtime state (hover, active, orientation, enabled, etc.),
+// unlike ViewTransition pseudo-elements which can be fully cached in StyleTreeResolver.
+// Caching all state combinations would be impractical (thousands of combinations), so we only
+// check the base style here. RenderScrollbar fetches the actual style with current state on demand.
+static bool scrollbarSubElementStyleIsInvalid(RenderElement* renderer, const RenderStyle& currentStyle, RenderStyle* newStyle)
+{
+    static const PseudoElementType scrollbarSubTypes[] = {
+        PseudoElementType::WebKitScrollbarThumb,
+        PseudoElementType::WebKitScrollbarTrack,
+        PseudoElementType::WebKitScrollbarTrackPiece,
+        PseudoElementType::WebKitScrollbarButton,
+        PseudoElementType::WebKitScrollbarCorner,
+    };
+    for (auto pseudoType : scrollbarSubTypes) {
+        auto* existingStyle = currentStyle.getCachedPseudoStyle({ pseudoType });
+        auto newPseudoStyle = renderer->getUncachedPseudoStyle({ pseudoType }, newStyle, newStyle);
+        if (newPseudoStyle && (!existingStyle || *existingStyle != *newPseudoStyle))
+            return true;
+    }
+    return false;
+}
+
 static bool pseudoStyleCacheIsInvalid(RenderElement* renderer, RenderStyle* newStyle)
 {
     const auto& currentStyle = renderer->style();
+    bool hasScrollbarPseudoStyle = false;
     for (auto& [key, value] : currentStyle.cachedPseudoStyles()) {
+        if (key.type == PseudoElementType::WebKitScrollbar)
+            hasScrollbarPseudoStyle = true;
         auto newPseudoStyle = renderer->getUncachedPseudoStyle(*value->pseudoElementIdentifier(), newStyle, newStyle);
         if (!newPseudoStyle)
             return true;
@@ -402,6 +427,11 @@ static bool pseudoStyleCacheIsInvalid(RenderElement* renderer, RenderStyle* newS
             return true;
         }
     }
+
+    // If element has custom scrollbar, also check scrollbar sub-element pseudo styles.
+    if (hasScrollbarPseudoStyle && scrollbarSubElementStyleIsInvalid(renderer, currentStyle, newStyle))
+        return true;
+
     return false;
 }
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -474,8 +474,15 @@ std::optional<ElementUpdate> TreeResolver::resolvePseudoElement(Element& element
             return { };
     }
 
-    if (pseudoElementIdentifier.type == PseudoElementType::WebKitScrollbar && elementUpdate.style->overflowX() != Overflow::Scroll && elementUpdate.style->overflowY() != Overflow::Scroll)
-        return { };
+    // Both overflow: scroll and overflow: auto can have custom scrollbars.
+    if (pseudoElementIdentifier.type == PseudoElementType::WebKitScrollbar) {
+        auto overflowX = elementUpdate.style->overflowX();
+        auto overflowY = elementUpdate.style->overflowY();
+        bool xCanHaveScrollbar = overflowX == Overflow::Scroll || overflowX == Overflow::Auto;
+        bool yCanHaveScrollbar = overflowY == Overflow::Scroll || overflowY == Overflow::Auto;
+        if (!xCanHaveScrollbar && !yCanHaveScrollbar)
+            return { };
+    }
 
     ASSERT_IMPLIES(pseudoElementIdentifier.type == PseudoElementType::ViewTransition
         || pseudoElementIdentifier.type == PseudoElementType::ViewTransitionGroup


### PR DESCRIPTION
#### b619928591ebdecb827e9fcec41f9d758c562b6f
<pre>
Custom scrollbar pseudo-element styles not updating on class change
<a href="https://bugs.webkit.org/show_bug.cgi?id=306435">https://bugs.webkit.org/show_bug.cgi?id=306435</a>

Reviewed by NOBODY (OOPS!).

When a CSS class is dynamically added or removed, custom scrollbar sub-element
styles (like ::-webkit-scrollbar-thumb) were not updating. Two issues were fixed:

1. StyleTreeResolver::resolvePseudoElement() only cached scrollbar pseudo-element
   styles for overflow: scroll, not overflow: auto.

2. RenderTreeUpdater::pseudoStyleCacheIsInvalid() did not check scrollbar
   sub-element styles (thumb, track, etc.) for invalidation.

 * LayoutTests/fast/css/scrollbar-thumb-dynamic-class-change-expected.html: Added.
 * LayoutTests/fast/css/scrollbar-thumb-dynamic-class-change.html: Added.
 * LayoutTests/fast/css/scrollbar-thumb-dynamic-class-remove-expected.html: Added.
 * LayoutTests/fast/css/scrollbar-thumb-dynamic-class-remove.html: Added.
 * Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
 (WebCore::scrollbarSubElementStyleIsInvalid):
 (WebCore::pseudoStyleCacheIsInvalid):
 * Source/WebCore/style/StyleTreeResolver.cpp:
 (WebCore::Style::TreeResolver::resolvePseudoElement):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b619928591ebdecb827e9fcec41f9d758c562b6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94264 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108462 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78525 "2 flakes 9 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10591 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8185 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152132 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116547 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116889 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12951 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123000 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68411 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13280 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2410 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13019 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/76985 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13218 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->