### PR TITLE
[YARR] Add JIT support for backreference in MatchOnly mode

### DIFF
--- a/JSTests/microbenchmarks/regexp-backreference-matchonly.js
+++ b/JSTests/microbenchmarks/regexp-backreference-matchonly.js
@@ -1,0 +1,62 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+// Microbenchmark for backreference patterns in MatchOnly mode (test() method).
+// This measures the performance of JIT-compiled backreference matching.
+
+(function() {
+    // Warmup and benchmark iterations
+    const iterations = 1000000;
+
+    // Test 1: Simple backreference
+    let re1 = /(.)\1/;
+    let str1_match = "aa";
+    let str1_nomatch = "ab";
+    for (let i = 0; i < iterations; ++i) {
+        re1.test(str1_match);
+        re1.test(str1_nomatch);
+    }
+
+    // Test 2: Multiple backreferences
+    let re2 = /(.)(.)\1\2/;
+    let str2_match = "abab";
+    let str2_nomatch = "abba";
+    for (let i = 0; i < iterations; ++i) {
+        re2.test(str2_match);
+        re2.test(str2_nomatch);
+    }
+
+    // Test 3: Quantified backreference
+    let re3 = /(.)\1+/;
+    let str3_match = "aaaa";
+    let str3_nomatch = "abcd";
+    for (let i = 0; i < iterations; ++i) {
+        re3.test(str3_match);
+        re3.test(str3_nomatch);
+    }
+
+    // Test 4: Named capture group
+    let re4 = /(?<char>.)\k<char>/;
+    let str4_match = "bb";
+    let str4_nomatch = "bc";
+    for (let i = 0; i < iterations; ++i) {
+        re4.test(str4_match);
+        re4.test(str4_nomatch);
+    }
+
+    // Test 5: Complex pattern (fences-style)
+    let re5 = /(`{3,}).*\1/;
+    let str5_match = "```code```";
+    let str5_nomatch = "```code``";
+    for (let i = 0; i < iterations / 10; ++i) {  // Fewer iterations for complex pattern
+        re5.test(str5_match);
+        re5.test(str5_nomatch);
+    }
+
+    // Test 6: Duplicate named capture groups
+    let re6 = /(?:(?<x>a)|(?<x>b))\k<x>/;
+    let str6_match = "aa";
+    let str6_nomatch = "ab";
+    for (let i = 0; i < iterations; ++i) {
+        re6.test(str6_match);
+        re6.test(str6_nomatch);
+    }
+})();

--- a/JSTests/stress/regexp-backreference-matchonly.js
+++ b/JSTests/stress/regexp-backreference-matchonly.js
@@ -1,0 +1,194 @@
+// Test backreferences in MatchOnly mode (test() method).
+// This tests the JIT implementation of backreferences when m_regs.output is not available.
+
+function testMatchOnly(re, str, expected, description) {
+    let result = re.test(str);
+    if (result !== expected)
+        throw new Error(`${description || re.toString()}.test("${str}") = ${result}, expected ${expected}`);
+}
+
+// ==== Basic backreferences ====
+
+// Simple backreference - match
+testMatchOnly(/(.)\1/, "aa", true, "simple backref match");
+testMatchOnly(/(.)\1/, "bb", true, "simple backref match 2");
+testMatchOnly(/(.)\1/, "11", true, "simple backref match digit");
+
+// Simple backreference - no match
+testMatchOnly(/(.)\1/, "ab", false, "simple backref no match");
+testMatchOnly(/(.)\1/, "a", false, "simple backref too short");
+testMatchOnly(/(.)\1/, "", false, "simple backref empty");
+
+// ==== Multiple backreferences ====
+
+testMatchOnly(/(.)(.)\1\2/, "abab", true, "multiple backref match");
+testMatchOnly(/(.)(.)\1\2/, "abba", false, "multiple backref no match");
+testMatchOnly(/(.)(.)\1\2/, "xyzxy", false, "multiple backref partial");
+
+// Three capture groups
+testMatchOnly(/(.)(.)(.)(\1\2\3)/, "abcabc", true, "three groups match");
+testMatchOnly(/(.)(.)(.)(\1\2\3)/, "abcdef", false, "three groups no match");
+
+// ==== Quantified backreferences ====
+
+// Greedy quantifiers
+testMatchOnly(/(.)\1+/, "aaa", true, "backref + match");
+testMatchOnly(/(.)\1+/, "a", false, "backref + no match (needs 2+)");
+testMatchOnly(/(.)\1*/, "a", true, "backref * match (0 repeats ok)");
+testMatchOnly(/(.)\1*/, "aaa", true, "backref * match multiple");
+testMatchOnly(/(.)\1?/, "a", true, "backref ? match (0 ok)");
+testMatchOnly(/(.)\1?/, "aa", true, "backref ? match (1 ok)");
+testMatchOnly(/(.)\1{2}/, "aaa", true, "backref {2} match");
+testMatchOnly(/(.)\1{2}/, "aa", false, "backref {2} no match");
+testMatchOnly(/(.)\1{2,4}/, "aaaa", true, "backref {2,4} match");
+testMatchOnly(/(.)\1{2,4}/, "aa", false, "backref {2,4} no match (too few)");
+
+// Non-greedy quantifiers
+testMatchOnly(/(.)\1+?/, "aaa", true, "backref +? match");
+testMatchOnly(/(.)\1*?/, "a", true, "backref *? match");
+testMatchOnly(/(.)\1??/, "a", true, "backref ?? match");
+
+// ==== Named capture groups ====
+
+testMatchOnly(/(?<char>.)\k<char>/, "aa", true, "named backref match");
+testMatchOnly(/(?<char>.)\k<char>/, "ab", false, "named backref no match");
+testMatchOnly(/(?<a>.)(?<b>.)\k<a>\k<b>/, "abab", true, "multiple named backref match");
+testMatchOnly(/(?<a>.)(?<b>.)\k<a>\k<b>/, "abba", false, "multiple named backref no match");
+
+// ==== Duplicate named capture groups ====
+
+testMatchOnly(/(?:(?<x>a)|(?<x>b))\k<x>/, "aa", true, "duplicate named group match a");
+testMatchOnly(/(?:(?<x>a)|(?<x>b))\k<x>/, "bb", true, "duplicate named group match b");
+testMatchOnly(/(?:(?<x>a)|(?<x>b))\k<x>/, "ab", false, "duplicate named group no match");
+testMatchOnly(/(?:(?<x>a)|(?<x>b))\k<x>/, "ba", false, "duplicate named group no match 2");
+
+// More complex duplicate named groups
+testMatchOnly(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/, "aabb", true, "repeated duplicate named group");
+testMatchOnly(/(?:(?:(?<x>a)|(?<x>b))\k<x>){2}/, "aaab", false, "repeated duplicate named group no match");
+
+// ==== Nested parentheses ====
+
+// /((.))\1\2/ captures one char in group 1 and 2 (same char), then expects that char twice more
+testMatchOnly(/((.))\1\2/, "aaaa", true, "nested groups match");
+testMatchOnly(/((.))\1\2/, "abab", false, "nested groups no match (different chars)");
+testMatchOnly(/((.))\1\2/, "abcd", false, "nested groups no match");
+
+// /((.)(.))\1/ captures two chars in group 1, then expects the same two chars
+testMatchOnly(/((.)(.))\1/, "abab", true, "nested with multiple chars");
+testMatchOnly(/((.)(.))\1/, "abcabc", false, "nested with multiple chars no match");
+
+// ==== Case insensitive ====
+
+testMatchOnly(/(.)\1/i, "aA", true, "ignoreCase match");
+testMatchOnly(/(.)\1/i, "Aa", true, "ignoreCase match reverse");
+testMatchOnly(/(.)\1/i, "ab", false, "ignoreCase no match");
+testMatchOnly(/(?<x>.)\k<x>/i, "aA", true, "named ignoreCase match");
+
+// ==== Unicode mode ====
+
+testMatchOnly(/(.)\1/u, "aa", true, "unicode mode match");
+testMatchOnly(/(.)\1/u, "ab", false, "unicode mode no match");
+
+// Non-BMP characters (surrogate pairs)
+testMatchOnly(/(.)\1/u, "\u{1F600}\u{1F600}", true, "emoji match");
+testMatchOnly(/(.)\1/u, "\u{1F600}\u{1F601}", false, "emoji no match");
+testMatchOnly(/(.)\1/u, "\u{10000}\u{10000}", true, "non-BMP match");
+
+// ==== Mixed with non-capturing groups ====
+
+testMatchOnly(/(?:a)(b)\1/, "abb", true, "non-capture prefix match");
+testMatchOnly(/(?:a)(b)\1/, "abc", false, "non-capture prefix no match");
+testMatchOnly(/(a)(?:b)\1/, "aba", true, "non-capture middle match");
+testMatchOnly(/(a)(?:b)(c)\1\2/, "abcac", true, "mixed groups match");
+
+// ==== Complex patterns (marked.js fences style) ====
+
+testMatchOnly(/(`{3,}).*\1/, "```code```", true, "fences pattern match");
+testMatchOnly(/(`{3,}).*\1/, "````code````", true, "fences pattern 4 backticks");
+testMatchOnly(/(`{3,}).*\1/, "```code``", false, "fences pattern no match (fewer)");
+testMatchOnly(/(`{3,}).*\1/, "```code", false, "fences pattern no match (none)");
+
+// Tilde variant
+testMatchOnly(/(~{3,}).*\1/, "~~~code~~~", true, "tilde fences match");
+testMatchOnly(/(~{3,}).*\1/, "~~~code~~", false, "tilde fences no match");
+
+// ==== Lookahead with backreference ====
+
+testMatchOnly(/(?=(.)\1)aa/, "aa", true, "lookahead with backref match");
+testMatchOnly(/(?=(.)\1)ab/, "ab", false, "lookahead with backref no match");
+
+// ==== Empty capture ====
+
+testMatchOnly(/()\1/, "", true, "empty capture match");
+testMatchOnly(/()\1a/, "a", true, "empty capture with char");
+testMatchOnly(/()?\1/, "", true, "optional empty capture");
+
+// ==== Backreference to unmatched group ====
+
+testMatchOnly(/(a)?\1/, "aa", true, "optional group matched");
+testMatchOnly(/(a)?\1/, "", true, "optional group unmatched (backref matches empty)");
+testMatchOnly(/(a)?\1/, "a", true, "optional group captures but backref empty ok");
+
+// ==== Long strings ====
+
+let longStr = "a".repeat(1000);
+testMatchOnly(/(.)\1{999}/, longStr, true, "long string match");
+testMatchOnly(/(.)\1{1000}/, longStr, false, "long string no match (off by one)");
+
+// Repeated pattern
+let repeatedPairs = "ab".repeat(500);
+testMatchOnly(/(..)\1{499}/, repeatedPairs, true, "repeated pairs match");
+
+// ==== Backreference at different positions ====
+
+testMatchOnly(/^(.)\1$/, "aa", true, "anchored backref match");
+testMatchOnly(/^(.)\1$/, "aaa", false, "anchored backref no match (too long)");
+testMatchOnly(/(.)\1$/, "baa", true, "end anchored backref match");
+testMatchOnly(/^(.)\1/, "aab", true, "start anchored backref match");
+
+// ==== Word boundaries ====
+
+testMatchOnly(/\b(.)\1\b/, "aa", true, "word boundary backref match");
+testMatchOnly(/(\w)\1/, "aa", true, "word char backref match");
+testMatchOnly(/(\w)\1/, "a1", false, "word char backref no match");
+
+// ==== Character classes ====
+
+testMatchOnly(/([aeiou])\1/, "ee", true, "vowel backref match");
+testMatchOnly(/([aeiou])\1/, "ea", false, "vowel backref no match");
+testMatchOnly(/([0-9])\1/, "55", true, "digit class backref match");
+testMatchOnly(/([^a])\1/, "bb", true, "negated class backref match");
+
+// ==== Multiline mode ====
+
+testMatchOnly(/^(.)\1/m, "aa\nbb", true, "multiline backref match");
+testMatchOnly(/(.)\1$/m, "ab\ncc", true, "multiline end backref match");
+
+// ==== dotAll mode ====
+
+testMatchOnly(/(.)\1/s, "aa", true, "dotAll backref match");
+testMatchOnly(/(.).\1/s, "a\na", true, "dotAll with newline match");
+testMatchOnly(/(.).\1/s, "a\nb", false, "dotAll with newline no match");
+
+// ==== Stress test: Many capture groups ====
+
+// 10 capture groups
+testMatchOnly(/(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)\1\2\3\4\5\6\7\8\9\10/,
+    "abcdefghijabcdefghij", true, "10 groups match");
+testMatchOnly(/(.)(.)(.)(.)(.)(.)(.)(.)(.)(.)\1\2\3\4\5\6\7\8\9\10/,
+    "abcdefghijabcdefghix", false, "10 groups no match");
+
+// ==== Alternation with backreference ====
+
+testMatchOnly(/(a|b)\1/, "aa", true, "alternation backref match a");
+testMatchOnly(/(a|b)\1/, "bb", true, "alternation backref match b");
+testMatchOnly(/(a|b)\1/, "ab", false, "alternation backref no match");
+testMatchOnly(/(a|b)\1/, "ba", false, "alternation backref no match 2");
+
+// ==== Complex alternation ====
+
+testMatchOnly(/(?:(a)|(b))\1\2/, "a", false, "complex alt - partial capture");
+testMatchOnly(/((?:a|b)+)\1/, "abab", true, "repeated alt group match");
+testMatchOnly(/((?:a|b)+)\1/, "abba", true, "repeated alt group match (bb part)");
+testMatchOnly(/((?:a|b)+)\1/, "abcd", false, "repeated alt group no match");
+


### PR DESCRIPTION
#### 98d1969d3ca5c58b8ed685c6b3e4f252ddc8587c
<pre>
[YARR] Add JIT support for backreference in MatchOnly mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=306511">https://bugs.webkit.org/show_bug.cgi?id=306511</a>

Reviewed by Yusuke Suzuki.

Previously, backreferences in MatchOnly mode fell back to the interpreter
because there was no output buffer to store subpattern captures. This patch
adds internal frame storage for subpattern data, enabling JIT compilation
of patterns with backreferences even in MatchOnly mode.

                                        TipOfTree                  Patched

regexp-backreference-matchonly      517.8507+-3.2870     ^    107.9545+-4.0184        ^ definitely 4.7969x faster

* JSTests/microbenchmarks/regexp-backreference-matchonly.js: Added.
* JSTests/stress/regexp-backreference-matchonly.js: Added.
(testMatchOnly):
(testMatchOnly.x.a):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/306861@main">https://commits.webkit.org/306861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/014c7e165490d8a6cd06f6abd47764064abffb83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151235 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109642 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12118 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11628 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9298 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1239 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134554 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153553 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3374 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117664 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117999 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30096 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14024 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70357 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14708 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3830 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173859 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14445 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78410 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44957 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->