### PR TITLE
[SaferCPP] Address issues in WebCore/platform/audio

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -367,7 +367,6 @@ platform/DragImage.cpp
 platform/ScrollView.cpp
 platform/ScrollingEffectsController.cpp
 platform/Widget.cpp
-platform/audio/PlatformMediaSession.cpp
 [ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/LowPowerModeNotifier.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -534,7 +534,6 @@ platform/ScrollView.cpp
 platform/ScrollableArea.cpp
 platform/Widget.cpp
 platform/animation/AcceleratedEffectValues.cpp
-platform/audio/cocoa/AudioFileReaderCocoa.cpp
 [ iOS ] platform/audio/ios/MediaSessionManagerIOS.mm
 [ Mac ] platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -32,8 +32,6 @@ page/cocoa/WebTextIndicatorLayer.mm
 [ Mac ] page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.mm
 [ Mac ] page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.mm
 [ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
-platform/audio/cocoa/AudioFileReaderCocoa.cpp
-platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
 [ iOS ] platform/audio/ios/MediaSessionHelperIOS.mm
 platform/cf/KeyedDecoderCF.cpp
 platform/cf/KeyedEncoderCF.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -21,8 +21,6 @@ loader/archive/cf/LegacyWebArchive.cpp
 [ Mac ] page/scrolling/mac/ScrollingStateScrollingNodeMac.mm
 [ Mac ] page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
 [ Mac ] page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
-platform/audio/cocoa/AudioEncoderCocoa.cpp
-platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
 [ iOS ] platform/audio/ios/AudioSessionIOS.mm
 platform/cf/KeyedDecoderCF.cpp
 [ iOS ] platform/cocoa/ContentFilterUnblockHandlerCocoa.mm

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -208,7 +208,7 @@ void PlatformMediaSession::beginInterruption(InterruptionType type)
         m_interruptionStack.append({ type, true });
         return;
     }
-    if (client().shouldOverrideBackgroundPlaybackRestriction(type)) {
+    if (checkedClient()->shouldOverrideBackgroundPlaybackRestriction(type)) {
         ALWAYS_LOG(LOGIDENTIFIER, "returning early because client says to override interruption");
         m_interruptionStack.append({ type, true });
         return;
@@ -218,7 +218,7 @@ void PlatformMediaSession::beginInterruption(InterruptionType type)
     m_stateToRestore = state();
     m_notifyingClient = true;
     setState(State::Interrupted);
-    client().suspendPlayback();
+    checkedClient()->suspendPlayback();
     m_notifyingClient = false;
 }
 
@@ -242,10 +242,10 @@ void PlatformMediaSession::endInterruption(OptionSet<EndInterruptionFlags> flags
     setState(stateToRestore);
 
     if (stateToRestore == State::Autoplaying)
-        client().resumeAutoplaying();
+        checkedClient()->resumeAutoplaying();
 
     bool shouldResume = flags.contains(EndInterruptionFlags::MayResumePlaying) && stateToRestore == State::Playing;
-    client().mayResumePlayback(shouldResume);
+    checkedClient()->mayResumePlayback(shouldResume);
 }
 
 void PlatformMediaSession::clientWillBeginAutoplaying()
@@ -337,13 +337,13 @@ void PlatformMediaSession::pauseSession()
     if (state() == State::Interrupted)
         m_stateToRestore = State::Paused;
 
-    client().suspendPlayback();
+    checkedClient()->suspendPlayback();
 }
 
 void PlatformMediaSession::stopSession()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    client().suspendPlayback();
+    checkedClient()->suspendPlayback();
     if (RefPtr manager = sessionManager())
         manager->removeSession(*this);
 }
@@ -352,7 +352,7 @@ void PlatformMediaSession::didReceiveRemoteControlCommand(RemoteControlCommandTy
 {
     ALWAYS_LOG(LOGIDENTIFIER, command);
 
-    client().didReceiveRemoteControlCommand(command, argument);
+    checkedClient()->didReceiveRemoteControlCommand(command, argument);
 }
 
 void PlatformMediaSession::isPlayingToWirelessPlaybackTargetChanged(bool isWireless)
@@ -409,17 +409,17 @@ bool PlatformMediaSession::canPlayConcurrently(const PlatformMediaSessionInterfa
     if (otherMediaType != mediaType && (!isPlayingAudio(mediaType) || !isPlayingAudio(otherMediaType)))
         return true;
 
-    auto groupID = client().mediaSessionGroupIdentifier();
-    auto otherGroupID = otherSession.client().mediaSessionGroupIdentifier();
+    auto groupID = checkedClient()->mediaSessionGroupIdentifier();
+    auto otherGroupID = otherSession.checkedClient()->mediaSessionGroupIdentifier();
     if (!groupID || !otherGroupID || groupID != otherGroupID)
         return false;
 
-    return client().hasMediaStreamSource() || otherSession.client().hasMediaStreamSource();
+    return checkedClient()->hasMediaStreamSource() || otherSession.checkedClient()->hasMediaStreamSource();
 }
 
 WeakPtr<PlatformMediaSessionInterface> PlatformMediaSession::selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSessionInterface>>& sessions, PlaybackControlsPurpose purpose)
 {
-    return client().selectBestMediaSession(sessions, purpose);
+    return checkedClient()->selectBestMediaSession(sessions, purpose);
 }
 
 void PlatformMediaSession::setActiveNowPlayingSession(bool isActiveNowPlayingSession)
@@ -433,12 +433,12 @@ void PlatformMediaSession::setActiveNowPlayingSession(bool isActiveNowPlayingSes
 #if !RELEASE_LOG_DISABLED
 const Logger& PlatformMediaSession::logger() const
 {
-    return client().logger();
+    return checkedClient()->logger();
 }
 
 uint64_t PlatformMediaSession::logIdentifier() const
 {
-    return client().logIdentifier();
+    return checkedClient()->logIdentifier();
 }
 
 WTFLogChannel& PlatformMediaSession::logChannel() const

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -197,7 +197,7 @@ std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(std::spa
         for (auto& audioTrack : init.audioTracks) {
             if (audioTrack.track) {
                 duration = init.duration;
-                audioTrackId = audioTrack.track->id();
+                audioTrackId = RefPtr { audioTrack.track }->id();
                 // FIXME: Use downcast instead.
                 track = unsafeRefPtrDowncast<AudioTrackPrivateWebM>(audioTrack.track);
                 return;
@@ -289,7 +289,7 @@ std::optional<size_t> AudioFileReader::decodeWebMData(AudioBufferList& bufferLis
         PAL::AudioConverterDispose(converter);
     });
     ASSERT(m_webmData && !m_webmData->m_samples.isEmpty() && m_webmData->m_samples[0]->sampleBuffer(), "Structure integrity was checked in numberOfFrames");
-    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(m_webmData->m_samples[0]->sampleBuffer());
+    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(RetainPtr { m_webmData->m_samples[0]->sampleBuffer() }.get());
     if (!formatDescription) {
         RELEASE_LOG_FAULT(WebAudio, "Unable to retrieve format description from first sample");
         return { };
@@ -485,7 +485,7 @@ std::optional<AudioStreamBasicDescription> AudioFileReader::fileDataFormat() con
     if (m_webmData->m_samples.isEmpty())
         return { };
 
-    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(m_webmData->m_samples[0]->sampleBuffer());
+    RetainPtr formatDescription = PAL::CMSampleBufferGetFormatDescription(RetainPtr { m_webmData->m_samples[0]->sampleBuffer() }.get());
     if (!formatDescription)
         return { };
 

--- a/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
@@ -151,9 +151,9 @@ PlatformRawAudioDataCocoa::PlatformRawAudioDataCocoa(Ref<MediaSampleAVFObjC>&& s
 
 const AudioStreamBasicDescription& PlatformRawAudioDataCocoa::asbd() const
 {
-    auto description = PAL::CMSampleBufferGetFormatDescription(m_sample->sampleBuffer());
+    RetainPtr description = PAL::CMSampleBufferGetFormatDescription(RetainPtr { m_sample->sampleBuffer() }.get());
     ASSERT(description);
-    const AudioStreamBasicDescription* const asbd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(description);
+    const AudioStreamBasicDescription* const asbd = PAL::CMAudioFormatDescriptionGetStreamBasicDescription(description.get());
     ASSERT(asbd);
     return *asbd;
 }
@@ -187,7 +187,7 @@ size_t PlatformRawAudioDataCocoa::numberOfChannels() const
 
 size_t PlatformRawAudioDataCocoa::numberOfFrames() const
 {
-    return PAL::CMSampleBufferGetNumSamples(m_sample->sampleBuffer());
+    return PAL::CMSampleBufferGetNumSamples(RetainPtr { m_sample->sampleBuffer() }.get());
 }
 
 std::optional<uint64_t> PlatformRawAudioDataCocoa::duration() const


### PR DESCRIPTION
#### dbe7b6c8e93a08da477c951e875d9464d8a0a3bf
<pre>
[SaferCPP] Address issues in WebCore/platform/audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=306505">https://bugs.webkit.org/show_bug.cgi?id=306505</a>
<a href="https://rdar.apple.com/169161617">rdar://169161617</a>

Reviewed by Geoffrey Garen.

Address remaining Safer CPP issues for several classes in WebCore/platform/audio

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::beginInterruption):
(WebCore::PlatformMediaSession::endInterruption):
(WebCore::PlatformMediaSession::pauseSession):
(WebCore::PlatformMediaSession::stopSession):
(WebCore::PlatformMediaSession::didReceiveRemoteControlCommand):
(WebCore::PlatformMediaSession::canPlayConcurrently const):
(WebCore::PlatformMediaSession::selectBestMediaSession):
(WebCore::PlatformMediaSession::logger const):
(WebCore::PlatformMediaSession::logIdentifier const):
* Source/WebCore/platform/audio/cocoa/AudioEncoderCocoa.cpp:
(WebCore::InternalAudioEncoderCocoa::processEncodedOutputs):
(WebCore::InternalAudioEncoderCocoa::encode):
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
(WebCore::AudioFileReader::decodeWebMData const):
(WebCore::AudioFileReader::fileDataFormat const):
* Source/WebCore/platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp:
(WebCore::PlatformRawAudioDataCocoa::asbd const):
(WebCore::PlatformRawAudioDataCocoa::numberOfFrames const):

Canonical link: <a href="https://commits.webkit.org/306492@main">https://commits.webkit.org/306492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/699a7c4d6e43f56ec28d397ce0de38210b4d6810

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94449 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd7f7c8b-b125-44f6-89d6-2bb4e797ad8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108600 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78612 "2 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fabdba9a-acfa-4a6a-b135-9637ad52c91a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89505 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15df89e2-1300-492b-b3f0-95586f3cc501) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8345 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152320 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116707 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117039 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13089 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68623 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13467 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2508 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13204 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->