### PR TITLE
Import WPT pageswap tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8216,3 +8216,7 @@ imported/w3c/web-platform-tests/editing/other/insertparagraph-in-child-of-html.t
 imported/w3c/web-platform-tests/editing/other/insertparagraph-in-child-of-html.tentative.html?designMode=on&white-space=pre-wrap [ Pass Failure ]
 
 webkit.org/b/288546 imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed.html [ Pass Failure ]
+
+# Tests that timed out
+imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-from-click.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-hidden-document.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: history
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on navigation from script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML>
+<title>Tests pageswap for cross-origin navigations</title>
+<link rel="author" title="Khushal Sagar"  href="mailto:khushalsagar@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+const expectedUrl = get_host_info().HTTPS_REMOTE_ORIGIN + "/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html?new";
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href + "?new";
+  const expectedEvents = ["pageswap", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on navigation from script`);
+} else if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.href = expectedUrl;
+    }));
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.activation != null)
+        window.opener.events.push("activation");
+      if (e.viewTransition != null)
+        window.opener.events.push("transition");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+      channel.postMessage("nav");
+    };
+  };
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Tests pageswap dispatch on iframe Documents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-iframe.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<title>Tests pageswap dispatch on iframe Documents</title>
+<link rel="author" title="Khushal Sagar"  href="mailto:khushalsagar@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+setup({explicit_done: true});
+
+function runTest(frame) {
+  let frameWindow = frame.contentWindow;
+
+  let pageswapfired = false;
+  let expectedUrl = frameWindow.location.href + '?new';
+  frameWindow.onpageswap = (e) => {
+      assert_equals(e.activation.entry.url, expectedUrl, 'activation url incorrect in pageswap');
+      assert_equals(e.activation.navigationType, "push", 'navigation type incorrect in pageswap');
+      assert_equals(e.activation.from, frameWindow.navigation.currentEntry, 'from entry incorrect in pageswap');
+      assert_false(e.activation.entry.sameDocument, 'new entry must be cross-document');
+      pageswapfired = true;
+  }
+
+  frameWindow.onpagehide = (e) => {
+      assert_true(pageswapfired, 'pageswap not fired');
+      done();
+  }
+
+  frame.src = expectedUrl;
+}
+
+promise_test(async t => {
+  onload = () => {
+    let frame = document.createElement('iframe');
+    frame.src = "/resources/blank.html";
+    frame.onload = () => {
+      frame.contentWindow.requestAnimationFrame(() => {
+        runTest(frame);
+      });
+    }
+    document.body.appendChild(frame);
+  };
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-initial-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-initial-navigation-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Tests pageswap dispatch on initial doc navigation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-initial-navigation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-initial-navigation.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<title>Tests pageswap dispatch on initial doc navigation</title>
+<link rel="author" title="Khushal Sagar"  href="mailto:khushalsagar@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+setup({explicit_done: true});
+
+function runTest(frame) {
+  let frameWindow = frame.contentWindow;
+
+  let pageswapfired = false;
+  frameWindow.onpageswap = (e) => {
+      pageswapfired = true;
+  }
+
+  frameWindow.onpagehide = (e) => {
+      assert_true(pageswapfired, 'pageswap fired');
+      done();
+  }
+
+  frame.srcdoc = '<html></html>';
+}
+
+promise_test(async t => {
+  onload = () => {
+    let frame = document.createElement('iframe');
+    document.body.appendChild(frame);
+    runTest(frame);
+  };
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-from-click.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-from-click.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for push navigations from user click</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+const expectedUrl = location.href + '?new';
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href + "?new";
+  const expectedEvents = ["pageswap", expectedUrl, "push","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      document.getElementById('nav_link').remove();
+      window.events = [];
+      popup = window.open("?popup");
+
+      popup.addEventListener("load", () => {
+        popup.requestAnimationFrame(
+          () => popup.requestAnimationFrame(() => {
+            let nav_link = popup.document.getElementById('nav_link');
+            test_driver
+                .click(nav_link)
+                .catch(() => assert_unreached("click failed"));
+          }));
+      });
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on navigation from user click`);
+} else if (is_popup_page) {
+  onpageswap = (e) => {
+    window.opener.events.push("pageswap");
+    if (e.viewTransition != null)
+      window.opener.events.push("transition");
+    window.opener.events.push(e.activation.entry.url);
+    window.opener.events.push(e.activation.navigationType);
+    if (e.activation.from == navigation.currentEntry)
+      window.opener.events.push("from");
+  };
+
+  onpagehide = () => {
+    window.opener.events.push("pagehide");
+    channel.postMessage("nav");
+  };
+}
+</script>
+<body>
+  <a id="nav_link" href='/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-from-click.html?new'>Click me</a>
+ </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on navigation from script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-hidden-document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-hidden-document.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<title>Tests pageswap dispatch on hidden Documents</title>
+<link rel="author" title="Khushal Sagar"  href="mailto:khushalsagar@chromium.org">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script>
+const expectedUrl = location.href + '?new';
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href + "?new";
+  const expectedEvents = ["pageswap", expectedUrl, "push","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = async () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on navigation from script`);
+} else if (is_popup_page) {
+    onload = async () => {
+      await test_driver.minimize_window();
+      assert_equals(document.visibilityState, "hidden");
+      assert_equals(document.hidden, true);
+
+      location.href = location.href.split('?')[0] + '?new';
+    };
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.viewTransition != null)
+      window.opener.events.push("transition");
+      window.opener.events.push(e.activation.entry.url);
+      window.opener.events.push(e.activation.navigationType);
+      if (e.activation.from == navigation.currentEntry)
+        window.opener.events.push("from");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+      channel.postMessage("nav");
+    };
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for push navigations</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const expectedUrl = location.href + '?new';
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href + "?new";
+  const expectedEvents = ["pageswap", expectedUrl, "push","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on navigation from script`);
+} else if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.href = location.href.split('?')[0] + '?new';
+    }));
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.viewTransition != null)
+      window.opener.events.push("transition");
+      window.opener.events.push(e.activation.entry.url);
+      window.opener.events.push(e.activation.navigationType);
+      if (e.activation.from == navigation.currentEntry)
+        window.opener.events.push("from");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+      channel.postMessage("nav");
+    };
+  };
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on navigation with same-origin redirect
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for push navigations with a  same-origin final url with cross-origin redirects</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href + "?new";
+  const expectedEvents = ["pageswap", "pagehide", "pagereveal", "activation"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on navigation with same-origin redirect`);
+} else if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      let newUrl = get_host_info().HTTPS_REMOTE_ORIGIN + "/common/redirect.py?location=" + location.href.split('?')[0] + "?new";
+      location.href = newUrl
+    }));
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.viewTransition != null)
+        window.opener.events.push("transition");
+      if (e.activation != null)
+        window.opener.events.push("activation");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+    };
+  };
+} else {
+  assert_true(is_new_page);
+  onpageshow = () => {
+    window.opener.events.push("pagereveal");
+    if (navigation.activation.from != null)
+      window.opener.events.push("activation");
+    channel.postMessage("nav");
+  }
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on navigation with same-origin redirect
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for push navigations with a same-origin redirect</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const expectedUrl = location.href + '?new';
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href + "?new";
+  const expectedEvents = ["pageswap", expectedUrl, "push","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on navigation with same-origin redirect`);
+} else if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.href = "/common/redirect.py?location=/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect.html?new";
+    }));
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.viewTransition != null)
+      window.opener.events.push("transition");
+      window.opener.events.push(e.activation.entry.url);
+      window.opener.events.push(e.activation.navigationType);
+      if (e.activation.from == navigation.currentEntry)
+        window.opener.events.push("from");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+      channel.postMessage("nav");
+    };
+  };
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-reload-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-reload-navigation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on replace navigation from script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-reload-navigation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-reload-navigation.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for replace navigations</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const expectedUrl = location.href + '?new';
+
+const params = new URLSearchParams(location.search);
+// The initial page in the popup.
+const is_popup_page = params.has('popup') && !window.opener.didreload;
+// The test page itself.
+const is_test_page = !params.has('popup');
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href.split('?')[0] + "?popup";
+  const expectedEvents = ["pageswap", "entry", "reload","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      window.didreload = false;
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on replace navigation from script`);
+} else if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      window.opener.didreload = true;
+      location.reload();
+    }));
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.viewTransition != null)
+        window.opener.events.push("transition");
+      if (e.activation.entry == navigation.currentEntry)
+        window.opener.events.push("entry");
+      window.opener.events.push(e.activation.navigationType);
+      if (e.activation.from == navigation.currentEntry)
+        window.opener.events.push("from");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+      channel.postMessage("nav");
+    };
+  };
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-navigation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-navigation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on replace navigation from script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-navigation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-navigation.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for replace navigations</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const expectedUrl = location.href + '?new';
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href.split('?')[0] + "?new";
+  const expectedEvents = ["pageswap", expectedUrl, "replace","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on replace navigation from script`);
+} else if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.replace(location.href.split('?')[0] + '?new');
+    }));
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.viewTransition != null)
+        window.opener.events.push("transition");
+      window.opener.events.push(e.activation.entry.url);
+      window.opener.events.push(e.activation.navigationType);
+      if (e.activation.from == navigation.currentEntry)
+        window.opener.events.push("from");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+      channel.postMessage("nav");
+    };
+  };
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on navigation with same-origin redirect
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for replace navigations with a  same-origin final url with cross-origin redirects</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+const channel = new BroadcastChannel("testchannel");
+
+if (is_test_page) {
+  const expectedUrl = location.href + "?new";
+  const expectedEvents = ["pageswap", "pagehide", "pagereveal", "activation"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on navigation with same-origin redirect`);
+} else if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      let newUrl = get_host_info().HTTPS_REMOTE_ORIGIN + "/common/redirect.py?location=" + location.href.split('?')[0] + "?new";
+      location.replace(newUrl);
+    }));
+
+    onpageswap = (e) => {
+      window.opener.events.push("pageswap");
+      if (e.viewTransition != null)
+        window.opener.events.push("transition");
+      if (e.activation != null)
+        window.opener.events.push("activation");
+    };
+
+    onpagehide = () => {
+      window.opener.events.push("pagehide");
+    };
+  };
+} else {
+  assert_true(is_new_page);
+  onpageshow = () => {
+    window.opener.events.push("pagereveal");
+    if (navigation.activation.from != null)
+      window.opener.events.push("activation");
+    channel.postMessage("nav");
+  }
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on traverse navigation from script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for traverse navigation when original navigation has cross-origin redirect</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/common.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/html/browsers/browsing-the-web/back-forward-cache/resources/disable_bfcache.js"></script>
+<style></style>
+<script>
+const channel = new BroadcastChannel("testchannel");
+
+const params = new URLSearchParams(location.search);
+const is_initial_page_first_navigation = params.has('popup') && navigation.entries().length == 1;
+const is_new_page = params.has('new');
+const is_test_page = !params.has('popup') && !params.has('new');
+
+// The test page which opens a popup for the navigation sequence.
+if (is_test_page) {
+  const expectedUrl = location.href.split('?')[0] + "?popup";
+  const expectedEvents = ["pageswap", expectedUrl, "traverse","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on traverse navigation from script`);
+} else if (is_initial_page_first_navigation) {
+  // The popup page which the user navigates back to.
+  onload = async () => {
+    await disableBFCache();
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      let newUrl = get_host_info().HTTPS_REMOTE_ORIGIN + "/common/redirect.py?location=" + location.href.split('?')[0] + "?new";
+      location.href = newUrl
+    }));
+  };
+
+  onpageshow = (e) => {
+    assert_false(e.persisted, 'the test should run without BFCache');
+  }
+} else if (is_new_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      navigation.back();
+    }));
+  };
+
+  onpageswap = (e) => {
+    window.opener.events.push("pageswap");
+    if (e.viewTransition != null)
+      window.opener.events.push("transition");
+    window.opener.events.push(e.activation.entry.url);
+    window.opener.events.push(e.activation.navigationType);
+    if (e.activation.from == navigation.currentEntry)
+      window.opener.events.push("from");
+  };
+
+  onpagehide = () => {
+    window.opener.events.push("pagehide");
+    channel.postMessage("nav");
+  };
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS pageswap on traverse navigation from script
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<title>pageswap navigationactivation for traverse navigations</title>
+<link rel="help" href="https://html.spec.whatwg.org/">
+<link rel="author" href="mailto:khushalsagar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/common.js"></script>
+<script src="/html/browsers/browsing-the-web/back-forward-cache/resources/disable_bfcache.js"></script>
+<style></style>
+<script>
+const channel = new BroadcastChannel("testchannel");
+
+const params = new URLSearchParams(location.search);
+const is_initial_page_first_navigation = params.has('popup') && navigation.entries().length == 1;
+const is_new_page = params.has('new');
+const is_test_page = !params.has('popup') && !params.has('new');
+
+// The test page which opens a popup for the navigation sequence.
+if (is_test_page) {
+  const expectedUrl = location.href.split('?')[0] + "?popup";
+  const expectedEvents = ["pageswap", expectedUrl, "traverse","from", "pagehide"];
+
+  promise_test(async t => {
+    let popup;
+    onload = () => {
+      window.events = [];
+      popup = window.open("?popup");
+    };
+
+    await new Promise(resolve => {
+      channel.addEventListener(
+        "message", t.step_func(async (e) => {
+          if (e.data === "nav") {
+            assert_array_equals(window.events, expectedEvents, 'incorrect event order');
+            popup.close();
+            resolve();
+          }
+      }));
+    });
+  }, `pageswap on traverse navigation from script`);
+} else if (is_initial_page_first_navigation) {
+  // The popup page which the user navigates back to.
+  onload = async () => {
+    await disableBFCache();
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.href = location.href.split('?')[0] + '?new';
+    }));
+  };
+
+  onpageshow = (e) => {
+    assert_false(e.persisted, 'the test should run without BFCache');
+  }
+} else if (is_new_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      navigation.back();
+    }));
+  };
+
+  onpageswap = (e) => {
+    window.opener.events.push("pageswap");
+    if (e.viewTransition != null)
+      window.opener.events.push("transition");
+    window.opener.events.push(e.activation.entry.url);
+    window.opener.events.push(e.activation.navigationType);
+    if (e.activation.from == navigation.currentEntry)
+      window.opener.events.push("from");
+  };
+
+  onpagehide = () => {
+    window.opener.events.push("pagehide");
+    channel.postMessage("nav");
+  };
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/w3c-import.log
@@ -1,0 +1,30 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-iframe.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-initial-navigation.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-from-click.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-hidden-document.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-reload-navigation.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-navigation.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https.html


### PR DESCRIPTION
#### d356bf2ccae98a8a53cbfba6e15e09ff70e281c6
<pre>
Import WPT pageswap tests
<a href="https://rdar.apple.com/169212557">rdar://169212557</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306567">https://bugs.webkit.org/show_bug.cgi?id=306567</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/79761834319b154a4da6a3c37df054bd82975493">https://github.com/web-platform-tests/wpt/commit/79761834319b154a4da6a3c37df054bd82975493</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-initial-navigation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-initial-navigation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-from-click.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-hidden-document.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-redirect.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-reload-navigation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-reload-navigation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-navigation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-navigation.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/w3c-import.log: Added.

Canonical link: <a href="https://commits.webkit.org/306551@main">https://commits.webkit.org/306551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81e21008b682cd547b1d11d866958a9a72992990

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150235 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d550a00a-ca8d-4b98-b4ef-65247b81e1a6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108857 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c77ae58-ccfa-44af-b020-1693bfc06411) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144612 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89757 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1447539-d995-4ea9-8982-2aa74a6d9cd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10952 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8590 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/308 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152628 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116955 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117280 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29882 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13313 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123502 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13776 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2783 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13515 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13562 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->