### PR TITLE
Reduce use of protected functions in Source/WebKit/GPUProcess

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -168,7 +168,6 @@ public:
 
 #if ENABLE(VIDEO)
     RemoteAudioVideoRendererProxyManager& remoteAudioVideoRendererProxyManager();
-    Ref<RemoteAudioVideoRendererProxyManager> protectedRemoteAudioVideoRendererProxyManager();
 #endif
 
     PAL::SessionID sessionID() const { return m_sessionID; }
@@ -212,17 +211,13 @@ public:
     const WebCore::ProcessIdentity& webProcessIdentity() const { return m_webProcessIdentity; }
 #if ENABLE(ENCRYPTED_MEDIA)
     RemoteCDMFactoryProxy& cdmFactoryProxy();
-    Ref<RemoteCDMFactoryProxy> protectedCdmFactoryProxy();
 #endif
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
     RemoteLegacyCDMFactoryProxy& legacyCdmFactoryProxy();
-    Ref<RemoteLegacyCDMFactoryProxy> protectedLegacyCdmFactoryProxy();
 #endif
     RemoteMediaEngineConfigurationFactoryProxy& mediaEngineConfigurationFactoryProxy();
-    Ref<RemoteMediaEngineConfigurationFactoryProxy> protectedMediaEngineConfigurationFactoryProxy();
 #if ENABLE(VIDEO)
     RemoteMediaPlayerManagerProxy& remoteMediaPlayerManagerProxy() { return m_remoteMediaPlayerManagerProxy.get(); }
-    Ref<RemoteMediaPlayerManagerProxy> protectedRemoteMediaPlayerManagerProxy();
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     VideoReceiverEndpointManager& videoReceiverEndpointManager();
@@ -233,7 +228,6 @@ public:
 
 #if HAVE(AVASSETREADER)
     RemoteImageDecoderAVFProxy& imageDecoderAVFProxy();
-    Ref<RemoteImageDecoderAVFProxy> protectedImageDecoderAVFProxy();
 #endif
 
     void updateSupportedRemoteCommands();
@@ -265,7 +259,6 @@ public:
 #endif
 
 #if ENABLE(VIDEO)
-    Ref<RemoteVideoFrameObjectHeap> protectedVideoFrameObjectHeap();
     void performWithMediaPlayerOnMainThread(WebCore::MediaPlayerIdentifier, Function<void(WebCore::MediaPlayer&)>&&);
 #endif
 
@@ -297,13 +290,10 @@ private:
 
 #if ENABLE(WEB_AUDIO)
     RemoteAudioDestinationManager& remoteAudioDestinationManager();
-    Ref<RemoteAudioDestinationManager> protectedRemoteAudioDestinationManager();
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     UserMediaCaptureManagerProxy& userMediaCaptureManagerProxy();
-    Ref<UserMediaCaptureManagerProxy> protectedUserMediaCaptureManagerProxy();
     RemoteAudioMediaStreamTrackRendererInternalUnitManager& audioMediaStreamTrackRendererInternalUnitManager();
-    Ref<RemoteAudioMediaStreamTrackRendererInternalUnitManager> protectedAudioMediaStreamTrackRendererInternalUnitManager();
 #endif
 
     void createRenderingBackend(RemoteRenderingBackendIdentifier, IPC::StreamServerConnection::Handle&&);
@@ -333,7 +323,6 @@ private:
 #endif
 
 #if USE(AUDIO_SESSION)
-    Ref<RemoteAudioSessionProxy> protectedAudioSessionProxy();
     using EnsureAudioSessionCompletion = CompletionHandler<void(const RemoteAudioSessionConfiguration&)>;
     void ensureAudioSession(EnsureAudioSessionCompletion&&);
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -599,11 +599,6 @@ RemoteAudioSessionProxyManager& GPUProcess::audioSessionManager() const
         m_audioSessionManager = RemoteAudioSessionProxyManager::create(const_cast<GPUProcess&>(*this));
     return *m_audioSessionManager;
 }
-
-Ref<RemoteAudioSessionProxyManager> GPUProcess::protectedAudioSessionManager() const
-{
-    return audioSessionManager();
-}
 #endif
 
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -122,7 +122,6 @@ public:
 
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     RemoteAudioSessionProxyManager& audioSessionManager() const;
-    Ref<RemoteAudioSessionProxyManager> protectedAudioSessionManager() const;
 #endif
 
     WebCore::NowPlayingManager& nowPlayingManager();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -65,7 +65,7 @@ WebCore::ProcessIdentifier RemoteAudioSessionProxy::processIdentifier()
 
 RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
 {
-    Ref session = protectedAudioSessionManager()->session();
+    Ref session = protect(audioSessionManager())->session();
     return {
         session->routingContextUID(),
         session->sampleRate(),
@@ -91,13 +91,13 @@ void RemoteAudioSessionProxy::setCategory(AudioSession::CategoryType category, A
     m_mode = mode;
     m_routeSharingPolicy = policy;
     m_isPlayingToBluetoothOverrideChanged = false;
-    protectedAudioSessionManager()->updateCategory();
+    protect(audioSessionManager())->updateCategory();
 }
 
 void RemoteAudioSessionProxy::setPreferredBufferSize(uint64_t size)
 {
     m_preferredBufferSize = size;
-    protectedAudioSessionManager()->updatePreferredBufferSizeForProcess();
+    protect(audioSessionManager())->updatePreferredBufferSizeForProcess();
 }
 
 void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& completion)
@@ -128,7 +128,7 @@ void RemoteAudioSessionProxy::tryToSetActive(bool active, SetActiveCompletion&& 
 void RemoteAudioSessionProxy::setIsPlayingToBluetoothOverride(std::optional<bool>&& value)
 {
     m_isPlayingToBluetoothOverrideChanged = true;
-    protectedAudioSessionManager()->protectedSession()->setIsPlayingToBluetoothOverride(WTF::move(value));
+    protect(protect(audioSessionManager())->session())->setIsPlayingToBluetoothOverride(WTF::move(value));
 }
 
 void RemoteAudioSessionProxy::configurationChanged()
@@ -150,34 +150,29 @@ void RemoteAudioSessionProxy::endInterruption(AudioSession::MayResume mayResume)
 
 void RemoteAudioSessionProxy::beginInterruptionRemote()
 {
-    protectedAudioSessionManager()->beginInterruptionRemote();
+    protect(audioSessionManager())->beginInterruptionRemote();
 }
 
 void RemoteAudioSessionProxy::endInterruptionRemote(AudioSession::MayResume mayResume)
 {
-    protectedAudioSessionManager()->endInterruptionRemote(mayResume);
+    protect(audioSessionManager())->endInterruptionRemote(mayResume);
 }
 
 void RemoteAudioSessionProxy::setSceneIdentifier(const String& sceneIdentifier)
 {
     m_sceneIdentifier = sceneIdentifier;
-    protectedAudioSessionManager()->updateSpatialExperience();
+    protect(audioSessionManager())->updateSpatialExperience();
 }
 
 void RemoteAudioSessionProxy::setSoundStageSize(AudioSession::SoundStageSize size)
 {
     m_soundStageSize = size;
-    protectedAudioSessionManager()->updateSpatialExperience();
+    protect(audioSessionManager())->updateSpatialExperience();
 }
 
 RemoteAudioSessionProxyManager& RemoteAudioSessionProxy::audioSessionManager()
 {
     return m_gpuConnection.get()->gpuProcess().audioSessionManager();
-}
-
-Ref<RemoteAudioSessionProxyManager> RemoteAudioSessionProxy::protectedAudioSessionManager()
-{
-    return audioSessionManager();
 }
 
 Ref<IPC::Connection> RemoteAudioSessionProxy::protectedConnection() const

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -107,7 +107,6 @@ private:
     void endInterruptionRemote(WebCore::AudioSession::MayResume);
 
     RemoteAudioSessionProxyManager& audioSessionManager();
-    Ref<RemoteAudioSessionProxyManager> protectedAudioSessionManager();
     Ref<IPC::Connection> protectedConnection() const;
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -69,8 +69,6 @@ public:
 
     WebCore::AudioSession& session() { return WebCore::AudioSession::singleton(); }
     const WebCore::AudioSession& session() const { return WebCore::AudioSession::singleton(); }
-    Ref<WebCore::AudioSession> protectedSession() { return WebCore::AudioSession::singleton(); }
-    Ref<const WebCore::AudioSession> protectedSession() const { return WebCore::AudioSession::singleton(); }
 
     void updatePresentingProcesses();
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -618,8 +618,8 @@ void RemoteAudioVideoRendererProxyManager::setLegacyCDMSession(RemoteAudioVideoR
         renderer->setCDMSession(nullptr);
         return;
     }
-    if (RefPtr cdmSession = m_gpuConnectionToWebProcess.get()->protectedLegacyCdmFactoryProxy()->getSession(*instanceId))
-        renderer->setCDMSession(cdmSession->protectedSession().get());
+    if (RefPtr cdmSession = protect(m_gpuConnectionToWebProcess.get()->legacyCdmFactoryProxy())->getSession(*instanceId))
+        renderer->setCDMSession(protect(cdmSession->session()).get());
     else
         ALWAYS_LOG(LOGIDENTIFIER, "Unable to find LegacyCDMSession: ", instanceId->loggingString());
 }
@@ -638,7 +638,7 @@ void RemoteAudioVideoRendererProxyManager::setCDMInstance(RemoteAudioVideoRender
         renderer->setCDMInstance(nullptr);
         return;
     }
-    if (RefPtr instanceProxy = m_gpuConnectionToWebProcess.get()->protectedCdmFactoryProxy()->getInstance(*instanceId))
+    if (RefPtr instanceProxy = protect(m_gpuConnectionToWebProcess.get()->cdmFactoryProxy())->getInstance(*instanceId))
         renderer->setCDMInstance(&instanceProxy->instance());
     else
         ALWAYS_LOG(LOGIDENTIFIER, "Unable to find CDMInstance: ", instanceId->loggingString());

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -121,7 +121,7 @@ void RemoteCDMInstanceProxy::createSession(uint64_t logIdentifier, CompletionHan
 
     auto identifier = RemoteCDMInstanceSessionIdentifier::generate();
     auto session = RemoteCDMInstanceSessionProxy::create(m_cdm.get(), privSession.releaseNonNull(), logIdentifier, identifier);
-    protectedCdm()->protectedFactory()->addSession(identifier, WTF::move(session));
+    protect(protectedCdm()->factory())->addSession(identifier, WTF::move(session));
     completion(identifier);
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp
@@ -96,7 +96,7 @@ void RemoteCDMProxy::createInstance(CompletionHandler<void(std::optional<RemoteC
     auto identifier = RemoteCDMInstanceIdentifier::generate();
     auto instance = RemoteCDMInstanceProxy::create(*this, privateInstance.releaseNonNull(), identifier);
     RemoteCDMInstanceConfiguration configuration = instance->configuration();
-    protectedFactory()->addInstance(identifier, WTF::move(instance));
+    protect(factory())->addInstance(identifier, WTF::move(instance));
     completion(identifier, WTF::move(configuration));
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMProxy.h
@@ -61,7 +61,6 @@ public:
     const RemoteCDMConfiguration& configuration() const { return m_configuration.get(); }
 
     RemoteCDMFactoryProxy* factory() const { return m_factory.get(); }
-    RefPtr<RemoteCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
 
     bool supportsInitData(const String&, const WebCore::SharedBuffer&);
     RefPtr<WebCore::SharedBuffer> sanitizeResponse(const WebCore::SharedBuffer& response);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -83,7 +83,7 @@ RefPtr<MediaPlayer> RemoteLegacyCDMProxy::cdmMediaPlayer(const LegacyCDM*) const
     if (!gpuConnectionToWebProcess)
         return nullptr;
 
-    return gpuConnectionToWebProcess->protectedRemoteMediaPlayerManagerProxy()->mediaPlayer(*m_playerId);
+    return protect(gpuConnectionToWebProcess->remoteMediaPlayerManagerProxy())->mediaPlayer(*m_playerId);
 }
 
 std::optional<SharedPreferencesForWebProcess> RemoteLegacyCDMProxy::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -55,8 +55,6 @@ private:
     friend class RemoteLegacyCDMFactoryProxy;
     RemoteLegacyCDMProxy(WeakPtr<RemoteLegacyCDMFactoryProxy>&&, std::optional<WebCore::MediaPlayerIdentifier>, Ref<WebCore::LegacyCDM>&&);
 
-    RefPtr<RemoteLegacyCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
-
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -208,12 +208,7 @@ std::optional<SharedPreferencesForWebProcess> RemoteLegacyCDMSessionProxy::share
     if (!m_factory)
         return std::nullopt;
 
-    return protectedFactory()->sharedPreferencesForWebProcess();
-}
-
-RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDMSessionProxy::protectedSession() const
-{
-    return m_session;
+    return protect(factory())->sharedPreferencesForWebProcess();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -60,7 +60,6 @@ public:
 
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }
     WebCore::LegacyCDMSession* session() const { return m_session.get(); }
-    RefPtr<WebCore::LegacyCDMSession> protectedSession() const;
 
     RefPtr<ArrayBuffer> getCachedKeyForKeyId(const String&);
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
@@ -68,8 +67,6 @@ public:
 private:
     friend class RemoteLegacyCDMFactoryProxy;
     RemoteLegacyCDMSessionProxy(RemoteLegacyCDMFactoryProxy&, uint64_t logIdentifier, RemoteLegacyCDMSessionIdentifier, WebCore::LegacyCDM&);
-
-    RefPtr<RemoteLegacyCDMFactoryProxy> protectedFactory() const { return m_factory.get(); }
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -811,7 +811,7 @@ RefPtr<ArrayBuffer> RemoteMediaPlayerProxy::mediaPlayerCachedKeyForKeyId(const S
     if (!m_legacySession)
         return nullptr;
 
-    if (RefPtr cdmSession = manager->gpuConnectionToWebProcess()->protectedLegacyCdmFactoryProxy()->getSession(*m_legacySession))
+    if (RefPtr cdmSession = protect(manager->gpuConnectionToWebProcess()->legacyCdmFactoryProxy())->getSession(*m_legacySession))
         return cdmSession->getCachedKeyForKeyId(keyId);
     return nullptr;
 }
@@ -1072,15 +1072,15 @@ void RemoteMediaPlayerProxy::setLegacyCDMSession(std::optional<RemoteLegacyCDMSe
     RefPtr player = m_player;
 
     if (m_legacySession) {
-        if (RefPtr cdmSession = manager->gpuConnectionToWebProcess()->protectedLegacyCdmFactoryProxy()->getSession(*m_legacySession))
+        if (RefPtr cdmSession = protect(manager->gpuConnectionToWebProcess()->legacyCdmFactoryProxy())->getSession(*m_legacySession))
             player->setCDMSession(nullptr);
     }
 
     m_legacySession = instanceId;
 
     if (m_legacySession) {
-        if (RefPtr cdmSession = manager->gpuConnectionToWebProcess()->protectedLegacyCdmFactoryProxy()->getSession(*m_legacySession))
-            player->setCDMSession(cdmSession->protectedSession().get());
+        if (RefPtr cdmSession = protect(manager->gpuConnectionToWebProcess()->legacyCdmFactoryProxy())->getSession(*m_legacySession))
+            player->setCDMSession(protect(cdmSession->session()).get());
     }
 }
 
@@ -1098,7 +1098,7 @@ void RemoteMediaPlayerProxy::cdmInstanceAttached(RemoteCDMInstanceIdentifier&& i
     if (!manager || !manager->gpuConnectionToWebProcess())
         return;
 
-    if (RefPtr instanceProxy = manager->gpuConnectionToWebProcess()->protectedCdmFactoryProxy()->getInstance(instanceId))
+    if (RefPtr instanceProxy = protect(manager->gpuConnectionToWebProcess()->cdmFactoryProxy())->getInstance(instanceId))
         protectedPlayer()->cdmInstanceAttached(instanceProxy->instance());
 }
 
@@ -1109,7 +1109,7 @@ void RemoteMediaPlayerProxy::cdmInstanceDetached(RemoteCDMInstanceIdentifier&& i
     if (!manager || !manager->gpuConnectionToWebProcess())
         return;
 
-    if (RefPtr instanceProxy = manager->gpuConnectionToWebProcess()->protectedCdmFactoryProxy()->getInstance(instanceId))
+    if (RefPtr instanceProxy = protect(manager->gpuConnectionToWebProcess()->cdmFactoryProxy())->getInstance(instanceId))
         protectedPlayer()->cdmInstanceDetached(instanceProxy->instance());
 }
 
@@ -1120,7 +1120,7 @@ void RemoteMediaPlayerProxy::attemptToDecryptWithInstance(RemoteCDMInstanceIdent
     if (!manager || !manager->gpuConnectionToWebProcess())
         return;
 
-    if (RefPtr instanceProxy = manager->gpuConnectionToWebProcess()->protectedCdmFactoryProxy()->getInstance(instanceId))
+    if (RefPtr instanceProxy = protect(manager->gpuConnectionToWebProcess()->cdmFactoryProxy())->getInstance(instanceId))
         protectedPlayer()->attemptToDecryptWithInstance(instanceProxy->instance());
 }
 #endif

--- a/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm
@@ -164,13 +164,13 @@ void VideoReceiverEndpointManager::setVideoTargetIfValidIdentifier(std::optional
     if (!playerIdentifier)
         return;
 
-    if (RefPtr player = protectedConnection()->protectedRemoteMediaPlayerManagerProxy()->mediaPlayer(playerIdentifier)) {
+    if (RefPtr player = protect(protectedConnection()->remoteMediaPlayerManagerProxy())->mediaPlayer(playerIdentifier)) {
         ALWAYS_LOG(LOGIDENTIFIER, "Update entry; ", !videoTarget ? "removing target" : "setting target", " on player ", playerIdentifier->loggingString());
         player->setVideoTarget(videoTarget);
         return;
     }
 
-    if (RefPtr renderer = protectedConnection()->protectedRemoteAudioVideoRendererProxyManager()->rendererFor(playerIdentifier)) {
+    if (RefPtr renderer = protect(protectedConnection()->remoteAudioVideoRendererProxyManager())->rendererFor(playerIdentifier)) {
         ALWAYS_LOG(LOGIDENTIFIER, "Update entry; ", !videoTarget ? "removing target" : "setting target", " on A/V renderer ", playerIdentifier->loggingString());
         renderer->setVideoTarget(videoTarget);
     }


### PR DESCRIPTION
#### 085e8165421facbe95e7895150b6f447db5137a8
<pre>
Reduce use of protected functions in Source/WebKit/GPUProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=306497">https://bugs.webkit.org/show_bug.cgi?id=306497</a>

Reviewed by Darin Adler.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
(WebKit::GPUConnectionToWebProcess::lowMemoryHandler):
(WebKit::GPUConnectionToWebProcess::remoteAudioDestinationManager):
(WebKit::GPUConnectionToWebProcess::audioMediaStreamTrackRendererInternalUnitManager):
(WebKit::GPUConnectionToWebProcess::remoteAudioVideoRendererProxyManager):
(WebKit::GPUConnectionToWebProcess::cdmFactoryProxy):
(WebKit::GPUConnectionToWebProcess::audioSessionProxy):
(WebKit::GPUConnectionToWebProcess::imageDecoderAVFProxy):
(WebKit::GPUConnectionToWebProcess::performWithMediaPlayerOnMainThread):
(WebKit::GPUConnectionToWebProcess::ensureAudioSession):
(WebKit::GPUConnectionToWebProcess::legacyCdmFactoryProxy):
(WebKit::GPUConnectionToWebProcess::mediaEngineConfigurationFactoryProxy):
(WebKit::GPUConnectionToWebProcess::dispatchMessage):
(WebKit::GPUConnectionToWebProcess::dispatchSyncMessage):
(WebKit::GPUConnectionToWebProcess::setOrientationForMediaCapture):
(WebKit::GPUConnectionToWebProcess::rotationAngleForCaptureDeviceChanged):
(WebKit::GPUConnectionToWebProcess::enableMediaPlaybackIfNecessary):
(WebKit::GPUConnectionToWebProcess::protectedRemoteAudioDestinationManager): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedUserMediaCaptureManagerProxy): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedAudioMediaStreamTrackRendererInternalUnitManager): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedRemoteAudioVideoRendererProxyManager): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedCdmFactoryProxy): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedAudioSessionProxy): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedImageDecoderAVFProxy): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedVideoFrameObjectHeap): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedRemoteMediaPlayerManagerProxy): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedLegacyCdmFactoryProxy): Deleted.
(WebKit::GPUConnectionToWebProcess::protectedMediaEngineConfigurationFactoryProxy): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::remoteMediaPlayerManagerProxy):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::audioSessionManager const):
(WebKit::GPUProcess::protectedAudioSessionManager const): Deleted.
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::configuration):
(WebKit::RemoteAudioSessionProxy::setCategory):
(WebKit::RemoteAudioSessionProxy::setPreferredBufferSize):
(WebKit::RemoteAudioSessionProxy::setIsPlayingToBluetoothOverride):
(WebKit::RemoteAudioSessionProxy::beginInterruptionRemote):
(WebKit::RemoteAudioSessionProxy::endInterruptionRemote):
(WebKit::RemoteAudioSessionProxy::setSceneIdentifier):
(WebKit::RemoteAudioSessionProxy::setSoundStageSize):
(WebKit::RemoteAudioSessionProxy::protectedAudioSessionManager): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:
(WebKit::RemoteAudioSessionProxyManager::session const):
(WebKit::RemoteAudioSessionProxyManager::protectedSession): Deleted.
(WebKit::RemoteAudioSessionProxyManager::protectedSession const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::setLegacyCDMSession):
(WebKit::RemoteAudioVideoRendererProxyManager::setCDMInstance):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::createSession):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.cpp:
(WebKit::RemoteCDMProxy::createInstance):
* Source/WebKit/GPUProcess/media/RemoteCDMProxy.h:
(WebKit::RemoteCDMProxy::factory const):
(WebKit::RemoteCDMProxy::protectedFactory const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::cdmMediaPlayer const):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
(WebKit::RemoteLegacyCDMProxy::protectedFactory const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp:
(WebKit::RemoteLegacyCDMSessionProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteLegacyCDMSessionProxy::protectedSession const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
(WebKit::RemoteLegacyCDMSessionProxy::session const):
(WebKit::RemoteLegacyCDMSessionProxy::protectedFactory const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerCachedKeyForKeyId const):
(WebKit::RemoteMediaPlayerProxy::setLegacyCDMSession):
(WebKit::RemoteMediaPlayerProxy::cdmInstanceAttached):
(WebKit::RemoteMediaPlayerProxy::cdmInstanceDetached):
(WebKit::RemoteMediaPlayerProxy::attemptToDecryptWithInstance):
* Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm:
(WebKit::VideoReceiverEndpointManager::setVideoTargetIfValidIdentifier const):

Canonical link: <a href="https://commits.webkit.org/306467@main">https://commits.webkit.org/306467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3978f93745e5d57c0f8cf3c0f89dbbb76a566db9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149842 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94365 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a8e3275-d830-4cf2-8ee2-6ffcadae6bb1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14363 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108532 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78569 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89437 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f12b480b-4107-4d2f-9c98-f1690aa7759c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10658 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8262 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119920 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152236 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13338 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116629 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116969 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13018 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123082 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68512 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13381 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2456 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77087 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->