### PR TITLE
Reduce use of protected functions in Source/WTF

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -338,7 +338,7 @@ void RemoteInspector::setupXPCConnectionIfNeeded()
     }
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptXPCObject(xpc_connection_create_mach_service(WIRXPCMachPortName, m_xpcQueue.get(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptOSObject(xpc_connection_create_mach_service(WIRXPCMachPortName, m_xpcQueue.get(), 0));
     if (!connection) {
         WTFLogAlways("RemoteInspector failed to create XPC connection.");
         return;

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h
@@ -72,7 +72,7 @@ private:
     // We make sure that m_client is thread safe and immediately cleared in close().
     Lock m_mutex;
 
-    XPCObjectPtr<xpc_connection_t> m_connection;
+    OSObjectPtr<xpc_connection_t> m_connection;
     OSObjectPtr<dispatch_queue_t> m_queue;
     Client* m_client;
     bool m_closed { false };

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm
@@ -105,7 +105,7 @@ RetainPtr<NSDictionary> RemoteInspectorXPCConnection::deserializeMessage(xpc_obj
     if (xpc_get_type(object) != XPC_TYPE_DICTIONARY)
         return nil;
 
-    XPCObjectPtr<xpc_object_t> xpcDictionary = xpc_dictionary_get_value(object, RemoteInspectorXPCConnectionSerializedMessageKey);
+    OSObjectPtr<xpc_object_t> xpcDictionary = xpc_dictionary_get_value(object, RemoteInspectorXPCConnectionSerializedMessageKey);
     if (!xpcDictionary || xpc_get_type(xpcDictionary.get()) != XPC_TYPE_DICTIONARY) {
         Locker locker { m_mutex };
         if (m_client)
@@ -187,7 +187,7 @@ void RemoteInspectorXPCConnection::sendMessage(NSString *messageName, NSDictiona
         return;
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto msg = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto msg = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_value(msg.get(), RemoteInspectorXPCConnectionSerializedMessageKey, xpcDictionary.get());
     xpc_connection_send_message(m_connection.get(), msg.get());
 }

--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -36,7 +36,6 @@ public:
     virtual ~LoggerHelper() = default;
 
     virtual const Logger& logger() const = 0;
-    Ref<const Logger> protectedLogger() const { return logger(); }
     virtual ASCIILiteral logClassName() const = 0;
     virtual WTFLogChannel& logChannel() const = 0;
     virtual uint64_t logIdentifier() const = 0;

--- a/Source/WTF/wtf/SchedulePair.h
+++ b/Source/WTF/wtf/SchedulePair.h
@@ -50,9 +50,7 @@ public:
 #endif
 
     CFRunLoopRef runLoop() const { return m_runLoop.get(); }
-    RetainPtr<CFRunLoopRef> protectedRunLoop() const { return m_runLoop; }
     CFStringRef mode() const { return m_mode.get(); }
-    RetainPtr<CFStringRef> protectedMode() const { return m_mode; }
 
     WTF_EXPORT_PRIVATE bool operator==(const SchedulePair& other) const;
 

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -53,7 +53,6 @@ public:
 
 #if USE(COCOA_EVENT_LOOP)
     dispatch_queue_t dispatchQueue() const { return m_dispatchQueue.get(); }
-    OSObjectPtr<dispatch_queue_t> protectedDispatchQueue() const { return dispatchQueue(); }
 #endif
 
     virtual void ref() const = 0;

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -96,7 +96,7 @@ void RunLoop::dispatch(const SchedulePairHashSet& schedulePairs, Function<void()
     }, function.leak());
 
     for (auto& schedulePair : schedulePairs)
-        CFRunLoopAddTimer(schedulePair->protectedRunLoop().get(), timer.get(), schedulePair->protectedMode().get());
+        CFRunLoopAddTimer(protect(schedulePair->runLoop()).get(), timer.get(), protect(schedulePair->mode()).get());
 }
 
 // RunLoop::Timer

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -53,14 +53,14 @@ bool hasEntitlement(audit_token_t token, ASCIILiteral entitlement)
 bool hasEntitlement(xpc_connection_t connection, StringView entitlement)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptXPCObject(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 
 bool hasEntitlement(xpc_connection_t connection, ASCIILiteral entitlement)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptXPCObject(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 

--- a/Source/WTF/wtf/darwin/DispatchOSObject.h
+++ b/Source/WTF/wtf/darwin/DispatchOSObject.h
@@ -60,6 +60,15 @@ WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_OS_OBJECT_DISPATCH_TYPE_CAST_TRAITS)
 WTF_OS_OBJECT_DISPATCH_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_DISPATCH)
 #undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_DISPATCH
 
+// Dispatch protect() functions.
+#define WTF_DECLARE_DISPATCH_PROTECT(TypeName) \
+ALWAYS_INLINE OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
+{ \
+    return ptr; \
+}
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_DISPATCH_PROTECT)
+#undef WTF_DECLARE_DISPATCH_PROTECT
+
 #if !__has_feature(objc_arc)
 // Template specializations for dispatch retain/release traits (non-ARC only).
 #define WTF_DECLARE_DISPATCH_OSOBJECT_RETAIN_TRAITS(TypeName) \

--- a/Source/WTF/wtf/darwin/NetworkOSObject.h
+++ b/Source/WTF/wtf/darwin/NetworkOSObject.h
@@ -56,6 +56,15 @@ WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_OS_OBJECT_NETWORK_TYPE_CAST_TRAITS)
 WTF_OS_OBJECT_NETWORK_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_NETWORK)
 #undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_NETWORK
 
+// Network protect() functions.
+#define WTF_DECLARE_NETWORK_PROTECT(TypeName) \
+ALWAYS_INLINE OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
+{ \
+    return ptr; \
+}
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_NETWORK_PROTECT)
+#undef WTF_DECLARE_NETWORK_PROTECT
+
 #if !__has_feature(objc_arc)
 // Template specializations for network retain/release traits (non-ARC only).
 #define WTF_DECLARE_NETWORK_OSOBJECT_RETAIN_TRAITS(TypeName) \

--- a/Source/WTF/wtf/darwin/XPCObjectPtr.h
+++ b/Source/WTF/wtf/darwin/XPCObjectPtr.h
@@ -26,35 +26,59 @@
 #pragma once
 
 #include <wtf/OSObjectPtr.h>
+#include <wtf/darwin/TypeCastsOSObject.h>
 #include <wtf/spi/darwin/XPCSPI.h>
+
+#define WTF_OS_OBJECT_XPC_TYPES(M) \
+    M(xpc_object)
+
+// Forward declarations for XPC base struct types.
+WTF_EXTERN_C_BEGIN
+#define WTF_DECLARE_OS_OBJECT_XPC_BASE_STRUCT(TypeName) \
+struct TypeName;
+WTF_OS_OBJECT_XPC_TYPES(WTF_DECLARE_OS_OBJECT_XPC_BASE_STRUCT)
+#undef WTF_DECLARE_OS_OBJECT_XPC_BASE_STRUCT
+WTF_EXTERN_C_END
 
 namespace WTF {
 
-template<typename arcEnabled = ARCEnabled>
-struct XPCObjectRetainTraits {
-    static ALWAYS_INLINE void retain(xpc_object_t ptr)
-    {
-#if __has_feature(objc_arc)
-        UNUSED_PARAM(ptr);
-#else
-        xpc_retain(ptr);
-#endif
-    }
-    static ALWAYS_INLINE void release(xpc_object_t ptr)
-    {
-#if __has_feature(objc_arc)
-        UNUSED_PARAM(ptr);
-#else
-        xpc_release(ptr);
-#endif
-    }
-};
+// XPC OSObject type cast traits.
+#define WTF_DECLARE_OS_OBJECT_XPC_TYPE_CAST_TRAITS(TypeName) \
+WTF_DECLARE_OS_OBJECT_TYPE_CAST_TRAITS_INTERNAL(TypeName, )
+WTF_OS_OBJECT_XPC_TYPES(WTF_DECLARE_OS_OBJECT_XPC_TYPE_CAST_TRAITS)
+#undef WTF_DECLARE_OS_OBJECT_XPC_TYPE_CAST_TRAITS
 
-template<typename T> using XPCObjectPtr = OSObjectPtr<T, XPCObjectRetainTraits<ARCEnabled>>;
+// XPC isOSObject functions.
+#define WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_XPC(TypeName) WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_INTERNAL(TypeName##_t, STRINGIZE_VALUE_OF(OS_OBJECT_CLASS(TypeName)))
+WTF_OS_OBJECT_XPC_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_XPC)
+#undef WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_XPC
 
-#define adoptXPCObject(x) adoptOSObject<decltype(x), XPCObjectRetainTraits<WTF::ARCEnabled>>(x)
+// XPC protect() functions.
+#define WTF_DECLARE_XPC_PROTECT(TypeName) \
+ALWAYS_INLINE OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
+{ \
+    return ptr; \
+}
+WTF_OS_OBJECT_XPC_TYPES(WTF_DECLARE_XPC_PROTECT)
+#undef WTF_DECLARE_XPC_PROTECT
+
+#if !__has_feature(objc_arc)
+// Template specializations for XPC retain/release traits (non-ARC only).
+#define WTF_DECLARE_XPC_OSOBJECT_RETAIN_TRAITS(TypeName) \
+template<> \
+struct DefaultOSObjectRetainTraits<TypeName##_t, std::false_type> { \
+    static ALWAYS_INLINE void retain(TypeName##_t ptr) \
+    { \
+        xpc_retain(ptr); \
+    } \
+    static ALWAYS_INLINE void release(TypeName##_t ptr) \
+    { \
+        xpc_release(ptr); \
+    } \
+}; \
+
+WTF_OS_OBJECT_XPC_TYPES(WTF_DECLARE_XPC_OSOBJECT_RETAIN_TRAITS)
+#undef WTF_DECLARE_XPC_OSOBJECT_RETAIN_TRAITS
+#endif // !__has_feature(objc_arc)
 
 } // namespace WTF
-
-using WTF::XPCObjectPtr;
-using WTF::XPCObjectRetainTraits;

--- a/Source/WebCore/platform/VideoReceiverEndpoint.h
+++ b/Source/WebCore/platform/VideoReceiverEndpoint.h
@@ -37,7 +37,7 @@ struct VideoReceiverEndpointIdentifierType;
 using VideoReceiverEndpointIdentifier = ObjectIdentifier<VideoReceiverEndpointIdentifierType>;
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-using VideoReceiverEndpoint = XPCObjectPtr<xpc_object_t>;
+using VideoReceiverEndpoint = OSObjectPtr<xpc_object_t>;
 #else
 using VideoReceiverEndpoint = void*;
 #endif

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -783,7 +783,7 @@ void SourceBufferPrivate::addTrackBuffer(TrackID trackId, RefPtr<MediaDescriptio
         auto trackBuffer = TrackBuffer::create(WTF::move(description), discontinuityTolerance);
 #if !RELEASE_LOG_DISABLED
         // False positive see webkit.org/b/302520
-        SUPPRESS_UNCOUNTED_ARG trackBuffer->setLogger(buffer.protectedLogger(), buffer.logIdentifier());
+        SUPPRESS_UNCOUNTED_ARG trackBuffer->setLogger(protect(buffer.logger()), buffer.logIdentifier());
 #endif
         buffer.m_trackBufferMap.try_emplace(trackId, WTF::move(trackBuffer));
         if (RefPtr mediaSource = buffer.m_mediaSource.get()) {

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -36,7 +36,7 @@ namespace WebKit {
 
 class GPUServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    GPUServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    GPUServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTF::move(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
+++ b/Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm
@@ -36,7 +36,7 @@ namespace WebKit {
 
 class ModelServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    ModelServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    ModelServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTF::move(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -72,7 +72,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
             if (!challengeID)
                 return;
 
-            XPCObjectPtr<xpc_object_t> xpcEndPoint = xpc_dictionary_get_value(event.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey);
+            OSObjectPtr<xpc_object_t> xpcEndPoint = xpc_dictionary_get_value(event.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey);
             if (!xpcEndPoint || xpc_get_type(xpcEndPoint.get()) != XPC_TYPE_ENDPOINT)
                 return;
             auto endPoint = adoptNS([[NSXPCListenerEndpoint alloc] init]);
@@ -84,14 +84,14 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
                 return;
             }
 
-            XPCObjectPtr<xpc_object_t> certificateDataArray = xpc_dictionary_get_array(event.get(), ClientCertificateAuthentication::XPCCertificatesKey);
+            OSObjectPtr<xpc_object_t> certificateDataArray = xpc_dictionary_get_array(event.get(), ClientCertificateAuthentication::XPCCertificatesKey);
             if (!certificateDataArray)
                 return;
             RetainPtr<NSMutableArray> certificates;
             if (auto total = xpc_array_get_count(certificateDataArray.get())) {
                 certificates = [NSMutableArray arrayWithCapacity:total];
                 for (size_t i = 0; i < total; i++) {
-                    XPCObjectPtr<xpc_object_t> certificateData = xpc_array_get_value(certificateDataArray.get(), i);
+                    OSObjectPtr<xpc_object_t> certificateData = xpc_array_get_value(certificateDataArray.get(), i);
                     RetainPtr cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(xpc_data_get_bytes_ptr(certificateData.get())), xpc_data_get_length(certificateData.get())));
                     RetainPtr certificate = adoptCF(SecCertificateCreateWithData(nullptr, cfData.get()));
                     if (!certificate)

--- a/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
+++ b/Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm
@@ -34,7 +34,7 @@ namespace WebKit {
 
 class NetworkServiceInitializerDelegate : public XPCServiceInitializerDelegate {
 public:
-    NetworkServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+    NetworkServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
         : XPCServiceInitializerDelegate(WTF::move(connection), initializerMessage)
     {
     }

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -44,11 +44,11 @@ void Connection::newConnectionWasInitialized() const
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(m_configuration));
 }
 
-static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
+static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
     auto xpcData = encoderToXPCData(WTF::move(encoder));
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebPushD::protocolVersionKey, WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h
@@ -75,7 +75,7 @@ private:
 
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)
-    XPCObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final { return nullptr; }
+    OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final { return nullptr; }
     void connectionReceivedEvent(xpc_object_t) final { }
 #endif
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h
@@ -52,7 +52,7 @@ private:
 
     void newConnectionWasInitialized() const final;
 #if PLATFORM(COCOA)
-    XPCObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final;
+    OSObjectPtr<xpc_object_t> dictionaryFromMessage(MessageType, Daemon::EncodedMessage&&) const final;
     void connectionReceivedEvent(xpc_object_t) final;
 #endif
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -60,10 +60,10 @@ void Connection::connectionReceivedEvent(xpc_object_t request)
     m_networkSession->networkProcess().broadcastConsoleMessage(m_networkSession->sessionID(), MessageSource::PrivateClickMeasurement, messageLevel, debugMessage);
 }
 
-XPCObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const
+OSObjectPtr<xpc_object_t> Connection::dictionaryFromMessage(MessageType messageType, EncodedMessage&& message) const
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     addVersionAndEncodedMessageToDictionary(WTF::move(message), dictionary.get());
     xpc_dictionary_set_uint64(dictionary.get(), protocolMessageTypeKey, static_cast<uint64_t>(messageType));
     return dictionary;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm
@@ -96,7 +96,7 @@ IOChannel::~IOChannel()
 void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue, Function<void(Data&&, int error)>&& completionHandler)
 {
     bool didCallCompletionHandler = false;
-    dispatch_io_read(m_dispatchIO.get(), offset, size, queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTF::move(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
+    dispatch_io_read(m_dispatchIO.get(), offset, size, protect(queue->dispatchQueue()).get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTF::move(completionHandler), didCallCompletionHandler](bool done, dispatch_data_t fileData, int error) mutable {
         ASSERT_UNUSED(done, done || !didCallCompletionHandler);
         if (didCallCompletionHandler)
             return;
@@ -110,7 +110,7 @@ void IOChannel::read(size_t offset, size_t size, Ref<WTF::WorkQueueBase>&& queue
 void IOChannel::write(size_t offset, const Data& data, Ref<WTF::WorkQueueBase>&& queue, Function<void(int error)>&& completionHandler)
 {
     RetainPtr dispatchData = data.dispatchData();
-    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData.get(), queue->protectedDispatchQueue().get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTF::move(completionHandler)](bool done, dispatch_data_t, int error) mutable {
+    dispatch_io_write(m_dispatchIO.get(), offset, dispatchData.get(), protect(queue->dispatchQueue()).get(), makeBlockPtr([protectedThis = Ref { *this }, queue, completionHandler = WTF::move(completionHandler)](bool done, dispatch_data_t, int error) mutable {
         if (!done) {
             RELEASE_LOG_ERROR(NetworkCacheStorage, "IOChannel::write only part of data is written.");
             return;

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h
@@ -44,7 +44,7 @@ public:
     static ASCIILiteral supplementName();
 
 private:
-    void startObserving(XPCObjectPtr<xpc_connection_t>);
+    void startObserving(OSObjectPtr<xpc_connection_t>);
 
     // XPCEndpoint
     ASCIILiteral xpcEndpointMessageNameKey() const override;
@@ -57,7 +57,7 @@ private:
 
     RetainPtr<id> m_observer;
     Lock m_connectionsLock;
-    Vector<XPCObjectPtr<xpc_connection_t>> m_connections WTF_GUARDED_BY_LOCK(m_connectionsLock);
+    Vector<OSObjectPtr<xpc_connection_t>> m_connections WTF_GUARDED_BY_LOCK(m_connectionsLock);
 };
 
 }

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -43,7 +43,7 @@ LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver(NetworkProcess&)
 #if HAVE(LSDATABASECONTEXT) && !HAVE(SYSTEM_CONTENT_LS_DATABASE)
     m_observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -61,7 +61,7 @@ ASCIILiteral LaunchServicesDatabaseObserver::supplementName()
     return "LaunchServicesDatabaseObserverSupplement"_s;
 }
 
-void LaunchServicesDatabaseObserver::startObserving(XPCObjectPtr<xpc_connection_t> connection)
+void LaunchServicesDatabaseObserver::startObserving(OSObjectPtr<xpc_connection_t> connection)
 {
     {
         Locker locker { m_connectionsLock };
@@ -73,7 +73,7 @@ void LaunchServicesDatabaseObserver::startObserving(XPCObjectPtr<xpc_connection_
         if (!object)
             return;
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, object);
 
@@ -83,7 +83,7 @@ void LaunchServicesDatabaseObserver::startObserving(XPCObjectPtr<xpc_connection_
 #elif HAVE(LSDATABASECONTEXT)
     RetainPtr<id> observer = [LSDatabaseContext.sharedDatabaseContext addDatabaseChangeObserver4WebKit:^(xpc_object_t change) {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
         xpc_dictionary_set_value(message.get(), LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey, change);
 
@@ -93,7 +93,7 @@ void LaunchServicesDatabaseObserver::startObserving(XPCObjectPtr<xpc_connection_
     [LSDatabaseContext.sharedDatabaseContext removeDatabaseChangeObserver4WebKit:observer.get()];
 #else
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName);
     xpc_connection_send_message(connection.get(), message.get());
 #endif

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -327,20 +327,20 @@ public:
             : port(port)
         {
         }
-        Identifier(mach_port_t port, XPCObjectPtr<xpc_connection_t> xpcConnection)
+        Identifier(mach_port_t port, OSObjectPtr<xpc_connection_t> xpcConnection)
             : port(port)
             , xpcConnection(WTF::move(xpcConnection))
         {
         }
         operator bool() const { return MACH_PORT_VALID(port); }
         mach_port_t port { MACH_PORT_NULL };
-        XPCObjectPtr<xpc_connection_t> xpcConnection;
+        OSObjectPtr<xpc_connection_t> xpcConnection;
 #endif
     };
 
 #if OS(DARWIN)
     xpc_connection_t xpcConnection() const { return m_xpcConnection.get(); }
-    XPCObjectPtr<xpc_connection_t> protectedXPCConnection() const { return xpcConnection(); }
+    OSObjectPtr<xpc_connection_t> protectedXPCConnection() const { return xpcConnection(); }
     std::optional<audit_token_t> getAuditToken();
     pid_t remoteProcessID() const;
 #endif
@@ -810,7 +810,7 @@ private:
 
     std::unique_ptr<MachMessage> m_pendingOutgoingMachMessage;
 
-    XPCObjectPtr<xpc_connection_t> m_xpcConnection;
+    OSObjectPtr<xpc_connection_t> m_xpcConnection;
     std::atomic<bool> m_didRequestProcessTermination { false };
     std::optional<audit_token_t> m_auditToken;
 #elif OS(WINDOWS)

--- a/Source/WebKit/Platform/IPC/DaemonConnection.h
+++ b/Source/WebKit/Platform/IPC/DaemonConnection.h
@@ -45,7 +45,7 @@ using EncodedMessage = Vector<uint8_t>;
 class Connection : public RefCountedAndCanMakeWeakPtr<Connection> {
 public:
 #if PLATFORM(COCOA)
-    static Ref<Connection> create(XPCObjectPtr<xpc_connection_t>&& connection)
+    static Ref<Connection> create(OSObjectPtr<xpc_connection_t>&& connection)
     {
         return adoptRef(*new Connection(WTF::move(connection)));
     }
@@ -63,14 +63,14 @@ protected:
     Connection() = default;
 
 #if PLATFORM(COCOA)
-    explicit Connection(XPCObjectPtr<xpc_connection_t>&& connection)
+    explicit Connection(OSObjectPtr<xpc_connection_t>&& connection)
         : m_connection(WTF::move(connection)) { }
 #endif
 
     virtual void initializeConnectionIfNeeded() const { }
 
 #if PLATFORM(COCOA)
-    mutable XPCObjectPtr<xpc_connection_t> m_connection;
+    mutable OSObjectPtr<xpc_connection_t> m_connection;
 #endif
 };
 
@@ -85,7 +85,7 @@ public:
     virtual void newConnectionWasInitialized() const = 0;
 
 #if PLATFORM(COCOA)
-    virtual XPCObjectPtr<xpc_object_t> dictionaryFromMessage(typename Traits::MessageType, EncodedMessage&&) const = 0;
+    virtual OSObjectPtr<xpc_object_t> dictionaryFromMessage(typename Traits::MessageType, EncodedMessage&&) const = 0;
     virtual void connectionReceivedEvent(xpc_object_t) = 0;
 #endif
 

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -199,7 +199,7 @@ void Connection::platformOpen()
     // Change the message queue length for the receive port.
     setMachPortQueueLength(m_receivePort, largeOutgoingMessageQueueCountThreshold);
 
-    m_receiveSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, m_connectionQueue->protectedDispatchQueue().get()));
+    m_receiveSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_RECV, m_receivePort, 0, protect(m_connectionQueue->dispatchQueue()).get()));
     dispatch_source_set_event_handler(m_receiveSource.get(), [this, protectedThis = Ref { *this }] {
         receiveSourceEventHandler();
     });
@@ -344,7 +344,7 @@ void Connection::initializeSendSource()
         return;
     RELEASE_ASSERT(m_sendPort != MACH_PORT_NULL);
 
-    m_sendSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, m_connectionQueue->protectedDispatchQueue().get()));
+    m_sendSource = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MACH_SEND, m_sendPort, DISPATCH_MACH_SEND_POSSIBLE, protect(m_connectionQueue->dispatchQueue()).get()));
     dispatch_source_set_registration_handler(m_sendSource.get(), [this, protectedThis = Ref { *this }] {
         if (!m_sendSource)
             return;

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -66,7 +66,7 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
     if (m_connection)
         return;
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create_mach_service(m_machServiceName.data(), mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptOSObject(xpc_connection_create_mach_service(m_machServiceName.data(), mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(m_connection.get(), [weakThis = WeakPtr { *this }](xpc_object_t event) {
         if (!weakThis)
             return;

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.h
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.h
@@ -109,7 +109,7 @@ public:
     static RetainPtr<BELayerHierarchyHostingTransactionCoordinator> createHostingUpdateCoordinator(WTF::MachSendRightAnnotated&&);
     static WTF::MachSendRightAnnotated fence(BELayerHierarchyHostingTransactionCoordinator *);
 #else
-    XPCObjectPtr<xpc_object_t> xpcRepresentation() const;
+    OSObjectPtr<xpc_object_t> xpcRepresentation() const;
     static RetainPtr<BELayerHierarchyHandle> createHostingHandle(uint64_t pid, uint64_t contextID);
     static RetainPtr<BELayerHierarchyHostingTransactionCoordinator> createHostingUpdateCoordinator(mach_port_t sendRight);
 #endif // ENABLE(MACH_PORT_LAYER_HOSTING)

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -223,7 +223,7 @@ RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(WTF::
     return handle;
 }
 #else
-XPCObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
+OSObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
 {
     if (!m_hostable)
         return nullptr;
@@ -233,7 +233,7 @@ XPCObjectPtr<xpc_object_t> LayerHostingContext::xpcRepresentation() const
 RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::createHostingUpdateCoordinator(mach_port_t sendRight)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpcRepresentation = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_mach_send(xpcRepresentation.get(), machPortKey, sendRight);
     NSError* error = nil;
     auto coordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithXPCRepresentation:xpcRepresentation.get() error:&error];
@@ -245,7 +245,7 @@ RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::cr
 RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(uint64_t pid, uint64_t contextID)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpcRepresentation = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpcRepresentation = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(xpcRepresentation.get(), processIDKey, pid);
     xpc_dictionary_set_uint64(xpcRepresentation.get(), contextIDKey, contextID);
     NSError* error = nil;

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -51,7 +51,7 @@ void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
 #if USE(EXIT_XPC_MESSAGE_WORKAROUND)
     // Give the process a chance to exit cleanly by sending a XPC message to request termination, then try xpc_connection_kill.
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto exitMessage = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto exitMessage = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(exitMessage.get(), messageNameKey, exitProcessMessage.characters());
     xpc_connection_send_message(connection, exitMessage.get());
 #endif

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
@@ -43,7 +43,7 @@ public:
 
     static ASCIILiteral messageName() { return "video-receiver-endpoint"_s; }
     static VideoReceiverEndpointMessage decode(xpc_object_t);
-    XPCObjectPtr<xpc_object_t> encode() const;
+    OSObjectPtr<xpc_object_t> encode() const;
 
     std::optional<WebCore::ProcessIdentifier> processIdentifier() const { return m_processIdentifier; }
     WebCore::HTMLMediaElementIdentifier mediaElementIdentifier() const { return m_mediaElementIdentifier; }
@@ -65,7 +65,7 @@ public:
 
     static ASCIILiteral messageName() { return "video-receiver-swap-endpoint"_s; }
     static VideoReceiverSwapEndpointsMessage decode(xpc_object_t);
-    XPCObjectPtr<xpc_object_t> encode() const;
+    OSObjectPtr<xpc_object_t> encode() const;
 
     std::optional<WebCore::ProcessIdentifier> processIdentifier() const { return m_processIdentifier; }
     WebCore::HTMLMediaElementIdentifier sourceMediaElementIdentifier() const { return m_sourceMediaElementIdentifier; }

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
@@ -71,10 +71,10 @@ VideoReceiverEndpointMessage VideoReceiverEndpointMessage::decode(xpc_object_t m
     };
 }
 
-XPCObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
+OSObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
     xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier ? m_processIdentifier->toUInt64() : 0);
     xpc_dictionary_set_uint64(message.get(), mediaElementIdentifierKey.characters(), m_mediaElementIdentifier.toUInt64());
@@ -110,10 +110,10 @@ VideoReceiverSwapEndpointsMessage VideoReceiverSwapEndpointsMessage::decode(xpc_
     };
 }
 
-XPCObjectPtr<xpc_object_t> VideoReceiverSwapEndpointsMessage::encode() const
+OSObjectPtr<xpc_object_t> VideoReceiverSwapEndpointsMessage::encode() const
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
     xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier ? m_processIdentifier->toUInt64() : 0);
     xpc_dictionary_set_uint64(message.get(), sourceMediaElementIdentifierKey.characters(), m_sourceMediaElementIdentifier.toUInt64());

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -115,7 +115,7 @@ void AuxiliaryProcess::platformInitialize(const AuxiliaryProcessInitializationPa
     setApplicationBundleIdentifier(parameters.clientBundleIdentifier);
 
 #if USE(SOURCE_APPLICATION_AUDIT_DATA)
-    if (XPCObjectPtr<xpc_connection_t> connection = parameters.connectionIdentifier.xpcConnection) {
+    if (OSObjectPtr<xpc_connection_t> connection = parameters.connectionIdentifier.xpcConnection) {
         audit_token_t auditToken { };
         xpc_connection_get_audit_token(connection.get(), &auditToken);
         setApplicationAuditToken(auditToken);

--- a/Source/WebKit/Shared/Cocoa/LaunchLogHook.h
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogHook.h
@@ -46,7 +46,7 @@ private:
     LaunchLogHook() = default;
 
     UnfairLock m_lock;
-    XPCObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_lock);
+    OSObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_lock);
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
+++ b/Source/WebKit/Shared/Cocoa/LaunchLogHook.mm
@@ -69,7 +69,7 @@ void LaunchLogHook::initialize(xpc_connection_t connection)
 
         if (auto messageString = adoptSystemMalloc(os_log_copy_message_string(msg))) {
             // FIXME: This is a false positive. <rdar://164843889>
-            SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, logMessageName);
             if (auto* subsystem = msg->subsystem)
                 xpc_dictionary_set_string(message.get(), subsystemKey, subsystem);
@@ -89,14 +89,14 @@ void LaunchLogHook::disable()
 {
     RELEASE_LOG(Process, "Disabling launch log hook");
 
-    XPCObjectPtr<xpc_connection_t> connection;
+    OSObjectPtr<xpc_connection_t> connection;
     {
         Locker locker { m_lock };
         connection = m_connection;
         m_connection = nullptr;
     }
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, disableLogMessageName);
     xpc_connection_send_message(connection.get(), message.get());
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
@@ -41,7 +41,7 @@ public:
 
     WK_EXPORT void sendEndpointToConnection(xpc_connection_t);
 
-    WK_EXPORT XPCObjectPtr<xpc_endpoint_t> endpoint() const;
+    WK_EXPORT OSObjectPtr<xpc_endpoint_t> endpoint() const;
 
     static constexpr auto xpcMessageNameKey = "message-name"_s;
 
@@ -51,8 +51,8 @@ private:
     virtual ASCIILiteral xpcEndpointNameKey() const = 0;
     virtual void handleEvent(xpc_connection_t, xpc_object_t) = 0;
 
-    XPCObjectPtr<xpc_connection_t> m_connection;
-    XPCObjectPtr<xpc_endpoint_t> m_endpoint;
+    OSObjectPtr<xpc_connection_t> m_connection;
+    OSObjectPtr<xpc_endpoint_t> m_endpoint;
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.mm
@@ -42,8 +42,8 @@ namespace WebKit {
 XPCEndpoint::XPCEndpoint()
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create(nullptr, nullptr));
-    SUPPRESS_RETAINPTR_CTOR_ADOPT m_endpoint = adoptXPCObject(xpc_endpoint_create(m_connection.get()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptOSObject(xpc_connection_create(nullptr, nullptr));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_endpoint = adoptOSObject(xpc_endpoint_create(m_connection.get()));
 
     xpc_connection_set_target_queue(m_connection.get(), mainDispatchQueueSingleton());
     xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
@@ -52,7 +52,7 @@ XPCEndpoint::XPCEndpoint()
         handleXPCExitMessage(message);
 #endif
         if (type == XPC_TYPE_CONNECTION) {
-            XPCObjectPtr<xpc_connection_t> connection = message;
+            OSObjectPtr<xpc_connection_t> connection = message;
 #if USE(APPLE_INTERNAL_SDK)
             auto pid = xpc_connection_get_pid(connection.get());
 
@@ -86,14 +86,14 @@ void XPCEndpoint::sendEndpointToConnection(xpc_connection_t connection)
         return;
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), xpcEndpointMessageNameKey(), xpcEndpointMessageName());
     xpc_dictionary_set_value(message.get(), xpcEndpointNameKey(), m_endpoint.get());
 
     xpc_connection_send_message(connection, message.get());
 }
 
-XPCObjectPtr<xpc_endpoint_t> XPCEndpoint::endpoint() const
+OSObjectPtr<xpc_endpoint_t> XPCEndpoint::endpoint() const
 {
     return m_endpoint;
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpointClient.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpointClient.h
@@ -41,14 +41,14 @@ public:
     WK_EXPORT void setEndpoint(xpc_endpoint_t);
 
 protected:
-    WK_EXPORT XPCObjectPtr<xpc_connection_t> connection();
+    WK_EXPORT OSObjectPtr<xpc_connection_t> connection();
 
 private:
     virtual void handleEvent(xpc_object_t) = 0;
     virtual void didConnect() = 0;
 
     Lock m_connectionLock;
-    XPCObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
+    OSObjectPtr<xpc_connection_t> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm
@@ -43,7 +43,7 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
             return;
 
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create_from_endpoint(endpoint));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptOSObject(xpc_connection_create_from_endpoint(endpoint));
 
         xpc_connection_set_target_queue(m_connection.get(), globalDispatchQueueSingleton(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
         xpc_connection_set_event_handler(m_connection.get(), ^(xpc_object_t message) {
@@ -58,7 +58,7 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
             if (type != XPC_TYPE_DICTIONARY)
                 return;
 
-            XPCObjectPtr<xpc_connection_t> connection = xpc_dictionary_get_remote_connection(message);
+            OSObjectPtr<xpc_connection_t> connection = xpc_dictionary_get_remote_connection(message);
             if (!connection)
                 return;
 #if USE(APPLE_INTERNAL_SDK)
@@ -77,7 +77,7 @@ void XPCEndpointClient::setEndpoint(xpc_endpoint_t endpoint)
     didConnect();
 }
 
-XPCObjectPtr<xpc_connection_t> XPCEndpointClient::connection()
+OSObjectPtr<xpc_connection_t> XPCEndpointClient::connection()
 {
     Locker locker { m_connectionLock };
     return m_connection;

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.h
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.h
@@ -36,7 +36,7 @@ class Encoder;
 namespace WebKit {
 
 void startListeningForMachServiceConnections(const char* serviceName, ASCIILiteral entitlement, void(*connectionAdded)(xpc_connection_t), void(*connectionRemoved)(xpc_connection_t), void(*eventHandler)(xpc_object_t));
-XPCObjectPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
-XPCObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
+OSObjectPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&&);
+OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
+++ b/Source/WebKit/Shared/Daemon/DaemonUtilities.mm
@@ -40,7 +40,7 @@ namespace WebKit {
 void startListeningForMachServiceConnections(const char* serviceName, ASCIILiteral entitlement, void(*connectionAdded)(xpc_connection_t), void(*connectionRemoved)(xpc_connection_t), void(*eventHandler)(xpc_object_t))
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT static NeverDestroyed<XPCObjectPtr<xpc_connection_t>> listener = adoptXPCObject(xpc_connection_create_mach_service(serviceName, mainDispatchQueueSingleton(), XPC_CONNECTION_MACH_SERVICE_LISTENER));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT static NeverDestroyed<OSObjectPtr<xpc_connection_t>> listener = adoptOSObject(xpc_connection_create_mach_service(serviceName, mainDispatchQueueSingleton(), XPC_CONNECTION_MACH_SERVICE_LISTENER));
     xpc_connection_set_event_handler(listener.get().get(), ^(xpc_object_t peer) {
         if (xpc_get_type(peer) != XPC_TYPE_CONNECTION)
             return;
@@ -81,13 +81,13 @@ void startListeningForMachServiceConnections(const char* serviceName, ASCIILiter
     xpc_connection_activate(listener.get().get());
 }
 
-XPCObjectPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&& vector)
+OSObjectPtr<xpc_object_t> vectorToXPCData(Vector<uint8_t>&& vector)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT return adoptXPCObject(xpc_data_create_with_dispatch_data(makeDispatchData(WTF::move(vector)).get()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT return adoptOSObject(xpc_data_create_with_dispatch_data(makeDispatchData(WTF::move(vector)).get()));
 }
 
-XPCObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&& encoder)
+OSObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&& encoder)
 {
     __block auto blockEncoder = WTF::move(encoder);
     auto buffer = blockEncoder->span();
@@ -97,7 +97,7 @@ XPCObjectPtr<xpc_object_t> encoderToXPCData(UniqueRef<IPC::Encoder>&& encoder)
     }));
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT return adoptXPCObject(xpc_data_create_with_dispatch_data(dispatchData.get()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT return adoptOSObject(xpc_data_create_with_dispatch_data(dispatchData.get()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
@@ -53,7 +53,7 @@ public:
     
 private:
     enum class DebugModeEnabled : bool { No, Yes };
-    HashMap<XPCObjectPtr<xpc_connection_t>, DebugModeEnabled> m_connections;
+    HashMap<OSObjectPtr<xpc_connection_t>, DebugModeEnabled> m_connections;
     size_t m_connectionsWithDebugModeEnabled { 0 };
 };
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm
@@ -84,7 +84,7 @@ bool DaemonConnectionSet::debugModeEnabled() const
 void DaemonConnectionSet::broadcastConsoleMessage(JSC::MessageLevel messageLevel, const String& message)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), protocolDebugMessageLevelKey, static_cast<uint64_t>(messageLevel));
     xpc_dictionary_set_string(dictionary.get(), protocolDebugMessageKey, message.utf8().data());
     for (auto& connection : m_connections.keys())

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -48,15 +48,15 @@
 
 namespace WebKit {
 
-static CompletionHandler<void(PCM::EncodedMessage&&)> replySender(PCM::MessageType messageType, XPCObjectPtr<xpc_object_t>&& request)
+static CompletionHandler<void(PCM::EncodedMessage&&)> replySender(PCM::MessageType messageType, OSObjectPtr<xpc_object_t>&& request)
 {
     if (!PCM::messageTypeSendsReply(messageType))
         return nullptr;
     return [request = WTF::move(request)] (PCM::EncodedMessage&& message) {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto reply = adoptXPCObject(xpc_dictionary_create_reply(request.get()));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto reply = adoptOSObject(xpc_dictionary_create_reply(request.get()));
         PCM::addVersionAndEncodedMessageToDictionary(WTF::move(message), reply.get());
-        xpc_connection_send_message(XPCObjectPtr<xpc_connection_t> { xpc_dictionary_get_remote_connection(request.get()) }.get(), reply.get());
+        xpc_connection_send_message(OSObjectPtr<xpc_connection_t> { xpc_dictionary_get_remote_connection(request.get()) }.get(), reply.get());
     };
 }
 
@@ -83,7 +83,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (xpc_activity_get_state(activity) == XPC_ACTIVITY_STATE_CHECK_IN) {
             NSLog(@"Activity checking in");
             // FIXME: This is a false positive. <rdar://164843889>
-            SUPPRESS_RETAINPTR_CTOR_ADOPT auto criteria = adoptXPCObject(xpc_activity_copy_criteria(activity));
+            SUPPRESS_RETAINPTR_CTOR_ADOPT auto criteria = adoptOSObject(xpc_activity_copy_criteria(activity));
 
             // These values should align with values from com.apple.webkit.adattributiond.plist
             constexpr auto oneHourSeconds = 3600;

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
@@ -42,7 +42,7 @@ namespace WebKit {
 #if HAVE(LSDATABASECONTEXT)
 static void handleLaunchServiceDatabaseMessage(xpc_object_t message)
 {
-    XPCObjectPtr<xpc_object_t> xpcEndPoint = xpc_dictionary_get_value(message, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointNameKey);
+    OSObjectPtr<xpc_object_t> xpcEndPoint = xpc_dictionary_get_value(message, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseXPCEndpointNameKey);
     if (!xpcEndPoint || xpc_get_type(xpcEndPoint.get()) != XPC_TYPE_ENDPOINT)
         return;
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -55,7 +55,7 @@ namespace WebKit {
 
 class XPCServiceInitializerDelegate {
 public:
-    XPCServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t>, xpc_object_t initializerMessage);
+    XPCServiceInitializerDelegate(OSObjectPtr<xpc_connection_t>, xpc_object_t initializerMessage);
 
     virtual ~XPCServiceInitializerDelegate();
 
@@ -73,8 +73,8 @@ protected:
     bool hasEntitlement(ASCIILiteral entitlement);
     bool isClientSandboxed();
 
-    XPCObjectPtr<xpc_connection_t> m_connection;
-    XPCObjectPtr<xpc_object_t> m_initializerMessage;
+    OSObjectPtr<xpc_connection_t> m_connection;
+    OSObjectPtr<xpc_object_t> m_initializerMessage;
 };
 
 template<typename XPCServiceType>
@@ -94,7 +94,7 @@ void setJSCOptions(xpc_object_t initializerMessage, EnableLockdownMode, EnableEn
 void disableJSC(NOESCAPE WTF::CompletionHandler<void(void)>&& beforeFinalizeHandler);
 
 template<typename XPCServiceType, typename XPCServiceInitializerDelegateType, bool isWebContentProcess = false>
-void XPCServiceInitializer(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+void XPCServiceInitializer(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
 {
     XPCServiceInitializerDelegateType delegate(WTF::move(connection), initializerMessage);
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -41,7 +41,7 @@
 
 namespace WebKit {
 
-XPCServiceInitializerDelegate::XPCServiceInitializerDelegate(XPCObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
+XPCServiceInitializerDelegate::XPCServiceInitializerDelegate(OSObjectPtr<xpc_connection_t> connection, xpc_object_t initializerMessage)
     : m_connection(WTF::move(connection))
     , m_initializerMessage(initializerMessage)
 {
@@ -125,7 +125,7 @@ bool XPCServiceInitializerDelegate::getClientProcessName(String& clientProcessNa
 
 bool XPCServiceInitializerDelegate::getExtraInitializationData(HashMap<String, String>& extraInitializationData)
 {
-    XPCObjectPtr<xpc_object_t> extraDataInitializationDataObject = xpc_dictionary_get_value(m_initializerMessage.get(), "extra-initialization-data");
+    OSObjectPtr<xpc_object_t> extraDataInitializationDataObject = xpc_dictionary_get_value(m_initializerMessage.get(), "extra-initialization-data");
 
     auto inspectorProcess = xpcDictionaryGetString(extraDataInitializationDataObject.get(), "inspector-process"_s);
     if (!inspectorProcess.isEmpty())

--- a/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm
@@ -41,17 +41,17 @@ void AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc(IPC::C
     ASSERT(secKeyProxyStore.isInitialized());
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), ClientCertificateAuthentication::XPCMessageNameKey, ClientCertificateAuthentication::XPCMessageNameValue);
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCChallengeIDKey, challengeID.toUInt64());
-    xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, XPCObjectPtr<xpc_endpoint_t> { RetainPtr { secKeyProxyStore.get() }.get().endpoint._endpoint }.get());
+    xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCSecKeyProxyEndpointKey, OSObjectPtr<xpc_endpoint_t> { RetainPtr { secKeyProxyStore.get() }.get().endpoint._endpoint }.get());
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto certificateDataArray = adoptXPCObject(xpc_array_create(nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto certificateDataArray = adoptOSObject(xpc_array_create(nullptr, 0));
     RetainPtr nsCredential = credential.nsCredential();
     for (id certificate in nsCredential.get().certificates) {
         auto data = adoptCF(SecCertificateCopyData((SecCertificateRef)certificate));
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT xpc_array_append_value(certificateDataArray.get(), adoptXPCObject(xpc_data_create(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()))).get());
+        SUPPRESS_RETAINPTR_CTOR_ADOPT xpc_array_append_value(certificateDataArray.get(), adoptOSObject(xpc_data_create(CFDataGetBytePtr(data.get()), CFDataGetLength(data.get()))).get());
     }
     xpc_dictionary_set_value(message.get(), ClientCertificateAuthentication::XPCCertificatesKey, certificateDataArray.get());
     xpc_dictionary_set_uint64(message.get(), ClientCertificateAuthentication::XPCPersistenceKey, static_cast<uint64_t>(nsCredential.get().persistence));

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -103,7 +103,7 @@ void AuxiliaryProcessProxy::platformStartConnectionTerminationWatchdog()
     if (!m_connection)
         return;
 
-    XPCObjectPtr<xpc_connection_t> xpcConnection = m_connection->xpcConnection();
+    OSObjectPtr<xpc_connection_t> xpcConnection = m_connection->xpcConnection();
     if (!xpcConnection)
         return;
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -1033,7 +1033,7 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
 
     Ref gpuProcess = process->processPool().ensureProtectedGPUProcess();
     Ref connection = gpuProcess->connection();
-    XPCObjectPtr<xpc_connection_t> xpcConnection = connection->xpcConnection();
+    OSObjectPtr<xpc_connection_t> xpcConnection = connection->xpcConnection();
     if (!xpcConnection)
         return;
 
@@ -1073,7 +1073,7 @@ void PlaybackSessionManagerProxy::swapVideoReceiverEndpoints(PlaybackSessionCont
 
     Ref gpuProcess = process->processPool().ensureProtectedGPUProcess();
     Ref connection = gpuProcess->connection();
-    XPCObjectPtr<xpc_connection_t> xpcConnection = connection->xpcConnection();
+    OSObjectPtr<xpc_connection_t> xpcConnection = connection->xpcConnection();
     if (!xpcConnection)
         return;
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1579,7 +1579,7 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
 #if ENABLE(MACH_PORT_LAYER_HOSTING)
         sendRightAnnotated = LayerHostingContext::fence(hostingUpdateCoordinator);
 #else
-        XPCObjectPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
+        OSObjectPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
         sendRightAnnotated.sendRight = MachSendRight::adopt(xpc_dictionary_copy_mach_send(xpcRepresentationHostingCoordinator.get(), machPortKey));
 #endif
         RELEASE_LOG(Media, "VideoPresentationManagerProxy::setVideoLayerFrame: x=%f y=%f w=%f h=%f send right %d, fence data size %lu", frame.x(), frame.y(), frame.width(), frame.height(), sendRightAnnotated.sendRight.sendRight(), sendRightAnnotated.data.size());

--- a/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h
@@ -179,7 +179,7 @@ private:
     CheckedPtr<Client> m_client;
 
 #if PLATFORM(COCOA)
-    XPCObjectPtr<xpc_connection_t> m_xpcConnection;
+    OSObjectPtr<xpc_connection_t> m_xpcConnection;
 #endif
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h
@@ -52,7 +52,7 @@ public:
     ExtensionProcess(BERenderingProcess *);
 
     void invalidate() const;
-    XPCObjectPtr<xpc_connection_t> makeLibXPCConnection() const;
+    OSObjectPtr<xpc_connection_t> makeLibXPCConnection() const;
     PlatformGrant grantCapability(const PlatformCapability&, BlockPtr<void()>&& invalidationHandler = ^{ }) const;
     RetainPtr<UIInteraction> createVisibilityPropagationInteraction() const;
 

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm
@@ -62,10 +62,10 @@ void ExtensionProcess::invalidate() const
     });
 }
 
-XPCObjectPtr<xpc_connection_t> ExtensionProcess::makeLibXPCConnection() const
+OSObjectPtr<xpc_connection_t> ExtensionProcess::makeLibXPCConnection() const
 {
     NSError *error = nil;
-    XPCObjectPtr<xpc_connection_t> xpcConnection;
+    OSObjectPtr<xpc_connection_t> xpcConnection;
     WTF::switchOn(m_process, [&] (auto& process) {
         xpcConnection = [process makeLibXPCConnectionError:&error];
     });

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -479,7 +479,7 @@ private:
     private:
         WeakPtr<NetworkProcessProxy> m_networkProcess;
     };
-    XPCObjectPtr<xpc_object_t> m_endpointMessage;
+    OSObjectPtr<xpc_object_t> m_endpointMessage;
 #endif
 
     WeakHashSet<WebsiteDataStore> m_websiteDataStores;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -99,10 +99,10 @@ bool NetworkProcessProxy::sendXPCEndpointToProcess(AuxiliaryProcessProxy& proces
         return false;
     if (!process.hasConnection())
         return false;
-    XPCObjectPtr<xpc_object_t> message = xpcEndpointMessage();
+    OSObjectPtr<xpc_object_t> message = xpcEndpointMessage();
     if (!message)
         return false;
-    XPCObjectPtr<xpc_connection_t> xpcConnection = process.connection().xpcConnection();
+    OSObjectPtr<xpc_connection_t> xpcConnection = process.connection().xpcConnection();
     RELEASE_ASSERT(xpcConnection);
     xpc_connection_send_message(xpcConnection.get(), message.get());
     return true;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -812,7 +812,7 @@ void PDFIncrementalLoader::threadEntry(Ref<PDFIncrementalLoader>&& protectedLoad
     BinarySemaphore firstPageSemaphore;
     auto firstPageQueue = WorkQueue::create("PDF first page work queue"_s);
 
-    [m_backgroundThreadDocument preloadDataOfPagesInRange:NSMakeRange(0, 1) onQueue:firstPageQueue->protectedDispatchQueue().get() completion:[&firstPageSemaphore, protectedThis = Ref { *this }] (NSIndexSet *) mutable {
+    [m_backgroundThreadDocument preloadDataOfPagesInRange:NSMakeRange(0, 1) onQueue:protect(firstPageQueue->dispatchQueue()).get() completion:[&firstPageSemaphore, protectedThis = Ref { *this }] (NSIndexSet *) mutable {
         callOnMainRunLoop([protectedThis] {
             protectedThis->transitionToMainThreadDocument();
         });

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -47,7 +47,7 @@ void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
     String messageName = xpcDictionaryGetString(message, XPCEndpoint::xpcMessageNameKey);
     if (messageName == LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName) {
 #if HAVE(LSDATABASECONTEXT)
-        XPCObjectPtr<xpc_object_t> database = xpc_dictionary_get_value(message, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey);
+        OSObjectPtr<xpc_object_t> database = xpc_dictionary_get_value(message, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey);
 
         RELEASE_LOG_FORWARDABLE(Loading, RECEIVED_LAUNCH_SERVICES_DATABASE);
 
@@ -62,7 +62,7 @@ void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
 void LaunchServicesDatabaseManager::didConnect()
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName);
 
     auto connection = this->connection();

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -126,7 +126,7 @@ private:
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
     void setProtocolVersionForTesting(unsigned, CompletionHandler<void()>&&);
 
-    XPCObjectPtr<xpc_connection_t> m_xpcConnection;
+    OSObjectPtr<xpc_connection_t> m_xpcConnection;
     String m_hostAppCodeSigningIdentifier;
     bool m_hostAppHasPushInjectEntitlement { false };
     String m_pushPartitionString;

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -148,8 +148,8 @@ private:
 #endif
 
     PushClientConnection* toPushClientConnection(xpc_connection_t);
-    HashSet<XPCObjectPtr<xpc_connection_t>> m_pendingConnectionSet;
-    HashMap<XPCObjectPtr<xpc_connection_t>, Ref<PushClientConnection>> m_connectionMap;
+    HashSet<OSObjectPtr<xpc_connection_t>> m_pendingConnectionSet;
+    HashMap<OSObjectPtr<xpc_connection_t>, Ref<PushClientConnection>> m_connectionMap;
 
     const RefPtr<PushService> m_pushService;
     bool m_usingMockPushService { false };

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -294,7 +294,7 @@ void WebPushDaemon::incomingPushTransactionTimerFired()
 
 static void tryCloseRequestConnection(xpc_object_t request)
 {
-    if (XPCObjectPtr<xpc_connection_t> connection = xpc_dictionary_get_remote_connection(request))
+    if (OSObjectPtr<xpc_connection_t> connection = xpc_dictionary_get_remote_connection(request))
         xpc_connection_cancel(connection.get());
 }
 
@@ -324,7 +324,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
         return;
     }
 
-    XPCObjectPtr<xpc_connection_t> xpcConnection = xpc_dictionary_get_remote_connection(request);
+    OSObjectPtr<xpc_connection_t> xpcConnection = xpc_dictionary_get_remote_connection(request);
     if (!xpcConnection)
         return;
 
@@ -361,7 +361,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
 #endif
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto reply = adoptXPCObject(xpc_dictionary_create_reply(request));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto reply = adoptOSObject(xpc_dictionary_create_reply(request));
     auto replyHandler = [xpcConnection = WTF::move(xpcConnection), reply = WTF::move(reply)] (UniqueRef<IPC::Encoder>&& encoder) {
         RELEASE_ASSERT(RunLoop::isMain());
         auto xpcData = WebKit::encoderToXPCData(WTF::move(encoder));

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -78,7 +78,7 @@ private:
     String m_bundleIdentifier;
     String m_pushPartition;
 
-    XPCObjectPtr<xpc_connection_t> m_connection;
+    OSObjectPtr<xpc_connection_t> m_connection;
     ASCIILiteral m_serviceName;
 };
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -79,7 +79,7 @@ Connection::Connection(PreferTestService preferTestService, String bundleIdentif
 void Connection::connectToService(WaitForServiceToExist waitForServiceToExist)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptXPCObject(xpc_connection_create_mach_service(m_serviceName, mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT m_connection = adoptOSObject(xpc_connection_create_mach_service(m_serviceName, mainDispatchQueueSingleton(), 0));
 
     xpc_connection_set_event_handler(m_connection.get(), [](xpc_object_t event) {
         if (event == XPC_ERROR_CONNECTION_INVALID || event == XPC_ERROR_CONNECTION_INTERRUPTED) {
@@ -150,11 +150,11 @@ void Connection::sendAuditToken()
     sendWithoutUsingIPCConnection(Messages::PushClientConnection::InitializeConnection(WTF::move(configuration)));
 }
 
-static XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
+static OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(UniqueRef<IPC::Encoder>&& encoder)
 {
     auto xpcData = WebKit::encoderToXPCData(WTF::move(encoder));
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_uint64(dictionary.get(), WebKit::WebPushD::protocolVersionKey, WebKit::WebPushD::protocolVersionValue);
     xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, xpcData.get());
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm
@@ -126,7 +126,7 @@ static bool registerDaemonWithLaunchD(WebPushTool::PreferTestService preferTestS
     const char* serviceName = (preferTestService == WebPushTool::PreferTestService::Yes) ? "org.webkit.webpushtestdaemon.service" : "com.apple.webkit.webpushd.service";
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto plist = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto plist = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_dictionary_set_string(plist.get(), "_ManagedBy", "webpushtool");
     xpc_dictionary_set_string(plist.get(), "Label", "org.webkit.webpushtestdaemon");
     xpc_dictionary_set_bool(plist.get(), "LaunchOnlyOnce", true);
@@ -134,20 +134,20 @@ static bool registerDaemonWithLaunchD(WebPushTool::PreferTestService preferTestS
 
     {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto environmentVariables = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto environmentVariables = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_FRAMEWORK_PATH", currentExecutableDirectoryURL.get().fileSystemRepresentation);
         xpc_dictionary_set_string(environmentVariables.get(), "DYLD_LIBRARY_PATH", currentExecutableDirectoryURL.get().fileSystemRepresentation);
         xpc_dictionary_set_value(plist.get(), "EnvironmentVariables", environmentVariables.get());
     }
     {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto machServices = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto machServices = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_bool(machServices.get(), serviceName, true);
         xpc_dictionary_set_value(plist.get(), "MachServices", machServices.get());
     }
     {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto programArguments = adoptXPCObject(xpc_array_create(nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto programArguments = adoptOSObject(xpc_array_create(nullptr, 0));
 #if PLATFORM(MAC)
         xpc_array_set_string(programArguments.get(), XPC_ARRAY_APPEND, daemonExecutablePathURL.get().fileSystemRepresentation);
 #else

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3053,7 +3053,7 @@ def check_wtf_os_object_ptr(clean_lines, line_number, file_state, error):
         return
 
 def check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error):
-    """Looks for usage of RetainPtr / OSObjectPtr with XPC objects, which should be replaced with XPCObjectPtr.
+    """Looks for usage of RetainPtr with XPC objects, which should be replaced with OSObjectPtr.
 
     Args:
       clean_lines: A CleansedLines instance containing the file.
@@ -3066,19 +3066,11 @@ def check_wtf_xpc_object_ptr(clean_lines, line_number, file_state, error):
     line = clean_lines.elided[line_number]  # Get rid of comments and strings.
     using_retain_ptr = search(r'RetainPtr<xpc_', line)
     if using_retain_ptr:
-        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'XPCObjectPtr' instead of 'RetainPtr' for XPC objects.")
+        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'OSObjectPtr' instead of 'RetainPtr' for XPC objects.")
         return
     using_adoptns = search(r'adoptNS\(xpc_', line)
     if using_adoptns:
-        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'adoptXPCObject()' instead of 'adoptNS()' for XPC objects.")
-        return
-    using_osobject_ptr = search(r'OSObjectPtr<xpc_', line)
-    if using_osobject_ptr:
-        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'XPCObjectPtr' instead of 'OSObjectPtr' for XPC objects.")
-        return
-    using_adoptosobject = search(r'adoptOSObject\(xpc_', line)
-    if using_adoptosobject:
-        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'adoptXPCObject()' instead of 'adoptOSObject()' for XPC objects.")
+        error(line_number, 'runtime/wtf_xpc_object_ptr', 4, "Use 'adoptOSObject()' instead of 'adoptNS()' for XPC objects.")
         return
 
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6406,32 +6406,30 @@ class WebKitStyleTest(CppStyleTestBase):
 
     def test_wtf_xpc_object_ptr(self):
         self.assert_lint(
-            'XPCObjectPtr<xpc_connection_t> connection = adoptXPCObject(xpc_connection_create_from_endpoint(endpoint));',
+            'OSObjectPtr<xpc_connection_t> connection = adoptOSObject(xpc_connection_create_from_endpoint(endpoint));',
             '',
             'foo.cpp')
 
         self.assert_lint(
             'RetainPtr<xpc_connection_t> m_connection;',
-            "Use 'XPCObjectPtr' instead of 'RetainPtr' for XPC objects."
+            "Use 'OSObjectPtr' instead of 'RetainPtr' for XPC objects."
             "  [runtime/wtf_xpc_object_ptr] [4]",
             'foo.mm')
 
         self.assert_lint(
             'OSObjectPtr<xpc_connection_t> m_connection;',
-            "Use 'XPCObjectPtr' instead of 'OSObjectPtr' for XPC objects."
-            "  [runtime/wtf_xpc_object_ptr] [4]",
+            '',
             'foo.mm')
 
         self.assert_lint(
             'auto connection = adoptNS(xpc_connection_create_from_endpoint(endpoint));',
-            "Use 'adoptXPCObject()' instead of 'adoptNS()' for XPC objects."
+            "Use 'adoptOSObject()' instead of 'adoptNS()' for XPC objects."
             "  [runtime/wtf_xpc_object_ptr] [4]",
             'foo.mm')
 
         self.assert_lint(
             'auto connection = adoptOSObject(xpc_connection_create_from_endpoint(endpoint));',
-            "Use 'adoptXPCObject()' instead of 'adoptOSObject()' for XPC objects."
-            "  [runtime/wtf_xpc_object_ptr] [4]",
+            '',
             'foo.mm')
 
     def test_lock_guard(self):

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -58,7 +58,7 @@ private:
             endpointReceivedMessageFromClient = true;
 
             // FIXME: This is a false positive. <rdar://164843889>
-            SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+            SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
             xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromEndpoint);
             xpc_connection_send_message(connection, message.get());
         }
@@ -76,7 +76,7 @@ private:
     void didConnect() final
     {
         // FIXME: This is a false positive. <rdar://164843889>
-        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT auto message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
         xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, testMessageFromClient);
         xpc_connection_send_message(connection().get(), message.get());
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -552,14 +552,14 @@ static void attemptConnectionInProcessWithoutEntitlement()
 #if USE(APPLE_INTERNAL_SDK)
     __block bool done = false;
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptXPCObject(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptOSObject(xpc_connection_create_mach_service("org.webkit.pcmtestdaemon.service", mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t event) {
         EXPECT_EQ(event, XPC_ERROR_CONNECTION_INTERRUPTED);
         done = true;
     });
     xpc_connection_activate(connection.get());
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     xpc_connection_send_message(connection.get(), dictionary.get());
     TestWebKitAPI::Util::run(&done);
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -427,16 +427,16 @@ public:
     void sendWithAsyncReplyWithoutUsingIPCConnection(M&&, CH&&) const;
 
 private:
-    XPCObjectPtr<xpc_object_t> messageDictionaryFromEncoder(TestEncoder&&) const;
+    OSObjectPtr<xpc_object_t> messageDictionaryFromEncoder(TestEncoder&&) const;
 
-    XPCObjectPtr<xpc_connection_t> m_connection;
+    OSObjectPtr<xpc_connection_t> m_connection;
     bool m_shouldIncrementProtocolVersionForTesting { false };
 };
 
-XPCObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder(TestEncoder&& encoder) const
+OSObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder(TestEncoder&& encoder) const
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto dictionary = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
 
     uint64_t protocolVersion = WebKit::WebPushD::protocolVersionValue;
     if (m_shouldIncrementProtocolVersionForTesting)
@@ -449,7 +449,7 @@ XPCObjectPtr<xpc_object_t> WebPushXPCConnectionMessageSender::messageDictionaryF
         blockBytes.clear();
     }));
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto encoderData = adoptXPCObject(xpc_data_create_with_dispatch_data(dispatchData.get()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto encoderData = adoptOSObject(xpc_data_create_with_dispatch_data(dispatchData.get()));
 
     xpc_dictionary_set_value(dictionary.get(), WebKit::WebPushD::protocolEncodedMessageKey, encoderData.get());
 
@@ -511,10 +511,10 @@ static WebKit::WebPushD::WebPushDaemonConnectionConfiguration defaultWebPushDaem
     IGNORE_CLANG_WARNINGS_END
 }
 
-XPCObjectPtr<xpc_connection_t> createAndConfigureConnectionToService(const char* serviceName, std::optional<WebKit::WebPushD::WebPushDaemonConnectionConfiguration> configuration = std::nullopt)
+OSObjectPtr<xpc_connection_t> createAndConfigureConnectionToService(const char* serviceName, std::optional<WebKit::WebPushD::WebPushDaemonConnectionConfiguration> configuration = std::nullopt)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptXPCObject(xpc_connection_create_mach_service(serviceName, mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptOSObject(xpc_connection_create_mach_service(serviceName, mainDispatchQueueSingleton(), 0));
     xpc_connection_set_event_handler(connection.get(), ^(xpc_object_t) { });
     xpc_connection_activate(connection.get());
     auto sender = WebPushXPCConnectionMessageSender { connection.get() };
@@ -531,7 +531,7 @@ TEST(WebPushD, BasicCommunication)
     NSURL *tempDir = setUpTestWebPushD();
 
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptXPCObject(xpc_connection_create_mach_service("org.webkit.webpushtestdaemon.service", mainDispatchQueueSingleton(), 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto connection = adoptOSObject(xpc_connection_create_mach_service("org.webkit.webpushtestdaemon.service", mainDispatchQueueSingleton(), 0));
 
     __block bool done = false;
     __block bool interrupted = false;

--- a/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm
@@ -81,10 +81,10 @@ RetainPtr<NSURL> currentExecutableDirectory()
 }
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
-static XPCObjectPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
+static OSObjectPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptXPCObject(xpc_array_create(nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptOSObject(xpc_array_create(nullptr, 0));
     for (id value in array) {
         if ([value isKindOfClass:NSString.class])
             xpc_array_set_string(xpc.get(), XPC_ARRAY_APPEND, [value UTF8String]);
@@ -94,10 +94,10 @@ static XPCObjectPtr<xpc_object_t> convertArrayToXPC(NSArray *array)
     return xpc;
 }
 
-static XPCObjectPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
+static OSObjectPtr<xpc_object_t> convertDictionaryToXPC(NSDictionary<NSString *, id> *dictionary)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptXPCObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto xpc = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
     for (NSString *key in dictionary) {
         ASSERT([key isKindOfClass:NSString.class]);
         const char* keyUTF8 = key.UTF8String;


### PR DESCRIPTION
#### 206bc9777c91c596011319fb365edfa848a5a933
<pre>
Reduce use of protected functions in Source/WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=306506">https://bugs.webkit.org/show_bug.cgi?id=306506</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Also make `protect()` work with `dispatch_*`, `nw_*` and `xpc_*` objects
so it returns an OSObjectPtr. In the process, I aligned the XPC object
support in OSObjectPtr with the support for `dispatch_*` and `nw_*`
objects, for consistency.

* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::setupXPCConnectionIfNeeded):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.h:
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorXPCConnection.mm:
(Inspector::RemoteInspectorXPCConnection::deserializeMessage):
(Inspector::RemoteInspectorXPCConnection::sendMessage):
* Source/WTF/wtf/LoggerHelper.h:
(WTF::LoggerHelper::protectedLogger const): Deleted.
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/SchedulePair.h:
(WTF::SchedulePair::runLoop const):
(WTF::SchedulePair::mode const):
(WTF::SchedulePair::protectedRunLoop const): Deleted.
(WTF::SchedulePair::protectedMode const): Deleted.
* Source/WTF/wtf/WorkQueue.h:
(WTF::WorkQueueBase::dispatchQueue const):
(WTF::WorkQueueBase::protectedDispatchQueue const): Deleted.
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::RunLoop::dispatch):
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlement):
* Source/WTF/wtf/darwin/DispatchOSObject.h:
* Source/WTF/wtf/darwin/NetworkOSObject.h:
* Source/WTF/wtf/darwin/XPCObjectPtr.h:
(WTF::XPCObjectRetainTraits::retain): Deleted.
(WTF::XPCObjectRetainTraits::release): Deleted.
* Source/WebCore/platform/VideoReceiverEndpoint.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::addTrackBuffer):
* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm:
(WebKit::GPUServiceInitializerDelegate::GPUServiceInitializerDelegate):
* Source/WebKit/ModelProcess/EntryPoint/Cocoa/XPCService/ModelServiceEntryPoint.mm:
(WebKit::ModelServiceInitializerDelegate::ModelServiceInitializerDelegate):
* Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/NetworkProcess/EntryPoint/Cocoa/XPCService/NetworkServiceEntryPoint.mm:
(WebKit::NetworkServiceInitializerDelegate::NetworkServiceInitializerDelegate):
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::messageDictionaryFromEncoder):
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementConnection.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm:
(WebKit::PCM::Connection::dictionaryFromMessage const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCocoa.mm:
(WebKit::NetworkCache::IOChannel::read):
(WebKit::NetworkCache::IOChannel::write):
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.h:
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::LaunchServicesDatabaseObserver):
(WebKit::LaunchServicesDatabaseObserver::startObserving):
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Identifier::Identifier):
(IPC::Connection::protectedXPCConnection const):
* Source/WebKit/Platform/IPC/DaemonConnection.h:
(WebKit::Daemon::Connection::create):
(WebKit::Daemon::Connection::Connection):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::platformOpen):
(IPC::Connection::initializeSendSource):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):
* Source/WebKit/Platform/cocoa/LayerHostingContext.h:
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::xpcRepresentation const):
(WebKit::LayerHostingContext::createHostingUpdateCoordinator):
(WebKit::LayerHostingContext::createHostingHandle):
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::terminateWithReason):
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h:
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm:
(WebKit::VideoReceiverEndpointMessage::encode const):
(WebKit::VideoReceiverSwapEndpointsMessage::encode const):
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::platformInitialize):
* Source/WebKit/Shared/Cocoa/LaunchLogHook.h:
* Source/WebKit/Shared/Cocoa/LaunchLogHook.mm:
(WebKit::LaunchLogHook::initialize):
(WebKit::LaunchLogHook::disable):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.h:
* Source/WebKit/Shared/Cocoa/XPCEndpoint.mm:
(WebKit::XPCEndpoint::XPCEndpoint):
(WebKit::XPCEndpoint::sendEndpointToConnection):
(WebKit::XPCEndpoint::endpoint const):
* Source/WebKit/Shared/Cocoa/XPCEndpointClient.h:
* Source/WebKit/Shared/Cocoa/XPCEndpointClient.mm:
(WebKit::XPCEndpointClient::setEndpoint):
(WebKit::XPCEndpointClient::connection):
* Source/WebKit/Shared/Daemon/DaemonUtilities.h:
* Source/WebKit/Shared/Daemon/DaemonUtilities.mm:
(WebKit::startListeningForMachServiceConnections):
(WebKit::vectorToXPCData):
(WebKit::encoderToXPCData):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.mm:
(WebKit::PCM::DaemonConnectionSet::broadcastConsoleMessage):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::CompletionHandler&lt;void):
(WebKit::registerScheduledActivityHandler):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm:
(WebKit::handleLaunchServiceDatabaseMessage):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
(WebKit::XPCServiceInitializer):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::XPCServiceInitializerDelegate::XPCServiceInitializerDelegate):
(WebKit::XPCServiceInitializerDelegate::getExtraInitializationData):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
(WebKit::XPCServiceMain):
* Source/WebKit/UIProcess/Authentication/cocoa/AuthenticationChallengeProxyCocoa.mm:
(WebKit::AuthenticationChallengeProxy::sendClientCertificateCredentialOverXpc):
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::platformStartConnectionTerminationWatchdog):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):
(WebKit::PlaybackSessionManagerProxy::swapVideoReceiverEndpoints):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.h:
* Source/WebKit/UIProcess/Launcher/cocoa/ExtensionProcess.mm:
(WebKit::ExtensionProcess::makeLibXPCConnection const):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::launchProcess):
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm:
(WebKit::NetworkProcessProxy::sendXPCEndpointToProcess):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::threadEntry):
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm:
(WebKit::LaunchServicesDatabaseManager::handleEvent):
(WebKit::LaunchServicesDatabaseManager::didConnect):
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::tryCloseRequestConnection):
(WebPushD::WebPushDaemon::connectionEventHandler):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::connectToService):
(WebPushTool::messageDictionaryFromEncoder):
* Source/WebKit/webpushd/webpushtool/WebPushToolMain.mm:
(registerDaemonWithLaunchD):
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_wtf_xpc_object_ptr):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_wtf_xpc_object_ptr):
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::attemptConnectionInProcessWithoutEntitlement):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::messageDictionaryFromEncoder const):
(TestWebKitAPI::createAndConfigureConnectionToService):
(TestWebKitAPI::TEST(WebPushD, BasicCommunication)):
* Tools/TestWebKitAPI/cocoa/DaemonTestUtilities.mm:
(TestWebKitAPI::convertArrayToXPC):
(TestWebKitAPI::convertDictionaryToXPC):

Canonical link: <a href="https://commits.webkit.org/306445@main">https://commits.webkit.org/306445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20ebac926c533eba54a85062ad7e0f8e6026a79e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/2993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149868 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9615c30-4955-46b4-acea-505b44024dc2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108559 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78592 "9 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3acf2cd3-a27d-4a03-b311-b50771c961ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89464 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0dab12e-3d65-4110-abb1-0d3f87f9dd98) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/140639 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10679 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8291 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133274 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152262 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2096 "Found 1 new JSC stress test failure: stress/re-enter-resolve-rope-string.js.no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13364 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116656 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116996 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29800 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13049 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123107 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68538 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13407 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172587 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13146 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77113 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44718 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13345 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->