### PR TITLE
[grid-lanes] Fix grid-lanes-subgrid-002a test to match cross-browser rendering behavior

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1817,7 +1817,6 @@ imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002g.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002h.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002i.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002b.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002c.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002d.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-expected.html
@@ -69,7 +69,7 @@ subgrid.extent {
   <item>1</item>
   <item>2</item>
   <item>3</item>
-  <subgrid style="grid: none / none">
+  <subgrid>
     <item>4a</item>
     <item>4b</item>
     <item>4c</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-ref.html
@@ -69,7 +69,7 @@ subgrid.extent {
   <item>1</item>
   <item>2</item>
   <item>3</item>
-  <subgrid style="grid: none / none">
+  <subgrid>
     <item>4a</item>
     <item>4b</item>
     <item>4c</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
@@ -67,15 +67,15 @@ subgrid.extent {
 <!-- auto-placed subgrid inhibits subgridding when parent is doing grid-lanes layout ... -->
 
 <grid class="rows">
-  <item>1</item>
-  <item>2</item>
-  <item>3</item>
-  <subgrid>
-    <item>4a</item>
-    <item>4b</item>
-    <item>4c</item>
+  <item style="height: 24px;">1</item>
+  <item style="height: 40px;">2</item>
+  <item style="height: 40px;">3</item>
+  <subgrid style="height: calc(30px + 4px + 20px);">
+    <item style="height: 13px;">4a</item>
+    <item style="height: 29px;">4b</item>
+    <item style="height: 19px;">4c</item>
   </subgrid>
-  <item>5</item>
+  <item style="height: 30px;">5</item>
 </grid>
 
 </body></html>


### PR DESCRIPTION
#### 7e6b3bf3ceffb8a635f8acb49d3f96b7c3b23a78
<pre>
[grid-lanes] Fix grid-lanes-subgrid-002a test to match cross-browser rendering behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=306448">https://bugs.webkit.org/show_bug.cgi?id=306448</a>
<a href="https://rdar.apple.com/problem/169113705">rdar://problem/169113705</a>

Reviewed by Elika Etemad.

grid-lanes-subgrid-002a

-ref and -expected tests are implemented on a grid, which sets the height of items.

So items 2 and 3 need to be 40 px as that is the height of the grid row 1.

Item 5 is a simple 30px too as that is just the height of the second row.

Now the subgrid requires special attention.

We first need to calculate the height of the subgrid, which is the row 2 + gap + row 3 heights.

Row 2 is a height of 30px, so 4a and 4b I would expect to add up to that.
Row 3 is similar a height of 20px, so we need to set 4c.

Now, we are losing a single pixel as these seem to be resolving to 29px for row 2 and 19px for row 3 heights.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html:

Canonical link: <a href="https://commits.webkit.org/306411@main">https://commits.webkit.org/306411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd684f325118d6e10a023980b93659482add6c16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94288 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5301423-5eb6-4c4d-84a9-61ba078009e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108481 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78535 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b125098-5c35-45a1-aa10-1f71603114f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11019 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89387 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f03824aa-3d2c-4421-b9a7-cc31405bbea2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10602 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8201 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152156 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13261 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116562 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13277 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116904 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29772 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/12964 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68435 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13304 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13242 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->