### PR TITLE
Document::updateLayout: reduce scope of checked pointer

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-embed-with-content-visibility-hidden-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-embed-with-content-visibility-hidden-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/scrolling/scroll-embed-with-content-visibility-hidden-crash.html
+++ b/LayoutTests/fast/scrolling/scroll-embed-with-content-visibility-hidden-crash.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+  #container { content-visibility: hidden; }
+  #embed {
+    padding-top: 200vh;
+    content-visibility: hidden;
+    container-type: size;
+  }
+</style>
+<div id="container"><embed id="embed" src="about:blank"></embed></div>
+<script>
+  window.testRunner?.dumpAsText();
+  embed.scrollBy({});
+  document.body.innerHTML = "PASS if no crash.";
+</script>


### PR DESCRIPTION
#### 2fd467bcfa39e4fa05a89900fa0bbcfade56b9c9
<pre>
Document::updateLayout: reduce scope of checked pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=306514">https://bugs.webkit.org/show_bug.cgi?id=306514</a>

Reviewed by Ryosuke Niwa and Geoffrey Garen.

After 306021@main introduced smart pointers in Document::updateLayout,
it&apos;s possible to hit an assertion when the checked pointer in
runForcedLayoutOnSkippedContentIfNeeded() goes out of scope at the end
of the function. Since this variable is only needed briefly, it&apos;s better
to reduce its scope as later calls in that method might delete the underlying
renderer object.

Test: fast/scrolling/scroll-embed-with-content-visibility-hidden-crash.html

* LayoutTests/fast/scrolling/scroll-embed-with-content-visibility-hidden-crash-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-embed-with-content-visibility-hidden-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayout): Reduce the scope of rootForLayout.

Canonical link: <a href="https://commits.webkit.org/306431@main">https://commits.webkit.org/306431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe1ba7049d92036582e0d2da8cbe519cd959277

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108561 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11109 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89466 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10682 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8294 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13372 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116665 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/116998 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13050 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68546 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13415 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13154 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77121 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13353 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13198 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->