### PR TITLE
Make buffer source toJS() conversions require correct nullness and subtyping

### DIFF
--- a/Source/JavaScriptCore/API/JSTypedArray.cpp
+++ b/Source/JavaScriptCore/API/JSTypedArray.cpp
@@ -302,7 +302,7 @@ JSObjectRef JSObjectGetTypedArrayBuffer(JSContextRef ctx, JSObjectRef objectRef,
 
     if (JSArrayBufferView* typedArray = jsDynamicCast<JSArrayBufferView*>(object)) {
         if (ArrayBuffer* buffer = typedArray->possiblySharedBuffer())
-            return toRef(vm.m_typedArrayController->toJS(globalObject, typedArray->globalObject(), buffer));
+            return toRef(vm.m_typedArrayController->toJS(globalObject, typedArray->globalObject(), *buffer));
 
         setException(ctx, exception, createOutOfMemoryError(globalObject));
     }

--- a/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBuffer.cpp
@@ -44,7 +44,7 @@ void JSArrayBuffer::finishCreation(VM& vm, JSGlobalObject* globalObject)
     Base::finishCreation(vm);
     // This probably causes GCs in the various VMs to overcount the impact of the array buffer.
     vm.heap.addReference(this, impl());
-    vm.m_typedArrayController->registerWrapper(globalObject, impl(), this);
+    vm.m_typedArrayController->registerWrapper(globalObject, *impl(), *this);
 }
 
 JSArrayBuffer* JSArrayBuffer::create(

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.cpp
@@ -242,7 +242,7 @@ JSArrayBuffer* JSArrayBufferView::unsharedJSBuffer(JSGlobalObject* globalObject)
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (ArrayBuffer* buffer = unsharedBuffer())
-        return vm.m_typedArrayController->toJS(globalObject, this->globalObject(), buffer);
+        return vm.m_typedArrayController->toJS(globalObject, this->globalObject(), *buffer);
     scope.throwException(globalObject, createOutOfMemoryError(globalObject));
     return nullptr;
 }
@@ -252,7 +252,7 @@ JSArrayBuffer* JSArrayBufferView::possiblySharedJSBuffer(JSGlobalObject* globalO
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (ArrayBuffer* buffer = possiblySharedBuffer())
-        return vm.m_typedArrayController->toJS(globalObject, this->globalObject(), buffer);
+        return vm.m_typedArrayController->toJS(globalObject, this->globalObject(), *buffer);
     scope.throwException(globalObject, createOutOfMemoryError(globalObject));
     return nullptr;
 }

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -1889,7 +1889,7 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSubarray(VM& vm, JSGl
         Structure* structure = globalObject->typedArrayStructure(ViewClass::TypedArrayStorageType, arrayBuffer->isResizableOrGrowableShared());
         return ViewClass::create(globalObject, structure, WTF::move(arrayBuffer), newByteOffset, count);
     }, [&](MarkedArgumentBuffer& args) {
-        args.append(vm.m_typedArrayController->toJS(globalObject, thisObject->globalObject(), arrayBuffer.get()));
+        args.append(vm.m_typedArrayController->toJS(globalObject, thisObject->globalObject(), *arrayBuffer));
         args.append(jsNumber(newByteOffset));
         if (count)
             args.append(jsNumber(count.value()));

--- a/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
+++ b/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
@@ -40,21 +40,20 @@ SimpleTypedArrayController::SimpleTypedArrayController(bool allowAtomicsWait)
 
 SimpleTypedArrayController::~SimpleTypedArrayController() = default;
 
-JSArrayBuffer* SimpleTypedArrayController::toJS(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, ArrayBuffer* native)
+JSArrayBuffer* SimpleTypedArrayController::toJS(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, ArrayBuffer& native)
 {
     UNUSED_PARAM(lexicalGlobalObject);
-    if (JSArrayBuffer* buffer = native->m_wrapper.get())
+    if (JSArrayBuffer* buffer = native.m_wrapper.get())
         return buffer;
 
     // The JSArrayBuffer::create function will register the wrapper in finishCreation.
-    JSArrayBuffer* result = JSArrayBuffer::create(globalObject->vm(), globalObject->arrayBufferStructure(native->sharingMode()), native);
-    return result;
+    return JSArrayBuffer::create(globalObject->vm(), globalObject->arrayBufferStructure(native.sharingMode()), &native);
 }
 
-void SimpleTypedArrayController::registerWrapper(JSGlobalObject*, ArrayBuffer* native, JSArrayBuffer* wrapper)
+void SimpleTypedArrayController::registerWrapper(JSGlobalObject*, ArrayBuffer& native, JSArrayBuffer& wrapper)
 {
-    ASSERT(!native->m_wrapper);
-    native->m_wrapper = Weak<JSArrayBuffer>(wrapper, &m_owner);
+    ASSERT(!native.m_wrapper);
+    native.m_wrapper = Weak<JSArrayBuffer>(&wrapper, &m_owner);
 }
 
 bool SimpleTypedArrayController::isAtomicsWaitAllowedOnCurrentThread()

--- a/Source/JavaScriptCore/runtime/SimpleTypedArrayController.h
+++ b/Source/JavaScriptCore/runtime/SimpleTypedArrayController.h
@@ -51,8 +51,8 @@ public:
     JS_EXPORT_PRIVATE SimpleTypedArrayController(bool allowAtomicsWait = true);
     ~SimpleTypedArrayController() final;
     
-    JSArrayBuffer* toJS(JSGlobalObject*, JSGlobalObject*, ArrayBuffer*) final;
-    void registerWrapper(JSGlobalObject*, ArrayBuffer*, JSArrayBuffer*) final;
+    JSArrayBuffer* toJS(JSGlobalObject*, JSGlobalObject*, ArrayBuffer&) final;
+    void registerWrapper(JSGlobalObject*, ArrayBuffer&, JSArrayBuffer&) final;
     bool isAtomicsWaitAllowedOnCurrentThread() final;
 
 private:

--- a/Source/JavaScriptCore/runtime/TypedArrayAdaptersForwardDeclarations.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayAdaptersForwardDeclarations.h
@@ -41,18 +41,18 @@ struct BigInt64Adaptor;
 struct BigUint64Adaptor;
 
 template<typename Adaptor> class GenericTypedArrayView;
-typedef GenericTypedArrayView<Int8Adaptor> Int8Array;
-typedef GenericTypedArrayView<Int16Adaptor> Int16Array;
-typedef GenericTypedArrayView<Int32Adaptor> Int32Array;
-typedef GenericTypedArrayView<Uint8Adaptor> Uint8Array;
-typedef GenericTypedArrayView<Uint8ClampedAdaptor> Uint8ClampedArray;
-typedef GenericTypedArrayView<Uint16Adaptor> Uint16Array;
-typedef GenericTypedArrayView<Uint32Adaptor> Uint32Array;
-typedef GenericTypedArrayView<Float16Adaptor> Float16Array;
-typedef GenericTypedArrayView<Float32Adaptor> Float32Array;
-typedef GenericTypedArrayView<Float64Adaptor> Float64Array;
-typedef GenericTypedArrayView<BigInt64Adaptor> BigInt64Array;
-typedef GenericTypedArrayView<BigUint64Adaptor> BigUint64Array;
+using Int8Array = GenericTypedArrayView<Int8Adaptor>;
+using Int16Array = GenericTypedArrayView<Int16Adaptor>;
+using Int32Array = GenericTypedArrayView<Int32Adaptor>;
+using Uint8Array = GenericTypedArrayView<Uint8Adaptor>;
+using Uint8ClampedArray = GenericTypedArrayView<Uint8ClampedAdaptor>;
+using Uint16Array = GenericTypedArrayView<Uint16Adaptor>;
+using Uint32Array = GenericTypedArrayView<Uint32Adaptor>;
+using Float16Array = GenericTypedArrayView<Float16Adaptor>;
+using Float32Array = GenericTypedArrayView<Float32Adaptor>;
+using Float64Array = GenericTypedArrayView<Float64Adaptor>;
+using BigInt64Array = GenericTypedArrayView<BigInt64Adaptor>;
+using BigUint64Array = GenericTypedArrayView<BigUint64Adaptor>;
 
 }
 

--- a/Source/JavaScriptCore/runtime/TypedArrayController.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayController.h
@@ -40,8 +40,8 @@ public:
     JS_EXPORT_PRIVATE TypedArrayController();
     JS_EXPORT_PRIVATE virtual ~TypedArrayController();
     
-    virtual JSArrayBuffer* toJS(JSGlobalObject*, JSGlobalObject*, ArrayBuffer*) = 0;
-    virtual void registerWrapper(JSGlobalObject*, ArrayBuffer*, JSArrayBuffer*) = 0;
+    virtual JSArrayBuffer* toJS(JSGlobalObject*, JSGlobalObject*, ArrayBuffer&) = 0;
+    virtual void registerWrapper(JSGlobalObject*, ArrayBuffer&, JSArrayBuffer&) = 0;
     virtual bool isAtomicsWaitAllowedOnCurrentThread() = 0;
 
     virtual bool isWebCoreTypedArrayController() const { return false; }

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.idl
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.idl
@@ -30,6 +30,6 @@
 ] interface CompressionStreamEncoder {
     constructor(byte format);
 
-    [PrivateIdentifier] Uint8Array encode(BufferSource chunk);
-    [PrivateIdentifier] Uint8Array flush();
+    [PrivateIdentifier] Uint8Array? encode(BufferSource chunk);
+    [PrivateIdentifier] Uint8Array? flush();
 };

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.idl
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.idl
@@ -30,6 +30,6 @@
 ] interface DecompressionStreamDecoder {
     constructor(byte format);
 
-    [PrivateIdentifier] Uint8Array decode(BufferSource chunk);
-    [PrivateIdentifier] Uint8Array flush();
+    [PrivateIdentifier] Uint8Array? decode(BufferSource chunk);
+    [PrivateIdentifier] Uint8Array? flush();
 };

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.idl
@@ -26,6 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/encrypted-media/#dom-mediakeymessageevent
 [
     Conditional=ENCRYPTED_MEDIA,
     EnabledBySetting=EncryptedMediaAPIEnabled,
@@ -35,5 +36,6 @@
     constructor([AtomString] DOMString type, MediaKeyMessageEventInit eventInitDict);
 
     readonly attribute MediaKeyMessageType messageType;
-    readonly attribute ArrayBuffer message;
+    // FIXME: `message` should not be nullable.
+    readonly attribute ArrayBuffer? message;
 };

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl
@@ -30,7 +30,7 @@
 ] interface WebKitMediaKeyMessageEvent : Event {
     constructor([AtomString] DOMString type, optional WebKitMediaKeyMessageEventInit eventInitDict = {});
 
-    readonly attribute Uint8Array message;
+    readonly attribute Uint8Array? message;
     readonly attribute DOMString destinationURL;
 };
 

--- a/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl
@@ -30,7 +30,7 @@
 ] interface WebKitMediaKeyNeededEvent : Event {
     constructor([AtomString] DOMString type, optional WebKitMediaKeyNeededEventInit eventInitDict = {});
 
-    readonly attribute Uint8Array initData;
+    readonly attribute Uint8Array? initData;
 };
 
 dictionary WebKitMediaKeyNeededEventInit : EventInit {

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -38,11 +38,11 @@ RTCEncodedFrame::RTCEncodedFrame(Ref<RTCRtpTransformableFrame>&& frame)
 {
 }
 
-RefPtr<JSC::ArrayBuffer> RTCEncodedFrame::data() const
+Ref<JSC::ArrayBuffer> RTCEncodedFrame::data() const
 {
     if (!m_data)
         m_data = m_isNeutered ? JSC::ArrayBuffer::create(static_cast<size_t>(0U), 1) : JSC::ArrayBuffer::create(m_frame->data());
-    return m_data;
+    return *m_data;
 }
 
 void RTCEncodedFrame::setData(JSC::ArrayBuffer& buffer)

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.h
@@ -43,7 +43,7 @@ class RTCEncodedFrame : public RefCounted<RTCEncodedFrame> {
 public:
     virtual ~RTCEncodedFrame() { }
 
-    RefPtr<JSC::ArrayBuffer> data() const;
+    Ref<JSC::ArrayBuffer> data() const;
     void setData(JSC::ArrayBuffer&);
 
     enum class ShouldNeuter : bool { No, Yes };

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -199,7 +199,8 @@ static void transformFrame(std::span<const uint8_t> data, JSDOMGlobalObject& glo
 {
     auto result = processFrame(data, transformer, identifier, weakTransform);
     auto buffer = result ? SharedBuffer::create(WTF::move(*result)) : SharedBuffer::create();
-    source.enqueue(toJS(&globalObject, &globalObject, buffer->tryCreateArrayBuffer().get()));
+    RefPtr arrayBuffer = buffer->tryCreateArrayBuffer();
+    source.enqueue(arrayBuffer ? toJS(&globalObject, &globalObject, *arrayBuffer) : JSC::jsNull());
 }
 
 template<typename Frame>

--- a/Source/WebCore/Modules/push-api/PushMessageData.idl
+++ b/Source/WebCore/Modules/push-api/PushMessageData.idl
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/push-api/#dom-pushmessagedata
+// FIXME: This should be marked as `SecureContext`.
 [
     EnabledBySetting=PushAPIEnabled,
     Exposed=ServiceWorker,

--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.h
@@ -45,7 +45,7 @@ struct AuthenticationExtensionsClientOutputs {
     };
 
     struct PRFValues {
-        RefPtr<ArrayBuffer> first;
+        Ref<ArrayBuffer> first;
         RefPtr<ArrayBuffer> second;
     };
 

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.idl
@@ -23,13 +23,16 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webauthn/#authenticatorassertionresponse
 [
     Conditional=WEB_AUTHN,
     EnabledBySetting=WebAuthenticationEnabled,
     Exposed=Window,
     SecureContext
 ] interface AuthenticatorAssertionResponse : AuthenticatorResponse {
-    [SameObject] readonly attribute ArrayBuffer authenticatorData;
-    [SameObject] readonly attribute ArrayBuffer signature;
+    // FIXME: `authenticatorData` should not be nullable.
+    [SameObject] readonly attribute ArrayBuffer? authenticatorData;
+    // FIXME: `signature` should not be nullable.
+    [SameObject] readonly attribute ArrayBuffer? signature;
     [SameObject] readonly attribute ArrayBuffer? userHandle;
 };

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -203,8 +203,7 @@ RegistrationResponseJSON::AuthenticatorAttestationResponseJSON AuthenticatorAtte
         value.authenticatorData = base64URLEncodeToString(authData->span());
     if (auto publicKey = getPublicKey())
         value.publicKey = base64URLEncodeToString(publicKey->span());
-    if (auto attestationObj = attestationObject())
-        value.attestationObject = base64URLEncodeToString(attestationObj->span());
+    value.attestationObject = base64URLEncodeToString(attestationObject().span());
     value.publicKeyAlgorithm = getPublicKeyAlgorithm();
 
     return value;

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.h
@@ -41,7 +41,7 @@ public:
 
     virtual ~AuthenticatorAttestationResponse() = default;
 
-    ArrayBuffer* attestationObject() const { return m_attestationObject.ptr(); }
+    ArrayBuffer& attestationObject() const { return m_attestationObject; }
     const Vector<AuthenticatorTransport>& getTransports() const { return m_transports; }
     RefPtr<ArrayBuffer> getAuthenticatorData() const;
     RefPtr<ArrayBuffer> getPublicKey() const;

--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.idl
@@ -25,6 +25,7 @@
 
 typedef long COSEAlgorithmIdentifier;
 
+// https://w3c.github.io/webauthn/#authenticatorattestationresponse
 [
     Conditional=WEB_AUTHN,
     EnabledBySetting=WebAuthenticationEnabled,
@@ -33,7 +34,8 @@ typedef long COSEAlgorithmIdentifier;
 ] interface AuthenticatorAttestationResponse : AuthenticatorResponse {
     [SameObject] readonly attribute ArrayBuffer attestationObject;
     sequence<AuthenticatorTransport> getTransports();
-    ArrayBuffer getAuthenticatorData();
+    // FIXME: `getAuthenticatorData` should not return a nullable type.
+    ArrayBuffer? getAuthenticatorData();
     ArrayBuffer? getPublicKey();
     COSEAlgorithmIdentifier getPublicKeyAlgorithm();
 };

--- a/Source/WebCore/Modules/webauthn/AuthenticatorResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorResponse.cpp
@@ -78,8 +78,7 @@ AuthenticationExtensionsClientOutputs AuthenticatorResponse::extensions() const
 
     // Clone ArrayBuffers to prevent detachment issues
     if (result.prf && result.prf->results) {
-        if (result.prf->results->first)
-            result.prf->results->first = ArrayBuffer::tryCreate(result.prf->results->first.get()->span());
+        result.prf->results->first = ArrayBuffer::create(result.prf->results->first->span());
         if (result.prf->results->second)
             result.prf->results->second = ArrayBuffer::tryCreate(result.prf->results->second.get()->span());
     }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorResponse.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorResponse.h
@@ -52,7 +52,7 @@ public:
     virtual Type type() const = 0;
     virtual AuthenticatorResponseData data() const;
 
-    ArrayBuffer* rawId() const { return m_rawId.ptr(); }
+    ArrayBuffer& rawId() const { return m_rawId; }
 
     WEBCORE_EXPORT void setExtensions(AuthenticationExtensionsClientOutputs&&);
     WEBCORE_EXPORT AuthenticationExtensionsClientOutputs extensions() const;

--- a/Source/WebCore/Modules/webauthn/AuthenticatorResponse.idl
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorResponse.idl
@@ -23,11 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webauthn/#authenticatorresponse
 [
     Conditional=WEB_AUTHN,
     EnabledBySetting=WebAuthenticationEnabled,
     Exposed=Window,
     SecureContext,
 ] interface AuthenticatorResponse {
-    [SameObject] readonly attribute ArrayBuffer clientDataJSON;
+    // FIXME: `clientDataJSON` should not be nullable.
+    [SameObject] readonly attribute ArrayBuffer? clientDataJSON;
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -58,7 +58,7 @@ Ref<PublicKeyCredential> PublicKeyCredential::create(Ref<AuthenticatorResponse>&
     return adoptRef(*new PublicKeyCredential(WTF::move(response)));
 }
 
-ArrayBuffer* PublicKeyCredential::rawId() const
+ArrayBuffer& PublicKeyCredential::rawId() const
 {
     return m_response->rawId();
 }
@@ -74,7 +74,7 @@ AuthenticatorAttachment PublicKeyCredential::authenticatorAttachment() const
 }
 
 PublicKeyCredential::PublicKeyCredential(Ref<AuthenticatorResponse>&& response)
-    : BasicCredential(base64URLEncodeToString(response->rawId()->span()), Type::PublicKey, Discovery::Remote)
+    : BasicCredential(base64URLEncodeToString(response->rawId().span()), Type::PublicKey, Discovery::Remote)
     , m_response(WTF::move(response))
 {
 }

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
@@ -58,7 +58,7 @@ class PublicKeyCredential final : public BasicCredential {
 public:
     static Ref<PublicKeyCredential> create(Ref<AuthenticatorResponse>&&);
 
-    ArrayBuffer* rawId() const;
+    ArrayBuffer& rawId() const;
     AuthenticatorResponse& response() const { return m_response; }
     AuthenticatorAttachment authenticatorAttachment() const;
     AuthenticationExtensionsClientOutputs getClientExtensionResults() const;

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -166,7 +166,7 @@ static std::optional<AuthenticationExtensionsClientOutputs> parseAuthenticatorDa
                 if (first) {
                     if (!outputs.prf)
                         outputs.prf = AuthenticationExtensionsClientOutputs::PRFOutputs { };
-                    outputs.prf->results = AuthenticationExtensionsClientOutputs::PRFValues { first, second };
+                    outputs.prf->results = AuthenticationExtensionsClientOutputs::PRFValues { first.releaseNonNull(), WTF::move(second) };
                 }
             }
         }

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -51,6 +51,7 @@ Modules/webaudio/OfflineAudioDestinationNode.cpp
 Modules/webaudio/OscillatorNode.cpp
 Modules/webaudio/PannerNode.cpp
 Modules/webaudio/ScriptProcessorNode.cpp
+Modules/webauthn/AuthenticatorResponse.cpp
 Modules/webcodecs/WebCodecsAudioData.cpp
 Modules/webcodecs/WebCodecsAudioInternalData.h
 Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -102,7 +103,6 @@ bindings/js/JSDOMBindingSecurity.cpp
 bindings/js/JSDOMBindingSecurity.h
 bindings/js/JSDOMBindingSecurityInlines.h
 bindings/js/JSDOMConvertBase.h
-bindings/js/JSDOMConvertBufferSource.h
 bindings/js/JSDOMConvertCallbacks.h
 bindings/js/JSDOMConvertEventListener.h
 bindings/js/JSDOMConvertNullable.h

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -202,8 +202,8 @@ struct IDLObject : IDLType<JSC::Strong<JSC::JSObject>> {
 template<typename T> struct IDLWrapper : IDLType<Ref<T>> {
     using RawType = T;
 
-    // FIXME: This is needed to work around unions storing non-nullable interfaces using RefPtr rather than Ref<>.
-    // See "Support using Ref for IDLInterfaces in IDL unions (https://bugs.webkit.org/show_bug.cgi?id=274729)".
+    // FIXME: This is needed to work around unions storing non-nullable interfaces and buffer source types using RefPtr rather than Ref<>.
+    // See "Support using Ref for interfaces and buffer source types in IDL unions (https://bugs.webkit.org/show_bug.cgi?id=274729)".
     using UnionStorageType = RefPtr<T>;
 
     using CallbackReturnType = Ref<T>;

--- a/Source/WebCore/bindings/js/JSDOMConvertUnion.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertUnion.h
@@ -408,9 +408,18 @@ template<typename... T> struct Converter<IDLUnion<T...>> : DefaultConverter<IDLU
 };
 
 // FIXME: This is needed to work around unions storing non-nullable interfaces using RefPtr rather than Ref<>.
-// See "Support using Ref for IDLInterfaces in IDL unions (https://bugs.webkit.org/show_bug.cgi?id=274729)".
-template<typename T> struct AddNullableIfInterface { using type = T; };
-template<typename T> struct AddNullableIfInterface<IDLInterface<T>> { using type = IDLNullable<IDLInterface<T>>; };
+// See "Support using Ref for interfaces and typed arrays in IDL unions (https://bugs.webkit.org/show_bug.cgi?id=274729)".
+template<typename T> struct AddNullableIfInterfaceOrArrayBufferSource {
+    using type = std::conditional_t<
+        IsIDLInterface<T>::value
+            || IsIDLTypedArray<T>::value
+            || IsIDLArrayBuffer<T>::value
+            || IsIDLArrayBufferView<T>::value
+            || std::same_as<T, IDLDataView>,
+        IDLNullable<T>,
+        T
+    >;
+};
 
 template<typename... T> struct JSConverter<IDLUnion<T...>> {
     using Type = IDLUnion<T...>;
@@ -430,7 +439,7 @@ template<typename... T> struct JSConverter<IDLUnion<T...>> {
         forEach<Sequence>([&]<typename I>() {
             if (I::value == index) {
                 ASSERT(!returnValue);
-                returnValue = toJS<typename AddNullableIfInterface<brigand::at<TypeList, I>>::type>(lexicalGlobalObject, globalObject, std::get<I::value>(variant));
+                returnValue = toJS<typename AddNullableIfInterfaceOrArrayBufferSource<brigand::at<TypeList, I>>::type>(lexicalGlobalObject, globalObject, std::get<I::value>(variant));
             }
         });
 

--- a/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp
@@ -206,16 +206,16 @@ JSValue convertToJSValue(JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject&
             return constructArray(&globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), list);
         },
         [&](const RefPtr<Float32Array>& array) -> JSValue {
-            return toJS(&lexicalGlobalObject, &globalObject, array.get());
+            return array ? toJS(&lexicalGlobalObject, &globalObject, *array) : jsNull();
         },
         [&](const RefPtr<Int32Array>& array) -> JSValue {
-            return toJS(&lexicalGlobalObject, &globalObject, array.get());
+            return array ? toJS(&lexicalGlobalObject, &globalObject, *array) : jsNull();
         },
         [&](const RefPtr<Uint8Array>& array) -> JSValue {
-            return toJS(&lexicalGlobalObject, &globalObject, array.get());
+            return array ? toJS(&lexicalGlobalObject, &globalObject, *array) : jsNull();
         },
         [&](const RefPtr<Uint32Array>& array) -> JSValue {
-            return toJS(&lexicalGlobalObject, &globalObject, array.get());
+            return array ? toJS(&lexicalGlobalObject, &globalObject, *array) : jsNull();
         },
         [&](const RefPtr<WebGLBuffer>& buffer) -> JSValue {
             return buffer ? toJS(&lexicalGlobalObject, &globalObject, *buffer) : jsNull();

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1538,7 +1538,7 @@ private:
         auto& vm = m_lexicalGlobalObject->vm();
         auto* globalObject = m_lexicalGlobalObject;
         if (globalObject->inherits<JSDOMGlobalObject>())
-            return toJS(globalObject, jsCast<JSDOMGlobalObject*>(globalObject), &arrayBuffer);
+            return toJS(globalObject, jsCast<JSDOMGlobalObject*>(globalObject), arrayBuffer);
 
         if (auto* buffer = arrayBuffer.m_wrapper.get())
             return buffer;
@@ -3859,45 +3859,43 @@ private:
                 return false;
         }
 
-        auto makeArrayBufferView = [&] (auto view) -> bool {
-            if (!view)
-                return false;
-            arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, WTF::move(view));
-            if (!arrayBufferView)
-                return false;
-            return true;
-        };
-
         if (!ArrayBufferView::verifySubRangeLength(arrayBuffer->byteLength(), byteOffset, length.value_or(0), 1))
             return false;
 
+        auto makeArrayBufferView = [&](auto&& view) -> bool {
+            if (!view)
+                return false;
+            arrayBufferView = toJS(m_lexicalGlobalObject, jsCast<JSDOMGlobalObject*>(m_globalObject), view.releaseNonNull());
+            return true;
+        };
+
         switch (arrayBufferViewSubtag) {
         case DataViewTag:
-            return makeArrayBufferView(DataView::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(DataView::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Int8ArrayTag:
-            return makeArrayBufferView(Int8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Int8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Uint8ArrayTag:
-            return makeArrayBufferView(Uint8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Uint8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Uint8ClampedArrayTag:
-            return makeArrayBufferView(Uint8ClampedArray::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Uint8ClampedArray::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Int16ArrayTag:
-            return makeArrayBufferView(Int16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Int16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Uint16ArrayTag:
-            return makeArrayBufferView(Uint16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Uint16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Int32ArrayTag:
-            return makeArrayBufferView(Int32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Int32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Uint32ArrayTag:
-            return makeArrayBufferView(Uint32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Uint32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Float16ArrayTag:
-            return makeArrayBufferView(Float16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Float16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Float32ArrayTag:
-            return makeArrayBufferView(Float32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Float32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case Float64ArrayTag:
-            return makeArrayBufferView(Float64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(Float64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case BigInt64ArrayTag:
-            return makeArrayBufferView(BigInt64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(BigInt64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         case BigUint64ArrayTag:
-            return makeArrayBufferView(BigUint64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            return makeArrayBufferView(BigUint64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length));
         default:
             return false;
         }
@@ -5378,8 +5376,7 @@ private:
 
             if (!m_arrayBuffers[index])
                 m_arrayBuffers[index] = ArrayBuffer::create(WTF::move(m_arrayBufferContents->at(index)));
-
-            return getJSValue(m_arrayBuffers[index].get());
+            return getJSValue(*m_arrayBuffers[index]);
         }
         case SharedArrayBufferTag: {
             // https://html.spec.whatwg.org/multipage/structured-data.html#structureddeserialize

--- a/Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp
+++ b/Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp
@@ -41,14 +41,14 @@ WebCoreTypedArrayController::WebCoreTypedArrayController(bool allowAtomicsWait)
 
 WebCoreTypedArrayController::~WebCoreTypedArrayController() = default;
 
-JSC::JSArrayBuffer* WebCoreTypedArrayController::toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSGlobalObject* globalObject, JSC::ArrayBuffer* buffer)
+JSC::JSArrayBuffer* WebCoreTypedArrayController::toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSGlobalObject* globalObject, JSC::ArrayBuffer& buffer)
 {
     return JSC::jsCast<JSC::JSArrayBuffer*>(WebCore::toJS(lexicalGlobalObject, JSC::jsCast<JSDOMGlobalObject*>(globalObject), buffer));
 }
 
-void WebCoreTypedArrayController::registerWrapper(JSC::JSGlobalObject* globalObject, JSC::ArrayBuffer* native, JSC::JSArrayBuffer* wrapper)
+void WebCoreTypedArrayController::registerWrapper(JSC::JSGlobalObject* globalObject, JSC::ArrayBuffer& native, JSC::JSArrayBuffer& wrapper)
 {
-    cacheWrapper(JSC::jsCast<JSDOMGlobalObject*>(globalObject)->world(), native, wrapper);
+    cacheWrapper(JSC::jsCast<JSDOMGlobalObject*>(globalObject)->world(), &native, &wrapper);
 }
 
 bool WebCoreTypedArrayController::isAtomicsWaitAllowedOnCurrentThread()

--- a/Source/WebCore/bindings/js/WebCoreTypedArrayController.h
+++ b/Source/WebCore/bindings/js/WebCoreTypedArrayController.h
@@ -35,13 +35,13 @@ class WeakHandleOwner;
 
 namespace WebCore {
 
-class WebCoreTypedArrayController : public JSC::TypedArrayController {
+class WebCoreTypedArrayController final : public JSC::TypedArrayController {
 public:
     WebCoreTypedArrayController(bool allowAtomicsWait);
     virtual ~WebCoreTypedArrayController();
     
-    JSC::JSArrayBuffer* toJS(JSC::JSGlobalObject*, JSC::JSGlobalObject*, JSC::ArrayBuffer*) override;
-    void registerWrapper(JSC::JSGlobalObject*, JSC::ArrayBuffer*, JSC::JSArrayBuffer*) override;
+    JSC::JSArrayBuffer* toJS(JSC::JSGlobalObject*, JSC::JSGlobalObject*, JSC::ArrayBuffer&) override;
+    void registerWrapper(JSC::JSGlobalObject*, JSC::ArrayBuffer&, JSC::JSArrayBuffer&) override;
     bool isAtomicsWaitAllowedOnCurrentThread() override;
 
     JSC::WeakHandleOwner* wrapperOwner() { return &m_owner; }

--- a/Source/WebCore/dom/TextEncoder.idl
+++ b/Source/WebCore/dom/TextEncoder.idl
@@ -23,6 +23,7 @@
 * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// https://encoding.spec.whatwg.org/#dictdef-textencoderencodeintoresult
 [
     JSGenerateToJSObject,
     LegacyNativeDictionaryRequiredInterfaceNullability,
@@ -31,6 +32,7 @@
     unsigned long long written;
 };
 
+// https://encoding.spec.whatwg.org/#textencoder
 [
     Exposed=*,
 ] interface TextEncoder {
@@ -38,6 +40,7 @@
 
     readonly attribute DOMString encoding;
 
-    [NewObject] Uint8Array encode(optional USVString input = "");
+    // FIXME: `encode` should not return a nullable type.
+    [NewObject] Uint8Array? encode(optional USVString input = "");
     TextEncoderEncodeIntoResult encodeInto(USVString source, [AllowShared] Uint8Array destination);
 };

--- a/Source/WebCore/dom/TextEncoderStreamEncoder.idl
+++ b/Source/WebCore/dom/TextEncoderStreamEncoder.idl
@@ -29,6 +29,6 @@
 ] interface TextEncoderStreamEncoder {
     constructor();
 
-    [PrivateIdentifier] Uint8Array encode(DOMString chunk);
-    [PrivateIdentifier] Uint8Array flush();
+    [PrivateIdentifier] Uint8Array? encode(DOMString chunk);
+    [PrivateIdentifier] Uint8Array? flush();
 };

--- a/Source/WebCore/fileapi/FileReaderSync.idl
+++ b/Source/WebCore/fileapi/FileReaderSync.idl
@@ -34,7 +34,8 @@
 ] interface FileReaderSync {
     constructor();
 
-    [CallWith=CurrentScriptExecutionContext] ArrayBuffer readAsArrayBuffer(Blob blob);
+    // FIXME: `readAsArrayBuffer` should not return a nullable type.
+    [CallWith=CurrentScriptExecutionContext] ArrayBuffer? readAsArrayBuffer(Blob blob);
     [CallWith=CurrentScriptExecutionContext] DOMString readAsBinaryString(Blob blob);
     [CallWith=CurrentScriptExecutionContext] DOMString readAsText(Blob blob, optional DOMString encoding = "");
     [CallWith=CurrentScriptExecutionContext] DOMString readAsDataURL(Blob blob);

--- a/Source/WebCore/html/track/DataCue.cpp
+++ b/Source/WebCore/html/track/DataCue.cpp
@@ -48,7 +48,7 @@ DataCue::DataCue(Document& document, const MediaTime& start, const MediaTime& en
     : TextTrackCue(document, start, end)
     , m_type(type)
 {
-    setData(data);
+    setData(&data);
 }
 
 DataCue::DataCue(Document& document, const MediaTime& start, const MediaTime& end, std::span<const uint8_t> data)
@@ -112,11 +112,15 @@ RefPtr<ArrayBuffer> DataCue::data() const
     return ArrayBuffer::create(*RefPtr { m_data });
 }
 
-void DataCue::setData(ArrayBuffer& data)
+ExceptionOr<void> DataCue::setData(ArrayBuffer* data)
 {
+    if (!data)
+        return Exception { ExceptionCode::TypeError, "The DataCue.data attribute must be an instance of ArrayBuffer"_s };
+
     m_platformValue = nullptr;
     m_value.clear();
-    m_data = ArrayBuffer::create(data);
+    m_data = ArrayBuffer::create(*data);
+    return { };
 }
 
 bool DataCue::cueContentsMatch(const TextTrackCue& cue) const

--- a/Source/WebCore/html/track/DataCue.h
+++ b/Source/WebCore/html/track/DataCue.h
@@ -54,7 +54,7 @@ public:
     virtual ~DataCue();
 
     RefPtr<JSC::ArrayBuffer> data() const;
-    void setData(JSC::ArrayBuffer&);
+    ExceptionOr<void> setData(JSC::ArrayBuffer*);
 
     const SerializedPlatformDataCue* platformValue() const { return m_platformValue.get(); }
     RefPtr<const SerializedPlatformDataCue> protectedPlatformValue() const { return m_platformValue.get(); }

--- a/Source/WebCore/html/track/DataCue.idl
+++ b/Source/WebCore/html/track/DataCue.idl
@@ -30,13 +30,13 @@
     Conditional=VIDEO,
     Exposed=Window
 ] interface DataCue : TextTrackCue {
-    [CallWith=CurrentDocument] constructor(unrestricted double startTime, unrestricted double endTime, ArrayBuffer data);
     // FIXME: Remove 'unrestricted' from 'startTime' to align with the specification: See: https://bugs.webkit.org/show_bug.cgi?id=260764
     [CallWith=CurrentDocument] constructor(unrestricted double startTime, unrestricted double endTime, any value, optional DOMString type);
-
-    attribute ArrayBuffer data;
-
-    // Proposed extensions.
     [CallWith=CurrentGlobalObject] attribute any value;
     readonly attribute DOMString type;
+
+    // FIXME: Remove constructor taking ArrayBuffer to align with the specification.
+    [CallWith=CurrentDocument] constructor(unrestricted double startTime, unrestricted double endTime, ArrayBuffer data);
+    // FIXME: Remove `data` to align with the specification.
+    attribute ArrayBuffer? data;
 };

--- a/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
+++ b/Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm
@@ -131,7 +131,8 @@ static JSValue *jsValueWithDataInContext(NSData *data, JSContext *context)
     auto dataArray = ArrayBuffer::tryCreate(span(data));
 
     auto* lexicalGlobalObject = toJS([context JSGlobalContextRef]);
-    JSC::JSValue array = toJS(lexicalGlobalObject, JSC::jsCast<JSDOMGlobalObject*>(lexicalGlobalObject), dataArray.get());
+    // FIXME: It is a layering violation to use the JSDOMGlobalObject type in the platform directory.
+    JSC::JSValue array = dataArray ? toJS(lexicalGlobalObject, JSC::jsCast<JSDOMGlobalObject*>(lexicalGlobalObject), *dataArray) : JSC::jsNull();
 
     return [JSValue valueWithJSValueRef:toRef(lexicalGlobalObject, array) inContext:context];
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1560,7 +1560,7 @@ struct WebCore::CredentialPropertiesOutput {
 };
 
 [Nested] struct WebCore::AuthenticationExtensionsClientOutputs::PRFValues {
-    RefPtr<JSC::ArrayBuffer> first;
+    Ref<JSC::ArrayBuffer> first;
     RefPtr<JSC::ArrayBuffer> second;
 };
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -1114,8 +1114,8 @@ static RetainPtr<NSArray<NSNumber *>> wkTransports(const Vector<WebCore::Authent
 static RetainPtr<_WKAuthenticationExtensionsClientOutputs> wkAuthenticationExtensionsClientOutputs(const WebCore::AuthenticationExtensionsClientOutputs& outputs)
 {
     RetainPtr<NSData> first;
-    if (outputs.prf && outputs.prf->results && outputs.prf->results->first)
-        first = WebCore::toNSData(WebCore::BufferSource { outputs.prf->results->first });
+    if (outputs.prf && outputs.prf->results)
+        first = WebCore::toNSData(WebCore::BufferSource { outputs.prf->results->first.ptr() });
     RetainPtr<NSData> second;
     if (outputs.prf && outputs.prf->results && outputs.prf->results->second)
         second = WebCore::toNSData(WebCore::BufferSource { outputs.prf->results->second });

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -667,7 +667,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     if (credential.get().prf.second)
                         second = toArrayBuffer(retainPtr(credential.get().prf.second).get());
                     if (first)
-                        extensionOutputs.prf = { credential.get().prf.isSupported, { { first, second } } };
+                        extensionOutputs.prf = { credential.get().prf.isSupported, { { first.releaseNonNull(), WTF::move(second) } } };
                     else
                         extensionOutputs.prf = { credential.get().prf.isSupported, std::nullopt };
                 }
@@ -702,7 +702,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     RefPtr<ArrayBuffer> second = nullptr;
                     if (credential.get().prf.second)
                         second = toArrayBuffer(retainPtr(credential.get().prf.second).get());
-                    extensionOutputs.prf = { std::nullopt, { { first, second } } };
+                    extensionOutputs.prf = { std::nullopt, { { first.releaseNonNull(), WTF::move(second) } } };
                 }
 #endif
 
@@ -725,7 +725,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     if (credential.get().prf.second)
                         second = toArrayBuffer(retainPtr(credential.get().prf.second).get());
                     if (first)
-                        extensionOutputs.prf = { credential.get().prf.isSupported, { { first, second } } };
+                        extensionOutputs.prf = { credential.get().prf.isSupported, { { first.releaseNonNull(), WTF::move(second) } } };
                     else
                         extensionOutputs.prf = { credential.get().prf.isSupported, std::nullopt };
                 }
@@ -755,7 +755,7 @@ void WebAuthenticatorCoordinatorProxy::performRequest(WebAuthenticationRequestDa
                     RefPtr<ArrayBuffer> second = nullptr;
                     if (credential.get().prf.second)
                         second = toArrayBuffer(retainPtr(credential.get().prf.second).get());
-                    extensionOutputs.prf = { std::nullopt, { { first, second } } };
+                    extensionOutputs.prf = { std::nullopt, { { first.releaseNonNull(), WTF::move(second) } } };
                 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
@@ -356,7 +356,7 @@ TEST(CTAPResponseTest, TestReadMakeCredentialResponse)
 {
     auto makeCredentialResponse = readCTAPMakeCredentialResponse(std::span { TestData::kTestMakeCredentialResponse }, AuthenticatorAttachment::CrossPlatform, { });
     ASSERT_TRUE(makeCredentialResponse);
-    auto cborAttestationObject = cbor::CBORReader::read(makeCredentialResponse->attestationObject()->toVector());
+    auto cborAttestationObject = cbor::CBORReader::read(makeCredentialResponse->attestationObject().toVector());
     ASSERT_TRUE(cborAttestationObject);
     ASSERT_TRUE(cborAttestationObject->isMap());
 
@@ -394,8 +394,8 @@ TEST(CTAPResponseTest, TestReadMakeCredentialResponse)
     ASSERT_EQ(certificate.getArray().size(), 1u);
     ASSERT_TRUE(certificate.getArray()[0].isByteString());
     EXPECT_EQ(certificate.getArray()[0].getByteString(), Vector<uint8_t> { TestData::kCtap2MakeCredentialCertificate });
-    EXPECT_EQ(makeCredentialResponse->rawId()->byteLength(), sizeof(TestData::kCtap2MakeCredentialCredentialId));
-    EXPECT_TRUE(equalSpans(makeCredentialResponse->rawId()->span(), std::span { TestData::kCtap2MakeCredentialCredentialId }));
+    EXPECT_EQ(makeCredentialResponse->rawId().byteLength(), sizeof(TestData::kCtap2MakeCredentialCredentialId));
+    EXPECT_TRUE(equalSpans(makeCredentialResponse->rawId().span(), std::span { TestData::kCtap2MakeCredentialCredentialId }));
 }
 
 // Leveraging example 5 of section 6.1 of the CTAP spec.
@@ -445,11 +445,11 @@ TEST(CTAPResponseTest, TestParseRegisterResponseData)
 {
     auto response = readU2fRegisterResponse(TestData::kRelyingPartyId, std::span { TestData::kTestU2fRegisterResponse }, AuthenticatorAttachment::CrossPlatform);
     ASSERT_TRUE(response);
-    EXPECT_EQ(response->rawId()->byteLength(), sizeof(TestData::kU2fSignKeyHandle));
-    EXPECT_TRUE(equalSpans(response->rawId()->span(), std::span { TestData::kU2fSignKeyHandle }));
+    EXPECT_EQ(response->rawId().byteLength(), sizeof(TestData::kU2fSignKeyHandle));
+    EXPECT_TRUE(equalSpans(response->rawId().span(), std::span { TestData::kU2fSignKeyHandle }));
     auto expectedAttestationObject = getTestAttestationObjectBytes();
-    EXPECT_EQ(response->attestationObject()->byteLength(), expectedAttestationObject.size());
-    EXPECT_TRUE(equalSpans(response->attestationObject()->span(), expectedAttestationObject.span()));
+    EXPECT_EQ(response->attestationObject().byteLength(), expectedAttestationObject.size());
+    EXPECT_TRUE(equalSpans(response->attestationObject().span(), expectedAttestationObject.span()));
 }
 
 // Test malformed user public key.
@@ -547,8 +547,8 @@ TEST(CTAPResponseTest, TestParseSignResponseData)
 {
     auto response = readU2fSignResponse(TestData::kRelyingPartyId, getTestCredentialRawIdBytes(), getTestSignResponse(), AuthenticatorAttachment::CrossPlatform);
     ASSERT_TRUE(response);
-    EXPECT_EQ(response->rawId()->byteLength(), sizeof(TestData::kU2fSignKeyHandle));
-    EXPECT_TRUE(equalSpans(response->rawId()->span(), std::span { TestData::kU2fSignKeyHandle }));
+    EXPECT_EQ(response->rawId().byteLength(), sizeof(TestData::kU2fSignKeyHandle));
+    EXPECT_TRUE(equalSpans(response->rawId().span(), std::span { TestData::kU2fSignKeyHandle }));
     EXPECT_EQ(response->authenticatorData()->byteLength(), sizeof(TestData::kTestSignAuthenticatorData));
     EXPECT_TRUE(equalSpans(response->authenticatorData()->span(), std::span { TestData::kTestSignAuthenticatorData }));
     EXPECT_EQ(response->signature()->byteLength(), sizeof(TestData::kU2fSignature));


### PR DESCRIPTION
#### 6e0c8e30ad2f1f8915549b6746fc43fa9c7f5a87
<pre>
Make buffer source toJS() conversions require correct nullness and subtyping
<a href="https://bugs.webkit.org/show_bug.cgi?id=306536">https://bugs.webkit.org/show_bug.cgi?id=306536</a>

Reviewed by Anne van Kesteren.

Following on from <a href="https://bugs.webkit.org/show_bug.cgi?id=305413">https://bugs.webkit.org/show_bug.cgi?id=305413</a>, which handled
IDL interfaces, this makes IDL buffer source toJS() conversions require correct
nullness and subtyping.

As with IDL interfaces, IDL files now need to be annotated accurately, so a number
of places where non-nullable buffer source types were used have been nullable with
a corresponding FIXME. Places where making the implementation non-null was trivial
have been fixed as well.

To keep dictionaries with buffer source types working, the `LegacyNativeDictionaryRequiredInterfaceNullability`
extended attribute has been extended to also work for buffer sources. (I have kept
the name the same to reduce churn, since it is expected that the attribute will be
relatively short lived. If that turns out not to be the case, we can rename it at
a later point.)

To keep unions with buffer source types working, the union converter type adjuster
for interfaces, `AddNullableIfInterface`, has been updated to support buffer source
types and renamed to `AddNullableIfInterfaceOrArrayBufferSource`.

To fix a number of the new FIXMEs, we will likely need a strategy for dealing with
the frequent use of failable create functions for the buffer source types (e.g
`tryCreate...()`), likely by throwing exceptions in more cases.

* Source/JavaScriptCore/API/JSTypedArray.cpp:
* Source/JavaScriptCore/runtime/JSArrayBuffer.cpp:
* Source/JavaScriptCore/runtime/JSArrayBufferView.cpp:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp:
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.h:
* Source/JavaScriptCore/runtime/TypedArrayAdaptersForwardDeclarations.h:
* Source/JavaScriptCore/runtime/TypedArrayController.h:
* Source/WebCore/Modules/compression/CompressionStreamEncoder.idl:
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.idl:
* Source/WebCore/Modules/encryptedmedia/MediaKeyMessageEvent.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyMessageEvent.idl:
* Source/WebCore/Modules/encryptedmedia/legacy/WebKitMediaKeyNeededEvent.idl:
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
* Source/WebCore/Modules/push-api/PushMessageData.idl:
* Source/WebCore/Modules/webauthn/AuthenticatorAssertionResponse.idl:
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.h:
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.idl:
* Source/WebCore/Modules/webauthn/AuthenticatorResponse.h:
* Source/WebCore/Modules/webauthn/AuthenticatorResponse.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp:
* Source/WebCore/Modules/webauthn/PublicKeyCredential.h:
* Source/WebCore/bindings/IDLTypes.h:
* Source/WebCore/bindings/js/JSDOMConvertBufferSource.h:
* Source/WebCore/bindings/js/JSDOMConvertUnion.h:
* Source/WebCore/bindings/js/JSDOMConvertWebGL.cpp:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
* Source/WebCore/bindings/js/StructuredClone.cpp:
* Source/WebCore/bindings/js/WebCoreTypedArrayController.cpp:
* Source/WebCore/bindings/js/WebCoreTypedArrayController.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/dom/TextEncoder.idl:
* Source/WebCore/dom/TextEncoderStreamEncoder.idl:
* Source/WebCore/fileapi/FileReaderSync.idl:
* Source/WebCore/html/track/DataCue.cpp:
* Source/WebCore/html/track/DataCue.h:
* Source/WebCore/html/track/DataCue.idl:
* Source/WebCore/platform/mac/SerializedPlatformDataCueMac.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
* Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp:

Canonical link: <a href="https://commits.webkit.org/306590@main">https://commits.webkit.org/306590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc208c1cc5705942bc68b40ba0d145a2effe9b44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94899 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14319 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/108949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11049 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8688 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/434 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133758 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152756 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2578 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13849 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3381 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117366 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29897 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13407 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123605 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13887 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2886 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173063 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77612 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44815 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13829 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->