### PR TITLE
Web Inspector: virtualized `WI.TreeOutline` shows nothing when filters are active

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js
@@ -705,11 +705,10 @@ WI.SourcesNavigationSidebarPanel = class SourcesNavigationSidebarPanel extends W
 
         let treeElement = this._callStackTreeOutline.children[0];
 
-        const ignoreHidden = true;
         const skipUnrevealed = true;
         const stayWithin = null;
         const dontPopulate = true;
-        while (!treeElement.revealed(ignoreHidden))
+        while (!treeElement.revealed)
             treeElement = treeElement.traverseNextTreeElement(skipUnrevealed, stayWithin, dontPopulate);
 
         let indentString = WI.indentString();

--- a/Source/WebInspectorUI/UserInterface/Views/TreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeElement.js
@@ -498,16 +498,16 @@ WI.TreeElement = class TreeElement extends WI.Object
             this.treeOutline.dispatchEventToListeners(WI.TreeOutline.Event.ElementRevealed, {element: this});
     }
 
-    revealed(ignoreHidden)
+    get revealed()
     {
-        if (!ignoreHidden && this.hidden)
+        if (this._hidden)
             return false;
 
         var currentAncestor = this.parent;
         while (currentAncestor && !currentAncestor.root) {
             if (!currentAncestor.expanded)
                 return false;
-            if (!ignoreHidden && currentAncestor.hidden)
+            if (currentAncestor._hidden)
                 return false;
             currentAncestor = currentAncestor.parent;
         }
@@ -590,7 +590,7 @@ WI.TreeElement = class TreeElement extends WI.Object
     traverseNextTreeElement(skipUnrevealed, stayWithin, dontPopulate, info)
     {
         function shouldSkip(element) {
-            return skipUnrevealed && !element.revealed(true);
+            return skipUnrevealed && !element.revealed;
         }
 
         var depthChange = 0;
@@ -623,7 +623,7 @@ WI.TreeElement = class TreeElement extends WI.Object
     traversePreviousTreeElement(skipUnrevealed, dontPopulate)
     {
         function shouldSkip(element) {
-            return skipUnrevealed && !element.revealed(true);
+            return skipUnrevealed && !element.revealed;
         }
 
         var element = this;

--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.js
@@ -141,6 +141,8 @@ WI.TreeOutline = class TreeOutline extends WI.Object
 
     set hidden(x)
     {
+        console.assert(false, "not expected to be called");
+
         if (this._hidden === x)
             return;
 
@@ -568,7 +570,7 @@ WI.TreeOutline = class TreeOutline extends WI.Object
                         this.selectedTreeElement.parent.collapse();
                 }
             } else if (event.keyIdentifier === expandKeyIdentifier) {
-                if (!this.selectedTreeElement.revealed()) {
+                if (!this.selectedTreeElement.revealed) {
                     this.selectedTreeElement.reveal();
                     handled = true;
                 } else if (this.selectedTreeElement.expandable) {
@@ -635,7 +637,7 @@ WI.TreeOutline = class TreeOutline extends WI.Object
         // this is the root, do nothing
     }
 
-    revealed()
+    get revealed()
     {
         return true;
     }
@@ -936,14 +938,13 @@ WI.TreeOutline = class TreeOutline extends WI.Object
         const skipUnrevealed = true;
         const stayWithin = null;
         const dontPopulate = true;
-        const ignoreHidden = true;
 
         let firstChild = this.children[0];
-        if (firstChild && !firstChild.revealed(ignoreHidden))
+        if (firstChild && !firstChild.revealed)
             firstChild = firstChild.traverseNextTreeElement(skipUnrevealed, stayWithin, dontPopulate);
 
         let shouldScroll = false;
-        if (focusedTreeElement && focusedTreeElement.revealed(false)) {
+        if (focusedTreeElement?.revealed) {
             let index = 0;
             for (let child = firstChild; child && child !== focusedTreeElement; child = child.traverseNextTreeElement(skipUnrevealed, stayWithin, dontPopulate))
                 ++index;


### PR DESCRIPTION
#### cd6fa76b38f1acc5826b31dfd07ca910035ac7a8
<pre>
Web Inspector: virtualized `WI.TreeOutline` shows nothing when filters are active
<a href="https://bugs.webkit.org/show_bug.cgi?id=306587">https://bugs.webkit.org/show_bug.cgi?id=306587</a>

Reviewed by BJ Burg.

None of the callsites that provide `ignoreHidden` probably actually want to ignore `hidden`, especially when trying to check if `revealed`.
Put another way, it cannot be `revealed` if it is `hidden`.

* Source/WebInspectorUI/UserInterface/Views/TreeElement.js:
(WI.TreeElement.prototype.get revealed): Renamed from `revealed` to match `WI.DataGridNode`.
(WI.TreeElement.prototype.traverseNextTreeElement.shouldSkip):
(WI.TreeElement.prototype.traversePreviousTreeElement.shouldSkip):
* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js:
(WI.TreeOutline.prototype._treeKeyDown):
(WI.TreeOutline.prototype.get revealed): Renamed from `revealed` to match `WI.DataGridNode`.
(WI.TreeOutline.prototype._updateVirtualizedElements):
* Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js:
(WI.SourceNavigationSidebarPanel.prototype.handleCopyEvent):

Canonical link: <a href="https://commits.webkit.org/306680@main">https://commits.webkit.org/306680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00fcde1f123bb373ad00237e55f679662aa62870

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150609 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15115 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109150 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11229 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8882 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/667 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152984 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14076 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117230 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117547 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29963 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13592 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69770 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14125 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77841 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->