### PR TITLE
[GStreamer][Quirks] Remove useless GST_CAT_DEFAULT undef in hole punch quirks

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp
@@ -58,8 +58,6 @@ bool GStreamerHolePunchQuirkRialto::setHolePunchVideoRectangle(GstElement* video
     return true;
 }
 
-#undef GST_CAT_DEFAULT
-
 } // namespace WebCore
 
 #endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
@@ -61,8 +61,6 @@ bool GStreamerHolePunchQuirkWesteros::setHolePunchVideoRectangle(GstElement* vid
     return true;
 }
 
-#undef GST_CAT_DEFAULT
-
 } // namespace WebCore
 
 #endif // USE(GSTREAMER)


### PR DESCRIPTION
#### c7d91a3a74bd5b880f758dfcbddddcd607bdc967
<pre>
[GStreamer][Quirks] Remove useless GST_CAT_DEFAULT undef in hole punch quirks
<a href="https://bugs.webkit.org/show_bug.cgi?id=306521">https://bugs.webkit.org/show_bug.cgi?id=306521</a>

Reviewed by Philippe Normand.

There is no matching define in the Rialto and Westeros hole punch quirks.

* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.cpp:
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp:

Canonical link: <a href="https://commits.webkit.org/306416@main">https://commits.webkit.org/306416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3b48bfb829754ec2e691413a36aa629c75854a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149886 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108571 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11120 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89476 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10692 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8304 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152280 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13382 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/2899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116669 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117008 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29773 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13060 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68563 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13425 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77131 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->