### PR TITLE
Reduce unsafe buffer usage by using C++20 std::to_address in WTF

### DIFF
--- a/Source/WTF/wtf/ButterflyArray.h
+++ b/Source/WTF/wtf/ButterflyArray.h
@@ -48,9 +48,9 @@ protected:
     {
         static_assert(std::is_final_v<Derived>);
         auto leadingSpan = this->leadingSpan();
-        VectorTypeOperations<LeadingType>::initializeIfNonPOD(leadingSpan.data(), leadingSpan.data() + leadingSpan.size());
+        VectorTypeOperations<LeadingType>::initializeIfNonPOD(leadingSpan.data(), std::to_address(leadingSpan.end()));
         auto trailingSpan = this->trailingSpan();
-        VectorTypeOperations<TrailingType>::initializeIfNonPOD(trailingSpan.data(), trailingSpan.data() + trailingSpan.size());
+        VectorTypeOperations<TrailingType>::initializeIfNonPOD(trailingSpan.data(), std::to_address(trailingSpan.end()));
     }
 
     template<typename... Args>
@@ -108,9 +108,9 @@ public:
     ~ButterflyArray()
     {
         auto leadingSpan = this->leadingSpan();
-        VectorTypeOperations<LeadingType>::destruct(leadingSpan.data(), leadingSpan.data() + leadingSpan.size());
+        VectorTypeOperations<LeadingType>::destruct(leadingSpan.data(), std::to_address(leadingSpan.end()));
         auto trailingSpan = this->trailingSpan();
-        VectorTypeOperations<TrailingType>::destruct(trailingSpan.data(), trailingSpan.data() + trailingSpan.size());
+        VectorTypeOperations<TrailingType>::destruct(trailingSpan.data(), std::to_address(trailingSpan.end()));
     }
 
 protected:

--- a/Source/WTF/wtf/SIMDHelpers.h
+++ b/Source/WTF/wtf/SIMDHelpers.h
@@ -594,7 +594,7 @@ ALWAYS_INLINE const CharacterType* find(std::span<const CharacterType> span, con
     using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
     static_assert(threshold >= stride);
     const auto* cursor = span.data();
-    const auto* end = span.data() + span.size();
+    const auto* end = std::to_address(span.end());
     if (span.size() >= threshold) {
         for (; cursor + stride <= end; cursor += stride) {
             if (auto index = vectorMatch(SIMD::load(std::bit_cast<const UnsignedType*>(cursor))))
@@ -622,7 +622,7 @@ ALWAYS_INLINE const CharacterType* findInterleaved(std::span<const CharacterType
     constexpr size_t stride = SIMD::stride<CharacterType> * 2;
     static_assert(threshold >= stride);
     const auto* cursor = span.data();
-    const auto* end = span.data() + span.size();
+    const auto* end = std::to_address(span.end());
     if (span.size() >= threshold) {
         for (; cursor + stride <= end; cursor += stride) {
             if (auto index = vectorMatch(simde_vld2q_u8(std::bit_cast<const uint8_t*>(cursor))))
@@ -651,7 +651,7 @@ ALWAYS_INLINE size_t count(std::span<const CharacterType> span, const auto& vect
     using UnsignedType = SameSizeUnsignedInteger<CharacterType>;
     static_assert(threshold >= stride);
     const auto* cursor = span.data();
-    const auto* end = span.data() + span.size();
+    const auto* end = std::to_address(span.end());
     size_t result = 0;
 
     // Per max * 4 * stride iteration (If CharacterType is uint8_t, it is 16320 (255 * 64)).

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1500,7 +1500,7 @@ inline NewlinePosition findNextNewline(std::span<const CharacterType> span, size
     constexpr size_t threshold = 32;
     auto* ptr = SIMD::find<CharacterType, threshold>(searchSpan, vectorMatch, scalarMatch);
 
-    if (ptr == searchSpan.data() + searchSpan.size())
+    if (ptr == std::to_address(searchSpan.end()))
         return { };
 
     CharacterType ch = *ptr;


### PR DESCRIPTION
#### c1d28b6bba76c0be7aec3b9c656e0360e8e10411
<pre>
Reduce unsafe buffer usage by using C++20 std::to_address in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=306586">https://bugs.webkit.org/show_bug.cgi?id=306586</a>
<a href="https://rdar.apple.com/169230060">rdar://169230060</a>

Reviewed by Chris Dumez.

* Source/WTF/wtf/ButterflyArray.h:
(WTF::ButterflyArray::ButterflyArray):
(WTF::ButterflyArray::~ButterflyArray):
* Source/WTF/wtf/SIMDHelpers.h:
(WTF::SIMD::find):
(WTF::SIMD::findInterleaved):
(WTF::SIMD::count):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::findNextNewline):

Canonical link: <a href="https://commits.webkit.org/306474@main">https://commits.webkit.org/306474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17b4af84b38c525a71568b9fc64eaee2be0db61f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94547 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/13993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89587 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10787 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8412 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/98 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133434 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152419 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2254 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13524 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116786 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117116 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29819 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13157 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13567 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2565 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172742 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77280 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44747 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->