### PR TITLE
Expose document identifier on _WKJSHandles from _WKRemoteObjectRegistry

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -110,7 +110,10 @@ static Ref<API::FrameInfo> protectedFrameInfo(WKFrameInfo *frameInfo)
 
 - (NSUUID *)_documentIdentifier
 {
-    return _frameInfo->documentID()->object().createNSUUID().autorelease();
+    auto documentID = _frameInfo->documentID();
+    if (!documentID)
+        return nil;
+    return documentID->object().createNSUUID().autorelease();
 }
 
 - (pid_t)_processIdentifier

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm
@@ -68,7 +68,10 @@ static JSValueRef javaScriptFunction(JSContextRef context, JSObjectRef, JSObject
             _WKRemoteObjectInterface *interface = [_WKRemoteObjectInterface remoteObjectInterfaceWithProtocol:@protocol(JSHandlePlugInProtocol)];
 
             id<JSHandlePlugInProtocol> remoteObject = [globalBrowserContextController._remoteObjectRegistry remoteObjectProxyWithInterface:interface];
-            [remoteObject receiveDictionaryFromWebProcess:@{ @"testkey" : handle }];
+            [remoteObject receiveDictionaryFromWebProcess:@{
+                @"testkey" : handle,
+                @"testdatakey" : [NSKeyedArchiver archivedDataWithRootObject:handle requiringSecureCoding:YES error:nullptr]
+            }];
         }
     }
     return JSValueMakeUndefined(context);


### PR DESCRIPTION
#### 9389120d2fda289828ced2e0c344b2779fcad33c
<pre>
Expose document identifier on _WKJSHandles from _WKRemoteObjectRegistry
<a href="https://bugs.webkit.org/show_bug.cgi?id=306491">https://bugs.webkit.org/show_bug.cgi?id=306491</a>
<a href="https://rdar.apple.com/169144968">rdar://169144968</a>

Reviewed by Ryosuke Niwa.

Initial adoption of 306304@main showed it was lacking in 2 ways:
1. We need to allow use of encoders and decoders other than WKRemoteObjectDecoder and Encoder.
2. We need the document identifier to be populated and not crash.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm

* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _documentIdentifier]):
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm:
(-[_WKJSHandle initWithCoder:]):
(-[_WKJSHandle encodeWithCoder:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSHandlePlugIn.mm:
(javaScriptFunction):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InjectedBundle)):

Canonical link: <a href="https://commits.webkit.org/306398@main">https://commits.webkit.org/306398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8202167b327f4bc407253d35ce85ae0fa3429f00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149855 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d611ed9-2689-4d64-b2e5-7ec83c2076a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13820 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108544 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8b4d495-f66d-4e0d-babd-5f33ebd835eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/11093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89449 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/119929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152249 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13351 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/116642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116982 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/13033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/123094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21793 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13394 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13133 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13177 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->