### PR TITLE
[JSC] YarrJIT should support fixed-count subpatterns with capture

### DIFF
--- a/JSTests/stress/regexp-fixed-count-parentheses-unroll.js
+++ b/JSTests/stress/regexp-fixed-count-parentheses-unroll.js
@@ -143,5 +143,3 @@ function shouldBeFalse(value, message) {
     shouldBeTrue(re.test("x"), "{1,5} should match 1");
     shouldBeTrue(re.test("xxxxx"), "{1,5} should match 5");
 })();
-
-print("All tests passed!");

--- a/JSTests/stress/regexp-fixedcount-backtrack-alternatives.js
+++ b/JSTests/stress/regexp-fixedcount-backtrack-alternatives.js
@@ -1,0 +1,57 @@
+//@ runDefault
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// Test cases that force backtracking between alternatives in FixedCount.
+// The key is that the first alternative must fail AFTER matching, forcing
+// a retry with the second alternative.
+
+// Pattern: (?:aa|a){2}b
+// Input: "aab"
+// Naive matching: "aa" for first iteration, then we're at position 2, need another iteration
+//   but only "b" left, can't match "aa" or "a" -> FAIL
+// Correct matching with backtracking: "a" for first iteration (position 1),
+//   "a" for second iteration (position 2), then "b" matches -> SUCCESS
+(function() {
+    var re = /(?:aa|a){2}b/;
+    var result = re.exec("aab");
+    shouldBe(result, ["aab"], "(?:aa|a){2}b on 'aab'");
+})();
+
+// Similar test with 3 alternatives
+(function() {
+    var re = /(?:aaa|aa|a){3}b/;
+    var result = re.exec("aaab");
+    shouldBe(result, ["aaab"], "(?:aaa|aa|a){3}b on 'aaab'");
+})();
+
+// Test where greedy first alternative consumes too much
+(function() {
+    var re = /(?:ab|a){2}c/;
+    var result = re.exec("aac");
+    shouldBe(result, ["aac"], "(?:ab|a){2}c on 'aac'");
+})();
+
+// Non-capturing FixedCount with 2 alternatives - simple case
+(function() {
+    var re = /(?:a|b){4}c/;
+    var result = re.exec("ababc");
+    shouldBe(result, ["ababc"], "(?:a|b){4}c on 'ababc'");
+})();
+
+// Non-capturing FixedCount with 3 alternatives
+(function() {
+    var re = /(?:a|b|c){3}d/;
+    var result = re.exec("abcd");
+    shouldBe(result, ["abcd"], "(?:a|b|c){3}d on 'abcd'");
+})();
+
+// Non-capturing FixedCount with alternatives, no match
+(function() {
+    var re = /(?:a|b){4}c/;
+    var result = re.exec("aaac");
+    shouldBe(result, null, "(?:a|b){4}c on 'aaac' (no match)");
+})();

--- a/JSTests/stress/regexp-yarr-jit-fixed-count-capture.js
+++ b/JSTests/stress/regexp-yarr-jit-fixed-count-capture.js
@@ -1,0 +1,94 @@
+//@ runDefault
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// Test 1: Basic fixed count with capture
+(function() {
+    var re = /^From\s+\S+\s+([a-zA-Z]{3}\s+){2}\d{1,2}\s+\d\d:\d\d/;
+    var result = re.exec("From abcd  Mon Sep 01 12:33:02 1997");
+    shouldBe(result[0], "From abcd  Mon Sep 01 12:33", "Test 1 full match");
+    shouldBe(result[1], "Sep ", "Test 1 capture");
+})();
+
+// Test 2: Backreference requiring within-iteration backtracking (main failing case)
+(function() {
+    var re = /(([a-c])b*?\2){3}/;
+    var result = re.exec("ababbbcbc");
+    shouldBe(result, ["ababbbcbc", "cbc", "c"], "Test 2 backreference");
+})();
+
+// Test 3: Simple fixed count capture
+(function() {
+    var re = /((x)){2}y/;
+    var result = re.exec("xxy");
+    shouldBe(result, ["xxy", "x", "x"], "Test 3 simple capture");
+})();
+
+// Test 4: Fixed count with no match
+(function() {
+    var re = /((x)){2}y/;
+    var result = re.exec("xxz");
+    shouldBe(result, null, "Test 4 no match");
+})();
+
+// Test 5: Alternatives inside fixed group
+(function() {
+    var re = /(x|y){3}z/;
+    var result = re.exec("xxyz");
+    shouldBe(result, ["xxyz", "y"], "Test 5 alternatives");
+})();
+
+// Test 6: Greedy inside fixed count (reference behavior from V8/interpreter)
+(function() {
+    var re = /(a+){2}b/;
+    var result = re.exec("aaab");
+    shouldBe(result, ["aaab", "a"], "Test 6 greedy inside fixed");
+})();
+
+// Test 7: Non-greedy inside fixed count
+(function() {
+    var re = /(a+?){2}b/;
+    var result = re.exec("aaab");
+    shouldBe(result, ["aaab", "aa"], "Test 7 non-greedy inside fixed");
+})();
+
+// Test 8: Deeply nested captures
+(function() {
+    var re = /(((a)b)+){2}c/;
+    var result = re.exec("ababababc");
+    // Iter1 of {2} matches "ababab" (greedy + inside)
+    // Iter2 of {2} matches "ab"
+    // Last capture of group 1 is "ab", group 2 is "ab", group 3 is "a"
+    shouldBe(result, ["ababababc", "ab", "ab", "a"], "Test 8 nested");
+})();
+
+// Test 9: Non-capturing fixed count (uses simpler FixedCount opcodes)
+(function() {
+    var re = /(?:abc){3}d/;
+    var result = re.exec("abcabcabcd");
+    shouldBe(result, ["abcabcabcd"], "Test 9 non-capturing fixed count");
+})();
+
+// Test 10: Non-capturing fixed count with alternatives
+(function() {
+    var re = /(?:a|b){4}c/;
+    var result = re.exec("ababc");
+    shouldBe(result, ["ababc"], "Test 10 non-capturing with alternatives");
+})();
+
+// Test 11: Non-capturing fixed count no match
+(function() {
+    var re = /(?:abc){3}d/;
+    var result = re.exec("abcabcd");
+    shouldBe(result, null, "Test 11 non-capturing no match");
+})();
+
+// Test 12: Mixed capturing and non-capturing
+(function() {
+    var re = /(?:x){2}(y){2}z/;
+    var result = re.exec("xxyyz");
+    shouldBe(result, ["xxyyz", "y"], "Test 12 mixed capturing and non-capturing");
+})();

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -40,7 +40,6 @@ namespace JSC { namespace Yarr {
 #define YarrStackSpaceForBackTrackInfoParentheticalAssertion 1
 #define YarrStackSpaceForBackTrackInfoParenthesesOnce 2
 #define YarrStackSpaceForBackTrackInfoParenthesesTerminal 1
-#define YarrStackSpaceForBackTrackInfoParenthesesFixedCount 2
 #define YarrStackSpaceForBackTrackInfoParentheses 4
 #define YarrStackSpaceForDotStarEnclosure 1
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -829,14 +829,6 @@ private:
         static unsigned beginIndex() { return offsetof(BackTrackInfoParenthesesTerminal, begin) / sizeof(uintptr_t); }
     };
 
-    struct BackTrackInfoParenthesesFixedCount {
-        uintptr_t begin;
-        uintptr_t matchAmount;
-
-        static unsigned beginIndex() { return offsetof(BackTrackInfoParenthesesFixedCount, begin) / sizeof(uintptr_t); }
-        static unsigned matchAmountIndex() { return offsetof(BackTrackInfoParenthesesFixedCount, matchAmount) / sizeof(uintptr_t); }
-    };
-
     struct BackTrackInfoParentheses {
         uintptr_t begin;
         uintptr_t returnAddress;


### PR DESCRIPTION
#### c8b66aa0832bb531bdc09889d1c483a9c02d15fd
<pre>
[JSC] YarrJIT should support fixed-count subpatterns with capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=306582">https://bugs.webkit.org/show_bug.cgi?id=306582</a>
<a href="https://rdar.apple.com/169224910">rdar://169224910</a>

Reviewed by Sosuke Suzuki.

This patch adds Yarr JIT support for FixedCount subpatterns.
For each iteration of subpattern, we need to capture the current state
since the next iteration will override the capture information.
Consider /(a+){2}b/ matching &quot;aaab&quot;:

    Iteration 1: (a+) greedily matches &quot;aaa&quot; → capture group 1 = &quot;aaa&quot;
    Iteration 2: (a+) needs at least one &apos;a&apos;, but only &apos;b&apos; remains → FAIL
    Backtrack to iteration 1: try (a+) = &quot;aa&quot; instead
    Iteration 2: (a+) = &quot;a&quot; → capture group 1 = &quot;a&quot;
    Match &apos;b&apos; → SUCCESS
    Result: [&quot;aaab&quot;, &quot;a&quot;]

When iteration 2 fails, we need to:
1. Restore iteration 1&apos;s starting state (position, captures before iteration 1 modified them)
2. Re-try iteration 1 with different choices

We store these information to ParenContext to restore when it fails.
The implementation works in this way, let&apos;s have /(x){3}/ matching &quot;xxx&quot;:

    Initial: head = null, matchAmount = 0, index = 0

    ━━━ Iteration 1 starts ━━━
        At m_reentry: index=0, matchAmount=0, captures=undefined
        Allocate context1, save: {begin=0, matchAmount=0, captures=undefined}
        Push: head → context1
        Match &apos;x&apos;, capture = &quot;x&quot;
        END: matchAmount = 1, loop back

    ━━━ Iteration 2 starts ━━━
        At m_reentry: index=1, matchAmount=1, captures=&quot;x&quot;
        Allocate context2, save: {begin=1, matchAmount=1, captures=&quot;x&quot;}
        Push: head → context2 → context1
        Match &apos;x&apos;, capture = &quot;x&quot;
        END: matchAmount = 2, loop back

    ━━━ Iteration 3 starts ━━━
        At m_reentry: index=2, matchAmount=2, captures=&quot;x&quot;
        Allocate context3, save: {begin=2, matchAmount=2, captures=&quot;x&quot;}
        Push: head → context3 → context2 → context1
        Match &apos;x&apos;, capture = &quot;x&quot;
        END: matchAmount = 3, done

So after this subpatterns part, frame is keeping context3.
When backtrack happens after this, we restore the already modified state
with context3 and popping it. This is the state before the 3rd iteration
starts. And we jump back to the END&apos;s backtrack code. And we continue
doing the same thing, and entire match fails.

Right now, we are not able to JIT for /(a+){3}/ because of the above.
When we backtrack, we do 2nd iteration&apos;s backtrack instead of 3rd&apos;s a+
part. So we cannot support this thing with the current form (saving and
restoring state at a boundary of (). This should be extended later.

* JSTests/stress/regexp-fixed-count-parentheses-unroll.js:
(testOneToN):
* JSTests/stress/regexp-fixedcount-backtrack-alternatives.js: Added.
(shouldBe):
(re):
* JSTests/stress/regexp-yarr-jit-fixed-count-capture.js: Added.
(shouldBe):
(re.From.s.S.s):
(re):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::BackTrackInfoParenthesesFixedCount::beginIndex): Deleted.
(JSC::Yarr::BackTrackInfoParenthesesFixedCount::matchAmountIndex): Deleted.

Canonical link: <a href="https://commits.webkit.org/306582@main">https://commits.webkit.org/306582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0605c212b1c8edf21b03b24efdd2357e54e4f3c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94821 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcde6a7f-31a6-4451-8d59-7444f461ac9e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108892 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78744 "7 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72686d6a-9e31-4220-a9e8-22dc6a8da149) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89789 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a30ad11-48ae-4f4f-8cef-de7f51528a20) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10983 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8621 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/347 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133686 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152667 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2506 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13777 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116988 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117311 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13344 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69385 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21876 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13815 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2831 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172991 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77540 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44800 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13757 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->