### PR TITLE
User-agent stylesheet cleanups for performance

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -153,7 +153,8 @@
     -webkit-backdrop-filter: blur(5px);
 }
 
-.stats-container > table > tr > :is(th, td) {
+.stats-container > table > tr > th,
+.stats-container > table > tr > td {
     margin: 0;
     padding: 0;
     pointer-events: auto;

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.css
@@ -129,6 +129,7 @@
 
 /* When disabled, we only want to show the track and turn off interaction. */
 
-.slider.default.disabled > .appearance > .fill > :is(.primary, .secondary) {
+.slider.default.disabled > .appearance > .fill > .primary,
+.slider.default.disabled > .appearance > .fill > .secondary {
     display: none;
 }

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
@@ -75,7 +75,8 @@
     bottom: calc(var(--tvos-controls-bottom-margin) + var(--tvos-controls-bar-height) + var(--tvos-metadata-container-bottom-margin));
 }
 
-.media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > :is(.primary, .secondary) {
+.media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > .primary,
+.media-controls.fullscreen.tvos .slider.default.disabled > .appearance > .fill > .secondary {
     display: initial;
 }
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -353,6 +353,7 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElementName(St
 
     auto type = findPseudoElementName(name);
     if (!type) {
+        ASSERT_WITH_MESSAGE(!isUASheetBehavior(context.mode), "Unknown pseudo-element %s in user-agent stylesheet", name.toString().utf8().data());
         if (name.startsWithIgnoringASCIICase("-webkit-"_s))
             return PseudoElement::WebKitUnknown;
         return type;

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -305,15 +305,24 @@ li {
     text-align: match-parent;
 }
 
-:is(dir, dl, menu, ol, ul) :is(dir, dl, menu, ol, ul) {
+/* The rightmost selector is written explicitly rather than with :is() to help with RuleSet bucketing.*/
+:is(dir, dl, menu, ol, ul) dir,
+:is(dir, dl, menu, ol, ul) dl,
+:is(dir, dl, menu, ol, ul) menu,
+:is(dir, dl, menu, ol, ul) ol,
+:is(dir, dl, menu, ol, ul) ul {
     margin-block: 0;
 }
 
-:is(dir, menu, ol, ul) :is(dir, menu, ul) {
+:is(dir, menu, ol, ul) dir,
+:is(dir, menu, ol, ul) menu,
+:is(dir, menu, ol, ul) ul {
     list-style-type: circle;
 }
 
-:is(dir, menu, ol, ul) :is(dir, menu, ol, ul) :is(dir, menu, ul) {
+:is(dir, menu, ol, ul) :is(dir, menu, ol, ul) dir,
+:is(dir, menu, ol, ul) :is(dir, menu, ol, ul) menu,
+:is(dir, menu, ol, ul) :is(dir, menu, ol, ul) ul {
     list-style-type: square;
 }
 
@@ -781,7 +790,7 @@ input:-webkit-autofill, input:-webkit-autofill-strong-password, input:-webkit-au
     color: #000000 !important;
 }
 
-:autofill {
+input:autofill {
     field-sizing: fixed !important;
 }
 
@@ -904,7 +913,7 @@ input[type="range"] {
     color: #909090;
 }
 
-input[type="range"]::-webkit-slider-container, input[type="range"]::-webkit-media-slider-container {
+input[type="range"]::-webkit-slider-container {
     flex: 1;
     box-sizing: border-box;
     display: flex;
@@ -919,7 +928,7 @@ input[type="range"]::-webkit-slider-runnable-track {
     display: block;
 }
 
-input[type="range"]::-webkit-slider-thumb, input[type="range"]::-webkit-media-slider-thumb {
+input[type="range"]::-webkit-slider-thumb {
     appearance: auto;
     box-sizing: border-box;
     display: block;
@@ -930,12 +939,6 @@ input[type="range"]::-webkit-slider-thumb, input[type="range"]::-webkit-slider-t
     background-color: white;
     border: initial;
     box-shadow: 0px 6px 13px rgba(0, 0, 0, 0.2), 0px 0.5px 4px rgba(0, 0, 0, 0.2);
-}
-
-input[type="range"]::-webkit-media-slider-thumb {
-    background-color: white;
-    border: 1px solid rgb(66, 66, 66);
-    padding: 0px;
 }
 
 input:disabled, textarea:disabled {

--- a/Source/WebCore/css/quirks.css
+++ b/Source/WebCore/css/quirks.css
@@ -29,12 +29,19 @@ li {
 }
 
 /* Restore outside position for lists inside lis */
-li :is(dir, menu, ol, ul) {
+li dir,
+li menu,
+li ol,
+li ul {
     list-style-position: outside;
 }
 
 /* Undo previous two rules for properly nested lists */
-:is(dir, menu, ol, ul) :is(dir, menu, ol, ul, li) {
+:is(dir, menu, ol, ul) dir,
+:is(dir, menu, ol, ul) menu,
+:is(dir, menu, ol, ul) ol,
+:is(dir, menu, ol, ul) ul,
+:is(dir, menu, ol, ul) li {
     list-style-position: unset;
 }
 


### PR DESCRIPTION
#### e6b6011bb5906dfd1ecb432e7dc9ec1c1c1e41b2
<pre>
User-agent stylesheet cleanups for performance
<a href="https://bugs.webkit.org/show_bug.cgi?id=306541">https://bugs.webkit.org/show_bug.cgi?id=306541</a>
<a href="https://rdar.apple.com/169191605">rdar://169191605</a>

Reviewed by Sam Weinig.

- remove some unused pseudo-elements
- expand subject position :is(foo, bar) rules (as those will miss bucketing optimizations)
- :autofill -&gt; input:autofill as it only ever applies to &lt;input&gt;.
- add C++ assertions against these things happening in UA sheets

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
* Source/WebCore/Modules/modern-media-controls/controls/slider.css:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::parsePseudoElementName):
* Source/WebCore/css/html.css:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::validateUserAgentSheetSelector):
(WebCore::CSSParser::consumeStyleRule):
* Source/WebCore/css/quirks.css:

Canonical link: <a href="https://commits.webkit.org/306487@main">https://commits.webkit.org/306487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d43f82ba08fa4f784ddf4a5ce5ec12418389726f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150088 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83e088fa-e07f-4e1c-9cc9-79a95d8ccb8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108735 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78dfbbec-c520-49bd-9812-e9cdcc9648ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89640 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b34a726e-ecf0-4d93-bd6e-e052871d6341) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10838 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8464 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/160 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152481 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13586 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116838 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13601 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117168 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13204 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123302 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13629 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2620 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13366 "Failed to checkout and rebase branch from PR 57487") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77343 "Failed to checkout and rebase branch from PR 57487") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13565 "Failed to checkout and rebase branch from PR 57487") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13413 "Failed to checkout and rebase branch from PR 57487") | | | | 
<!--EWS-Status-Bubble-End-->