### PR TITLE
Table cell background painting should check all background layers for `background-clip: text`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+:root {
+  font-size: 24pt;
+}
+.box {
+  background:
+    linear-gradient(rgba(0, 128, 0, 0.2), rgba(128, 0, 0, 0.2)) border-box,
+    linear-gradient(green, yellow) text;
+  color: transparent;
+  display: inline-block;
+  font-weight: bold;
+  padding: 1px;
+}
+</style>
+</head>
+<body>
+<div class="box">Text</div>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+:root {
+  font-size: 24pt;
+}
+.box {
+  background:
+    linear-gradient(rgba(0, 128, 0, 0.2), rgba(128, 0, 0, 0.2)) border-box,
+    linear-gradient(green, yellow) text;
+  color: transparent;
+  display: inline-block;
+  font-weight: bold;
+  padding: 1px;
+}
+</style>
+</head>
+<body>
+<div class="box">Text</div>
+</body>
+</html>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test background layers work fine in table elements</title>
+<link rel="match" href="gradient-text-thead-ref.html">
+<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-370">
+<style>
+:root {
+  font-size: 24pt;
+}
+thead {
+  background:
+    linear-gradient(rgba(0, 128, 0, 0.2), rgba(128, 0, 0, 0.2)) border-box,
+    linear-gradient(green, yellow) text;
+  color: transparent;
+}
+table {
+  border-collapse: collapse;
+}
+</style>
+</head>
+<body>
+<table>
+  <thead>
+    <tr>
+      <th>Text</th>
+    </tr>
+  </thead>
+</table>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1611,7 +1611,13 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
         fillRect = LayoutRect { adjustedPaintOffset, size() };
     auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
     BackgroundPainter painter { *this, paintInfo };
-    auto hasBackgroundClipText = style.backgroundLayers().usedFirst().clip() == FillBox::Text;
+
+    bool hasBackgroundClipText = false;
+    for (auto& backgroundLayer : style.backgroundLayers().usedValues()) {
+        if (backgroundLayer.clip() == FillBox::Text)
+            hasBackgroundClipText = true;
+    }
+
     if (backgroundObject != this && !hasBackgroundClipText) {
         painter.setOverrideClip(FillBox::BorderBox);
         painter.setOverrideOrigin(FillBox::BorderBox);


### PR DESCRIPTION
#### 863b0ce184ae27276da97c1b4e4a031a5977dda1
<pre>
Table cell background painting should check all background layers for `background-clip: text`
<a href="https://bugs.webkit.org/show_bug.cgi?id=306974">https://bugs.webkit.org/show_bug.cgi?id=306974</a>

Reviewed by Simon Fraser.

In commit 43fea43, solved problem that if `background-clip: text` was applied to a table cell,
the background was being painted for the entire cell instead of only the text.
It currently checks only the first layer for search for `background-clip: text`,
but since a table cell can have multiple background layers, the code should check all of them.

* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::paintBackgroundsBehindCell):
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-multiple-layers-table-cell.html: Added.

Canonical link: <a href="https://commits.webkit.org/306956@main">https://commits.webkit.org/306956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa9e96f1d6b9fd1cac818229877d842d2efa0cbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142882 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/15354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/151556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144749 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/16011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/15435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/151556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145831 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/16011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/5906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/151556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/16011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/5906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1555 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/16011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/5906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153869 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/15017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/15435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118233 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/5906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22027 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/15023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78734 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/14820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->