### PR TITLE
[Form Controls][iOS] Form controls in cross-origin subframes have incorrect interaction rects

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -48,6 +48,7 @@
 @property (nonatomic, readonly) CGRect _dragCaretRect;
 @property (nonatomic, readonly, getter=_isAnimatingDragCancel) BOOL _animatingDragCancel;
 @property (nonatomic, readonly) CGRect _tapHighlightViewRect;
+@property (nonatomic, readonly) CGRect _focusedElementInteractionRect;
 @property (nonatomic, readonly) UIGestureRecognizer *_imageAnalysisGestureRecognizer;
 @property (nonatomic, readonly) UITapGestureRecognizer *_singleTapGestureRecognizer;
 @property (nonatomic, readonly, getter=_isKeyboardScrollingAnimationRunning) BOOL _keyboardScrollingAnimationRunning;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -438,6 +438,11 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
     return [_contentView tapHighlightViewRect];
 }
 
+- (CGRect)_focusedElementInteractionRect
+{
+    return [_contentView focusedElementInformation].interactionRect;
+}
+
 - (UIGestureRecognizer *)_imageAnalysisGestureRecognizer
 {
     return [_contentView imageAnalysisGestureRecognizer];

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3371,6 +3371,7 @@ private:
 
     void elementDidFocus(IPC::Connection&, const FocusedElementInformation&, bool userIsInteracting, bool blurPreviousNode, OptionSet<WebCore::ActivityState> activityStateChanges, const UserData&);
     void elementDidBlur();
+    void convertFocusedElementInformationRectsToMainFrameCoordinates(FocusedElementInformation, CompletionHandler<void(FocusedElementInformation)>&&);
     void updateInputContextAfterBlurringAndRefocusingElement();
     void didProgrammaticallyClearFocusedElement(WebCore::ElementContext&&);
     void updateFocusedElementInformation(const FocusedElementInformation&);

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -67,6 +67,7 @@
 #import "WebAuthenticatorCoordinatorProxy.h"
 #import "WebAutocorrectionContext.h"
 #import "WebAutocorrectionData.h"
+#import "WebFrameProxy.h"
 #import "WebPage.h"
 #import "WebPageMessages.h"
 #import "WebPageProxyInternals.h"
@@ -929,7 +930,20 @@ void WebPageProxy::elementDidFocus(IPC::Connection& connection, const FocusedEle
         return;
 
     RefPtr userDataObject = WebProcessProxy::fromConnection(connection)->transformHandlesToObjects(protect(userData.object())).get();
-    pageClient->elementDidFocus(information, userIsInteracting, blurPreviousNode, activityStateChanges, userDataObject.get());
+
+    convertFocusedElementInformationRectsToMainFrameCoordinates(information,
+        [weakThis = WeakPtr { *this }, userIsInteracting, blurPreviousNode, activityStateChanges, userDataObject = WTF::move(userDataObject)] (FocusedElementInformation convertedInfo) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            RefPtr pageClient = protectedThis->pageClient();
+            if (!pageClient)
+                return;
+
+            pageClient->elementDidFocus(convertedInfo, userIsInteracting,
+                blurPreviousNode, activityStateChanges, userDataObject.get());
+        });
 }
 
 void WebPageProxy::elementDidBlur()
@@ -941,8 +955,48 @@ void WebPageProxy::elementDidBlur()
 
 void WebPageProxy::updateFocusedElementInformation(const FocusedElementInformation& information)
 {
-    if (RefPtr pageClient = this->pageClient())
-        pageClient->updateFocusedElementInformation(information);
+    convertFocusedElementInformationRectsToMainFrameCoordinates(information,
+        [weakThis = WeakPtr { *this }](FocusedElementInformation convertedInfo) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            if (RefPtr pageClient = protectedThis->pageClient())
+                pageClient->updateFocusedElementInformation(convertedInfo);
+        });
+}
+
+void WebPageProxy::convertFocusedElementInformationRectsToMainFrameCoordinates(FocusedElementInformation information, CompletionHandler<void(FocusedElementInformation)>&& completionHandler)
+{
+    if (!information.frame || information.frame->isMainFrame) {
+        completionHandler(WTF::move(information));
+        return;
+    }
+
+    RefPtr frame = WebFrameProxy::webFrame(information.frame->frameID);
+    if (!frame) {
+        completionHandler(WTF::move(information));
+        return;
+    }
+
+    Vector<FloatRect> rects;
+    rects.append(information.interactionRect);
+    if (information.hasNextNode)
+        rects.append(information.nextNodeRect);
+    if (information.hasPreviousNode)
+        rects.append(information.previousNodeRect);
+
+    convertRectsToMainFrameCoordinates(WTF::move(rects), frame->rootFrame()->frameID(), [information = WTF::move(information), completionHandler = WTF::move(completionHandler)](std::optional<Vector<FloatRect>> convertedRects) mutable {
+        if (convertedRects) {
+            size_t index = 0;
+            information.interactionRect = IntRect(convertedRects->at(index++));
+            if (information.hasNextNode)
+                information.nextNodeRect = IntRect(convertedRects->at(index++));
+            if (information.hasPreviousNode)
+                information.previousNodeRect = IntRect(convertedRects->at(index++));
+        }
+        completionHandler(WTF::move(information));
+    });
 }
 
 void WebPageProxy::focusedElementDidChangeInputMode(WebCore::InputMode mode)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -24,20 +24,22 @@
  */
 
 #import "config.h"
+#import "FrameTreeChecks.h"
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Utilities.h"
 #import "Helpers/cocoa/DragAndDropSimulator.h"
 #import "Helpers/cocoa/FindInPageUtilities.h"
-#import "FrameTreeChecks.h"
 #import "Helpers/cocoa/HTTPServer.h"
-#import "Helpers/PlatformUtilities.h"
 #import "Helpers/cocoa/TestCocoa.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestScriptMessageHandler.h"
 #import "Helpers/cocoa/TestUIDelegate.h"
-#import "TestURLSchemeHandler.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "Helpers/cocoa/UserMediaCaptureUIDelegate.h"
-#import "Helpers/Utilities.h"
 #import "Helpers/cocoa/WKWebViewConfigurationExtras.h"
+#import "InstanceMethodSwizzler.h"
+#import "TestInputDelegate.h"
+#import "TestURLSchemeHandler.h"
 #import "WKWebViewFindStringFindDelegate.h"
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebCore/SQLiteDatabase.h>
@@ -68,15 +70,15 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/text/MakeString.h>
 
+#if PLATFORM(IOS_FAMILY)
+#import "UIKitSPIForTesting.h"
+#import <MobileCoreServices/MobileCoreServices.h>
+#endif
+
 #if ENABLE(IMAGE_ANALYSIS)
 #import "Helpers/cocoa/ImageAnalysisTestingUtilities.h"
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>
 #import <pal/cocoa/VisionKitCoreSoftLink.h>
-#endif
-
-#if PLATFORM(IOS_FAMILY)
-#import "UIKitSPIForTesting.h"
-#import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
 @interface WKWebView ()
@@ -7710,6 +7712,53 @@ TEST(SiteIsolation, ColorInputPickerLocation)
 }
 
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+
+TEST(SiteIsolation, SelectMultiplePickerLocationInCrossOriginIframe)
+{
+    HTTPServer server({
+        { "/mainframe"_s, { "<body style='margin: 0'><iframe style='margin: 100px; width: 400px; height: 300px; border: none;' src='https://webkit.org/iframe'></iframe></body>"_s } },
+        { "/iframe"_s, { "<!DOCTYPE html><body style='margin: 0'><select multiple style='margin: 50px; width: 100px; height: 50px; appearance: none; border: none; padding: 0;'><option>A</option><option>B</option></select></body>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    __block bool pickerPresented = false;
+
+    InstanceMethodSwizzler swizzler {
+        UIViewController.class,
+        @selector(presentViewController:animated:completion:),
+        imp_implementationWithBlock(^(UIViewController *, UIViewController *, BOOL, id) {
+            pickerPresented = true;
+        })
+    };
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+
+    RetainPtr hostViewController = adoptNS([[UIViewController alloc] init]);
+    [[webView window] setRootViewController:hostViewController.get()];
+    [[hostViewController view] addSubview:webView.get()];
+
+    RetainPtr inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
+    [inputDelegate setFocusStartsInputSessionPolicyHandler:[](WKWebView *, id<_WKFocusedElementInfo>) {
+        return _WKFocusStartsInputSessionPolicyAllow;
+    }];
+    [webView _setInputDelegate:inputDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/mainframe"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView waitForNextPresentationUpdate];
+
+    [webView evaluateJavaScript:@"document.querySelector('select').focus()" inFrame:[webView firstChildFrame] completionHandler:nil];
+
+    Util::run(&pickerPresented);
+
+    // The select element is at (50, 50) in iframe coordinates with size (100, 50).
+    // The iframe is at (100, 100) in main frame coordinates (margin: 100px, border: none).
+    // After conversion, the focused element's interaction rect should be (150, 150, 100, 50) in main frame coordinates.
+    EXPECT_EQ([webView _focusedElementInteractionRect], CGRectMake(150, 150, 100, 50));
+}
+
+#endif // PLATFORM(IOS_FAMILY)
 
 #if ENABLE(IMAGE_ANALYSIS)
 


### PR DESCRIPTION
#### 4597139ad795447d6414c328e01fcea59df9de37
<pre>
[Form Controls][iOS] Form controls in cross-origin subframes have incorrect interaction rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=306569">https://bugs.webkit.org/show_bug.cgi?id=306569</a>
<a href="https://rdar.apple.com/168716669">rdar://168716669</a>

Reviewed by Aditya Keerthi.

When a form control is focused inside a site-isolated cross-origin iframe, the
FocusedElementInformation struct sent from the WebProcess contains coordinates
relative to that subframe&apos;s viewport. On iOS, the UIProcess expects these
coordinates to be relative to the main frame, causing native UI overlays (such as
the form accessory bar, selection handles, and picker positioning) to appear in
the wrong location.

This affects all iOS form controls that rely on FocusedElementInformation for
positioning, including:
- &lt;select&gt; element dropdown pickers
- &lt;input type=&quot;color&quot;&gt; native color picker
- &lt;input type=&quot;date/time/month/week/datetime-local&quot;&gt; date and time pickers
- &lt;input type=&quot;text/email/url/tel/search/number/password&quot;&gt; keyboard accessory
  bar and input positioning
- &lt;textarea&gt; keyboard accessory bar and input positioning
- Form navigation (next/previous element) positioning

This patch introduces convertFocusedElementInformationRectsToMainFrameCoordinates
in WebPageProxy. This helper asynchronously converts the interactionRect,
nextNodeRect, and previousNodeRect from the focused frame&apos;s coordinate space to
the main frame&apos;s coordinate space using the existing geometry mapping logic in
WebFrameProxy.

We now wait for this conversion to complete before calling
pageClient-&gt;elementDidFocus or pageClient-&gt;updateFocusedElementInformation.

* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _focusedElementInteractionRect]):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::elementDidFocus):
(WebKit::WebPageProxy::updateFocusedElementInformation):
(WebKit::WebPageProxy::convertFocusedElementInformationRectsToMainFrameCoordinates):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, SelectMultiplePickerLocationInCrossOriginIframe)):

Canonical link: <a href="https://commits.webkit.org/311229@main">https://commits.webkit.org/311229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6af5e74562a03ab340550cf6812152dc33f886f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156261 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165082 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158132 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121005 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101676 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22287 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20456 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12854 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167561 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11677 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129131 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129244 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35032 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86886 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24066 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16746 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92785 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28355 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28583 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->