### PR TITLE
[iOS] MediaPlayerPrivateWirelessPlayback should load URLs via MediaDeviceRoute

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/load-url-mms-fallback-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-mms-fallback-expected.txt
@@ -1,0 +1,10 @@
+Test that the MMS fallback URL is loaded when a MediaDeviceRoute activates.
+
+
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EXPECTED (actualURL == '/LayoutTests/media/content/test.mp4') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/load-url-mms-fallback.html
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-mms-fallback.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+            var actualURL;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.createElement('video');
+
+                const mediaType = 'video/mp4';
+                const mediaURL = findMediaFile('video', '../content/test');
+                const mediaSource = new ManagedMediaSource();
+
+                const firstSource = document.createElement('source');
+                firstSource.type = mediaType;
+                firstSource.src = URL.createObjectURL(mediaSource);
+                video.appendChild(firstSource);
+
+                const secondSource = document.createElement('source');
+                secondSource.src = mediaURL;
+                secondSource.type = mediaType;
+                video.appendChild(secondSource);
+
+                await new Promise((resolve) => {
+                    mediaSource.addEventListener('sourceopen', resolve, { once: true });
+                    document.body.appendChild(video);
+                });
+
+                await new Promise((resolve) => {
+                    mediaSource.onstartstreaming = async () => {
+                        const sourceBuffer = mediaSource.addSourceBuffer(mediaType);
+                        const mediaResource = await fetch(mediaURL);
+                        const mediaBuffer = await mediaResource.arrayBuffer();
+                        sourceBuffer.addEventListener('updateend', resolve, { once: true });
+                        sourceBuffer.appendBuffer(mediaBuffer);
+                    };
+                });
+
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const loadedURL = await urlPromise;
+                const expectedURL = new URL(mediaURL, document.baseURI).href.substring(document.baseURI.indexOf('/LayoutTests/'));
+                actualURL = loadedURL.substring(loadedURL.indexOf('/LayoutTests/'));
+
+                testExpected('actualURL', expectedURL);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <p>Test that the MMS fallback URL is loaded when a MediaDeviceRoute activates.</p> 
+    </body>
+</html>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2497,6 +2497,7 @@ set(WebCoreTestSupport_IDL_FILES
     testing/MockContentFilterSettings.idl
     testing/MockMediaDeviceRoute.idl
     testing/MockMediaDeviceRouteController.idl
+    testing/MockMediaDeviceRouteURLCallback.idl
     testing/MockPageOverlay.idl
     testing/MockWebAuthenticationConfiguration.idl
     testing/ServiceWorkerInternals.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -518,8 +518,8 @@ $(PROJECT_DIR)/Modules/highlight/Highlight.idl
 $(PROJECT_DIR)/Modules/highlight/HighlightRegistry.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredential.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredentialGetRequest.idl
-$(PROJECT_DIR)/Modules/identity/DigitalCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/identity/DigitalCredentialPresentationProtocol.idl
+$(PROJECT_DIR)/Modules/identity/DigitalCredentialRequestOptions.idl
 $(PROJECT_DIR)/Modules/identity/protocols/ISO18013/MobileDocumentRequest.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursor.idl
 $(PROJECT_DIR)/Modules/indexeddb/IDBCursorDirection.idl
@@ -2154,6 +2154,7 @@ $(PROJECT_DIR)/testing/MockCaptionDisplaySettingsClientCallback.idl
 $(PROJECT_DIR)/testing/MockContentFilterSettings.idl
 $(PROJECT_DIR)/testing/MockMediaDeviceRoute.idl
 $(PROJECT_DIR)/testing/MockMediaDeviceRouteController.idl
+$(PROJECT_DIR)/testing/MockMediaDeviceRouteURLCallback.idl
 $(PROJECT_DIR)/testing/MockPageOverlay.idl
 $(PROJECT_DIR)/testing/MockPaymentAddress.idl
 $(PROJECT_DIR)/testing/MockPaymentContactFields.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -909,6 +909,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredential.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialGetRequest.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialGetRequest.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialPresentationProtocol.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialPresentationProtocol.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialRequestOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDistanceModelType.cpp
@@ -1747,8 +1749,6 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIIRFilterOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIPAddressSpace.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIPAddressSpace.h
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialPresentationProtocol.cpp
-$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSDigitalCredentialPresentationProtocol.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleDeadline.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSIdleRequestCallback.cpp
@@ -2011,6 +2011,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRoute.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRoute.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRouteController.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRouteController.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRouteURLCallback.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockMediaDeviceRouteURLCallback.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockPageOverlay.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockPageOverlay.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSMockPaymentAddress.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1789,6 +1789,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/testing/MockContentFilterSettings.idl \
 	$(WebCore)/testing/MockMediaDeviceRoute.idl \
 	$(WebCore)/testing/MockMediaDeviceRouteController.idl \
+	$(WebCore)/testing/MockMediaDeviceRouteURLCallback.idl \
     $(WebCore)/testing/MockPageOverlay.idl \
     $(WebCore)/testing/MockPaymentAddress.idl \
     $(WebCore)/testing/MockPaymentContactFields.idl \

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -57,7 +57,7 @@ public:
     void markAsHandled();
 
     enum class Status { Pending, Fulfilled, Rejected };
-    Status status() const;
+    WEBCORE_EXPORT Status status() const;
 
     static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&);
 

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
+#include "MediaDeviceRouteLoadURLResult.h"
 #include <WebKitAdditions/MediaDeviceRouteAdditions.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Forward.h>
@@ -130,6 +131,8 @@ public:
 
     const WTF::UUID& identifier() const { return m_identifier; }
     WebMediaDevicePlatformRoute *platformRoute() const;
+
+    void loadURL(const String&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
 
     float minValue() const;
     float maxValue() const;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
@@ -43,8 +43,8 @@ MediaDeviceRouteController& MediaDeviceRouteController::singleton()
 }
 
 MediaDeviceRouteController::MediaDeviceRouteController()
-    : m_controller { adoptNS([[WebMediaDeviceRouteController alloc] init]) }
 #if HAVE(AVROUTING_FRAMEWORK)
+    : m_controller { adoptNS([[WebMediaDeviceRouteController alloc] init]) }
     , m_platformController { [WebMediaDevicePlatformRouteControllerClass sharedRoutingSystemController] }
 #endif
 {

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteLoadURLResult.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteLoadURLResult.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+
+enum class MediaDeviceRouteLoadURLError : uint8_t {
+    NoRoute,
+    InvalidURL,
+    PlatformError,
+};
+
+using MediaDeviceRouteLoadURLResult = Expected<void, MediaDeviceRouteLoadURLError>;
+
+} // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -30,6 +30,7 @@
 
 #include "MediaDeviceRoute.h"
 #include "MediaDeviceRouteController.h"
+#include <wtf/CompletionHandler.h>
 #include <wtf/UUID.h>
 
 namespace WebCore {
@@ -71,6 +72,15 @@ String MediaPlaybackTargetWirelessPlayback::deviceName() const
     if (auto identifier = this->identifier())
         return identifier->toString();
     return { };
+}
+
+void MediaPlaybackTargetWirelessPlayback::loadURL(const String& urlString, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&& completionHandler)
+{
+    RefPtr route = m_route;
+    if (!route)
+        return completionHandler(makeUnexpected(MediaDeviceRouteLoadURLError::NoRoute));
+
+    route->loadURL(urlString, WTF::move(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
+#include <WebCore/MediaDeviceRouteLoadURLResult.h>
 #include <WebCore/MediaPlaybackTarget.h>
 #include <wtf/UUID.h>
 
@@ -44,6 +45,8 @@ public:
     WEBCORE_EXPORT std::optional<WTF::UUID> identifier() const;
 
     MediaDeviceRoute* route() const;
+
+    void loadURL(const String&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
 
 private:
     MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&&, bool hasActiveRoute);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -81,8 +81,8 @@ MediaPlayerPrivateWirelessPlayback::~MediaPlayerPrivateWirelessPlayback() = defa
 
 void MediaPlayerPrivateWirelessPlayback::load(const String& urlString)
 {
-    m_urlString = urlString;
     ALWAYS_LOG(LOGIDENTIFIER, urlString);
+    m_urlString = urlString;
     updateURLStringIfNeeded();
 }
 
@@ -155,7 +155,9 @@ void MediaPlayerPrivateWirelessPlayback::updateURLStringIfNeeded()
     if (!playbackTarget)
         return;
 
-    // FIXME: pass the URL to the route
+    playbackTarget->loadURL(m_urlString, [](const MediaDeviceRouteLoadURLResult&) {
+        // FIXME: Advance readyState once the target has loaded the URL
+    });
 }
 
 #endif // ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
+#include "MockMediaDeviceRouteURLCallback.h"
 #include <WebKitAdditions/MediaDeviceRouteAdditions.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -43,6 +44,8 @@ public:
     static Ref<MockMediaDeviceRoute> create();
 
     WebMediaDevicePlatformRoute *platformRoute() const;
+
+    void setURLCallback(MockMediaDeviceRouteURLCallback*);
 
 private:
     MockMediaDeviceRoute();

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -28,4 +28,5 @@
     EnabledBySetting=WirelessPlaybackMediaPlayerEnabled,
     LegacyNoInterfaceObject,
 ] interface MockMediaDeviceRoute {
+    undefined setURLCallback(MockMediaDeviceRouteURLCallback? callback);
 };

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -50,6 +50,11 @@ WebMediaDevicePlatformRoute *MockMediaDeviceRoute::platformRoute() const
     return m_platformRoute.get();
 }
 
+void MockMediaDeviceRoute::setURLCallback(MockMediaDeviceRouteURLCallback* urlCallback)
+{
+    [m_platformRoute setURLCallback:urlCallback];
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/MockMediaDeviceRouteURLCallback.h
+++ b/Source/WebCore/testing/MockMediaDeviceRouteURLCallback.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+
+#include "ActiveDOMCallback.h"
+#include "CallbackResult.h"
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+
+namespace WebCore {
+
+class DOMPromise;
+
+class MockMediaDeviceRouteURLCallback : public RefCounted<MockMediaDeviceRouteURLCallback>, public ActiveDOMCallback {
+public:
+    using ActiveDOMCallback::ActiveDOMCallback;
+
+    virtual bool isJSMockMediaDeviceRouteURLCallback() const { return false; }
+    virtual CallbackResult<Ref<DOMPromise>> invoke(const String& url) = 0;
+
+    // ContextDestructionObserver
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+private:
+    virtual bool hasCallback() const = 0;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/MockMediaDeviceRouteURLCallback.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRouteURLCallback.idl
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WIRELESS_PLAYBACK_MEDIA_PLAYER,
+    GenerateIsReachable=ImplScriptExecutionContext
+] callback MockMediaDeviceRouteURLCallback = Promise<undefined> (USVString url);

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -30,9 +30,14 @@
 #import <WebKitAdditions/MediaDeviceRouteAdditions.h>
 #import <WebKitAdditions/WebMockMediaDeviceRouteAdditions.h>
 
+namespace WebCore {
+class MockMediaDeviceRouteURLCallback;
+}
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WebMockMediaDeviceRoute : NSObject <WebMediaDevicePlatformRoute>
+@property (nonatomic, nullable, setter=setURLCallback:) WebCore::MockMediaDeviceRouteURLCallback* urlCallback;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### 5290b1a24ad1ffd68237f3956878c4d041e5ee1b
<pre>
[iOS] MediaPlayerPrivateWirelessPlayback should load URLs via MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=306443">https://bugs.webkit.org/show_bug.cgi?id=306443</a>
<a href="https://rdar.apple.com/169109604">rdar://169109604</a>

Reviewed by Jer Noble.

Taught MediaPlayerPrivateWirelessPlayback to load URLs via MediaDeviceRoute. Added a URL handler
callback to MockMediaDeviceRoute so that layout tests can set a URL handler and accept or reject
various URLs. Created load-url-mms-fallback.html to exercise this capability.

Test: media/wireless-playback-media-player/load-url-mms-fallback.html

* LayoutTests/media/wireless-playback-media-player/load-url-mms-fallback-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/load-url-mms-fallback.html: Added.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSDOMPromise.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm:
(WebCore::MediaDeviceRouteController::MediaDeviceRouteController):
* Source/WebCore/platform/audio/ios/MediaDeviceRouteLoadURLResult.h: Copied from Source/WebCore/testing/MockMediaDeviceRoute.idl.
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp:
(WebCore::MediaPlaybackTargetWirelessPlayback::loadURL):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::load):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLStringIfNeeded):
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::setURLCallback):
* Source/WebCore/testing/MockMediaDeviceRouteURLCallback.h: Copied from Source/WebCore/testing/MockMediaDeviceRoute.idl.
(WebCore::MockMediaDeviceRouteURLCallback::isJSMockMediaDeviceRouteURLCallback const):
* Source/WebCore/testing/MockMediaDeviceRouteURLCallback.idl: Copied from Source/WebCore/testing/MockMediaDeviceRoute.idl.
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute urlCallback]):
(-[WebMockMediaDeviceRoute setURLCallback:]):
(-[WebMockMediaDeviceRoute startApplicationWithURL:launchType:withCompletionHandler:]):

Canonical link: <a href="https://commits.webkit.org/306432@main">https://commits.webkit.org/306432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a8a13b64cf19998c1cb24712f0abb83381467f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/141372 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/13760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/3084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/149950 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/143245 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/14471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/13915 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/149950 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/144323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/14471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/3084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/149950 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/14471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/3084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/22 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/14471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/3084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/152342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/13447 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/3084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/152342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/13463 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/13915 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/152342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/29792 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/3084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21807 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/13489 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/3084 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/13226 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13426 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/13272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->