### PR TITLE
[LOL] Add support for is_<type> bytecodes

### DIFF
--- a/Source/JavaScriptCore/lol/LOLJIT.h
+++ b/Source/JavaScriptCore/lol/LOLJIT.h
@@ -75,6 +75,16 @@ namespace JSC::LOL {
     macro(op_bitor) \
     macro(op_bitxor) \
     macro(op_mov) \
+    macro(op_is_empty) \
+    macro(op_typeof_is_undefined) \
+    macro(op_typeof_is_function) \
+    macro(op_is_undefined_or_null) \
+    macro(op_is_boolean) \
+    macro(op_is_number) \
+    macro(op_is_big_int) \
+    macro(op_is_object) \
+    macro(op_is_cell_with_type) \
+    macro(op_has_structure_with_flags) \
 
 
 #define FOR_EACH_OP_WITH_SLOW_CASE(macro) \

--- a/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
+++ b/Source/JavaScriptCore/lol/LOLRegisterAllocator.h
@@ -229,7 +229,17 @@ using ReplayRegisterAllocator = RegisterAllocator<ReplayBackend>;
     macro(OpToNumeric, m_operand, 0) \
     macro(OpBitnot, m_operand, 0) \
     macro(OpResolveScope, m_scope, 1) \
-    macro(OpGetFromScope, m_scope, 1)
+    macro(OpGetFromScope, m_scope, 1) \
+    macro(OpIsEmpty, m_operand, 0) \
+    macro(OpTypeofIsUndefined, m_operand, 0) \
+    macro(OpTypeofIsFunction, m_operand, 0) \
+    macro(OpIsUndefinedOrNull, m_operand, 0) \
+    macro(OpIsBoolean, m_operand, 0) \
+    macro(OpIsNumber, m_operand, 0) \
+    macro(OpIsBigInt, m_operand, 0) \
+    macro(OpIsObject, m_operand, 0) \
+    macro(OpIsCellWithType, m_operand, 0) \
+    macro(OpHasStructureWithFlags, m_operand, 0)
 
 #define ALLOCATE_USE_DEFS_FOR_UNARY_OP(Struct, operand, scratchCount) \
 template<typename Backend> \


### PR DESCRIPTION
#### da58be75db0b68b3c528eb8623c8b84b85178af5
<pre>
[LOL] Add support for is_&lt;type&gt; bytecodes
<a href="https://rdar.apple.com/169197463">rdar://169197463</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306552">https://bugs.webkit.org/show_bug.cgi?id=306552</a>

Reviewed by Marcus Plutowski.

Pretty straightforward migration. Most of these just worked out of the
box but I had to make a few changes when the operand and destination
were the same virtual register and we ended up clobbering the operand
too early.

No new tests, no behavior change.

Canonical link: <a href="https://commits.webkit.org/306451@main">https://commits.webkit.org/306451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40b6c497c59338782d95592ede0749bd26bcf748

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/149958 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23d8a9cc-9b88-4170-8b99-fc3b9f082e60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108619 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c7761b1-fb9d-4749-8b05-8356fa2b95c1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89527 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a3bb69f-db40-4ec4-8073-2d22d32281e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10739 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8364 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/30 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133366 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152350 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2186 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13455 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116727 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117058 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13109 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123165 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68653 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13497 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172674 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13234 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77210 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44734 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13280 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->