### PR TITLE
[threaded-animations] test `compositing/backing/backing-store-attachment-animating-outside-viewport.html` fails with "Threaded Time-based Animations" enabled

### DIFF
--- a/LayoutTests/compositing/backing/backing-store-attachment-animating-outside-viewport.html
+++ b/LayoutTests/compositing/backing/backing-store-attachment-animating-outside-viewport.html
@@ -32,39 +32,25 @@
 
 </style>
 <script src="../resources/compositing-test-utils.js"></script>
+<script src="../../webanimations/threaded-animations/threaded-animations-utils.js"></script>
 <script>
-if (window.testRunner) {
-    testRunner.dumpAsText();
-    testRunner.waitUntilDone();
-}
 
-function dumpLayerTree()
-{
-    if (!window.internals)
-        return;
+window.testRunner?.dumpAsText();
+window.testRunner?.waitUntilDone();
 
-    var out = document.getElementById('out');
-    out.innerText = layerTreeWithoutTransforms(internals.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
-}
-
-function dumpLayersSoon()
-{
-    setTimeout(function() {
-        dumpLayerTree();
-        if (window.testRunner)
-            testRunner.notifyDone();
-    }, 0);
-}
-
-function runTest()
-{
+window.addEventListener('load', async () => {
     makeDots(5, 5, 60);
-    let box = document.getElementById('box');
-    box.addEventListener('animationstart', dumpLayersSoon, false);
-    box.classList.add('animating');
-}
 
-window.addEventListener('load', runTest, false);
+    const box = document.getElementById('box');
+    box.classList.add('animating');
+
+    await new Promise(resolve => box.addEventListener('animationstart', resolve));
+    await animationAcceleration(box.getAnimations()[0]);
+
+    document.getElementById('out').innerText = layerTreeWithoutTransforms(window.internals?.LAYER_TREE_INCLUDES_BACKING_STORE_ATTACHED);
+
+    window.testRunner?.notifyDone();
+});
 
 </script>
 </head>


### PR DESCRIPTION
#### 6368b42280b63b18bd488f5031f0ff0c78a9750b
<pre>
[threaded-animations] test `compositing/backing/backing-store-attachment-animating-outside-viewport.html` fails with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306512">https://bugs.webkit.org/show_bug.cgi?id=306512</a>
<a href="https://rdar.apple.com/169170357">rdar://169170357</a>

Reviewed by Anne van Kesteren.

We now use the `acceleratedAnimation()` promise to abstract away the assumption made
with `setTimeout()` in this test about accelerated animation readiness before dumping
the layer tree state. Since we had to use a promise there, we improve the way this test
was written to use promises to make the test flow a bit clearer and avoid callbacks.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedTimeBasedAnimationsEnabled=true`.

* LayoutTests/compositing/backing/backing-store-attachment-animating-outside-viewport.html:

Canonical link: <a href="https://commits.webkit.org/306414@main">https://commits.webkit.org/306414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d46cc86304b9c62f91abfb6594a4ed0d5520d9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149875 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13840 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108560 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11115 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89465 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10687 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8296 "Found 1 new API test failure: TestWebKitAPI.WebCoreNSURLSessionTest.InvalidateEmpty (failure)") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152269 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13371 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116657 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116997 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13048 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123111 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68545 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21799 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13414 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13153 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13352 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->