### PR TITLE
[AutoFill Debugging] Extracted text sometimes contains extra trailing and leading whitespace

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt
@@ -12,9 +12,11 @@ root
         input,'text',uid=…,placeholder='Enter text here'
         'Clickable Div'
     section,uid=…
-        'Name Field\n\n        \nDescription'
+        'Name Field'
+        'Description'
         input,'text',uid=…,placeholder='Your name'
         'This region is labeled by another element.'
         input,'text',uid=…,placeholder='Full name'
-        'User Profile\n\n        \n\n            Username:'
+        'User Profile'
+        'Username:'
         input,'text',uid=…,label='Username:'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -14,7 +14,8 @@ root
             input,'text',uid=…,[…],placeholder='Enter text here'
             uid=…,role='button',events=[click,keyboard],'Clickable Div',[…]
         section,aria-label='ARIA Labeling Examples'
-            'Name Field\n\n        \nDescription',[…]
+            'Name Field',[…]
+            'Description',[…]
             input,'text',uid=…,[…],aria-labelledby='Name Field',placeholder='Your name'
             role='region',aria-labelledby='Description','This region is labeled by another element.',[…]
             input,'text',uid=…,[…],aria-labelledby='Name Field',placeholder='Full name'
@@ -23,7 +24,10 @@ root
                 'Username:',[…]
                 input,'text',uid=…,[…],label='Username:'
         section,aria-label='Content with Roles'
-            article,role='article','Article Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content with highlighted text.',[…]
+            article,role='article'
+                'Article Title',[…]
+                'January 1, 2024',[…]
+                'This is some article content with highlighted text.',[…]
             role='complementary',aria-label='Related information'
                 'Related Links',[…]
                 list

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-data-detectors-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-data-detectors-expected.txt
@@ -1,9 +1,6 @@
 Sale - 20% Off
 Premium Wireless Headphones
 High-fidelity audio with active noise cancellation. Features 30-hour battery life, comfortable over-ear design, and seamless Bluetooth connectivity.
-
-$79.99
-~~$99.99~~
+$79.99 ~~$99.99~~
 You save $20.00
-
 In Stock - Ships within 24 hours

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -16,7 +16,10 @@ root
             input,'text',uid=…,placeholder='Enter text here'
             role='button',title='Test action','Clickable Div'
         section,aria-label='Content with Roles'
-            article,role='article','Article Title\n\nJanuary 1, 2024\nThis is some article content with highlighted text.'
+            article,role='article'
+                'Article Title'
+                'January 1, 2024'
+                'This is some article content with highlighted text.'
             role='complementary',aria-label='Related information'
                 'Related Links'
                 list
@@ -66,7 +69,11 @@ root
             <div role='button' title='Test action'>Clickable Div</div>
         </section>
         <section aria-label='Content with Roles'>
-            <article role='article'>Article Title  January 1, 2024 This is some article content with highlighted text.</article>
+            <article role='article'>
+                Article Title
+                January 1, 2024
+                This is some article content with highlighted text.
+            </article>
             <aside role='complementary' aria-label='Related information'>
                 Related Links
                 <ul>
@@ -238,7 +245,15 @@ root
               "children": [
                 {
                   "type": "text",
-                  "content": "Article Title January 1, 2024 This is some article content with highlighted text."
+                  "content": "Article Title"
+                },
+                {
+                  "type": "text",
+                  "content": "January 1, 2024"
+                },
+                {
+                  "type": "text",
+                  "content": "This is some article content with highlighted text."
                 }
               ]
             },

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt
@@ -13,7 +13,10 @@ root
         input,'text',placeholder='Enter text here'
         'Clickable Div'
     section
-        article,'Article Title\n\n\n                January 1, 2024\n            \n\n            \nThis is some article content…'
+        article
+            'Article Title'
+            'January 1, 2024'
+            'This is some article content…'
         'Related Links'
         list
             list-item
@@ -22,4 +25,5 @@ root
                 link,'Test Link'
         'Ready'
         button,'Update Status'
-    'The quick brown fox jumped…\n\n\n\n\n    \nFooter content with © 2024'
+    'The quick brown fox jumped…'
+    'Footer content with © 2024'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt
@@ -20,7 +20,8 @@
             <div uid=… role='button'>Clickable Div</div>
         </section>
         <section aria-label='ARIA Labeling Examples'>
-            Name Field           Description
+            Name Field
+            Description
             <input type='text' uid=… aria-labelledby='Name Field' placeholder='Your name'>
             <div role='region' aria-labelledby='Description'>This region is labeled by another element.</div>
             <input type='text' uid=… aria-labelledby='Name Field' placeholder='Full name'>
@@ -31,7 +32,11 @@
             </div>
         </section>
         <section aria-label='Content with Roles'>
-            <article role='article'>Article Title                   January 1, 2024                            This is some article content with highlighted text.</article>
+            <article role='article'>
+                Article Title
+                January 1, 2024
+                This is some article content with highlighted text.
+            </article>
             <aside role='complementary' aria-label='Related information'>
                 Related Links
                 <ul>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -384,7 +384,8 @@ TEST(TextExtractionTests, VisibleTextOnly)
 
     EXPECT_TRUE([debugText containsString:@"Test"]);
     EXPECT_TRUE([debugText containsString:@"foo"]);
-    EXPECT_TRUE([debugText containsString:@"Subject “The quick brown fox jumped over the lazy dog”"]);
+    EXPECT_TRUE([debugText containsString:@"Subject"]);
+    EXPECT_TRUE([debugText containsString:@"“The quick brown fox jumped over the lazy dog”"]);
     EXPECT_TRUE([debugText containsString:@"0"]);
 #if ENABLE(TEXT_EXTRACTION_FILTER)
     EXPECT_FALSE([debugText containsString:@"Here’s to the crazy ones"]);
@@ -500,8 +501,9 @@ TEST(TextExtractionTests, NodesToSkip)
     }()];
 
     NSArray<NSString *> *lines = [debugText componentsSeparatedByString:@"\n"];
-    EXPECT_EQ([lines count], 1u);
-    EXPECT_WK_STREQ("Test 0", lines[0]);
+    EXPECT_EQ([lines count], 2u);
+    EXPECT_WK_STREQ("Test", lines[0]);
+    EXPECT_WK_STREQ("0", lines[1]);
 }
 
 TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)


### PR DESCRIPTION
#### 2bfbbefcfdee9bf201c0a205242a0e0ab4c988f1
<pre>
[AutoFill Debugging] Extracted text sometimes contains extra trailing and leading whitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=306494">https://bugs.webkit.org/show_bug.cgi?id=306494</a>
<a href="https://rdar.apple.com/168978618">rdar://168978618</a>

Reviewed by Richard Robinson.

Only merge adjacent runs of text in the case where they&apos;re inside the same enclosing block
container. We currently try to merge all adjacent text runs instead, which leads to extra whitespace
being unnecessarily included in the results, or text that is visually separate being squished
together in the same line.

Covered by rebaselining various layout and API tests.

* LayoutTests/fast/text-extraction/debug-text-extraction-all-container-uids-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-data-detectors-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-markup-expected.txt:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::canMerge):

See above for more details.

(WebCore::TextExtraction::extractRecursive):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, VisibleTextOnly)):
(TestWebKitAPI::TEST(TextExtractionTests, NodesToSkip)):

Canonical link: <a href="https://commits.webkit.org/306400@main">https://commits.webkit.org/306400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6da2c1d6b05a9d18d8f1a6c3d042e4a6ef610fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149837 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8057fb7b-f57c-4093-8704-d1bc88ecad67) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108528 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c4ca168-9b3f-4121-94be-27de917c88bc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11076 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89433 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/488d55e1-3d48-4997-af7f-7d691fbff70f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10650 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8260 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152231 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13333 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116626 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116966 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13016 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123076 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68507 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13376 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77082 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13159 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->