### PR TITLE
[MacOS]accessibility/password-notifications-timing.html is a flaky text failure.

### DIFF
--- a/LayoutTests/accessibility/password-notifications-timing-expected.txt
+++ b/LayoutTests/accessibility/password-notifications-timing-expected.txt
@@ -1,9 +1,9 @@
 This test ensures that password notifications are spaced out in time in no less than a prefixed interval.
 
 Field value length: 9
-PASS: elapsed >= interval === true
-PASS: elapsed >= interval === true
-PASS: elapsed >= interval === true
+PASS: elapsed >= interval - tolerance === true
+PASS: elapsed >= interval - tolerance === true
+PASS: elapsed >= interval - tolerance === true
 Field value length: 12
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/password-notifications-timing.html
+++ b/LayoutTests/accessibility/password-notifications-timing.html
@@ -15,6 +15,7 @@ var output = "This test ensures that password notifications are spaced out in ti
 var notificationsCount = 0;
 var lastNotificationTime = Date.now();
 var interval = 25; // Notifications shouldn't come in less than 25 milliseconds.
+var tolerance = 10; // Allow 10ms tolerance for timer precision and Date.now() rounding.
 function notificationCallback(notification) {
     if (notification != "AXValueChanged")
         return;
@@ -22,7 +23,7 @@ function notificationCallback(notification) {
     now = Date.now();
     elapsed = now - lastNotificationTime;
     lastNotificationTime = now;
-    output += expect("elapsed >= interval", "true");
+    output += expect("elapsed >= interval - tolerance", "true");
 
     ++notificationsCount;
 }


### PR DESCRIPTION
#### 9374ab2737cb2841b855dedcf2d73dcdfd1377d7
<pre>
[MacOS]accessibility/password-notifications-timing.html is a flaky text failure.
<a href="https://rdar.apple.com/169218506">rdar://169218506</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306573">https://bugs.webkit.org/show_bug.cgi?id=306573</a>

Reviewed by Tyler Wilcock and Jonathan Bedard.

Flaky failure appears to be caused by timing issue within test, resolved with the following:

    - Added a 10ms tolerance to account for timer precision and Date.now() rounding during high CPU usage.
    - Changed the assertion from elapsed &gt;= interval (strict 25ms) to elapsed &gt;= interval - tolerance
    - Updated the expected output file to match the new assertion format

* LayoutTests/accessibility/password-notifications-timing-expected.txt:
* LayoutTests/accessibility/password-notifications-timing.html:

Canonical link: <a href="https://commits.webkit.org/307120@main">https://commits.webkit.org/307120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9622a76818a0a6b97a7e35d2efa869d2fdb9396e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94535 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108665 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78642 "1 flakes 6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8400 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/86 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152407 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13512 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/2992 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117101 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30412 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13142 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68709 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13554 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2550 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->