### PR TITLE
Support duration in iOS + macOS <model>

### DIFF
--- a/Source/WebCore/Modules/model-element/WebModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/WebModelPlayer.h
@@ -101,6 +101,7 @@ private:
     bool paused() const final;
     void play(bool);
     void simulate(float elapsedTime);
+    double duration() const final;
 
     void ensureOnMainThreadWithProtectedThis(Function<void(Ref<WebModelPlayer>)>&& task);
     void setStageMode(WebCore::StageModeOperation) final;

--- a/Source/WebCore/Modules/model-element/WebModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/WebModelPlayer.mm
@@ -141,6 +141,11 @@ void WebModelPlayer::ensureOnMainThreadWithProtectedThis(Function<void(Ref<WebMo
     });
 }
 
+double WebModelPlayer::duration() const
+{
+    return [m_modelLoader duration];
+}
+
 static Vector<uint8_t> loadData(RetainPtr<CFStringRef> filename)
 {
     RetainPtr<NSBundle> myBundle = [NSBundle bundleWithIdentifier:@"com.apple.WebCore"];
@@ -419,8 +424,9 @@ void WebModelPlayer::setIsLoopingAnimation(bool, CompletionHandler<void(bool suc
 {
 }
 
-void WebModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&&)
+void WebModelPlayer::animationDuration(CompletionHandler<void(std::optional<Seconds>&&)>&& completion)
 {
+    completion(Seconds(duration()));
 }
 
 void WebModelPlayer::animationCurrentTime(CompletionHandler<void(std::optional<Seconds>&&)>&&)

--- a/Source/WebGPU/WebGPU/ModelTypes.h
+++ b/Source/WebGPU/WebGPU/ModelTypes.h
@@ -405,6 +405,7 @@ NS_SWIFT_SENDABLE
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
+- (double)duration;
 - (void)loadModelFrom:(NSURL *)url;
 - (void)update:(double)deltaTime;
 - (void)requestCompleted:(NSObject *)request;

--- a/Source/WebGPU/WebGPU/USDModel.swift
+++ b/Source/WebGPU/WebGPU/USDModel.swift
@@ -1103,6 +1103,14 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
         }
     }
 
+    func duration() -> Double {
+        if timeCodePerSecond > 0 {
+            return (endTime - startTime) / timeCodePerSecond
+        }
+
+        return 0.0
+    }
+
     func loadModel(from data: Data) {
     }
 
@@ -1162,6 +1170,14 @@ extension WebBridgeModelLoader {
     @objc
     func requestCompleted(_ request: NSObject) {
         retainedRequests.remove(request)
+    }
+
+    @objc
+    func duration() -> Double {
+        guard let loader else {
+            return 0.0
+        }
+        return loader.duration()
     }
 
     fileprivate func updateMesh(webRequest: WebBridgeUpdateMesh) {
@@ -1351,6 +1367,11 @@ extension WebBridgeModelLoader {
 
     @objc
     func requestCompleted(_ request: NSObject) {
+    }
+
+    @objc
+    func duration() -> Double {
+        0.0
     }
 }
 #endif


### PR DESCRIPTION
#### bc5ceaa032eb13101d74706079e5a5c29ff79fc6
<pre>
Support duration in iOS + macOS &lt;model&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=306480">https://bugs.webkit.org/show_bug.cgi?id=306480</a>
<a href="https://rdar.apple.com/169131687">rdar://169131687</a>

Reviewed by Anne van Kesteren.

Return duration for animation models.

* Source/WebCore/Modules/model-element/DDModelPlayer.h:
* Source/WebCore/Modules/model-element/DDModelPlayer.mm:
(WebCore::DDModelPlayer::animationDuration):
(WebCore::DDModelPlayer::duration const):
* Source/WebGPU/WebGPU/DDModelTypes.h:
* Source/WebGPU/WebGPU/USDModel.swift:
(USDModelLoader.duration):
(DDBridgeModelLoader.duration):

Canonical link: <a href="https://commits.webkit.org/306640@main">https://commits.webkit.org/306640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/740110c4b52640d1fbfb70a98d3474ebdfefebef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95081 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59f63bca-df82-4325-815f-d392c82ebdf4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109067 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/105a9da1-0c1e-423d-9ae0-bb347b3ad948) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144855 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89964 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ecd2b1c-5b54-4686-a29c-51756d34e03d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11154 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8797 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/566 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120474 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152888 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13981 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117147 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117468 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29933 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13513 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69670 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14019 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3166 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13758 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77744 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13961 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13805 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->