### PR TITLE
[ WIP ] add expectations to api-tests

### DIFF
--- a/APITestExpectations/TestExpectations
+++ b/APITestExpectations/TestExpectations
@@ -1,0 +1,54 @@
+# API Test Expectations
+#
+# This file contains test expectations for API tests (TestWebKitAPI, TestWTF, etc.)
+# that apply to all platforms. Platform-specific expectations go in the
+# platform/<platform>/TestExpectations files.
+#
+# Format:
+#     [optional bug] [optional config] test_name_or_pattern [ expectations ]
+#
+# Examples:
+#     TestWebKitAPI.WTF.HashSet [ Fail ]
+#     webkit.org/b/12345 TestWebKitAPI.WTF.Test [ Pass Fail ]
+#     rdar://98765432 TestWebKitAPI.WebKit.Bug [ Crash ]
+#     [ debug ] TestWebKitAPI.WTF.DebugOnly [ Skip ]
+#     [ mac Sonoma+ ] TestWebKitAPI.WebKit.NewFeature [ Pass ]
+#     [ ios simulator arm64 ] TestWebKitAPI.WTF.Test [ Timeout ]
+#     TestWebKitAPI.WTF.* [ Skip ]
+#     TestWebKitAPI.WebKit.SlowTest [ Slow ]
+#     TestWebKitAPI.WebKit.VerySlowTest [ Slow:120s ]
+#     [ wk2 siteisolation ] TestWebKitAPI.WebKit.SiteIsolation [ Pass ]
+#
+# Supported expectations:
+#     Pass     - Test expected to pass
+#     Fail     - Test expected to fail
+#     Crash    - Test expected to crash
+#     Timeout  - Test expected to timeout
+#     Skip     - Don't run this test
+#
+# Supported modifiers:
+#     Slow       - Use 5x default timeout
+#     Slow:NNs   - Use NN seconds as timeout (e.g., Slow:120s)
+#
+# Configuration specifiers (order: less to more specific):
+#     Platform:     mac, ios, linux, win, gtk, wpe
+#     Version:      Sonoma, Ventura, iOS17, iOS18, etc.
+#                   Sonoma+       (Sonoma and later)
+#                   Sonoma-       (Sonoma and earlier)
+#                   Ventura-Sequoia (range, inclusive)
+#     Style:        debug, release, asan, guardmalloc
+#     Hardware:     simulator, device, iphone, ipad
+#     Architecture: arm64, x86_64, x86, arm64_32, armv7k
+#     Flavor:       wk1, wk2, siteisolation, etc. (freeform)
+#
+# Wildcards:
+#     TestWebKitAPI.WTF.*   - Matches all tests in WTF suite
+#     TestWTF.*             - Matches all tests in TestWTF binary
+#
+# Bug identifiers (optional):
+#     webkit.org/b/12345    - WebKit bug tracker
+#     rdar://12345          - Apple radar
+#     rdar://problem/12345  - Apple radar (alternate format)
+#     Bug(identifier)       - Other bug tracker
+#
+

--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -29,6 +29,7 @@ import sys
 import traceback
 
 from webkitpy.api_tests.manager import Manager
+from webkitpy.api_tests.test_expectations import APITestExpectations, EXPECTATION_NAMES
 from webkitpy.common.host import Host
 from webkitpy.layout_tests.views.metered_stream import MeteredStream
 from webkitpy.port import configuration_options, platform_options, base, win
@@ -57,6 +58,18 @@ def main(argv, stdout, stderr):
         print('{} cannot run API tests'.format(port.operating_system()), file=stderr)
         return EXCEPTIONAL_EXIT_STATUS
 
+    # Handle --lint-test-files option
+    if options.lint_test_files:
+        return lint_expectations(port, options, args, stderr)
+
+    # Handle --print-expectations option
+    if options.print_expectations:
+        return print_expectations(port, options, args, stderr)
+
+    # Handle --print-summary option
+    if options.print_summary:
+        return print_summary(port, options, args, stderr)
+
     # Add site-isolation results report flavor for API tests when ran
     if options.site_isolation:
         if options.result_report_flavor:
@@ -72,6 +85,151 @@ def main(argv, stdout, stderr):
             print('\n%s raised: %s' % (e.__class__.__name__, str(e)), file=stderr)
             traceback.print_exc(file=stderr)
         return EXCEPTIONAL_EXIT_STATUS
+
+
+def lint_expectations(port, options, args, logging_stream):
+    """Validate test expectations files without running tests."""
+    print('Linting API test expectations...', file=logging_stream)
+
+    # Load expectations
+    expectations = APITestExpectations(port)
+    expectations.parse_all_expectations()
+
+    # Collect all tests for stale entry detection
+    from webkitpy.api_tests.manager import Manager
+    from webkitpy.common.system.executive import ScriptError
+
+    print('Collecting tests...', file=logging_stream)
+    all_tests = []
+    try:
+        tests_by_binary = Manager.collect_tests_by_binary(port)
+        for tests in tests_by_binary.values():
+            all_tests.extend(tests)
+    except ScriptError as e:
+        print(f'Warning: Could not collect tests for stale detection: {e}', file=logging_stream)
+
+    # Run lint
+    warnings = expectations.lint(all_tests)
+
+    if warnings:
+        print('\nWarnings:', file=logging_stream)
+        for warning in warnings:
+            print(f'  {warning}', file=logging_stream)
+        print(f'\n{len(warnings)} warning(s) found.', file=logging_stream)
+        return 1
+    else:
+        print('No issues found.', file=logging_stream)
+        return 0
+
+
+def print_expectations(port, options, args, logging_stream):
+    """Print test expectations without running tests."""
+    # Load expectations
+    expectations = APITestExpectations(port)
+    expectations.parse_all_expectations()
+    model = expectations.model()
+    config = expectations.get_current_configuration()
+
+    if args:
+        # Print expectations for specified tests
+        for test_pattern in args:
+            exp = model.get_expectation(test_pattern, config)
+            if exp:
+                exp_names = ', '.join(EXPECTATION_NAMES.get(e, str(e)) for e in exp.expectations)
+                print(f'{test_pattern}: [ {exp_names} ]', file=logging_stream)
+            else:
+                print(f'{test_pattern}: [ Pass ] (default)', file=logging_stream)
+    else:
+        # Print all expectations
+        for exp in model.all_expectations():
+            if exp.matches_configuration(config):
+                exp_names = ', '.join(EXPECTATION_NAMES.get(e, str(e)) for e in exp.expectations)
+                bug_str = ' '.join(exp.bug_ids) + ' ' if exp.bug_ids else ''
+                config_str = '[ {} ] '.format(' '.join(exp.configurations)) if exp.configurations else ''
+                print(f'{bug_str}{config_str}{exp.test_pattern} [ {exp_names} ]', file=logging_stream)
+
+    return 0
+
+
+def print_summary(port, options, args, logging_stream):
+    """Print a summary of test expectations grouped by binary/suite."""
+    from webkitpy.api_tests.manager import Manager
+    from webkitpy.api_tests.test_expectations import PASS, FAIL, CRASH, TIMEOUT, SKIP
+    from webkitpy.common.system.executive import ScriptError
+
+    # Load expectations
+    expectations = APITestExpectations(port)
+    expectations.parse_all_expectations()
+    model = expectations.model()
+    config = expectations.get_current_configuration()
+
+    # Collect all tests
+    print('Collecting tests...', file=logging_stream)
+    try:
+        tests_by_binary = Manager.collect_tests_by_binary(port)
+    except ScriptError as e:
+        print(f'Error collecting tests: {e}', file=logging_stream)
+        return 1
+
+    # Calculate stats for each binary and suite
+    print('\nTest Expectations Summary', file=logging_stream)
+    print('=' * 60, file=logging_stream)
+
+    total_stats = {'total': 0, 'pass': 0, 'skip': 0, 'fail': 0, 'flaky': 0}
+
+    for binary_name, tests in sorted(tests_by_binary.items()):
+        binary_stats = {'total': 0, 'pass': 0, 'skip': 0, 'fail': 0, 'flaky': 0}
+        suite_stats = {}
+
+        for test in tests:
+            # Extract suite name (binary.suite.test -> suite)
+            parts = test.split('.')
+            suite = parts[1] if len(parts) > 2 else 'Unknown'
+
+            if suite not in suite_stats:
+                suite_stats[suite] = {'total': 0, 'pass': 0, 'skip': 0, 'fail': 0, 'flaky': 0}
+
+            exp = model.get_expectation(test, config)
+            binary_stats['total'] += 1
+            suite_stats[suite]['total'] += 1
+
+            if exp is None or exp.expectations == {PASS}:
+                binary_stats['pass'] += 1
+                suite_stats[suite]['pass'] += 1
+            elif exp.is_skip():
+                binary_stats['skip'] += 1
+                suite_stats[suite]['skip'] += 1
+            elif exp.is_flaky():
+                binary_stats['flaky'] += 1
+                suite_stats[suite]['flaky'] += 1
+            else:
+                binary_stats['fail'] += 1
+                suite_stats[suite]['fail'] += 1
+
+        # Print binary summary
+        print(f'\n{binary_name}: {binary_stats["total"]} tests', file=logging_stream)
+        print(f'  Pass: {binary_stats["pass"]}, Skip: {binary_stats["skip"]}, '
+              f'Fail: {binary_stats["fail"]}, Flaky: {binary_stats["flaky"]}', file=logging_stream)
+
+        # Print suite breakdown if there are expectations
+        if binary_stats['skip'] or binary_stats['fail'] or binary_stats['flaky']:
+            for suite, stats in sorted(suite_stats.items()):
+                if stats['skip'] or stats['fail'] or stats['flaky']:
+                    print(f'    {suite}: {stats["total"]} tests '
+                          f'(skip={stats["skip"]}, fail={stats["fail"]}, flaky={stats["flaky"]})',
+                          file=logging_stream)
+
+        # Update totals
+        for key in total_stats:
+            total_stats[key] += binary_stats.get(key, 0)
+
+    # Print totals
+    print(f'\n{"=" * 60}', file=logging_stream)
+    print(f'Total: {total_stats["total"]} tests', file=logging_stream)
+    print(f'  Pass: {total_stats["pass"]}, Skip: {total_stats["skip"]}, '
+          f'Fail: {total_stats["fail"]}, Flaky: {total_stats["flaky"]}', file=logging_stream)
+
+    return 0
 
 
 def run(port, options, args, logging_stream):
@@ -164,6 +322,34 @@ def parse_args(args):
                              help='Enable GPU process DOM rendering'),
         optparse.make_option('--no-use-gpu-process', action='store_true', default=False,
                              help='Disable GPU process DOM rendering'),
+    ]))
+
+    option_group_definitions.append(('Expectation Options', [
+        optparse.make_option('--additional-expectations', action='append', default=[],
+                             help='Path to a test expectations file that will override previous expectations. '
+                                  'Specify multiple times for multiple sets of overrides.'),
+        optparse.make_option('--skip-failing-tests', action='store_true', default=False,
+                             help='Skip tests that are marked as failing or flaky. '
+                                  'Note: When using this option, you might miss new crashes in these tests.'),
+        optparse.make_option('--skip-flaky-tests', action='store_true', default=False,
+                             help='Skip tests that are marked as flaky. '
+                                  'Note: When using this option, you might miss new crashes in these tests.'),
+        optparse.make_option('--skipped', action='store', default='default',
+                             choices=['default', 'ignore', 'only', 'always'],
+                             help="control how tests marked SKIP are run. "
+                                  "'default' == Skip tests unless explicitly listed on the command line, "
+                                  "'ignore' == Run them anyway, "
+                                  "'only' == only run the SKIP tests, "
+                                  "'always' == always skip, even if listed on the command line."),
+        optparse.make_option('--lint-test-files', action='store_true', default=False,
+                             help='Makes sure the test expectations files parse correctly and have no stale entries. '
+                                  'Does not run any tests.'),
+        optparse.make_option('--print-expectations', action='store_true', default=False,
+                             help='Print the expected outcome for the given test, or all tests listed in TestExpectations. '
+                                  'Does not run any tests.'),
+        optparse.make_option('--print-summary', action='store_true', default=False,
+                             help='Print a summary of how tests are expected to run, grouped by binary/suite. '
+                                  'Does not run any tests.'),
     ]))
     option_group_definitions.append(('Upload Options', upload_options()))
 

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -27,6 +27,10 @@ import re
 import time
 
 from webkitpy.api_tests.runner import Runner
+from webkitpy.api_tests.test_expectations import (
+    APITestExpectations, PASS, FAIL, CRASH, TIMEOUT, SKIP, EXPECTATION_NAMES,
+    runner_status_to_expectation
+)
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.results.upload import Upload
@@ -50,6 +54,7 @@ class Manager(object):
         self.host = port.host
         self._options = options
         self._stream = stream
+        self._expectations = None
 
     @staticmethod
     def _test_list_from_output(output, prefix=''):
@@ -57,27 +62,57 @@ class Manager(object):
         current_test_suite = None
         for line in output.split('\n'):
             line = line.split("#")[0]  # Value-parametrized tests contain #.
-            striped_line = line.lstrip().rstrip()
-            if not striped_line:
+            stripped_line = line.lstrip().rstrip()
+            if not stripped_line:
                 continue
 
-            if striped_line[-1] == '.':
-                current_test_suite = striped_line[:-1]
+            if stripped_line[-1] == '.':
+                current_test_suite = stripped_line[:-1]
             else:
-                striped_line = striped_line.lstrip()
-                if ' ' in striped_line:
+                stripped_line = stripped_line.lstrip()
+                if ' ' in stripped_line:
                     continue
-                val = f'{prefix}{current_test_suite}.{striped_line}'
+                val = f'{prefix}{current_test_suite}.{stripped_line}'
                 if val not in result:
                     result.append(val)
         return result
+
+    @staticmethod
+    def collect_tests_by_binary(port, binaries=None):
+        """Collect all tests from API test binaries."""
+        tests_by_binary = {}
+        for binary_name, path in port.path_to_api_test_binaries().items():
+            if binaries is not None and binary_name not in binaries:
+                continue
+            if not port.host.filesystem.exists(path):
+                continue
+
+            to_be_listed = path
+            if not port.host.platform.is_win():
+                to_be_listed = port.host.filesystem.join(port.host.filesystem.dirname(path), 'ToBeListed')
+                port.host.filesystem.copyfile(path, to_be_listed)
+                port.host.filesystem.copymode(path, to_be_listed)
+            try:
+                output = port.host.executive.run_command(
+                    Runner.command_for_port(port, [to_be_listed, '--gtest_list_tests']),
+                    env=port.environment_for_api_tests())
+                tests_by_binary[binary_name] = Manager._test_list_from_output(output, f'{binary_name}.')
+            except ScriptError:
+                _log.error(f'Failed to list {binary_name} tests')
+                raise
+            finally:
+                if not port.host.platform.is_win() and port.host.filesystem.exists(to_be_listed):
+                    port.host.filesystem.remove(to_be_listed)
+
+        return tests_by_binary
 
     @staticmethod
     def _find_test_subset(superset, arg_filter):
         result = []
         for arg in arg_filter:
             # Might match <binary>.<suite>.<test> or just <suite>.<test>
-            arg_re = re.compile(f'^{arg.replace("*", ".*")}$')
+            arg_escaped = re.escape(arg).replace(r'\*', '.*')
+            arg_re = re.compile(f'^{arg_escaped}$')
             for test in superset:
                 if arg_re.match(test):
                     result.append(test)
@@ -101,28 +136,12 @@ class Manager(object):
         return result
 
     def _collect_tests(self, args):
-        available_tests = []
         specified_binaries = self._binaries_for_arguments(args)
-        for canonicalized_binary, path in self._port.path_to_api_test_binaries().items():
-            if canonicalized_binary not in specified_binaries:
-                continue
+        tests_by_binary = Manager.collect_tests_by_binary(self._port, specified_binaries)
 
-            to_be_listed = path
-            if not self._port.host.platform.is_win():
-                to_be_listed = self.host.filesystem.join(self.host.filesystem.dirname(path), 'ToBeListed')
-                self.host.filesystem.copyfile(path, to_be_listed)
-                self.host.filesystem.copymode(path, to_be_listed)
-            try:
-                output = self.host.executive.run_command(
-                    Runner.command_for_port(self._port, [to_be_listed, '--gtest_list_tests']),
-                    env=self._port.environment_for_api_tests())
-                available_tests += Manager._test_list_from_output(output, f'{canonicalized_binary}.')
-            except ScriptError:
-                _log.error(f'Failed to list {canonicalized_binary} tests')
-                raise
-            finally:
-                if not self._port.host.platform.is_win():
-                    self.host.filesystem.remove(to_be_listed)
+        available_tests = []
+        for tests in tests_by_binary.values():
+            available_tests.extend(tests)
 
         if len(args) == 0:
             return sorted(available_tests)
@@ -166,6 +185,32 @@ class Manager(object):
                 # If the user specifies a test-name without a binary, we need to search both binaries
                 return self._port.path_to_api_test_binaries().keys()
         return binaries or self._port.path_to_api_test_binaries().keys()
+
+    def _load_expectations(self, test_names):
+        """Load test expectations for the current platform."""
+        self._expectations = APITestExpectations(self._port, tests=test_names)
+        self._expectations.parse_all_expectations()
+
+        additional_expectations = self._options.additional_expectations if hasattr(self._options, 'additional_expectations') else []
+        for filepath in additional_expectations:
+            if self.host.filesystem.exists(filepath):
+                _log.debug(f'Loading additional expectations from {filepath}')
+                content = self.host.filesystem.read_text_file(filepath)
+                self._expectations._parse_file(filepath, content)
+            else:
+                _log.warning(f'Additional expectations file not found: {filepath}')
+
+        return self._expectations
+
+    def _get_current_configuration(self):
+        """Return set of current configuration strings for expectation matching."""
+        config = set()
+        configuration = self._port.get_option('configuration')
+        if configuration:
+            config.add(configuration.lower())
+        if hasattr(self._port, 'architecture') and self._port.architecture():
+            config.add(self._port.architecture().lower())
+        return config
 
     def _update_worker_count(self):
         child_processes_option_value = int(self._options.child_processes or 0)
@@ -232,6 +277,52 @@ class Manager(object):
                 self._stream.writeln(test)
             return Manager.SUCCESS
 
+        self._stream.write_update('Loading test expectations ...')
+        self._load_expectations(test_names)
+        current_config = self._get_current_configuration()
+        model = self._expectations.model()
+
+        skipped_option = getattr(self._options, 'skipped', 'default')
+
+        if skipped_option == 'always':
+            self._stream.writeln('--skipped=always: Skipping all tests')
+            return Manager.SUCCESS
+
+        original_test_count = len(test_names)
+        skip_failing_tests = getattr(self._options, 'skip_failing_tests', False)
+        skip_flaky_tests = getattr(self._options, 'skip_flaky_tests', False)
+        skipped_by_expectation = set()
+        skipped_as_failing = set()
+        skipped_as_flaky = set()
+
+        for test in test_names:
+            exp = model.get_expectation(test, current_config)
+            if not exp:
+                continue
+
+            if skipped_option != 'ignore' and exp.is_skip():
+                skipped_by_expectation.add(test)
+                continue
+
+            if skip_failing_tests and (exp.is_flaky() or FAIL in exp.expectations or CRASH in exp.expectations or TIMEOUT in exp.expectations):
+                skipped_as_failing.add(test)
+            elif skip_flaky_tests and exp.is_flaky():
+                skipped_as_flaky.add(test)
+
+        if skipped_option == 'only':
+            test_names = [t for t in test_names if t in skipped_by_expectation]
+            skipped_by_expectation = set()  # Don't skip them, we want to run them
+
+        all_skipped = skipped_by_expectation | skipped_as_failing | skipped_as_flaky
+        test_names = [t for t in test_names if t not in all_skipped]
+
+        if skipped_by_expectation:
+            self._stream.write_update(f'Skipping {len(skipped_by_expectation)} tests marked [ Skip ]')
+        if skipped_as_failing:
+            self._stream.write_update(f'Skipping {len(skipped_as_failing)} tests marked as failing (--skip-failing-tests)')
+        if skipped_as_flaky:
+            self._stream.write_update(f'Skipping {len(skipped_as_flaky)} flaky tests (--skip-flaky-tests)')
+
         test_names = [test for test in test_names for _ in range(self._options.repeat_each)]
         if self._options.repeat_each != 1:
             _log.debug(f'Repeating each test {self._options.iterations} times')
@@ -239,7 +330,7 @@ class Manager(object):
         runner = None
         try:
             _log.info('Running tests')
-            runner = Runner(self._port, self._stream)
+            runner = Runner(self._port, self._stream, expectations=self._expectations)
             for i in range(self._options.iterations):
                 _log.debug(f'\nIteration {i + 1}')
                 runner.run(test_names, int(self._options.child_processes) if self._options.child_processes else None)
@@ -261,36 +352,62 @@ class Manager(object):
         test_parallel_safety_tests = self._port.get_option('test_parallel_safety') or []
         is_parallel_safety_mode = bool(test_parallel_safety_tests)
 
-        _log.info(f'Ran {len(runner.results) - disabled} tests of {len(set(test_names))} with {len(successful)} successful')
+        unexpected_failures = {}
+        expected_failures = {}
+        unexpected_passes = {}
+
+        for test, test_result in iteritems(runner.results):
+            status = test_result[0]
+            exp = model.get_expectation(test, current_config)
+
+            expectation_status = runner_status_to_expectation(status)
+
+            if exp is None or exp.expectations == {PASS}:
+                if status != runner.STATUS_PASSED:
+                    unexpected_failures[test] = test_result
+            else:
+                is_expected = exp.result_is_expected(expectation_status) if expectation_status is not None else False
+                if is_expected:
+                    if status != runner.STATUS_PASSED:
+                        expected_failures[test] = test_result
+                else:
+                    if status == runner.STATUS_PASSED:
+                        unexpected_passes[test] = test_result
+                    else:
+                        unexpected_failures[test] = test_result
+
+        _log.info(f'Ran {len(runner.results) - disabled} tests of {original_test_count} with {len(successful)} successful')
 
         result_dictionary = {
             'Skipped': [],
             'Failed': [],
             'Crashed': [],
             'Timedout': [],
+            'UnexpectedFailures': [],
+            'ExpectedFailures': [],
+            'UnexpectedPasses': [],
         }
 
         self._stream.writeln('-' * 30)
         result = Manager.SUCCESS
 
-        # Count actual failures (not skipped)
-        failed_tests = runner.result_map_by_status(runner.STATUS_FAILED)
-        crashed_tests = runner.result_map_by_status(runner.STATUS_CRASHED)
-        timedout_tests = runner.result_map_by_status(runner.STATUS_TIMEOUT)
-        has_real_failures = bool(failed_tests or crashed_tests or timedout_tests)
+        has_unexpected_failures = bool(unexpected_failures)
 
         if is_parallel_safety_mode:
             # In parallel-safety mode, skipped tests are expected
             # Only fail if there are actual failures, crashes, or timeouts
-            if has_real_failures:
+            if has_unexpected_failures:
                 self._stream.writeln('Test suite failed')
                 result = Manager.FAILED_TESTS
             else:
                 self._stream.writeln('All parallel-safety tests passed!')
                 if json_output:
                     self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
-        elif len(successful) + disabled == len(set(test_names)):
-            self._stream.writeln('All tests successfully passed!')
+        elif not has_unexpected_failures:
+            if expected_failures:
+                self._stream.writeln(f'All tests passed! ({len(expected_failures)} expected failures)')
+            else:
+                self._stream.writeln('All tests successfully passed!')
             if json_output:
                 self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
         else:
@@ -298,37 +415,45 @@ class Manager(object):
             result = Manager.FAILED_TESTS
 
         # Always collect skipped/failed info for reporting
-        if result != Manager.SUCCESS or is_parallel_safety_mode:
+        self._stream.writeln('')
+
+        all_skipped_tests = list(skipped_by_expectation | skipped_as_failing | skipped_as_flaky)
+        for test in all_skipped_tests:
+            result_dictionary['Skipped'].append({'name': test, 'output': None})
+        if all_skipped_tests:
+            self._stream.writeln(f'Skipped {len(all_skipped_tests)} tests')
             self._stream.writeln('')
 
-            skipped = []
-            for test in test_names:
-                if test not in runner.results:
-                    skipped.append(test)
-                    result_dictionary['Skipped'].append({'name': test, 'output': None})
-            if skipped:
-                self._stream.writeln(f'Skipped {len(skipped)} tests')
-                self._stream.writeln('')
-                if self._options.verbose:
-                    for test in skipped:
-                        self._stream.writeln(f'    {test}')
-
-            self._print_tests_result_with_status(runner.STATUS_FAILED, runner)
-            self._print_tests_result_with_status(runner.STATUS_CRASHED, runner)
-            self._print_tests_result_with_status(runner.STATUS_TIMEOUT, runner)
-
-            for test, test_result in iteritems(runner.results):
-                status_to_string = {
+        if unexpected_failures:
+            self._stream.writeln('** UNEXPECTED FAILURES **')
+            self._stream.writeln('')
+            for test, test_result in iteritems(unexpected_failures):
+                Manager._print_test_result(self._stream, test, test_result[1])
+                status_str = {
                     runner.STATUS_FAILED: 'Failed',
                     runner.STATUS_CRASHED: 'Crashed',
                     runner.STATUS_TIMEOUT: 'Timedout',
-                }.get(test_result[0])
-                if not status_to_string:
-                    continue
-                result_dictionary[status_to_string].append({'name': test, 'output': test_result[1]})
+                }.get(test_result[0], 'Failed')
+                result_dictionary['UnexpectedFailures'].append({'name': test, 'output': test_result[1], 'status': status_str})
+                result_dictionary[status_str].append({'name': test, 'output': test_result[1]})
 
-            if json_output:
-                self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
+        if expected_failures:
+            self._stream.writeln('Expected failures (not blocking):')
+            for test in expected_failures:
+                self._stream.writeln(f'    {test}')
+                test_result = expected_failures[test]
+                result_dictionary['ExpectedFailures'].append({'name': test, 'output': test_result[1]})
+            self._stream.writeln('')
+
+        if unexpected_passes:
+            self._stream.writeln('Unexpected passes (may need expectation update):')
+            for test in unexpected_passes:
+                self._stream.writeln(f'    {test}')
+                result_dictionary['UnexpectedPasses'].append({'name': test})
+            self._stream.writeln('')
+
+        if json_output:
+            self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
 
         if self._options.report_urls:
             self._stream.writeln('\n')
@@ -340,6 +465,35 @@ class Manager(object):
                 runner.STATUS_CRASHED: Upload.Expectations.CRASH,
                 runner.STATUS_TIMEOUT: Upload.Expectations.TIMEOUT,
             }
+
+            upload_results = {}
+            for test, test_result in iteritems(runner.results):
+                status = test_result[0]
+                if status not in status_to_test_result:
+                    continue
+
+                actual = status_to_test_result[status]
+                elapsed = test_result[2] if len(test_result) > 2 else None
+
+                expected = None
+                exp = model.get_expectation(test, current_config)
+                if exp and exp.expectations != {PASS}:
+                    expectation_to_upload = {
+                        PASS: Upload.Expectations.PASS,
+                        CRASH: Upload.Expectations.CRASH,
+                        TIMEOUT: Upload.Expectations.TIMEOUT,
+                        FAIL: Upload.Expectations.FAIL,
+                    }
+                    expected_parts = [expectation_to_upload[e] for e in exp.expectations if e in expectation_to_upload]
+                    if expected_parts:
+                        expected = ' '.join(expected_parts)
+
+                upload_results[test] = Upload.create_test_result(
+                    actual=actual,
+                    expected=expected,
+                    time=int(elapsed * 1000) if elapsed else None,
+                )
+
             upload = Upload(
                 suite=self._options.suite or 'api-tests',
                 configuration=configuration_for_upload,
@@ -349,12 +503,8 @@ class Manager(object):
                     start_time=start_time,
                     end_time=end_time,
                     tests_skipped=len(result_dictionary['Skipped']),
-                ), results={
-                    test: Upload.create_test_result(
-                        actual=status_to_test_result[result[0]],
-                        time=int(result[2] * 1000),
-                    ) for test, result in iteritems(runner.results) if result[0] in status_to_test_result
-                },
+                ),
+                results=upload_results,
             )
             for url in self._options.report_urls:
                 self._stream.write_update(f'Uploading to {url} ...')

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -102,7 +102,7 @@ class Runner(object):
 
     instance = None
 
-    def __init__(self, port, printer, log_limit=250):
+    def __init__(self, port, printer, log_limit=250, expectations=None):
         self.port = port
         self.printer = printer
         self.tests_run = 0
@@ -110,6 +110,7 @@ class Runner(object):
         self.log_limit = log_limit
         self._has_logged_for_test = True  # Suppress an empty line between "Running tests" and the first test's output.
         self.results = {}
+        self.expectations = expectations  # APITestExpectations instance
 
     # FIXME API tests should run as an app, we won't need this function <https://bugs.webkit.org/show_bug.cgi?id=175204>
     @staticmethod
@@ -313,6 +314,20 @@ class _Worker(object):
         return result.rstrip()
 
     def _run_single_test(self, binary_name, test):
+        full_test_name = f'{binary_name}.{test}'
+
+        # Determine timeout - check if test is marked Slow
+        timeout = self._timeout
+        if Runner.instance and Runner.instance.expectations:
+            model = Runner.instance.expectations.model()
+            exp = model.get_expectation(full_test_name, set())
+            if exp and exp.is_slow():
+                custom_timeout = exp.slow_timeout
+                if custom_timeout is not None:
+                    timeout = custom_timeout
+                else:
+                    timeout = self._timeout * 5  # 5x default for Slow without custom value
+
         server_process = ServerProcess(
             self._port, binary_name,
             Runner.command_for_port(self._port, [self._port.path_to_api_test(binary_name), f'--gtest_filter={test}']),
@@ -332,7 +347,7 @@ class _Worker(object):
                 server_process.start()
 
             while status == Runner.STATUS_RUNNING:
-                stdout_line, stderr_line = server_process.read_either_stdout_or_stderr_line(started + self._timeout)
+                stdout_line, stderr_line = server_process.read_either_stdout_or_stderr_line(started + timeout)
                 if not stderr_line and not stdout_line:
                     break
                 if stdout_line:

--- a/Tools/Scripts/webkitpy/api_tests/test_expectations.py
+++ b/Tools/Scripts/webkitpy/api_tests/test_expectations.py
@@ -1,0 +1,1085 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""A helper class for reading in and dealing with test expectations for API tests."""
+
+import enum
+import fnmatch
+import logging
+import re
+from collections import defaultdict
+
+_log = logging.getLogger(__name__)
+
+
+# Configuration category enum - ordered from least to most specific
+class ConfigurationCategory(enum.IntEnum):
+    PLATFORM = 1      # mac, ios, linux, win, gtk, wpe
+    VERSION = 2       # Sonoma, iOS17, with +/-/range modifiers
+    STYLE = 3         # debug, release, asan, guardmalloc
+    HARDWARE = 4      # simulator, device, iphone, ipad
+    ARCHITECTURE = 5  # arm64, x86_64, x86, arm64_32, armv7k
+    FLAVOR = 6        # freeform: wk1, wk2, siteisolation, etc.
+
+
+# Static tokens by category (alphabetically ordered within each)
+PLATFORM_TOKENS = frozenset({'gtk', 'ios', 'linux', 'mac', 'win', 'wpe'})
+STYLE_TOKENS = frozenset({'asan', 'debug', 'guardmalloc', 'release'})
+HARDWARE_TOKENS = frozenset({'device', 'ipad', 'iphone', 'simulator'})
+ARCHITECTURE_TOKENS = frozenset({'arm64', 'arm64_32', 'armv7k', 'x86', 'x86_64'})
+
+# Category to token set mapping
+CATEGORY_TOKENS = {
+    ConfigurationCategory.PLATFORM: PLATFORM_TOKENS,
+    ConfigurationCategory.STYLE: STYLE_TOKENS,
+    ConfigurationCategory.HARDWARE: HARDWARE_TOKENS,
+    ConfigurationCategory.ARCHITECTURE: ARCHITECTURE_TOKENS,
+    # VERSION and FLAVOR are dynamic - handled separately
+}
+
+# Category display names for error messages
+CATEGORY_NAMES = {
+    ConfigurationCategory.PLATFORM: 'Platform',
+    ConfigurationCategory.VERSION: 'Version',
+    ConfigurationCategory.STYLE: 'Style',
+    ConfigurationCategory.HARDWARE: 'Hardware',
+    ConfigurationCategory.ARCHITECTURE: 'Architecture',
+    ConfigurationCategory.FLAVOR: 'Flavor',
+}
+
+
+# Expectation constants (values 0-3 match Runner.STATUS_*)
+PASS = 0
+FAIL = 1
+CRASH = 2
+TIMEOUT = 3
+SKIP = 4
+SLOW = 5
+
+# String to constant mappings
+EXPECTATION_MAP = {
+    'pass': PASS,
+    'fail': FAIL,
+    'failure': FAIL,
+    'crash': CRASH,
+    'timeout': TIMEOUT,
+    'skip': SKIP,
+}
+
+EXPECTATION_NAMES = {
+    PASS: 'Pass',
+    FAIL: 'Fail',
+    CRASH: 'Crash',
+    TIMEOUT: 'Timeout',
+    SKIP: 'Skip',
+    SLOW: 'Slow',
+}
+
+# Combined set of all static configuration tokens (for backwards compatibility)
+CONFIGURATION_TOKENS = PLATFORM_TOKENS | STYLE_TOKENS | HARDWARE_TOKENS | ARCHITECTURE_TOKENS
+
+
+class VersionSpecifier(object):
+    """Represents a version constraint with optional range/modifier."""
+
+    class Type(enum.Enum):
+        EXACT = 'exact'           # Sonoma (this version only)
+        AND_LATER = 'and_later'   # Sonoma+ (this and later)
+        AND_EARLIER = 'and_earlier'  # Sonoma- (this and earlier)
+        RANGE = 'range'           # Ventura-Sequoia (inclusive range)
+
+    def __init__(self, base_version, end_version=None, specifier_type=None):
+        self.base_version = base_version.lower()
+        self.end_version = end_version.lower() if end_version else None
+        self.type = specifier_type or self.Type.EXACT
+        self._original = None
+
+    @classmethod
+    def parse(cls, token):
+        """Parse a version token into a VersionSpecifier.
+
+        Returns None if the token is not a version specifier.
+        """
+        # Check for range first: Ventura-Sequoia (not ending with -)
+        if '-' in token and not token.endswith('-'):
+            parts = token.split('-', 1)
+            if len(parts) == 2:
+                spec = cls(parts[0], parts[1], cls.Type.RANGE)
+                spec._original = token
+                return spec
+        # Check for and_later: Sonoma+
+        elif token.endswith('+'):
+            spec = cls(token[:-1], specifier_type=cls.Type.AND_LATER)
+            spec._original = token
+            return spec
+        # Check for and_earlier: Sonoma-
+        elif token.endswith('-'):
+            spec = cls(token[:-1], specifier_type=cls.Type.AND_EARLIER)
+            spec._original = token
+            return spec
+        # Exact version (handled during token categorization)
+        return None
+
+    def matches(self, current_version, version_order):
+        """Check if current_version satisfies this specifier.
+
+        Args:
+            current_version: The version string to check (lowercase)
+            version_order: List of version strings in order from oldest to newest
+        """
+        current_version = current_version.lower()
+        try:
+            current_idx = version_order.index(current_version)
+            base_idx = version_order.index(self.base_version)
+        except ValueError:
+            return False
+
+        if self.type == self.Type.EXACT:
+            return current_version == self.base_version
+        elif self.type == self.Type.AND_LATER:
+            return current_idx >= base_idx
+        elif self.type == self.Type.AND_EARLIER:
+            return current_idx <= base_idx
+        elif self.type == self.Type.RANGE:
+            try:
+                end_idx = version_order.index(self.end_version)
+            except ValueError:
+                return False
+            return base_idx <= current_idx <= end_idx
+        return False
+
+    def __repr__(self):
+        if self._original:
+            return 'VersionSpecifier({!r})'.format(self._original)
+        return 'VersionSpecifier({!r}, type={})'.format(self.base_version, self.type.value)
+
+
+def get_token_category(token, version_tokens=None):
+    """Return the ConfigurationCategory for a token, or None if unknown.
+
+    Args:
+        token: The configuration token (lowercase)
+        version_tokens: Optional set of valid version tokens
+    """
+    token_lower = token.lower()
+
+    # Check static categories first
+    if token_lower in PLATFORM_TOKENS:
+        return ConfigurationCategory.PLATFORM
+    if token_lower in STYLE_TOKENS:
+        return ConfigurationCategory.STYLE
+    if token_lower in HARDWARE_TOKENS:
+        return ConfigurationCategory.HARDWARE
+    if token_lower in ARCHITECTURE_TOKENS:
+        return ConfigurationCategory.ARCHITECTURE
+
+    # Check if it's a version specifier (with +, -, or range)
+    if token.endswith('+') or token.endswith('-') or ('-' in token and not token.endswith('-')):
+        return ConfigurationCategory.VERSION
+
+    # Check if it's a known version token
+    if version_tokens and token_lower in version_tokens:
+        return ConfigurationCategory.VERSION
+
+    # If it looks like an identifier, treat as flavor (freeform)
+    if token_lower.isidentifier() or re.match(r'^[a-z][a-z0-9_-]*$', token_lower):
+        return ConfigurationCategory.FLAVOR
+
+    return None
+
+
+def runner_status_to_expectation(runner_status):
+    """Convert a Runner status code to an expectation constant."""
+    from webkitpy.api_tests.runner import Runner
+    mapping = {
+        Runner.STATUS_PASSED: PASS,
+        Runner.STATUS_FAILED: FAIL,
+        Runner.STATUS_CRASHED: CRASH,
+        Runner.STATUS_TIMEOUT: TIMEOUT,
+    }
+    return mapping.get(runner_status)
+
+
+class ParseError(Exception):
+    """Exception raised when parsing test expectations fails."""
+    def __init__(self, warnings):
+        super(ParseError, self).__init__()
+        self.warnings = warnings
+
+    def __str__(self):
+        return '\n'.join(str(w) for w in self.warnings)
+
+
+class ExpectationWarning(object):
+    """Represents a warning or error from parsing an expectation line."""
+    def __init__(self, filename, line_number, line, error, test=None):
+        self.filename = filename
+        self.line_number = line_number
+        self.line = line
+        self.error = error
+        self.test = test
+
+    def __str__(self):
+        return '{}:{}: {} {}'.format(
+            self.filename, self.line_number, self.error,
+            self.test if self.test else self.line)
+
+
+class APITestExpectation(object):
+    """Represents expectations for a single API test or pattern."""
+
+    def __init__(self, test_pattern, expectations, configurations=None,
+                 slow_timeout=None, bug_ids=None, filename=None, line_number=None,
+                 version_specifiers=None):
+        self.test_pattern = test_pattern
+        self.expectations = frozenset(expectations)
+        self.configurations = frozenset(configurations) if configurations else frozenset()
+        self.version_specifiers = tuple(version_specifiers) if version_specifiers else ()
+        self.slow_timeout = slow_timeout
+        self.bug_ids = tuple(bug_ids) if bug_ids else ()
+        self.filename = filename
+        self.line_number = line_number
+        self._is_wildcard = test_pattern.endswith('*')
+        self._prefix = test_pattern[:-1] if self._is_wildcard else None
+
+    @property
+    def is_wildcard(self):
+        """Returns True if this expectation uses a wildcard pattern."""
+        return self._is_wildcard
+
+    def is_skip(self):
+        """Returns True if test should be skipped."""
+        return SKIP in self.expectations
+
+    def is_slow(self):
+        """Returns True if test is marked slow."""
+        return self.slow_timeout is not None or SLOW in self.expectations
+
+    def get_timeout(self, default_timeout):
+        """Returns timeout for this test."""
+        if self.slow_timeout is not None:
+            return self.slow_timeout
+        if SLOW in self.expectations:
+            return default_timeout * 5
+        return default_timeout
+
+    def is_flaky(self):
+        """Returns True if test can have multiple outcomes."""
+        actual_expectations = self.expectations - {SKIP, SLOW}
+        return len(actual_expectations) > 1
+
+    def matches_test(self, test_name):
+        """Check if this expectation matches the given test name."""
+        if self._is_wildcard:
+            return test_name.startswith(self._prefix)
+        return test_name == self.test_pattern
+
+    def matches_configuration(self, current_config, current_version=None, version_order=None):
+        """Check if this expectation applies to current configuration.
+
+        Args:
+            current_config: Set of current configuration tokens (platform, style, etc.)
+            current_version: Current OS version string (e.g., 'sonoma')
+            version_order: List of version strings in order from oldest to newest
+        """
+        # Check non-version configurations
+        if self.configurations and not self.configurations.issubset(current_config):
+            return False
+
+        # Check version specifiers
+        if self.version_specifiers:
+            if not current_version or not version_order:
+                return False
+            for spec in self.version_specifiers:
+                if not spec.matches(current_version, version_order):
+                    return False
+
+        return True
+
+    def result_is_expected(self, actual_status):
+        """Check if an actual result matches expectations."""
+        if self.is_skip() and actual_status == SKIP:
+            return True
+        return actual_status in self.expectations
+
+    def __repr__(self):
+        return 'APITestExpectation({!r}, {}, config={}, slow={})'.format(
+            self.test_pattern,
+            {EXPECTATION_NAMES.get(e, e) for e in self.expectations},
+            self.configurations,
+            self.slow_timeout)
+
+
+class APITestExpectationParser(object):
+    """Provides parsing facilities for lines in API test expectation files."""
+
+    WEBKIT_BUG_PREFIX = 'webkit.org/b/'
+    RADAR_BUG_PREFIX = 'rdar://'
+    BUG_PATTERN = re.compile(r'Bug\((\w+)\)$', re.IGNORECASE)
+    RADAR_PATTERN = re.compile(r'^rdar://(?:problem/)?(\d+)$')
+    SLOW_TIMEOUT_PATTERN = re.compile(r'^Slow:(\d+)s?$', re.IGNORECASE)
+
+    def __init__(self, version_tokens=None):
+        """Initialize the parser.
+
+        Args:
+            version_tokens: Optional set of valid version token strings (lowercase)
+        """
+        self._version_tokens = version_tokens or set()
+
+    def parse(self, filename, content):
+        """Parse an expectations file and return list of expectation lines."""
+        results = []
+        line_number = 0
+        for line in content.split('\n'):
+            line_number += 1
+            expectation, warnings = self._parse_line(filename, line, line_number)
+            results.append((expectation, warnings))
+        return results
+
+    def _parse_line(self, filename, line, line_number):
+        """Parse a single line from an expectations file."""
+        warnings = []
+
+        comment_index = line.find('#')
+        if comment_index != -1:
+            line = line[:comment_index]
+
+        line = ' '.join(line.split())
+        if not line:
+            return None, warnings
+
+        if line.startswith('//'):
+            warnings.append(ExpectationWarning(
+                filename, line_number, line,
+                'Use "#" instead of "//" for comments'))
+            return None, warnings
+
+        bug_ids = []
+        configurations = set()
+        version_specifiers = []
+        test_pattern = None
+        expectations = set()
+        slow_timeout = None
+
+        tokens = line.split()
+        state = 'start'
+
+        for token in tokens:
+            # Handle bug identifiers (webkit.org, rdar://, Bug())
+            if token.startswith(self.WEBKIT_BUG_PREFIX) or token.startswith(self.RADAR_BUG_PREFIX) or token.lower().startswith('bug('):
+                if state != 'start':
+                    warnings.append(ExpectationWarning(
+                        filename, line_number, line,
+                        '"{}" is not at the start of the line'.format(token)))
+                    break
+                if token.startswith(self.WEBKIT_BUG_PREFIX):
+                    bug_ids.append(token)
+                elif token.startswith(self.RADAR_BUG_PREFIX):
+                    match = self.RADAR_PATTERN.match(token)
+                    if match:
+                        bug_ids.append(token)
+                    else:
+                        warnings.append(ExpectationWarning(
+                            filename, line_number, line,
+                            'Invalid radar format "{}". Use rdar://XXXXX or rdar://problem/XXXXX'.format(token)))
+                        break
+                else:
+                    match = self.BUG_PATTERN.match(token)
+                    if match:
+                        bug_ids.append('Bug({})'.format(match.group(1)))
+                    else:
+                        warnings.append(ExpectationWarning(
+                            filename, line_number, line,
+                            'Unrecognized bug identifier "{}"'.format(token)))
+                        break
+
+            elif token == '[':
+                if state == 'start':
+                    state = 'configuration'
+                elif state == 'name_found':
+                    state = 'expectations'
+                else:
+                    warnings.append(ExpectationWarning(
+                        filename, line_number, line,
+                        'Unexpected "["'))
+                    break
+
+            elif token == ']':
+                if state == 'configuration':
+                    state = 'name'
+                elif state == 'expectations':
+                    state = 'done'
+                else:
+                    warnings.append(ExpectationWarning(
+                        filename, line_number, line,
+                        'Unexpected "]"'))
+                    break
+
+            elif state == 'configuration':
+                token_lower = token.lower()
+                # Get the category for this token
+                category = get_token_category(token, self._version_tokens)
+                if category is not None:
+                    if category == ConfigurationCategory.VERSION:
+                        # Try to parse as a version specifier with modifiers
+                        spec = VersionSpecifier.parse(token)
+                        if spec:
+                            version_specifiers.append(spec)
+                        else:
+                            # Plain version token (e.g., "Sonoma" without +/-)
+                            spec = VersionSpecifier(token, specifier_type=VersionSpecifier.Type.EXACT)
+                            spec._original = token
+                            version_specifiers.append(spec)
+                    else:
+                        configurations.add(token_lower)
+                else:
+                    warnings.append(ExpectationWarning(
+                        filename, line_number, line,
+                        'Unrecognized configuration "{}"'.format(token)))
+                    break
+
+            elif state == 'expectations':
+                token_lower = token.lower()
+                slow_match = self.SLOW_TIMEOUT_PATTERN.match(token)
+                if slow_match:
+                    slow_timeout = int(slow_match.group(1))
+                    if slow_timeout < 1 or slow_timeout > 3600:
+                        warnings.append(ExpectationWarning(
+                            filename, line_number, line,
+                            'Slow timeout must be between 1 and 3600 seconds, got {}'.format(slow_timeout)))
+                        break
+                    expectations.add(SLOW)
+                elif token_lower == 'slow':
+                    expectations.add(SLOW)
+                elif token_lower in EXPECTATION_MAP:
+                    expectations.add(EXPECTATION_MAP[token_lower])
+                else:
+                    warnings.append(ExpectationWarning(
+                        filename, line_number, line,
+                        'Unrecognized expectation "{}"'.format(token)))
+                    break
+
+            elif state == 'name_found':
+                warnings.append(ExpectationWarning(
+                    filename, line_number, line,
+                    'Expecting "[", "#", or end of line instead of "{}"'.format(token)))
+                break
+
+            else:
+                test_pattern = token
+                state = 'name_found'
+
+        if not warnings:
+            if not test_pattern:
+                warnings.append(ExpectationWarning(
+                    filename, line_number, line,
+                    'Did not find a test name'))
+            elif state not in ('name_found', 'done'):
+                warnings.append(ExpectationWarning(
+                    filename, line_number, line,
+                    'Missing a "]"'))
+
+        if SKIP in expectations and len(expectations - {SKIP, SLOW}) > 0:
+            warnings.append(ExpectationWarning(
+                filename, line_number, line,
+                'A test marked Skip must not have other expectations'))
+
+        if SLOW in expectations and TIMEOUT in expectations:
+            warnings.append(ExpectationWarning(
+                filename, line_number, line,
+                'A test cannot be both Slow and Timeout'))
+
+        if not expectations and not warnings:
+            expectations.add(PASS)
+
+        if warnings:
+            return None, warnings
+
+        expectation = APITestExpectation(
+            test_pattern=test_pattern,
+            expectations=expectations,
+            configurations=configurations,
+            slow_timeout=slow_timeout,
+            bug_ids=bug_ids,
+            filename=filename,
+            line_number=line_number,
+            version_specifiers=version_specifiers,
+        )
+        return expectation, warnings
+
+
+class APITestExpectationsModel(object):
+    """In-memory model of all expectations with lookup by test name."""
+
+    def __init__(self):
+        self._exact_expectations = {}
+        self._wildcard_expectations = []
+        self._all_expectations = []
+        self._seen_patterns = {}
+
+    def add_expectation(self, expectation):
+        """Add an expectation to the model. Later additions override earlier ones."""
+        warning = None
+
+        key = expectation.test_pattern
+        if key in self._seen_patterns:
+            prev_file, prev_line = self._seen_patterns[key]
+            if prev_file == expectation.filename:
+                warning = ExpectationWarning(
+                    expectation.filename,
+                    expectation.line_number,
+                    expectation.test_pattern,
+                    'Duplicate expectation (previous at line {})'.format(prev_line),
+                    test=expectation.test_pattern
+                )
+
+        self._seen_patterns[key] = (expectation.filename, expectation.line_number)
+        self._all_expectations.append(expectation)
+        if expectation.is_wildcard:
+            self._wildcard_expectations = [
+                e for e in self._wildcard_expectations
+                if e.test_pattern != expectation.test_pattern
+            ]
+            self._wildcard_expectations.append(expectation)
+        else:
+            self._exact_expectations[expectation.test_pattern] = expectation
+
+        return warning
+
+    def get_expectation(self, test_name, current_config=None):
+        """Get the expectation for a specific test."""
+        if current_config is None:
+            current_config = set()
+
+        if test_name in self._exact_expectations:
+            exp = self._exact_expectations[test_name]
+            if exp.matches_configuration(current_config):
+                return exp
+
+        best_match = None
+        best_prefix_len = -1
+        for exp in self._wildcard_expectations:
+            if exp.matches_test(test_name) and exp.matches_configuration(current_config):
+                prefix_len = len(exp._prefix) if exp._prefix else 0
+                if prefix_len > best_prefix_len:
+                    best_match = exp
+                    best_prefix_len = prefix_len
+
+        return best_match
+
+    def get_expectation_or_pass(self, test_name, current_config=None):
+        """Get expectation for test, defaulting to PASS if none specified."""
+        exp = self.get_expectation(test_name, current_config)
+        if exp:
+            return exp
+        return APITestExpectation(test_name, {PASS})
+
+    def get_skipped_tests(self, all_tests, current_config=None):
+        """Return set of test names that should be skipped."""
+        skipped = set()
+        for test in all_tests:
+            exp = self.get_expectation(test, current_config)
+            if exp and exp.is_skip():
+                skipped.add(test)
+        return skipped
+
+    def get_slow_tests(self, all_tests, current_config=None):
+        """Return dict of slow tests to their timeouts."""
+        slow_tests = {}
+        for test in all_tests:
+            exp = self.get_expectation(test, current_config)
+            if exp and exp.is_slow():
+                slow_tests[test] = exp.slow_timeout
+        return slow_tests
+
+    def all_expectations(self):
+        """Return all expectations for iteration."""
+        return self._all_expectations
+
+
+class APITestExpectations(object):
+    """Main facade for loading and querying API test expectations."""
+
+    def __init__(self, port, tests=None):
+        self._port = port
+        self._tests = set(tests) if tests else None
+        self._model = APITestExpectationsModel()
+        # Get version tokens from port if available
+        version_tokens = set()
+        if hasattr(port, 'api_test_version_tokens'):
+            version_tokens = set(port.api_test_version_tokens().keys())
+        self._parser = APITestExpectationParser(version_tokens=version_tokens)
+        self._version_tokens = version_tokens
+        self._warnings = []
+
+    def model(self):
+        """Return the underlying model."""
+        return self._model
+
+    def warnings(self):
+        """Return list of all warnings from parsing."""
+        return self._warnings
+
+    def parse_all_expectations(self):
+        """Load and parse all relevant expectations files."""
+        for filepath in self._expectations_files():
+            if self._port.host.filesystem.exists(filepath):
+                _log.debug('Loading expectations from {}'.format(filepath))
+                content = self._port.host.filesystem.read_text_file(filepath)
+                self._parse_file(filepath, content)
+
+    def _parse_file(self, filepath, content):
+        """Parse a single expectations file and add to model."""
+        results = self._parser.parse(filepath, content)
+        for expectation, warnings in results:
+            self._warnings.extend(warnings)
+            if expectation:
+                dup_warning = self._model.add_expectation(expectation)
+                if dup_warning:
+                    self._warnings.append(dup_warning)
+
+    def _expectations_files(self):
+        """Return list of expectations files in cascade order."""
+        if hasattr(self._port, 'api_test_expectations_files'):
+            return self._port.api_test_expectations_files()
+
+        files = []
+        base = self._api_test_expectations_dir()
+        fs = self._port.host.filesystem
+
+        generic_path = fs.join(base, 'TestExpectations')
+        files.append(generic_path)
+
+        for platform_dir in self._platform_cascade():
+            platform_path = fs.join(base, 'platform', platform_dir, 'TestExpectations')
+            files.append(platform_path)
+
+        return files
+
+    def _api_test_expectations_dir(self):
+        """Return path to APITestExpectations directory."""
+        if hasattr(self._port, 'api_test_expectations_dir'):
+            return self._port.api_test_expectations_dir()
+        return self._port.host.filesystem.join(
+            self._port.path_from_webkit_base(), 'APITestExpectations')
+
+    def _platform_cascade(self):
+        """Return platform directories from least to most specific."""
+        cascade = []
+        port_name = self._port.port_name
+        if 'mac' in port_name:
+            cascade.append('mac')
+        elif 'ios' in port_name:
+            cascade.append('ios')
+            if 'simulator' in port_name:
+                cascade.append('ios-simulator')
+        elif 'gtk' in port_name:
+            cascade.append('gtk')
+        elif 'wpe' in port_name:
+            cascade.append('wpe')
+        elif 'win' in port_name:
+            cascade.append('win')
+        return cascade
+
+    def get_current_configuration(self):
+        """Return set of current configuration strings."""
+        config = set()
+        if self._port.get_option('configuration'):
+            config.add(self._port.get_option('configuration').lower())
+        return config
+
+    def lint(self, all_tests):
+        """Validate expectations and return warnings."""
+        lint_warnings = list(self._warnings)
+        test_set = set(all_tests)
+
+        for exp in self._model.all_expectations():
+            if exp.is_wildcard:
+                matches = [t for t in all_tests if exp.matches_test(t)]
+                if not matches:
+                    lint_warnings.append(ExpectationWarning(
+                        exp.filename, exp.line_number, exp.test_pattern,
+                        'Stale wildcard pattern - matches no tests',
+                        test=exp.test_pattern))
+            else:
+                if exp.test_pattern not in test_set:
+                    lint_warnings.append(ExpectationWarning(
+                        exp.filename, exp.line_number, exp.test_pattern,
+                        'Stale expectation - test does not exist',
+                        test=exp.test_pattern))
+
+        return lint_warnings
+
+
+class LintWarning(object):
+    """Represents a linting warning with optional fix."""
+    def __init__(self, filename, line_number, message, fixable=False, fix_description=None):
+        self.filename = filename
+        self.line_number = line_number
+        self.message = message
+        self.fixable = fixable
+        self.fix_description = fix_description
+
+    def __str__(self):
+        prefix = '[fixable] ' if self.fixable else ''
+        return '{}:{}: {}{}'.format(self.filename, self.line_number, prefix, self.message)
+
+
+class LineFix(object):
+    """Represents a fix to apply to a specific line."""
+    def __init__(self, line_number, new_content=None, delete=False):
+        self.line_number = line_number
+        self.new_content = new_content
+        self.delete = delete
+
+
+class APITestExpectationsLinter(object):
+    """Linter for API test expectations files with auto-fix support."""
+
+    def __init__(self, port, content, filepath, version_tokens=None):
+        """Initialize the linter.
+
+        Args:
+            port: The port object
+            content: The file content to lint
+            filepath: Path to the file being linted
+            version_tokens: Optional set of valid version token strings
+        """
+        self._port = port
+        self._content = content
+        self._filepath = filepath
+        self._version_tokens = version_tokens or set()
+        self._lines = content.split('\n')
+        self._parsed_entries = []  # List of (line_num, raw_line, parsed_data)
+        self._warnings = []
+        self._fixes = []
+
+    def lint(self):
+        """Run all linting rules and return warnings."""
+        self._parse_all_lines()
+        self._check_category_ordering()
+        self._check_alphabetical_ordering()
+        self._check_combination_collapse()
+        self._check_universal_skip()
+        return self._warnings
+
+    def get_fixes(self):
+        """Return list of fixes that can be applied."""
+        return self._fixes
+
+    def apply_fixes(self):
+        """Apply all fixes and return the fixed content."""
+        if not self._fixes:
+            return self._content
+
+        # Sort fixes in reverse line order to preserve line numbers
+        sorted_fixes = sorted(self._fixes, key=lambda f: -f.line_number)
+
+        lines = self._lines[:]
+        for fix in sorted_fixes:
+            if fix.delete:
+                del lines[fix.line_number - 1]
+            elif fix.new_content is not None:
+                lines[fix.line_number - 1] = fix.new_content
+
+        return '\n'.join(lines)
+
+    def _parse_all_lines(self):
+        """Parse all lines to extract test entries."""
+        for line_num, line in enumerate(self._lines, 1):
+            # Skip comments and blank lines
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
+                continue
+
+            # Extract configuration tokens if present
+            config_tokens = []
+            test_pattern = None
+            expectations = []
+
+            # Simple parsing to extract parts
+            comment_idx = line.find('#')
+            if comment_idx != -1:
+                line_content = line[:comment_idx]
+            else:
+                line_content = line
+
+            # Find configuration block
+            config_match = re.search(r'\[\s*([^\]]*)\s*\]', line_content)
+            if config_match:
+                config_str = config_match.group(1)
+                # Check if this is config or expectations based on position
+                config_start = config_match.start()
+                before_config = line_content[:config_start].strip()
+
+                # If there's a test pattern before the bracket, it's expectations
+                # Remove bug identifiers from before_config
+                before_words = before_config.split()
+                non_bug_words = [w for w in before_words
+                                 if not w.startswith('webkit.org/b/')
+                                 and not w.startswith('rdar://')
+                                 and not w.lower().startswith('bug(')]
+
+                if non_bug_words:
+                    # There's a test pattern, so this bracket is expectations
+                    test_pattern = non_bug_words[-1]
+                    expectations = config_str.split()
+                else:
+                    # No test pattern yet, so this is config
+                    config_tokens = config_str.split()
+                    # Look for test pattern after
+                    rest = line_content[config_match.end():].strip()
+                    # Find expectations bracket if present
+                    exp_match = re.search(r'\[\s*([^\]]*)\s*\]', rest)
+                    if exp_match:
+                        test_pattern = rest[:exp_match.start()].strip()
+                        expectations = exp_match.group(1).split()
+                    else:
+                        test_pattern = rest
+            else:
+                # No brackets, find test pattern
+                words = line_content.split()
+                for word in words:
+                    if not word.startswith('webkit.org/b/') and \
+                       not word.startswith('rdar://') and \
+                       not word.lower().startswith('bug('):
+                        test_pattern = word
+                        break
+
+            if test_pattern:
+                self._parsed_entries.append({
+                    'line_number': line_num,
+                    'raw_line': line,
+                    'config_tokens': config_tokens,
+                    'test_pattern': test_pattern,
+                    'expectations': expectations,
+                })
+
+    def _check_category_ordering(self):
+        """Check that tokens in [ ] blocks appear in correct category order."""
+        for entry in self._parsed_entries:
+            config_tokens = entry['config_tokens']
+            if len(config_tokens) < 2:
+                continue
+
+            last_category = None
+            for token in config_tokens:
+                category = get_token_category(token, self._version_tokens)
+                if category is None:
+                    continue
+
+                if last_category is not None and category < last_category:
+                    self._warnings.append(LintWarning(
+                        self._filepath,
+                        entry['line_number'],
+                        'Configuration tokens out of order: "{}" ({}) appears after {} category. '
+                        'Expected order: Platform -> Version -> Style -> Hardware -> Architecture -> Flavor'.format(
+                            token, CATEGORY_NAMES.get(category, str(category)),
+                            CATEGORY_NAMES.get(last_category, str(last_category))),
+                        fixable=True
+                    ))
+                    # Create fix with reordered tokens
+                    self._add_reorder_fix(entry)
+                    break
+
+                last_category = category
+
+    def _check_alphabetical_ordering(self):
+        """Check alphabetical ordering within categories and in the file."""
+        # Check alphabetical ordering within categories for each entry
+        for entry in self._parsed_entries:
+            config_tokens = entry['config_tokens']
+            if len(config_tokens) < 2:
+                continue
+
+            # Group tokens by category
+            by_category = defaultdict(list)
+            for token in config_tokens:
+                category = get_token_category(token, self._version_tokens)
+                if category:
+                    by_category[category].append(token.lower())
+
+            # Check each category is alphabetically ordered
+            for category, tokens in by_category.items():
+                sorted_tokens = sorted(tokens)
+                if tokens != sorted_tokens:
+                    self._warnings.append(LintWarning(
+                        self._filepath,
+                        entry['line_number'],
+                        'Tokens in {} category not alphabetically ordered: {} should be {}'.format(
+                            CATEGORY_NAMES.get(category, str(category)),
+                            tokens, sorted_tokens),
+                        fixable=True
+                    ))
+                    self._add_reorder_fix(entry)
+
+        # Check test entries are alphabetically ordered in the file
+        prev_test = None
+        prev_line_num = None
+        for entry in self._parsed_entries:
+            test = entry['test_pattern']
+            if prev_test and test.lower() < prev_test.lower():
+                self._warnings.append(LintWarning(
+                    self._filepath,
+                    entry['line_number'],
+                    'Test "{}" should appear before "{}" (line {}) for alphabetical order'.format(
+                        test, prev_test, prev_line_num),
+                    fixable=True,
+                    fix_description='Reorder test entries alphabetically'
+                ))
+            prev_test = test
+            prev_line_num = entry['line_number']
+
+    def _check_combination_collapse(self):
+        """Check for entries that can be collapsed."""
+        # Group entries by test pattern
+        by_test = defaultdict(list)
+        for entry in self._parsed_entries:
+            by_test[entry['test_pattern']].append(entry)
+
+        for test_pattern, entries in by_test.items():
+            if len(entries) < 2:
+                continue
+
+            # Check if all entries have the same expectations
+            expectations_set = set(tuple(sorted(e['expectations'])) for e in entries)
+            if len(expectations_set) != 1:
+                continue  # Different expectations, can't collapse
+
+            # Check which categories are fully covered
+            for category, all_values in CATEGORY_TOKENS.items():
+                if not all_values:
+                    continue
+
+                covered_values = set()
+                entries_with_category = []
+                for entry in entries:
+                    cat_values = {t.lower() for t in entry['config_tokens']
+                                  if get_token_category(t, self._version_tokens) == category}
+                    if cat_values:
+                        covered_values.update(cat_values)
+                        entries_with_category.append(entry)
+
+                if covered_values == all_values and len(entries_with_category) == len(all_values):
+                    line_nums = [e['line_number'] for e in entries_with_category]
+                    self._warnings.append(LintWarning(
+                        self._filepath,
+                        line_nums[0],
+                        'Test "{}" has entries covering all {} values (lines {}). '
+                        'Can be collapsed by removing {} specifier.'.format(
+                            test_pattern,
+                            CATEGORY_NAMES.get(category, str(category)),
+                            ', '.join(str(n) for n in line_nums),
+                            CATEGORY_NAMES.get(category, str(category))),
+                        fixable=True
+                    ))
+                    # Mark extra lines for deletion, update first line
+                    self._add_collapse_fix(entries_with_category, category)
+
+    def _check_universal_skip(self):
+        """Check for tests skipped on all configurations."""
+        # Group entries by test pattern
+        by_test = defaultdict(list)
+        for entry in self._parsed_entries:
+            by_test[entry['test_pattern']].append(entry)
+
+        for test_pattern, entries in by_test.items():
+            # Check if all entries are Skip
+            all_skip = all(
+                any(e.lower() == 'skip' for e in entry['expectations'])
+                for entry in entries
+            )
+            if not all_skip:
+                continue
+
+            # Check if there's an unconditional entry or all platforms covered
+            has_unconditional = any(not entry['config_tokens'] for entry in entries)
+            covered_platforms = set()
+            for entry in entries:
+                for token in entry['config_tokens']:
+                    if token.lower() in PLATFORM_TOKENS:
+                        covered_platforms.add(token.lower())
+
+            if has_unconditional or covered_platforms >= PLATFORM_TOKENS:
+                line_nums = [e['line_number'] for e in entries]
+                self._warnings.append(LintWarning(
+                    self._filepath,
+                    line_nums[0],
+                    'Test "{}" is skipped on all configurations (lines {}). '
+                    'Consider removing the test entirely.'.format(
+                        test_pattern,
+                        ', '.join(str(n) for n in line_nums)),
+                    fixable=False  # Removing tests is a manual decision
+                ))
+
+    def _add_reorder_fix(self, entry):
+        """Add a fix to reorder tokens in an entry."""
+        config_tokens = entry['config_tokens']
+        if not config_tokens:
+            return
+
+        # Sort tokens by category, then alphabetically within category
+        def sort_key(token):
+            category = get_token_category(token, self._version_tokens)
+            return (category or ConfigurationCategory.FLAVOR, token.lower())
+
+        sorted_tokens = sorted(config_tokens, key=sort_key)
+        if sorted_tokens == config_tokens:
+            return  # Already sorted
+
+        # Reconstruct the line with sorted tokens
+        old_line = entry['raw_line']
+
+        # Find and replace the config block
+        new_config = '[ {} ]'.format(' '.join(sorted_tokens))
+        new_line = re.sub(r'\[\s*[^\]]*\s*\]', new_config, old_line, count=1)
+
+        # Only add if not already in fixes
+        existing = [f for f in self._fixes if f.line_number == entry['line_number']]
+        if not existing:
+            self._fixes.append(LineFix(entry['line_number'], new_line))
+
+    def _add_collapse_fix(self, entries, category):
+        """Add fixes to collapse entries by removing category specifier."""
+        if len(entries) < 2:
+            return
+
+        # Keep first entry, modify to remove category, delete rest
+        first_entry = entries[0]
+        config_tokens = [t for t in first_entry['config_tokens']
+                         if get_token_category(t, self._version_tokens) != category]
+
+        old_line = first_entry['raw_line']
+
+        if config_tokens:
+            new_config = '[ {} ]'.format(' '.join(config_tokens))
+            new_line = re.sub(r'\[\s*[^\]]*\s*\]', new_config, old_line, count=1)
+        else:
+            # Remove the entire config block
+            new_line = re.sub(r'\[\s*[^\]]*\s*\]\s*', '', old_line, count=1)
+
+        self._fixes.append(LineFix(first_entry['line_number'], new_line))
+
+        # Delete other entries
+        for entry in entries[1:]:
+            self._fixes.append(LineFix(entry['line_number'], delete=True))

--- a/Tools/Scripts/webkitpy/api_tests/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/api_tests/test_expectations_unittest.py
@@ -1,0 +1,830 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from webkitpy.api_tests.test_expectations import (
+    APITestExpectation,
+    APITestExpectationParser,
+    APITestExpectationsModel,
+    APITestExpectationsLinter,
+    VersionSpecifier,
+    ConfigurationCategory,
+    get_token_category,
+    PASS, FAIL, CRASH, TIMEOUT, SKIP, SLOW,
+    EXPECTATION_MAP,
+    PLATFORM_TOKENS,
+    STYLE_TOKENS,
+    HARDWARE_TOKENS,
+    ARCHITECTURE_TOKENS,
+)
+
+
+class APITestExpectationParserTest(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = APITestExpectationParser()
+
+    def test_parse_simple_failure(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Fail ]')
+        self.assertEqual(len(results), 1)
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+        self.assertEqual(exp.test_pattern, 'TestWebKitAPI.WTF.Test')
+        self.assertIn(FAIL, exp.expectations)
+
+    def test_parse_multiple_expectations(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Pass Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(PASS, exp.expectations)
+        self.assertIn(FAIL, exp.expectations)
+        self.assertTrue(exp.is_flaky())
+
+    def test_parse_with_bug_id(self):
+        results = self.parser.parse('test.txt', 'webkit.org/b/12345 TestWebKitAPI.WTF.Test [ Crash ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(exp.bug_ids, ('webkit.org/b/12345',))
+        self.assertIn(CRASH, exp.expectations)
+
+    def test_parse_with_bug_parenthesis(self):
+        results = self.parser.parse('test.txt', 'Bug(test) TestWebKitAPI.WTF.Test [ Timeout ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(exp.bug_ids, ('Bug(test)',))
+        self.assertIn(TIMEOUT, exp.expectations)
+
+    def test_parse_skip(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Skip ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.is_skip())
+
+    def test_parse_slow(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.is_slow())
+        self.assertIsNone(exp.slow_timeout)  # No custom timeout
+
+    def test_parse_slow_with_custom_timeout(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow:120s ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.is_slow())
+        self.assertEqual(exp.slow_timeout, 120)
+
+    def test_parse_slow_with_custom_timeout_no_s(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow:60 ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.is_slow())
+        self.assertEqual(exp.slow_timeout, 60)
+
+    def test_parse_slow_timeout_too_large(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow:9999 ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('3600', str(warnings[0]))  # Max timeout is 3600 seconds (1 hour)
+        self.assertIsNone(exp)
+
+    def test_parse_slow_timeout_zero(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow:0 ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn('1 and 3600', str(warnings[0]))
+        self.assertIsNone(exp)
+
+    def test_parse_configuration_debug(self):
+        results = self.parser.parse('test.txt', '[ Debug ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('debug', exp.configurations)
+        self.assertIn(FAIL, exp.expectations)
+
+    def test_parse_configuration_release_arm64(self):
+        results = self.parser.parse('test.txt', '[ Release arm64 ] TestWebKitAPI.WTF.Test [ Crash ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('release', exp.configurations)
+        self.assertIn('arm64', exp.configurations)
+
+    def test_parse_comment_line(self):
+        results = self.parser.parse('test.txt', '# This is a comment')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertEqual(len(warnings), 0)
+
+    def test_parse_empty_line(self):
+        results = self.parser.parse('test.txt', '')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertEqual(len(warnings), 0)
+
+    def test_parse_inline_comment(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Fail ] # comment')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+        self.assertEqual(exp.test_pattern, 'TestWebKitAPI.WTF.Test')
+
+    def test_parse_wildcard(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.* [ Skip ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.is_wildcard)
+        self.assertEqual(exp.test_pattern, 'TestWebKitAPI.WTF.*')
+
+    def test_parse_error_missing_bracket(self):
+        results = self.parser.parse('test.txt', '[ Debug TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertTrue(len(warnings) > 0)
+
+    def test_parse_error_skip_with_other_expectations(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Skip Fail ]')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertTrue(len(warnings) > 0)
+        self.assertTrue(any('Skip must not have other' in str(w) for w in warnings))
+
+    def test_parse_error_slow_and_timeout(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow Timeout ]')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertTrue(len(warnings) > 0)
+        self.assertTrue(any('Slow and Timeout' in str(w) for w in warnings))
+
+    def test_parse_multiline(self):
+        content = '''# Comment
+TestWebKitAPI.WTF.Test1 [ Fail ]
+TestWebKitAPI.WTF.Test2 [ Pass Crash ]
+[ Debug ] TestWebKitAPI.WTF.Test3 [ Skip ]
+'''
+        results = self.parser.parse('test.txt', content)
+        self.assertEqual(len(results), 5)  # Including empty line at start
+
+        # Test1
+        exp, warnings = results[1]
+        self.assertEqual(exp.test_pattern, 'TestWebKitAPI.WTF.Test1')
+
+        # Test2
+        exp, warnings = results[2]
+        self.assertTrue(exp.is_flaky())
+
+        # Test3
+        exp, warnings = results[3]
+        self.assertIn('debug', exp.configurations)
+
+
+class APITestExpectationTest(unittest.TestCase):
+
+    def test_matches_test_exact(self):
+        exp = APITestExpectation('TestWebKitAPI.WTF.Test', {PASS})
+        self.assertTrue(exp.matches_test('TestWebKitAPI.WTF.Test'))
+        self.assertFalse(exp.matches_test('TestWebKitAPI.WTF.Other'))
+
+    def test_matches_test_wildcard(self):
+        exp = APITestExpectation('TestWebKitAPI.WTF.*', {SKIP})
+        self.assertTrue(exp.matches_test('TestWebKitAPI.WTF.Test'))
+        self.assertTrue(exp.matches_test('TestWebKitAPI.WTF.Other'))
+        self.assertTrue(exp.matches_test('TestWebKitAPI.WTF.Suite.Test'))
+        self.assertFalse(exp.matches_test('TestWebKitAPI.WebKit.Test'))
+
+    def test_matches_configuration_empty(self):
+        exp = APITestExpectation('Test', {PASS}, configurations=set())
+        self.assertTrue(exp.matches_configuration(set()))
+        self.assertTrue(exp.matches_configuration({'debug'}))
+
+    def test_matches_configuration_single(self):
+        exp = APITestExpectation('Test', {PASS}, configurations={'debug'})
+        self.assertTrue(exp.matches_configuration({'debug'}))
+        self.assertTrue(exp.matches_configuration({'debug', 'arm64'}))
+        self.assertFalse(exp.matches_configuration({'release'}))
+        self.assertFalse(exp.matches_configuration(set()))
+
+    def test_matches_configuration_multiple(self):
+        exp = APITestExpectation('Test', {PASS}, configurations={'debug', 'arm64'})
+        self.assertTrue(exp.matches_configuration({'debug', 'arm64'}))
+        self.assertTrue(exp.matches_configuration({'debug', 'arm64', 'mac'}))
+        self.assertFalse(exp.matches_configuration({'debug'}))
+        self.assertFalse(exp.matches_configuration({'arm64'}))
+
+    def test_matches_configuration_with_version_specifier_and_later(self):
+        """Test matches_configuration with Sonoma+ style version specifier."""
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_LATER)
+        exp = APITestExpectation('Test', {PASS}, configurations={'mac'},
+                                 version_specifiers=[spec])
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+        # Should match mac config + ventura or later
+        self.assertTrue(exp.matches_configuration({'mac'}, 'ventura', version_order))
+        self.assertTrue(exp.matches_configuration({'mac'}, 'sonoma', version_order))
+        self.assertTrue(exp.matches_configuration({'mac'}, 'sequoia', version_order))
+
+        # Should not match earlier versions
+        self.assertFalse(exp.matches_configuration({'mac'}, 'monterey', version_order))
+
+        # Should not match without version info
+        self.assertFalse(exp.matches_configuration({'mac'}))
+
+    def test_matches_configuration_with_version_specifier_and_earlier(self):
+        """Test matches_configuration with Sonoma- style version specifier."""
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_EARLIER)
+        exp = APITestExpectation('Test', {PASS}, configurations={'mac'},
+                                 version_specifiers=[spec])
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+        # Should match mac config + ventura or earlier
+        self.assertTrue(exp.matches_configuration({'mac'}, 'monterey', version_order))
+        self.assertTrue(exp.matches_configuration({'mac'}, 'ventura', version_order))
+
+        # Should not match later versions
+        self.assertFalse(exp.matches_configuration({'mac'}, 'sonoma', version_order))
+        self.assertFalse(exp.matches_configuration({'mac'}, 'sequoia', version_order))
+
+    def test_matches_configuration_with_version_specifier_range(self):
+        """Test matches_configuration with Ventura-Sonoma style version range."""
+        spec = VersionSpecifier('ventura', 'sonoma', VersionSpecifier.Type.RANGE)
+        exp = APITestExpectation('Test', {PASS}, configurations={'mac'},
+                                 version_specifiers=[spec])
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+        # Should match within range
+        self.assertTrue(exp.matches_configuration({'mac'}, 'ventura', version_order))
+        self.assertTrue(exp.matches_configuration({'mac'}, 'sonoma', version_order))
+
+        # Should not match outside range
+        self.assertFalse(exp.matches_configuration({'mac'}, 'monterey', version_order))
+        self.assertFalse(exp.matches_configuration({'mac'}, 'sequoia', version_order))
+
+    def test_matches_configuration_with_version_specifier_exact(self):
+        """Test matches_configuration with exact version match."""
+        spec = VersionSpecifier('sonoma', specifier_type=VersionSpecifier.Type.EXACT)
+        exp = APITestExpectation('Test', {PASS}, configurations={'mac'},
+                                 version_specifiers=[spec])
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+        # Should match exact version only
+        self.assertTrue(exp.matches_configuration({'mac'}, 'sonoma', version_order))
+        self.assertFalse(exp.matches_configuration({'mac'}, 'ventura', version_order))
+        self.assertFalse(exp.matches_configuration({'mac'}, 'sequoia', version_order))
+
+    def test_matches_configuration_wrong_platform(self):
+        """Test that version specifier match requires platform match too."""
+        spec = VersionSpecifier('sonoma', specifier_type=VersionSpecifier.Type.AND_LATER)
+        exp = APITestExpectation('Test', {PASS}, configurations={'mac'},
+                                 version_specifiers=[spec])
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+        # Should not match ios even with correct version
+        self.assertFalse(exp.matches_configuration({'ios'}, 'sonoma', version_order))
+
+    def test_matches_configuration_multiple_version_specifiers(self):
+        """Multiple version specifiers must all match (AND logic)."""
+        # Create a range by combining AND_LATER and AND_EARLIER
+        spec1 = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_LATER)
+        spec2 = VersionSpecifier('sonoma', specifier_type=VersionSpecifier.Type.AND_EARLIER)
+        exp = APITestExpectation('Test', {PASS}, version_specifiers=[spec1, spec2])
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+        # Should match versions in range [ventura, sonoma]
+        self.assertTrue(exp.matches_configuration(set(), 'ventura', version_order))
+        self.assertTrue(exp.matches_configuration(set(), 'sonoma', version_order))
+
+        # Should not match versions outside range
+        self.assertFalse(exp.matches_configuration(set(), 'monterey', version_order))
+        self.assertFalse(exp.matches_configuration(set(), 'sequoia', version_order))
+
+    def test_result_is_expected_pass(self):
+        exp = APITestExpectation('Test', {PASS})
+        self.assertTrue(exp.result_is_expected(PASS))
+        self.assertFalse(exp.result_is_expected(FAIL))
+
+    def test_result_is_expected_flaky(self):
+        exp = APITestExpectation('Test', {PASS, FAIL})
+        self.assertTrue(exp.result_is_expected(PASS))
+        self.assertTrue(exp.result_is_expected(FAIL))
+        self.assertFalse(exp.result_is_expected(CRASH))
+
+    def test_result_is_expected_skip(self):
+        exp = APITestExpectation('Test', {SKIP})
+        self.assertTrue(exp.result_is_expected(SKIP))
+
+    def test_get_timeout_default(self):
+        exp = APITestExpectation('Test', {PASS})
+        self.assertEqual(exp.get_timeout(30), 30)
+
+    def test_get_timeout_slow(self):
+        exp = APITestExpectation('Test', {SLOW})
+        self.assertEqual(exp.get_timeout(30), 150)  # 5x default
+
+    def test_get_timeout_custom(self):
+        exp = APITestExpectation('Test', {SLOW}, slow_timeout=120)
+        self.assertEqual(exp.get_timeout(30), 120)
+
+
+class APITestExpectationsModelTest(unittest.TestCase):
+
+    def test_add_and_get_expectation(self):
+        model = APITestExpectationsModel()
+        exp = APITestExpectation('TestWebKitAPI.WTF.Test', {FAIL})
+        model.add_expectation(exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Test')
+        self.assertEqual(result, exp)
+
+    def test_get_expectation_not_found(self):
+        model = APITestExpectationsModel()
+        result = model.get_expectation('NonExistent.Test')
+        self.assertIsNone(result)
+
+    def test_wildcard_matching(self):
+        model = APITestExpectationsModel()
+        exp = APITestExpectation('TestWebKitAPI.WTF.*', {SKIP})
+        model.add_expectation(exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Test')
+        self.assertEqual(result, exp)
+
+        result = model.get_expectation('TestWebKitAPI.WebKit.Test')
+        self.assertIsNone(result)
+
+    def test_exact_overrides_wildcard(self):
+        model = APITestExpectationsModel()
+        wildcard_exp = APITestExpectation('TestWebKitAPI.WTF.*', {SKIP})
+        exact_exp = APITestExpectation('TestWebKitAPI.WTF.Specific', {FAIL})
+        model.add_expectation(wildcard_exp)
+        model.add_expectation(exact_exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Specific')
+        self.assertEqual(result, exact_exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Other')
+        self.assertEqual(result, wildcard_exp)
+
+    def test_more_specific_wildcard_wins(self):
+        model = APITestExpectationsModel()
+        broad = APITestExpectation('TestWebKitAPI.*', {SKIP})
+        specific = APITestExpectation('TestWebKitAPI.WTF.*', {FAIL})
+        model.add_expectation(broad)
+        model.add_expectation(specific)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Test')
+        self.assertEqual(result, specific)
+
+        result = model.get_expectation('TestWebKitAPI.WebKit.Test')
+        self.assertEqual(result, broad)
+
+    def test_get_skipped_tests(self):
+        model = APITestExpectationsModel()
+        model.add_expectation(APITestExpectation('Test1', {SKIP}))
+        model.add_expectation(APITestExpectation('Test2', {FAIL}))
+        model.add_expectation(APITestExpectation('TestWTF.*', {SKIP}))
+
+        all_tests = ['Test1', 'Test2', 'TestWTF.A', 'TestWTF.B', 'Other']
+        skipped = model.get_skipped_tests(all_tests)
+
+        self.assertIn('Test1', skipped)
+        self.assertNotIn('Test2', skipped)
+        self.assertIn('TestWTF.A', skipped)
+        self.assertIn('TestWTF.B', skipped)
+        self.assertNotIn('Other', skipped)
+
+    def test_get_slow_tests(self):
+        model = APITestExpectationsModel()
+        model.add_expectation(APITestExpectation('Test1', {SLOW}))
+        model.add_expectation(APITestExpectation('Test2', {SLOW}, slow_timeout=120))
+        model.add_expectation(APITestExpectation('Test3', {FAIL}))
+
+        all_tests = ['Test1', 'Test2', 'Test3']
+        slow = model.get_slow_tests(all_tests)
+
+        self.assertIn('Test1', slow)
+        self.assertIsNone(slow['Test1'])  # Default 5x
+        self.assertIn('Test2', slow)
+        self.assertEqual(slow['Test2'], 120)
+        self.assertNotIn('Test3', slow)
+
+    def test_configuration_filtering(self):
+        model = APITestExpectationsModel()
+        debug_exp = APITestExpectation('Test', {FAIL}, configurations={'debug'})
+        model.add_expectation(debug_exp)
+
+        # Should match debug config
+        result = model.get_expectation('Test', {'debug'})
+        self.assertEqual(result, debug_exp)
+
+        # Should not match release config
+        result = model.get_expectation('Test', {'release'})
+        self.assertIsNone(result)
+
+    def test_get_expectation_or_pass(self):
+        model = APITestExpectationsModel()
+        model.add_expectation(APITestExpectation('Test1', {FAIL}))
+
+        result = model.get_expectation_or_pass('Test1')
+        self.assertIn(FAIL, result.expectations)
+
+        result = model.get_expectation_or_pass('Unknown')
+        self.assertIn(PASS, result.expectations)
+
+
+class VersionSpecifierTest(unittest.TestCase):
+
+    def test_parse_exact_version(self):
+        """Exact version should return None from parse (handled separately)."""
+        spec = VersionSpecifier.parse('Sonoma')
+        self.assertIsNone(spec)  # Exact versions handled by token categorization
+
+    def test_parse_and_later(self):
+        spec = VersionSpecifier.parse('Sonoma+')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, 'sonoma')
+        self.assertEqual(spec.type, VersionSpecifier.Type.AND_LATER)
+        self.assertIsNone(spec.end_version)
+
+    def test_parse_and_earlier(self):
+        spec = VersionSpecifier.parse('Ventura-')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, 'ventura')
+        self.assertEqual(spec.type, VersionSpecifier.Type.AND_EARLIER)
+        self.assertIsNone(spec.end_version)
+
+    def test_parse_range(self):
+        spec = VersionSpecifier.parse('Ventura-Sequoia')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, 'ventura')
+        self.assertEqual(spec.end_version, 'sequoia')
+        self.assertEqual(spec.type, VersionSpecifier.Type.RANGE)
+
+    def test_parse_empty_modifiers(self):
+        """Empty strings with just modifiers should return None or handle gracefully."""
+        # Just a plus sign - would create empty base_version
+        spec = VersionSpecifier.parse('+')
+        # This creates a spec with empty base_version, which won't match anything
+        if spec:
+            self.assertEqual(spec.base_version, '')
+
+        # Just a minus sign
+        spec = VersionSpecifier.parse('-')
+        if spec:
+            self.assertEqual(spec.base_version, '')
+
+    def test_matches_exact(self):
+        spec = VersionSpecifier('sonoma', specifier_type=VersionSpecifier.Type.EXACT)
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.assertTrue(spec.matches('sonoma', version_order))
+        self.assertFalse(spec.matches('ventura', version_order))
+
+    def test_matches_and_later(self):
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_LATER)
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.assertFalse(spec.matches('monterey', version_order))
+        self.assertTrue(spec.matches('ventura', version_order))
+        self.assertTrue(spec.matches('sonoma', version_order))
+        self.assertTrue(spec.matches('sequoia', version_order))
+
+    def test_matches_and_earlier(self):
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_EARLIER)
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.assertTrue(spec.matches('monterey', version_order))
+        self.assertTrue(spec.matches('ventura', version_order))
+        self.assertFalse(spec.matches('sonoma', version_order))
+        self.assertFalse(spec.matches('sequoia', version_order))
+
+    def test_matches_range(self):
+        spec = VersionSpecifier('ventura', 'sonoma', VersionSpecifier.Type.RANGE)
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.assertFalse(spec.matches('monterey', version_order))
+        self.assertTrue(spec.matches('ventura', version_order))
+        self.assertTrue(spec.matches('sonoma', version_order))
+        self.assertFalse(spec.matches('sequoia', version_order))
+
+    def test_matches_unknown_version(self):
+        """Unknown version in specifier should not match anything."""
+        spec = VersionSpecifier('unknown', specifier_type=VersionSpecifier.Type.AND_LATER)
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.assertFalse(spec.matches('sonoma', version_order))
+        self.assertFalse(spec.matches('unknown', version_order))
+
+    def test_matches_unknown_current_version(self):
+        """Unknown current version should not match."""
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_LATER)
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.assertFalse(spec.matches('unknown', version_order))
+
+    def test_matches_case_insensitive(self):
+        """Version matching should be case insensitive."""
+        spec = VersionSpecifier('Sonoma', specifier_type=VersionSpecifier.Type.EXACT)
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.assertTrue(spec.matches('SONOMA', version_order))
+        self.assertTrue(spec.matches('sonoma', version_order))
+        self.assertTrue(spec.matches('Sonoma', version_order))
+
+
+class ConfigurationCategoryTest(unittest.TestCase):
+
+    def test_get_token_category_platform(self):
+        self.assertEqual(get_token_category('mac'), ConfigurationCategory.PLATFORM)
+        self.assertEqual(get_token_category('ios'), ConfigurationCategory.PLATFORM)
+        self.assertEqual(get_token_category('linux'), ConfigurationCategory.PLATFORM)
+
+    def test_get_token_category_style(self):
+        self.assertEqual(get_token_category('debug'), ConfigurationCategory.STYLE)
+        self.assertEqual(get_token_category('release'), ConfigurationCategory.STYLE)
+        self.assertEqual(get_token_category('asan'), ConfigurationCategory.STYLE)
+        self.assertEqual(get_token_category('guardmalloc'), ConfigurationCategory.STYLE)
+
+    def test_get_token_category_hardware(self):
+        self.assertEqual(get_token_category('simulator'), ConfigurationCategory.HARDWARE)
+        self.assertEqual(get_token_category('device'), ConfigurationCategory.HARDWARE)
+        self.assertEqual(get_token_category('iphone'), ConfigurationCategory.HARDWARE)
+        self.assertEqual(get_token_category('ipad'), ConfigurationCategory.HARDWARE)
+
+    def test_get_token_category_architecture(self):
+        self.assertEqual(get_token_category('arm64'), ConfigurationCategory.ARCHITECTURE)
+        self.assertEqual(get_token_category('x86_64'), ConfigurationCategory.ARCHITECTURE)
+
+    def test_get_token_category_version_specifier(self):
+        self.assertEqual(get_token_category('Sonoma+'), ConfigurationCategory.VERSION)
+        self.assertEqual(get_token_category('Ventura-'), ConfigurationCategory.VERSION)
+        self.assertEqual(get_token_category('Monterey-Sonoma'), ConfigurationCategory.VERSION)
+
+    def test_get_token_category_version_token(self):
+        version_tokens = {'sonoma', 'ventura', 'monterey'}
+        self.assertEqual(get_token_category('sonoma', version_tokens), ConfigurationCategory.VERSION)
+        self.assertEqual(get_token_category('Ventura', version_tokens), ConfigurationCategory.VERSION)
+
+    def test_get_token_category_flavor(self):
+        # Freeform tokens that don't match other categories
+        self.assertEqual(get_token_category('wk1'), ConfigurationCategory.FLAVOR)
+        self.assertEqual(get_token_category('wk2'), ConfigurationCategory.FLAVOR)
+        self.assertEqual(get_token_category('siteisolation'), ConfigurationCategory.FLAVOR)
+
+    def test_category_ordering(self):
+        """Categories should be ordered from least to most specific."""
+        self.assertLess(ConfigurationCategory.PLATFORM, ConfigurationCategory.VERSION)
+        self.assertLess(ConfigurationCategory.VERSION, ConfigurationCategory.STYLE)
+        self.assertLess(ConfigurationCategory.STYLE, ConfigurationCategory.HARDWARE)
+        self.assertLess(ConfigurationCategory.HARDWARE, ConfigurationCategory.ARCHITECTURE)
+        self.assertLess(ConfigurationCategory.ARCHITECTURE, ConfigurationCategory.FLAVOR)
+
+
+class RadarBugTest(unittest.TestCase):
+
+    def test_parse_radar_simple(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', 'rdar://12345 TestWebKitAPI.WTF.Test [ Crash ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+        self.assertEqual(exp.bug_ids, ('rdar://12345',))
+
+    def test_parse_radar_with_problem(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', 'rdar://problem/12345 TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+        self.assertEqual(exp.bug_ids, ('rdar://problem/12345',))
+
+    def test_parse_radar_invalid_format(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', 'rdar://abc TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertTrue(len(warnings) > 0)
+        self.assertTrue(any('Invalid radar format' in str(w) for w in warnings))
+
+    def test_parse_multiple_bugs(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', 'webkit.org/b/12345 rdar://67890 TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(len(exp.bug_ids), 2)
+        self.assertIn('webkit.org/b/12345', exp.bug_ids)
+        self.assertIn('rdar://67890', exp.bug_ids)
+
+
+class FlavorTokenTest(unittest.TestCase):
+
+    def test_parse_flavor_wk1(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', '[ wk1 ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('wk1', exp.configurations)
+
+    def test_parse_flavor_wk2(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', '[ wk2 ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('wk2', exp.configurations)
+
+    def test_parse_flavor_siteisolation(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', '[ siteisolation ] TestWebKitAPI.WTF.Test [ Pass ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('siteisolation', exp.configurations)
+
+    def test_parse_combined_config_and_flavor(self):
+        parser = APITestExpectationParser()
+        results = parser.parse('test.txt', '[ mac debug wk2 ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('mac', exp.configurations)
+        self.assertIn('debug', exp.configurations)
+        self.assertIn('wk2', exp.configurations)
+
+
+class LinterTest(unittest.TestCase):
+
+    def test_lint_category_ordering(self):
+        content = '[ arm64 mac ] TestWebKitAPI.WTF.Test [ Fail ]'  # Wrong order
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('out of order' in w.message for w in warnings))
+
+    def test_lint_correct_category_ordering(self):
+        content = '[ mac arm64 ] TestWebKitAPI.WTF.Test [ Fail ]'  # Correct order
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertFalse(any('out of order' in w.message for w in warnings))
+
+    def test_lint_alphabetical_ordering_within_category(self):
+        content = '[ release debug ] TestWebKitAPI.WTF.Test [ Fail ]'  # Wrong alpha order
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('alphabetically ordered' in w.message for w in warnings))
+
+    def test_lint_combination_collapse(self):
+        # Cover all style values: debug, release, asan, guardmalloc
+        content = '''[ debug ] TestWebKitAPI.WTF.Test [ Skip ]
+[ release ] TestWebKitAPI.WTF.Test [ Skip ]
+[ asan ] TestWebKitAPI.WTF.Test [ Skip ]
+[ guardmalloc ] TestWebKitAPI.WTF.Test [ Skip ]'''
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('collapsed' in w.message for w in warnings))
+
+    def test_lint_universal_skip(self):
+        content = 'TestWebKitAPI.WTF.Test [ Skip ]'  # Unconditional skip
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('skipped on all configurations' in w.message for w in warnings))
+
+    def test_apply_fixes_reorder(self):
+        content = '[ arm64 mac ] TestWebKitAPI.WTF.Test [ Fail ]'
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        linter.lint()
+        fixed = linter.apply_fixes()
+        self.assertIn('[ mac arm64 ]', fixed)
+
+    def test_no_warnings_for_valid_file(self):
+        content = '''# Comment
+[ mac debug arm64 ] TestWebKitAPI.WTF.Test1 [ Fail ]
+[ ios release ] TestWebKitAPI.WTF.Test2 [ Crash ]
+'''
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        # Filter out alphabetical order warnings for test entries
+        significant_warnings = [w for w in warnings if 'should appear before' not in w.message]
+        self.assertEqual(len(significant_warnings), 0)
+
+
+class VersionSpecifierParsingTest(unittest.TestCase):
+    """Tests for parsing version specifiers through the full parser."""
+
+    def test_parse_version_specifier_and_later(self):
+        """Parser should extract Sonoma+ as a version specifier."""
+        version_tokens = {'sonoma', 'ventura', 'monterey', 'sequoia'}
+        parser = APITestExpectationParser(version_tokens=version_tokens)
+        results = parser.parse('test.txt', '[ mac Sonoma+ ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+        self.assertIn('mac', exp.configurations)
+        # Version specifier should be extracted, not in configurations
+        self.assertNotIn('sonoma+', exp.configurations)
+        self.assertNotIn('sonoma', exp.configurations)
+        self.assertEqual(len(exp.version_specifiers), 1)
+        self.assertEqual(exp.version_specifiers[0].type, VersionSpecifier.Type.AND_LATER)
+        self.assertEqual(exp.version_specifiers[0].base_version, 'sonoma')
+
+    def test_parse_version_specifier_and_earlier(self):
+        """Parser should extract Ventura- as a version specifier."""
+        version_tokens = {'sonoma', 'ventura', 'monterey'}
+        parser = APITestExpectationParser(version_tokens=version_tokens)
+        results = parser.parse('test.txt', '[ mac Ventura- ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(len(exp.version_specifiers), 1)
+        self.assertEqual(exp.version_specifiers[0].type, VersionSpecifier.Type.AND_EARLIER)
+        self.assertEqual(exp.version_specifiers[0].base_version, 'ventura')
+
+    def test_parse_version_specifier_range(self):
+        """Parser should extract Ventura-Sonoma as a version range."""
+        version_tokens = {'sonoma', 'ventura', 'monterey'}
+        parser = APITestExpectationParser(version_tokens=version_tokens)
+        results = parser.parse('test.txt', '[ mac Ventura-Sonoma ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(len(exp.version_specifiers), 1)
+        self.assertEqual(exp.version_specifiers[0].type, VersionSpecifier.Type.RANGE)
+        self.assertEqual(exp.version_specifiers[0].base_version, 'ventura')
+        self.assertEqual(exp.version_specifiers[0].end_version, 'sonoma')
+
+    def test_parse_version_specifier_exact(self):
+        """Parser should extract plain version name as exact version specifier."""
+        version_tokens = {'sonoma', 'ventura', 'monterey'}
+        parser = APITestExpectationParser(version_tokens=version_tokens)
+        results = parser.parse('test.txt', '[ mac Sonoma ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(len(exp.version_specifiers), 1)
+        self.assertEqual(exp.version_specifiers[0].type, VersionSpecifier.Type.EXACT)
+        self.assertEqual(exp.version_specifiers[0].base_version, 'sonoma')
+
+
+class EmptyModelTest(unittest.TestCase):
+    """Tests for empty model operations."""
+
+    def test_empty_model_get_expectation(self):
+        model = APITestExpectationsModel()
+        self.assertIsNone(model.get_expectation('NonExistent'))
+
+    def test_empty_model_get_expectation_or_pass(self):
+        model = APITestExpectationsModel()
+        result = model.get_expectation_or_pass('NonExistent')
+        self.assertIsNotNone(result)
+        self.assertIn(PASS, result.expectations)
+
+    def test_empty_model_get_skipped_tests(self):
+        model = APITestExpectationsModel()
+        all_tests = ['Test1', 'Test2', 'Test3']
+        skipped = model.get_skipped_tests(all_tests)
+        self.assertEqual(len(skipped), 0)
+
+    def test_empty_model_get_slow_tests(self):
+        model = APITestExpectationsModel()
+        all_tests = ['Test1', 'Test2', 'Test3']
+        slow = model.get_slow_tests(all_tests)
+        self.assertEqual(len(slow), 0)
+
+    def test_empty_model_all_expectations(self):
+        model = APITestExpectationsModel()
+        self.assertEqual(len(model.all_expectations()), 0)
+
+
+class LinterAllSkipTest(unittest.TestCase):
+    """Tests to verify the all_skip bug fix."""
+
+    def test_all_skip_with_single_skip_entry(self):
+        """Single unconditional skip should trigger warning."""
+        content = 'TestWebKitAPI.WTF.Test [ Skip ]'
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('skipped on all configurations' in w.message for w in warnings))
+
+    def test_all_skip_with_non_skip_entry(self):
+        """Non-skip entry should not trigger universal skip warning."""
+        content = 'TestWebKitAPI.WTF.Test [ Fail ]'
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertFalse(any('skipped on all configurations' in w.message for w in warnings))
+
+    def test_all_skip_with_mixed_entries(self):
+        """Mixed skip and non-skip for same test should not trigger warning."""
+        content = '''[ debug ] TestWebKitAPI.WTF.Test [ Skip ]
+[ release ] TestWebKitAPI.WTF.Test [ Fail ]'''
+        linter = APITestExpectationsLinter(None, content, 'test.txt')
+        warnings = linter.lint()
+        self.assertFalse(any('skipped on all configurations' in w.message for w in warnings))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1253,6 +1253,100 @@ class Port(object):
     def path_to_api_test_binaries(self):
         return {binary: self.path_to_api_test(binary) for binary in self.API_TEST_BINARY_NAMES}
 
+    def api_test_expectations_dir(self):
+        """Return the path to the APITestExpectations directory."""
+        return self._filesystem.join(self.path_from_webkit_base(), 'APITestExpectations')
+
+    def _apple_api_test_expectations_path(self, platform):
+        """Return the path to internal API test expectations for a platform."""
+        if not port_config.apple_additions():
+            return None
+        internal_base = port_config.apple_additions().layout_tests_path()
+        parent = self._filesystem.dirname(internal_base)
+        return self._filesystem.join(parent, 'APITestExpectationsForUnreleasedSoftware', platform)
+
+    def api_test_expectations_files(self):
+        """Return list of API test expectations files in cascade order."""
+        files = []
+        base = self.api_test_expectations_dir()
+
+        generic_path = self._filesystem.join(base, 'TestExpectations')
+        files.append(generic_path)
+
+        for platform_entry in self._api_test_platform_cascade():
+            if isinstance(platform_entry, tuple):
+                public_name, internal_name = platform_entry
+            else:
+                public_name = platform_entry
+                internal_name = None
+
+            platform_path = self._filesystem.join(base, 'platform', public_name, 'TestExpectations')
+            files.append(platform_path)
+
+            if internal_name and port_config.apple_additions():
+                internal_path = self._apple_api_test_expectations_path(internal_name)
+                if internal_path:
+                    files.append(self._filesystem.join(internal_path, 'TestExpectations'))
+
+        return files
+
+    def api_test_version_tokens(self):
+        """Return dict mapping version token (lowercase) to version order index.
+
+        Used by API test expectations for parsing and ordering version specifiers.
+        Subclasses should override to provide platform-specific version tokens.
+
+        Returns:
+            Dict[str, int]: Mapping of version name to its position in version order
+                            (lower index = older version)
+        """
+        return {}
+
+    def api_test_version_order(self):
+        """Return list of version names in order from oldest to newest.
+
+        Used for matching version range specifiers like 'Sonoma+' or 'Ventura-Sequoia'.
+        Subclasses should override to provide platform-specific version ordering.
+
+        Returns:
+            List[str]: Version names in chronological order (oldest first)
+        """
+        return []
+
+    def api_test_current_configuration(self):
+        """Return the current runtime configuration for matching expectations.
+
+        Returns:
+            Dict[str, Any]: Configuration values for the current run
+        """
+        config = {}
+
+        # Platform
+        config['platform'] = self.port_name.split('-')[0] if self.port_name else None
+
+        # Style (build configuration)
+        configuration = self.get_option('configuration')
+        if configuration:
+            config['style'] = configuration.lower()
+
+        # Architecture
+        if hasattr(self, 'architecture'):
+            config['architecture'] = self.architecture()
+
+        return config
+
+    def _api_test_platform_cascade(self):
+        """Return platform directories from least to most specific."""
+        cascade = []
+        port_name = self.port_name
+        if 'mac' in port_name:
+            cascade.append('mac')
+        elif 'ios' in port_name:
+            cascade.append('ios')
+            if 'simulator' in port_name:
+                cascade.append('ios-simulator')
+        return cascade
+
     def _webkit_baseline_path(self, platform):
         """Return the  full path to the top of the baseline tree for a
         given platform."""

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -111,6 +111,82 @@ class IOSPort(EmbeddedPort):
 
         return expectations
 
+    def _api_test_platform_cascade(self):
+        """Return platform directories for API test expectations cascade."""
+        cascade = []
+        version_name_map = VersionNameMap.map(self.host.platform)
+
+        internal_version_name = None
+        if apple_additions():
+            internal_version_name = version_name_map.to_name(self._os_version, platform=IOSPort.port_name, table=INTERNAL_TABLE)
+            if internal_version_name:
+                internal_version_name = internal_version_name.lower().replace(' ', '')
+
+        internal_name = 'ios-{}'.format(internal_version_name) if internal_version_name else None
+        cascade.append(('ios', internal_name))
+
+        if self._os_version:
+            public_name = 'ios-{}'.format(self._os_version.major)
+            cascade.append((public_name, internal_name))
+
+        if 'simulator' in self.SDK:
+            internal_sim_name = 'ios-{}-simulator'.format(internal_version_name) if internal_version_name else None
+            cascade.append(('ios-simulator', internal_sim_name))
+            if self._os_version:
+                public_sim_version = 'ios-simulator-{}'.format(self._os_version.major)
+                cascade.append((public_sim_version, internal_sim_name))
+
+        return cascade
+
+    def api_test_version_tokens(self):
+        """Return dict mapping version token (lowercase) to version order index."""
+        tokens = {}
+        version_name_map = VersionNameMap.map(self.host.platform)
+        versions = self._allowed_versions()
+        for idx, version in enumerate(versions):
+            for table in [PUBLIC_TABLE, INTERNAL_TABLE]:
+                version_name = version_name_map.to_name(version, platform=IOSPort.port_name, table=table)
+                if version_name:
+                    tokens[version_name.lower().replace(' ', '')] = idx
+            # Also add numeric version like 'ios17', 'ios18'
+            tokens['ios{}'.format(version.major)] = idx
+        return tokens
+
+    def api_test_version_order(self):
+        """Return list of version names in order from oldest to newest."""
+        version_order = []
+        for version in self._allowed_versions():
+            # Use numeric naming for iOS (iOS 17, iOS 18, etc.)
+            version_order.append('ios{}'.format(version.major))
+        return version_order
+
+    def api_test_current_configuration(self):
+        """Return the current runtime configuration for matching expectations."""
+        config = super(IOSPort, self).api_test_current_configuration()
+        config['platform'] = 'ios'
+
+        # Add version
+        if self._os_version:
+            config['version'] = 'ios{}'.format(self._os_version.major)
+
+        # Hardware: simulator vs device, and iphone/ipad
+        if 'simulator' in self.SDK:
+            config['hardware'] = 'simulator'
+        else:
+            config['hardware'] = 'device'
+
+        # Device type: iphone/ipad
+        if self.DEVICE_TYPE:
+            hw_family = getattr(self.DEVICE_TYPE, 'hardware_family', None)
+            if hw_family:
+                hw_family_lower = hw_family.lower()
+                if hw_family_lower == 'iphone':
+                    config['hardware_type'] = 'iphone'
+                elif hw_family_lower == 'ipad':
+                    config['hardware_type'] = 'ipad'
+
+        return config
+
     def port_adjust_environment_for_test_driver(self, env):
         env = super(IOSPort, self).port_adjust_environment_for_test_driver(env)
         env['CA_DISABLE_GENERIC_SHADERS'] = '1'

--- a/Tools/Scripts/webkitpy/port/mac.py
+++ b/Tools/Scripts/webkitpy/port/mac.py
@@ -151,6 +151,69 @@ class MacPort(DarwinPort):
             expectations.append(self._webkit_baseline_path('wk2'))
         return expectations
 
+    def _api_test_platform_cascade(self):
+        """Return platform directories for API test expectations cascade."""
+        cascade = []
+        version_name_map = VersionNameMap.map(self.host.platform)
+
+        internal_name = None
+        if apple_additions():
+            internal_name = version_name_map.to_name(self._os_version, platform=self.port_name, table=INTERNAL_TABLE)
+            if internal_name:
+                internal_name = 'mac-{}'.format(internal_name.lower().replace(' ', ''))
+        cascade.append(('mac', internal_name))
+
+        version_name = version_name_map.to_name(self._os_version, platform=self.port_name)
+        if version_name:
+            public_name = 'mac-{}'.format(version_name.lower().replace(' ', ''))
+            cascade.append((public_name, internal_name))
+
+        return cascade
+
+    def api_test_version_tokens(self):
+        """Return dict mapping version token (lowercase) to version order index."""
+        tokens = {}
+        version_name_map = VersionNameMap.map(self.host.platform)
+        versions = self._allowed_versions()
+        for idx, version in enumerate(versions):
+            for table in [PUBLIC_TABLE, INTERNAL_TABLE]:
+                version_name = version_name_map.to_name(version, platform=self.port_name, table=table)
+                if version_name:
+                    tokens[version_name.lower().replace(' ', '')] = idx
+        return tokens
+
+    def api_test_version_order(self):
+        """Return list of version names in order from oldest to newest."""
+        version_order = []
+        version_name_map = VersionNameMap.map(self.host.platform)
+        for version in self._allowed_versions():
+            version_name = version_name_map.to_name(version, platform=self.port_name)
+            if not version_name:
+                version_name = version_name_map.to_name(version, platform=self.port_name, table=INTERNAL_TABLE)
+            if version_name:
+                version_order.append(version_name.lower().replace(' ', ''))
+        return version_order
+
+    def api_test_current_configuration(self):
+        """Return the current runtime configuration for matching expectations."""
+        config = super(MacPort, self).api_test_current_configuration()
+        config['platform'] = 'mac'
+
+        # Add version
+        version_name_map = VersionNameMap.map(self.host.platform)
+        version_name = version_name_map.to_name(self._os_version, platform=self.port_name)
+        if version_name:
+            config['version'] = version_name.lower().replace(' ', '')
+
+        # Style: asan, guardmalloc, debug, release
+        if self.get_option('guard_malloc'):
+            config['style'] = 'guardmalloc'
+
+        # Hardware: always 'device' for mac (no simulator)
+        config['hardware'] = 'device'
+
+        return config
+
     @memoized
     def configuration_specifier_macros(self):
         config_map = {}


### PR DESCRIPTION
#### f72b83b015607bf270e8f5558135db87de0c54ed
<pre>
[ WIP ] add expectations to api-tests
<a href="https://rdar.apple.com/169154912">rdar://169154912</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306499">https://bugs.webkit.org/show_bug.cgi?id=306499</a>

Reviewed by NOBODY (OOPS!).

* APITestExpectations/TestExpectations: Added.
* Tools/Scripts/run-api-tests:
(main):
(lint_expectations):
(print_expectations):
(print_summary):
(parse_args):
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager.__init__):
(Manager._test_list_from_output):
(Manager):
(Manager.collect_tests_by_binary):
(Manager._find_test_subset):
(Manager._collect_tests):
(Manager._load_expectations):
(Manager._get_current_configuration):
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner.__init__):
(_Worker._run_single_test):
* Tools/Scripts/webkitpy/api_tests/test_expectations.py: Added.
(ConfigurationCategory):
(VersionSpecifier):
(VersionSpecifier.Type):
(VersionSpecifier.__init__):
(VersionSpecifier.parse):
(VersionSpecifier.matches):
(VersionSpecifier.__repr__):
(get_token_category):
(runner_status_to_expectation):
(ParseError):
(ParseError.__init__):
(ParseError.__str__):
(ExpectationWarning):
(ExpectationWarning.__init__):
(ExpectationWarning.__str__):
(APITestExpectation):
(APITestExpectation.__init__):
(APITestExpectation.is_wildcard):
(APITestExpectation.is_skip):
(APITestExpectation.is_slow):
(APITestExpectation.get_timeout):
(APITestExpectation.is_flaky):
(APITestExpectation.matches_test):
(APITestExpectation.matches_configuration):
(APITestExpectation.result_is_expected):
(APITestExpectation.__repr__):
(APITestExpectationParser):
(APITestExpectationParser.__init__):
(APITestExpectationParser.parse):
(APITestExpectationParser._parse_line):
(APITestExpectationsModel):
(APITestExpectationsModel.__init__):
(APITestExpectationsModel.add_expectation):
(APITestExpectationsModel.get_expectation):
(APITestExpectationsModel.get_expectation_or_pass):
(APITestExpectationsModel.get_skipped_tests):
(APITestExpectationsModel.get_slow_tests):
(APITestExpectationsModel.all_expectations):
(APITestExpectations):
(APITestExpectations.__init__):
(APITestExpectations.model):
(APITestExpectations.warnings):
(APITestExpectations.parse_all_expectations):
(APITestExpectations._parse_file):
(APITestExpectations._expectations_files):
(APITestExpectations._api_test_expectations_dir):
(APITestExpectations._platform_cascade):
(APITestExpectations.get_current_configuration):
(APITestExpectations.lint):
(LintWarning):
(LintWarning.__init__):
(LintWarning.__str__):
(LineFix):
(LineFix.__init__):
(APITestExpectationsLinter):
(APITestExpectationsLinter.__init__):
(APITestExpectationsLinter.lint):
(APITestExpectationsLinter.get_fixes):
(APITestExpectationsLinter.apply_fixes):
(APITestExpectationsLinter._parse_all_lines):
(APITestExpectationsLinter._check_category_ordering):
(APITestExpectationsLinter._check_alphabetical_ordering):
(APITestExpectationsLinter._check_combination_collapse):
(APITestExpectationsLinter._check_universal_skip):
(APITestExpectationsLinter._add_reorder_fix):
(APITestExpectationsLinter._add_reorder_fix.sort_key):
(APITestExpectationsLinter._add_collapse_fix):
* Tools/Scripts/webkitpy/api_tests/test_expectations_unittest.py: Added.
(APITestExpectationParserTest):
(APITestExpectationParserTest.setUp):
(APITestExpectationParserTest.test_parse_simple_failure):
(APITestExpectationParserTest.test_parse_multiple_expectations):
(APITestExpectationParserTest.test_parse_with_bug_id):
(APITestExpectationParserTest.test_parse_with_bug_parenthesis):
(APITestExpectationParserTest.test_parse_skip):
(APITestExpectationParserTest.test_parse_slow):
(APITestExpectationParserTest.test_parse_slow_with_custom_timeout):
(APITestExpectationParserTest.test_parse_slow_with_custom_timeout_no_s):
(APITestExpectationParserTest.test_parse_slow_timeout_too_large):
(APITestExpectationParserTest.test_parse_slow_timeout_zero):
(APITestExpectationParserTest.test_parse_configuration_debug):
(APITestExpectationParserTest.test_parse_configuration_release_arm64):
(APITestExpectationParserTest.test_parse_comment_line):
(APITestExpectationParserTest.test_parse_empty_line):
(APITestExpectationParserTest.test_parse_inline_comment):
(APITestExpectationParserTest.test_parse_wildcard):
(APITestExpectationParserTest.test_parse_error_missing_bracket):
(APITestExpectationParserTest.test_parse_error_skip_with_other_expectations):
(APITestExpectationParserTest.test_parse_error_slow_and_timeout):
(APITestExpectationParserTest.test_parse_multiline):
(APITestExpectationTest):
(APITestExpectationTest.test_matches_test_exact):
(APITestExpectationTest.test_matches_test_wildcard):
(APITestExpectationTest.test_matches_configuration_empty):
(APITestExpectationTest.test_matches_configuration_single):
(APITestExpectationTest.test_matches_configuration_multiple):
(APITestExpectationTest.test_result_is_expected_pass):
(APITestExpectationTest.test_result_is_expected_flaky):
(APITestExpectationTest.test_result_is_expected_skip):
(APITestExpectationTest.test_get_timeout_default):
(APITestExpectationTest.test_get_timeout_slow):
(APITestExpectationTest.test_get_timeout_custom):
(APITestExpectationsModelTest):
(APITestExpectationsModelTest.test_add_and_get_expectation):
(APITestExpectationsModelTest.test_get_expectation_not_found):
(APITestExpectationsModelTest.test_wildcard_matching):
(APITestExpectationsModelTest.test_exact_overrides_wildcard):
(APITestExpectationsModelTest.test_more_specific_wildcard_wins):
(APITestExpectationsModelTest.test_get_skipped_tests):
(APITestExpectationsModelTest.test_get_slow_tests):
(APITestExpectationsModelTest.test_configuration_filtering):
(APITestExpectationsModelTest.test_get_expectation_or_pass):
(VersionSpecifierTest):
(VersionSpecifierTest.test_parse_exact_version):
(VersionSpecifierTest.test_parse_and_later):
(VersionSpecifierTest.test_parse_and_earlier):
(VersionSpecifierTest.test_parse_range):
(VersionSpecifierTest.test_matches_exact):
(VersionSpecifierTest.test_matches_and_later):
(VersionSpecifierTest.test_matches_and_earlier):
(VersionSpecifierTest.test_matches_range):
(ConfigurationCategoryTest):
(ConfigurationCategoryTest.test_get_token_category_platform):
(ConfigurationCategoryTest.test_get_token_category_style):
(ConfigurationCategoryTest.test_get_token_category_hardware):
(ConfigurationCategoryTest.test_get_token_category_architecture):
(ConfigurationCategoryTest.test_get_token_category_version_specifier):
(ConfigurationCategoryTest.test_get_token_category_version_token):
(ConfigurationCategoryTest.test_get_token_category_flavor):
(ConfigurationCategoryTest.test_category_ordering):
(RadarBugTest):
(RadarBugTest.test_parse_radar_simple):
(RadarBugTest.test_parse_radar_with_problem):
(RadarBugTest.test_parse_radar_invalid_format):
(RadarBugTest.test_parse_multiple_bugs):
(FlavorTokenTest):
(FlavorTokenTest.test_parse_flavor_wk1):
(FlavorTokenTest.test_parse_flavor_wk2):
(FlavorTokenTest.test_parse_flavor_siteisolation):
(FlavorTokenTest.test_parse_combined_config_and_flavor):
(LinterTest):
(LinterTest.test_lint_category_ordering):
(LinterTest.test_lint_correct_category_ordering):
(LinterTest.test_lint_alphabetical_ordering_within_category):
(LinterTest.test_lint_combination_collapse):
(test_lint_universal_skip):
(test_apply_fixes_reorder):
(test_no_warnings_for_valid_file):
* Tools/Scripts/webkitpy/port/base.py:
(Port.api_test_expectations_dir):
(Port):
(Port._apple_api_test_expectations_path):
(Port.api_test_expectations_files):
(Port.api_test_version_tokens):
(Port.api_test_version_order):
(Port.api_test_current_configuration):
(Port._api_test_platform_cascade):
* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort._api_test_platform_cascade):
(IOSPort):
(IOSPort.api_test_version_tokens):
(IOSPort.api_test_version_order):
(IOSPort.api_test_current_configuration):
* Tools/Scripts/webkitpy/port/mac.py:
(MacPort._api_test_platform_cascade):
(MacPort):
(MacPort.api_test_version_tokens):
(MacPort.api_test_version_order):
(MacPort.api_test_current_configuration):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f72b83b015607bf270e8f5558135db87de0c54ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94492 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6db72833-278b-49eb-8887-b826e5533c87) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108630 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78628 "6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33686f63-4928-4980-a40e-a3c69ef61813) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11179 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126526 "Found 143 new API test failures: TestWebKitAPI.NowPlayingTest.DISABLED_AudioElement, TestWebKitAPI.ResourceLoadStatistics.DISABLED_MigrateDataFromIncorrectCreateTableSchema, TestWebKitAPI.MediaSessionCoordinatorTest.DISABLED_JoinAndLeave, TestWebKitAPI.ResourceLoadStatistics.DISABLED_MigrateDistinctDataFromTableWithMissingIndexes, TestWebKitAPI.VideoControlsManager.DISABLED_VideoControlsManagerMultipleVideosShowControlsForLastInteractedVideo, TestWebKitAPI.ShareableBitmap.DISABLED_ensureCOWBothMapsROSenderWrite, TestWebKitAPI.NowPlayingControlsTests.DISABLED_NowPlayingUpdatesThrottled, TestWebKitAPI.HSTS.DISABLED_ThirdParty, TestWebKitAPI.AudioRoutingArbitration.DISABLED_Basic, TestWebKitAPI.MediaSessionTest.DISABLED_OnlyOneHandler ... (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89539 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c2285b4-c1c4-45f1-bd99-162dc895c47b) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/140738 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10751 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8373 "Found 155 new API test failures: TestWebKitAPI.NowPlayingTest.DISABLED_AudioElement, TestWebKitAPI.ResourceLoadStatistics.DISABLED_MigrateDataFromIncorrectCreateTableSchema, TestWebKitAPI.MediaSessionCoordinatorTest.DISABLED_JoinAndLeave, TestWebKitAPI.ResourceLoadStatistics.DISABLED_MigrateDistinctDataFromTableWithMissingIndexes, TestWebKitAPI.VideoControlsManager.DISABLED_VideoControlsManagerMultipleVideosShowControlsForLastInteractedVideo, TestWebKitAPI.ShareableBitmap.DISABLED_ensureCOWBothMapsROSenderWrite, TestWebKitAPI.NowPlayingControlsTests.DISABLED_NowPlayingUpdatesThrottled, TestWebKitAPI.HSTS.DISABLED_ThirdParty, TestWebKitAPI.AudioRoutingArbitration.DISABLED_Basic, TestWebKitAPI.MediaSessionTest.DISABLED_OnlyOneHandler ... (failure)") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122283 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; run-api-tests (failure); re-run-api-tests (failure); Compiled WebKit (warnings); run-api-tests-without-change (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152364 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13468 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116737 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117068 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13119 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123184 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68666 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13510 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2524 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13247 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13447 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13293 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->