### PR TITLE
[macOS] EditorStateTests.UnionRectInVisibleSelectedRangeAndDocumentVisibleRect is a flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
@@ -620,6 +620,9 @@ TEST(EditorStateTests, UnionRectInVisibleSelectedRangeAndDocumentVisibleRect)
     [webView mouseDownAtPoint:NSMakePoint(15, 390) simulatePressure:NO];
     [webView mouseDragToPoint:NSMakePoint(300, 390)];
     [webView mouseUpAtPoint:NSMakePoint(300, 390)];
+    [webView waitForPendingMouseEvents];
+    [webView waitForNextPresentationUpdate];
+
     [webView stringByEvaluatingJavaScript:@"document.execCommand('selectAll', true)"];
     [webView waitForNextPresentationUpdate];
 


### PR DESCRIPTION
#### 2a74b9f3f360d55866a10ae5be5103424c15cf2f
<pre>
[macOS] EditorStateTests.UnionRectInVisibleSelectedRangeAndDocumentVisibleRect is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=306532">https://bugs.webkit.org/show_bug.cgi?id=306532</a>
<a href="https://rdar.apple.com/169186649">rdar://169186649</a>

Reviewed by Abrar Rahman Protyasha.

This is a speculative fix for this API test, since I was not able to reproduce it locally — wait for
all pending mouse events to be handled before attempting to proceed with script-triggered text
selection using `execCommand`.

This should ensure that the page has had a ranged text selection set by the user.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeAndDocumentVisibleRect)):

Canonical link: <a href="https://commits.webkit.org/306437@main">https://commits.webkit.org/306437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a0b0fd89bf65ae04177ae92e1b18a514a2728c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94423 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba1e8370-ec0e-4e2c-9364-735a2b43aeac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13863 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108583 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a4041be-5dfe-474c-ab72-78c46ff84840) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11132 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89488 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b7446b8-c7e2-48f6-bcb8-206e9ed3a39c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8327 "Passed tests") | [⏳ 🛠 wpe-libwebrtc ](https://ews-build.webkit.org/#/builders/WPE-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/119974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152292 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13394 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116681 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117019 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13072 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68602 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13437 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13176 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13375 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13220 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->