### PR TITLE
[build.webkit.org] Bring up post-commit Safer CPP iOS queue

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -69,6 +69,8 @@
                   { "name": "bot632", "platform": "mac-sequoia" },
 
                   { "name": "bot304", "platform": "ios-26" },
+                  { "name": "bot2004", "platform": "ios-26" },
+                  { "name": "bot2005", "platform": "ios-26" },
                   { "name": "bot305", "platform": "ios-simulator-26" },
                   { "name": "bot306", "platform": "ios-simulator-26" },
                   { "name": "bot307", "platform": "ios-simulator-26" },
@@ -422,6 +424,11 @@
                     "platform": "ios-simulator-26", "configuration": "debug", "architectures": ["x86_64", "arm64"], "device_model": "ipad",
                     "additionalArguments": ["--no-retry-failures", "--no-sample-on-timeout", "--child-processes=6"],
                     "workernames": ["bot664"]
+                  },
+                  {
+                    "name": "Apple-iOS-26-Safer-CPP-Checks", "factory": "SaferCPPStaticAnalyzerFactory",
+                    "platform": "ios-26", "configuration": "release", "architectures": ["arm64"],
+                    "workernames": ["bot2004", "bot2005"]
                   },
                   {
                     "name": "Apple-visionOS-26-Release-Build", "factory": "BuildFactory",

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -321,6 +321,12 @@ class SaferCPPStaticAnalyzerFactory(Factory):
         self.addStep(PrintClangVersion())
         self.addStep(CheckOutLLVMProject())
         self.addStep(UpdateClang())
+        if platform.startswith('ios'):
+            self.addStep(GetSwiftTagName())
+            self.addStep(PrintSwiftVersion())
+            self.addStep(CheckOutSwiftProject())
+            self.addStep(UpdateSwiftCheckouts())
+            self.addStep(BuildSwift())
         self.addStep(ScanBuild())
 
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -756,6 +756,28 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'builtins-generator-tests',
             'trigger-crash-log-submission'
         ],
+        'Apple-iOS-26-Safer-CPP-Checks': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'install-cmake',
+            'install-ninja',
+            'get-llvm-version',
+            'print-clang-version',
+            'checkout-llvm-project',
+            'update-clang',
+            'get-swift-tag-name',
+            'print-swift-version',
+            'checkout-swift-project',
+            'update-swift-checkouts',
+            'build-swift',
+            'scan-build'
+        ],
         'Apple-iPadOS-26-Simulator-Release-WK2-Tests': [
             'configure-build',
             'configuration',


### PR DESCRIPTION
#### 580a56ab00d334da78aac094b819bdc831bea869
<pre>
[build.webkit.org] Bring up post-commit Safer CPP iOS queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=306446">https://bugs.webkit.org/show_bug.cgi?id=306446</a>
<a href="https://rdar.apple.com/163591974">rdar://163591974</a>

Reviewed by Jonathan Bedard.

Add configuration changes and Safer CPP iOS factory.

* Tools/CISupport/build-webkit-org/config.json:
    - Add all config changes except for the scheduler.
* Tools/CISupport/build-webkit-org/factories.py:
(SaferCPPStaticAnalyzerFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):

Canonical link: <a href="https://commits.webkit.org/306731@main">https://commits.webkit.org/306731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/350f952a6e9bb3a21891e09514d20fe981402c84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95144 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac472742-d4c2-40dc-88c6-6dcb3d9cd547) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14513 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109119 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78892 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84818ef0-eded-4adf-979a-9dd7f79d6049) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90015 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45a77f45-2c24-4c04-8cee-2d48fd2e67be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11200 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8852 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/637 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152950 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117199 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/141386 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14065 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117516 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13567 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69737 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21933 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14090 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3243 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13824 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14028 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13869 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->