### PR TITLE
webkitexpectationspy: a package for test expectations that supports plugins for different test harnesses

### DIFF
--- a/Tools/Scripts/libraries/webkitexpectationspy/MANIFEST.in
+++ b/Tools/Scripts/libraries/webkitexpectationspy/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/Tools/Scripts/libraries/webkitexpectationspy/README.md
+++ b/Tools/Scripts/libraries/webkitexpectationspy/README.md
@@ -1,0 +1,161 @@
+# webkitexpectationspy
+
+A pluggable test expectations management system for WebKit.
+
+## Overview
+
+`webkitexpectationspy` provides a unified system for parsing, querying, and linting test expectation files across WebKit's test infrastructure. It supports:
+
+- **API tests** (TestWebKitAPI, TestIPC, TestWGSL, TestWTF)
+- **Layout tests** (LayoutTests) with ImageOnlyFailure, Text, Audio, Leak expectations
+- **Custom formats** via plugins
+
+## Features
+
+- **Unified format**: One consistent syntax across all test types
+- **Version specifiers**: `Sonoma+`, `Ventura-`, `Monterey-Sonoma`
+- **Configuration categories**: Platform, Version, Style, Hardware, Architecture, Flavor
+- **Smart linting**: Category ordering, alphabetical ordering, combination collapse detection
+- **Auto-fix**: Automatic correction of common issues
+- **Plugin architecture**: Extend for custom test formats
+
+## Installation
+
+```bash
+pip install webkitexpectationspy
+```
+
+Or for development:
+
+```bash
+cd Tools/Scripts/libraries/webkitexpectationspy
+pip install -e .
+```
+
+## Quick Start
+
+```python
+from webkitexpectationspy import ExpectationsManager
+from webkitexpectationspy.plugins import APITestPlugin
+
+# Create manager with API test plugin
+manager = ExpectationsManager(plugin=APITestPlugin())
+
+# Load expectations file
+manager.load_file('TestExpectations')
+
+# Query expectations
+exp = manager.get_expectation('TestWebKitAPI.WTF.StringTest')
+if exp and exp.is_skip():
+    print('Test is skipped')
+
+# Get skipped tests for current configuration
+skipped = manager.get_skipped_tests(
+    all_tests,
+    current_config={'mac', 'debug', 'arm64'}
+)
+```
+
+### Layout Tests Example
+
+```python
+from webkitexpectationspy import ExpectationsManager
+from webkitexpectationspy.plugins import LayoutTestPlugin
+
+# Create manager with layout test plugin
+manager = ExpectationsManager(plugin=LayoutTestPlugin())
+
+# Load expectations file
+manager.load_file('LayoutTests/TestExpectations')
+
+# Query expectations - supports directory wildcards
+exp = manager.get_expectation('fast/css/border-radius.html')
+
+# Layout test-specific expectations
+# ImageOnlyFailure, Text, Audio, Leak
+```
+
+## Expectation File Format
+
+```
+# Basic format
+[bug-ids] [configurations] test-pattern [expectations]
+
+# Examples
+TestWebKitAPI.WTF.StringTest [ Pass ]
+webkit.org/b/12345 [ mac Sonoma+ ] TestWebKitAPI.WebKit.Bug [ Fail ]
+rdar://98765 [ ios simulator ] TestWebKitAPI.iOS.Test [ Skip ]
+[ debug arm64 ] TestWebKitAPI.WTF.* [ Slow:120s ]
+```
+
+### Configuration Categories (ordered)
+
+1. **Platform**: mac, ios, linux, win, gtk, wpe
+2. **Version**: Sonoma, iOS18, with `+`/`-`/range modifiers
+3. **Style**: debug, release, asan, guardmalloc
+4. **Hardware**: simulator, device, iphone, ipad
+5. **Architecture**: arm64, x86_64, x86, arm64_32, armv7k
+6. **Flavor**: wk1, wk2, siteisolation, etc. (freeform)
+
+### Version Specifiers
+
+| Syntax | Meaning |
+|--------|---------|
+| `Sonoma` | Exact version only |
+| `Sonoma+` | This version and later |
+| `Sonoma-` | This version and earlier |
+| `Ventura-Sequoia` | Inclusive range |
+
+### Bug Identifiers
+
+- `webkit.org/b/12345` - WebKit bug tracker
+- `rdar://12345` - Apple Radar
+- `Bug(identifier)` - Other trackers
+
+## Linting
+
+```python
+# Lint expectations
+warnings = manager.lint(all_tests=test_list)
+for w in warnings:
+    print(w)
+```
+
+The linter checks for:
+- Configuration token ordering
+- Alphabetical ordering within categories
+- Collapsible duplicate entries
+- Universal skip detection
+- Stale expectations
+
+## Creating Plugins
+
+```python
+from webkitexpectationspy.plugins import FormatPlugin
+
+class MyTestPlugin(FormatPlugin):
+    @property
+    def name(self):
+        return 'my-tests'
+
+    @property
+    def expectation_map(self):
+        return {
+            'pass': 0,
+            'fail': 1,
+            'skip': 4,
+            # Add custom expectations
+        }
+
+    @property
+    def version_tokens(self):
+        return {'v1', 'v2', 'v3'}
+
+    @property
+    def version_order(self):
+        return ['v1', 'v2', 'v3']
+```
+
+## License
+
+Modified BSD License. See LICENSE file.

--- a/Tools/Scripts/libraries/webkitexpectationspy/lint
+++ b/Tools/Scripts/libraries/webkitexpectationspy/lint
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import os
+import platform
+import sys
+
+from webkitcorepy import AutoInstall
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+
+from webkitexpectationspy.linter import ExpectationsLinter
+from webkitexpectationspy.suites.api_tests import APITestSuite
+from webkitexpectationspy.suites.base import TestSuiteFormat
+from webkitexpectationspy.suites.layout_tests import LayoutTestSuite
+
+
+_SUITES = {
+    'generic': TestSuiteFormat,
+    'api-tests': APITestSuite,
+    'layout-tests': LayoutTestSuite,
+}
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description='Lint a test expectations file.')
+    parser.add_argument('file', help='Path to the expectations file to lint.')
+    parser.add_argument(
+        '--suite', choices=sorted(_SUITES), default='generic',
+        help='Test suite format to use (default: generic).')
+    parser.add_argument(
+        '--fix', action='store_true',
+        help='Apply auto-fixes in place.')
+    args = parser.parse_args(argv)
+
+    if not os.path.isfile(args.file):
+        sys.stderr.write('error: file not found: {}\n'.format(args.file))
+        return 2
+
+    with open(args.file, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    linter = ExpectationsLinter(content, args.file, suite=_SUITES[args.suite]())
+    warnings = linter.lint()
+
+    for warning in warnings:
+        print(warning)
+
+    if args.fix and any(w.fixable for w in warnings):
+        fixed = linter.apply_fixes()
+        # Some warnings (cross-line reordering) are only fixable via a
+        # full-file reorder, which apply_fixes() does not handle.
+        relinter = ExpectationsLinter(fixed, args.file, suite=_SUITES[args.suite]())
+        relinter.lint()
+        fixed = relinter.generate_sorted_content()
+        if fixed != content:
+            with open(args.file, 'w', encoding='utf-8') as f:
+                f.write(fixed)
+            print('applied fixes to {}'.format(args.file))
+
+    return 1 if warnings else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/Tools/Scripts/libraries/webkitexpectationspy/run-tests
+++ b/Tools/Scripts/libraries/webkitexpectationspy/run-tests
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+# See LICENSE file for license terms.
+
+import os
+import logging
+import platform
+import sys
+import webkitexpectationspy
+
+from webkitcorepy import AutoInstall, log, __path__ as wcp_paths
+from webkitcorepy.testing import PythonTestRunner
+
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.WARNING)
+
+    sys.exit(PythonTestRunner(
+        description='Run unit tests for the webkitexpectationspy module.',
+        modules={
+            os.path.dirname(__file__): ['webkitexpectationspy'],
+            os.path.dirname(wcp_paths[0]): ['webkitcorepy'],
+        }, loggers=[logging.getLogger(), log],
+    ).main(*sys.argv[1:]))

--- a/Tools/Scripts/libraries/webkitexpectationspy/setup.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/setup.py
@@ -1,0 +1,49 @@
+from setuptools import setup
+
+
+def readme():
+    with open('README.md') as f:
+        return f.read()
+
+
+setup(
+    name='webkitexpectationspy',
+    version='1.0.0',
+    description='Test expectations management for WebKit',
+    long_description=readme(),
+    long_description_content_type='text/markdown',
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: Other/Proprietary License',
+        'Operating System :: MacOS',
+        'Operating System :: POSIX :: Linux',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Topic :: Software Development :: Testing',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
+    keywords='webkit testing expectations',
+    url='https://github.com/WebKit/WebKit/tree/main/Tools/Scripts/libraries/webkitexpectationspy',
+    author='Apple Inc.',
+    author_email='webkit-dev@lists.webkit.org',
+    license='Modified BSD',
+    packages=[
+        'webkitexpectationspy',
+        'webkitexpectationspy.suites',
+        'webkitexpectationspy.plugins',
+        'webkitexpectationspy.mocks',
+        'webkitexpectationspy.tests',
+    ],
+    install_requires=[],
+    extras_require={
+        'webkit': ['webkitcorepy'],
+    },
+    python_requires='>=3.9',
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/__init__.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/__init__.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""webkitexpectationspy - Test expectations management for WebKit.
+
+A system for parsing, querying, and linting test expectation files.
+Supports API tests and layout tests with suite-specific plugins.
+
+Example usage:
+    from webkitexpectationspy import ExpectationsManager, ResultStatus
+    from webkitexpectationspy.suites import APITestSuite
+
+    manager = ExpectationsManager(suite=APITestSuite())
+    manager.load_file('TestExpectations')
+
+    exp = manager.get_expectation('TestWebKitAPI.WTF.StringTest')
+    if exp.skip:
+        print('Test is skipped')
+    if ResultStatus.FAIL in exp.expected:
+        print('Test expected to fail')
+"""
+
+__version__ = '3.0.0'
+
+from webkitexpectationspy.expectations import Expectation, ResultStatus
+from webkitexpectationspy.modifiers import ModifiersBase, LayoutTestModifiers
+from webkitexpectationspy.suites.layout_tests import LayoutTestStatus
+from webkitexpectationspy.manager import ExpectationsManager
+
+__all__ = [
+    '__version__',
+    'Expectation',
+    'ExpectationsManager',
+    'ResultStatus',
+    'LayoutTestStatus',
+    'ModifiersBase',
+    'LayoutTestModifiers',
+]

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/configuration.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/configuration.py
@@ -1,0 +1,227 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Configuration categories, typed enums, and ConfigurationSpecifier for test expectations."""
+
+import enum
+import re
+from dataclasses import dataclass, field
+from typing import FrozenSet, Optional, Set, List
+
+
+class ConfigurationCategory(enum.Enum):
+    """Configuration category — declaration order defines the canonical ordering."""
+    PLATFORM = 'platform'
+    VERSION = 'version'
+    STYLE = 'style'
+    HARDWARE = 'hardware'
+    ARCHITECTURE = 'architecture'
+    FLAVOR = 'flavor'
+
+
+_CATEGORY_ORDER = {cat: i for i, cat in enumerate(ConfigurationCategory)}
+
+
+class Platform(enum.Enum):
+    MAC = 'mac'
+    IOS = 'ios'
+    WATCHOS = 'watchos'
+    TVOS = 'tvos'
+    VISIONOS = 'visionos'
+    LINUX = 'linux'
+    WIN = 'win'
+    GTK = 'gtk'
+    WPE = 'wpe'
+
+
+class BuildType(enum.Enum):
+    DEBUG = 'debug'
+    RELEASE = 'release'
+    PRODUCTION = 'production'
+    ASAN = 'asan'
+    GUARDMALLOC = 'guardmalloc'
+
+
+class Architecture(enum.Enum):
+    ARM64 = 'arm64'
+    X86_64 = 'x86_64'
+    X86 = 'x86'
+    ARM64_32 = 'arm64_32'
+    ARMV7K = 'armv7k'
+
+
+class Hardware(enum.Enum):
+    SIMULATOR = 'simulator'
+    DEVICE = 'device'
+    IPHONE = 'iphone'
+    IPAD = 'ipad'
+    VISION = 'vision'
+    WATCH = 'watch'
+    TV = 'tv'
+
+
+_PLATFORM_BY_VALUE = {p.value: p for p in Platform}
+_BUILD_TYPE_BY_VALUE = {b.value: b for b in BuildType}
+_ARCHITECTURE_BY_VALUE = {a.value: a for a in Architecture}
+_HARDWARE_BY_VALUE = {h.value: h for h in Hardware}
+
+PLATFORM_TOKENS = frozenset(p.value for p in Platform)
+STYLE_TOKENS = frozenset(b.value for b in BuildType)
+HARDWARE_TOKENS = frozenset(h.value for h in Hardware)
+ARCHITECTURE_TOKENS = frozenset(a.value for a in Architecture)
+
+
+# Future-proofing escape hatch: any lowercase token ending in "os" (e.g. a
+# future platform like "xros") is recognized as a platform without requiring
+# the Platform enum to be amended. The enum remains the source of truth for
+# enumerated iteration and linter token ordering; this regex only broadens
+# classification.
+_PLATFORM_SHAPE_RE = re.compile(r'^[a-z]+os$')
+
+CATEGORY_TOKENS = {
+    ConfigurationCategory.PLATFORM: PLATFORM_TOKENS,
+    ConfigurationCategory.STYLE: STYLE_TOKENS,
+    ConfigurationCategory.HARDWARE: HARDWARE_TOKENS,
+    ConfigurationCategory.ARCHITECTURE: ARCHITECTURE_TOKENS,
+}
+
+CATEGORY_NAMES = {
+    ConfigurationCategory.PLATFORM: 'Platform',
+    ConfigurationCategory.VERSION: 'Version',
+    ConfigurationCategory.STYLE: 'Style',
+    ConfigurationCategory.HARDWARE: 'Hardware',
+    ConfigurationCategory.ARCHITECTURE: 'Architecture',
+    ConfigurationCategory.FLAVOR: 'Flavor',
+}
+
+
+@dataclass(frozen=True)
+class ConfigurationSpecifier:
+    platforms: FrozenSet[Platform] = field(default_factory=frozenset)
+    architectures: FrozenSet[Architecture] = field(default_factory=frozenset)
+    build_types: FrozenSet[BuildType] = field(default_factory=frozenset)
+    hardware: FrozenSet[Hardware] = field(default_factory=frozenset)
+    flavors: FrozenSet[str] = field(default_factory=frozenset)
+    version_specifier: Optional[object] = None
+
+    @classmethod
+    def from_tokens(cls, tokens: Set[str], version_specifiers=None):
+        platforms = frozenset(
+            _PLATFORM_BY_VALUE[t] for t in tokens if t in _PLATFORM_BY_VALUE
+        )
+        build_types = frozenset(
+            _BUILD_TYPE_BY_VALUE[t] for t in tokens if t in _BUILD_TYPE_BY_VALUE
+        )
+        architectures = frozenset(
+            _ARCHITECTURE_BY_VALUE[t] for t in tokens if t in _ARCHITECTURE_BY_VALUE
+        )
+        hardware_set = frozenset(
+            _HARDWARE_BY_VALUE[t] for t in tokens if t in _HARDWARE_BY_VALUE
+        )
+        known = PLATFORM_TOKENS | STYLE_TOKENS | HARDWARE_TOKENS | ARCHITECTURE_TOKENS
+        flavors = frozenset(t for t in tokens if t not in known)
+
+        vs = tuple(version_specifiers) if version_specifiers else None
+
+        return cls(
+            platforms=platforms,
+            architectures=architectures,
+            build_types=build_types,
+            hardware=hardware_set,
+            flavors=flavors,
+            version_specifier=vs,
+        )
+
+    def matches(self, current_tokens: Set[str],
+                current_version: Optional[str] = None,
+                version_order: Optional[List[str]] = None) -> bool:
+        if self.platforms:
+            if not any(p.value in current_tokens for p in self.platforms):
+                return False
+        if self.build_types:
+            if not any(b.value in current_tokens for b in self.build_types):
+                return False
+        if self.architectures:
+            if not any(a.value in current_tokens for a in self.architectures):
+                return False
+        if self.hardware:
+            if not any(h.value in current_tokens for h in self.hardware):
+                return False
+        if self.flavors:
+            if not self.flavors.issubset(current_tokens):
+                return False
+        if self.version_specifier:
+            if not current_version or not version_order:
+                return False
+            specs = self.version_specifier if isinstance(self.version_specifier, tuple) else (self.version_specifier,)
+            for spec in specs:
+                if not spec.matches(current_version, version_order):
+                    return False
+        return True
+
+    def to_tokens(self) -> Set[str]:
+        tokens = set()
+        for p in self.platforms:
+            tokens.add(p.value)
+        for b in self.build_types:
+            tokens.add(b.value)
+        for a in self.architectures:
+            tokens.add(a.value)
+        for h in self.hardware:
+            tokens.add(h.value)
+        tokens.update(self.flavors)
+        return tokens
+
+
+def matches_platform(token):
+    token_lower = token.lower()
+    if token_lower in PLATFORM_TOKENS:
+        return True
+    if _PLATFORM_SHAPE_RE.match(token_lower):
+        return True
+    return False
+
+
+def get_token_category(token, version_tokens=None):
+    token_lower = token.lower()
+
+    if token_lower in PLATFORM_TOKENS:
+        return ConfigurationCategory.PLATFORM
+    if _PLATFORM_SHAPE_RE.match(token_lower):
+        return ConfigurationCategory.PLATFORM
+    if token_lower in STYLE_TOKENS:
+        return ConfigurationCategory.STYLE
+    if token_lower in HARDWARE_TOKENS:
+        return ConfigurationCategory.HARDWARE
+    if token_lower in ARCHITECTURE_TOKENS:
+        return ConfigurationCategory.ARCHITECTURE
+
+    if token.endswith('+') or token.endswith('-') or ('-' in token and not token.endswith('-')):
+        return ConfigurationCategory.VERSION
+
+    if version_tokens and token_lower in version_tokens:
+        return ConfigurationCategory.VERSION
+
+    if token_lower.isidentifier() or re.match(r'^[a-z][a-z0-9_-]*$', token_lower):
+        return ConfigurationCategory.FLAVOR
+
+    return None

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/expectation_file.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/expectation_file.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Line-based expectation file format (TestExpectations).
+
+This is the primary format used by WebKit layout tests and API tests.
+Each non-blank, non-comment line describes one expectation.
+"""
+
+from typing import List
+
+from webkitexpectationspy.expectations import Expectation
+from webkitexpectationspy.parser import ExpectationParser, ParseWarning
+
+
+class ExpectationFile:
+    def __init__(self, filename, raw_content, parsed_expectations, parse_warnings):
+        self._filename = filename
+        self._raw_content = raw_content
+        self._expectations = parsed_expectations
+        self._warnings = parse_warnings
+
+    @classmethod
+    def parse(cls, filename, content, suite=None):
+        parser = ExpectationParser(suite=suite)
+        results = parser.parse(filename, content)
+
+        expectations = []
+        warnings = []
+        for exp, line_warnings in results:
+            warnings.extend(line_warnings)
+            if exp is not None:
+                expectations.append(exp)
+
+        return cls(filename, content, expectations, warnings)
+
+    def serialize(self) -> str:
+        lines = []
+        for exp in self._expectations:
+            lines.append(repr(exp))
+        return '\n'.join(lines)
+
+    def expectations(self) -> List[Expectation]:
+        return self._expectations
+
+    def warnings(self) -> List[ParseWarning]:
+        return self._warnings
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+
+    @property
+    def raw_content(self) -> str:
+        return self._raw_content

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/expectations.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/expectations.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Core expectation classes for test expectations.
+
+This module provides:
+- ResultStatus: Generic Flag enum for result statuses (PASS, FAIL, CRASH, TIMEOUT, SKIP)
+- Expectation: Frozen dataclass combining expected results, modifiers, and configuration
+"""
+
+from dataclasses import dataclass, field
+from enum import Flag, auto
+from typing import FrozenSet, Optional, Set, Tuple
+
+
+from webkitexpectationspy.modifiers import ModifiersBase
+
+
+class ResultStatus(Flag):
+    """Generic result status Flag enum for test suites.
+
+    The member declaration order defines the canonical serialization order.
+    """
+    PASS = auto()
+    FAIL = auto()
+    CRASH = auto()
+    TIMEOUT = auto()
+    SKIP = auto()
+
+    def __str__(self):
+        return self.name.title() if self.name else str(self.value)
+
+    @classmethod
+    def from_string(cls, name):
+        """Case-insensitive lookup by name."""
+        for member in cls:
+            if member.name.lower() == name.lower():
+                return member
+        raise ValueError('{!r} is not a valid {}'.format(name, cls.__name__))
+
+
+def _flag_members(flag_value):
+    """Return a frozenset of individual Flag members in a combined Flag value."""
+    if flag_value is None:
+        return frozenset()
+    return frozenset(m for m in type(flag_value) if m in flag_value)
+
+
+@dataclass(frozen=True)
+class Expectation:
+    test_pattern: str
+    expected: Flag = None
+    modifiers: ModifiersBase = field(default_factory=ModifiersBase)
+    configurations: FrozenSet[str] = field(default_factory=frozenset)
+    version_specifiers: tuple = ()
+    bug_ids: Tuple[str, ...] = ()
+    filename: Optional[str] = None
+    line_number: Optional[int] = None
+
+    def __post_init__(self):
+        if self.expected is None:
+            object.__setattr__(self, 'expected', ResultStatus.PASS)
+        elif isinstance(self.expected, set):
+            combined = None
+            for flag in self.expected:
+                combined = flag if combined is None else (combined | flag)
+            object.__setattr__(self, 'expected', combined if combined is not None else ResultStatus.PASS)
+        if isinstance(self.configurations, set):
+            object.__setattr__(self, 'configurations', frozenset(self.configurations))
+        if isinstance(self.version_specifiers, list):
+            object.__setattr__(self, 'version_specifiers', tuple(self.version_specifiers))
+        if isinstance(self.bug_ids, list):
+            object.__setattr__(self, 'bug_ids', tuple(self.bug_ids))
+
+    @property
+    def skip(self) -> bool:
+        return self.modifiers.skip
+
+    @property
+    def slow(self) -> bool:
+        return self.modifiers.slow is not None
+
+    @property
+    def flaky(self) -> bool:
+        return len(_flag_members(self.expected)) > 1
+
+    @property
+    def slow_timeout(self) -> Optional[float]:
+        return self.modifiers.slow
+
+    def is_skip(self) -> bool:
+        return self.modifiers.skip
+
+    def is_slow(self) -> bool:
+        return self.modifiers.slow is not None
+
+    def is_flaky(self) -> bool:
+        return self.flaky
+
+    def is_wontfix(self) -> bool:
+        return getattr(self.modifiers, 'wontfix', False)
+
+    def get_timeout(self, default_timeout: int, multiplier: int = 5) -> int:
+        if self.modifiers.slow is not None:
+            if isinstance(self.modifiers.slow, (int, float)) and self.modifiers.slow > 1:
+                return int(self.modifiers.slow)
+            return default_timeout * multiplier
+        return default_timeout
+
+    def matches_test(self, test_name: str) -> bool:
+        if self.test_pattern.endswith('*'):
+            return test_name.startswith(self.test_pattern[:-1])
+        return test_name == self.test_pattern
+
+    def matches_configuration(self, current_config: Set[str],
+                              current_version: Optional[str] = None,
+                              version_order=None) -> bool:
+        if self.configurations and not self.configurations.issubset(current_config):
+            return False
+        if self.version_specifiers:
+            if not current_version or not version_order:
+                return False
+            for spec in self.version_specifiers:
+                if not spec.matches(current_version, version_order):
+                    return False
+        return True
+
+    def result_is_expected(self, actual_status) -> bool:
+        return actual_status in self.expected
+
+    def __gt__(self, other):
+        if not isinstance(other, Expectation):
+            return NotImplemented
+        return _flag_members(other.expected) < _flag_members(self.expected)
+
+    def __lt__(self, other):
+        if not isinstance(other, Expectation):
+            return NotImplemented
+        return _flag_members(self.expected) < _flag_members(other.expected)
+
+    def __repr__(self) -> str:
+        result_names = sorted(str(e) for e in _flag_members(self.expected))
+        return 'Expectation({!r}, results={}, config={})'.format(
+            self.test_pattern, result_names,
+            set(self.configurations) or 'None')

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/linter.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/linter.py
@@ -1,0 +1,494 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Linter for test expectations files with 3-section sorting and auto-fix support.
+
+Sections are ordered:
+  0 - Unannotated: no bug IDs and no inline comment
+  1 - Commented:   has an inline ``# comment`` but no bug IDs
+  2 - Bug-tracked: has ANY bug ID (rdar://, webkit.org/b/, Bug())
+
+Within each section, entries are sorted by:
+  1. Wildcard patterns (ending with ``*``) before exact patterns
+  2. Alphabetical by test_pattern (case-insensitive)
+"""
+
+import re
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import List, Optional
+
+from webkitexpectationspy.configuration import (
+    ConfigurationCategory, CATEGORY_TOKENS, CATEGORY_NAMES,
+    PLATFORM_TOKENS, get_token_category, _CATEGORY_ORDER,
+)
+
+
+@dataclass
+class LintWarning:
+    filename: str
+    line_number: int
+    message: str
+    fixable: bool = False
+    fix_description: Optional[str] = None
+
+    def __str__(self):
+        prefix = '[fixable] ' if self.fixable else ''
+        return '{}:{}: {}{}'.format(self.filename, self.line_number, prefix, self.message)
+
+    def __repr__(self):
+        return 'LintWarning({!r}, {}, {!r})'.format(
+            self.filename, self.line_number, self.message)
+
+
+@dataclass
+class LineFix:
+    line_number: int
+    new_content: Optional[str] = None
+    delete: bool = False
+
+
+_BUG_PREFIXES = ('webkit.org/b/', 'rdar://')
+_BUG_RE = re.compile(r'Bug\(\w+\)', re.IGNORECASE)
+
+
+def _line_has_bug_id(line: str) -> bool:
+    for prefix in _BUG_PREFIXES:
+        if prefix in line:
+            return True
+    return bool(_BUG_RE.search(line))
+
+
+def _line_has_inline_comment(line: str) -> bool:
+    idx = line.find('#')
+    if idx < 0:
+        return False
+    return len(line[:idx].strip()) > 0
+
+
+def _classify_section(line: str) -> int:
+    if _line_has_bug_id(line):
+        return 2
+    if _line_has_inline_comment(line):
+        return 1
+    return 0
+
+
+class LintRule(ABC):
+    @abstractmethod
+    def check(self, entries, filepath, version_tokens):
+        """Return (warnings, fixes) for the given parsed entries."""
+        ...
+
+
+class CategoryOrderingRule(LintRule):
+    """Check that configuration tokens within a bracket are in canonical category order."""
+
+    def check(self, entries, filepath, version_tokens):
+        warnings = []
+        fixes = []
+        for entry in entries:
+            config_tokens = entry['config_tokens']
+            if len(config_tokens) < 2:
+                continue
+
+            last_category = None
+            for token in config_tokens:
+                category = get_token_category(token, version_tokens)
+                if category is None:
+                    continue
+                if last_category is not None and _CATEGORY_ORDER[category] < _CATEGORY_ORDER[last_category]:
+                    warnings.append(LintWarning(
+                        filepath,
+                        entry['line_number'],
+                        'Configuration tokens out of order: "{}" ({}) appears after {} category. '
+                        'Expected order: Platform -> Version -> Style -> Hardware -> Architecture -> Flavor'.format(
+                            token, CATEGORY_NAMES.get(category, str(category)),
+                            CATEGORY_NAMES.get(last_category, str(last_category))),
+                        fixable=True
+                    ))
+                    fix = _make_reorder_fix(entry, version_tokens)
+                    if fix:
+                        fixes.append(fix)
+                    break
+                last_category = category
+
+        return warnings, fixes
+
+
+class SectionOrderingRule(LintRule):
+    """Check 3-section ordering and alphabetical order within sections."""
+
+    def check(self, entries, filepath, version_tokens):
+        warnings = []
+        fixes = []
+
+        # Alphabetical within config categories
+        for entry in entries:
+            config_tokens = entry['config_tokens']
+            if len(config_tokens) < 2:
+                continue
+
+            by_category = defaultdict(list)
+            for token in config_tokens:
+                category = get_token_category(token, version_tokens)
+                if category:
+                    by_category[category].append(token.lower())
+
+            for category, tokens in by_category.items():
+                sorted_tokens = sorted(tokens)
+                if tokens != sorted_tokens:
+                    warnings.append(LintWarning(
+                        filepath,
+                        entry['line_number'],
+                        'Tokens in {} category not alphabetically ordered: {} should be {}'.format(
+                            CATEGORY_NAMES.get(category, str(category)),
+                            tokens, sorted_tokens),
+                        fixable=True
+                    ))
+                    fix = _make_reorder_fix(entry, version_tokens)
+                    if fix:
+                        fixes.append(fix)
+
+        # Entry ordering across sections
+        prev_key = None
+        prev_entry = None
+        for entry in entries:
+            raw_line = entry['raw_line']
+            section = _classify_section(raw_line)
+            is_wildcard = entry['test_pattern'].endswith('*')
+            key = (section, 0 if is_wildcard else 1, entry['test_pattern'].lower())
+
+            if prev_key is not None and key < prev_key:
+                if key[0] < prev_key[0]:
+                    section_names = {0: 'unannotated', 1: 'commented', 2: 'bug-tracked'}
+                    warnings.append(LintWarning(
+                        filepath,
+                        entry['line_number'],
+                        'Test "{}" is {} (section {}) but appears after {} entry "{}" (section {}). '
+                        'Expected order: unannotated -> commented -> bug-tracked'.format(
+                            entry['test_pattern'],
+                            section_names.get(key[0], str(key[0])), key[0],
+                            section_names.get(prev_key[0], str(prev_key[0])),
+                            prev_entry['test_pattern'], prev_key[0]),
+                        fixable=True,
+                        fix_description='Reorder entries by section then alphabetically'
+                    ))
+                elif key[0] == prev_key[0] and key[1] < prev_key[1]:
+                    warnings.append(LintWarning(
+                        filepath,
+                        entry['line_number'],
+                        'Wildcard pattern "{}" should appear before exact pattern "{}" within section'.format(
+                            entry['test_pattern'], prev_entry['test_pattern']),
+                        fixable=True,
+                        fix_description='Reorder: wildcards before exact patterns'
+                    ))
+                else:
+                    warnings.append(LintWarning(
+                        filepath,
+                        entry['line_number'],
+                        'Test "{}" should appear before "{}" (line {}) for alphabetical order'.format(
+                            entry['test_pattern'], prev_entry['test_pattern'],
+                            prev_entry['line_number']),
+                        fixable=True,
+                        fix_description='Reorder test entries alphabetically'
+                    ))
+            prev_key = key
+            prev_entry = entry
+
+        return warnings, fixes
+
+
+class CombinationCollapseRule(LintRule):
+    """Detect entries that cover all values in a category and can be collapsed."""
+
+    def check(self, entries, filepath, version_tokens):
+        warnings = []
+        fixes = []
+
+        by_test = defaultdict(list)
+        for entry in entries:
+            by_test[entry['test_pattern']].append(entry)
+
+        for test_pattern, test_entries in by_test.items():
+            if len(test_entries) < 2:
+                continue
+
+            expectations_set = set(tuple(sorted(e['expectations'])) for e in test_entries)
+            if len(expectations_set) != 1:
+                continue
+
+            for category, all_values in CATEGORY_TOKENS.items():
+                if not all_values:
+                    continue
+
+                covered_values = set()
+                entries_with_category = []
+                for entry in test_entries:
+                    cat_values = {t.lower() for t in entry['config_tokens']
+                                  if get_token_category(t, version_tokens) == category}
+                    if cat_values:
+                        covered_values.update(cat_values)
+                        entries_with_category.append(entry)
+
+                if covered_values == all_values and len(entries_with_category) == len(all_values):
+                    line_nums = [e['line_number'] for e in entries_with_category]
+                    warnings.append(LintWarning(
+                        filepath,
+                        line_nums[0],
+                        'Test "{}" has entries covering all {} values (lines {}). '
+                        'Can be collapsed by removing {} specifier.'.format(
+                            test_pattern,
+                            CATEGORY_NAMES.get(category, str(category)),
+                            ', '.join(str(n) for n in line_nums),
+                            CATEGORY_NAMES.get(category, str(category))),
+                        fixable=True
+                    ))
+                    collapse_fixes = _make_collapse_fixes(entries_with_category, category, version_tokens)
+                    fixes.extend(collapse_fixes)
+
+        return warnings, fixes
+
+
+class UniversalSkipRule(LintRule):
+    """Detect tests skipped on all configurations."""
+
+    def check(self, entries, filepath, version_tokens):
+        warnings = []
+
+        by_test = defaultdict(list)
+        for entry in entries:
+            by_test[entry['test_pattern']].append(entry)
+
+        for test_pattern, test_entries in by_test.items():
+            all_skip = all(
+                any(e.lower() == 'skip' for e in entry['expectations'])
+                for entry in test_entries
+            )
+            if not all_skip:
+                continue
+
+            has_unconditional = any(not entry['config_tokens'] for entry in test_entries)
+            covered_platforms = set()
+            for entry in test_entries:
+                for token in entry['config_tokens']:
+                    if token.lower() in PLATFORM_TOKENS:
+                        covered_platforms.add(token.lower())
+
+            if has_unconditional or covered_platforms >= PLATFORM_TOKENS:
+                line_nums = [e['line_number'] for e in test_entries]
+                warnings.append(LintWarning(
+                    filepath,
+                    line_nums[0],
+                    'Test "{}" is skipped on all configurations (lines {}). '
+                    'Consider removing the test entirely.'.format(
+                        test_pattern,
+                        ', '.join(str(n) for n in line_nums)),
+                    fixable=False
+                ))
+
+        return warnings, []
+
+
+def _make_reorder_fix(entry, version_tokens):
+    config_tokens = entry['config_tokens']
+    if not config_tokens:
+        return None
+
+    def sort_key(token):
+        category = get_token_category(token, version_tokens)
+        return (_CATEGORY_ORDER.get(category, _CATEGORY_ORDER[ConfigurationCategory.FLAVOR]), token.lower())
+
+    sorted_tokens = sorted(config_tokens, key=sort_key)
+    if sorted_tokens == config_tokens:
+        return None
+
+    old_line = entry['raw_line']
+    new_config = '[ {} ]'.format(' '.join(sorted_tokens))
+    new_line = re.sub(r'\[\s*[^\]]*\s*\]', new_config, old_line, count=1)
+    return LineFix(entry['line_number'], new_line)
+
+
+def _make_collapse_fixes(entries, category, version_tokens):
+    if len(entries) < 2:
+        return []
+
+    fixes = []
+    first_entry = entries[0]
+    config_tokens = [t for t in first_entry['config_tokens']
+                     if get_token_category(t, version_tokens) != category]
+
+    old_line = first_entry['raw_line']
+    if config_tokens:
+        new_config = '[ {} ]'.format(' '.join(config_tokens))
+        new_line = re.sub(r'\[\s*[^\]]*\s*\]', new_config, old_line, count=1)
+    else:
+        new_line = re.sub(r'\[\s*[^\]]*\s*\]\s*', '', old_line, count=1)
+
+    fixes.append(LineFix(first_entry['line_number'], new_line))
+    for entry in entries[1:]:
+        fixes.append(LineFix(entry['line_number'], delete=True))
+
+    return fixes
+
+
+_DEFAULT_RULES = [
+    CategoryOrderingRule(),
+    SectionOrderingRule(),
+    CombinationCollapseRule(),
+    UniversalSkipRule(),
+]
+
+
+class ExpectationsLinter:
+    def __init__(self, content, filepath, suite=None, rules=None):
+        self._content = content
+        self._filepath = filepath
+        self._suite = suite
+        self._version_tokens = self._suite.version_tokens if self._suite else set()
+        self._lines = content.split('\n')
+        self._parsed_entries = []
+        self._warnings = []
+        self._fixes = []
+        self._rules = rules or _DEFAULT_RULES
+
+    def lint(self):
+        self._parse_all_lines()
+        seen_fix_lines = set()
+        for rule in self._rules:
+            rule_warnings, rule_fixes = rule.check(
+                self._parsed_entries, self._filepath, self._version_tokens)
+            self._warnings.extend(rule_warnings)
+            for fix in rule_fixes:
+                if fix.line_number not in seen_fix_lines:
+                    self._fixes.append(fix)
+                    seen_fix_lines.add(fix.line_number)
+        return self._warnings
+
+    def get_fixes(self):
+        return self._fixes
+
+    def apply_fixes(self):
+        if not self._fixes:
+            return self._content
+
+        sorted_fixes = sorted(self._fixes, key=lambda f: -f.line_number)
+        lines = self._lines[:]
+        for fix in sorted_fixes:
+            if fix.delete:
+                del lines[fix.line_number - 1]
+            elif fix.new_content is not None:
+                lines[fix.line_number - 1] = fix.new_content
+
+        return '\n'.join(lines)
+
+    def generate_sorted_content(self) -> str:
+        """Generate a full-file reorder producing correct 3-section ordering."""
+        groups = []
+        header_lines = []
+        entry_index = 0
+
+        for line_num, line in enumerate(self._lines, 1):
+            is_entry = any(e['line_number'] == line_num for e in self._parsed_entries)
+            if is_entry:
+                entry = self._parsed_entries[entry_index]
+                entry_index += 1
+                groups.append((list(header_lines), line, entry))
+                header_lines = []
+            else:
+                header_lines.append(line)
+
+        def sort_key(group):
+            _, raw_line, entry = group
+            section = _classify_section(raw_line)
+            is_wildcard = entry['test_pattern'].endswith('*')
+            return (section, 0 if is_wildcard else 1, entry['test_pattern'].lower())
+
+        sorted_groups = sorted(groups, key=sort_key)
+
+        result_lines = []
+        for header, entry_line, _ in sorted_groups:
+            result_lines.extend(header)
+            result_lines.append(entry_line)
+        result_lines.extend(header_lines)
+
+        return '\n'.join(result_lines)
+
+    def _parse_all_lines(self):
+        for line_num, line in enumerate(self._lines, 1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#'):
+                continue
+
+            config_tokens = []
+            test_pattern = None
+            expectations = []
+            inline_comment = None
+
+            comment_idx = line.find('#')
+            if comment_idx != -1:
+                inline_comment = line[comment_idx + 1:].strip()
+            line_content = line[:comment_idx] if comment_idx != -1 else line
+
+            config_match = re.search(r'\[\s*([^\]]*)\s*\]', line_content)
+            if config_match:
+                config_str = config_match.group(1)
+                config_start = config_match.start()
+                before_config = line_content[:config_start].strip()
+
+                before_words = before_config.split()
+                non_bug_words = [w for w in before_words
+                                 if not w.startswith('webkit.org/b/')
+                                 and not w.startswith('rdar://')
+                                 and not w.lower().startswith('bug(')]
+
+                if non_bug_words:
+                    test_pattern = non_bug_words[-1]
+                    expectations = config_str.split()
+                else:
+                    config_tokens = config_str.split()
+                    rest = line_content[config_match.end():].strip()
+                    exp_match = re.search(r'\[\s*([^\]]*)\s*\]', rest)
+                    if exp_match:
+                        test_pattern = rest[:exp_match.start()].strip()
+                        expectations = exp_match.group(1).split()
+                    else:
+                        test_pattern = rest
+            else:
+                words = line_content.split()
+                for word in words:
+                    if (not word.startswith('webkit.org/b/') and
+                            not word.startswith('rdar://') and
+                            not word.lower().startswith('bug(')):
+                        test_pattern = word
+                        break
+
+            if test_pattern:
+                self._parsed_entries.append({
+                    'line_number': line_num,
+                    'raw_line': line,
+                    'config_tokens': config_tokens,
+                    'test_pattern': test_pattern,
+                    'expectations': expectations,
+                    'inline_comment': inline_comment,
+                })

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/manager.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/manager.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""High-level manager for test expectations."""
+
+import logging
+import os
+from typing import List, Set, Dict, Optional
+
+from webkitexpectationspy.expectations import Expectation
+from webkitexpectationspy.parser import ExpectationParser, ParseWarning
+from webkitexpectationspy.model import ExpectationsModel
+from webkitexpectationspy.linter import ExpectationsLinter, LintWarning
+from webkitexpectationspy.suites.base import TestSuiteFormat
+
+_log = logging.getLogger(__name__)
+
+
+class ExpectationsManager:
+    """High-level facade for loading and querying test expectations."""
+
+    def __init__(
+        self,
+        suite: Optional[TestSuiteFormat] = None,
+    ) -> None:
+        self._suite = suite
+        self._parser = ExpectationParser(self._suite)
+        self._model = ExpectationsModel(self._suite)
+        self._warnings: List[ParseWarning] = []
+        self._loaded_files: List[str] = []
+
+    def load_file(self, path: str) -> List[ParseWarning]:
+        if not os.path.exists(path):
+            _log.debug('Expectations file not found: {}'.format(path))
+            return []
+
+        _log.debug('Loading expectations from {}'.format(path))
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        return self._parse_content(path, content)
+
+    def load_files(self, paths: List[str]) -> List[ParseWarning]:
+        """Load expectations from multiple files in order; later files override earlier ones."""
+        all_warnings: List[ParseWarning] = []
+        for path in paths:
+            warnings = self.load_file(path)
+            all_warnings.extend(warnings)
+        return all_warnings
+
+    def load_content(self, filename: str, content: str) -> List[ParseWarning]:
+        return self._parse_content(filename, content)
+
+    def _parse_content(self, filename: str, content: str) -> List[ParseWarning]:
+        results = self._parser.parse(filename, content)
+        file_warnings = []
+
+        for expectation, warnings in results:
+            file_warnings.extend(warnings)
+            self._warnings.extend(warnings)
+            if expectation:
+                dup_warning = self._model.add_expectation(expectation)
+                if dup_warning:
+                    file_warnings.append(dup_warning)
+                    self._warnings.append(dup_warning)
+
+        self._loaded_files.append((filename, content))
+        return file_warnings
+
+    def get_expectation(
+        self,
+        test_name: str,
+        current_config: Optional[Set[str]] = None,
+        current_version: Optional[str] = None,
+        version_order: Optional[List[str]] = None
+    ) -> Optional[Expectation]:
+        if version_order is None and self._suite:
+            version_order = self._suite.version_order
+        return self._model.get_expectation(
+            test_name, current_config, current_version, version_order)
+
+    def get_expectation_or_pass(
+        self,
+        test_name: str,
+        current_config: Optional[Set[str]] = None,
+        current_version: Optional[str] = None,
+        version_order: Optional[List[str]] = None
+    ) -> Expectation:
+        if version_order is None and self._suite:
+            version_order = self._suite.version_order
+        return self._model.get_expectation_or_pass(
+            test_name, current_config, current_version, version_order)
+
+    def get_skipped_tests(
+        self,
+        all_tests: List[str],
+        current_config: Optional[Set[str]] = None,
+        current_version: Optional[str] = None,
+        version_order: Optional[List[str]] = None
+    ) -> Set[str]:
+        if version_order is None and self._suite:
+            version_order = self._suite.version_order
+        return self._model.get_skipped_tests(
+            all_tests, current_config, current_version, version_order)
+
+    def get_slow_tests(
+        self,
+        all_tests: List[str],
+        current_config: Optional[Set[str]] = None,
+        current_version: Optional[str] = None,
+        version_order: Optional[List[str]] = None
+    ) -> Dict[str, Optional[int]]:
+        """Return dict mapping slow test names to timeouts (None for default 5x)."""
+        if version_order is None and self._suite:
+            version_order = self._suite.version_order
+        return self._model.get_slow_tests(
+            all_tests, current_config, current_version, version_order)
+
+    def lint(self, all_tests=None):
+        """Validate expectations and return warnings; pass all_tests to detect stale entries."""
+        lint_warnings = list(self._warnings)
+
+        # Lint each loaded file
+        for filename, content in self._loaded_files:
+            linter = ExpectationsLinter(content, filename, self._suite)
+            lint_warnings.extend(linter.lint())
+
+        # Check for stale expectations
+        if all_tests:
+            test_set = set(all_tests)
+            for exp in self._model.all_expectations():
+                is_wildcard = (
+                    self._suite.is_wildcard_pattern(exp.test_pattern)
+                    if self._suite else exp.test_pattern.endswith('*')
+                )
+                if is_wildcard:
+                    matches = [t for t in all_tests
+                               if (self._suite.matches_test(exp.test_pattern, t)
+                                   if self._suite else exp.matches_test(t))]
+                    if not matches:
+                        lint_warnings.append(ParseWarning(
+                            exp.filename, exp.line_number, exp.test_pattern,
+                            'Stale wildcard pattern - matches no tests',
+                            test=exp.test_pattern))
+                else:
+                    if exp.test_pattern not in test_set:
+                        lint_warnings.append(ParseWarning(
+                            exp.filename, exp.line_number, exp.test_pattern,
+                            'Stale expectation - test does not exist',
+                            test=exp.test_pattern))
+
+        return lint_warnings
+
+    def all_expectations(self):
+        return self._model.all_expectations()
+
+    def warnings(self):
+        return self._warnings
+
+    def clear(self):
+        self._model.clear()
+        self._warnings.clear()
+        self._loaded_files.clear()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/model.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/model.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""In-memory model of test expectations with lookup support."""
+
+from typing import Dict, List, Set, Optional
+
+from webkitexpectationspy.expectations import Expectation, ResultStatus
+from webkitexpectationspy.parser import ParseWarning
+
+
+class ExpectationsModel:
+    def __init__(self, suite=None):
+        self._suite = suite
+        self._exact_expectations = {}
+        self._wildcard_expectations = []
+        self._all_expectations = []
+        self._seen_patterns = {}
+
+    def add_expectation(self, expectation):
+        warning = None
+
+        key = (expectation.test_pattern, expectation.configurations, expectation.version_specifiers)
+        if key in self._seen_patterns:
+            prev_file, prev_line = self._seen_patterns[key]
+            if prev_file == expectation.filename:
+                warning = ParseWarning(
+                    expectation.filename,
+                    expectation.line_number,
+                    expectation.test_pattern,
+                    'Duplicate expectation (previous at line {})'.format(prev_line),
+                    test=expectation.test_pattern
+                )
+
+        self._seen_patterns[key] = (expectation.filename, expectation.line_number)
+        self._all_expectations.append(expectation)
+
+        is_wildcard = (
+            self._suite.is_wildcard_pattern(expectation.test_pattern)
+            if self._suite else expectation.test_pattern.endswith('*')
+        )
+
+        if is_wildcard:
+            self._wildcard_expectations.append(expectation)
+        else:
+            if expectation.test_pattern not in self._exact_expectations:
+                self._exact_expectations[expectation.test_pattern] = []
+            self._exact_expectations[expectation.test_pattern].append(expectation)
+
+        return warning
+
+    def get_expectation(self, test_name, current_config=None,
+                        current_version=None, version_order=None):
+        if current_config is None:
+            current_config = set()
+
+        if test_name in self._exact_expectations:
+            for exp in self._exact_expectations[test_name]:
+                if exp.matches_configuration(current_config, current_version, version_order):
+                    return exp
+
+        best_match = None
+        best_prefix_len = -1
+        for exp in self._wildcard_expectations:
+            if self._matches_test(exp, test_name):
+                if exp.matches_configuration(current_config, current_version, version_order):
+                    prefix_len = len(exp.test_pattern)
+                    if prefix_len > best_prefix_len:
+                        best_match = exp
+                        best_prefix_len = prefix_len
+
+        return best_match
+
+    def _matches_test(self, expectation, test_name):
+        if self._suite:
+            return self._suite.matches_test(expectation.test_pattern, test_name)
+        return expectation.matches_test(test_name)
+
+    def get_expectation_or_pass(self, test_name, current_config=None,
+                                current_version=None, version_order=None):
+        exp = self.get_expectation(test_name, current_config, current_version, version_order)
+        if exp:
+            return exp
+        return Expectation(test_name, expected={ResultStatus.PASS})
+
+    def get_skipped_tests(self, all_tests, current_config=None,
+                          current_version=None, version_order=None):
+        skipped = set()
+        for test in all_tests:
+            exp = self.get_expectation(test, current_config, current_version, version_order)
+            if exp and exp.skip:
+                skipped.add(test)
+        return skipped
+
+    def get_slow_tests(self, all_tests, current_config=None,
+                       current_version=None, version_order=None):
+        slow_tests = {}
+        for test in all_tests:
+            exp = self.get_expectation(test, current_config, current_version, version_order)
+            if exp and exp.slow:
+                timeout = exp.modifiers.slow
+                slow_tests[test] = None if (timeout is not None and timeout < 0) else timeout
+        return slow_tests
+
+    def get_wontfix_tests(self, all_tests, current_config=None,
+                          current_version=None, version_order=None):
+        wontfix = set()
+        for test in all_tests:
+            exp = self.get_expectation(test, current_config, current_version, version_order)
+            if exp and exp.is_wontfix():
+                wontfix.add(test)
+        return wontfix
+
+    def all_expectations(self):
+        return self._all_expectations
+
+    def clear(self):
+        self._exact_expectations.clear()
+        self._wildcard_expectations.clear()
+        self._all_expectations.clear()
+        self._seen_patterns.clear()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/modifiers.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/modifiers.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Modifier dataclasses for test execution control.
+
+Modifiers describe how to run a test (skip it, allow more time, etc.)
+rather than what outcomes to expect.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class ModifiersBase:
+    skip: bool = False
+    slow: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class LayoutTestModifiers(ModifiersBase):
+    wontfix: bool = False
+    rebaseline: bool = False

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/parser.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/parser.py
@@ -1,0 +1,309 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Parser for test expectation files.
+
+This parser creates Expectation objects parameterised by the suite's
+result status Flag enum and modifier dataclass.
+"""
+
+import re
+from typing import List, Optional, Set
+
+from webkitexpectationspy.expectations import Expectation, ResultStatus
+from webkitexpectationspy.modifiers import ModifiersBase
+from webkitexpectationspy.configuration import (
+    ConfigurationCategory, get_token_category
+)
+from webkitexpectationspy.version_specifier import VersionSpecifier
+
+
+class ParseWarning:
+    def __init__(self, filename, line_number, line, error, test=None):
+        self.filename = filename
+        self.line_number = line_number
+        self.line = line
+        self.error = error
+        self.test = test
+
+    def __str__(self):
+        return '{}:{}: {} {}'.format(
+            self.filename, self.line_number, self.error,
+            self.test if self.test else self.line)
+
+    def __repr__(self):
+        return 'ParseWarning({!r}, {}, {!r})'.format(
+            self.filename, self.line_number, self.error)
+
+
+class ExpectationParser:
+    WEBKIT_BUG_PREFIX = 'webkit.org/b/'
+    RADAR_BUG_PREFIX = 'rdar://'
+    BUG_PATTERN = re.compile(r'Bug\((\w+)\)$', re.IGNORECASE)
+    RADAR_PATTERN = re.compile(r'^rdar://(?:problem/)?([\d/]+)$')
+    SLOW_TIMEOUT_PATTERN = re.compile(r'^Slow:(\d+)s?$', re.IGNORECASE)
+
+    def __init__(self, suite=None):
+        self._suite = suite
+
+        if self._suite:
+            self._expectation_map = self._suite.expectation_map
+            self._modifier_map = self._suite.modifier_map
+            self._modifier_class = self._suite.modifier_class
+        else:
+            self._expectation_map = {
+                'pass': ResultStatus.PASS,
+                'fail': ResultStatus.FAIL,
+                'failure': ResultStatus.FAIL,
+                'crash': ResultStatus.CRASH,
+                'timeout': ResultStatus.TIMEOUT,
+            }
+            self._modifier_map = {'skip', 'slow'}
+            self._modifier_class = ModifiersBase
+
+        self._version_tokens = self._suite.version_tokens if self._suite else set()
+
+    def parse(self, filename, content):
+        results = []
+        line_number = 0
+        for line in content.split('\n'):
+            line_number += 1
+            expectation, warnings = self._parse_line(filename, line, line_number)
+            results.append((expectation, warnings))
+        return results
+
+    def _parse_line(self, filename, line, line_number):
+        warnings = []
+
+        comment_index = line.find('#')
+        if comment_index != -1:
+            line = line[:comment_index]
+
+        line = ' '.join(line.split())
+        if not line:
+            return None, warnings
+
+        if line.startswith('//'):
+            warnings.append(ParseWarning(
+                filename, line_number, line,
+                'Use "#" instead of "//" for comments'))
+            return None, warnings
+
+        bug_ids = []
+        configurations = set()
+        version_specifiers = []
+        test_pattern = None
+        expected_results = set()
+        modifier_fields = {}
+        slow_timeout = None
+
+        tokens = line.split()
+        state = 'start'
+
+        for token in tokens:
+            if (token.startswith(self.WEBKIT_BUG_PREFIX) or
+                    token.startswith(self.RADAR_BUG_PREFIX) or
+                    token.lower().startswith('bug(')):
+                if state != 'start':
+                    warnings.append(ParseWarning(
+                        filename, line_number, line,
+                        '"{}" is not at the start of the line'.format(token)))
+                    break
+                if token.startswith(self.WEBKIT_BUG_PREFIX):
+                    bug_ids.append(token)
+                elif token.startswith(self.RADAR_BUG_PREFIX):
+                    match = self.RADAR_PATTERN.match(token)
+                    if match:
+                        bug_ids.append(token)
+                    else:
+                        warnings.append(ParseWarning(
+                            filename, line_number, line,
+                            'Invalid radar format "{}". Use rdar://XXXXX or rdar://problem/XXXXX'.format(token)))
+                        break
+                else:
+                    match = self.BUG_PATTERN.match(token)
+                    if match:
+                        bug_ids.append('Bug({})'.format(match.group(1)))
+                    else:
+                        warnings.append(ParseWarning(
+                            filename, line_number, line,
+                            'Unrecognized bug identifier "{}"'.format(token)))
+                        break
+
+            elif token == '[':
+                if state == 'start':
+                    state = 'configuration'
+                elif state == 'name_found':
+                    state = 'expectations'
+                else:
+                    warnings.append(ParseWarning(
+                        filename, line_number, line,
+                        'Unexpected "["'))
+                    break
+
+            elif token == ']':
+                if state == 'configuration':
+                    state = 'name'
+                elif state == 'expectations':
+                    state = 'done'
+                else:
+                    warnings.append(ParseWarning(
+                        filename, line_number, line,
+                        'Unexpected "]"'))
+                    break
+
+            elif state == 'configuration':
+                token_lower = token.lower()
+                category = get_token_category(token, self._version_tokens)
+                if category is not None:
+                    if category == ConfigurationCategory.VERSION:
+                        spec = VersionSpecifier.parse(token)
+                        if spec:
+                            version_specifiers.append(spec)
+                        else:
+                            spec = VersionSpecifier(token, specifier_type=VersionSpecifier.Type.EXACT)
+                            spec._original = token
+                            version_specifiers.append(spec)
+                    else:
+                        configurations.add(token_lower)
+                else:
+                    warnings.append(ParseWarning(
+                        filename, line_number, line,
+                        'Unrecognized configuration "{}"'.format(token)))
+                    break
+
+            elif state == 'expectations':
+                token_lower = token.lower()
+
+                slow_match = self.SLOW_TIMEOUT_PATTERN.match(token)
+                if slow_match:
+                    if self._suite and not self._suite.supports_custom_timeout():
+                        warnings.append(ParseWarning(
+                            filename, line_number, line,
+                            'Custom timeout not supported in this format'))
+                        break
+                    slow_timeout = int(slow_match.group(1))
+                    if slow_timeout < 1 or slow_timeout > 3600:
+                        warnings.append(ParseWarning(
+                            filename, line_number, line,
+                            'Slow timeout must be between 1 and 3600 seconds, got {}'.format(slow_timeout)))
+                        break
+                    modifier_fields['slow'] = float(slow_timeout)
+
+                elif self._is_modifier(token_lower):
+                    if token_lower == 'skip':
+                        modifier_fields['skip'] = True
+                    elif token_lower == 'slow':
+                        modifier_fields['slow'] = -1.0
+                    elif token_lower == 'wontfix':
+                        modifier_fields['wontfix'] = True
+                    elif token_lower == 'rebaseline':
+                        modifier_fields['rebaseline'] = True
+
+                elif token_lower in self._expectation_map:
+                    expected_results.add(self._expectation_map[token_lower])
+
+                else:
+                    warnings.append(ParseWarning(
+                        filename, line_number, line,
+                        'Unrecognized expectation "{}"'.format(token)))
+                    break
+
+            elif state == 'name_found':
+                warnings.append(ParseWarning(
+                    filename, line_number, line,
+                    'Expecting "[", "#", or end of line instead of "{}"'.format(token)))
+                break
+
+            else:
+                if self._suite:
+                    validated = self._suite.validate_test_pattern(token)
+                    if validated is None:
+                        warnings.append(ParseWarning(
+                            filename, line_number, line,
+                            'Invalid test pattern "{}"'.format(token)))
+                        break
+                    test_pattern = validated
+                else:
+                    test_pattern = token
+                state = 'name_found'
+
+        if not warnings:
+            if not test_pattern:
+                warnings.append(ParseWarning(
+                    filename, line_number, line,
+                    'Did not find a test name'))
+            elif state not in ('name_found', 'done'):
+                warnings.append(ParseWarning(
+                    filename, line_number, line,
+                    'Missing a "]"'))
+
+        if 'slow' in modifier_fields:
+            timeout_status = self._expectation_map.get('timeout')
+            if timeout_status and timeout_status in expected_results:
+                warnings.append(ParseWarning(
+                    filename, line_number, line,
+                    'A test cannot be both Slow and Timeout'))
+
+        if not expected_results and not warnings:
+            default_pass = self._expectation_map.get('pass', ResultStatus.PASS)
+            expected_results.add(default_pass)
+
+        if warnings:
+            return None, warnings
+
+        modifiers = self._build_modifiers(modifier_fields)
+
+        combined_expected = None
+        for flag in expected_results:
+            combined_expected = flag if combined_expected is None else (combined_expected | flag)
+
+        expectation = Expectation(
+            test_pattern=test_pattern,
+            expected=combined_expected,
+            modifiers=modifiers,
+            configurations=frozenset(configurations),
+            bug_ids=tuple(bug_ids),
+            filename=filename,
+            line_number=line_number,
+            version_specifiers=tuple(version_specifiers),
+        )
+        return expectation, warnings
+
+    def _is_modifier(self, token_lower):
+        return token_lower in self._modifier_map
+
+    def _build_modifiers(self, fields):
+        slow_val = fields.get('slow')
+        if slow_val is not None and slow_val < 0:
+            slow_val = -1.0
+
+        kwargs = {
+            'skip': fields.get('skip', False),
+            'slow': slow_val,
+        }
+        if hasattr(self._modifier_class, 'wontfix'):
+            kwargs['wontfix'] = fields.get('wontfix', False)
+        if hasattr(self._modifier_class, 'rebaseline'):
+            kwargs['rebaseline'] = fields.get('rebaseline', False)
+
+        return self._modifier_class(**kwargs)

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/resultsdb.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/resultsdb.py
@@ -1,0 +1,102 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""ResultsDB status codes and severity-ordered sort helpers.
+
+ResultsDB stores test outcomes as integer codes whose numeric ordering is the
+canonical severity order (lowest = most severe). This module is the single
+authority for that ordering — callers who need to sort result statuses should
+use ``sort_key`` rather than reinventing one.
+"""
+
+from enum import Flag, IntEnum
+from typing import Iterable
+
+from webkitexpectationspy.expectations import ResultStatus
+
+
+class ResultsDBStatus(IntEnum):
+    CRASH = 0x00
+    TIMEOUT = 0x08
+    LEAK = 0x10
+    AUDIO = 0x18
+    TEXT = 0x20
+    IMAGE_PLUS_TEXT = 0x24
+    FAIL = 0x28
+    IMAGE = 0x30
+    MISSING = 0x38
+    PASS = 0x40
+    SKIP = 0x50
+
+
+_RESULTSDB_MAP = {
+    'PASS': ResultsDBStatus.PASS,
+    'FAIL': ResultsDBStatus.FAIL,
+    'CRASH': ResultsDBStatus.CRASH,
+    'TIMEOUT': ResultsDBStatus.TIMEOUT,
+    'SKIP': ResultsDBStatus.SKIP,
+    'IMAGE': ResultsDBStatus.IMAGE,
+    'TEXT': ResultsDBStatus.TEXT,
+    'IMAGE_PLUS_TEXT': ResultsDBStatus.IMAGE_PLUS_TEXT,
+    'AUDIO': ResultsDBStatus.AUDIO,
+    'LEAK': ResultsDBStatus.LEAK,
+    'MISSING': ResultsDBStatus.MISSING,
+}
+
+_RESULTSDB_REVERSE = {v: k for k, v in _RESULTSDB_MAP.items()}
+
+
+def to_resultsdb(status: Flag) -> int:
+    name = status.name
+    if name in _RESULTSDB_MAP:
+        return int(_RESULTSDB_MAP[name])
+    return -1
+
+
+def from_resultsdb(code: int, status_type: type) -> Flag:
+    try:
+        rdb = ResultsDBStatus(code)
+    except ValueError:
+        raise ValueError('Unknown ResultsDB code: {:#x}'.format(code))
+    name = _RESULTSDB_REVERSE.get(rdb)
+    if name is None:
+        raise ValueError('No mapping for ResultsDB code: {:#x}'.format(code))
+    try:
+        return status_type[name]
+    except KeyError:
+        raise ValueError('{} has no member {!r}'.format(status_type.__name__, name))
+
+
+def sort_key(status: Flag) -> int:
+    """Severity key for ``status`` — use with ``sorted(..., key=sort_key)``.
+
+    When ``status`` is a combined Flag value (multiple members set), the key is
+    the most severe constituent. Unknown statuses sort after all known ones.
+    """
+    members = [m for m in type(status) if m in status] if status is not None else []
+    if not members:
+        return 2**31 - 1
+    return min(to_resultsdb(m) if to_resultsdb(m) >= 0 else 2**30 for m in members)
+
+
+def sorted_by_severity(statuses: Iterable[Flag]) -> list:
+    return sorted(statuses, key=sort_key)

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/__init__.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Test suite formats for webkitexpectationspy."""
+
+from webkitexpectationspy.suites.base import TestSuiteFormat
+from webkitexpectationspy.suites.api_tests import APITestSuite
+from webkitexpectationspy.suites.layout_tests import LayoutTestSuite, LayoutTestStatus
+
+__all__ = [
+    'TestSuiteFormat',
+    'APITestSuite',
+    'LayoutTestSuite',
+    'LayoutTestStatus',
+]

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/api_tests.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/api_tests.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from typing import Optional
+
+from webkitexpectationspy.suites.base import TestSuiteFormat
+
+
+class APITestSuite(TestSuiteFormat):
+    @property
+    def name(self) -> str:
+        return 'api-tests'
+
+    def validate_test_pattern(self, pattern: str) -> Optional[str]:
+        if not pattern:
+            return None
+        if pattern.endswith('*'):
+            base = pattern[:-1]
+            if base and (base.endswith('.') or '.' in base):
+                return pattern
+            return None
+        if '.' in pattern:
+            return pattern
+        if pattern.isidentifier() or pattern.replace('-', '').replace('_', '').isalnum():
+            return pattern
+        return None
+
+    def matches_test(self, pattern: str, test_name: str) -> bool:
+        if pattern.endswith('*'):
+            return test_name.startswith(pattern[:-1])
+        return pattern == test_name

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/base.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/base.py
@@ -1,0 +1,111 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Generic, instantiable base class for test suite formats.
+
+``TestSuiteFormat()`` is directly usable for any suite whose results fit
+``pass``/``fail``/``crash``/``timeout`` with ``skip``/``slow`` modifiers.
+Suites with richer status sets (layout tests) or extra modifiers subclass
+and override only the differing pieces.
+"""
+
+from typing import Dict, Set, Optional, List, Type, Tuple
+
+from webkitexpectationspy.configuration import ConfigurationCategory
+from webkitexpectationspy.expectations import ResultStatus
+from webkitexpectationspy.modifiers import ModifiersBase
+
+
+class TestSuiteFormat:
+
+    @property
+    def name(self) -> str:
+        return 'generic'
+
+    @property
+    def expectation_map(self) -> Dict:
+        return {
+            'pass': ResultStatus.PASS,
+            'fail': ResultStatus.FAIL,
+            'failure': ResultStatus.FAIL,
+            'crash': ResultStatus.CRASH,
+            'timeout': ResultStatus.TIMEOUT,
+        }
+
+    @property
+    def modifier_map(self) -> Set[str]:
+        return {'skip', 'slow'}
+
+    @property
+    def modifier_class(self) -> Type[ModifiersBase]:
+        return ModifiersBase
+
+    @property
+    def status_type(self) -> type:
+        return type(next(iter(self.expectation_map.values())))
+
+    @property
+    def status_names(self) -> Dict:
+        return {member: str(member) for member in self.status_type}
+
+    @property
+    def expectation_order(self) -> Tuple:
+        return tuple(self.status_type)
+
+    @property
+    def version_tokens(self) -> Set[str]:
+        return set()
+
+    @property
+    def version_order(self) -> List[str]:
+        return []
+
+    @property
+    def additional_tokens(self) -> Dict[ConfigurationCategory, Set[str]]:
+        return {}
+
+    def matches_test(self, pattern: str, test_name: str) -> bool:
+        return pattern == test_name
+
+    def is_wildcard_pattern(self, pattern: str) -> bool:
+        return False
+
+    def validate_test_pattern(self, pattern: str) -> Optional[str]:
+        if pattern and not pattern.isspace():
+            return pattern
+        return None
+
+    def supports_custom_timeout(self) -> bool:
+        return True
+
+    def result_was_expected(self, actual_status, expected, modifiers=None) -> bool:
+        if actual_status in expected:
+            return True
+        # SKIP is both a result and a modifier; a skipped test that reports SKIP
+        # is still considered to match the expectation.
+        if modifiers and modifiers.skip:
+            if hasattr(actual_status, 'name') and actual_status.name == 'SKIP':
+                return True
+        return False
+
+    def get_expectation_name(self, constant) -> str:
+        return str(constant)

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/layout_tests.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/suites/layout_tests.py
@@ -1,0 +1,191 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Layout test suite format with LayoutTestStatus enum."""
+
+from enum import Flag, auto
+from typing import Dict, Set, Optional, List, Type, Tuple
+
+from webkitexpectationspy.suites.base import TestSuiteFormat
+from webkitexpectationspy.modifiers import ModifiersBase, LayoutTestModifiers
+
+
+class LayoutTestStatus(Flag):
+    """Result statuses for layout tests.
+
+    The member declaration order defines the canonical serialization order.
+    Supports case-insensitive lookup via ``LayoutTestStatus['fail']``.
+    """
+    PASS = auto()
+    FAIL = auto()
+    CRASH = auto()
+    TIMEOUT = auto()
+    SKIP = auto()
+    IMAGE = auto()
+    TEXT = auto()
+    IMAGE_PLUS_TEXT = auto()
+    AUDIO = auto()
+    LEAK = auto()
+    MISSING = auto()
+
+    def __str__(self):
+        _DISPLAY = {
+            'IMAGE': 'ImageOnlyFailure',
+            'IMAGE_PLUS_TEXT': 'ImagePlusText',
+        }
+        if self.name:
+            return _DISPLAY.get(self.name, self.name.title())
+        return str(self.value)
+
+    @classmethod
+    def from_string(cls, name):
+        """Case-insensitive lookup by name."""
+        for member in cls:
+            if member.name.lower() == name.lower():
+                return member
+        raise ValueError('{!r} is not a valid {}'.format(name, cls.__name__))
+
+
+class LayoutTestSuite(TestSuiteFormat):
+    @property
+    def name(self) -> str:
+        return 'layout-tests'
+
+    @property
+    def expectation_map(self) -> Dict:
+        return {
+            'pass': LayoutTestStatus.PASS,
+            'fail': LayoutTestStatus.FAIL,
+            'failure': LayoutTestStatus.FAIL,
+            'crash': LayoutTestStatus.CRASH,
+            'timeout': LayoutTestStatus.TIMEOUT,
+            'imageonlyfailure': LayoutTestStatus.IMAGE,
+            'image': LayoutTestStatus.IMAGE,
+            'text': LayoutTestStatus.TEXT,
+            'audio': LayoutTestStatus.AUDIO,
+            'leak': LayoutTestStatus.LEAK,
+            'missing': LayoutTestStatus.MISSING,
+        }
+
+    @property
+    def modifier_map(self) -> Set[str]:
+        return {'skip', 'slow', 'wontfix', 'rebaseline'}
+
+    @property
+    def modifier_class(self) -> Type[ModifiersBase]:
+        return LayoutTestModifiers
+
+    @property
+    def status_names(self) -> Dict:
+        return {member: str(member) for member in LayoutTestStatus}
+
+    @property
+    def expectation_order(self) -> Tuple:
+        return tuple(LayoutTestStatus)
+
+    @property
+    def version_tokens(self) -> Set[str]:
+        return {
+            'monterey', 'ventura', 'sonoma', 'sequoia',
+            'ios16', 'ios17', 'ios18',
+            'bigsur', 'catalina', 'mojave',
+        }
+
+    @property
+    def version_order(self) -> List[str]:
+        return [
+            'mojave', 'catalina', 'bigsur', 'monterey', 'ventura', 'sonoma', 'sequoia',
+            'ios16', 'ios17', 'ios18',
+        ]
+
+    def is_wildcard_pattern(self, pattern: str) -> bool:
+        if pattern.endswith('*'):
+            return True
+        if pattern.endswith('/'):
+            return True
+        if '/' in pattern and '.' not in pattern.split('/')[-1]:
+            return True
+        return False
+
+    def validate_test_pattern(self, pattern: str) -> Optional[str]:
+        if not pattern:
+            return None
+        if pattern.startswith('/'):
+            return None
+        if '/' in pattern or '.' in pattern or pattern.endswith('*'):
+            return pattern
+        if pattern.replace('-', '').replace('_', '').isalnum():
+            return pattern
+        return pattern
+
+    def matches_test(self, pattern: str, test_name: str) -> bool:
+        if pattern == test_name:
+            return True
+        if pattern.endswith('/'):
+            return test_name.startswith(pattern)
+        if pattern.endswith('*'):
+            return test_name.startswith(pattern[:-1])
+        if '.' not in pattern.split('/')[-1]:
+            if test_name.startswith(pattern + '/'):
+                return True
+        return False
+
+    def result_was_expected(self, actual_result, expected, modifiers=None):
+        if actual_result in expected:
+            return True
+        if actual_result in (LayoutTestStatus.TEXT, LayoutTestStatus.IMAGE_PLUS_TEXT, LayoutTestStatus.AUDIO):
+            if LayoutTestStatus.FAIL in expected:
+                return True
+        if actual_result == LayoutTestStatus.MISSING:
+            if modifiers and hasattr(modifiers, 'rebaseline') and modifiers.rebaseline:
+                return True
+        if actual_result == LayoutTestStatus.SKIP:
+            if modifiers and modifiers.skip:
+                return True
+        return False
+
+    def remove_pixel_failures(self, expected):
+        members = set()
+        for member in type(expected):
+            if member in expected:
+                members.add(member)
+        members.discard(LayoutTestStatus.IMAGE)
+        if LayoutTestStatus.IMAGE_PLUS_TEXT in members:
+            members.discard(LayoutTestStatus.IMAGE_PLUS_TEXT)
+            members.add(LayoutTestStatus.TEXT)
+        combined = None
+        for m in members:
+            combined = m if combined is None else (combined | m)
+        return combined
+
+    def remove_leak_failures(self, expected):
+        members = set()
+        for member in type(expected):
+            if member in expected and member != LayoutTestStatus.LEAK:
+                members.add(member)
+        combined = None
+        for m in members:
+            combined = m if combined is None else (combined | m)
+        return combined
+
+    def get_expectation_name(self, constant) -> str:
+        return str(constant)

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/__init__.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for webkitexpectationspy."""

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/api_plugin_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/api_plugin_unittest.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for API test suite."""
+
+import unittest
+
+from webkitexpectationspy.suites.api_tests import APITestSuite
+from webkitexpectationspy.expectations import ResultStatus
+
+PASS = ResultStatus.PASS
+FAIL = ResultStatus.FAIL
+CRASH = ResultStatus.CRASH
+TIMEOUT = ResultStatus.TIMEOUT
+
+
+class APITestSuiteTest(unittest.TestCase):
+
+    def setUp(self):
+        self.suite = APITestSuite()
+
+    def test_name(self):
+        self.assertEqual(self.suite.name, 'api-tests')
+
+    def test_expectation_map(self):
+        exp_map = self.suite.expectation_map
+        self.assertEqual(exp_map['pass'], PASS)
+        self.assertEqual(exp_map['fail'], FAIL)
+        self.assertEqual(exp_map['crash'], CRASH)
+        self.assertEqual(exp_map['timeout'], TIMEOUT)
+
+    def test_modifier_map(self):
+        mod_map = self.suite.modifier_map
+        self.assertIn('skip', mod_map)
+        self.assertIn('slow', mod_map)
+        self.assertNotIn('skip', self.suite.expectation_map)
+        self.assertNotIn('slow', self.suite.expectation_map)
+
+    def test_matches_test_exact(self):
+        self.assertTrue(self.suite.matches_test('TestWebKitAPI.WTF.Test', 'TestWebKitAPI.WTF.Test'))
+        self.assertFalse(self.suite.matches_test('TestWebKitAPI.WTF.Test', 'TestWebKitAPI.WTF.Other'))
+
+    def test_matches_test_wildcard(self):
+        self.assertTrue(self.suite.matches_test('TestWebKitAPI.WTF.*', 'TestWebKitAPI.WTF.Test'))
+        self.assertTrue(self.suite.matches_test('TestWebKitAPI.WTF.*', 'TestWebKitAPI.WTF.Other'))
+        self.assertFalse(self.suite.matches_test('TestWebKitAPI.WTF.*', 'TestWebKitAPI.WebKit.Test'))
+
+    def test_matches_test_broad_wildcard(self):
+        self.assertTrue(self.suite.matches_test('TestWebKitAPI.*', 'TestWebKitAPI.WTF.Test'))
+        self.assertTrue(self.suite.matches_test('TestWebKitAPI.*', 'TestWebKitAPI.WebKit.Other'))
+        self.assertFalse(self.suite.matches_test('TestWebKitAPI.*', 'TestIPC.Suite.Test'))
+
+    def test_supports_testipc_suite(self):
+        self.assertTrue(self.suite.matches_test('TestIPC.IPCTests.Test', 'TestIPC.IPCTests.Test'))
+        self.assertTrue(self.suite.matches_test('TestIPC.IPCTests.*', 'TestIPC.IPCTests.AnyTest'))
+        self.assertTrue(self.suite.matches_test('TestIPC.*', 'TestIPC.IPCTests.Test'))
+        self.assertIsNotNone(self.suite.validate_test_pattern('TestIPC.IPCTests.Test'))
+        self.assertIsNotNone(self.suite.validate_test_pattern('TestIPC.IPCTests.*'))
+
+    def test_supports_testwgsl_suite(self):
+        self.assertTrue(self.suite.matches_test('TestWGSL.Shaders.Test', 'TestWGSL.Shaders.Test'))
+        self.assertTrue(self.suite.matches_test('TestWGSL.Shaders.*', 'TestWGSL.Shaders.AnyTest'))
+        self.assertTrue(self.suite.matches_test('TestWGSL.*', 'TestWGSL.Shaders.Test'))
+        self.assertIsNotNone(self.suite.validate_test_pattern('TestWGSL.Shaders.Test'))
+        self.assertIsNotNone(self.suite.validate_test_pattern('TestWGSL.Shaders.*'))
+
+    def test_supports_testwtf_suite(self):
+        self.assertTrue(self.suite.matches_test('TestWTF.WTF.Test', 'TestWTF.WTF.Test'))
+        self.assertTrue(self.suite.matches_test('TestWTF.WTF.*', 'TestWTF.WTF.AnyTest'))
+        self.assertIsNotNone(self.suite.validate_test_pattern('TestWTF.WTF.Test'))
+
+    def test_supports_any_binary_prefix(self):
+        self.assertTrue(self.suite.matches_test('SomeNewBinary.Suite.Test', 'SomeNewBinary.Suite.Test'))
+        self.assertTrue(self.suite.matches_test('InternalTest.Suite.*', 'InternalTest.Suite.Foo'))
+        self.assertIsNotNone(self.suite.validate_test_pattern('CustomBinary.Suite.Test'))
+
+    def test_validate_valid_patterns(self):
+        valid_patterns = [
+            'TestWebKitAPI.WTF.StringTest',
+            'TestWebKitAPI.WTF.*',
+            'TestWebKitAPI.*',
+            'TestIPC.IPCTests.Connection',
+            'TestWGSL.Shaders.Compile',
+            'TestWTF.Memory.Buffer',
+        ]
+        for pattern in valid_patterns:
+            self.assertIsNotNone(self.suite.validate_test_pattern(pattern),
+                                 f"Pattern should be valid: {pattern}")
+
+    def test_validate_invalid_patterns(self):
+        invalid_patterns = [
+            '',
+            '*',
+        ]
+        for pattern in invalid_patterns:
+            self.assertIsNone(self.suite.validate_test_pattern(pattern),
+                              f"Pattern should be invalid: {pattern}")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/configuration_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/configuration_unittest.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for configuration token classification."""
+
+import unittest
+
+from webkitexpectationspy.configuration import (
+    ConfigurationCategory, get_token_category, matches_platform,
+)
+
+
+class PlatformClassificationTest(unittest.TestCase):
+    """Platform recognition covers both the explicit Platform enum and the
+    ``*os`` shape regex, so a future platform like ``xros`` is recognized
+    without amending the enum."""
+
+    def test_explicit_platform_tokens_classify_as_platform(self):
+        for token in ('mac', 'ios', 'watchos', 'tvos', 'visionos', 'linux', 'win', 'gtk', 'wpe'):
+            self.assertEqual(
+                get_token_category(token), ConfigurationCategory.PLATFORM,
+                msg='{} should classify as PLATFORM'.format(token))
+
+    def test_unknown_os_shape_classifies_as_platform(self):
+        # xros is not in the Platform enum but matches the *os shape, so
+        # the library should still treat it as a platform.
+        self.assertEqual(get_token_category('xros'), ConfigurationCategory.PLATFORM)
+        self.assertTrue(matches_platform('xros'))
+
+    def test_unknown_non_os_token_does_not_classify_as_platform(self):
+        # "foobar" is not a platform shape; it falls through to FLAVOR.
+        self.assertEqual(get_token_category('foobar'), ConfigurationCategory.FLAVOR)
+        self.assertFalse(matches_platform('foobar'))
+
+
+class TokenCategoryTest(unittest.TestCase):
+
+    def test_style_tokens(self):
+        for token in ('debug', 'release', 'production'):
+            self.assertEqual(get_token_category(token), ConfigurationCategory.STYLE)
+
+    def test_architecture_tokens(self):
+        for token in ('arm64', 'x86_64'):
+            self.assertEqual(get_token_category(token), ConfigurationCategory.ARCHITECTURE)
+
+    def test_hardware_tokens(self):
+        for token in ('simulator', 'device', 'iphone', 'ipad'):
+            self.assertEqual(get_token_category(token), ConfigurationCategory.HARDWARE)
+
+    def test_version_specifier_tokens(self):
+        self.assertEqual(get_token_category('sonoma+'), ConfigurationCategory.VERSION)
+        self.assertEqual(get_token_category('ventura-sequoia'), ConfigurationCategory.VERSION)

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/generic_suite_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/generic_suite_unittest.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the generic TestSuiteFormat contract."""
+
+import unittest
+
+from webkitexpectationspy.expectations import ResultStatus
+from webkitexpectationspy.modifiers import ModifiersBase
+from webkitexpectationspy.parser import ExpectationParser
+from webkitexpectationspy.suites.base import TestSuiteFormat
+
+
+class GenericSuiteRoundTripTest(unittest.TestCase):
+    """TestSuiteFormat must be usable standalone — a caller should be able to
+    instantiate it and parse a minimal expectations file without any suite
+    subclass."""
+
+    def test_generic_suite_is_instantiable(self):
+        suite = TestSuiteFormat()
+        self.assertEqual(suite.modifier_class, ModifiersBase)
+        self.assertIn('pass', suite.expectation_map)
+        self.assertEqual(suite.expectation_map['pass'], ResultStatus.PASS)
+
+    def test_parser_works_with_generic_suite(self):
+        suite = TestSuiteFormat()
+        parser = ExpectationParser(suite=suite)
+        results = parser.parse('generic.txt', 'my_test [ Fail ]\nother_test [ Pass Crash ]\n')
+        # Filter to successful parses.
+        expectations = [exp for exp, warnings in results if exp is not None]
+        self.assertEqual(len(expectations), 2)
+        first, second = expectations
+        self.assertEqual(first.test_pattern, 'my_test')
+        self.assertIn(ResultStatus.FAIL, first.expected)
+        self.assertEqual(second.test_pattern, 'other_test')
+        self.assertIn(ResultStatus.PASS, second.expected)
+        self.assertIn(ResultStatus.CRASH, second.expected)
+
+    def test_generic_suite_modifiers_only_skip_and_slow(self):
+        suite = TestSuiteFormat()
+        self.assertEqual(suite.modifier_map, {'skip', 'slow'})

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/layout_plugin_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/layout_plugin_unittest.py
@@ -1,0 +1,208 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for layout test suite."""
+
+import unittest
+
+from webkitexpectationspy.suites.layout_tests import LayoutTestSuite, LayoutTestStatus
+
+PASS = LayoutTestStatus.PASS
+FAIL = LayoutTestStatus.FAIL
+CRASH = LayoutTestStatus.CRASH
+TIMEOUT = LayoutTestStatus.TIMEOUT
+
+
+class LayoutTestSuiteTest(unittest.TestCase):
+
+    def setUp(self):
+        self.suite = LayoutTestSuite()
+
+    def test_name(self):
+        self.assertEqual(self.suite.name, 'layout-tests')
+
+    def test_expectation_map_basic(self):
+        exp_map = self.suite.expectation_map
+        self.assertEqual(exp_map['pass'], PASS)
+        self.assertEqual(exp_map['fail'], FAIL)
+        self.assertEqual(exp_map['crash'], CRASH)
+        self.assertEqual(exp_map['timeout'], TIMEOUT)
+
+    def test_modifier_map(self):
+        mod_map = self.suite.modifier_map
+        self.assertIn('skip', mod_map)
+        self.assertIn('slow', mod_map)
+        self.assertNotIn('skip', self.suite.expectation_map)
+
+    def test_expectation_map_layout_specific(self):
+        exp_map = self.suite.expectation_map
+        self.assertEqual(exp_map['imageonlyfailure'], LayoutTestStatus.IMAGE)
+        self.assertEqual(exp_map['image'], LayoutTestStatus.IMAGE)
+        self.assertEqual(exp_map['text'], LayoutTestStatus.TEXT)
+        self.assertEqual(exp_map['audio'], LayoutTestStatus.AUDIO)
+        self.assertEqual(exp_map['leak'], LayoutTestStatus.LEAK)
+
+    def test_matches_test_exact(self):
+        self.assertTrue(self.suite.matches_test(
+            'fast/css/test.html', 'fast/css/test.html'))
+        self.assertFalse(self.suite.matches_test(
+            'fast/css/test.html', 'fast/css/other.html'))
+
+    def test_matches_test_directory_with_slash(self):
+        self.assertTrue(self.suite.matches_test('fast/css/', 'fast/css/test.html'))
+        self.assertTrue(self.suite.matches_test('fast/css/', 'fast/css/subdir/test.html'))
+        self.assertFalse(self.suite.matches_test('fast/css/', 'fast/dom/test.html'))
+
+    def test_matches_test_wildcard(self):
+        self.assertTrue(self.suite.matches_test('fast/css/*', 'fast/css/test.html'))
+        self.assertFalse(self.suite.matches_test('fast/css/*', 'fast/dom/test.html'))
+
+    def test_matches_test_prefix_wildcard(self):
+        self.assertTrue(self.suite.matches_test('fast/css/border*', 'fast/css/border-radius.html'))
+        self.assertFalse(self.suite.matches_test('fast/css/border*', 'fast/css/margin.html'))
+
+    def test_matches_test_directory_without_slash(self):
+        self.assertTrue(self.suite.matches_test('fast/css', 'fast/css/test.html'))
+        self.assertFalse(self.suite.matches_test('fast/css', 'fast/dom/test.html'))
+
+    def test_validate_test_pattern_valid(self):
+        for pattern in ['fast/css/test.html', 'fast/css/', 'fast/css/*', 'fast']:
+            self.assertIsNotNone(self.suite.validate_test_pattern(pattern))
+
+    def test_validate_test_pattern_invalid(self):
+        for pattern in ['', '/absolute/path/test.html']:
+            self.assertIsNone(self.suite.validate_test_pattern(pattern))
+
+    def test_version_tokens(self):
+        tokens = self.suite.version_tokens
+        self.assertIn('sonoma', tokens)
+        self.assertIn('ventura', tokens)
+
+    def test_version_order(self):
+        order = self.suite.version_order
+        self.assertTrue(order.index('monterey') < order.index('ventura'))
+        self.assertTrue(order.index('ventura') < order.index('sonoma'))
+
+    def test_is_wildcard_pattern(self):
+        self.assertTrue(self.suite.is_wildcard_pattern('fast/css/*'))
+        self.assertTrue(self.suite.is_wildcard_pattern('fast/css/'))
+        self.assertTrue(self.suite.is_wildcard_pattern('fast/css'))
+        self.assertFalse(self.suite.is_wildcard_pattern('fast/css/test.html'))
+
+    def test_layout_test_status_enum(self):
+        self.assertIsNotNone(LayoutTestStatus.TEXT)
+        self.assertIsNotNone(LayoutTestStatus.IMAGE)
+        self.assertIsNotNone(LayoutTestStatus.AUDIO)
+        self.assertIsNotNone(LayoutTestStatus.LEAK)
+
+    def test_layout_test_status_str(self):
+        self.assertEqual(str(LayoutTestStatus.IMAGE), 'ImageOnlyFailure')
+        self.assertEqual(str(LayoutTestStatus.IMAGE_PLUS_TEXT), 'ImagePlusText')
+        self.assertEqual(str(LayoutTestStatus.PASS), 'Pass')
+
+    def test_remove_pixel_failures(self):
+        expected = LayoutTestStatus.IMAGE | LayoutTestStatus.TEXT
+        result = self.suite.remove_pixel_failures(expected)
+        self.assertNotIn(LayoutTestStatus.IMAGE, result)
+        self.assertIn(LayoutTestStatus.TEXT, result)
+
+    def test_remove_leak_failures(self):
+        expected = LayoutTestStatus.LEAK | LayoutTestStatus.FAIL
+        result = self.suite.remove_leak_failures(expected)
+        self.assertNotIn(LayoutTestStatus.LEAK, result)
+        self.assertIn(LayoutTestStatus.FAIL, result)
+
+
+class LayoutTestSuiteIntegrationTest(unittest.TestCase):
+
+    def test_parse_layout_test_expectations(self):
+        from webkitexpectationspy.parser import ExpectationParser
+        parser = ExpectationParser(suite=LayoutTestSuite())
+        results = parser.parse('test.txt', 'fast/css/test.html [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(FAIL, exp.expected)
+
+    def test_parse_image_only_failure(self):
+        from webkitexpectationspy.parser import ExpectationParser
+        parser = ExpectationParser(suite=LayoutTestSuite())
+        results = parser.parse('test.txt', 'fast/css/test.html [ ImageOnlyFailure ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(LayoutTestStatus.IMAGE, exp.expected)
+
+    def test_parse_text_expectation(self):
+        from webkitexpectationspy.parser import ExpectationParser
+        parser = ExpectationParser(suite=LayoutTestSuite())
+        results = parser.parse('test.txt', 'fast/css/test.html [ Text ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(LayoutTestStatus.TEXT, exp.expected)
+
+    def test_parse_multiple_layout_expectations(self):
+        from webkitexpectationspy.parser import ExpectationParser
+        parser = ExpectationParser(suite=LayoutTestSuite())
+        results = parser.parse('test.txt', 'fast/css/test.html [ Pass Fail ImageOnlyFailure ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(PASS, exp.expected)
+        self.assertIn(FAIL, exp.expected)
+        self.assertIn(LayoutTestStatus.IMAGE, exp.expected)
+
+    def test_parse_leak_expectation(self):
+        from webkitexpectationspy.parser import ExpectationParser
+        parser = ExpectationParser(suite=LayoutTestSuite())
+        results = parser.parse('test.txt', 'fast/dom/test.html [ Leak ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(LayoutTestStatus.LEAK, exp.expected)
+
+    def test_manager_with_layout_suite(self):
+        from webkitexpectationspy.manager import ExpectationsManager
+        manager = ExpectationsManager(suite=LayoutTestSuite())
+        manager.load_content('TestExpectations', '''fast/css/border-radius.html [ ImageOnlyFailure ]
+fast/dom/ [ Skip ]
+fast/css/test.html [ Pass Fail ]''')
+
+        exp = manager.get_expectation('fast/css/border-radius.html')
+        self.assertIsNotNone(exp)
+        self.assertIn(LayoutTestStatus.IMAGE, exp.expected)
+
+        exp = manager.get_expectation('fast/dom/test.html')
+        self.assertIsNotNone(exp)
+        self.assertTrue(exp.skip)
+
+        exp = manager.get_expectation('fast/css/test.html')
+        self.assertTrue(exp.flaky)
+
+    def test_parse_skip_with_expected_result(self):
+        from webkitexpectationspy.parser import ExpectationParser
+        parser = ExpectationParser(suite=LayoutTestSuite())
+        results = parser.parse('test.txt', 'fast/css/test.html [ Skip ImageOnlyFailure ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.skip)
+        self.assertIn(LayoutTestStatus.IMAGE, exp.expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/linter_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/linter_unittest.py
@@ -1,0 +1,186 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+# See LICENSE file for license terms.
+
+"""Tests for expectations linter with 3-section sorting."""
+
+import unittest
+
+from webkitexpectationspy.linter import ExpectationsLinter
+
+
+class ExpectationsLinterTest(unittest.TestCase):
+
+    def test_lint_category_ordering(self):
+        content = '[ arm64 mac ] TestWebKitAPI.WTF.Test [ Fail ]'  # Wrong order
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('out of order' in w.message for w in warnings))
+
+    def test_lint_correct_category_ordering(self):
+        content = '[ mac arm64 ] TestWebKitAPI.WTF.Test [ Fail ]'  # Correct order
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertFalse(any('out of order' in w.message for w in warnings))
+
+    def test_lint_alphabetical_ordering_within_category(self):
+        content = '[ release debug ] TestWebKitAPI.WTF.Test [ Fail ]'  # Wrong order
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('alphabetically ordered' in w.message for w in warnings))
+
+    def test_lint_combination_collapse(self):
+        content = '''[ debug ] TestWebKitAPI.WTF.Test [ Skip ]
+[ release ] TestWebKitAPI.WTF.Test [ Skip ]
+[ production ] TestWebKitAPI.WTF.Test [ Skip ]
+[ asan ] TestWebKitAPI.WTF.Test [ Skip ]
+[ guardmalloc ] TestWebKitAPI.WTF.Test [ Skip ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('collapsed' in w.message for w in warnings))
+
+    def test_lint_universal_skip(self):
+        content = 'TestWebKitAPI.WTF.Test [ Skip ]'
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('skipped on all configurations' in w.message for w in warnings))
+
+    def test_apply_fixes_reorder(self):
+        content = '[ arm64 mac ] TestWebKitAPI.WTF.Test [ Fail ]'
+        linter = ExpectationsLinter(content, 'test.txt')
+        linter.lint()
+        fixed = linter.apply_fixes()
+        self.assertIn('[ mac arm64 ]', fixed)
+
+    def test_no_fixes_for_valid_file(self):
+        content = '[ mac arm64 ] TestWebKitAPI.WTF.Test [ Fail ]'
+        linter = ExpectationsLinter(content, 'test.txt')
+        linter.lint()
+        fixes = linter.get_fixes()
+        self.assertEqual(len(fixes), 0)
+
+    def test_all_skip_with_mixed_entries(self):
+        content = '''[ debug ] TestWebKitAPI.WTF.Test [ Skip ]
+[ release ] TestWebKitAPI.WTF.Test [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertFalse(any('skipped on all configurations' in w.message for w in warnings))
+
+
+class ThreeSectionSortingTest(unittest.TestCase):
+    """Tests for 3-section sorting: unannotated -> commented -> bug-tracked."""
+
+    def test_section_classification_unannotated(self):
+        content = 'TestA [ Fail ]'
+        linter = ExpectationsLinter(content, 'test.txt')
+        linter.lint()
+        # Single entry, no ordering issue
+        ordering_warnings = [w for w in linter._warnings if 'section' in w.message or 'alphabetical' in w.message]
+        self.assertEqual(len(ordering_warnings), 0)
+
+    def test_section_classification_bug_tracked(self):
+        content = '''rdar://12345 TestB [ Fail ]
+TestA [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        # TestA (unannotated, section 0) should come before rdar://12345 TestB (section 2)
+        self.assertTrue(any('section' in w.message or 'unannotated' in w.message for w in warnings))
+
+    def test_correct_three_section_order(self):
+        content = '''TestA [ Fail ]
+TestB [ Pass ] # known issue
+webkit.org/b/123 TestC [ Crash ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        ordering_warnings = [w for w in warnings if 'section' in w.message or 'alphabetical' in w.message or 'order' in w.message.lower()]
+        # Filter out non-ordering warnings (like "skipped on all" etc.)
+        section_warnings = [w for w in ordering_warnings if 'Configuration' not in w.message]
+        self.assertEqual(len(section_warnings), 0)
+
+    def test_bug_with_comment_goes_to_section_2(self):
+        content = '''rdar://12345 TestB [ Fail ] # some note
+TestA [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        # Line with bug + comment should be section 2, TestA section 0 should come first
+        self.assertTrue(any('section' in w.message or 'unannotated' in w.message for w in warnings))
+
+    def test_wildcard_before_exact_within_section(self):
+        content = '''TestExact [ Fail ]
+TestWild.* [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('Wildcard' in w.message or 'wildcard' in w.message.lower() for w in warnings))
+
+    def test_correct_wildcard_ordering(self):
+        content = '''TestWild.* [ Fail ]
+TestExact [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        wildcard_warnings = [w for w in warnings if 'wildcard' in w.message.lower()]
+        self.assertEqual(len(wildcard_warnings), 0)
+
+    def test_alphabetical_within_section(self):
+        content = '''TestZ [ Fail ]
+TestA [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('alphabetical' in w.message for w in warnings))
+
+    def test_generate_sorted_content(self):
+        content = '''rdar://12345 TestC [ Crash ]
+TestB [ Pass ] # known issue
+TestA [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        linter.lint()  # Must lint first to parse entries
+        sorted_content = linter.generate_sorted_content()
+        lines = [line for line in sorted_content.split('\n') if line.strip()]
+        # Section 0 (unannotated) first: TestA
+        self.assertIn('TestA', lines[0])
+        # Section 1 (commented): TestB
+        self.assertIn('TestB', lines[1])
+        # Section 2 (bug-tracked): TestC
+        self.assertIn('TestC', lines[2])
+
+    def test_generate_sorted_wildcard_first(self):
+        content = '''TestExact [ Fail ]
+TestWild.* [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        linter.lint()
+        sorted_content = linter.generate_sorted_content()
+        lines = [line for line in sorted_content.split('\n') if line.strip()]
+        self.assertIn('TestWild.*', lines[0])
+        self.assertIn('TestExact', lines[1])
+
+    def test_generate_sorted_preserves_header_comments(self):
+        content = '''# Header for B
+rdar://12345 TestB [ Crash ]
+# Header for A
+TestA [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        linter.lint()
+        sorted_content = linter.generate_sorted_content()
+        lines = sorted_content.split('\n')
+        # TestA (section 0) should come first, with its header
+        non_empty = [line for line in lines if line.strip()]
+        self.assertIn('Header for A', non_empty[0])
+        self.assertIn('TestA', non_empty[1])
+        self.assertIn('Header for B', non_empty[2])
+        self.assertIn('TestB', non_empty[3])
+
+    def test_webkit_bug_is_section_2(self):
+        content = '''webkit.org/b/999 TestB [ Fail ]
+TestA [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('section' in w.message or 'unannotated' in w.message for w in warnings))
+
+    def test_bug_function_is_section_2(self):
+        content = '''Bug(user) TestB [ Fail ]
+TestA [ Fail ]'''
+        linter = ExpectationsLinter(content, 'test.txt')
+        warnings = linter.lint()
+        self.assertTrue(any('section' in w.message or 'unannotated' in w.message for w in warnings))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/manager_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/manager_unittest.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for ExpectationsManager."""
+
+import unittest
+
+from webkitexpectationspy.manager import ExpectationsManager
+from webkitexpectationspy.suites.api_tests import APITestSuite
+from webkitexpectationspy.expectations import ResultStatus
+
+PASS = ResultStatus.PASS
+FAIL = ResultStatus.FAIL
+CRASH = ResultStatus.CRASH
+TIMEOUT = ResultStatus.TIMEOUT
+
+
+class ExpectationsManagerTest(unittest.TestCase):
+
+    def test_create_with_default_suite(self):
+        manager = ExpectationsManager()
+        self.assertIsNotNone(manager)
+
+    def test_create_with_custom_suite(self):
+        suite = APITestSuite()
+        manager = ExpectationsManager(suite=suite)
+        self.assertEqual(manager._suite, suite)
+
+    def test_load_content(self):
+        manager = ExpectationsManager()
+        warnings = manager.load_content('test.txt', 'TestWebKitAPI.WTF.Test [ Fail ]')
+        self.assertEqual(len(warnings), 0)
+
+        exp = manager.get_expectation('TestWebKitAPI.WTF.Test')
+        self.assertIsNotNone(exp)
+        self.assertIn(FAIL, exp.expected)
+
+    def test_load_multiple_content(self):
+        manager = ExpectationsManager()
+        manager.load_content('file1.txt', 'Test1 [ Fail ]')
+        manager.load_content('file2.txt', 'Test2 [ Skip ]')
+
+        exp1 = manager.get_expectation('Test1')
+        exp2 = manager.get_expectation('Test2')
+        self.assertIn(FAIL, exp1.expected)
+        self.assertTrue(exp2.skip)
+
+    def test_get_expectation_with_configuration(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', '''[ debug ] TestDebug.Test [ Fail ]
+[ release ] TestRelease.Test [ Pass ]''')
+
+        exp_debug = manager.get_expectation('TestDebug.Test', current_config={'debug'})
+        self.assertIsNotNone(exp_debug)
+        self.assertIn(FAIL, exp_debug.expected)
+
+        exp_release = manager.get_expectation('TestRelease.Test', current_config={'release'})
+        self.assertIsNotNone(exp_release)
+        self.assertIn(PASS, exp_release.expected)
+
+        exp_wrong = manager.get_expectation('TestDebug.Test', current_config={'release'})
+        self.assertIsNone(exp_wrong)
+
+    def test_get_skipped_tests(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', '''Test1 [ Skip ]
+Test2 [ Fail ]
+TestWTF.* [ Skip ]''')
+
+        all_tests = ['Test1', 'Test2', 'TestWTF.A', 'TestWTF.B', 'Test3']
+        skipped = manager.get_skipped_tests(all_tests)
+
+        self.assertIn('Test1', skipped)
+        self.assertNotIn('Test2', skipped)
+        self.assertIn('TestWTF.A', skipped)
+        self.assertIn('TestWTF.B', skipped)
+        self.assertNotIn('Test3', skipped)
+
+    def test_get_slow_tests(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', '''Test1 [ Slow ]
+Test2 [ Slow:120s ]
+Test3 [ Fail ]''')
+
+        all_tests = ['Test1', 'Test2', 'Test3']
+        slow = manager.get_slow_tests(all_tests)
+
+        self.assertIn('Test1', slow)
+        self.assertIsNone(slow['Test1'])
+        self.assertEqual(slow['Test2'], 120.0)
+        self.assertNotIn('Test3', slow)
+
+    def test_lint_returns_warnings(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', '[ arm64 mac ] Test [ Fail ]')
+
+        warnings = manager.lint()
+        self.assertTrue(any('order' in str(w) for w in warnings))
+
+    def test_all_expectations(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', '''Test1 [ Fail ]
+Test2 [ Skip ]''')
+
+        all_exps = manager.all_expectations()
+        self.assertEqual(len(all_exps), 2)
+
+    def test_clear(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', 'Test [ Fail ]')
+
+        self.assertIsNotNone(manager.get_expectation('Test'))
+        manager.clear()
+        self.assertIsNone(manager.get_expectation('Test'))
+
+    def test_skip_with_expected_result(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', 'Test [ Skip Fail ]')
+
+        exp = manager.get_expectation('Test')
+        self.assertIsNotNone(exp)
+        self.assertTrue(exp.skip)
+        self.assertIn(FAIL, exp.expected)
+
+
+class ExpectationsManagerMultiSuiteTest(unittest.TestCase):
+
+    def test_multiple_test_suites(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', '''TestWebKitAPI.WTF.String [ Fail ]
+TestIPC.Connection.Test [ Skip ]
+TestWGSL.Shaders.Compile [ Crash ]
+TestWTF.Memory.Leak [ Timeout ]''')
+
+        self.assertIn(FAIL, manager.get_expectation('TestWebKitAPI.WTF.String').expected)
+        self.assertTrue(manager.get_expectation('TestIPC.Connection.Test').skip)
+        self.assertIn(CRASH, manager.get_expectation('TestWGSL.Shaders.Compile').expected)
+        self.assertIn(TIMEOUT, manager.get_expectation('TestWTF.Memory.Leak').expected)
+
+    def test_wildcard_across_suites(self):
+        manager = ExpectationsManager()
+        manager.load_content('exp.txt', '''TestIPC.* [ Skip ]
+TestWGSL.Shaders.* [ Fail ]''')
+
+        all_tests = [
+            'TestIPC.Connection.Test',
+            'TestIPC.Messages.Send',
+            'TestWGSL.Shaders.Compile',
+            'TestWGSL.Shaders.Link',
+            'TestWGSL.Memory.Alloc',
+            'TestWebKitAPI.WTF.String',
+        ]
+        skipped = manager.get_skipped_tests(all_tests)
+
+        self.assertIn('TestIPC.Connection.Test', skipped)
+        self.assertIn('TestIPC.Messages.Send', skipped)
+        self.assertNotIn('TestWGSL.Shaders.Compile', skipped)
+        self.assertNotIn('TestWebKitAPI.WTF.String', skipped)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/model_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/model_unittest.py
@@ -1,0 +1,248 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for expectations model."""
+
+import unittest
+
+from webkitexpectationspy.model import ExpectationsModel
+from webkitexpectationspy.expectations import Expectation, ResultStatus
+from webkitexpectationspy.modifiers import ModifiersBase, LayoutTestModifiers
+from webkitexpectationspy.version_specifier import VersionSpecifier
+
+PASS = ResultStatus.PASS
+FAIL = ResultStatus.FAIL
+CRASH = ResultStatus.CRASH
+TIMEOUT = ResultStatus.TIMEOUT
+
+
+class ExpectationsModelTest(unittest.TestCase):
+
+    def test_add_and_get_expectation(self):
+        model = ExpectationsModel()
+        exp = Expectation('TestWebKitAPI.WTF.Test', expected={FAIL})
+        model.add_expectation(exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Test')
+        self.assertEqual(result, exp)
+
+    def test_get_expectation_not_found(self):
+        model = ExpectationsModel()
+        result = model.get_expectation('NonExistent.Test')
+        self.assertIsNone(result)
+
+    def test_wildcard_matching(self):
+        model = ExpectationsModel()
+        exp = Expectation('TestWebKitAPI.WTF.*', modifiers=ModifiersBase(skip=True))
+        model.add_expectation(exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Test')
+        self.assertEqual(result, exp)
+
+        result = model.get_expectation('TestWebKitAPI.WebKit.Test')
+        self.assertIsNone(result)
+
+    def test_exact_overrides_wildcard(self):
+        model = ExpectationsModel()
+        wildcard_exp = Expectation('TestWebKitAPI.WTF.*', modifiers=ModifiersBase(skip=True))
+        exact_exp = Expectation('TestWebKitAPI.WTF.Specific', expected={FAIL})
+        model.add_expectation(wildcard_exp)
+        model.add_expectation(exact_exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Specific')
+        self.assertEqual(result, exact_exp)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Other')
+        self.assertEqual(result, wildcard_exp)
+
+    def test_more_specific_wildcard_wins(self):
+        model = ExpectationsModel()
+        broad = Expectation('TestWebKitAPI.*', modifiers=ModifiersBase(skip=True))
+        specific = Expectation('TestWebKitAPI.WTF.*', expected={FAIL})
+        model.add_expectation(broad)
+        model.add_expectation(specific)
+
+        result = model.get_expectation('TestWebKitAPI.WTF.Test')
+        self.assertEqual(result, specific)
+
+        result = model.get_expectation('TestWebKitAPI.WebKit.Test')
+        self.assertEqual(result, broad)
+
+    def test_get_skipped_tests(self):
+        model = ExpectationsModel()
+        model.add_expectation(Expectation('Test1', modifiers=ModifiersBase(skip=True)))
+        model.add_expectation(Expectation('Test2', expected={FAIL}))
+        model.add_expectation(Expectation('TestWTF.*', modifiers=ModifiersBase(skip=True)))
+
+        all_tests = ['Test1', 'Test2', 'TestWTF.A', 'TestWTF.B', 'Other']
+        skipped = model.get_skipped_tests(all_tests)
+
+        self.assertIn('Test1', skipped)
+        self.assertNotIn('Test2', skipped)
+        self.assertIn('TestWTF.A', skipped)
+        self.assertIn('TestWTF.B', skipped)
+
+    def test_get_slow_tests(self):
+        model = ExpectationsModel()
+        model.add_expectation(Expectation('Test1', modifiers=ModifiersBase(slow=-1.0)))
+        model.add_expectation(Expectation('Test2', modifiers=ModifiersBase(slow=120.0)))
+        model.add_expectation(Expectation('Test3', expected={FAIL}))
+
+        all_tests = ['Test1', 'Test2', 'Test3']
+        slow = model.get_slow_tests(all_tests)
+
+        self.assertIn('Test1', slow)
+        self.assertIsNone(slow['Test1'])
+        self.assertEqual(slow['Test2'], 120.0)
+        self.assertNotIn('Test3', slow)
+
+    def test_get_wontfix_tests(self):
+        model = ExpectationsModel()
+        model.add_expectation(Expectation('Test1', modifiers=LayoutTestModifiers(wontfix=True)))
+        model.add_expectation(Expectation('Test2', expected={FAIL}))
+
+        all_tests = ['Test1', 'Test2']
+        wontfix = model.get_wontfix_tests(all_tests)
+
+        self.assertIn('Test1', wontfix)
+        self.assertNotIn('Test2', wontfix)
+
+    def test_configuration_filtering(self):
+        model = ExpectationsModel()
+        debug_exp = Expectation('Test', expected={FAIL}, configurations={'debug'})
+        model.add_expectation(debug_exp)
+
+        result = model.get_expectation('Test', {'debug'})
+        self.assertEqual(result, debug_exp)
+
+        result = model.get_expectation('Test', {'release'})
+        self.assertIsNone(result)
+
+    def test_version_specifier_matching(self):
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_LATER)
+        exp = Expectation('Test', expected={FAIL}, configurations={'mac'},
+                          version_specifiers=[spec])
+        model = ExpectationsModel()
+        model.add_expectation(exp)
+
+        version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+        result = model.get_expectation('Test', {'mac'}, 'sonoma', version_order)
+        self.assertEqual(result, exp)
+
+        result = model.get_expectation('Test', {'mac'}, 'monterey', version_order)
+        self.assertIsNone(result)
+
+    def test_get_expectation_or_pass(self):
+        model = ExpectationsModel()
+        model.add_expectation(Expectation('Test1', expected={FAIL}))
+
+        result = model.get_expectation_or_pass('Test1')
+        self.assertIn(FAIL, result.expected)
+
+        result = model.get_expectation_or_pass('Unknown')
+        self.assertIn(PASS, result.expected)
+
+    def test_empty_model(self):
+        model = ExpectationsModel()
+        self.assertIsNone(model.get_expectation('Test'))
+        self.assertEqual(len(model.get_skipped_tests(['Test'])), 0)
+        self.assertEqual(len(model.get_slow_tests(['Test'])), 0)
+        self.assertEqual(len(model.all_expectations()), 0)
+
+    def test_clear(self):
+        model = ExpectationsModel()
+        model.add_expectation(Expectation('Test', expected={FAIL}))
+        self.assertIsNotNone(model.get_expectation('Test'))
+
+        model.clear()
+        self.assertIsNone(model.get_expectation('Test'))
+
+    def test_same_pattern_different_configurations(self):
+        model = ExpectationsModel()
+
+        mac_exp = Expectation('Test', expected={FAIL}, configurations={'mac'})
+        warning1 = model.add_expectation(mac_exp)
+        self.assertIsNone(warning1)
+
+        linux_exp = Expectation('Test', expected={PASS}, configurations={'linux'})
+        warning2 = model.add_expectation(linux_exp)
+        self.assertIsNone(warning2)
+
+        result_mac = model.get_expectation('Test', {'mac'})
+        self.assertEqual(result_mac, mac_exp)
+
+        result_linux = model.get_expectation('Test', {'linux'})
+        self.assertEqual(result_linux, linux_exp)
+
+    def test_true_duplicate_same_configuration(self):
+        model = ExpectationsModel()
+
+        exp1 = Expectation('Test', expected={FAIL}, configurations={'mac'}, filename='test.txt', line_number=1)
+        warning1 = model.add_expectation(exp1)
+        self.assertIsNone(warning1)
+
+        exp2 = Expectation('Test', expected={PASS}, configurations={'mac'}, filename='test.txt', line_number=5)
+        warning2 = model.add_expectation(exp2)
+        self.assertIsNotNone(warning2)
+        self.assertIn('Duplicate', warning2.error)
+
+    def test_skip_with_expected_results(self):
+        model = ExpectationsModel()
+        exp = Expectation('Test', expected={FAIL}, modifiers=ModifiersBase(skip=True))
+        model.add_expectation(exp)
+
+        result = model.get_expectation('Test')
+        self.assertTrue(result.skip)
+        self.assertIn(FAIL, result.expected)
+
+    def test_combined_modifiers(self):
+        model = ExpectationsModel()
+        exp = Expectation('Test',
+                          expected={FAIL},
+                          modifiers=ModifiersBase(skip=True, slow=-1.0))
+        model.add_expectation(exp)
+
+        result = model.get_expectation('Test')
+        self.assertTrue(result.skip)
+        self.assertTrue(result.slow)
+
+    def test_expectation_ordering(self):
+        exp_fail = Expectation('Test', expected={FAIL})
+        exp_fail_crash = Expectation('Test', expected={FAIL, CRASH})
+        self.assertTrue(exp_fail_crash > exp_fail)
+        self.assertTrue(exp_fail < exp_fail_crash)
+
+    def test_expectation_frozen(self):
+        exp = Expectation('Test', expected={FAIL})
+        with self.assertRaises(AttributeError):
+            exp.test_pattern = 'Other'
+
+    def test_expectation_hashable(self):
+        exp1 = Expectation('Test', expected={FAIL})
+        exp2 = Expectation('Test', expected={FAIL})
+        self.assertEqual(hash(exp1), hash(exp2))
+        self.assertEqual({exp1, exp2}, {exp1})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/parser_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/parser_unittest.py
@@ -1,0 +1,181 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for expectation parser."""
+
+import unittest
+
+from webkitexpectationspy.parser import ExpectationParser
+from webkitexpectationspy.expectations import ResultStatus
+from webkitexpectationspy.modifiers import ModifiersBase
+from webkitexpectationspy.suites.api_tests import APITestSuite
+
+
+PASS = ResultStatus.PASS
+FAIL = ResultStatus.FAIL
+CRASH = ResultStatus.CRASH
+TIMEOUT = ResultStatus.TIMEOUT
+
+
+class ExpectationParserTest(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = ExpectationParser()
+
+    def test_parse_simple_failure(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Fail ]')
+        self.assertEqual(len(results), 1)
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+        self.assertEqual(exp.test_pattern, 'TestWebKitAPI.WTF.Test')
+        self.assertIn(FAIL, exp.expected)
+
+    def test_parse_multiple_expectations(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Pass Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(PASS, exp.expected)
+        self.assertIn(FAIL, exp.expected)
+        self.assertTrue(exp.flaky)
+
+    def test_parse_with_webkit_bug(self):
+        results = self.parser.parse('test.txt', 'webkit.org/b/12345 TestWebKitAPI.WTF.Test [ Crash ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(exp.bug_ids, ('webkit.org/b/12345',))
+        self.assertIn(CRASH, exp.expected)
+
+    def test_parse_with_radar_bug(self):
+        results = self.parser.parse('test.txt', 'rdar://12345 TestWebKitAPI.WTF.Test [ Crash ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(exp.bug_ids, ('rdar://12345',))
+
+    def test_parse_with_radar_problem(self):
+        results = self.parser.parse('test.txt', 'rdar://problem/12345 TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertEqual(exp.bug_ids, ('rdar://problem/12345',))
+
+    def test_parse_skip(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Skip ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.skip)
+        self.assertTrue(exp.modifiers.skip)
+
+    def test_parse_slow(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.slow)
+        self.assertIsNotNone(exp.modifiers.slow)
+
+    def test_parse_slow_with_timeout(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Slow:120s ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.slow)
+        self.assertEqual(exp.modifiers.slow, 120.0)
+
+    def test_parse_configuration_debug(self):
+        results = self.parser.parse('test.txt', '[ Debug ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('debug', exp.configurations)
+
+    def test_parse_configuration_multiple(self):
+        results = self.parser.parse('test.txt', '[ mac arm64 ] TestWebKitAPI.WTF.Test [ Crash ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('mac', exp.configurations)
+        self.assertIn('arm64', exp.configurations)
+
+    def test_parse_wildcard(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.* [ Skip ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.test_pattern.endswith('*'))
+
+    def test_parse_comment_line(self):
+        results = self.parser.parse('test.txt', '# This is a comment')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertEqual(len(warnings), 0)
+
+    def test_parse_empty_line(self):
+        results = self.parser.parse('test.txt', '')
+        exp, warnings = results[0]
+        self.assertIsNone(exp)
+        self.assertEqual(len(warnings), 0)
+
+    def test_parse_skip_with_other_expectations(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Skip Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+        self.assertTrue(exp.skip)
+        self.assertIn(FAIL, exp.expected)
+
+    def test_parse_version_specifier(self):
+        parser = ExpectationParser()
+        results = parser.parse('test.txt', '[ mac Sonoma+ ] TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn('mac', exp.configurations)
+        self.assertEqual(len(exp.version_specifiers), 1)
+
+    def test_parse_no_expectations_defaults_to_pass(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIn(PASS, exp.expected)
+
+    def test_parse_combined_modifiers(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Skip Slow Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertTrue(exp.skip)
+        self.assertTrue(exp.slow)
+        self.assertIn(FAIL, exp.expected)
+
+    def test_case_insensitive_status_lookup(self):
+        self.assertEqual(ResultStatus.from_string('fail'), ResultStatus.FAIL)
+        self.assertEqual(ResultStatus.from_string('PASS'), ResultStatus.PASS)
+        self.assertEqual(ResultStatus.from_string('Crash'), ResultStatus.CRASH)
+
+
+class ExpectationParserWithSuiteTest(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = ExpectationParser(suite=APITestSuite())
+
+    def test_parse_with_suite(self):
+        results = self.parser.parse('test.txt', 'TestWebKitAPI.WTF.Test [ Fail ]')
+        exp, warnings = results[0]
+        self.assertEqual(len(warnings), 0)
+        self.assertIsNotNone(exp)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/resultsdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/resultsdb_unittest.py
@@ -1,0 +1,75 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for ResultsDB severity sorting."""
+
+import unittest
+
+from webkitexpectationspy.expectations import ResultStatus
+from webkitexpectationspy.resultsdb import (
+    ResultsDBStatus, sort_key, sorted_by_severity, to_resultsdb, from_resultsdb,
+)
+from webkitexpectationspy.suites.layout_tests import LayoutTestStatus
+
+
+class SortKeyTest(unittest.TestCase):
+    """sort_key returns the ResultsDB integer code so higher-level code
+    sorts by severity without reinventing an ordering."""
+
+    def test_sort_key_matches_resultsdb_codes(self):
+        self.assertEqual(sort_key(ResultStatus.CRASH), ResultsDBStatus.CRASH.value)
+        self.assertEqual(sort_key(ResultStatus.TIMEOUT), ResultsDBStatus.TIMEOUT.value)
+        self.assertEqual(sort_key(ResultStatus.PASS), ResultsDBStatus.PASS.value)
+        self.assertEqual(sort_key(ResultStatus.SKIP), ResultsDBStatus.SKIP.value)
+
+    def test_sorted_by_severity_puts_crash_first(self):
+        statuses = [ResultStatus.PASS, ResultStatus.CRASH, ResultStatus.FAIL, ResultStatus.TIMEOUT]
+        ordered = sorted_by_severity(statuses)
+        self.assertEqual(ordered[0], ResultStatus.CRASH)
+        self.assertEqual(ordered[1], ResultStatus.TIMEOUT)
+        self.assertEqual(ordered[-1], ResultStatus.PASS)
+
+    def test_combined_flag_uses_most_severe_member(self):
+        # A combined Flag value (e.g. PASS | FAIL) should sort by its most
+        # severe constituent — FAIL here.
+        combined = ResultStatus.PASS | ResultStatus.FAIL
+        self.assertEqual(sort_key(combined), ResultsDBStatus.FAIL.value)
+
+    def test_layout_test_statuses_sort_by_severity(self):
+        statuses = [
+            LayoutTestStatus.PASS,
+            LayoutTestStatus.CRASH,
+            LayoutTestStatus.IMAGE,
+            LayoutTestStatus.LEAK,
+        ]
+        ordered = sorted_by_severity(statuses)
+        self.assertEqual(ordered[0], LayoutTestStatus.CRASH)
+        self.assertEqual(ordered[-1], LayoutTestStatus.PASS)
+
+
+class ConversionRoundTripTest(unittest.TestCase):
+
+    def test_to_and_from_resultsdb_round_trip(self):
+        for status in (ResultStatus.PASS, ResultStatus.FAIL, ResultStatus.CRASH,
+                       ResultStatus.TIMEOUT, ResultStatus.SKIP):
+            code = to_resultsdb(status)
+            self.assertEqual(from_resultsdb(code, ResultStatus), status)

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/version_specifier_unittest.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/version_specifier_unittest.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for version specifier handling."""
+
+import unittest
+
+from webkitexpectationspy.version_specifier import VersionSpecifier
+
+
+class VersionSpecifierParseTest(unittest.TestCase):
+
+    def test_parse_exact_version_returns_none(self):
+        spec = VersionSpecifier.parse('Sonoma')
+        self.assertIsNone(spec)
+
+    def test_parse_and_later(self):
+        spec = VersionSpecifier.parse('Sonoma+')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, 'sonoma')
+        self.assertEqual(spec.type, VersionSpecifier.Type.AND_LATER)
+        self.assertIsNone(spec.end_version)
+
+    def test_parse_and_earlier(self):
+        spec = VersionSpecifier.parse('Ventura-')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, 'ventura')
+        self.assertEqual(spec.type, VersionSpecifier.Type.AND_EARLIER)
+
+    def test_parse_range(self):
+        spec = VersionSpecifier.parse('Ventura-Sequoia')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, 'ventura')
+        self.assertEqual(spec.end_version, 'sequoia')
+        self.assertEqual(spec.type, VersionSpecifier.Type.RANGE)
+
+    def test_parse_numeric_version_and_later(self):
+        spec = VersionSpecifier.parse('15.0+')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, '15.0')
+        self.assertEqual(spec.type, VersionSpecifier.Type.AND_LATER)
+
+    def test_parse_numeric_range(self):
+        spec = VersionSpecifier.parse('13.0-15.0')
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.base_version, '13.0')
+        self.assertEqual(spec.end_version, '15.0')
+        self.assertEqual(spec.type, VersionSpecifier.Type.RANGE)
+
+
+class VersionSpecifierMatchTest(unittest.TestCase):
+
+    def setUp(self):
+        self.version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+
+    def test_matches_exact(self):
+        spec = VersionSpecifier('sonoma', specifier_type=VersionSpecifier.Type.EXACT)
+        self.assertTrue(spec.matches('sonoma', self.version_order))
+        self.assertFalse(spec.matches('ventura', self.version_order))
+
+    def test_matches_and_later(self):
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_LATER)
+        self.assertFalse(spec.matches('monterey', self.version_order))
+        self.assertTrue(spec.matches('ventura', self.version_order))
+        self.assertTrue(spec.matches('sonoma', self.version_order))
+        self.assertTrue(spec.matches('sequoia', self.version_order))
+
+    def test_matches_and_earlier(self):
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_EARLIER)
+        self.assertTrue(spec.matches('monterey', self.version_order))
+        self.assertTrue(spec.matches('ventura', self.version_order))
+        self.assertFalse(spec.matches('sonoma', self.version_order))
+
+    def test_matches_range(self):
+        spec = VersionSpecifier('ventura', 'sonoma', VersionSpecifier.Type.RANGE)
+        self.assertFalse(spec.matches('monterey', self.version_order))
+        self.assertTrue(spec.matches('ventura', self.version_order))
+        self.assertTrue(spec.matches('sonoma', self.version_order))
+        self.assertFalse(spec.matches('sequoia', self.version_order))
+
+    def test_matches_unknown_version(self):
+        spec = VersionSpecifier('unknown', specifier_type=VersionSpecifier.Type.AND_LATER)
+        self.assertFalse(spec.matches('sonoma', self.version_order))
+
+    def test_matches_case_insensitive(self):
+        spec = VersionSpecifier('Sonoma', specifier_type=VersionSpecifier.Type.EXACT)
+        self.assertTrue(spec.matches('SONOMA', self.version_order))
+        self.assertTrue(spec.matches('sonoma', self.version_order))
+
+
+class VersionSpecifierNumericTest(unittest.TestCase):
+
+    def setUp(self):
+        self.version_order = ['monterey', 'ventura', 'sonoma', 'sequoia']
+        self.version_name_map = {
+            'monterey': (12,),
+            'ventura': (13,),
+            'sonoma': (14,),
+            'sequoia': (15,),
+        }
+
+    def test_numeric_exact(self):
+        spec = VersionSpecifier('sonoma', specifier_type=VersionSpecifier.Type.EXACT)
+        self.assertTrue(spec.matches('sonoma', self.version_order, self.version_name_map))
+        self.assertFalse(spec.matches('ventura', self.version_order, self.version_name_map))
+
+    def test_numeric_and_later(self):
+        spec = VersionSpecifier('ventura', specifier_type=VersionSpecifier.Type.AND_LATER)
+        self.assertFalse(spec.matches('monterey', self.version_order, self.version_name_map))
+        self.assertTrue(spec.matches('ventura', self.version_order, self.version_name_map))
+        self.assertTrue(spec.matches('sonoma', self.version_order, self.version_name_map))
+
+    def test_numeric_range(self):
+        spec = VersionSpecifier('ventura', 'sonoma', VersionSpecifier.Type.RANGE)
+        self.assertFalse(spec.matches('monterey', self.version_order, self.version_name_map))
+        self.assertTrue(spec.matches('ventura', self.version_order, self.version_name_map))
+        self.assertTrue(spec.matches('sonoma', self.version_order, self.version_name_map))
+        self.assertFalse(spec.matches('sequoia', self.version_order, self.version_name_map))
+
+    def test_raw_version_number_matching(self):
+        spec = VersionSpecifier('14.0', specifier_type=VersionSpecifier.Type.AND_LATER)
+        # '14.0' matches via raw number even though it's not in version_order
+        self.assertTrue(spec.matches('sonoma', ['monterey', 'ventura', 'sonoma'],
+                                     self.version_name_map))
+        self.assertFalse(spec.matches('monterey', ['monterey', 'ventura', 'sonoma'],
+                                      self.version_name_map))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/version_specifier.py
+++ b/Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/version_specifier.py
@@ -1,0 +1,168 @@
+# Copyright (C) 2024-2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Version specifier handling for test expectations.
+
+Supports both version names (e.g. "Sequoia") and version numbers (e.g. "15.0").
+When a version_name_map is provided, comparisons use version numbers for
+precision; otherwise falls back to position in version_order.
+"""
+
+import enum
+import re
+
+
+_VERSION_NUMBER_RE = re.compile(r'^\d+(\.\d+)*$')
+
+_MAX_VERSION_PARTS = 3
+
+
+def _normalize_version(version_tuple, parts=_MAX_VERSION_PARTS):
+    """Pad a version tuple to a fixed length for consistent comparison."""
+    return version_tuple + (0,) * (parts - len(version_tuple))
+
+
+class VersionSpecifier:
+    """Represents a version constraint with optional range/modifier.
+
+    Supports:
+        - EXACT: 'Sonoma' or '14.0' (this version only)
+        - AND_LATER: 'Sonoma+' or '14.0+' (this and later versions)
+        - AND_EARLIER: 'Sonoma-' or '14.0-' (this and earlier versions)
+        - RANGE: 'Ventura-Sequoia' or '13.0-15.0' (inclusive range)
+    """
+
+    class Type(enum.Enum):
+        EXACT = 'exact'
+        AND_LATER = 'and_later'
+        AND_EARLIER = 'and_earlier'
+        RANGE = 'range'
+
+    def __init__(self, base_version, end_version=None, specifier_type=None):
+        self.base_version = base_version.lower()
+        self.end_version = end_version.lower() if end_version else None
+        self.type = specifier_type or self.Type.EXACT
+        self._original = None
+
+    @classmethod
+    def parse(cls, token):
+        """Parse a version token into a VersionSpecifier.
+
+        Returns a VersionSpecifier instance, or None if the token is a plain
+        version name (which should be handled as EXACT by the caller).
+        """
+        if '-' in token and not token.endswith('-'):
+            parts = token.split('-', 1)
+            if len(parts) == 2:
+                spec = cls(parts[0], parts[1], cls.Type.RANGE)
+                spec._original = token
+                return spec
+        elif token.endswith('+'):
+            spec = cls(token[:-1], specifier_type=cls.Type.AND_LATER)
+            spec._original = token
+            return spec
+        elif token.endswith('-'):
+            spec = cls(token[:-1], specifier_type=cls.Type.AND_EARLIER)
+            spec._original = token
+            return spec
+        return None
+
+    def matches(self, current_version, version_order, version_name_map=None):
+        """Check if current_version satisfies this specifier.
+
+        Args:
+            current_version: The version string to check (will be lowercased).
+            version_order: List of version strings in order from oldest to newest.
+            version_name_map: Optional dict mapping version names to version
+                number tuples (e.g. {"sequoia": (15,), "sonoma": (14,)}).
+                When provided, enables numeric comparison for precision.
+
+        Returns:
+            True if the current version matches this specifier.
+        """
+        current_version = current_version.lower()
+
+        if version_name_map:
+            current_num = self._resolve_version_number(current_version, version_name_map)
+            base_num = self._resolve_version_number(self.base_version, version_name_map)
+            if current_num is not None and base_num is not None:
+                return self._matches_numeric(current_num, base_num, version_name_map)
+
+        # Fallback: position-based comparison
+        try:
+            current_idx = version_order.index(current_version)
+            base_idx = version_order.index(self.base_version)
+        except ValueError:
+            return False
+
+        if self.type == self.Type.EXACT:
+            return current_version == self.base_version
+        elif self.type == self.Type.AND_LATER:
+            return current_idx >= base_idx
+        elif self.type == self.Type.AND_EARLIER:
+            return current_idx <= base_idx
+        elif self.type == self.Type.RANGE:
+            try:
+                end_idx = version_order.index(self.end_version)
+            except ValueError:
+                return False
+            return base_idx <= current_idx <= end_idx
+        return False
+
+    def _resolve_version_number(self, version_str, version_name_map):
+        if version_str in version_name_map:
+            return version_name_map[version_str]
+        if _VERSION_NUMBER_RE.match(version_str):
+            return tuple(int(x) for x in version_str.split('.'))
+        return None
+
+    def _matches_numeric(self, current_num, base_num, version_name_map):
+        current_num = _normalize_version(current_num)
+        base_num = _normalize_version(base_num)
+        if self.type == self.Type.EXACT:
+            return current_num == base_num
+        elif self.type == self.Type.AND_LATER:
+            return current_num >= base_num
+        elif self.type == self.Type.AND_EARLIER:
+            return current_num <= base_num
+        elif self.type == self.Type.RANGE:
+            end_num = self._resolve_version_number(self.end_version, version_name_map) if self.end_version else None
+            if end_num is None:
+                return False
+            end_num = _normalize_version(end_num)
+            return base_num <= current_num <= end_num
+        return False
+
+    def __repr__(self):
+        if self._original:
+            return 'VersionSpecifier({!r})'.format(self._original)
+        return 'VersionSpecifier({!r}, type={})'.format(self.base_version, self.type.value)
+
+    def __eq__(self, other):
+        if not isinstance(other, VersionSpecifier):
+            return False
+        return (self.base_version == other.base_version and
+                self.end_version == other.end_version and
+                self.type == other.type)
+
+    def __hash__(self):
+        return hash((self.base_version, self.end_version, self.type))


### PR DESCRIPTION
#### 575bd26bf14f2880c4ec145dc952fc4f89766a82
<pre>
webkitexpectationspy: a package for test expectations that supports plugins for different test harnesses
<a href="https://rdar.apple.com/169210427">rdar://169210427</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306564">https://bugs.webkit.org/show_bug.cgi?id=306564</a>

Reviewed by Jonathan Bedard.

* Tools/Scripts/libraries/webkitexpectationspy/MANIFEST.in: Added.
* Tools/Scripts/libraries/webkitexpectationspy/README.md: Added.
* Tools/Scripts/libraries/webkitexpectationspy/run-tests: Added.
* Tools/Scripts/libraries/webkitexpectationspy/setup.py: Added.
(readme):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/__init__.py: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/configuration.py: Added.
(ConfigurationCategory):
(get_token_category):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/expectations.py: Added.
(Expectation):
Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/filesystem.py: Added.
(FilesystemProtocol):

* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/linter.py: Added.
(LintWarning):
(LintWarning.__init__):
(LintWarning.__str__):
(LintWarning.__repr__):
(LineFix):
(LineFix.__init__):
(ExpectationsLinter):
(ExpectationsLinter.__init__):
(ExpectationsLinter.lint):
(ExpectationsLinter.get_fixes):
(ExpectationsLinter.apply_fixes):
(ExpectationsLinter._parse_all_lines):
(ExpectationsLinter._check_category_ordering):
(ExpectationsLinter._check_alphabetical_ordering):
(ExpectationsLinter._check_combination_collapse):
(ExpectationsLinter._check_universal_skip):
(ExpectationsLinter._add_reorder_fix):
(ExpectationsLinter._add_reorder_fix.sort_key):
(ExpectationsLinter._add_collapse_fix):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/manager.py: Added.
(ExpectationsManager):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/mocks/__init__.py: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/model.py: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/parser.py: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/plugins/__init__.py: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/plugins/api_tests.py: Added.
(APITestPlugin):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/plugins/base.py: Added.
(FormatPlugin):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/plugins/layout_tests.py: Added.
(LayoutTestPlugin):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/py.typed: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/__init__.py: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/test_api_plugin.py: Added.
(APITestPluginTest):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/test_layout_plugin.py: Added.
(LayoutTestPluginTest):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/test_linter.py: Added.
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/test_manager.py: Added.
(MockFilesystem):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/test_model.py: Added.
(ExpectationsModelTest):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/test_parser.py: Added.
(ExpectationParserTest):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/tests/test_version_specifier.py: Added.
(VersionSpecifierParseTest):
* Tools/Scripts/libraries/webkitexpectationspy/webkitexpectationspy/version_specifier.py: Added.
(VersionSpecifier):

Canonical link: <a href="https://commits.webkit.org/312308@main">https://commits.webkit.org/312308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eaf1b37dc012e67c6dcf06ce4de7d2071790924

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/159501 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/32968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/26046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/113881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2a3c500-0a6a-40f2-af41-7f9beff9fc30) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/161370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33002 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/32921 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/168339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/113881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2ee3c30-57e6-4b1f-9ad6-f64a265a1bb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/162458 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/25842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/143269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/168339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3eba083-da66-407d-947a-fa6b1d2b90b0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/158821 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/24895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/23350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16109 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/134586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/21041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/22672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/170830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/32623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/27426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/170830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35671 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/32575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/142834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/90714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/32575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/19648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/32141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/31600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/31872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/31789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->