### PR TITLE
Auto and Fixed table layout should treat calc(% + 0px) as percentage

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6604,8 +6604,6 @@ imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-7.htm
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-dynamic-8.html [ Skip ]
 
 # Imported WPT /css/css-tables which are crashing or fails.
-imported/w3c/web-platform-tests/css/css-tables/calc-percent-plus-0px-auto.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-tables/calc-percent-plus-0px-fixed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/col-definite-max-size-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/col-definite-size-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-tables/absolute-tables-007.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -32,6 +32,7 @@
 #include "RenderTableInlines.h"
 #include "RenderTableSection.h"
 #include "RenderView.h"
+#include "StyleCalculationValue.h"
 #include "StylePreferredSize.h"
 
 namespace WebCore {
@@ -110,6 +111,7 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
                         if (fixedCellLogicalWidth->resolveZoom(cellUsedZoom) > cCellMaxWidth)
                             cellLogicalWidth = Style::PreferredSize::Fixed { cCellMaxWidth };
                     }
+
                     WTF::switchOn(cellLogicalWidth,
                         [&](const Style::PreferredSize::Fixed& fixedCellLogicalWidth) {
                             if (fixedCellLogicalWidth.isPositiveOrZero() && !columnLayout.logicalWidth.isPercentOrCalculated()) {
@@ -135,8 +137,15 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
                             if (auto percentageColumnLayoutLogicalWidth = columnLayout.logicalWidth.tryPercentage(); percentageCellLogicalWidth.value > 0 && (!percentageColumnLayoutLogicalWidth || percentageCellLogicalWidth.value > percentageColumnLayoutLogicalWidth->value))
                                 columnLayout.logicalWidth = cellLogicalWidth;
                         },
-                        [&](const Style::PreferredSize::Calc&) {
-                            columnLayout.logicalWidth = CSS::Keyword::Auto { };
+                        [&](const Style::PreferredSize::Calc& calc) {
+                            // Per https://github.com/w3c/csswg-drafts/issues/3482
+                            // treat calc(% + 0px) as pure percentage, others as auto.
+                            if (auto percentage = Style::Calculation::extractPurePercentageForTableLayout(calc.calculation().tree())) {
+                                m_hasPercent = true;
+                                if (auto percentageColumnLayoutLogicalWidth = columnLayout.logicalWidth.tryPercentage(); *percentage > 0 && (!percentageColumnLayoutLogicalWidth || *percentage > percentageColumnLayoutLogicalWidth->value))
+                                    columnLayout.logicalWidth = Style::PreferredSize::Percentage { static_cast<float>(*percentage) };
+                            } else
+                                columnLayout.logicalWidth = CSS::Keyword::Auto { };
                         },
                         [&](const auto&) { }
                     );

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -27,6 +27,7 @@
 #include "RenderTableCol.h"
 #include "RenderTableInlines.h"
 #include "RenderTableSection.h"
+#include "StyleCalculationValue.h"
 #include "StylePreferredSize.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 
@@ -103,8 +104,12 @@ float FixedTableLayout::calcWidthArray()
         float effectiveColWidth = 0;
         if (auto fixedColStyleLogicalWidth = colStyleLogicalWidth.tryFixed(); fixedColStyleLogicalWidth && fixedColStyleLogicalWidth->isPositive())
             effectiveColWidth = fixedColStyleLogicalWidth->resolveZoom(colUsedZoom);
-        else if (colStyleLogicalWidth.isCalculated())
-            colStyleLogicalWidth = CSS::Keyword::Auto { };
+        else if (auto calc = colStyleLogicalWidth.tryCalc()) {
+            if (auto percentage = Style::Calculation::extractPurePercentageForTableLayout(calc->calculation().tree()))
+                colStyleLogicalWidth = Style::PreferredSize::Percentage { static_cast<float>(*percentage) };
+            else
+                colStyleLogicalWidth = CSS::Keyword::Auto { };
+        }
 
         unsigned span = col->span();
         while (span) {
@@ -151,8 +156,12 @@ float FixedTableLayout::calcWidthArray()
         if (auto fixedLogicalWidth = logicalWidth.tryFixed(); fixedLogicalWidth && fixedLogicalWidth->isPositive()) {
             fixedBorderBoxLogicalWidth = cell->adjustBorderBoxLogicalWidthForBoxSizing(*fixedLogicalWidth);
             logicalWidth = Style::PreferredSize::Fixed { fixedBorderBoxLogicalWidth };
-        } else if (logicalWidth.isCalculated())
-            logicalWidth = CSS::Keyword::Auto { };
+        } else if (auto calc = logicalWidth.tryCalc()) {
+            if (auto percentage = Style::Calculation::extractPurePercentageForTableLayout(calc->calculation().tree()))
+                logicalWidth = Style::PreferredSize::Percentage { static_cast<float>(*percentage) };
+            else
+                logicalWidth = CSS::Keyword::Auto { };
+        }
 
         unsigned usedSpan = 0;
         while (usedSpan < span && currentColumn < nEffCols) {

--- a/Source/WebCore/style/calc/StyleCalculationTree.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree.cpp
@@ -133,6 +133,44 @@ size_t computeDepth(const Tree& tree)
     return computeDepth(tree.root);
 }
 
+std::optional<double> extractPurePercentageForTableLayout(const Tree& tree)
+{
+    return WTF::switchOn(tree.root.value,
+        [&](const Percentage& percentage) -> std::optional<double> {
+            return percentage.value;
+        },
+        [&](const IndirectNode<Sum>& sum) -> std::optional<double> {
+            if (sum->children.size() != 2)
+                return std::nullopt;
+
+            bool hasPercentage = false;
+            bool hasZeroDimension = false;
+            double percentValue = 0;
+
+            for (const auto& child : sum->children) {
+                WTF::switchOn(child.value,
+                    [&](const Percentage& percentage) {
+                        hasPercentage = true;
+                        percentValue = percentage.value;
+                    },
+                    [&](const Dimension& dimension) {
+                        if (!dimension.value)
+                            hasZeroDimension = true;
+                    },
+                    [&](const auto&) { }
+                );
+            }
+
+            if (hasPercentage && hasZeroDimension)
+                return percentValue;
+            return std::nullopt;
+        },
+        [&](const auto&) -> std::optional<double> {
+            return std::nullopt;
+        }
+    );
+}
+
 template<typename Op>
 static auto dumpVariadic(TextStream&, const IndirectNode<Op>&, ASCIILiteral prefix, ASCIILiteral between) -> TextStream&;
 

--- a/Source/WebCore/style/calc/StyleCalculationTree.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree.h
@@ -229,6 +229,8 @@ struct Tree {
 
 size_t computeDepth(const Tree&);
 
+std::optional<double> extractPurePercentageForTableLayout(const Tree&);
+
 // Math Operators.
 
 struct Sum {


### PR DESCRIPTION
#### 17ce51af7a0323a42a3d3865e0b02fc8fb01df1c
<pre>
Auto and Fixed table layout should treat calc(% + 0px) as percentage
<a href="https://bugs.webkit.org/show_bug.cgi?id=306454">https://bugs.webkit.org/show_bug.cgi?id=306454</a>
<a href="https://rdar.apple.com/169120748">rdar://169120748</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per [1], in auto and fixed table layout, calc(% + 0px) should be treated
as a pure percentage, while calc expressions with non-zero pixel components
should be treated as auto.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/3482">https://github.com/w3c/csswg-drafts/issues/3482</a>

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::recalcColumn):
* Source/WebCore/rendering/FixedTableLayout.cpp:
(WebCore::FixedTableLayout::calcWidthArray):
* Source/WebCore/style/calc/StyleCalculationTree.cpp:
(WebCore::Style::Calculation::extractPurePercentageForTableLayout):
* Source/WebCore/style/calc/StyleCalculationTree.h:
* LayoutTests/TestExpectations: Progression
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17ce51af7a0323a42a3d3865e0b02fc8fb01df1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/32633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/168034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/113289 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89f3463c-d56a-4868-af59-71d2e08dcde0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/123343 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86602 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fe9e0a6-3879-4b97-b8ac-db4e5418ab84) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104010 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea269524-f421-4066-8701-8eac1639e00f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24667 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/23089 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15807 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/134353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/170529 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/16365 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/22409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/131535 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/32322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/27159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131647 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/32266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142576 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/90329 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/26345 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/19385 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31777 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97969 "Build is in progress. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Found 32657 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/31297 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/31570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/31452 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->