### PR TITLE
AX: Log timeout failures in accessibility-helper.js waitFor()

### DIFF
--- a/LayoutTests/accessibility/mac/style-range.html
+++ b/LayoutTests/accessibility/mac/style-range.html
@@ -21,7 +21,12 @@ async function styleRangeForElementMatches(id, expectedString, moveOffStartBy = 
     await waitFor(() => {
         return expectedString == webArea.stringForTextMarkerRange(webArea.styleTextMarkerRangeForTextMarker(marker));
     });
-    output += `PASS: The style range for the start marker of #${id} was "${expectedString}".\n`
+    let actualString = webArea.stringForTextMarkerRange(webArea.styleTextMarkerRangeForTextMarker(marker));
+    if (expectedString != actualString) {
+        // waitFor must have timed out, log the expected and actual values.
+        output += `FAIL: expected '${expectedString.replaceAll("\n", "\\n")}' but got '${webArea.stringForTextMarkerRange(webArea.styleTextMarkerRangeForTextMarker(marker))}'\n`;
+    } else
+        output += `PASS: The style range for the start marker of #${id} was "${expectedString}".\n`
 }
 
 if (window.accessibilityController) {
@@ -52,4 +57,3 @@ if (window.accessibilityController) {
 </script>
 </body>
 </html>
-

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2445,7 +2445,7 @@ accessibility/tree-update-with-dynamically-ignored-tabindex-div.html [ Pass ]
 accessibility/url-test.html [ Pass ]
 accessibility/video-element-url-attribute.html [ Pass ]
 accessibility/visible-character-range-height-changes.html [ Pass ]
-accessibility/visible-character-range-vertical-rl.html [ Pass ]
+webkit.org/b/306555 accessibility/visible-character-range-vertical-rl.html [ Failure ]
 accessibility/visibility-visible-inside-hidden.html [ Pass ]
 
 # Enable "aria-current" tests for iOS.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -118,6 +118,8 @@ webkit.org/b/21916 tables/mozilla_expected_failures/bugs/bug178855.xml [ Pass Im
 fast/dom/Window/slow-unload-handler.html
 fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html
 
+webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
+
 # Skip glib-only combobox accessibility tests.
 accessibility/combobox/gtk [ Skip ]
 

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -1,7 +1,15 @@
 function axDebug(msg)
 {
-    getOrCreate("console", "div").innerText += `${msg}\n`;
-};
+    var log = document.getElementById("log");
+    if (!log)
+        log = document.getElementById("console");
+    if (!log) {
+        log = document.createElement("div");
+        log.id = "console";
+        document.body.insertBefore(log, document.body.firstChild);
+    }
+    log.innerText += `${msg}\n`;
+}
 
 // This function is necessary when printing AX attributes that are stringified with angle brackets:
 //    AXChildren: <array of size 0>
@@ -240,10 +248,17 @@ function waitFor(condition)
         // Schedule a timeout after 3 seconds if condition is never met.
         let timeoutID = setTimeout(() => {
             clearInterval(intervalID);
+
+            // Output a message to indicate that this call is timing out and avoid masking any possible failure.
+            let conditionString = condition.toString();
+            if (conditionString.length > 80)
+                conditionString = `${conditionString.substring(0, 80)}...`;
+            axDebug(`Condition '${conditionString}' was not satisfied in 3s, timing out.`);
+
             resolve(false);
         }, 3000);
 
-	// Repeatedly poll for the condition to be true.
+        // Repeatedly poll for the condition to be true.
         let intervalID = setInterval(() => {
             try {
                 if (condition()) {


### PR DESCRIPTION
#### 17d5e50216e5a463279ee5dfe806efb4c2c3afbd
<pre>
AX: Log timeout failures in accessibility-helper.js waitFor()
<a href="https://bugs.webkit.org/show_bug.cgi?id=306495">https://bugs.webkit.org/show_bug.cgi?id=306495</a>
&lt;<a href="https://rdar.apple.com/problem/169152792">rdar://problem/169152792</a>&gt;

Reviewed by Tyler Wilcock.

The accessibility-helper.js waitFor function was timing out silently, masking real test failures in some situations. With this change, when waitFor() times out after 3 seconds, it logs a debug message showing that the condition was not satisfied. The condition function body is truncated to 80 characters to keep the output readable.

Also fixed incorrect tab indentation on a nearby comment.

* LayoutTests/accessibility/mac/style-range.html:
This test was silently failing and reported as passing. Added some extra logging in the test code to make the failure more explicit.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
Added the uncovered failures.

* LayoutTests/resources/accessibility-helper.js:
(axDebug):
Refactored to be self-contained since it is used in waitFor that in turn is called in many tests that may not include the js-test.js.
(waitFor):

Canonical link: <a href="https://commits.webkit.org/306670@main">https://commits.webkit.org/306670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26b3c8cae79fef3913b579ad0d20654952d49ecc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150058 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94579 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108707 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78665 "1 flakes 10 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89612 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10810 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8437 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/130 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152451 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13556 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116810 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117141 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29955 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13179 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123263 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68753 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13599 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2583 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13335 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13534 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->