### PR TITLE
Compilation error with -Wunsafe-buffer-usage-in-format-attr-call when using latest Swift toolchain

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -702,20 +702,24 @@ static constexpr bool unreachableForValue = false;
 #define PUBLIC_LOG_STRING "{public}s"
 #define PRIVATE_LOG_STRING "{private}s"
 #define SENSITIVE_LOG_STRING "{sensitive}s"
-#define RELEASE_LOG(channel, ...) SUPPRESS_UNCOUNTED_LOCAL os_log(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__)
-#define RELEASE_LOG_ERROR(channel, ...) SUPPRESS_UNCOUNTED_LOCAL os_log_error(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__)
-#define RELEASE_LOG_FAULT(channel, ...) SUPPRESS_UNCOUNTED_LOCAL os_log_fault(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__)
+#define RELEASE_LOG(channel, ...) WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN SUPPRESS_UNCOUNTED_LOCAL os_log(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__) WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+#define RELEASE_LOG_ERROR(channel, ...) WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN SUPPRESS_UNCOUNTED_LOCAL os_log_error(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__) WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+#define RELEASE_LOG_FAULT(channel, ...) WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN SUPPRESS_UNCOUNTED_LOCAL os_log_fault(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__) WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #define RELEASE_LOG_FAULT_WITH_PAYLOAD(channel, message) os_fault_with_payload(OS_REASON_WEBKIT, 0, nullptr, 0, message, 0)
-#define RELEASE_LOG_INFO(channel, ...) SUPPRESS_UNCOUNTED_LOCAL os_log_info(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__)
-#define RELEASE_LOG_DEBUG(channel, ...) SUPPRESS_UNCOUNTED_LOCAL os_log_debug(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__)
+#define RELEASE_LOG_INFO(channel, ...) WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN SUPPRESS_UNCOUNTED_LOCAL os_log_info(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__) WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+#define RELEASE_LOG_DEBUG(channel, ...) WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN SUPPRESS_UNCOUNTED_LOCAL os_log_debug(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__) WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #define RELEASE_LOG_WITH_LEVEL(channel, logLevel, ...) do { \
     if (LOG_CHANNEL(channel).level >= (logLevel)) \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
         SUPPRESS_UNCOUNTED_LOCAL os_log(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__); \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 } while (0)
 
 #define RELEASE_LOG_WITH_LEVEL_IF(isAllowed, channel, logLevel, ...) do { \
     if ((isAllowed) && LOG_CHANNEL(channel).level >= (logLevel)) \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
         SUPPRESS_UNCOUNTED_LOCAL os_log(LOG_CHANNEL(channel).osLogChannel, __VA_ARGS__); \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 } while (0)
 
 #elif OS(ANDROID)

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -649,7 +649,8 @@
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Wunknown-warning-option\"") \
     _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage\"") \
-    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage-in-libc-call\"")
+    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage-in-libc-call\"") \
+    _Pragma("clang diagnostic ignored \"-Wunsafe-buffer-usage-in-format-attr-call\"")
 
 #define WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
     _Pragma("clang diagnostic pop")

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -372,7 +372,9 @@ private:
 #if RELEASE_LOG_DISABLED
         WTFLog(&channel, "%s", logMessage.utf8().data());
 #elif USE(OS_LOG)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         SUPPRESS_UNRETAINED_LOCAL os_log(channel.osLogChannel, "%{public}s", logMessage.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #elif OS(ANDROID)
         __android_log_print(ANDROID_LOG_VERBOSE, LOG_CHANNEL_WEBKIT_SUBSYSTEM, "[%s] %s", channel.name, logMessage.utf8().data());
 #elif ENABLE(JOURNALD_LOG)
@@ -406,7 +408,9 @@ private:
 #if RELEASE_LOG_DISABLED
         WTFLogVerbose(file, line, function, &channel, "%s", logMessage.utf8().data());
 #elif USE(OS_LOG)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         SUPPRESS_UNRETAINED_LOCAL os_log(channel.osLogChannel, "%{public}s", logMessage.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         UNUSED_PARAM(file);
         UNUSED_PARAM(line);
         UNUSED_PARAM(function);

--- a/Source/WTF/wtf/StatisticsManager.cpp
+++ b/Source/WTF/wtf/StatisticsManager.cpp
@@ -101,6 +101,7 @@ void StatisticsManager::dumpStatistics()
         double stddev = std::sqrt(variance);
 
         CString utf8ID = id.utf8();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         dataLogF(
             "Statistics for %s:\n"
             "  Count    : %zu\n"
@@ -111,6 +112,7 @@ void StatisticsManager::dumpStatistics()
             "  Std Dev  : %.6f\n"
             "  Histogram:\n",
             utf8ID.data(), count, min, max, mean, variance, stddev);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
         dumpHistogram(locker, values, min, max);
         dataLogF("\n");

--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -405,11 +405,13 @@ enum WTFOSSignpostType {
         RetainPtr<os_log_t> wtfHandle = WTFSignpostLogHandle(); \
         const void* wtfPointer = (const void *)(pointer); \
         os_signpost_id_t wtfSignpostID = wtfPointer ? os_signpost_id_make_with_pointer(wtfHandle.get(), wtfPointer) : OS_SIGNPOST_ID_EXCLUSIVE; \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
         emitMacro(wtfHandle.get(), wtfSignpostID, #name, format, ##__VA_ARGS__); \
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
     } while (0)
 
 #define WTFEmitSignpostIndirectlyWithType(type, pointer, name, specificTime, format, ...) \
-    SUPPRESS_UNCOUNTED_LOCAL os_log(WTFSignpostLogHandle(), "type=%d name=%d p=%" PRIuPTR " ts=%llu " format, type, WTFOSSignpostName ## name, reinterpret_cast<uintptr_t>(pointer), specificTime, ##__VA_ARGS__)
+    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN SUPPRESS_UNCOUNTED_LOCAL os_log(WTFSignpostLogHandle(), "type=%d name=%d p=%" PRIuPTR " ts=%llu " format, type, WTFOSSignpostName ## name, reinterpret_cast<uintptr_t>(pointer), specificTime, ##__VA_ARGS__) WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #define WTFSetCounter(name, value) do { } while (0)
 

--- a/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp
@@ -44,7 +44,9 @@ os_log_t WTFSignpostLogHandle()
 
 #define WTF_SIGNPOST_EVENT_EMIT_FUNC_CASE_LABEL(emitFunc, name, timeFormat) \
     case WTFOSSignpostName ## name : \
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN \
         emitFunc(log, signpostIdentifier, #name, "pid: %d | %{public}s" timeFormat, pid, logString, timestamp); \
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
         break;
 
 static void beginSignpostInterval(os_log_t log, WTFOSSignpostName signpostName, uint64_t signpostIdentifier, uint64_t timestamp, pid_t pid, const char* logString)

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -97,7 +97,9 @@ LibraryPathDiagnosticsLogger::LibraryPathDiagnosticsLogger()
 void LibraryPathDiagnosticsLogger::logJSONPayload(const JSON::Object &object)
 {
     auto textRepresentation = object.toJSONString();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     os_log(m_osLog, "%{public}s", textRepresentation.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void LibraryPathDiagnosticsLogger::logString(std::span<const String> path, const String& string)
@@ -136,9 +138,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     va_start(argList, format);
     stream.vprintf(format, argList);
     va_end(argList);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     os_log_error(m_osLog, "%{public}s", stream.toCString().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 void LibraryPathDiagnosticsLogger::logExecutablePath(void)
@@ -173,20 +175,26 @@ void LibraryPathDiagnosticsLogger::logDynamicLibraryInfo(const String& installNa
 
     const struct mach_header *header = _dyld_get_dlopen_image_header(handle);
     if (!header) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         logError("Unable to locate mach header for %s", installName.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return;
     }
 
     Dl_info info = { };
     int dladdr_ret = dladdr(header, &info);
     if (!dladdr_ret) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         logError("No info returned from dladdr() for %s", installName.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return;
     }
 
     uuid_t uuid = { 0 };
     if (!_dyld_get_image_uuid(header, uuid)) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         logError("No UUID found for %s", installName.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         return;
     }
 

--- a/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionCompiler.cpp
@@ -330,7 +330,9 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
             status = URLFilterParser::Ok;
         }
         if (status != URLFilterParser::Ok) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             dataLogF("Error while parsing %s: %s\n", trigger.urlFilter.utf8().data(), URLFilterParser::statusString(status).characters());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             return ContentExtensionError::JSONInvalidRegex;
         }
 
@@ -347,7 +349,9 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
                     status = URLFilterParser::Ok;
                 }
                 if (status != URLFilterParser::Ok) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     dataLogF("Error while parsing %s: %s\n", condition.utf8().data(), URLFilterParser::statusString(status).characters());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     return ContentExtensionError::JSONInvalidRegex;
                 }
                 break;
@@ -359,7 +363,9 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
                     status = URLFilterParser::Ok;
                 }
                 if (status != URLFilterParser::Ok) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     dataLogF("Error while parsing %s: %s\n", condition.utf8().data(), URLFilterParser::statusString(status).characters());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     return ContentExtensionError::JSONInvalidRegex;
                 }
                 break;
@@ -374,7 +380,9 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
 
 #if CONTENT_EXTENSIONS_PERFORMANCE_REPORTING
     MonotonicTime patternPartitioningEnd = MonotonicTime::now();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     dataLogF("    Time spent partitioning the rules into groups: %f\n", (patternPartitioningEnd - patternPartitioningStart).seconds());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
     LOG_LARGE_STRUCTURES(filtersWithoutConditions, filtersWithoutConditions.memoryUsed());
@@ -404,7 +412,9 @@ std::error_code compileRuleList(ContentExtensionCompilationClient& client, Strin
 
 #if CONTENT_EXTENSIONS_PERFORMANCE_REPORTING
     MonotonicTime totalNFAToByteCodeBuildTimeEnd = MonotonicTime::now();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     dataLogF("    Time spent building and compiling the DFAs: %f\n", (totalNFAToByteCodeBuildTimeEnd - totalNFAToByteCodeBuildTimeStart).seconds());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
     client.finalize();

--- a/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
+++ b/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
@@ -53,10 +53,12 @@ static void logStackTrace(WTFLogChannel* channel)
     int frameCount = kDefaultFramesToShow + kDefaultFramesToSkip;
     WTFGetBacktrace(stack.data(), &frameCount);
     StackTraceSymbolResolver { std::span { stack }.first(frameCount) }.forEach([&](int frameNumber, void* stackFrame, const char* name) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         if (name)
             os_log(channel->osLogChannel, "%-3d %p %{public}s", frameNumber, stackFrame, name);
         else
             os_log(channel->osLogChannel, "%-3d %p", frameNumber, stackFrame);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     });
 }
 #define RELEASE_LOG_STACKTRACE(channel) logStackTrace(&LOG_CHANNEL(channel))

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -193,7 +193,9 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
 
 #if HAVE(OS_SIGNPOST)
     if (momentumPhase == PlatformWheelEventPhase::Began)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         SUPPRESS_UNRETAINED_ARG os_signpost_interval_begin(WTFSignpostLogHandle(), OS_SIGNPOST_ID_EXCLUSIVE, "Momentum scroll", "isAnimation=YES");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
     if (!m_momentumScrollInProgress && (momentumPhase == PlatformWheelEventPhase::Began || momentumPhase == PlatformWheelEventPhase::Changed))
@@ -241,7 +243,9 @@ bool ScrollingEffectsController::handleWheelEvent(const PlatformWheelEvent& whee
 
     if (m_momentumScrollInProgress && momentumPhase == PlatformWheelEventPhase::Ended) {
 #if HAVE(OS_SIGNPOST)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         SUPPRESS_UNRETAINED_ARG os_signpost_interval_end(WTFSignpostLogHandle(), OS_SIGNPOST_ID_EXCLUSIVE, "Momentum scroll");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
         m_momentumScrollInProgress = false;
         m_ignoreMomentumScrolls = false;

--- a/Source/WebCore/xml/XSLTUnicodeSort.cpp
+++ b/Source/WebCore/xml/XSLTUnicodeSort.cpp
@@ -71,7 +71,9 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr* rawSorts,
                 } else if (xmlStrEqual(stype, reinterpret_cast<const xmlChar*>("number")))
                     number[j] = 1;
                 else
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     xsltTransformError(ctxt, nullptr, sorts[j], "xsltDoSortFunction: no support for data-type = %s\n", stype);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 xmlFree(stype);
             }
         } else
@@ -85,7 +87,9 @@ void xsltUnicodeSortFunction(xsltTransformContextPtr ctxt, xmlNodePtr* rawSorts,
                 } else if (xmlStrEqual(order, reinterpret_cast<const xmlChar*>("descending")))
                     desc[j] = 1;
                 else
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     xsltTransformError(ctxt, nullptr, sorts[j], "xsltDoSortFunction: invalid value %s for order\n", order);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 xmlFree(order);
             }
         } else

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1168,7 +1168,9 @@ static void warningHandler(void* closure, const char* message, ...)
 {
     va_list args;
     va_start(args, message);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     protectedParser(closure)->error(XMLErrors::Type::Warning, message, args);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     va_end(args);
 }
 
@@ -1177,7 +1179,9 @@ static void fatalErrorHandler(void* closure, const char* message, ...)
 {
     va_list args;
     va_start(args, message);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     protectedParser(closure)->error(XMLErrors::Type::Fatal, message, args);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     va_end(args);
 }
 
@@ -1186,7 +1190,9 @@ static void normalErrorHandler(void* closure, const char* message, ...)
 {
     va_list args;
     va_start(args, message);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     protectedParser(closure)->error(XMLErrors::Type::NonFatal, message, args);
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     va_end(args);
 }
 

--- a/Source/WebKit/Scripts/generate-derived-log-sources.py
+++ b/Source/WebKit/Scripts/generate-derived-log-sources.py
@@ -97,6 +97,7 @@ def generate_message_receiver_implementations_file(log_messages, log_messages_re
                 file.write("    auto osLog = adoptOSObject(os_log_create(\"com.apple.WebKit\", \"" + category + "\"));\n")
                 file.write("    auto osLogPointer = osLog.get();\n")
 
+            file.write("WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN\n")
             file.write("    os_log_with_type(osLogPointer, " + os_log_type + ", \"WebContent[%d]: \"" + format_string)
             file.write(", static_cast<uint32_t>(m_pid)")
             arguments_string = log_declarations_module.get_arguments_string(parameters, log_declarations_module.PARAMETER_LIST_INCLUDE_NAME | log_declarations_module.PARAMETER_LIST_MODIFY_CSTRING)
@@ -104,6 +105,7 @@ def generate_message_receiver_implementations_file(log_messages, log_messages_re
                 file.write(", ")
             file.write(arguments_string)
             file.write(");\n")
+            file.write("WTF_ALLOW_UNSAFE_BUFFER_USAGE_END\n")
             file.write("}\n\n")
         file.close()
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
+++ b/Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp
@@ -219,9 +219,11 @@ String toErrorString(const String& callingAPIName, const String& sourceKey, Stri
     va_start(arguments, underlyingErrorString);
 
 ALLOW_NONLITERAL_FORMAT_BEGIN
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     String formattedUnderlyingErrorString = formatString(underlyingErrorString.utf8().data(), arguments).trim([](char16_t character) -> bool {
         return character == '.';
     });
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 ALLOW_NONLITERAL_FORMAT_END
 
     va_end(arguments);
@@ -234,13 +236,19 @@ ALLOW_NONLITERAL_FORMAT_END
     }
 
     if (!callingAPIName.isEmpty() && !source.isEmpty())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return formatString("Invalid call to %s. The '%s' value is invalid, because %s.", callingAPIName.utf8().data(), source.utf8().data(), lowercaseFirst(formattedUnderlyingErrorString).utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (callingAPIName.isEmpty() && !source.isEmpty())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return formatString("The '%s' value is invalid, because %s.", source.utf8().data(), lowercaseFirst(formattedUnderlyingErrorString).utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     if (!callingAPIName.isEmpty())
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return formatString("Invalid call to %s. %s.", callingAPIName.utf8().data(), uppercaseFirst(formattedUnderlyingErrorString).utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     return formattedUnderlyingErrorString;
 }

--- a/Source/WebKit/Shared/LogStream.cpp
+++ b/Source/WebKit/Shared/LogStream.cpp
@@ -102,7 +102,9 @@ void LogStream::logOnBehalfOfWebContent(std::span<const uint8_t> logSubsystem, s
 
     // Use '%{public}s' in the format string for the preprocessed string from the WebContent process.
     // This should not reveal any redacted information in the string, since it has already been composed in the WebContent process.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     os_log_with_type(osLogPointer, static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", m_pid, byteCast<char>(nullTerminatedLogString).data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -408,7 +408,9 @@ bool WebProcessProxy::WebProcessXPCEventHandler::handleXPCEvent(xpc_object_t eve
             osLog = adoptOSObject(os_log_create(subsystem.utf8().data(), category.utf8().data()));
 
         auto osLogPointer = osLog ? osLog.get() : OS_LOG_DEFAULT;
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         os_log_with_type(osLogPointer, static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", static_cast<int>(pid), messageString.utf8().data());
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         webProcess->m_didReceiveLogsDuringLaunchForTesting = true;
     } else if (messageName == disableLogMessageName) {
         RefPtr webProcess = m_webProcess.get();

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12194,7 +12194,9 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 
         if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::SendsNativeMouseEvents)
             && WTF::IOSApplication::isEssentialSkeleton()) { // <rdar://problem/62694519>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             os_log_error(OS_LOG_DEFAULT, "WARNING: This application has been observed to ignore mouse events in web content; touch events will be sent until it is built against the iOS 13.4 SDK, but after that, the web content must respect mouse or pointer events in addition to touch events in order to behave correctly when a trackpad or mouse is used.");
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             return NO;
         }
 


### PR DESCRIPTION
#### ca919f13d3de9afe81d33a543893a616a81df5e7
<pre>
Compilation error with -Wunsafe-buffer-usage-in-format-attr-call when using latest Swift toolchain
<a href="https://bugs.webkit.org/show_bug.cgi?id=306542">https://bugs.webkit.org/show_bug.cgi?id=306542</a>

Reviewed by David Kilzer.

Suppress the unsafe-buffer-usage-in-format-attr-call warning in SystemTracingCocoa.cpp by adding
-Wunsafe-buffer-usage-in-format-attr-call to the list of warnings to suppress in
WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN and deploying that macro in the cpp file.

No new tests since there should be no behavioral changes.

* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/Compiler.h:
* Source/WTF/wtf/Logger.h:
(WTF::Logger::log):
(WTF::Logger::logVerbose):
* Source/WTF/wtf/StatisticsManager.cpp:
(WTF::StatisticsManager::dumpStatistics):
* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/cocoa/SystemTracingCocoa.cpp:
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::LibraryPathDiagnosticsLogger::logJSONPayload):
(WTF::LibraryPathDiagnosticsLogger::logError):
(WTF::LibraryPathDiagnosticsLogger::logDynamicLibraryInfo):
* Source/WebCore/contentextensions/ContentExtensionCompiler.cpp:
(WebCore::ContentExtensions::compileRuleList):
* Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp:
(WebCore::logStackTrace):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::handleWheelEvent):
* Source/WebCore/xml/XSLTUnicodeSort.cpp:
(WebCore::xsltUnicodeSortFunction):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::warningHandler):
(WebCore::fatalErrorHandler):
(WebCore::normalErrorHandler):
* Source/WebKit/Scripts/generate-derived-log-sources.py:
(generate_message_receiver_implementations_file):
* Source/WebKit/Shared/Extensions/WebExtensionUtilities.cpp:
(WebKit::toErrorString):
* Source/WebKit/Shared/LogStream.cpp:
(WebKit::LogStream::logOnBehalfOfWebContent):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::WebProcessXPCEventHandler::handleXPCEvent):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView shouldUseMouseGestureRecognizer]):

Canonical link: <a href="https://commits.webkit.org/306552@main">https://commits.webkit.org/306552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/707b44be6cc0c0913cc875892f120b2b7a4fea8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141677 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150249 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108870 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2366506-ad2a-44d0-a24f-eef5cc9c0264) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89770 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/510915b2-f8d3-426e-bb47-7e117be5cfe2) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/141016 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8602 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/322 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133661 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152642 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2481 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13752 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116968 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117293 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13326 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123516 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21854 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13790 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2797 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172966 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13529 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77515 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44792 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13732 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13576 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->