### PR TITLE
[AutoFill Debugging] Extract select element options for non-markdown output formats

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt
@@ -40,6 +40,14 @@ root
                 input,'text',uid=…,placeholder='Username',name='username',minlength=3,maxlength=20,required
                 input,'text',uid=…,placeholder='Email',pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$',name='email',required
                 input,'text',uid=…,placeholder='Zip Code',pattern='[0-9]{5}',name='zipcode',minlength=5,maxlength=5
+            select,uid=…
+                option,value='one','Number 1'
+                option,value='two','Number 2'
+                option,selected,value='three','Number 3'
+            select,uid=…,multiple
+                option,selected,value='banana'
+                option,selected,value='pear'
+                option,value='apple'
     role='contentinfo'
         'Footer content with'
         role='img',aria-label='copyright symbol','©'
@@ -102,6 +110,16 @@ root
                 <input type='text' uid=… placeholder='Email' pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$' name='email' required>
                 <input type='text' uid=… placeholder='Zip Code' pattern='[0-9]{5}' name='zipcode' minlength=5 maxlength=5>
             </form>
+            <select uid=…>
+                <option value='one'>Number 1</option>
+                <option value='two'>Number 2</option>
+                <option value='three' selected>Number 3</option>
+            </select>
+            <select uid=…>
+                <option value='banana' selected>Banana</option>
+                <option value='pear' selected>Pear</option>
+                <option value='apple'>Apple</option>
+            </select>
         </section>
     </main>
     <footer role='contentinfo'>
@@ -436,6 +454,51 @@ root
                   ]
                 }
               ]
+            },
+            {
+              "type": "select",
+              "nodeName": "select",
+              "uid": "…",
+              "options": [
+                {
+                  "value": "one",
+                  "label": "Number 1",
+                  "selected": false
+                },
+                {
+                  "value": "two",
+                  "label": "Number 2",
+                  "selected": false
+                },
+                {
+                  "value": "three",
+                  "label": "Number 3",
+                  "selected": true
+                }
+              ]
+            },
+            {
+              "type": "select",
+              "nodeName": "select",
+              "uid": "…",
+              "options": [
+                {
+                  "value": "banana",
+                  "label": "Banana",
+                  "selected": true
+                },
+                {
+                  "value": "pear",
+                  "label": "Pear",
+                  "selected": true
+                },
+                {
+                  "value": "apple",
+                  "label": "Apple",
+                  "selected": false
+                }
+              ],
+              "multiple": true
             }
           ]
         }

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -75,6 +75,16 @@
             <input name="email" placeholder="Email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" required />
             <input name="zipcode" placeholder="Zip Code" pattern="[0-9]{5}" minlength="5" maxlength="5" />
         </form>
+        <select>
+            <option value="one">Number 1</option>
+            <option value="two">Number 2</option>
+            <option selected value="three">Number 3</option>
+        </select>
+        <select multiple>
+            <option selected value="banana">Banana</option>
+            <option selected value="pear">Pear</option>
+            <option value="apple">Apple</option>
+        </select>
     </section>
 </main>
 <footer role="contentinfo">

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -550,11 +550,11 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
                 continue;
 
             if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*item)) {
-                if (!option->selected())
-                    continue;
-
-                if (auto optionValue = option->value(); !optionValue.isEmpty())
-                    selectData.selectedValues.append(WTF::move(optionValue));
+                selectData.options.append({
+                    .value = option->value(),
+                    .label = option->label(),
+                    .isSelected = option->selected(),
+                });
             }
         }
         selectData.isMultiple = select->multiple();

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -167,8 +167,14 @@ struct TextFormControlData {
     bool isChecked { false };
 };
 
+struct SelectOptionData {
+    String value;
+    String label;
+    bool isSelected { false };
+};
+
 struct SelectData {
-    Vector<String> selectedValues;
+    Vector<SelectOptionData> options;
     bool isMultiple { false };
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6936,8 +6936,15 @@ header: <WebCore/TextExtractionTypes.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::SelectOptionData {
+    String value;
+    String label;
+    bool isSelected;
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::SelectData {
-    Vector<String> selectedValues;
+    Vector<WebCore::TextExtraction::SelectOptionData> options;
     bool isMultiple;
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm
@@ -157,8 +157,13 @@ inline static RetainPtr<WKTextExtractionItem> createItemWithChildren(const TextE
                 accessibilityRole:accessibilityRole.get()
                 nodeIdentifier:nodeIdentifier.get()]);
         }, [&](const TextExtraction::SelectData& data) -> RetainPtr<WKTextExtractionItem> {
+            auto selectedValues = WTF::compactMap(data.options, [](auto& option) -> std::optional<String> {
+                if (option.isSelected)
+                    return { option.value };
+                return { };
+            });
             return adoptNS([[WKTextExtractionSelectItem alloc]
-                initWithSelectedValues:createNSArray(data.selectedValues).get()
+                initWithSelectedValues:createNSArray(selectedValues).get()
                 supportsMultiple:data.isMultiple
                 rectInWebView:rectInWebView
                 children:children


### PR DESCRIPTION
#### b619a68d4e0db12af94be758d3db497db6aa36dd
<pre>
[AutoFill Debugging] Extract select element options for non-markdown output formats
<a href="https://bugs.webkit.org/show_bug.cgi?id=306547">https://bugs.webkit.org/show_bug.cgi?id=306547</a>
<a href="https://rdar.apple.com/169134455">rdar://169134455</a>

Reviewed by Abrar Rahman Protyasha.

Surface `option` elements under `select` during text extraction. The text tree representation looks
like:

```
select
    option,value=&apos;one&apos;,&apos;Number 1&apos;
    option,value=&apos;two&apos;,&apos;Number 2&apos;
    option,selected,value=&apos;three&apos;,&apos;Number 3&apos;
```

...the HTML representation looks like:

```
&lt;select&gt;
    &lt;option value=&apos;one&apos;&gt;Number 1&lt;/option&gt;
    &lt;option value=&apos;two&apos;&gt;Number 2&lt;/option&gt;
    &lt;option value=&apos;three&apos; selected&gt;Number 3&lt;/option&gt;
&lt;/select&gt;
```

...and the JSON representation looks like:

```
{
  &quot;type&quot;: &quot;select&quot;,
  &quot;nodeName&quot;: &quot;select&quot;,
  &quot;options&quot;: [
    { &quot;value&quot;: &quot;one&quot;, &quot;label&quot;: &quot;Number 1&quot;, &quot;selected&quot;: false },
    { &quot;value&quot;: &quot;two&quot;, &quot;label&quot;: &quot;Number 2&quot;, &quot;selected&quot;: false },
    { &quot;value&quot;: &quot;three&quot;, &quot;label&quot;: &quot;Number 3&quot;, &quot;selected&quot;: true }
  ]
}
```

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html:

Augment an existing layout test to include selects.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::populateJSONForItem):
(WebKit::addPartsForItem):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::createItemWithChildren):

Canonical link: <a href="https://commits.webkit.org/306449@main">https://commits.webkit.org/306449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fb613387a0f3445f6fb24f160c7a503a4aec89f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149972 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af1cde9a-3c54-42df-a601-0cb0d3aa4da9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108631 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab01eded-ecd8-473d-a2de-2510164d14b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11182 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89540 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/356ad19e-e3ed-431d-862b-5ef459383e0f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/44 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13469 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116736 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13485 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29801 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13120 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123181 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13511 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13248 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13448 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13294 "Failed to checkout and rebase branch from PR 57494") | | | | 
<!--EWS-Status-Bubble-End-->