### PR TITLE
[threaded-animations] test `webanimations/accelerated-animation-removed-permanently-when-forward-filling.html` fails with "Threaded Time-based Animations"

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Two replacing animations with explicit keyframes for the same accelerated property yield only a single accelerated animation.
+PASS An animation with an implicit keyframe for an accelerated property can run accelerated.
+PASS Two animations with implicit keyframes for the same accelerated property prevents acceleration throughout the stack.
+PASS Dynamically adding an animation with an implicit keyframe for an accelerated property with an accelerated animation targeting that same property lower down the stack prevents the stack from being accelerated.
+

--- a/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=false ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=true ] -->
 <body>
-<script src="../resources/testharness.js"></script>
-<script src="../resources/testharnessreport.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
 <style>
 
 div {
@@ -42,8 +42,8 @@ promise_test(async test => {
     animations.push(target.animate({ transform: ["none", "translateX(100px)"] }, duration));
     animations.push(target.animate({ transform: ["none", "translateY(100px)"] }, duration));
     await allAnimationsAreReadyToAnimateAccelerated(animations);
-    assert_equals(internals.acceleratedAnimationsForElement(target).length, 2);
-}, "Two replacing animations with explicit keyframes for the same accelerated property can run accelerated.");
+    assert_equals(internals.acceleratedAnimationsForElement(target).length, 1);
+}, "Two replacing animations with explicit keyframes for the same accelerated property yield only a single accelerated animation.");
 
 promise_test(async test => {
     const target = createDiv(test);

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -102,6 +102,7 @@ public:
     std::optional<WebAnimationTime> holdTime() const { return m_holdTime; }
 
     const OptionSet<AcceleratedEffectProperty>& disallowedProperties() const { return m_disallowedProperties; }
+    const OptionSet<AcceleratedEffectProperty>& replacedProperties() const { return m_replacedProperties; }
 
     bool animatesTransformRelatedProperty() const;
 
@@ -128,6 +129,7 @@ private:
     RefPtr<TimingFunction> m_defaultKeyframeTimingFunction;
     OptionSet<AcceleratedEffectProperty> m_animatedProperties;
     OptionSet<AcceleratedEffectProperty> m_disallowedProperties;
+    OptionSet<AcceleratedEffectProperty> m_replacedProperties;
     bool m_paused { false };
     double m_playbackRate { 1 };
     std::optional<WebAnimationTime> m_startTime;


### PR DESCRIPTION
#### 7ac36254a04f025e99a9bfcb10e4c7916712d920
<pre>
[threaded-animations] test `webanimations/accelerated-animation-removed-permanently-when-forward-filling.html` fails with &quot;Threaded Time-based Animations&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=306531">https://bugs.webkit.org/show_bug.cgi?id=306531</a>
<a href="https://rdar.apple.com/169186310">rdar://169186310</a>

Reviewed by Cameron McCormack.

The test `webanimations/accelerated-animation-removed-permanently-when-forward-filling.html`  assumes that
effects associated with a &quot;replaced&quot; animation [0], in other words effects that have no noticeable effect
because other effects further up the effect stack override them, are not accelerated, and neither are
effects which are associated with an animation that is not in the &quot;running&quot; state [1].

These assumptions did not hold in the world of threaded animations where, because we support additivity [2],
we chose to have all effects that are associated with a &quot;relevant&quot; animation [3] reflected in the remote
layer tree.

However, it is desirable to keep passing such a test and have a minimal amount of animations in the remote
layer tree. So we now implement similar logic in `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()`
where we make the following changes:

1. iterate over effects in reverse and only add effects which are not completely replaced,
2. iterate over those effects in case there are properties that are animated by an effect and yet have no
   visible effect.

To that end, we now keep a list of &quot;replaced properties&quot; on `AcceleratedEffect` including all properties
that have an explicit &quot;from&quot; and &quot;to&quot; value and have a &quot;replace&quot; composite operation. Then, as we iterate
over effects in `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()`, we keep several list of
properties:

1. a list of all encountered animated properties
2. a list of all interpolating animated properties
3. a list of all animated properties that have been replaced by an effect

Using the first two lists we can determine a list of non-interpolating properties, which we use to implement
step 2 above. Using the third list, we implement step 1 above.

This changes the behavior of one of the existing tests, `webanimations/accelerated-animations-and-implicit-keyframes.html`,
which now has improved, more restrictive behavior, so we make sure this test turns off &quot;Threaded Time-based Animations&quot;
to keep testing the existing behavior, and duplicate it in a test where we test the new behavior with the flag
enabled.

[0] <a href="https://drafts.csswg.org/web-animations-1/#replacing-animations">https://drafts.csswg.org/web-animations-1/#replacing-animations</a>
[1] <a href="https://drafts.csswg.org/web-animations-1/#play-state-running">https://drafts.csswg.org/web-animations-1/#play-state-running</a>
[2] <a href="https://drafts.csswg.org/web-animations-1/#composite-operation-add">https://drafts.csswg.org/web-animations-1/#composite-operation-add</a>
[3] <a href="https://drafts.csswg.org/web-animations-1/#relevant-animations-section">https://drafts.csswg.org/web-animations-1/#relevant-animations-section</a>

Test: webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html

* LayoutTests/webanimations/accelerated-animations-and-implicit-keyframes.html:
* LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/accelerated-animations-and-implicit-keyframes.html: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::AcceleratedEffect):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
(WebCore::AcceleratedEffect::replacedProperties const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAcceleratedEffectsAndBaseValues):

Canonical link: <a href="https://commits.webkit.org/306475@main">https://commits.webkit.org/306475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26706a6d94f3b7c85bda8cfa778b1fa13f308ea2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13870 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/3220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150059 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14027 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144436 "Failed to checkout and rebase branch from PR 57480") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/11250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89613 "Failed to checkout and rebase branch from PR 57480") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/131 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152452 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13557 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/3037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116811 "Failed to checkout and rebase branch from PR 57480") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13572 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117142 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/13180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/123267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21828 "Built successfully and passed tests") | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13600 "Failed to checkout and rebase branch from PR 57480") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13336 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13536 "Failed to checkout and rebase branch from PR 57480") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13384 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->