### PR TITLE
Digital Credentials: Add ISO 18013 Document Request Info

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -308,6 +308,10 @@
 #define ENABLE_IOS_TOUCH_EVENTS 0
 #endif
 
+#if !defined(ENABLE_ISO18013_DOCUMENT_REQUEST_INFO)
+#define ENABLE_ISO18013_DOCUMENT_REQUEST_INFO 0
+#endif
+
 #if !defined(ENABLE_IPC_TESTING_API)
 /* Enable IPC testing on all ASAN builds and debug builds. */
 #if (ASAN_ENABLED || !defined(NDEBUG)) && PLATFORM(COCOA)

--- a/Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013.h
+++ b/Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013.h
@@ -26,6 +26,9 @@
 #pragma once
 
 #include <WebCore/ISO18013DocumentRequest.h>
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+#include <WebCore/ISO18013DocumentRequestInfo.h>
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
 #include <WebCore/ISO18013DocumentRequestSet.h>
 #include <WebCore/ISO18013ElementInfo.h>
 #include <WebCore/ISO18013PresentmentRequest.h>

--- a/Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013DocumentRequest.h
+++ b/Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013DocumentRequest.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+#include <WebCore/ISO18013DocumentRequestInfo.h>
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
 #include <WebCore/ISO18013ElementInfo.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -38,6 +41,9 @@ using ISO18013ElementNamespacesVector = Vector<std::pair<String, ISO18013Element
 struct ISO18013DocumentRequest {
     String documentType;
     ISO18013ElementNamespacesVector namespaces;
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    std::optional<ISO18013DocumentRequestInfo> requestInfo;
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
 };
 
 using ISO18013DocumentRequests = Vector<ISO18013DocumentRequest>;

--- a/Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013DocumentRequestInfo.h
+++ b/Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013DocumentRequestInfo.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+#include <wtf/Box.h>
+#include <wtf/HashMap.h>
+#include <wtf/Variant.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+using ISO18013IssuerIdentifiers = Vector<String>;
+
+using ISO18013ElementReference = HashMap<String, String>;
+
+using ISO18013AlternativeDataElementSet = Vector<ISO18013ElementReference>;
+
+using ISO18013AlternativeDataElementSets = Vector<ISO18013AlternativeDataElementSet>;
+
+struct ISO18013AlternativeDataElementsSet {
+    ISO18013ElementReference requestedElement;
+    ISO18013AlternativeDataElementSets alternativeElementSets;
+};
+
+struct ISO18013ZkSystemSpec {
+    String zkSystemId;
+    String system;
+};
+
+struct ISO18013ZkRequest {
+    Vector<ISO18013ZkSystemSpec> systemSpecs;
+    bool zkRequired;
+};
+
+struct ISO18013Any {
+    Variant<
+        std::monostate,
+        int,
+        bool,
+        String,
+        Vector<Box<ISO18013Any>>,
+        HashMap<String, Box<ISO18013Any>>
+    > data;
+};
+
+using ISO18013DocumentRequestInfoExtension = HashMap<String, ISO18013Any>;
+
+struct ISO18013DocumentRequestInfo {
+    std::optional<ISO18013AlternativeDataElementsSet> alternativeDataElements;
+    std::optional<ISO18013IssuerIdentifiers> issuerIdentifiers;
+    std::optional<bool> uniqueDocSetRequired;
+    std::optional<uint32_t> maximumResponseSize;
+    std::optional<ISO18013ZkRequest> zkRequest;
+    std::optional<String> encryptionParameterBytes;
+    ISO18013DocumentRequestInfoExtension extension;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6393,9 +6393,45 @@ header: <WebCore/ISO18013.h>
     bool isRetaining;
 };
 
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+[Nested] struct WebCore::ISO18013Any {
+    Variant<std::monostate, int, bool, String, Vector<Box<WebCore::ISO18013Any>>, HashMap<String, Box<WebCore::ISO18013Any>>> data;
+};
+
+[Nested] struct WebCore::ISO18013ZkSystemSpec {
+    String zkSystemId;
+    String system;
+};
+
+[Nested] struct WebCore::ISO18013ZkRequest {
+    Vector<WebCore::ISO18013ZkSystemSpec> systemSpecs;
+    bool zkRequired;
+};
+
+[Nested] struct WebCore::ISO18013AlternativeDataElementsSet {
+    HashMap<String, String> requestedElement;
+    Vector<Vector<HashMap<String, String>>> alternativeElementSets;
+};
+
+[Nested] struct WebCore::ISO18013DocumentRequestInfo {
+    std::optional<WebCore::ISO18013AlternativeDataElementsSet> alternativeDataElements;
+    std::optional<Vector<String>> issuerIdentifiers;
+    std::optional<bool> uniqueDocSetRequired;
+    std::optional<uint32_t> maximumResponseSize;
+    std::optional<WebCore::ISO18013ZkRequest> zkRequest;
+    std::optional<String> encryptionParameterBytes;
+    HashMap<String, WebCore::ISO18013Any> extension;
+};
+
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
 [Nested] struct WebCore::ISO18013DocumentRequest {
     String documentType;
     Vector<std::pair<String, Vector<std::pair<String, WebCore::ISO18013ElementInfo>>>> namespaces;
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    std::optional<WebCore::ISO18013DocumentRequestInfo> requestInfo;
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
 };
 
 [Nested] struct WebCore::ISO18013DocumentRequestSet {


### PR DESCRIPTION
#### e38b7c21d59a724ce370b31bb5d914718eb16192
<pre>
Digital Credentials: Add ISO 18013 Document Request Info
<a href="https://bugs.webkit.org/show_bug.cgi?id=306450">https://bugs.webkit.org/show_bug.cgi?id=306450</a>
<a href="https://rdar.apple.com/problem/169114744">rdar://problem/169114744</a>

Reviewed by Abrar Rahman Protyasha.

Add structure definitions for ISO 18013 Document Request Info.

* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013.h:
* Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013DocumentRequest.h:
* Source/WebCore/Modules/identity/protocols/ISO18013/ISO18013DocumentRequestInfo.h: Added.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/306678@main">https://commits.webkit.org/306678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddd1cbdc945439ea05203742ef8735301a5ba549

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95130 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109109 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78888 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144903 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90006 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8843 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/614 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133938 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152936 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2758 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14029 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117188 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29961 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13556 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124109 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69723 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14067 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3228 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173243 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77792 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44850 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14009 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13853 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->