### PR TITLE
MediaKeySession.sessionId always returns empty string

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/fps-sessionId-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-sessionId-expected.txt
@@ -1,0 +1,11 @@
+PROMISE: requestMediaKeySystemAccess resolved
+PROMISE: createMediaKeys resolved
+FETCH: server certificate recieved
+PROMISE: arrayBuffer resolved
+PROMISE: setServerCertificate resolved
+EVENT(message)
+PROMISE: licenseResponse resolved
+PROMISE: session.update() resolved
+EXPECTED (session.sessionId != '') OK
+END OF TEST
+

--- a/LayoutTests/http/tests/media/fairplay/fps-sessionId.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-sessionId.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>fps-init-data-sinf</title>
+    <script src=../../../media-resources/video-test.js></script>
+    <script src=eme2016.js></script>
+    <script src=support.js></script>
+    <script>
+    window.addEventListener('load', async event => {
+        startTest().then(endTest).catch(failTest);
+    });
+
+    var session;
+
+    async function startTest() {
+        var access = await navigator.requestMediaKeySystemAccess("com.apple.fps", [{
+            initDataTypes: ['sinf'],
+            videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
+            distinctiveIdentifier: 'not-allowed',
+            persistentState: 'not-allowed',
+            sessionTypes: ['temporary'],
+        }]);
+
+        consoleWrite('PROMISE: requestMediaKeySystemAccess resolved');
+        var keys = await access.createMediaKeys();
+
+        consoleWrite('PROMISE: createMediaKeys resolved');
+        var certificateResponse = await fetch('resources/cert.der');
+
+        consoleWrite('FETCH: server certificate recieved');
+        var arrayBuffer = await certificateResponse.arrayBuffer();
+
+        consoleWrite('PROMISE: arrayBuffer resolved');
+        await keys.setServerCertificate(arrayBuffer);
+
+        consoleWrite('PROMISE: setServerCertificate resolved');
+        session = keys.createSession();
+
+        var initData = new TextEncoder().encode(JSON.stringify({
+            sinf: [
+                "AAAADGZybWFtcDRhAAAAFHNjaG0AAAAAY2JjcwABAAAAAAA5c2NoaQAAADF0ZW5jAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAENwoLj77jCjwCAAw3SqKao8=",
+            ]
+        }));
+
+        session.generateRequest('sinf', initData);
+        let message = await waitFor(session, 'message');
+        let response = await getResponse(message);
+        await session.update(response);
+        consoleWrite('PROMISE: session.update() resolved');
+
+        testExpected('session.sessionId', '', '!=');
+    }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/fairplay/inspector-getMediaStats-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/inspector-getMediaStats-expected.txt
@@ -1,0 +1,3 @@
+FAIL: Timed out waiting for notifyDone to be called
+
+

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
@@ -1558,8 +1558,10 @@ bool CDMInstanceSessionFairPlayStreamingAVFObjC::shouldRetryRequestForReason(AVC
 void CDMInstanceSessionFairPlayStreamingAVFObjC::sessionIdentifierChanged(NSData *sessionIdentifier)
 {
     String sessionId = emptyString();
-    if (sessionIdentifier)
-        sessionId = adoptNS([[NSString alloc] initWithData:sessionIdentifier encoding:NSUTF8StringEncoding]).get();
+    if (sessionIdentifier) {
+        Ref sessionIdentifierBuffer = SharedBuffer::create(sessionIdentifier);
+        sessionId = toHexString(sessionIdentifierBuffer->span());
+    }
 
     if (m_sessionId == sessionId)
         return;


### PR DESCRIPTION
#### e9ec62cd2a34bf1f0fbdaf0dc1fdbe7acb2bf6fa
<pre>
MediaKeySession.sessionId always returns empty string
<a href="https://rdar.apple.com/169140031">rdar://169140031</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306485">https://bugs.webkit.org/show_bug.cgi?id=306485</a>

Reviewed by Eric Carlson.

When converting the NSData given to us by FairPlay to a string,
don&apos;t assume the content is utf-8 encoded, and just convert the
data to the hex equivalent.

Test: http/tests/media/fairplay/fps-sessionId.html

* LayoutTests/http/tests/media/fairplay/fps-sessionId-expected.txt: Added.
* LayoutTests/http/tests/media/fairplay/fps-sessionId.html: Added.
* LayoutTests/http/tests/media/fairplay/inspector-getMediaStats-expected.txt: Added.
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::sessionIdentifierChanged):

Canonical link: <a href="https://commits.webkit.org/306491@main">https://commits.webkit.org/306491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60ff22a8a7438be30185e175fc2f4b14049c52df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94388 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea898166-cdf3-40e6-843b-cb23bf2805be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143164 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108554 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78588 "1 flakes 6 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/795981aa-5bf7-4742-bfaf-87ccb10465a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89459 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2dd81001-d140-4597-8c9b-19d6084493f2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8289 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152259 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116651 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116991 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29833 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13043 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68535 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13404 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2468 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77110 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13342 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->