### PR TITLE
WGSL feature detection added for texture-formats-tier1

### DIFF
--- a/Source/WebCore/Modules/WebGPU/WGSLLanguageFeatures.cpp
+++ b/Source/WebCore/Modules/WebGPU/WGSLLanguageFeatures.cpp
@@ -35,6 +35,7 @@ void WGSLLanguageFeatures::initializeSetLike(DOMSetAdapter& set) const
     set.add<IDLDOMString>("packed_4x8_integer_dot_product"_s);
     set.add<IDLDOMString>("pointer_composite_access"_s);
     set.add<IDLDOMString>("readonly_and_readwrite_storage_textures"_s);
+    set.add<IDLDOMString>("texture_formats_tier1"_s);
     set.add<IDLDOMString>("unrestricted_pointer_parameters"_s);
 }
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -440,7 +440,7 @@ Result<void> Parser<Lexer>::parseRequireDirective()
         CONSUME_TYPE_NAMED(identifier, Identifier);
         auto* languageFeature = parseLanguageFeature(identifier.ident);
         if (!languageFeature)
-            FAIL("Expected 'readonly_and_readwrite_storage_textures', 'packed_4x8_integer_dot_product', 'unrestricted_pointer_parameters' or 'pointer_composite_access'"_s);
+            FAIL("Expected 'readonly_and_readwrite_storage_textures', 'packed_4x8_integer_dot_product', 'unrestricted_pointer_parameters', 'texture_formats_tier1', or 'pointer_composite_access'"_s);
         m_shaderModule.requiredFeatures().add(*languageFeature);
 
         if (current().type != TokenType::Comma)

--- a/Source/WebGPU/WGSL/WGSLEnums.h
+++ b/Source/WebGPU/WGSL/WGSLEnums.h
@@ -132,7 +132,8 @@ namespace WGSL {
     value(Packed4x8IntegerDotProduct, packed_4x8_integer_dot_product, 1 << 0) \
     value(PointerCompositeAccess, pointer_composite_access, 1 << 1) \
     value(ReadonlyAndReadwriteStorageTextures, readonly_and_readwrite_storage_textures, 1 << 2) \
-    value(UnrestrictedPointerParameters, unrestricted_pointer_parameters, 1 << 3) \
+    value(TextureFormatsTier1, texture_formats_tier1, 1 << 3) \
+    value(UnrestrictedPointerParameters, unrestricted_pointer_parameters, 1 << 4) \
 
 #define ENUM_DECLARE_VALUE(__value, _, ...) \
     __value __VA_OPT__(=) __VA_ARGS__,


### PR DESCRIPTION
#### 6ba4f6aefbc037146e1bbe3a0efcb2cb02a1c67a
<pre>
WGSL feature detection added for texture-formats-tier1
<a href="https://bugs.webkit.org/show_bug.cgi?id=306489">https://bugs.webkit.org/show_bug.cgi?id=306489</a>
<a href="https://rdar.apple.com/169138808">rdar://169138808</a>

Reviewed by Dan Glastonbury and Tadeu Zagallo.

We already support texture-formats-tier1, there is no change
needed from the website, this PR just advertises support for
them as required by <a href="https://github.com/gpuweb/gpuweb/pull/5526">https://github.com/gpuweb/gpuweb/pull/5526</a>

* Source/WebCore/Modules/WebGPU/WGSLLanguageFeatures.cpp:
(WebCore::WGSLLanguageFeatures::initializeSetLike const):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseRequireDirective):
* Source/WebGPU/WGSL/WGSLEnums.h:

Canonical link: <a href="https://commits.webkit.org/306504@main">https://commits.webkit.org/306504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e335bdcc71a486804eccc9e594ed5b183af3faf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149822 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94345 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108514 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78564 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ae8379f-3e1c-4ba7-a997-d39da20463db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89419 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10636 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8247 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152216 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13318 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116613 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29844 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13000 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68492 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13361 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2444 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13299 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->