### PR TITLE
[GFC] Add some initial logic for computing grid item used minimum sizes.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -41,6 +41,9 @@ LayoutUnit computeGapValue(const Style::GapGutter&);
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit columnsSize);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
 
+LayoutUnit usedInlineMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit columnsSize);
+LayoutUnit usedBlockMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
+
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSizes&, LayoutUnit gap);
 


### PR DESCRIPTION
#### 941a729b4b0d30e3b761cb7d39fad05e19da4c42
<pre>
[GFC] Add some initial logic for computing grid item used minimum sizes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306501">https://bugs.webkit.org/show_bug.cgi?id=306501</a>
<a href="https://rdar.apple.com/169155238">rdar://169155238</a>

Reviewed by Brandon Stewart.

We currently have some helper functions that help us resolve the used
preferred size for grid items in both dimensions. We will need to have a
similar set of functions for the minimum sizes. This patch serves as a
first step towards supporting that functionality by adding some initial
code that we can build upon.

The main function that callers will use is used{Inline,Block}MinimumSize
whenever they need to get the minimum size for a grid item. For some
cases, such as fixed and percentages, this is fairly straightforward to
resolve. The more interesting bit will be the automatic sizes since the
grid spec defines an algorithm to be used to figure out these automatic
sizes.

In this patch we add the two main helper functions that have an
implementation for resolving the sizes in the fixed, percentage, and
calculated cases since this is fairly straightforward. For the auto case
we also add some additional skeleton utility functions that will be
populated over time to properly resolve the auto sizes. The skeleton
follows the outline of the steps defined in:
<a href="https://drafts.csswg.org/css-grid-1/#min-size-auto">https://drafts.csswg.org/css-grid-1/#min-size-auto</a>

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::containsAutoMinTrackSizingFunction):
(WebCore::Layout::GridLayoutUtils::containsFlexMaxTrackSizingFunction):
(WebCore::Layout::GridLayoutUtils::hasScrollableInlineOverflow):
(WebCore::Layout::GridLayoutUtils::hasScrollableBlockOverflow):
These set of functions are primarily used to determine whether or not
the grid item has a non-zero automatic minimum size as defined by the
set of requirements at the beginning of 6.6 of the spec.

(WebCore::Layout::GridLayoutUtils::inlineSpecifiedSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::inlineTransferredSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::inlineContentSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::blockSpecifiedSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::blockTransferredSizeSuggestion):
(WebCore::Layout::GridLayoutUtils::blockContentSizeSuggestion):
These six functions are used to help determine what the &quot;content-based
minimum size,&quot; will be since it will need to be one of these values
depending on the axis.

Canonical link: <a href="https://commits.webkit.org/306456@main">https://commits.webkit.org/306456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d45fcd8062bf54e8fa3dc747a220267b1c575cc6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149964 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42e1c474-9665-4ed8-9e29-64956f4122c6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11171 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89532 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95d51b7e-20e1-4c3f-9c61-8d6d500fd266) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8367 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/36 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152356 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13461 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116732 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117063 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13128 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68659 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13503 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13240 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13440 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/13329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->