### PR TITLE
[Model element] Support `playbackRate` in GPU process model element

### DIFF
--- a/Source/WebCore/Modules/model-element/WebModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/WebModelPlayer.h
@@ -64,40 +64,41 @@ private:
 
     void updateScene();
 
-    // ModelPlayer overrides.
-    void load(Model&, LayoutSize) override;
-    void sizeDidChange(LayoutSize) override;
-    void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) override;
-    void enterFullscreen() override;
-    void handleMouseDown(const LayoutPoint&, MonotonicTime) override;
-    void handleMouseMove(const LayoutPoint&, MonotonicTime) override;
-    void handleMouseUp(const LayoutPoint&, MonotonicTime) override;
-    void getCamera(CompletionHandler<void(std::optional<HTMLModelElementCamera>&&)>&&) override;
-    void setCamera(HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) override;
-    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) override;
-    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) override;
-    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
-    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) override;
-    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) override;
-    void hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) override;
-    void setIsMuted(bool, CompletionHandler<void(bool success)>&&) override;
-    ModelPlayerAccessibilityChildren accessibilityChildren() override;
+    // ModelPlayer finals.
+    void load(Model&, LayoutSize) final;
+    void sizeDidChange(LayoutSize) final;
+    void configureGraphicsLayer(GraphicsLayer&, ModelPlayerGraphicsLayerConfiguration&&) final;
+    void enterFullscreen() final;
+    void handleMouseDown(const LayoutPoint&, MonotonicTime) final;
+    void handleMouseMove(const LayoutPoint&, MonotonicTime) final;
+    void handleMouseUp(const LayoutPoint&, MonotonicTime) final;
+    void getCamera(CompletionHandler<void(std::optional<HTMLModelElementCamera>&&)>&&) final;
+    void setCamera(HTMLModelElementCamera, CompletionHandler<void(bool success)>&&) final;
+    void isPlayingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setAnimationIsPlaying(bool, CompletionHandler<void(bool success)>&&) final;
+    void isLoopingAnimation(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsLoopingAnimation(bool, CompletionHandler<void(bool success)>&&) final;
+    void animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&) final;
+    void setAnimationCurrentTime(Seconds, CompletionHandler<void(bool success)>&&) final;
+    void hasAudio(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void isMuted(CompletionHandler<void(std::optional<bool>&&)>&&) final;
+    void setIsMuted(bool, CompletionHandler<void(bool success)>&&) final;
+    ModelPlayerAccessibilityChildren accessibilityChildren() final;
 #if PLATFORM(COCOA)
     std::optional<TransformationMatrix> entityTransform() const final;
 #endif
     void setEntityTransform(TransformationMatrix) final;
-    bool supportsTransform(TransformationMatrix) override;
-    bool supportsMouseInteraction() override;
+    bool supportsTransform(TransformationMatrix) final;
+    bool supportsMouseInteraction() final;
 
     const MachSendRight* displayBuffer() const;
     GraphicsLayerContentsDisplayDelegate* contentsDisplayDelegate();
 
-    void setAutoplay(bool) override;
-    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) override;
-    bool paused() const override;
+    void setPlaybackRate(double, CompletionHandler<void(double effectivePlaybackRate)>&&) final;
+    void setAutoplay(bool) final;
+    void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) final;
+    bool paused() const final;
     void play(bool);
     void simulate(float elapsedTime);
 
@@ -130,6 +131,7 @@ private:
     float m_pitchAcceleration { 0.f };
     float m_yaw { 0.f };
     float m_pitch { 0.f };
+    float m_playbackRate { 1.0f };
 };
 
 }

--- a/Source/WebCore/Modules/model-element/WebModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/WebModelPlayer.mm
@@ -504,12 +504,18 @@ void WebModelPlayer::simulate(float elapsedTime)
     model->setRotation(m_yaw, m_pitch);
 }
 
+void WebModelPlayer::setPlaybackRate(double newRate, CompletionHandler<void(double effectivePlaybackRate)>&& completion)
+{
+    m_playbackRate = newRate;
+    completion(newRate);
+}
+
 void WebModelPlayer::update()
 {
     constexpr float elapsedTime = 1.f / 60.f;
     simulate(elapsedTime);
 
-    [m_modelLoader update:elapsedTime];
+    [m_modelLoader update:paused() ? 0.f : (m_playbackRate * elapsedTime)];
     if (m_didFinishLoading) {
         if (RefPtr currentModel = m_currentModel)
             currentModel->render();


### PR DESCRIPTION
#### a85a346017b3ba4b0cd47b075b6e6685d7376929
<pre>
[Model element] Support `playbackRate` in GPU process model element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299476">https://bugs.webkit.org/show_bug.cgi?id=299476</a>
<a href="https://rdar.apple.com/161268411">rdar://161268411</a>

Reviewed by Anne van Kesteren.

&lt;model&gt; allows for speeding up / slowing down animations but they
only impact the animation and not the user interaction with the model,
so we only need to multiply the playback rate by the requested animation
speed.

* Source/WebCore/Modules/model-element/DDModelPlayer.h:
* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
(WebCore::DDModelPlayer::update):
(WebCore::DDModelPlayer::setPlaybackRate):

Canonical link: <a href="https://commits.webkit.org/306605@main">https://commits.webkit.org/306605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e8765eb7cba96ed12c4fd83ca441681f5742ac9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94928 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c788c32e-ba7f-437c-aeb7-0c7be4e4c30c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143670 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108971 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78803 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0314ddb2-7c96-4a27-bf94-02b4e0432b8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89867 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f34b318d-3302-4ed2-83f5-48566f133a5a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11072 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8711 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/463 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152785 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117061 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117383 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29905 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13432 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123628 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69535 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13916 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2909 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13655 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13858 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13702 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->