### PR TITLE
Further reduce use of protected member functions in Source/WebKit

### DIFF
--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -84,7 +84,6 @@ public:
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess); }
 
     IPC::Connection& connection() { return m_connection.get(); }
-    Ref<IPC::Connection> protectedConnection() { return m_connection; }
     IPC::MessageReceiverMap& messageReceiverMap() { return m_messageReceiverMap; }
     ModelProcess& modelProcess() { return m_modelProcess.get(); }
     WebCore::ProcessIdentifier webProcessIdentifier() const { return m_webProcessIdentifier; }

--- a/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp
@@ -69,7 +69,7 @@ void ModelProcessModelPlayerManagerProxy::createModelPlayer(WebCore::ModelPlayer
     ASSERT(m_modelConnectionToWebProcess);
     ASSERT(!m_proxies.contains(identifier));
 
-    auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, m_modelConnectionToWebProcess->protectedConnection(), m_modelConnectionToWebProcess->attributionTaskID(), m_modelConnectionToWebProcess->debugEntityMemoryLimit());
+    auto proxy = ModelProcessModelPlayerProxy::create(*this, identifier, protect(m_modelConnectionToWebProcess->connection()), m_modelConnectionToWebProcess->attributionTaskID(), m_modelConnectionToWebProcess->debugEntityMemoryLimit());
     m_proxies.add(identifier, WTF::move(proxy));
 }
 

--- a/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -52,7 +52,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
     WeakPtr weakThis { *this };
     // The following xpc event handler overwrites the boostrap event handler and is only used
     // to capture client certificate credential.
-    xpc_connection_set_event_handler(connection->protectedXPCConnection().get(), ^(xpc_object_t event) {
+    xpc_connection_set_event_handler(protect(connection->xpcConnection()).get(), ^(xpc_object_t event) {
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
         handleXPCExitMessage(event);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -302,13 +302,13 @@ bool NetworkConnectionToWebProcess::dispatchMessage(IPC::Connection& connection,
 #endif
 #if USE(LIBWEBRTC)
     if (decoder.messageReceiverName() == Messages::NetworkRTCMonitor::messageReceiverName()) {
-        protectedRTCProvider()->didReceiveNetworkRTCMonitorMessage(connection, decoder);
+        protect(rtcProvider())->didReceiveNetworkRTCMonitorMessage(connection, decoder);
         return true;
     }
 #endif
 #if ENABLE(WEB_RTC)
     if (decoder.messageReceiverName() == Messages::NetworkMDNSRegister::messageReceiverName()) {
-        protectedMDNSRegister()->didReceiveMessage(connection, decoder);
+        protect(mdnsRegister())->didReceiveMessage(connection, decoder);
         return true;
     }
 #endif
@@ -409,13 +409,13 @@ void NetworkConnectionToWebProcess::registerToRTCDataChannelProxy()
     if (m_isRegisteredToRTCDataChannelProxy)
         return;
     m_isRegisteredToRTCDataChannelProxy = true;
-    m_networkProcess->protectedRTCDataChannelProxy()->registerConnectionToWebProcess(*this);
+    protect(m_networkProcess->rtcDataChannelProxy())->registerConnectionToWebProcess(*this);
 }
 
 void NetworkConnectionToWebProcess::unregisterToRTCDataChannelProxy()
 {
     if (m_isRegisteredToRTCDataChannelProxy)
-        m_networkProcess->protectedRTCDataChannelProxy()->unregisterConnectionToWebProcess(*this);
+        protect(m_networkProcess->rtcDataChannelProxy())->unregisterConnectionToWebProcess(*this);
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -268,7 +268,6 @@ public:
 
 #if ENABLE(WEB_RTC)
     NetworkMDNSRegister& mdnsRegister() { return m_mdnsRegister; }
-    Ref<NetworkMDNSRegister> protectedMDNSRegister() { return m_mdnsRegister; }
 #if PLATFORM(COCOA)
     bool webRTCInterfaceMonitoringViaNWEnabled() const { return m_sharedPreferencesForWebProcess.webRTCInterfaceMonitoringViaNWEnabled; }
 #endif
@@ -385,7 +384,6 @@ private:
 
 #if USE(LIBWEBRTC)
     NetworkRTCProvider& rtcProvider();
-    Ref<NetworkRTCProvider> protectedRTCProvider() { return rtcProvider(); }
 #endif
 #if ENABLE(WEB_RTC)
     void registerToRTCDataChannelProxy();

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -156,7 +156,6 @@ private:
 #endif
 
     RefPtr<NetworkCORSPreflightChecker> protectedCORSPreflightChecker() const;
-    RefPtr<WebCore::SecurityOrigin> protectedOrigin() const { return m_origin; }
     RefPtr<WebCore::SecurityOrigin> parentOrigin() const { return m_parentOrigin; }
 
     bool checkTAO(const WebCore::ResourceResponse&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3219,11 +3219,6 @@ RTCDataChannelRemoteManagerProxy& NetworkProcess::rtcDataChannelProxy()
         m_rtcDataChannelProxy = RTCDataChannelRemoteManagerProxy::create(*this);
     return *m_rtcDataChannelProxy;
 }
-
-Ref<RTCDataChannelRemoteManagerProxy> NetworkProcess::protectedRTCDataChannelProxy()
-{
-    return rtcDataChannelProxy();
-}
 #endif
 
 void NetworkProcess::addWebPageNetworkParameters(PAL::SessionID sessionID, WebPageProxyIdentifier pageID, WebPageNetworkParameters&& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -177,12 +177,6 @@ public:
     }
 
     template<typename T>
-    RefPtr<T> protectedSupplement()
-    {
-        return supplement<T>();
-    }
-
-    template<typename T>
     void addSupplement()
     {
         m_supplements.add(T::supplementName(), makeUnique<T>(*this));
@@ -436,7 +430,6 @@ public:
 
 #if ENABLE(WEB_RTC)
     RTCDataChannelRemoteManagerProxy& rtcDataChannelProxy();
-    Ref<RTCDataChannelRemoteManagerProxy> protectedRTCDataChannelProxy();
 #endif
 
     bool ftpEnabled() const { return m_ftpEnabled; }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1704,7 +1704,7 @@ void NetworkResourceLoader::didRetrieveCacheEntry(std::unique_ptr<NetworkCache::
     response = sanitizeResponseIfPossible(WTF::move(response), ResourceResponse::SanitizationType::CrossOriginSafe);
     if (isSynchronous()) {
         m_synchronousLoadData->response = WTF::move(response);
-        sendReplyToSynchronousRequest(*m_synchronousLoadData, entry->protectedBuffer().get(), { });
+        sendReplyToSynchronousRequest(*m_synchronousLoadData, protect(entry->buffer()).get(), { });
         cleanup(LoadResult::Success);
         return;
     }
@@ -1752,7 +1752,7 @@ void NetworkResourceLoader::sendResultForCacheEntry(std::unique_ptr<NetworkCache
 #if ENABLE(SHAREABLE_RESOURCE)
     if (auto handle = entry->shareableResourceHandle()) {
 #if ENABLE(CONTENT_FILTERING)
-        if (contentFilter && !contentFilter->continueAfterDataReceived(entry->protectedBuffer()->makeContiguous())) {
+        if (contentFilter && !contentFilter->continueAfterDataReceived(protect(entry->buffer())->makeContiguous())) {
             contentFilter->continueAfterNotifyFinished(m_parameters.request.url());
             contentFilter->stopFilteringMainResource();
             dispatchDidFinishResourceLoad();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -91,7 +91,6 @@ public:
 
 #if PLATFORM(COCOA)
     dispatch_data_t dispatchData() const { return m_dispatchData.get(); }
-    OSObjectPtr<dispatch_data_t> protectedDispatchData() const;
     Data copyData() const;
 #endif
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -201,11 +201,6 @@ WebCore::FragmentedSharedBuffer* Entry::buffer() const
     return m_buffer.get();
 }
 
-RefPtr<WebCore::FragmentedSharedBuffer> Entry::protectedBuffer() const
-{
-    return buffer();
-}
-
 #if ENABLE(SHAREABLE_RESOURCE)
 std::optional<WebCore::ShareableResource::Handle> Entry::shareableResourceHandle() const
 {

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h
@@ -59,7 +59,6 @@ public:
     const Vector<std::pair<String, String>>& varyingRequestHeaders() const { return m_varyingRequestHeaders; }
 
     WebCore::FragmentedSharedBuffer* buffer() const;
-    RefPtr<WebCore::FragmentedSharedBuffer> protectedBuffer() const;
     const std::optional<WebCore::ResourceRequest>& redirectRequest() const { return m_redirectRequest; }
 
 #if ENABLE(SHAREABLE_RESOURCE)

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -146,7 +146,7 @@ void LaunchServicesDatabaseObserver::handleEvent(xpc_connection_t connection, xp
 
 void LaunchServicesDatabaseObserver::initializeConnection(IPC::Connection* connection)
 {
-    sendEndpointToConnection(connection->protectedXPCConnection().get());
+    sendEndpointToConnection(protect(connection->xpcConnection()).get());
 }
 
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1235,7 +1235,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if ENABLE(LEGACY_CUSTOM_PROTOCOL_MANAGER)
-    networkProcess.protectedSupplement<LegacyCustomProtocolManager>()->registerProtocolClass(configuration.get());
+    protect(networkProcess.supplement<LegacyCustomProtocolManager>())->registerProtocolClass(configuration.get());
 #endif
 
     configuration.get()._timingDataOptions = _TimingDataOptionsEnableW3CNavigationTiming;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -80,7 +80,6 @@ protected:
 
     bool isAlwaysOnLoggingAllowed() const { return m_isAlwaysOnLoggingAllowed; }
     virtual NSURLSessionTask* task() const = 0;
-    RetainPtr<NSURLSessionTask> protectedTask() const;
     virtual WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const = 0;
 
 private:

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -111,7 +111,7 @@ static void registerMDNSNameCallback(DNSServiceRef service, DNSRecordRef record,
     MDNS_RELEASE_LOG_IN_CALLBACK(request->sessionID, "registerMDNSNameCallback with error %d", errorCode);
 
     if (errorCode) {
-        request->connection->protectedMDNSRegister()->closeAndForgetService(service);
+        protect(request->connection->mdnsRegister())->closeAndForgetService(service);
         request->completionHandler(request->name, WebCore::MDNSRegisterError::DNSSD);
         return;
     }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -185,7 +185,7 @@ void NetworkRTCProvider::createResolver(LibWebRTCResolverIdentifier identifier, 
     }
 
     RefPtr connection = m_connection.get();
-    if (connection && connection->protectedMDNSRegister()->hasRegisteredName(address)) {
+    if (connection && protect(connection->mdnsRegister())->hasRegisteredName(address)) {
         Vector<WebKit::WebRTCNetwork::IPAddress> ipAddresses;
         Ref rtcMonitor = m_rtcMonitor;
         if (!rtcMonitor->ipv4().isUnspecified())

--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1276,7 +1276,7 @@ void Connection::dispatchSyncMessage(Decoder& decoder)
         } else
             decoder.markInvalid();
     } else
-        protectedClient()->didReceiveSyncMessage(*this, decoder, replyEncoder);
+        protect(client())->didReceiveSyncMessage(*this, decoder, replyEncoder);
 
     // If the message was not handled, i.e. replyEncoder was not consumed, reply with cancel
     // message. We do not distinquish between a decode failure and failure to find a
@@ -1294,7 +1294,7 @@ void Connection::dispatchDidReceiveInvalidMessage(MessageName messageName, const
     dispatchToClient([protectedThis = Ref { *this }, messageName, indicesOfObjectsFailingDecoding] {
         if (!protectedThis->isValid())
             return;
-        protectedThis->protectedClient()->didReceiveInvalidMessage(protectedThis, messageName, indicesOfObjectsFailingDecoding);
+        protect(protectedThis->client())->didReceiveInvalidMessage(protectedThis, messageName, indicesOfObjectsFailingDecoding);
     });
 }
 
@@ -1443,7 +1443,7 @@ void Connection::dispatchMessage(UniqueRef<Decoder> message)
             if (m_ignoreInvalidMessageForTesting)
                 return;
 #endif
-            protectedClient()->didReceiveInvalidMessage(*this, message->messageName(), message->indicesOfObjectsFailingDecoding());
+            protect(client())->didReceiveInvalidMessage(*this, message->messageName(), message->indicesOfObjectsFailingDecoding());
             return;
         }
         m_inDispatchMessageMarkedToUseFullySynchronousModeForTesting++;
@@ -1489,7 +1489,7 @@ void Connection::dispatchMessage(UniqueRef<Decoder> message)
         return;
 #endif
     if (didReceiveInvalidMessage && isValid())
-        protectedClient()->didReceiveInvalidMessage(*this, message->messageName(), message->indicesOfObjectsFailingDecoding());
+        protect(client())->didReceiveInvalidMessage(*this, message->messageName(), message->indicesOfObjectsFailingDecoding());
 }
 
 size_t Connection::numberOfMessagesToProcess(size_t totalMessages)

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -340,7 +340,6 @@ public:
 
 #if OS(DARWIN)
     xpc_connection_t xpcConnection() const { return m_xpcConnection.get(); }
-    OSObjectPtr<xpc_connection_t> protectedXPCConnection() const { return xpcConnection(); }
     std::optional<audit_token_t> getAuditToken();
     pid_t remoteProcessID() const;
 #endif
@@ -362,7 +361,6 @@ public:
     ~Connection();
 
     Client* client() const { return m_client.get(); }
-    RefPtr<Client> protectedClient() const { return m_client.get(); }
 
     enum UniqueIDType { };
     using UniqueID = AtomicObjectIdentifier<UniqueIDType>;
@@ -960,7 +958,7 @@ template<typename T> Error Connection::waitForAndDispatchImmediately(uint64_t de
         return Error::InvalidConnection;
 
     ASSERT(decoderOrError.value()->destinationID() == destinationID);
-    protectedClient()->didReceiveMessage(*this, decoderOrError.value());
+    protect(client())->didReceiveMessage(*this, decoderOrError.value());
     return Error::NoError;
 }
 

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -218,7 +218,7 @@ bool StreamServerConnection::processStreamMessage(Decoder& decoder, StreamMessag
     if (decoder.isSyncMessage()) {
         result = m_buffer.releaseAll();
         if (m_syncReplyToDispatch)
-            protectedConnection()->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTF::move(m_syncReplyToDispatch)));
+            protect(connection())->sendSyncReply(makeUniqueRefFromNonNullUniquePtr(WTF::move(m_syncReplyToDispatch)));
     } else
         result = m_buffer.release(decoder.currentBufferOffset());
     if (result == WakeUpClient::Yes)

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -98,7 +98,6 @@ public:
     void stopReceivingMessages(ReceiverName, uint64_t destinationID);
 
     Connection& connection() { return m_connection; }
-    Ref<Connection> protectedConnection() { return m_connection; }
 
     enum DispatchResult : bool {
         HasNoMessages,

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -83,7 +83,6 @@ public:
 
     void setRootLayer(CALayer *);
     CALayer *rootLayer() const;
-    RetainPtr<CALayer> protectedRootLayer() const;
 
     LayerHostingContextID contextID() const;
     void invalidate();

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -125,11 +125,6 @@ CALayer *LayerHostingContext::rootLayer() const
     return [m_context layer];
 }
 
-RetainPtr<CALayer> LayerHostingContext::protectedRootLayer() const
-{
-    return rootLayer();
-}
-
 LayerHostingContextID LayerHostingContext::contextID() const
 {
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm
@@ -130,7 +130,7 @@ void LayerHostingContextManager::setVideoLayerSizeIfPossible()
     // We do not want animations here.
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
-    [m_inlineLayerHostingContext->protectedRootLayer() setFrame:CGRectMake(0, 0, m_videoLayerSize.width(), m_videoLayerSize.height())];
+    [protect(m_inlineLayerHostingContext->rootLayer()) setFrame:CGRectMake(0, 0, m_videoLayerSize.width(), m_videoLayerSize.height())];
     [CATransaction commit];
 }
 

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -145,7 +145,7 @@ void AuxiliaryProcess::didReceiveInvalidMessage(IPC::Connection&, IPC::MessageNa
 
 bool AuxiliaryProcess::parentProcessHasEntitlement(ASCIILiteral entitlement)
 {
-    return WTF::hasEntitlement(protect(parentProcessConnection())->protectedXPCConnection().get(), entitlement);
+    return WTF::hasEntitlement(protect(protect(parentProcessConnection())->xpcConnection()).get(), entitlement);
 }
 
 void AuxiliaryProcess::platformStopRunLoop()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp
@@ -57,7 +57,7 @@ Ref<WebCore::WebGPU::BindGroupLayout> RemoteComputePipelineProxy::getBindGroupLa
     auto sendResult = send(Messages::RemoteComputePipeline::GetBindGroupLayout(index, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteBindGroupLayoutProxy::create(m_parent->protectedRoot(), m_convertToBackingContext, identifier);
+    return RemoteBindGroupLayoutProxy::create(protect(m_parent->root()), m_convertToBackingContext, identifier);
 }
 
 void RemoteComputePipelineProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp
@@ -152,7 +152,7 @@ RefPtr<WebCore::WebGPU::Texture> RemoteDeviceProxy::createTexture(const WebCore:
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteTextureProxy::create(protectedRoot(), m_convertToBackingContext, identifier);
+    auto result = RemoteTextureProxy::create(protect(root()), m_convertToBackingContext, identifier);
     result->setLabel(WTF::move(convertedDescriptor->label));
     return result;
 }
@@ -225,7 +225,7 @@ RefPtr<WebCore::WebGPU::BindGroupLayout> RemoteDeviceProxy::createBindGroupLayou
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteBindGroupLayoutProxy::create(protectedRoot(), m_convertToBackingContext, identifier);
+    auto result = RemoteBindGroupLayoutProxy::create(protect(root()), m_convertToBackingContext, identifier);
     result->setLabel(WTF::move(convertedDescriptor->label));
     return result;
 }
@@ -367,7 +367,7 @@ RefPtr<WebCore::WebGPU::CommandEncoder> RemoteDeviceProxy::createCommandEncoder(
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteCommandEncoderProxy::create(protectedRoot(), m_convertToBackingContext, identifier);
+    auto result = RemoteCommandEncoderProxy::create(protect(root()), m_convertToBackingContext, identifier);
     if (convertedDescriptor)
         result->setLabel(WTF::move(convertedDescriptor->label));
     return result;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -55,7 +55,6 @@ public:
 
     RemoteAdapterProxy& parent() const { return m_parent; }
     RemoteGPUProxy& root() { return m_parent->root(); }
-    Ref<RemoteGPUProxy> protectedRoot() { return m_parent->root(); }
     WebGPUIdentifier backing() const { return m_backing; }
 
 private:

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp
@@ -77,7 +77,7 @@ RefPtr<WebCore::WebGPU::Texture> RemotePresentationContextProxy::getCurrentTextu
         if (sendResult != IPC::Error::NoError)
             return nullptr;
 
-        m_currentTexture[frameIndex] = RemoteTextureProxy::create(protectedRoot(), m_convertToBackingContext, identifier, true);
+        m_currentTexture[frameIndex] = RemoteTextureProxy::create(protect(root()), m_convertToBackingContext, identifier, true);
     } else
         RefPtr { m_currentTexture[frameIndex] }->undestroy();
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -55,7 +55,6 @@ public:
 
     RemoteGPUProxy& parent() const { return m_parent; }
     RemoteGPUProxy& root() { return m_parent->root(); }
-    Ref<RemoteGPUProxy> protectedRoot() { return m_parent->root(); }
 
     void present(uint32_t frameIndex, bool = false) final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp
@@ -57,7 +57,7 @@ Ref<WebCore::WebGPU::BindGroupLayout> RemoteRenderPipelineProxy::getBindGroupLay
     auto sendResult = send(Messages::RemoteRenderPipeline::GetBindGroupLayout(index, identifier));
     UNUSED_VARIABLE(sendResult);
 
-    return RemoteBindGroupLayoutProxy::create(m_parent->protectedRoot(), m_convertToBackingContext, identifier);
+    return RemoteBindGroupLayoutProxy::create(protect(m_parent->root()), m_convertToBackingContext, identifier);
 }
 
 void RemoteRenderPipelineProxy::setLabelInternal(const String& label)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp
@@ -62,7 +62,7 @@ RefPtr<WebCore::WebGPU::XRProjectionLayer> RemoteXRBindingProxy::createProjectio
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteXRProjectionLayerProxy::create(protectedRoot(), m_convertToBackingContext, identifier);
+    auto result = RemoteXRProjectionLayerProxy::create(protect(root()), m_convertToBackingContext, identifier);
     return result;
 }
 
@@ -79,7 +79,7 @@ RefPtr<WebCore::WebGPU::XRSubImage> RemoteXRBindingProxy::getViewSubImage(WebCor
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    auto result = RemoteXRSubImageProxy::create(protectedRoot(), m_convertToBackingContext, identifier);
+    auto result = RemoteXRSubImageProxy::create(protect(root()), m_convertToBackingContext, identifier);
     return result;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
@@ -60,7 +60,6 @@ public:
 
     RemoteDeviceProxy& parent() const { return m_parent; }
     RemoteGPUProxy& root() { return m_parent->root(); }
-    Ref<RemoteGPUProxy> protectedRoot() { return m_parent->root(); }
 
 private:
     friend class DowncastConvertToBackingContext;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.cpp
@@ -62,7 +62,7 @@ RefPtr<WebCore::WebGPU::Texture> RemoteXRSubImageProxy::colorTexture()
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    lazyInitialize(m_currentTexture, RemoteTextureProxy::create(protectedRoot(), m_convertToBackingContext, identifier));
+    lazyInitialize(m_currentTexture, RemoteTextureProxy::create(protect(root()), m_convertToBackingContext, identifier));
     return m_currentTexture;
 }
 
@@ -76,7 +76,7 @@ RefPtr<WebCore::WebGPU::Texture> RemoteXRSubImageProxy::depthStencilTexture()
     if (sendResult != IPC::Error::NoError)
         return nullptr;
 
-    lazyInitialize(m_currentDepthTexture, RemoteTextureProxy::create(protectedRoot(), m_convertToBackingContext, identifier));
+    lazyInitialize(m_currentDepthTexture, RemoteTextureProxy::create(protect(root()), m_convertToBackingContext, identifier));
     return m_currentDepthTexture;
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
@@ -56,7 +56,6 @@ public:
 
     RemoteGPUProxy& parent() { return m_parent; }
     RemoteGPUProxy& root() { return m_parent; }
-    Ref<RemoteGPUProxy> protectedRoot() { return m_parent; }
 
 private:
     friend class DowncastConvertToBackingContext;

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -205,7 +205,6 @@ private:
     // Logger
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     ASCIILiteral logClassName() const final { return "AudioVideoRendererRemote"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -239,7 +239,7 @@ void MediaPlayerPrivateRemote::prepareForPlayback(bool privateMode, MediaPlayer:
     auto pitchCorrectionAlgorithm = player->pitchCorrectionAlgorithm();
     auto isFullscreen = player->isInFullscreenOrPictureInPicture();
 
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PrepareForPlayback(privateMode, preload, preservesPitch, pitchCorrectionAlgorithm, prepareToPlay, prepareToRender, presentationSize, scale, isFullscreen, preferredDynamicRangeMode, platformDynamicRangeLimit), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::PrepareForPlayback(privateMode, preload, preservesPitch, pitchCorrectionAlgorithm, prepareToPlay, prepareToRender, presentationSize, scale, isFullscreen, preferredDynamicRangeMode, platformDynamicRangeLimit), m_id);
 }
 
 void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
@@ -251,7 +251,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
 
         auto createExtension = [&] {
 #if HAVE(AUDIT_TOKEN)
-            if (auto auditToken = manager()->protectedGPUProcessConnection()->auditToken()) {
+            if (auto auditToken = protect(manager()->gpuProcessConnection())->auditToken()) {
                 if (auto createdHandle = SandboxExtension::createHandleForReadByAuditToken(fileSystemPath, auditToken.value())) {
                     handle = WTF::move(*createdHandle);
                     return true;
@@ -277,7 +277,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
         sandboxExtensionHandle = WTF::move(handle);
     }
 
-    protectedConnection()->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, WTF::move(sandboxExtensionHandle), options), [weakThis = ThreadSafeWeakPtr { *this }](auto&& configuration) {
+    protect(connection())->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::Load(url, WTF::move(sandboxExtensionHandle), options), [weakThis = ThreadSafeWeakPtr { *this }](auto&& configuration) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -293,60 +293,60 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
 
 void MediaPlayerPrivateRemote::cancelLoad()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::CancelLoad(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::CancelLoad(), m_id);
 }
 
 void MediaPlayerPrivateRemote::prepareToPlay()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PrepareToPlay(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::PrepareToPlay(), m_id);
 }
 
 void MediaPlayerPrivateRemote::play()
 {
     m_cachedState.paused = false;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::Play(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::Play(), m_id);
 }
 
 void MediaPlayerPrivateRemote::pause()
 {
     m_cachedState.paused = true;
     m_currentTimeEstimator.pause();
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::Pause(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::Pause(), m_id);
 }
 
 void MediaPlayerPrivateRemote::setPreservesPitch(bool preservesPitch)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPreservesPitch(preservesPitch), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPreservesPitch(preservesPitch), m_id);
 }
 
 void MediaPlayerPrivateRemote::setPitchCorrectionAlgorithm(WebCore::MediaPlayer::PitchCorrectionAlgorithm algorithm)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPitchCorrectionAlgorithm(algorithm), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPitchCorrectionAlgorithm(algorithm), m_id);
 }
 
 void MediaPlayerPrivateRemote::setVolumeLocked(bool volumeLocked)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetVolumeLocked(volumeLocked), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetVolumeLocked(volumeLocked), m_id);
 }
 
 void MediaPlayerPrivateRemote::setVolumeDouble(double volume)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetVolume(volume), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetVolume(volume), m_id);
 }
 
 void MediaPlayerPrivateRemote::setMuted(bool muted)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetMuted(muted), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetMuted(muted), m_id);
 }
 
 void MediaPlayerPrivateRemote::setPreload(MediaPlayer::Preload preload)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPreload(preload), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPreload(preload), m_id);
 }
 
 void MediaPlayerPrivateRemote::setPrivateBrowsingMode(bool privateMode)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPrivateBrowsingMode(privateMode), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPrivateBrowsingMode(privateMode), m_id);
 }
 
 MediaTime MediaPlayerPrivateRemote::duration() const
@@ -434,7 +434,7 @@ void MediaPlayerPrivateRemote::seekToTarget(const WebCore::SeekTarget& target)
     ALWAYS_LOG(LOGIDENTIFIER, target);
     m_seeking = true;
     m_currentTimeEstimator.setTime({ target.time, false, MonotonicTime::now() });
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SeekToTarget(target), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SeekToTarget(target), m_id);
 }
 
 bool MediaPlayerPrivateRemote::didLoadingProgress() const
@@ -445,7 +445,7 @@ bool MediaPlayerPrivateRemote::didLoadingProgress() const
 
 void MediaPlayerPrivateRemote::didLoadingProgressAsync(MediaPlayer::DidLoadingProgressCompletionHandler&& callback) const
 {
-    protectedConnection()->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::DidLoadingProgress(), WTF::move(callback), m_id);
+    protect(connection())->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::DidLoadingProgress(), WTF::move(callback), m_id);
 }
 
 bool MediaPlayerPrivateRemote::hasVideo() const
@@ -649,7 +649,7 @@ bool MediaPlayerPrivateRemote::supportsAcceleratedRendering() const
 void MediaPlayerPrivateRemote::acceleratedRenderingStateChanged()
 {
     if (RefPtr player = m_player.get()) {
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::AcceleratedRenderingStateChanged(player->renderingCanBeAccelerated()), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::AcceleratedRenderingStateChanged(player->renderingCanBeAccelerated()), m_id);
     }
 }
 
@@ -718,7 +718,7 @@ bool MediaPlayerPrivateRemote::shouldIgnoreIntrinsicSize()
 
 void MediaPlayerPrivateRemote::prepareForRendering()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PrepareForRendering(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::PrepareForRendering(), m_id);
 }
 
 void MediaPlayerPrivateRemote::setPageIsVisible(bool visible)
@@ -729,7 +729,7 @@ void MediaPlayerPrivateRemote::setPageIsVisible(bool visible)
     ALWAYS_LOG(LOGIDENTIFIER, visible);
 
     m_pageIsVisible = visible;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPageIsVisible(visible), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPageIsVisible(visible), m_id);
 }
 
 void MediaPlayerPrivateRemote::setShouldMaintainAspectRatio(bool maintainRatio)
@@ -738,12 +738,12 @@ void MediaPlayerPrivateRemote::setShouldMaintainAspectRatio(bool maintainRatio)
         return;
 
     m_shouldMaintainAspectRatio = maintainRatio;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetShouldMaintainAspectRatio(maintainRatio), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetShouldMaintainAspectRatio(maintainRatio), m_id);
 }
 
 void MediaPlayerPrivateRemote::setShouldDisableSleep(bool disable)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetShouldDisableSleep(disable), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetShouldDisableSleep(disable), m_id);
 }
 
 FloatSize MediaPlayerPrivateRemote::naturalSize() const
@@ -758,7 +758,7 @@ void MediaPlayerPrivateRemote::addRemoteAudioTrack(AudioTrackPrivateRemoteConfig
 
     m_audioTracks.erase(configuration.trackId);
 
-    auto addResult = m_audioTracks.emplace(configuration.trackId, AudioTrackPrivateRemote::create(manager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
+    auto addResult = m_audioTracks.emplace(configuration.trackId, AudioTrackPrivateRemote::create(protect(manager()->gpuProcessConnection()), m_id, WTF::move(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -808,7 +808,7 @@ void MediaPlayerPrivateRemote::addRemoteTextTrack(TextTrackPrivateRemoteConfigur
 
     m_textTracks.erase(configuration.trackId);
 
-    auto addResult = m_textTracks.emplace(configuration.trackId, TextTrackPrivateRemote::create(manager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
+    auto addResult = m_textTracks.emplace(configuration.trackId, TextTrackPrivateRemote::create(protect(manager()->gpuProcessConnection()), m_id, WTF::move(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -972,7 +972,7 @@ void MediaPlayerPrivateRemote::addRemoteVideoTrack(VideoTrackPrivateRemoteConfig
 
     m_videoTracks.erase(configuration.trackId);
 
-    auto addResult = m_videoTracks.emplace(configuration.trackId, VideoTrackPrivateRemote::create(manager()->protectedGPUProcessConnection(), m_id, WTF::move(configuration)));
+    auto addResult = m_videoTracks.emplace(configuration.trackId, VideoTrackPrivateRemote::create(protect(manager()->gpuProcessConnection()), m_id, WTF::move(configuration)));
     ASSERT(addResult.second);
 
 #if ENABLE(MEDIA_SOURCE)
@@ -1031,7 +1031,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options, 
             }
             return RemoteMediaSourceIdentifier::generate();
         }();
-        protectedConnection()->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::LoadMediaSource(url, options, identifier), [weakThis = ThreadSafeWeakPtr { *this }](RemoteMediaPlayerConfiguration&& configuration) {
+        protect(connection())->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::LoadMediaSource(url, options, identifier), [weakThis = ThreadSafeWeakPtr { *this }](RemoteMediaPlayerConfiguration&& configuration) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
@@ -1048,7 +1048,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options, 
             // MediaSource can only be re-opened after RemoteMediaPlayerProxy::LoadMediaSource has been called.
             client.reOpen();
         } else
-            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(manager()->protectedGPUProcessConnection(), identifier, manager()->checkedTypeCache(m_remoteEngineIdentifier), *this, client);
+            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(protect(manager()->gpuProcessConnection()), identifier, manager()->checkedTypeCache(m_remoteEngineIdentifier), *this, client);
         return;
     }
 
@@ -1110,7 +1110,7 @@ void MediaPlayerPrivateRemote::setVideoFullscreenLayer(PlatformLayer* videoFulls
 
 void MediaPlayerPrivateRemote::updateVideoFullscreenInlineImage()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::UpdateVideoFullscreenInlineImage(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::UpdateVideoFullscreenInlineImage(), m_id);
 }
 
 void MediaPlayerPrivateRemote::setVideoFullscreenFrame(const WebCore::FloatRect& rect)
@@ -1124,12 +1124,12 @@ void MediaPlayerPrivateRemote::setVideoFullscreenFrame(const WebCore::FloatRect&
 void MediaPlayerPrivateRemote::setVideoFullscreenGravity(WebCore::MediaPlayerEnums::VideoGravity gravity)
 {
     m_videoFullscreenGravity = gravity;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetVideoFullscreenGravity(gravity), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetVideoFullscreenGravity(gravity), m_id);
 }
 
 void MediaPlayerPrivateRemote::setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode mode)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetVideoFullscreenMode(mode), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetVideoFullscreenMode(mode), m_id);
 }
 
 void MediaPlayerPrivateRemote::videoFullscreenStandbyChanged()
@@ -1138,7 +1138,7 @@ void MediaPlayerPrivateRemote::videoFullscreenStandbyChanged()
     if (!player)
         return;
 
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::VideoFullscreenStandbyChanged(player->isVideoFullscreenStandby()), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::VideoFullscreenStandbyChanged(player->isVideoFullscreenStandby()), m_id);
 }
 #endif
 
@@ -1151,14 +1151,14 @@ NSArray* MediaPlayerPrivateRemote::timedMetadata() const
 
 String MediaPlayerPrivateRemote::accessLog() const
 {
-    auto sendResult = protectedConnection()->sendSync(Messages::RemoteMediaPlayerProxy::AccessLog(), m_id);
+    auto sendResult = protect(connection())->sendSync(Messages::RemoteMediaPlayerProxy::AccessLog(), m_id);
     auto [log] = sendResult.takeReplyOr(emptyString());
     return log;
 }
 
 String MediaPlayerPrivateRemote::errorLog() const
 {
-    auto sendResult = protectedConnection()->sendSync(Messages::RemoteMediaPlayerProxy::ErrorLog(), m_id);
+    auto sendResult = protect(connection())->sendSync(Messages::RemoteMediaPlayerProxy::ErrorLog(), m_id);
     auto [log] = sendResult.takeReplyOr(emptyString());
     return log;
 }
@@ -1166,7 +1166,7 @@ String MediaPlayerPrivateRemote::errorLog() const
 
 void MediaPlayerPrivateRemote::setBufferingPolicy(MediaPlayer::BufferingPolicy policy)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetBufferingPolicy(policy), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetBufferingPolicy(policy), m_id);
 }
 
 bool MediaPlayerPrivateRemote::canSaveMediaData() const
@@ -1186,7 +1186,7 @@ MediaTime MediaPlayerPrivateRemote::startTime() const
 
 void MediaPlayerPrivateRemote::setRateDouble(double rate)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetRate(rate), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetRate(rate), m_id);
 }
 
 bool MediaPlayerPrivateRemote::hasClosedCaptions() const
@@ -1232,7 +1232,7 @@ unsigned long long MediaPlayerPrivateRemote::totalBytes() const
 
 void MediaPlayerPrivateRemote::setPresentationSize(const IntSize& size)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPresentationSize(size), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPresentationSize(size), m_id);
 }
 
 void MediaPlayerPrivateRemote::paint(GraphicsContext& context, const FloatRect& rect)
@@ -1261,14 +1261,14 @@ RefPtr<WebCore::VideoFrame> MediaPlayerPrivateRemote::videoFrameForCurrentTime()
         return m_videoFrameGatheredWithVideoFrameMetadata;
 #endif
 
-    auto sendResult = protectedConnection()->sendSync(Messages::RemoteMediaPlayerProxy::VideoFrameForCurrentTimeIfChanged(), m_id);
+    auto sendResult = protect(connection())->sendSync(Messages::RemoteMediaPlayerProxy::VideoFrameForCurrentTimeIfChanged(), m_id);
     if (!sendResult.succeeded())
         return nullptr;
 
     auto [result, changed] = sendResult.takeReply();
     if (changed) {
         if (result)
-            m_videoFrameForCurrentTime = RemoteVideoFrameProxy::create(protectedConnection(), protectedVideoFrameObjectHeapProxy(), WTF::move(*result));
+            m_videoFrameForCurrentTime = RemoteVideoFrameProxy::create(protect(connection()), protect(videoFrameObjectHeapProxy()), WTF::move(*result));
         else
             m_videoFrameForCurrentTime = nullptr;
     }
@@ -1294,7 +1294,7 @@ Ref<MediaPlayerPrivateRemote::BitmapImagePromise> MediaPlayerPrivateRemote::bitm
     if (readyState() < MediaPlayer::ReadyState::HaveCurrentData)
         return BitmapImagePromise::createAndReject();
 
-    return protectedConnection()->sendWithPromisedReply(Messages::RemoteMediaPlayerProxy::BitmapImageForCurrentTime(), m_id)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) -> Ref<BitmapImagePromise> {
+    return protect(connection())->sendWithPromisedReply(Messages::RemoteMediaPlayerProxy::BitmapImageForCurrentTime(), m_id)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) -> Ref<BitmapImagePromise> {
         RefPtr protectedThis = weakThis.get();
         if (!result || !result.value() || !protectedThis)
             return BitmapImagePromise::createAndReject();
@@ -1331,7 +1331,7 @@ void MediaPlayerPrivateRemote::setWirelessVideoPlaybackDisabled(bool disabled)
     // Update the cache state so we don't have to make this a synchronous message send to avoid a
     // race condition with the web process fetching the new state immediately after change.
     m_cachedState.wirelessVideoPlaybackDisabled = disabled;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetWirelessVideoPlaybackDisabled(disabled), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetWirelessVideoPlaybackDisabled(disabled), m_id);
 }
 
 void MediaPlayerPrivateRemote::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackTargetWireless)
@@ -1348,12 +1348,12 @@ bool MediaPlayerPrivateRemote::isCurrentPlaybackTargetWireless() const
 
 void MediaPlayerPrivateRemote::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& target)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetWirelessPlaybackTarget(MediaPlaybackTargetContextSerialized { target.get() }), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetWirelessPlaybackTarget(MediaPlaybackTargetContextSerialized { target.get() }), m_id);
 }
 
 void MediaPlayerPrivateRemote::setShouldPlayToPlaybackTarget(bool shouldPlay)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetShouldPlayToPlaybackTarget(shouldPlay), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetShouldPlayToPlaybackTarget(shouldPlay), m_id);
 }
 #endif
 
@@ -1370,7 +1370,7 @@ std::optional<bool> MediaPlayerPrivateRemote::isCrossOrigin(const SecurityOrigin
     if (auto result = m_isCrossOriginCache.get(origin.data()))
         return result;
 
-    auto sendResult = protectedConnection()->sendSync(Messages::RemoteMediaPlayerProxy::IsCrossOrigin(origin.data()), m_id);
+    auto sendResult = protect(connection())->sendSync(Messages::RemoteMediaPlayerProxy::IsCrossOrigin(origin.data()), m_id);
     auto [crossOrigin] = sendResult.takeReplyOr(std::nullopt);
     if (crossOrigin)
         m_isCrossOriginCache.add(origin.data(), crossOrigin);
@@ -1441,17 +1441,17 @@ void MediaPlayerPrivateRemote::setCDM(LegacyCDM* cdm)
 void MediaPlayerPrivateRemote::setCDMSession(LegacyCDMSession* session)
 {
     if (!session || session->type() != CDMSessionTypeRemote) {
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetLegacyCDMSession(std::nullopt), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetLegacyCDMSession(std::nullopt), m_id);
         return;
     }
 
     auto* remoteSession = downcast<RemoteLegacyCDMSession>(session);
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetLegacyCDMSession(remoteSession->identifier()), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetLegacyCDMSession(remoteSession->identifier()), m_id);
 }
 
 void MediaPlayerPrivateRemote::keyAdded()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::KeyAdded(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::KeyAdded(), m_id);
 }
 
 void MediaPlayerPrivateRemote::mediaPlayerKeyNeeded(std::span<const uint8_t> message)
@@ -1465,19 +1465,19 @@ void MediaPlayerPrivateRemote::mediaPlayerKeyNeeded(std::span<const uint8_t> mes
 void MediaPlayerPrivateRemote::cdmInstanceAttached(CDMInstance& instance)
 {
     if (auto* remoteInstance = dynamicDowncast<RemoteCDMInstance>(instance))
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::CdmInstanceAttached(remoteInstance->identifier()), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::CdmInstanceAttached(remoteInstance->identifier()), m_id);
 }
 
 void MediaPlayerPrivateRemote::cdmInstanceDetached(CDMInstance& instance)
 {
     if (auto* remoteInstance = dynamicDowncast<RemoteCDMInstance>(instance))
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::CdmInstanceDetached(remoteInstance->identifier()), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::CdmInstanceDetached(remoteInstance->identifier()), m_id);
 }
 
 void MediaPlayerPrivateRemote::attemptToDecryptWithInstance(CDMInstance& instance)
 {
     if (auto* remoteInstance = dynamicDowncast<RemoteCDMInstance>(instance))
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::AttemptToDecryptWithInstance(remoteInstance->identifier()), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::AttemptToDecryptWithInstance(remoteInstance->identifier()), m_id);
 }
 
 void MediaPlayerPrivateRemote::waitingForKeyChanged(bool waitingForKey)
@@ -1503,7 +1503,7 @@ bool MediaPlayerPrivateRemote::waitingForKey() const
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)
 void MediaPlayerPrivateRemote::setShouldContinueAfterKeyNeeded(bool should)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetShouldContinueAfterKeyNeeded(should), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetShouldContinueAfterKeyNeeded(should), m_id);
 }
 #endif
 
@@ -1524,7 +1524,7 @@ void MediaPlayerPrivateRemote::syncTextTrackBounds()
 
 void MediaPlayerPrivateRemote::tracksChanged()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::TracksChanged(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::TracksChanged(), m_id);
 }
 
 String MediaPlayerPrivateRemote::languageOfPrimaryAudioTrack() const
@@ -1547,7 +1547,7 @@ void MediaPlayerPrivateRemote::reportGPUMemoryFootprint(uint64_t footPrint)
 void MediaPlayerPrivateRemote::updateVideoPlaybackMetricsUpdateInterval(const Seconds& interval)
 {
     m_videoPlaybackMetricsUpdateInterval = interval;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetVideoPlaybackMetricsUpdateInterval(m_videoPlaybackMetricsUpdateInterval.value()), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetVideoPlaybackMetricsUpdateInterval(m_videoPlaybackMetricsUpdateInterval.value()), m_id);
 }
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateRemote::videoPlaybackQualityMetrics()
@@ -1568,13 +1568,13 @@ std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateRemote::videoPlayba
 
 void MediaPlayerPrivateRemote::notifyTrackModeChanged()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::NotifyTrackModeChanged(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::NotifyTrackModeChanged(), m_id);
 }
 
 void MediaPlayerPrivateRemote::notifyActiveSourceBuffersChanged()
 {
     // FIXME: this just rounds trip up and down to activeSourceBuffersChanged(). Should this call ::activeSourceBuffersChanged directly?
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::NotifyActiveSourceBuffersChanged(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::NotifyActiveSourceBuffersChanged(), m_id);
 }
 
 bool MediaPlayerPrivateRemote::inVideoFullscreenOrPictureInPicture() const
@@ -1588,22 +1588,22 @@ bool MediaPlayerPrivateRemote::inVideoFullscreenOrPictureInPicture() const
 
 void MediaPlayerPrivateRemote::applicationWillResignActive()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::ApplicationWillResignActive(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::ApplicationWillResignActive(), m_id);
 }
 
 void MediaPlayerPrivateRemote::applicationDidBecomeActive()
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::ApplicationDidBecomeActive(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::ApplicationDidBecomeActive(), m_id);
 }
 
 void MediaPlayerPrivateRemote::setPreferredDynamicRangeMode(WebCore::DynamicRangeMode mode)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPreferredDynamicRangeMode(mode), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPreferredDynamicRangeMode(mode), m_id);
 }
 
 void MediaPlayerPrivateRemote::setPlatformDynamicRangeLimit(WebCore::PlatformDynamicRangeLimit platformDynamicRangeLimit)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPlatformDynamicRangeLimit(platformDynamicRangeLimit), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPlatformDynamicRangeLimit(platformDynamicRangeLimit), m_id);
 }
 
 bool MediaPlayerPrivateRemote::performTaskAtTime(WTF::Function<void(const MediaTime&)>&& task, const MediaTime& mediaTime)
@@ -1616,7 +1616,7 @@ bool MediaPlayerPrivateRemote::performTaskAtTime(WTF::Function<void(const MediaT
         task(*currentTime);
     };
 
-    protectedConnection()->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::PerformTaskAtTime(mediaTime), WTF::move(asyncReplyHandler), m_id);
+    protect(connection())->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::PerformTaskAtTime(mediaTime), WTF::move(asyncReplyHandler), m_id);
 
     return true;
 }
@@ -1625,7 +1625,7 @@ bool MediaPlayerPrivateRemote::playAtHostTime(const MonotonicTime& time)
 {
     if (!m_configuration.supportsPlayAtHostTime)
         return false;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PlayAtHostTime(time), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::PlayAtHostTime(time), m_id);
     return true;
 }
 
@@ -1633,7 +1633,7 @@ bool MediaPlayerPrivateRemote::pauseAtHostTime(const MonotonicTime& time)
 {
     if (!m_configuration.supportsPauseAtHostTime)
         return false;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PauseAtHostTime(time), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::PauseAtHostTime(time), m_id);
     return true;
 }
 
@@ -1646,7 +1646,7 @@ std::optional<VideoFrameMetadata> MediaPlayerPrivateRemote::videoFrameMetadata()
 void MediaPlayerPrivateRemote::startVideoFrameMetadataGathering()
 {
     m_isGatheringVideoFrameMetadata = true;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::StartVideoFrameMetadataGathering(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::StartVideoFrameMetadataGathering(), m_id);
 }
 
 void MediaPlayerPrivateRemote::stopVideoFrameMetadataGathering()
@@ -1655,17 +1655,17 @@ void MediaPlayerPrivateRemote::stopVideoFrameMetadataGathering()
 #if PLATFORM(COCOA)
     m_videoFrameGatheredWithVideoFrameMetadata = nullptr;
 #endif
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::StopVideoFrameMetadataGathering(), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::StopVideoFrameMetadataGathering(), m_id);
 }
 
 void MediaPlayerPrivateRemote::playerContentBoxRectChanged(const LayoutRect& contentRect)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PlayerContentBoxRectChanged(contentRect), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::PlayerContentBoxRectChanged(contentRect), m_id);
 }
 
 void MediaPlayerPrivateRemote::setShouldDisableHDR(bool shouldDisable)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetShouldDisableHDR(shouldDisable), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetShouldDisableHDR(shouldDisable), m_id);
 }
 
 void MediaPlayerPrivateRemote::resourceNotSupported()
@@ -1703,7 +1703,7 @@ void MediaPlayerPrivateRemote::requestHostingContext(LayerHostingContextCallback
     }
 
     m_layerHostingContextRequests.append(WTF::move(completionHandler));
-    protectedConnection()->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::RequestHostingContext(), [weakThis = ThreadSafeWeakPtr { *this }] (WebCore::HostingContext context) {
+    protect(connection())->sendWithAsyncReply(Messages::RemoteMediaPlayerProxy::RequestHostingContext(), [weakThis = ThreadSafeWeakPtr { *this }] (WebCore::HostingContext context) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->setLayerHostingContext(WTF::move(context));
     }, m_id);
@@ -1756,7 +1756,7 @@ RefPtr<TextTrackPrivateRemote> MediaPlayerPrivateRemote::textTrackPrivateRemote(
 
 void MediaPlayerPrivateRemote::setShouldCheckHardwareSupport(bool value)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetShouldCheckHardwareSupport(value), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetShouldCheckHardwareSupport(value), m_id);
 }
 
 
@@ -1772,7 +1772,7 @@ void MediaPlayerPrivateRemote::setDefaultSpatialTrackingLabel(const String& defa
         return;
 
     m_defaultSpatialTrackingLabel = defaultSpatialTrackingLabel;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetDefaultSpatialTrackingLabel(m_defaultSpatialTrackingLabel), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetDefaultSpatialTrackingLabel(m_defaultSpatialTrackingLabel), m_id);
 }
 
 String MediaPlayerPrivateRemote::spatialTrackingLabel() const
@@ -1786,7 +1786,7 @@ void MediaPlayerPrivateRemote::setSpatialTrackingLabel(const String& spatialTrac
         return;
 
     m_spatialTrackingLabel = spatialTrackingLabel;
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetSpatialTrackingLabel(m_spatialTrackingLabel), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetSpatialTrackingLabel(m_spatialTrackingLabel), m_id);
 }
 #endif
 
@@ -1795,19 +1795,19 @@ void MediaPlayerPrivateRemote::setSpatialTrackingLabel(const String& spatialTrac
 void MediaPlayerPrivateRemote::prefersSpatialAudioExperienceChanged()
 {
     if (RefPtr player = m_player.get())
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPrefersSpatialAudioExperience(player->prefersSpatialAudioExperience()), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetPrefersSpatialAudioExperience(player->prefersSpatialAudioExperience()), m_id);
 }
 #endif
 
 void MediaPlayerPrivateRemote::soundStageSizeDidChange()
 {
     if (RefPtr player = m_player.get())
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetSoundStageSize(player->soundStageSize()), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetSoundStageSize(player->soundStageSize()), m_id);
 }
 
 void MediaPlayerPrivateRemote::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::IsInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::IsInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture), m_id);
 }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -1841,7 +1841,7 @@ bool MediaPlayerPrivateRemote::supportsLinearMediaPlayer() const
 void MediaPlayerPrivateRemote::audioOutputDeviceChanged()
 {
     if (RefPtr player = m_player.get())
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::AudioOutputDeviceChanged { player->audioOutputDeviceId() }, m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::AudioOutputDeviceChanged { player->audioOutputDeviceId() }, m_id);
 }
 
 void MediaPlayerPrivateRemote::commitAllTransactions(CompletionHandler<void()>&& completionHandler)
@@ -1858,14 +1858,14 @@ Ref<RemoteMediaPlayerManager> MediaPlayerPrivateRemote::manager() const
 void MediaPlayerPrivateRemote::sceneIdentifierDidChange()
 {
     if (RefPtr player = m_player.get())
-        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetSceneIdentifier(player->sceneIdentifier()), m_id);
+        protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetSceneIdentifier(player->sceneIdentifier()), m_id);
 }
 #endif
 
 void MediaPlayerPrivateRemote::setMessageClientForTesting(WeakPtr<MessageClientForTesting> client)
 {
     m_internalMessageClient = WTF::move(client);
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetHasMessageClientForTesting(!!m_internalMessageClient), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetHasMessageClientForTesting(!!m_internalMessageClient), m_id);
 }
 
 void MediaPlayerPrivateRemote::sendInternalMessage(const WebCore::MessageForTesting& message)
@@ -1877,7 +1877,7 @@ void MediaPlayerPrivateRemote::sendInternalMessage(const WebCore::MessageForTest
 
     // We were sent a message, but no internal message client exists. Notify the
     // GPU process that we have no internal message client.
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetHasMessageClientForTesting(false), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetHasMessageClientForTesting(false), m_id);
 }
 
 void MediaPlayerPrivateRemote::createResourceLoader(RemoteMediaResourceLoaderIdentifier identifier)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -115,7 +115,6 @@ public:
     WebCore::MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier() const { return m_remoteEngineIdentifier; }
     std::optional<WebCore::MediaPlayerIdentifier> identifier() const final { return m_id; }
     IPC::Connection& connection() const { return manager()->gpuProcessConnection().connection(); }
-    Ref<IPC::Connection> protectedConnection() const { return manager()->gpuProcessConnection().connection(); }
     RefPtr<WebCore::MediaPlayer> player() const { return m_player.get(); }
 
     WebCore::MediaPlayer::ReadyState readyState() const final { return m_readyState; }
@@ -497,8 +496,7 @@ private:
 #if PLATFORM(COCOA)
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);
 #endif
-    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return manager()->protectedGPUProcessConnection()->videoFrameObjectHeapProxy(); }
-    Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const { return videoFrameObjectHeapProxy(); }
+    RemoteVideoFrameObjectHeapProxy& videoFrameObjectHeapProxy() const { return protect(manager()->gpuProcessConnection())->videoFrameObjectHeapProxy(); }
 
     Ref<RemoteMediaPlayerManager> manager() const;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -286,11 +286,6 @@ GPUProcessConnection& RemoteMediaPlayerManager::gpuProcessConnection()
     return WebProcess::singleton().ensureGPUProcessConnection();
 }
 
-Ref<GPUProcessConnection> RemoteMediaPlayerManager::protectedGPUProcessConnection()
-{
-    return gpuProcessConnection();
-}
-
 void RemoteMediaPlayerManager::gpuProcessConnectionDidClose(GPUProcessConnection& connection)
 {
     ASSERT(m_gpuProcessConnection.get() == &connection);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -57,7 +57,6 @@ public:
     void setUseGPUProcess(bool);
 
     GPUProcessConnection& gpuProcessConnection();
-    Ref<GPUProcessConnection> protectedGPUProcessConnection();
 
     void didReceivePlayerMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm
@@ -51,7 +51,7 @@ PlatformLayerContainer MediaPlayerPrivateRemote::createVideoFullscreenLayer()
 
 void MediaPlayerPrivateRemote::pushVideoFrameMetadata(WebCore::VideoFrameMetadata&& videoFrameMetadata, RemoteVideoFrameProxy::Properties&& properties)
 {
-    auto videoFrame = RemoteVideoFrameProxy::create(protectedConnection(), protectedVideoFrameObjectHeapProxy(), WTF::move(properties));
+    auto videoFrame = RemoteVideoFrameProxy::create(protect(connection()), protect(videoFrameObjectHeapProxy()), WTF::move(properties));
     if (!m_isGatheringVideoFrameMetadata)
         return;
     m_videoFrameMetadata = WTF::move(videoFrameMetadata);
@@ -75,7 +75,7 @@ WebCore::DestinationColorSpace MediaPlayerPrivateRemote::colorSpace()
     if (readyState() < MediaPlayer::ReadyState::HaveCurrentData)
         return DestinationColorSpace::SRGB();
 
-    auto sendResult = protectedConnection()->sendSync(Messages::RemoteMediaPlayerProxy::ColorSpace(), m_id);
+    auto sendResult = protect(connection())->sendSync(Messages::RemoteMediaPlayerProxy::ColorSpace(), m_id);
     auto [colorSpace] = sendResult.takeReplyOr(DestinationColorSpace::SRGB());
     return colorSpace;
 }
@@ -106,7 +106,7 @@ WebCore::FloatSize MediaPlayerPrivateRemote::videoLayerSize() const
 
 void MediaPlayerPrivateRemote::setVideoLayerSizeFenced(const FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated)), m_id);
+    protect(connection())->send(Messages::RemoteMediaPlayerProxy::SetVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated)), m_id);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -327,22 +327,22 @@ WKBundleBackForwardListRef WKBundlePageGetBackForwardList(WKBundlePageRef pageRe
 
 void WKBundlePageInstallPageOverlay(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*protect(WebKit::toImpl(pageOverlayRef)->coreOverlay()), WebCore::PageOverlay::FadeMode::DoNotFade);
 }
 
 void WKBundlePageUninstallPageOverlay(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::DoNotFade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*protect(WebKit::toImpl(pageOverlayRef)->coreOverlay()), WebCore::PageOverlay::FadeMode::DoNotFade);
 }
 
 void WKBundlePageInstallPageOverlayWithAnimation(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().installPageOverlay(*protect(WebKit::toImpl(pageOverlayRef)->coreOverlay()), WebCore::PageOverlay::FadeMode::Fade);
 }
 
 void WKBundlePageUninstallPageOverlayWithAnimation(WKBundlePageRef pageRef, WKBundlePageOverlayRef pageOverlayRef)
 {
-    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*WebKit::toImpl(pageOverlayRef)->protectedCoreOverlay(), WebCore::PageOverlay::FadeMode::Fade);
+    WebKit::toImpl(pageRef)->corePage()->pageOverlayController().uninstallPageOverlay(*protect(WebKit::toImpl(pageOverlayRef)->coreOverlay()), WebCore::PageOverlay::FadeMode::Fade);
 }
 
 void WKBundlePageSetTopOverhangImage(WKBundlePageRef pageRef, WKImageRef imageRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -124,11 +124,6 @@ Node* InjectedBundleNodeHandle::coreNode()
     return m_node.get();
 }
 
-RefPtr<Node> InjectedBundleNodeHandle::protectedCoreNode()
-{
-    return m_node.get();
-}
-
 RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::document()
 {
     if (!m_node)
@@ -154,7 +149,7 @@ IntRect InjectedBundleNodeHandle::absoluteBoundingRect(bool* isReplaced)
     if (!m_node)
         return { };
 
-    return protectedCoreNode()->pixelSnappedAbsoluteBoundingRect(isReplaced);
+    return protect(coreNode())->pixelSnappedAbsoluteBoundingRect(isReplaced);
 }
 
 static RefPtr<WebImage> imageForRect(LocalFrameView* frameView, const IntRect& paintingRect, const std::optional<float>& bitmapWidth, SnapshotOptions options)

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -55,7 +55,6 @@ public:
     virtual ~InjectedBundleNodeHandle();
 
     WebCore::Node* coreNode();
-    RefPtr<WebCore::Node> protectedCoreNode();
 
     // Convenience DOM Operations
     RefPtr<InjectedBundleNodeHandle> document();

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -59,7 +59,7 @@ InjectedBundleDOMWindowExtension* InjectedBundleDOMWindowExtension::get(DOMWindo
 }
 
 InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension(WebFrame* frame, InjectedBundleScriptWorld* world)
-    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? protect(frame->coreLocalFrame())->protectedWindow().get() : nullptr, world->protectedCoreWorld().get()))
+    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? protect(frame->coreLocalFrame())->protectedWindow().get() : nullptr, protect(world->coreWorld()).get()))
 {
     allExtensions().add(m_coreExtension.get(), *this);
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -165,14 +165,4 @@ void InjectedBundleScriptWorld::disableOverrideBuiltinsBehavior()
     m_world->disableLegacyOverrideBuiltInsBehavior();
 }
 
-Ref<const WebCore::DOMWrapperWorld> InjectedBundleScriptWorld::protectedCoreWorld() const
-{
-    return m_world;
-}
-
-Ref<WebCore::DOMWrapperWorld> InjectedBundleScriptWorld::protectedCoreWorld()
-{
-    return m_world;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -56,8 +56,6 @@ public:
 
     const WebCore::DOMWrapperWorld& coreWorld() const;
     WebCore::DOMWrapperWorld& coreWorld();
-    Ref<const WebCore::DOMWrapperWorld> protectedCoreWorld() const;
-    Ref<WebCore::DOMWrapperWorld> protectedCoreWorld();
 
     void clearWrappers();
     void setAllowAutofill();

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -95,7 +95,7 @@ void ModelProcessModelPlayer::didCreateLayer(WebCore::LayerHostingContextIdentif
     RELEASE_ASSERT(modelProcessEnabled());
 
     m_layerHostingContextIdentifier = identifier;
-    protectedClient()->didUpdate(*this);
+    protect(client())->didUpdate(*this);
 }
 
 void ModelProcessModelPlayer::didFinishLoading(const WebCore::FloatPoint3D& boundingBoxCenter, const WebCore::FloatPoint3D& boundingBoxExtents)
@@ -116,7 +116,7 @@ void ModelProcessModelPlayer::didFailLoading()
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer didFailLoading id=%" PRIu64, this, m_id.toUInt64());
     RELEASE_ASSERT(modelProcessEnabled());
 
-    protectedClient()->didFailLoading(*this, WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Failed to load model data"_s });
+    protect(client())->didFailLoading(*this, WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Failed to load model data"_s });
 }
 
 /// This comes from Model Process side, so that Web Process has the most up-to-date knowledge about the transform actually applied to the entity.
@@ -126,7 +126,7 @@ void ModelProcessModelPlayer::didUpdateEntityTransform(const WebCore::Transforma
     RELEASE_ASSERT(modelProcessEnabled());
 
     m_entityTransform = transform;
-    protectedClient()->didUpdateEntityTransform(*this, transform);
+    protect(client())->didUpdateEntityTransform(*this, transform);
 }
 
 void ModelProcessModelPlayer::didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)
@@ -143,7 +143,7 @@ void ModelProcessModelPlayer::didFinishEnvironmentMapLoading(bool succeeded)
 {
     RELEASE_ASSERT(modelProcessEnabled());
 
-    protectedClient()->didFinishEnvironmentMapLoading(*this, succeeded);
+    protect(client())->didFinishEnvironmentMapLoading(*this, succeeded);
 }
 
 // MARK: - WebCore::ModelPlayer

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -66,7 +66,6 @@ private:
 
     WebPage* page() { return m_page.get(); }
     WebCore::ModelPlayerClient* client() { return m_client.get(); }
-    RefPtr<WebCore::ModelPlayerClient> protectedClient() { return m_client.get(); }
 
     template<typename T> void send(T&& message);
     template<typename T, typename C> void sendWithAsyncReply(T&& message, C&& completionHandler);

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -173,7 +173,7 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
     }
 
     if (decoder.messageReceiverName() == Messages::WebSWClientConnection::messageReceiverName()) {
-        protectedServiceWorkerConnection()->didReceiveMessage(connection, decoder);
+        protect(serviceWorkerConnection())->didReceiveMessage(connection, decoder);
         return true;
     }
     if (decoder.messageReceiverName() == Messages::WebSWContextManagerConnection::messageReceiverName()) {
@@ -183,7 +183,7 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
         return true;
     }
     if (decoder.messageReceiverName() == Messages::WebSharedWorkerObjectConnection::messageReceiverName()) {
-        protectedSharedWorkerConnection()->didReceiveMessage(connection, decoder);
+        protect(sharedWorkerConnection())->didReceiveMessage(connection, decoder);
         return true;
     }
     if (decoder.messageReceiverName() == Messages::WebSharedWorkerContextManagerConnection::messageReceiverName()) {
@@ -322,21 +322,11 @@ WebSWClientConnection& NetworkProcessConnection::serviceWorkerConnection()
     return *m_swConnection;
 }
 
-Ref<WebSWClientConnection> NetworkProcessConnection::protectedServiceWorkerConnection()
-{
-    return serviceWorkerConnection();
-}
-
 WebSharedWorkerObjectConnection& NetworkProcessConnection::sharedWorkerConnection()
 {
     if (!m_sharedWorkerConnection)
         m_sharedWorkerConnection = WebSharedWorkerObjectConnection::create();
     return *m_sharedWorkerConnection;
-}
-
-Ref<WebSharedWorkerObjectConnection> NetworkProcessConnection::protectedSharedWorkerConnection()
-{
-    return sharedWorkerConnection();
 }
 
 void NetworkProcessConnection::messagesAvailableForPort(const WebCore::MessagePortIdentifier& messagePortIdentifier)

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.h
@@ -80,9 +80,7 @@ public:
     WebIDBConnectionToServer& idbConnectionToServer();
 
     WebSWClientConnection& serviceWorkerConnection();
-    Ref<WebSWClientConnection> protectedServiceWorkerConnection();
     WebSharedWorkerObjectConnection& sharedWorkerConnection();
-    Ref<WebSharedWorkerObjectConnection> protectedSharedWorkerConnection();
 
 #if HAVE(AUDIT_TOKEN)
     void setNetworkProcessAuditToken(std::optional<audit_token_t> auditToken) { m_networkProcessAuditToken = auditToken; }

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -732,7 +732,7 @@ void WebLoaderStrategy::networkProcessCrashed()
     WEBLOADERSTRATEGY_RELEASE_LOG_ERROR_BASIC("networkProcessCrashed: failing all pending resource loaders");
 
     for (auto& loader : m_webResourceLoaders.values()) {
-        scheduleInternallyFailedLoad(*loader->protectedResourceLoader());
+        scheduleInternallyFailedLoad(*protect(loader->resourceLoader()));
         loader->detachFromCoreLoader();
     }
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -94,7 +94,7 @@ IPC::Connection* WebResourceLoader::messageSenderConnection() const
 uint64_t WebResourceLoader::messageSenderDestinationID() const
 {
     RELEASE_ASSERT(RunLoop::isMain());
-    return protectedResourceLoader()->identifier()->toUInt64();
+    return protect(resourceLoader())->identifier()->toUInt64();
 }
 
 void WebResourceLoader::detachFromCoreLoader()
@@ -152,7 +152,7 @@ void WebResourceLoader::willSendRequest(ResourceRequest&& proposedRequest, IPC::
 
 void WebResourceLoader::didSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent)
 {
-    protectedResourceLoader()->didSendData(bytesSent, totalBytesToBeSent);
+    protect(resourceLoader())->didSendData(bytesSent, totalBytesToBeSent);
 }
 
 static ASCIILiteral toString(WebCore::RouterSourceEnum source)
@@ -459,11 +459,6 @@ size_t WebResourceLoader::calculateBytesTransferredOverNetworkDelta(size_t bytes
 
     m_bytesTransferredOverNetwork = bytesTransferredOverNetwork;
     return delta;
-}
-
-RefPtr<WebCore::ResourceLoader> WebResourceLoader::protectedResourceLoader() const
-{
-    return RefPtr { m_coreLoader };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -74,7 +74,6 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 
     WebCore::ResourceLoader* resourceLoader() const { return m_coreLoader.get(); }
-    RefPtr<WebCore::ResourceLoader> protectedResourceLoader() const;
 
     void detachFromCoreLoader();
 

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -171,11 +171,6 @@ IPC::Connection& SpeechRecognitionRealtimeMediaSourceManager::connection() const
     return *m_process->parentProcessConnection();
 }
 
-Ref<IPC::Connection> SpeechRecognitionRealtimeMediaSourceManager::protectedConnection() const
-{
-    return *m_process->parentProcessConnection();
-}
-
 void SpeechRecognitionRealtimeMediaSourceManager::ref() const
 {
     m_process->ref();
@@ -196,7 +191,7 @@ void SpeechRecognitionRealtimeMediaSourceManager::createSource(RealtimeMediaSour
     }
 
     ASSERT(!m_sources.contains(identifier));
-    m_sources.add(identifier, makeUnique<Source>(identifier, result.source(), protectedConnection()));
+    m_sources.add(identifier, makeUnique<Source>(identifier, result.source(), protect(connection())));
 }
 
 void SpeechRecognitionRealtimeMediaSourceManager::deleteSource(RealtimeMediaSourceIdentifier identifier)

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h
@@ -66,7 +66,6 @@ private:
     uint64_t messageSenderDestinationID() const final;
 
     IPC::Connection& connection() const;
-    Ref<IPC::Connection> protectedConnection() const;
 
     WeakRef<WebProcess> m_process;
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp
@@ -75,7 +75,7 @@ void WebServiceWorkerProvider::updateThrottleState(bool isThrottleable)
 
 void WebServiceWorkerProvider::terminateWorkerForTesting(WebCore::ServiceWorkerIdentifier identifier, CompletionHandler<void()>&& callback)
 {
-    WebProcess::singleton().ensureProtectedNetworkProcessConnection()->protectedServiceWorkerConnection()->terminateWorkerForTesting(identifier, WTF::move(callback));
+    protect(WebProcess::singleton().ensureProtectedNetworkProcessConnection()->serviceWorkerConnection())->terminateWorkerForTesting(identifier, WTF::move(callback));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -74,7 +74,7 @@ Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayer(PlatformCALaye
     Ref result = PlatformCALayerRemote::create(layerType, owner, context.get());
 
     if (result->canHaveBackingStore()) {
-        RefPtr localMainFrameView = context->protectedWebPage()->localMainFrameView();
+        RefPtr localMainFrameView = protect(context->webPage())->localMainFrameView();
         result->setContentsFormat(PlatformCALayer::contentsFormatForLayer(owner));
     }
     return WTF::move(result);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -272,7 +272,6 @@ public:
 
     void moveToContext(RemoteLayerTreeContext&);
     RemoteLayerTreeContext* context() const { return m_context.get(); }
-    RefPtr<RemoteLayerTreeContext> protectedContext() const { return m_context.get(); }
 
     void markFrontBufferVolatileForTesting() override;
     virtual void populateCreationProperties(RemoteLayerTreeTransaction::LayerCreationProperties&, const RemoteLayerTreeContext&, WebCore::PlatformCALayer::LayerType);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -125,7 +125,7 @@ PlatformCALayerRemote::PlatformCALayerRemote(const PlatformCALayerRemote& other,
 Ref<PlatformCALayer> PlatformCALayerRemote::clone(PlatformCALayerClient* owner) const
 {
     RELEASE_ASSERT(m_context.get());
-    Ref clone = PlatformCALayerRemote::create(*this, owner, *protectedContext());
+    Ref clone = PlatformCALayerRemote::create(*this, owner, *protect(context()));
 
     updateClonedLayerProperties(clone);
 
@@ -1178,7 +1178,7 @@ void PlatformCALayerRemote::setAppleVisualEffectData(WebCore::AppleVisualEffectD
 Ref<PlatformCALayer> PlatformCALayerRemote::createCompatibleLayer(PlatformCALayer::LayerType layerType, PlatformCALayerClient* client) const
 {
     RELEASE_ASSERT(m_context.get());
-    return PlatformCALayerRemote::create(layerType, client, *protectedContext());
+    return PlatformCALayerRemote::create(layerType, client, *protect(context()));
 }
 
 void PlatformCALayerRemote::enumerateRectsBeingDrawn(WebCore::GraphicsContext& context, void (^block)(WebCore::FloatRect))

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -109,9 +109,7 @@ public:
     bool canShowWhileLocked() const;
 #endif
 
-    WebPage& webPage();
-    Ref<WebPage> protectedWebPage();
-    Ref<const WebPage> protectedWebPage() const;
+    WebPage& webPage() const;
 
 private:
     explicit RemoteLayerTreeContext(WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -81,7 +81,7 @@ void RemoteLayerTreeContext::adoptLayersFromContext(RemoteLayerTreeContext& oldC
 
 float RemoteLayerTreeContext::deviceScaleFactor() const
 {
-    return protectedWebPage()->deviceScaleFactor();
+    return protect(webPage())->deviceScaleFactor();
 }
 
 std::optional<DrawingAreaIdentifier> RemoteLayerTreeContext::drawingAreaIdentifier() const
@@ -101,7 +101,7 @@ std::optional<WebCore::DestinationColorSpace> RemoteLayerTreeContext::displayCol
 
 UseLosslessCompression RemoteLayerTreeContext::useIOSurfaceLosslessCompression() const
 {
-    return protectedWebPage()->isIOSurfaceLosslessCompressionEnabled() ? UseLosslessCompression::Yes : UseLosslessCompression::No;
+    return protect(webPage())->isIOSurfaceLosslessCompressionEnabled() ? UseLosslessCompression::Yes : UseLosslessCompression::No;
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -140,7 +140,7 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
         videoElement.naturalSize()
     };
 
-    protect(protectedWebPage()->videoPresentationManager())->setupRemoteLayerHosting(videoElement);
+    protect(protect(webPage())->videoPresentationManager())->setupRemoteLayerHosting(videoElement);
     m_videoLayers.add(layerID, videoElement.identifier());
 
     m_createdLayers.add(layerID, WTF::move(creationProperties));
@@ -148,17 +148,7 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
 }
 #endif
 
-WebPage& RemoteLayerTreeContext::webPage()
-{
-    return m_webPage.get();
-}
-
-Ref<WebPage> RemoteLayerTreeContext::protectedWebPage()
-{
-    return m_webPage.get();
-}
-
-Ref<const WebPage> RemoteLayerTreeContext::protectedWebPage() const
+WebPage& RemoteLayerTreeContext::webPage() const
 {
     return m_webPage.get();
 }
@@ -170,7 +160,7 @@ void RemoteLayerTreeContext::layerWillLeaveContext(PlatformCALayerRemote& layer)
 #if HAVE(AVKIT)
     auto videoLayerIter = m_videoLayers.find(layerID);
     if (videoLayerIter != m_videoLayers.end()) {
-        protect(protectedWebPage()->videoPresentationManager())->willRemoveLayerForID(videoLayerIter->value);
+        protect(protect(webPage())->videoPresentationManager())->willRemoveLayerForID(videoLayerIter->value);
         m_videoLayers.remove(videoLayerIter);
     }
 #endif
@@ -246,7 +236,7 @@ void RemoteLayerTreeContext::animationDidEnd(WebCore::PlatformLayerIdentifier la
 
 RemoteRenderingBackendProxy& RemoteLayerTreeContext::ensureRemoteRenderingBackendProxy()
 {
-    return protectedWebPage()->ensureRemoteRenderingBackendProxy();
+    return protect(webPage())->ensureRemoteRenderingBackendProxy();
 }
 
 Ref<RemoteRenderingBackendProxy> RemoteLayerTreeContext::ensureProtectedRemoteRenderingBackendProxy()

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -894,7 +894,7 @@ JSGlobalContextRef WebFrame::jsContextForWorld(DOMWrapperWorld& world)
 
 JSGlobalContextRef WebFrame::jsContextForWorld(InjectedBundleScriptWorld* world)
 {
-    return jsContextForWorld(world->protectedCoreWorld());
+    return jsContextForWorld(protect(world->coreWorld()));
 }
 
 JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(DOMWrapperWorld& world)
@@ -907,7 +907,7 @@ JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(DOMWrapperWorld& wor
 
 JSGlobalContextRef WebFrame::jsContextForServiceWorkerWorld(InjectedBundleScriptWorld* world)
 {
-    return jsContextForServiceWorkerWorld(world->protectedCoreWorld());
+    return jsContextForServiceWorkerWorld(protect(world->coreWorld()));
 }
 
 void WebFrame::setAccessibleName(const AtomString& accessibleName)
@@ -1095,7 +1095,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleCSSStyleDeclarationHandle* 
     if (!localFrame)
         return nullptr;
 
-    auto* globalObject = localFrame->checkedScript()->globalObject(world->protectedCoreWorld());
+    auto* globalObject = localFrame->checkedScript()->globalObject(protect(world->coreWorld()));
 
     JSLockHolder lock(globalObject);
     return toRef(globalObject, toJS(globalObject, globalObject, cssStyleDeclarationHandle->coreCSSStyleDeclaration()));
@@ -1107,7 +1107,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleNodeHandle* nodeHandle, Inj
     if (!localFrame)
         return nullptr;
 
-    auto* globalObject = localFrame->checkedScript()->globalObject(world->protectedCoreWorld());
+    auto* globalObject = localFrame->checkedScript()->globalObject(protect(world->coreWorld()));
 
     JSLockHolder lock(globalObject);
     RefPtr coreNode = nodeHandle->coreNode();
@@ -1120,7 +1120,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleRangeHandle* rangeHandle, I
     if (!localFrame)
         return nullptr;
 
-    auto* globalObject = localFrame->checkedScript()->globalObject(world->protectedCoreWorld());
+    auto* globalObject = localFrame->checkedScript()->globalObject(protect(world->coreWorld()));
 
     JSLockHolder lock(globalObject);
     return toRef(globalObject, toJS(globalObject, globalObject, Ref { rangeHandle->coreRange() }.get()));

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4541,7 +4541,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
     };
 
     JSLockHolder lock(commonVM());
-    protect(frame->coreLocalFrame())->checkedScript()->executeAsynchronousUserAgentScriptInWorld(world->protectedCoreWorld(), WTF::move(coreParameters), WTF::move(resolveFunction));
+    protect(frame->coreLocalFrame())->checkedScript()->executeAsynchronousUserAgentScriptInWorld(protect(world->coreWorld()), WTF::move(coreParameters), WTF::move(resolveFunction));
 }
 
 void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parameters, std::optional<WebCore::FrameIdentifier> frameID, const ContentWorldData& worldData, bool wantsResult, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>)>&& completionHandler)
@@ -5624,7 +5624,7 @@ void WebPage::unapplyEditCommand(uint32_t undoVersion, WebUndoStepID stepID, Com
     if (!step)
         return completionHandler();
 
-    step->protectedStep()->unapply();
+    protect(step->step())->unapply();
     completionHandler();
 }
 
@@ -5640,7 +5640,7 @@ void WebPage::reapplyEditCommand(uint32_t undoVersion, WebUndoStepID stepID, Com
         return completionHandler();
 
     setIsInRedo(true);
-    step->protectedStep()->reapply();
+    protect(step->step())->reapply();
     setIsInRedo(false);
     completionHandler();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp
@@ -73,17 +73,17 @@ WebPageOverlay* WebPageOverlay::fromCoreOverlay(PageOverlay& overlay)
 
 void WebPageOverlay::setNeedsDisplay(const IntRect& dirtyRect)
 {
-    protectedCoreOverlay()->setNeedsDisplay(dirtyRect);
+    protect(coreOverlay())->setNeedsDisplay(dirtyRect);
 }
 
 void WebPageOverlay::setNeedsDisplay()
 {
-    protectedCoreOverlay()->setNeedsDisplay();
+    protect(coreOverlay())->setNeedsDisplay();
 }
 
 void WebPageOverlay::clear()
 {
-    protectedCoreOverlay()->clear();
+    protect(coreOverlay())->clear();
 }
 
 void WebPageOverlay::willMoveToPage(PageOverlay&, Page* page)

--- a/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageOverlay.h
@@ -87,7 +87,6 @@ public:
     void clear();
 
     WebCore::PageOverlay* coreOverlay() const { return m_overlay.get(); }
-    RefPtr<WebCore::PageOverlay> protectedCoreOverlay() const { return m_overlay; }
     Client& client() const { return *m_client; }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
@@ -63,15 +63,10 @@ void WebURLSchemeHandlerProxy::startNewTask(ResourceLoader& loader, WebFrame& we
     task->startLoading();
 }
 
-Ref<WebPage> WebURLSchemeHandlerProxy::protectedPage()
-{
-    return m_webPage.get();
-}
-
 void WebURLSchemeHandlerProxy::loadSynchronously(WebCore::ResourceLoaderIdentifier loadIdentifier, WebFrame& webFrame, const ResourceRequest& request, ResourceResponse& response, ResourceError& error, Vector<uint8_t>& data)
 {
     data.shrink(0);
-    auto sendResult = protectedPage()->sendSync(Messages::WebPageProxy::LoadSynchronousURLSchemeTask(URLSchemeTaskParameters { m_identifier, loadIdentifier, request, webFrame.info() }));
+    auto sendResult = protect(page())->sendSync(Messages::WebPageProxy::LoadSynchronousURLSchemeTask(URLSchemeTaskParameters { m_identifier, loadIdentifier, request, webFrame.info() }));
     if (sendResult.succeeded())
         std::tie(response, error, data) = sendResult.takeReply();
     else

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h
@@ -58,7 +58,6 @@ public:
 
     WebURLSchemeHandlerIdentifier identifier() const { return m_identifier; }
     WebPage& page() { return m_webPage.get(); }
-    Ref<WebPage> protectedPage();
 
     void taskDidPerformRedirection(WebCore::ResourceLoaderIdentifier, WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
     void taskDidReceiveResponse(WebCore::ResourceLoaderIdentifier, WebCore::ResourceResponse&&);

--- a/Source/WebKit/WebProcess/WebPage/WebUndoStep.h
+++ b/Source/WebKit/WebProcess/WebPage/WebUndoStep.h
@@ -37,7 +37,6 @@ public:
     ~WebUndoStep();
 
     WebCore::UndoStep& step() const { return m_step.get(); }
-    Ref<WebCore::UndoStep> protectedStep() const { return m_step; }
     WebUndoStepID stepID() const { return m_stepID; }
 
     void didRemoveFromUndoManager() { m_step->didRemoveFromUndoManager(); }

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -129,7 +129,6 @@ private:
     void commitTransientZoom(double scale, WebCore::FloatPoint origin, CompletionHandler<void()>&&) override;
     void applyTransientZoomToPage(double scale, WebCore::FloatPoint origin);
     WebCore::PlatformCALayer* layerForTransientZoom() const;
-    RefPtr<WebCore::PlatformCALayer> protectedLayerForTransientZoom() const;
     WebCore::PlatformCALayer* shadowLayerForTransientZoom() const;
 
     void applyTransientZoomToLayers(double scale, WebCore::FloatPoint origin);

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -646,11 +646,6 @@ PlatformCALayer* TiledCoreAnimationDrawingArea::layerForTransientZoom() const
     return scaledLayer->platformCALayer();
 }
 
-RefPtr<WebCore::PlatformCALayer> TiledCoreAnimationDrawingArea::protectedLayerForTransientZoom() const
-{
-    return layerForTransientZoom();
-}
-
 PlatformCALayer* TiledCoreAnimationDrawingArea::shadowLayerForTransientZoom() const
 {
     CheckedPtr frameView =  Ref { m_webPage.get() }->localMainFrameView();
@@ -813,7 +808,7 @@ void TiledCoreAnimationDrawingArea::applyTransientZoomToPage(double scale, Float
     // and not apply the transform, so we can't depend on it to do so.
     TransformationMatrix finalTransform;
     finalTransform.scale(scale);
-    protectedLayerForTransientZoom()->setTransform(finalTransform);
+    protect(layerForTransientZoom())->setTransform(finalTransform);
     
     Ref frameView = *webPage->localMainFrameView();
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1373,7 +1373,7 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
         m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled(WebCore::LegacySchemeRegistry::allURLSchemesRegisteredAsCORSEnabled()), 0);
 
         if (!Document::allDocuments().isEmpty() || SharedWorkerThreadProxy::hasInstances())
-            protectedNetworkProcessConnection()->protectedServiceWorkerConnection()->registerServiceWorkerClients();
+            protect(protectedNetworkProcessConnection()->serviceWorkerConnection())->registerServiceWorkerClients();
 
 #if HAVE(LSDATABASECONTEXT)
         // On Mac, this needs to be called before NSApplication is being initialized.


### PR DESCRIPTION
#### df860c109093087cda05a05bbce1d184aee6d1f5
<pre>
Further reduce use of protected member functions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=306502">https://bugs.webkit.org/show_bug.cgi?id=306502</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
(WebKit::ModelConnectionToWebProcess::connection):
(WebKit::ModelConnectionToWebProcess::protectedConnection): Deleted.
* Source/WebKit/ModelProcess/ModelProcessModelPlayerManagerProxy.cpp:
(WebKit::ModelProcessModelPlayerManagerProxy::createModelPlayer):
* Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::dispatchMessage):
(WebKit::NetworkConnectionToWebProcess::registerToRTCDataChannelProxy):
(WebKit::NetworkConnectionToWebProcess::unregisterToRTCDataChannelProxy):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkTAO):
(WebKit::NetworkLoadChecker::continueCheckingRequest):
(WebKit::NetworkLoadChecker::checkCORSRedirectedRequest):
(WebKit::NetworkLoadChecker::contentSecurityPolicy):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
(WebKit::NetworkLoadChecker::protectedOrigin const): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::rtcDataChannelProxy):
(WebKit::NetworkProcess::protectedRTCDataChannelProxy): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didRetrieveCacheEntry):
(WebKit::NetworkResourceLoader::sendResultForCacheEntry):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
(WebKit::NetworkCache::Data::dispatchData const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::copyData const):
(WebKit::NetworkCache::Data::empty):
(WebKit::NetworkCache::Data::subrange const):
(WebKit::NetworkCache::concatenate):
(WebKit::NetworkCache::Data::protectedDispatchData const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
(WebKit::NetworkCache::Entry::protectedBuffer const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::initializeConnection):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::setCookieTransformForFirstPartyRequest):
(WebKit::NetworkTaskCocoa::blockCookies):
(WebKit::NetworkTaskCocoa::unblockCookies):
(WebKit::NetworkTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkTaskCocoa::protectedTask const): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::registerMDNSNameCallback):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::createResolver):
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::dispatchSyncMessage):
(IPC::Connection::dispatchDidReceiveInvalidMessage):
(IPC::Connection::dispatchMessage):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::xpcConnection const):
(IPC::Connection::client const):
(IPC::Connection::waitForAndDispatchImmediately):
(IPC::Connection::protectedXPCConnection const): Deleted.
(IPC::Connection::protectedClient const): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::processStreamMessage):
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::protectedRootLayer const): Deleted.
* Source/WebKit/Platform/cocoa/LayerHostingContextManager.mm:
(WebKit::LayerHostingContextManager::setVideoLayerSizeIfPossible):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::parentProcessHasEntitlement):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.cpp:
(WebKit::WebGPU::RemoteComputePipelineProxy::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.cpp:
(WebKit::WebGPU::RemoteDeviceProxy::createTexture):
(WebKit::WebGPU::RemoteDeviceProxy::createBindGroupLayout):
(WebKit::WebGPU::RemoteDeviceProxy::createCommandEncoder):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.cpp:
(WebKit::WebGPU::RemotePresentationContextProxy::getCurrentTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.cpp:
(WebKit::WebGPU::RemoteRenderPipelineProxy::getBindGroupLayout):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.cpp:
(WebKit::WebGPU::RemoteXRBindingProxy::createProjectionLayer):
(WebKit::WebGPU::RemoteXRBindingProxy::getViewSubImage):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.cpp:
(WebKit::WebGPU::RemoteXRSubImageProxy::colorTexture):
(WebKit::WebGPU::RemoteXRSubImageProxy::depthStencilTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::prepareForPlayback):
(WebKit::MediaPlayerPrivateRemote::load):
(WebKit::MediaPlayerPrivateRemote::cancelLoad):
(WebKit::MediaPlayerPrivateRemote::prepareToPlay):
(WebKit::MediaPlayerPrivateRemote::play):
(WebKit::MediaPlayerPrivateRemote::pause):
(WebKit::MediaPlayerPrivateRemote::setPreservesPitch):
(WebKit::MediaPlayerPrivateRemote::setPitchCorrectionAlgorithm):
(WebKit::MediaPlayerPrivateRemote::setVolumeLocked):
(WebKit::MediaPlayerPrivateRemote::setVolumeDouble):
(WebKit::MediaPlayerPrivateRemote::setMuted):
(WebKit::MediaPlayerPrivateRemote::setPreload):
(WebKit::MediaPlayerPrivateRemote::setPrivateBrowsingMode):
(WebKit::MediaPlayerPrivateRemote::seekToTarget):
(WebKit::MediaPlayerPrivateRemote::didLoadingProgressAsync const):
(WebKit::MediaPlayerPrivateRemote::acceleratedRenderingStateChanged):
(WebKit::MediaPlayerPrivateRemote::prepareForRendering):
(WebKit::MediaPlayerPrivateRemote::setPageIsVisible):
(WebKit::MediaPlayerPrivateRemote::setShouldMaintainAspectRatio):
(WebKit::MediaPlayerPrivateRemote::setShouldDisableSleep):
(WebKit::MediaPlayerPrivateRemote::addRemoteAudioTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteTextTrack):
(WebKit::MediaPlayerPrivateRemote::addRemoteVideoTrack):
(WebKit::MediaPlayerPrivateRemote::updateVideoFullscreenInlineImage):
(WebKit::MediaPlayerPrivateRemote::setVideoFullscreenGravity):
(WebKit::MediaPlayerPrivateRemote::setVideoFullscreenMode):
(WebKit::MediaPlayerPrivateRemote::videoFullscreenStandbyChanged):
(WebKit::MediaPlayerPrivateRemote::accessLog const):
(WebKit::MediaPlayerPrivateRemote::errorLog const):
(WebKit::MediaPlayerPrivateRemote::setBufferingPolicy):
(WebKit::MediaPlayerPrivateRemote::setRateDouble):
(WebKit::MediaPlayerPrivateRemote::setPresentationSize):
(WebKit::MediaPlayerPrivateRemote::videoFrameForCurrentTime):
(WebKit::MediaPlayerPrivateRemote::bitmapImageForCurrentTime):
(WebKit::MediaPlayerPrivateRemote::setWirelessVideoPlaybackDisabled):
(WebKit::MediaPlayerPrivateRemote::setWirelessPlaybackTarget):
(WebKit::MediaPlayerPrivateRemote::setShouldPlayToPlaybackTarget):
(WebKit::MediaPlayerPrivateRemote::isCrossOrigin const):
(WebKit::MediaPlayerPrivateRemote::setCDMSession):
(WebKit::MediaPlayerPrivateRemote::keyAdded):
(WebKit::MediaPlayerPrivateRemote::cdmInstanceAttached):
(WebKit::MediaPlayerPrivateRemote::cdmInstanceDetached):
(WebKit::MediaPlayerPrivateRemote::attemptToDecryptWithInstance):
(WebKit::MediaPlayerPrivateRemote::setShouldContinueAfterKeyNeeded):
(WebKit::MediaPlayerPrivateRemote::tracksChanged):
(WebKit::MediaPlayerPrivateRemote::updateVideoPlaybackMetricsUpdateInterval):
(WebKit::MediaPlayerPrivateRemote::notifyTrackModeChanged):
(WebKit::MediaPlayerPrivateRemote::notifyActiveSourceBuffersChanged):
(WebKit::MediaPlayerPrivateRemote::applicationWillResignActive):
(WebKit::MediaPlayerPrivateRemote::applicationDidBecomeActive):
(WebKit::MediaPlayerPrivateRemote::setPreferredDynamicRangeMode):
(WebKit::MediaPlayerPrivateRemote::setPlatformDynamicRangeLimit):
(WebKit::MediaPlayerPrivateRemote::performTaskAtTime):
(WebKit::MediaPlayerPrivateRemote::playAtHostTime):
(WebKit::MediaPlayerPrivateRemote::pauseAtHostTime):
(WebKit::MediaPlayerPrivateRemote::startVideoFrameMetadataGathering):
(WebKit::MediaPlayerPrivateRemote::stopVideoFrameMetadataGathering):
(WebKit::MediaPlayerPrivateRemote::playerContentBoxRectChanged):
(WebKit::MediaPlayerPrivateRemote::setShouldDisableHDR):
(WebKit::MediaPlayerPrivateRemote::requestHostingContext):
(WebKit::MediaPlayerPrivateRemote::setShouldCheckHardwareSupport):
(WebKit::MediaPlayerPrivateRemote::setDefaultSpatialTrackingLabel):
(WebKit::MediaPlayerPrivateRemote::setSpatialTrackingLabel):
(WebKit::MediaPlayerPrivateRemote::prefersSpatialAudioExperienceChanged):
(WebKit::MediaPlayerPrivateRemote::soundStageSizeDidChange):
(WebKit::MediaPlayerPrivateRemote::isInFullscreenOrPictureInPictureChanged):
(WebKit::MediaPlayerPrivateRemote::audioOutputDeviceChanged):
(WebKit::MediaPlayerPrivateRemote::sceneIdentifierDidChange):
(WebKit::MediaPlayerPrivateRemote::setMessageClientForTesting):
(WebKit::MediaPlayerPrivateRemote::sendInternalMessage):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::protectedGPUProcessConnection): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/GPU/media/cocoa/MediaPlayerPrivateRemoteCocoa.mm:
(WebKit::MediaPlayerPrivateRemote::pushVideoFrameMetadata):
(WebKit::MediaPlayerPrivateRemote::colorSpace):
(WebKit::MediaPlayerPrivateRemote::setVideoLayerSizeFenced):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageInstallPageOverlay):
(WKBundlePageUninstallPageOverlay):
(WKBundlePageInstallPageOverlayWithAnimation):
(WKBundlePageUninstallPageOverlayWithAnimation):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::InjectedBundleNodeHandle::absoluteBoundingRect):
(WebKit::InjectedBundleNodeHandle::protectedCoreNode): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::protectedCoreWorld const): Deleted.
(WebKit::InjectedBundleScriptWorld::protectedCoreWorld): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didCreateLayer):
(WebKit::ModelProcessModelPlayer::didFailLoading):
(WebKit::ModelProcessModelPlayer::didUpdateEntityTransform):
(WebKit::ModelProcessModelPlayer::didFinishEnvironmentMapLoading):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
(WebKit::ModelProcessModelPlayer::client):
(WebKit::ModelProcessModelPlayer::protectedClient): Deleted.
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::dispatchMessage):
(WebKit::NetworkProcessConnection::protectedServiceWorkerConnection): Deleted.
(WebKit::NetworkProcessConnection::protectedSharedWorkerConnection): Deleted.
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::networkProcessCrashed):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::messageSenderDestinationID const):
(WebKit::WebResourceLoader::didSendData):
(WebKit::WebResourceLoader::protectedResourceLoader const): Deleted.
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
(WebKit::WebResourceLoader::resourceLoader const):
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::createSource):
(WebKit::SpeechRecognitionRealtimeMediaSourceManager::protectedConnection const): Deleted.
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.h:
* Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.cpp:
(WebKit::WebServiceWorkerProvider::terminateWorkerForTesting):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createPlatformCALayer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
(WebKit::PlatformCALayerRemote::context const):
(WebKit::PlatformCALayerRemote::protectedContext const): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::clone const):
(WebKit::PlatformCALayerRemote::createCompatibleLayer const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::deviceScaleFactor const):
(WebKit::RemoteLayerTreeContext::useIOSurfaceLosslessCompression const):
(WebKit::RemoteLayerTreeContext::layerDidEnterContext):
(WebKit::RemoteLayerTreeContext::webPage const):
(WebKit::RemoteLayerTreeContext::layerWillLeaveContext):
(WebKit::RemoteLayerTreeContext::ensureRemoteRenderingBackendProxy):
(WebKit::RemoteLayerTreeContext::webPage): Deleted.
(WebKit::RemoteLayerTreeContext::protectedWebPage): Deleted.
(WebKit::RemoteLayerTreeContext::protectedWebPage const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::jsContextForWorld):
(WebKit::WebFrame::jsContextForServiceWorkerWorld):
(WebKit::WebFrame::jsWrapperForWorld):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::unapplyEditCommand):
(WebKit::WebPage::reapplyEditCommand):
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.cpp:
(WebKit::WebPageOverlay::setNeedsDisplay):
(WebKit::WebPageOverlay::clear):
* Source/WebKit/WebProcess/WebPage/WebPageOverlay.h:
(WebKit::WebPageOverlay::coreOverlay const):
(WebKit::WebPageOverlay::protectedCoreOverlay const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp:
(WebKit::WebURLSchemeHandlerProxy::loadSynchronously):
(WebKit::WebURLSchemeHandlerProxy::protectedPage): Deleted.
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.h:
(WebKit::WebURLSchemeHandlerProxy::page):
* Source/WebKit/WebProcess/WebPage/WebUndoStep.h:
(WebKit::WebUndoStep::step const):
(WebKit::WebUndoStep::protectedStep const): Deleted.
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToPage):
(WebKit::TiledCoreAnimationDrawingArea::protectedLayerForTransientZoom const): Deleted.
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):

Canonical link: <a href="https://commits.webkit.org/306494@main">https://commits.webkit.org/306494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d98728694bd82e4e86dabdae2d65c2322dcfe77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94612 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5e812ea-74b4-400b-93ba-982132a4dfff) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14059 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108737 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ba9e8de-d1fc-4157-a0f4-7ba4f65c9fd1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89642 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/645b3d64-5035-47f1-9ec0-3ceddcf49c8b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10841 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8466 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/163 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120116 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152484 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3078 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116839 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13604 "Failed to checkout and rebase branch from PR 57457") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117169 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29836 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68786 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13632 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2626 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13568 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13416 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->