### PR TITLE
Reserve capacity for DocumentSharedObjectPool to improve perf of parserSetAttributes

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4386,7 +4386,7 @@ void Document::setParsing(bool b)
     m_bParsing = b;
 
     if (m_bParsing && !m_sharedObjectPool)
-        m_sharedObjectPool = makeUnique<DocumentSharedObjectPool>();
+        m_sharedObjectPool = makeUnique<DocumentSharedObjectPool>(RegistrableDomain { securityOrigin().data() });
 
     if (!m_bParsing && view() && !view()->needsLayout())
         protect(view())->fireLayoutRelatedMilestonesIfNeeded();

--- a/Source/WebCore/dom/DocumentSharedObjectPool.h
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "RegistrableDomain.h"
 #include <memory>
 #include <wtf/HashSet.h>
 #include <wtf/RefPtr.h>
@@ -40,12 +41,15 @@ class ShareableElementData;
 class DocumentSharedObjectPool {
     WTF_MAKE_TZONE_ALLOCATED(DocumentSharedObjectPool);
 public:
+    explicit DocumentSharedObjectPool(RegistrableDomain&&);
+    ~DocumentSharedObjectPool();
     Ref<ShareableElementData> cachedShareableElementDataWithAttributes(std::span<const Attribute>);
 
 private:
     struct ShareableElementDataHash;
     using ShareableElementDataCache = HashSet<Ref<ShareableElementData>, ShareableElementDataHash>;
     ShareableElementDataCache m_shareableElementDataCache;
+    RegistrableDomain m_domain;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e25d72b12cd9aea37de3dd55b87620b9c33ed13c
<pre>
Reserve capacity for DocumentSharedObjectPool to improve perf of parserSetAttributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=306548">https://bugs.webkit.org/show_bug.cgi?id=306548</a>
<a href="https://rdar.apple.com/169193738">rdar://169193738</a>

Reviewed by Ryosuke Niwa.

We spend ~12% of time in WebCore::DocumentSharedObjectPool::cachedShareableElementDataWithAttributes
during parserSetAttributes which adds attributes to a HashSet&lt;Ref, ShareableElementDataHash&gt;.
After a closer look at the disassembly of cachedShareableElementDataWithAttributes(), we spend ~38%
of the time of this function doing quadratic probing.

Track peak element count (rounded up to nearest power of 2) per RegistrableDomain.
On subsequent visits to the same domain, reserve the set&apos;s capacity upfront with
its previously known peak count.

After reserving initial capacity, profiling shows that
DocumentSharedObjectPool::cachedShareableElementDataWithAttributes now shows
fewer quadratic probing operations.

This also reduces hash set resize events that were occurring.

This shows a small perf improvement.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setParsing):
* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::peakSizeInPast):
(WebCore::DocumentSharedObjectPool::DocumentSharedObjectPool):
(WebCore::DocumentSharedObjectPool::~DocumentSharedObjectPool):
* Source/WebCore/dom/DocumentSharedObjectPool.h:

Canonical link: <a href="https://commits.webkit.org/307651@main">https://commits.webkit.org/307651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dd61335030ddcea9e36d6ebce0467279acaf09a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98302 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65b87199-3788-40f5-9e42-d2c52eb685be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111257 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79774 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0b927f1-8f96-4b8d-a018-6d7693386b13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147630 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129894 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92152 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12994 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10749 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/783 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155650 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17198 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119274 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119591 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30743 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15408 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127846 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72740 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16820 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6201 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16556 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80599 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16765 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16620 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->