### PR TITLE
Rebaseline resource-timing/font-timestamps.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1273,7 +1273,6 @@ imported/w3c/web-platform-tests/eventsource/dedicated-worker/eventsource-constru
 imported/w3c/web-platform-tests/mediacapture-fromelement/capture.html [ Failure ]
 imported/w3c/web-platform-tests/mediacapture-fromelement/ended.html [ Failure ]
 imported/w3c/web-platform-tests/mediacapture-fromelement/creation.html [ Pass Failure ]
-imported/w3c/web-platform-tests/resource-timing/font-timestamps.html [ Failure ]
 imported/w3c/web-platform-tests/resource-timing/cross-origin-start-end-time-with-redirects.html [ Pass Failure ]
 imported/w3c/web-platform-tests/resource-timing/resource_timing_content_length.html [ Skip ]
 imported/w3c/web-platform-tests/resource-timing/SO-XO-SO-redirect-chain-tao.https.html [ Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/resource-timing/font-timestamps-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resource-timing/font-timestamps-expected.txt
@@ -1,5 +1,5 @@
 This fetches ahem font.
 
-FAIL Test a font's timestamps assert_greater_than_equal: domainLookupStart should be more than 0 in same-origin redirect. expected a number greater than or equal to <nondeterministic test output> but got 0
+PASS Test a font's timestamps
 PASS Test a font's timestamps with delays
 


### PR DESCRIPTION
#### 81a77e6273f8c9a70fee4ce2eeaa6829ef10393d
<pre>
Rebaseline resource-timing/font-timestamps.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=306579">https://bugs.webkit.org/show_bug.cgi?id=306579</a>
<a href="https://rdar.apple.com/169222493">rdar://169222493</a>

Reviewed by NOBODY (OOPS!).

I removed the test failure expectation and rebaselined the test.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/resource-timing/font-timestamps-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81a77e6273f8c9a70fee4ce2eeaa6829ef10393d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94533 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9bb8e6a9-030e-40d4-b48b-a74dbe49a00c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108664 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78641 "13 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/deb23962-8fcc-4ec5-a1bb-79d05a93f3f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3d3978b-838a-4a83-8e1f-06b6c1a21255) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10779 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8399 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/84 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152405 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13510 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2993 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116770 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13525 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11789 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117100 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13141 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123223 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68707 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13552 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2551 "Exiting early after 10 failures. 10 tests run. 1 flakes") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13288 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13335 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->