### PR TITLE
Table sections with explicit height should constrain contained rows

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/computing-row-measure-0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/computing-row-measure-0-expected.txt
@@ -4,7 +4,7 @@ This is testing that the table root's minimum is max(table-root width, capmin, g
 
 
 PASS Checking intermediate min-content height for span 1 (1)
-FAIL Checking intermediate min-content height for span 1 (2) assert_equals: expected 10 but got 1
+PASS Checking intermediate min-content height for span 1 (2)
 PASS Checking intermediate min-content height for span 1 (3)
-FAIL Checking intermediate min-content height for span 1 (4) assert_equals: expected 10 but got 1
+PASS Checking intermediate min-content height for span 1 (4)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-height-redistribution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-height-redistribution-expected.txt
@@ -39,7 +39,7 @@ FF adds tbody height to table?
 b:100
 tbody has fixed height > table
 Legacy: table size wins. FF: table size wins, but body grows to 300px?
-b:100
+b:200
 tr has fixed height > table
 FF: table size wins, but body is 300.
 b:200
@@ -118,7 +118,7 @@ Sized THEAD/TBODY
 
 FF does not prioritize TBODY for distribution
 20px thead, 30px tbody
-h:18
+h:20
 b:82
 x
 x
@@ -151,11 +151,7 @@ height expected 80 but got 100
 PASS table 8
 PASS table 9
 PASS table 10
-FAIL table 11 assert_equals:
-<table data-expected-height="200">
-  <tbody style="height:200px" data-expected-height="200"><tr></tr></tbody>
-</table>
-height expected 200 but got 100
+PASS table 11
 PASS table 12
 PASS table 13
 PASS table 14
@@ -202,7 +198,7 @@ FAIL table 29 assert_equals:
     <tr><td>x</td></tr>
   </tbody>
 </table>
-height expected 20 but got 18
+height expected 100 but got 102
 PASS table 30
 PASS table 31
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/tbody-height-redistribution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/tbody-height-redistribution-expected.txt
@@ -69,7 +69,7 @@ FAIL table 3 assert_equals:
     </tr>
   </tbody>
 </table>
-height expected 100 but got 40
+height expected 25 but got 10
 FAIL table 4 assert_equals:
 <table id="four">
   <tbody style="height:100px">
@@ -140,7 +140,7 @@ FAIL table 11 assert_equals:
     <tr data-expected-height="25"></tr>
   </tbody>
 </table>
-height expected 75 but got 0
+height expected 25 but got 0
 FAIL table 12 assert_equals:
 <table id="ten" style="width:50px">
   <tbody style="height:50px" data-expected-height="50">
@@ -149,5 +149,5 @@ FAIL table 12 assert_equals:
     <tr data-expected-height="25"><td></td></tr>
   </tbody>
 </table>
-height expected 50 but got 0
+height expected 25 but got 0
 

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2276
+layer at (0,0) size 785x2756
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2276
-  RenderBlock {HTML} at (0,0) size 785x2276
-    RenderBody {BODY} at (8,8) size 769x2260 [bgcolor=#19BCD2]
+layer at (0,0) size 785x2756
+  RenderBlock {HTML} at (0,0) size 785x2756
+    RenderBody {BODY} at (8,8) size 769x2740 [bgcolor=#19BCD2]
       RenderTable {TABLE} at (0,0) size 769x200 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 767x198
           RenderTableRow {TR} at (0,0) size 767x159
@@ -15,8 +15,8 @@ layer at (0,0) size 785x2276
                 text run at (1,1) width 158: "20% of table 200px table"
       RenderBlock (anonymous) at (0,199) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,217) size 769x43 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 767x40
+      RenderTable {TABLE} at (0,217) size 769x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 767x200
           RenderTableRow {TR} at (0,0) size 767x20
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 130x18
@@ -25,10 +25,10 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,20) size 767x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 130x18
                 text run at (1,1) width 130: "20% of 200px tbody"
-      RenderBlock (anonymous) at (0,259) size 769x19
+      RenderBlock (anonymous) at (0,419) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,277) size 769x43 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 767x40
+      RenderTable {TABLE} at (0,437) size 769x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 767x200
           RenderTableRow {TR} at (0,0) size 767x20
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 130x18
@@ -37,9 +37,9 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,20) size 767x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 130x18
                 text run at (1,1) width 130: "20% of 200px tbody"
-      RenderBlock (anonymous) at (0,319) size 769x19
+      RenderBlock (anonymous) at (0,639) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,337) size 769x201 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,657) size 769x201 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 767x198
           RenderTableRow {TR} at (0,0) size 767x159
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -49,10 +49,10 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,158) size 767x21 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 153x18
                 text run at (1,1) width 153: "row 20% of 200px table"
-      RenderBlock (anonymous) at (0,537) size 769x19
+      RenderBlock (anonymous) at (0,857) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,555) size 769x43 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 767x40
+      RenderTable {TABLE} at (0,875) size 769x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 767x200
           RenderTableRow {TR} at (0,0) size 767x20
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 159x18
@@ -61,9 +61,9 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,20) size 767x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 159x18
                 text run at (1,1) width 159: "row 20% of 200px tbody"
-      RenderBlock (anonymous) at (0,597) size 769x19
+      RenderBlock (anonymous) at (0,1077) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,615) size 769x381 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1095) size 769x381 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 767x378
           RenderTableRow {TR} at (0,0) size 767x378
             RenderTableCell {TD} at (0,0) size 767x648 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -122,9 +122,9 @@ layer at (0,0) size 785x2276
                       RenderBR {BR} at (4,234) size 0x18
                       RenderText {#text} at (0,252) size 4x18
                         text run at (0,252) width 4: " "
-      RenderBlock (anonymous) at (0,995) size 769x19
+      RenderBlock (anonymous) at (0,1475) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,1013) size 600x401 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1493) size 600x401 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 598x398
           RenderTableRow {TR} at (0,2) size 598x394
             RenderTableCell {TD} at (2,2) size 594x394 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -138,18 +138,18 @@ layer at (0,0) size 785x2276
                             RenderTableCell {TD} at (2,178) size 574x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                               RenderText {#text} at (2,178) size 21x18
                                 text run at (2,2) width 21: "foo"
-      RenderBlock (anonymous) at (0,1413) size 769x19
+      RenderBlock (anonymous) at (0,1893) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,1431) size 62x23 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1911) size 62x23 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 60x20
           RenderTableRow {TR} at (0,0) size 60x20
             RenderTableCell {TD} at (0,0) size 60x20 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,1) size 58x18
                 text run at (1,1) width 58: "blah blah"
           RenderTableRow {TR} at (0,20) size 60x0
-      RenderBlock (anonymous) at (0,1453) size 769x19
+      RenderBlock (anonymous) at (0,1933) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,1471) size 602x365 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1951) size 602x365 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 600x362
           RenderTableRow {TR} at (0,0) size 600x0
             RenderTableCell {TD} at (0,0) size 503x362 [bgcolor=#FFFFFF] [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=2]
@@ -158,9 +158,9 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (502,171) size 98x20 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=6]
               RenderText {#text} at (72,172) size 25x18
                 text run at (72,1) width 25: "xxx"
-      RenderBlock (anonymous) at (0,1835) size 769x19
+      RenderBlock (anonymous) at (0,2315) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (10,1853) size 749x407 [bgcolor=#808080]
+      RenderTable {TABLE} at (10,2333) size 749x407 [bgcolor=#808080]
         RenderTableSection {TBODY} at (0,0) size 748x406
           RenderTableRow {TR} at (0,4) size 748x398
             RenderTableCell {TD} at (4,4) size 740x398 [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt
@@ -1,18 +1,18 @@
-layer at (0,0) size 785x1323
+layer at (0,0) size 785x1378
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1323
-  RenderBlock {HTML} at (0,0) size 785x1323
-    RenderBody {BODY} at (8,8) size 769x1299
-      RenderBlock {CENTER} at (0,0) size 769x1299
+layer at (0,0) size 785x1378
+  RenderBlock {HTML} at (0,0) size 785x1378
+    RenderBody {BODY} at (8,8) size 769x1354
+      RenderBlock {CENTER} at (0,0) size 769x1354
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (252,0) size 265x18
             text run at (252,0) width 265: "Build 1999/10/27/08 Win95 - Daily Build"
           RenderBR {BR} at (516,0) size 1x18
-        RenderTable {TABLE} at (74,18) size 621x1157 [border: (10px outset #000000)]
+        RenderTable {TABLE} at (74,18) size 621x1212 [border: (10px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 620x18
             RenderText {#text} at (267,0) size 86x18
               text run at (267,0) width 86: "January 2000"
-          RenderTableSection {TBODY} at (10,28) size 600x1119
+          RenderTableSection {TBODY} at (10,28) size 600x1174
             RenderTableRow {TR} at (0,0) size 600x430
               RenderTableCell {TD} at (0,0) size 87x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
@@ -105,16 +105,16 @@ layer at (0,0) size 785x1323
                                     text run at (0,36) width 29: "food"
                 RenderBlock (anonymous) at (2,182) size 83x18
                   RenderBR {BR} at (0,0) size 0x18
-              RenderTableCell {TD} at (87,430) size 84x80 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=1 c=1 rs=1 cs=1]
-                RenderTable {TABLE} at (2,2) size 80x76 [color=#000000]
-                  RenderTableSection {TBODY} at (0,0) size 80x76
-                    RenderTableRow {TR} at (0,0) size 80x76
+              RenderTableCell {TD} at (87,430) size 84x86 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=1 c=1 rs=1 cs=1]
+                RenderTable {TABLE} at (2,2) size 80x82 [color=#000000]
+                  RenderTableSection {TBODY} at (0,0) size 80x82
+                    RenderTableRow {TR} at (0,0) size 80x82
                       RenderTableCell {TD} at (0,0) size 18x27 [color=#FFFF00] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 16x25
                           text run at (1,1) width 16: "3."
-                      RenderTableCell {TD} at (18,0) size 62x76 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 60x74 [color=#000000]
-                          RenderTableSection {TBODY} at (0,0) size 60x74 [bgcolor=#FFFF00]
+                      RenderTableCell {TD} at (18,0) size 62x82 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 60x80 [color=#000000]
+                          RenderTableSection {TBODY} at (0,0) size 60x80 [bgcolor=#FFFF00]
                             RenderTableRow {TR} at (0,0) size 60x74
                               RenderTableCell {TD} at (0,0) size 60x74 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                                 RenderBlock {P} at (1,1) size 58x72
@@ -445,17 +445,17 @@ layer at (0,0) size 785x1323
                                     text run at (0,0) width 28: "This"
                                     text run at (0,18) width 38: "bug is"
                                     text run at (0,36) width 32: "fixed"
-            RenderTableRow {TR} at (0,1066) size 600x31
-              RenderTableCell {TD} at (0,1066) size 87x31 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=0 rs=1 cs=1]
-                RenderTable {TABLE} at (2,2) size 83x27 [color=#000000]
-                  RenderTableSection {TBODY} at (0,0) size 83x27
-                    RenderTableRow {TR} at (0,0) size 83x27
+            RenderTableRow {TR} at (0,1066) size 600x86
+              RenderTableCell {TD} at (0,1066) size 87x86 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=0 rs=1 cs=1]
+                RenderTable {TABLE} at (2,2) size 83x82 [color=#000000]
+                  RenderTableSection {TBODY} at (0,0) size 83x82
+                    RenderTableRow {TR} at (0,0) size 83x82
                       RenderTableCell {TD} at (0,0) size 29x27 [color=#FFFF00] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 27x25
                           text run at (1,1) width 27: "16."
-                      RenderTableCell {TD} at (29,0) size 54x22 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 52x20 [color=#000000]
-                          RenderTableSection {TBODY} at (0,0) size 52x20 [bgcolor=#FFFF00]
+                      RenderTableCell {TD} at (29,0) size 54x82 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 52x80 [color=#000000]
+                          RenderTableSection {TBODY} at (0,0) size 52x80 [bgcolor=#FFFF00]
                             RenderTableRow {TR} at (0,0) size 52x20
                               RenderTableCell {TD} at (0,0) size 52x20 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (1,1) size 7x18
@@ -478,33 +478,33 @@ layer at (0,0) size 785x1323
               RenderTableCell {TD} at (509,1066) size 91x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=6 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-            RenderTableRow {TR} at (0,1097) size 600x22
-              RenderTableCell {TD} at (0,1097) size 87x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,1152) size 600x22
+              RenderTableCell {TD} at (0,1152) size 87x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-              RenderTableCell {TD} at (87,1097) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (87,1152) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-              RenderTableCell {TD} at (171,1097) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (171,1152) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-              RenderTableCell {TD} at (255,1097) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (255,1152) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-              RenderTableCell {TD} at (339,1097) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=4 rs=1 cs=1]
+              RenderTableCell {TD} at (339,1152) size 84x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=4 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-              RenderTableCell {TD} at (423,1097) size 86x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=5 rs=1 cs=1]
+              RenderTableCell {TD} at (423,1152) size 86x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=5 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-              RenderTableCell {TD} at (509,1097) size 91x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=6 rs=1 cs=1]
+              RenderTableCell {TD} at (509,1152) size 91x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=6 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 5x18
                   text run at (2,2) width 5: "-"
-        RenderBlock (anonymous) at (0,1175) size 769x36
+        RenderBlock (anonymous) at (0,1230) size 769x36
           RenderBR {BR} at (384,0) size 1x18
           RenderText {#text} at (4,18) size 761x18
             text run at (4,18) width 761: "Notice the scrollbars, they are rendered outside of the table columns, and the yellow day numbers are hidden under them."
-        RenderBlock {P} at (0,1227) size 769x72
+        RenderBlock {P} at (0,1282) size 769x72
           RenderText {#text} at (7,0) size 755x72
             text run at (9,0) width 751: "This is probably another bug already covered, or fixed, but day 3 & 16 should have no scrollbar, but the area where the"
             text run at (7,18) width 416: "other scrollbars are drawn is drawn funny. They are not rendered. "

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug51000-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug51000-expected.txt
@@ -1,23 +1,23 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {P} at (0,0) size 784x18
+layer at (0,0) size 785x952
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x952
+  RenderBlock {HTML} at (0,0) size 785x952
+    RenderBody {BODY} at (8,8) size 769x936
+      RenderBlock {P} at (0,0) size 769x18
         RenderText {#text} at (0,0) size 373x18
           text run at (0,0) width 373: "300xp height value set on THEAD, TBODY, and TFOOT"
-      RenderTable {TABLE} at (0,34) size 250x76 [border: (1px outset #000000)]
-        RenderTableSection {THEAD} at (1,1) size 248x26
+      RenderTable {TABLE} at (0,34) size 250x902 [border: (1px outset #000000)]
+        RenderTableSection {THEAD} at (1,1) size 248x300
           RenderTableRow {TR} at (0,2) size 248x22
             RenderTableCell {TH} at (2,2) size 244x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 240x18
                 text run at (2,2) width 240: "This THEAD should be 300px high"
-        RenderTableSection {TFOOT} at (1,51) size 248x24
+        RenderTableSection {TFOOT} at (1,601) size 248x300
           RenderTableRow {TR} at (0,0) size 248x22
             RenderTableCell {TD} at (2,0) size 244x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 226x18
                 text run at (2,2) width 226: "This TFOOT should be 300px high"
-        RenderTableSection {TBODY} at (1,27) size 248x24
+        RenderTableSection {TBODY} at (1,301) size 248x300
           RenderTableRow {TR} at (0,0) size 248x22
             RenderTableCell {TD} at (2,0) size 244x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 234x18

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2416
+layer at (0,0) size 785x2448
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2416
-  RenderBlock {HTML} at (0,0) size 785x2417
-    RenderBody {BODY} at (8,8) size 769x2393
+layer at (0,0) size 785x2448
+  RenderBlock {HTML} at (0,0) size 785x2449
+    RenderBody {BODY} at (8,8) size 769x2425
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 432x37
           text run at (0,0) width 432: "Example 4: Some simple tables."
@@ -472,8 +472,8 @@ layer at (0,0) size 785x2416
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 407x18
           text run at (0,18) width 407: "This is like the previous table plus the list's overflow property set"
-      RenderTable at (0,1360) size 230x19
-        RenderTableSection {UL} at (0,0) size 230x18
+      RenderTable at (0,1360) size 230x51
+        RenderTableSection {UL} at (0,0) size 230x50
           RenderTableRow (anonymous) at (0,0) size 230x18
             RenderTableCell {LI} at (0,0) size 34x18 [bgcolor=#FFA500] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 34x18
@@ -493,9 +493,9 @@ layer at (0,0) size 785x2416
             RenderTableCell {LI} at (204,0) size 26x18 [bgcolor=#FFA500] [r=0 c=5 rs=1 cs=1]
               RenderText {#text} at (0,0) size 26x18
                 text run at (0,0) width 26: "SIX"
-      RenderBlock (anonymous) at (0,1378) size 769x19
+      RenderBlock (anonymous) at (0,1410) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,1412) size 769x201
+      RenderBlock {P} at (0,1444) size 769x201
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 426x18
             text run at (0,0) width 426: "The following table will have its rows and columns in red collapsed"
@@ -582,7 +582,7 @@ layer at (0,0) size 785x2416
               RenderTableCell {TD} at (35,26) size 66x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1628) size 769x245
+      RenderBlock {P} at (0,1660) size 769x245
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 745x18
             text run at (0,0) width 745: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -698,7 +698,7 @@ layer at (0,0) size 785x2416
               RenderTableCell {TD} at (62,76) size 31x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,1888) size 769x227
+      RenderBlock {P} at (0,1920) size 769x227
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 455x18
             text run at (0,0) width 455: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -825,7 +825,7 @@ layer at (0,0) size 785x2416
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,208) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,2130) size 769x263
+      RenderBlock {P} at (0,2162) size 769x263
         RenderBlock (anonymous) at (0,0) size 769x36
           RenderText {#text} at (0,0) size 755x36
             text run at (0,0) width 554: "The following table is similar to a previous table except that the direction is right-to-left. "

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x2364
+layer at (0,0) size 800x2832
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x2364
-  RenderBlock {HTML} at (0,0) size 800x2364
-    RenderBody {BODY} at (8,8) size 784x2348 [bgcolor=#19BCD2]
+layer at (0,0) size 800x2832
+  RenderBlock {HTML} at (0,0) size 800x2832
+    RenderBody {BODY} at (8,8) size 784x2816 [bgcolor=#19BCD2]
       RenderTable {TABLE} at (0,0) size 784x200 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 782x198
           RenderTableRow {TR} at (0,0) size 782x159
@@ -15,8 +15,8 @@ layer at (0,0) size 800x2364
                 text run at (1,1) width 161: "20% of table 200px table"
       RenderBlock (anonymous) at (0,199) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,219) size 784x47 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 782x44
+      RenderTable {TABLE} at (0,219) size 784x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 782x200
           RenderTableRow {TR} at (0,0) size 782x22
             RenderTableCell {TD} at (0,0) size 782x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x20
@@ -25,10 +25,10 @@ layer at (0,0) size 800x2364
             RenderTableCell {TD} at (0,22) size 782x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x20
                 text run at (1,1) width 132: "20% of 200px tbody"
-      RenderBlock (anonymous) at (0,265) size 784x21
+      RenderBlock (anonymous) at (0,421) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,285) size 784x47 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 782x44
+      RenderTable {TABLE} at (0,441) size 784x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 782x200
           RenderTableRow {TR} at (0,0) size 782x22
             RenderTableCell {TD} at (0,0) size 782x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x20
@@ -37,9 +37,9 @@ layer at (0,0) size 800x2364
             RenderTableCell {TD} at (0,22) size 782x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x20
                 text run at (1,1) width 132: "20% of 200px tbody"
-      RenderBlock (anonymous) at (0,331) size 784x21
+      RenderBlock (anonymous) at (0,643) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,351) size 784x201 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,663) size 784x201 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 782x198
           RenderTableRow {TR} at (0,0) size 782x159
             RenderTableCell {TD} at (0,0) size 782x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -49,10 +49,10 @@ layer at (0,0) size 800x2364
             RenderTableCell {TD} at (0,158) size 782x23 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 155x20
                 text run at (1,1) width 155: "row 20% of 200px table"
-      RenderBlock (anonymous) at (0,551) size 784x21
+      RenderBlock (anonymous) at (0,863) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,571) size 784x47 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 782x44
+      RenderTable {TABLE} at (0,883) size 784x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 782x200
           RenderTableRow {TR} at (0,0) size 782x22
             RenderTableCell {TD} at (0,0) size 782x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 160x20
@@ -61,9 +61,9 @@ layer at (0,0) size 800x2364
             RenderTableCell {TD} at (0,22) size 782x22 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 160x20
                 text run at (1,1) width 160: "row 20% of 200px tbody"
-      RenderBlock (anonymous) at (0,617) size 784x21
+      RenderBlock (anonymous) at (0,1085) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,637) size 784x405 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1105) size 784x405 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 782x402
           RenderTableRow {TR} at (0,0) size 782x402
             RenderTableCell {TD} at (0,0) size 782x402 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -122,9 +122,9 @@ layer at (0,0) size 800x2364
                       RenderBR {BR} at (4,260) size 0x20
                       RenderText {#text} at (0,280) size 4x20
                         text run at (0,280) width 4: " "
-      RenderBlock (anonymous) at (0,1041) size 784x21
+      RenderBlock (anonymous) at (0,1509) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,1061) size 600x401 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1529) size 600x401 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 598x398
           RenderTableRow {TR} at (0,2) size 598x394
             RenderTableCell {TD} at (2,2) size 594x394 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -138,18 +138,18 @@ layer at (0,0) size 800x2364
                             RenderTableCell {TD} at (2,177) size 574x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                               RenderText {#text} at (2,177) size 22x20
                                 text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,1461) size 784x21
+      RenderBlock (anonymous) at (0,1929) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,1481) size 64x25 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1949) size 64x25 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 62x22
           RenderTableRow {TR} at (0,0) size 62x22
             RenderTableCell {TD} at (0,0) size 62x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,1) size 60x20
                 text run at (1,1) width 60: "blah blah"
           RenderTableRow {TR} at (0,22) size 62x0
-      RenderBlock (anonymous) at (0,1505) size 784x21
+      RenderBlock (anonymous) at (0,1973) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (0,1525) size 602x365 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1993) size 602x365 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 600x362
           RenderTableRow {TR} at (0,0) size 600x0
             RenderTableCell {TD} at (0,0) size 503x362 [bgcolor=#FFFFFF] [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=2]
@@ -158,9 +158,9 @@ layer at (0,0) size 800x2364
             RenderTableCell {TD} at (502,170) size 98x22 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=6]
               RenderText {#text} at (72,171) size 25x20
                 text run at (72,1) width 25: "xxx"
-      RenderBlock (anonymous) at (0,1889) size 784x21
+      RenderBlock (anonymous) at (0,2357) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderTable {TABLE} at (18,1909) size 748x439 [bgcolor=#808080]
+      RenderTable {TABLE} at (18,2377) size 748x439 [bgcolor=#808080]
         RenderTableSection {TBODY} at (0,0) size 748x438
           RenderTableRow {TR} at (0,4) size 748x430
             RenderTableCell {TD} at (4,4) size 740x430 [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt
@@ -1,18 +1,18 @@
-layer at (0,0) size 800x1440
+layer at (0,0) size 800x1494
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x1440
-  RenderBlock {HTML} at (0,0) size 800x1440
-    RenderBody {BODY} at (8,8) size 784x1416
-      RenderBlock {CENTER} at (0,0) size 784x1416
+layer at (0,0) size 800x1494
+  RenderBlock {HTML} at (0,0) size 800x1494
+    RenderBody {BODY} at (8,8) size 784x1470
+      RenderBlock {CENTER} at (0,0) size 784x1470
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (257,0) size 270x20
             text run at (257,0) width 270: "Build 1999/10/27/08 Win95 - Daily Build"
           RenderBR {BR} at (526,0) size 1x20
-        RenderTable {TABLE} at (79,20) size 626x1260 [border: (10px outset #000000)]
+        RenderTable {TABLE} at (79,20) size 626x1314 [border: (10px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 626x20
             RenderText {#text} at (269,0) size 87x20
               text run at (269,0) width 87: "January 2000"
-          RenderTableSection {TBODY} at (10,30) size 606x1220
+          RenderTableSection {TBODY} at (10,30) size 606x1274
             RenderTableRow {TR} at (0,0) size 606x468
               RenderTableCell {TD} at (0,0) size 89x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
@@ -445,17 +445,17 @@ layer at (0,0) size 800x1440
                                     text run at (0,0) width 29: "This"
                                     text run at (0,20) width 39: "bug is"
                                     text run at (0,40) width 33: "fixed"
-            RenderTableRow {TR} at (0,1164) size 606x32
-              RenderTableCell {TD} at (0,1164) size 89x32 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=0 rs=1 cs=1]
-                RenderTable {TABLE} at (2,2) size 85x28 [color=#000000]
-                  RenderTableSection {TBODY} at (0,0) size 85x28
-                    RenderTableRow {TR} at (0,0) size 85x28
+            RenderTableRow {TR} at (0,1164) size 606x86
+              RenderTableCell {TD} at (0,1164) size 89x86 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=0 rs=1 cs=1]
+                RenderTable {TABLE} at (2,2) size 85x82 [color=#000000]
+                  RenderTableSection {TBODY} at (0,0) size 85x82
+                    RenderTableRow {TR} at (0,0) size 85x82
                       RenderTableCell {TD} at (0,0) size 29x28 [color=#FFFF00] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,1) size 27x26
                           text run at (1,1) width 27: "16."
-                      RenderTableCell {TD} at (28,0) size 57x24 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 54x22 [color=#000000]
-                          RenderTableSection {TBODY} at (0,0) size 54x22 [bgcolor=#FFFF00]
+                      RenderTableCell {TD} at (28,0) size 57x82 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 54x80 [color=#000000]
+                          RenderTableSection {TBODY} at (0,0) size 54x80 [bgcolor=#FFFF00]
                             RenderTableRow {TR} at (0,0) size 54x22
                               RenderTableCell {TD} at (0,0) size 54x22 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (1,1) size 8x20
@@ -478,33 +478,33 @@ layer at (0,0) size 800x1440
               RenderTableCell {TD} at (513,1164) size 93x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=6 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-            RenderTableRow {TR} at (0,1196) size 606x24
-              RenderTableCell {TD} at (0,1196) size 89x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,1250) size 606x24
+              RenderTableCell {TD} at (0,1250) size 89x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (88,1196) size 86x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (88,1250) size 86x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (173,1196) size 85x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (173,1250) size 85x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (257,1196) size 85x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (257,1250) size 85x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (341,1196) size 86x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=4 rs=1 cs=1]
+              RenderTableCell {TD} at (341,1250) size 86x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=4 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (426,1196) size 88x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=5 rs=1 cs=1]
+              RenderTableCell {TD} at (426,1250) size 88x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=5 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (513,1196) size 93x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=6 rs=1 cs=1]
+              RenderTableCell {TD} at (513,1250) size 93x24 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=6 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x20
                   text run at (2,2) width 6: "-"
-        RenderBlock (anonymous) at (0,1280) size 784x40
+        RenderBlock (anonymous) at (0,1334) size 784x40
           RenderBR {BR} at (392,0) size 0x20
           RenderText {#text} at (4,20) size 776x20
             text run at (4,20) width 776: "Notice the scrollbars, they are rendered outside of the table columns, and the yellow day numbers are hidden under them."
-        RenderBlock {P} at (0,1336) size 784x80
+        RenderBlock {P} at (0,1390) size 784x80
           RenderText {#text} at (0,0) size 784x80
             text run at (11,0) width 762: "This is probably another bug already covered, or fixed, but day 3 & 16 should have no scrollbar, but the area where the"
             text run at (9,20) width 423: "other scrollbars are drawn is drawn funny. They are not rendered. "

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug51000-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug51000-expected.txt
@@ -1,23 +1,23 @@
-layer at (0,0) size 800x600
+layer at (0,0) size 800x954
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x584
+layer at (0,0) size 800x954
+  RenderBlock {HTML} at (0,0) size 800x954
+    RenderBody {BODY} at (8,8) size 784x938
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 371x20
           text run at (0,0) width 371: "300xp height value set on THEAD, TBODY, and TFOOT"
-      RenderTable {TABLE} at (0,36) size 250x82 [border: (1px outset #000000)]
-        RenderTableSection {THEAD} at (1,1) size 248x28
+      RenderTable {TABLE} at (0,36) size 250x902 [border: (1px outset #000000)]
+        RenderTableSection {THEAD} at (1,1) size 248x300
           RenderTableRow {TR} at (0,2) size 248x24
             RenderTableCell {TH} at (2,2) size 244x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 240x20
                 text run at (2,2) width 240: "This THEAD should be 300px high"
-        RenderTableSection {TFOOT} at (1,55) size 248x26
+        RenderTableSection {TFOOT} at (1,601) size 248x300
           RenderTableRow {TR} at (0,0) size 248x24
             RenderTableCell {TD} at (2,0) size 244x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 226x20
                 text run at (2,2) width 226: "This TFOOT should be 300px high"
-        RenderTableSection {TBODY} at (1,29) size 248x26
+        RenderTableSection {TBODY} at (1,301) size 248x300
           RenderTableRow {TR} at (0,0) size 248x24
             RenderTableCell {TD} at (2,0) size 244x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 234x20

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x2635
+layer at (0,0) size 800x2665
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x2635
-  RenderBlock {HTML} at (0,0) size 800x2636
-    RenderBody {BODY} at (8,8) size 784x2612
+layer at (0,0) size 800x2665
+  RenderBlock {HTML} at (0,0) size 800x2666
+    RenderBody {BODY} at (8,8) size 784x2642
       RenderBlock {H1} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 432x36
           text run at (0,1) width 432: "Example 4: Some simple tables."
@@ -472,8 +472,8 @@ layer at (0,0) size 800x2635
         RenderBR {BR} at (0,0) size 0x20
         RenderText {#text} at (0,20) size 418x20
           text run at (0,20) width 418: "This is like the previous table plus the list's overflow property set"
-      RenderTable at (0,1485) size 225x21
-        RenderTableSection {UL} at (0,0) size 225x20
+      RenderTable at (0,1485) size 225x51
+        RenderTableSection {UL} at (0,0) size 225x50
           RenderTableRow (anonymous) at (0,0) size 225x20
             RenderTableCell {LI} at (0,0) size 33x20 [bgcolor=#FFA500] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 33x20
@@ -493,9 +493,9 @@ layer at (0,0) size 800x2635
             RenderTableCell {LI} at (199,0) size 26x20 [bgcolor=#FFA500] [r=0 c=5 rs=1 cs=1]
               RenderText {#text} at (0,0) size 26x20
                 text run at (0,0) width 26: "SIX"
-      RenderBlock (anonymous) at (0,1505) size 784x21
+      RenderBlock (anonymous) at (0,1535) size 784x21
         RenderBR {BR} at (0,0) size 0x20
-      RenderBlock {P} at (0,1541) size 784x219
+      RenderBlock {P} at (0,1571) size 784x219
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 435x20
             text run at (0,0) width 435: "The following table will have its rows and columns in red collapsed"
@@ -582,7 +582,7 @@ layer at (0,0) size 800x2635
               RenderTableCell {TD} at (34,28) size 68x24 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x20
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1775) size 784x269
+      RenderBlock {P} at (0,1805) size 784x269
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 756x20
             text run at (0,0) width 756: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -698,7 +698,7 @@ layer at (0,0) size 800x2635
               RenderTableCell {TD} at (61,84) size 32x24 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x20
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,2059) size 784x249
+      RenderBlock {P} at (0,2089) size 784x249
         RenderBlock (anonymous) at (0,0) size 784x20
           RenderText {#text} at (0,0) size 463x20
             text run at (0,0) width 463: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -825,7 +825,7 @@ layer at (0,0) size 800x2635
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,228) size 784x20
           RenderBR {BR} at (0,0) size 0x20
-      RenderBlock {P} at (0,2323) size 784x289
+      RenderBlock {P} at (0,2353) size 784x289
         RenderBlock (anonymous) at (0,0) size 784x40
           RenderText {#text} at (0,0) size 775x40
             text run at (0,0) width 571: "The following table is similar to a previous table except that the direction is right-to-left. "

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2276
+layer at (0,0) size 785x2756
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2276
-  RenderBlock {HTML} at (0,0) size 785x2276
-    RenderBody {BODY} at (8,8) size 769x2260 [bgcolor=#19BCD2]
+layer at (0,0) size 785x2756
+  RenderBlock {HTML} at (0,0) size 785x2756
+    RenderBody {BODY} at (8,8) size 769x2740 [bgcolor=#19BCD2]
       RenderTable {TABLE} at (0,0) size 769x200 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 767x198
           RenderTableRow {TR} at (0,0) size 767x159
@@ -15,8 +15,8 @@ layer at (0,0) size 785x2276
                 text run at (1,1) width 161: "20% of table 200px table"
       RenderBlock (anonymous) at (0,199) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,217) size 769x43 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 767x40
+      RenderTable {TABLE} at (0,217) size 769x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 767x200
           RenderTableRow {TR} at (0,0) size 767x20
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x18
@@ -25,10 +25,10 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,20) size 767x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x18
                 text run at (1,1) width 132: "20% of 200px tbody"
-      RenderBlock (anonymous) at (0,259) size 769x19
+      RenderBlock (anonymous) at (0,419) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,277) size 769x43 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 767x40
+      RenderTable {TABLE} at (0,437) size 769x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 767x200
           RenderTableRow {TR} at (0,0) size 767x20
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x18
@@ -37,9 +37,9 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,20) size 767x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 132x18
                 text run at (1,1) width 132: "20% of 200px tbody"
-      RenderBlock (anonymous) at (0,319) size 769x19
+      RenderBlock (anonymous) at (0,639) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,337) size 769x201 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,657) size 769x201 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 767x198
           RenderTableRow {TR} at (0,0) size 767x159
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -49,10 +49,10 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,158) size 767x21 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 155x18
                 text run at (1,1) width 155: "row 20% of 200px table"
-      RenderBlock (anonymous) at (0,537) size 769x19
+      RenderBlock (anonymous) at (0,857) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,555) size 769x43 [bgcolor=#FFA500] [border: (1px outset #000000)]
-        RenderTableSection {TBODY} at (1,1) size 767x40
+      RenderTable {TABLE} at (0,875) size 769x203 [bgcolor=#FFA500] [border: (1px outset #000000)]
+        RenderTableSection {TBODY} at (1,1) size 767x200
           RenderTableRow {TR} at (0,0) size 767x20
             RenderTableCell {TD} at (0,0) size 767x20 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 160x18
@@ -61,9 +61,9 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (0,20) size 767x20 [border: (1px inset #000000)] [r=1 c=0 rs=1 cs=1]
               RenderText {#text} at (1,1) size 160x18
                 text run at (1,1) width 160: "row 20% of 200px tbody"
-      RenderBlock (anonymous) at (0,597) size 769x19
+      RenderBlock (anonymous) at (0,1077) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,615) size 769x381 [bgcolor=#FFA500] [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1095) size 769x381 [bgcolor=#FFA500] [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 767x378
           RenderTableRow {TR} at (0,0) size 767x378
             RenderTableCell {TD} at (0,0) size 767x648 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -122,9 +122,9 @@ layer at (0,0) size 785x2276
                       RenderBR {BR} at (4,234) size 0x18
                       RenderText {#text} at (0,252) size 4x18
                         text run at (0,252) width 4: " "
-      RenderBlock (anonymous) at (0,995) size 769x19
+      RenderBlock (anonymous) at (0,1475) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,1013) size 600x401 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1493) size 600x401 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 598x398
           RenderTableRow {TR} at (0,2) size 598x394
             RenderTableCell {TD} at (2,2) size 594x394 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
@@ -138,18 +138,18 @@ layer at (0,0) size 785x2276
                             RenderTableCell {TD} at (2,178) size 574x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
                               RenderText {#text} at (2,178) size 22x18
                                 text run at (2,2) width 22: "foo"
-      RenderBlock (anonymous) at (0,1413) size 769x19
+      RenderBlock (anonymous) at (0,1893) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,1431) size 64x23 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1911) size 64x23 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 62x20
           RenderTableRow {TR} at (0,0) size 62x20
             RenderTableCell {TD} at (0,0) size 62x20 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (1,1) size 60x18
                 text run at (1,1) width 60: "blah blah"
           RenderTableRow {TR} at (0,20) size 62x0
-      RenderBlock (anonymous) at (0,1453) size 769x19
+      RenderBlock (anonymous) at (0,1933) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (0,1471) size 602x365 [border: (1px outset #000000)]
+      RenderTable {TABLE} at (0,1951) size 602x365 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 600x362
           RenderTableRow {TR} at (0,0) size 600x0
             RenderTableCell {TD} at (0,0) size 503x362 [bgcolor=#FFFFFF] [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=2]
@@ -158,9 +158,9 @@ layer at (0,0) size 785x2276
             RenderTableCell {TD} at (502,171) size 98x20 [border: (1px inset #000000)] [r=1 c=2 rs=1 cs=6]
               RenderText {#text} at (72,172) size 25x18
                 text run at (72,1) width 25: "xxx"
-      RenderBlock (anonymous) at (0,1835) size 769x19
+      RenderBlock (anonymous) at (0,2315) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderTable {TABLE} at (10,1853) size 749x407 [bgcolor=#808080]
+      RenderTable {TABLE} at (10,2333) size 749x407 [bgcolor=#808080]
         RenderTableSection {TBODY} at (0,0) size 748x406
           RenderTableRow {TR} at (0,4) size 748x398
             RenderTableCell {TD} at (4,4) size 740x398 [r=0 c=0 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt
@@ -1,18 +1,18 @@
-layer at (0,0) size 785x1340
+layer at (0,0) size 785x1396
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x1340
-  RenderBlock {HTML} at (0,0) size 785x1340
-    RenderBody {BODY} at (8,8) size 769x1316
-      RenderBlock {CENTER} at (0,0) size 769x1316
+layer at (0,0) size 785x1396
+  RenderBlock {HTML} at (0,0) size 785x1396
+    RenderBody {BODY} at (8,8) size 769x1372
+      RenderBlock {CENTER} at (0,0) size 769x1372
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (250,0) size 269x18
             text run at (250,0) width 269: "Build 1999/10/27/08 Win95 - Daily Build"
           RenderBR {BR} at (518,0) size 1x18
-        RenderTable {TABLE} at (71,18) size 627x1156 [border: (10px outset #000000)]
+        RenderTable {TABLE} at (71,18) size 627x1212 [border: (10px outset #000000)]
           RenderBlock {CAPTION} at (0,0) size 626x18
             RenderText {#text} at (269,0) size 87x18
               text run at (269,0) width 87: "January 2000"
-          RenderTableSection {TBODY} at (10,28) size 606x1118
+          RenderTableSection {TBODY} at (10,28) size 606x1174
             RenderTableRow {TR} at (0,0) size 606x430
               RenderTableCell {TD} at (0,0) size 89x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=0 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
@@ -105,16 +105,16 @@ layer at (0,0) size 785x1340
                                     text run at (0,36) width 30: "food"
                 RenderBlock (anonymous) at (2,182) size 85x18
                   RenderBR {BR} at (0,0) size 0x18
-              RenderTableCell {TD} at (88,430) size 86x80 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=1 c=1 rs=1 cs=1]
-                RenderTable {TABLE} at (2,2) size 81x76 [color=#000000]
-                  RenderTableSection {TBODY} at (0,0) size 81x76
-                    RenderTableRow {TR} at (0,0) size 81x76
+              RenderTableCell {TD} at (88,430) size 86x86 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=1 c=1 rs=1 cs=1]
+                RenderTable {TABLE} at (2,2) size 81x82 [color=#000000]
+                  RenderTableSection {TBODY} at (0,0) size 81x82
+                    RenderTableRow {TR} at (0,0) size 81x82
                       RenderTableCell {TD} at (0,0) size 18x26 [color=#FFFF00] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,0) size 16x26
                           text run at (1,0) width 16: "3."
-                      RenderTableCell {TD} at (18,0) size 63x76 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 61x74 [color=#000000]
-                          RenderTableSection {TBODY} at (0,0) size 61x74 [bgcolor=#FFFF00]
+                      RenderTableCell {TD} at (18,0) size 63x82 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 61x80 [color=#000000]
+                          RenderTableSection {TBODY} at (0,0) size 61x80 [bgcolor=#FFFF00]
                             RenderTableRow {TR} at (0,0) size 61x74
                               RenderTableCell {TD} at (0,0) size 61x74 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                                 RenderBlock {P} at (1,1) size 59x72
@@ -445,17 +445,17 @@ layer at (0,0) size 785x1340
                                     text run at (0,0) width 29: "This"
                                     text run at (0,18) width 39: "bug is"
                                     text run at (0,36) width 32: "fixed"
-            RenderTableRow {TR} at (0,1066) size 606x30
-              RenderTableCell {TD} at (0,1066) size 89x30 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=0 rs=1 cs=1]
-                RenderTable {TABLE} at (2,2) size 85x26 [color=#000000]
-                  RenderTableSection {TBODY} at (0,0) size 85x26
-                    RenderTableRow {TR} at (0,0) size 85x26
+            RenderTableRow {TR} at (0,1066) size 606x86
+              RenderTableCell {TD} at (0,1066) size 89x86 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=0 rs=1 cs=1]
+                RenderTable {TABLE} at (2,2) size 85x82 [color=#000000]
+                  RenderTableSection {TBODY} at (0,0) size 85x82
+                    RenderTableRow {TR} at (0,0) size 85x82
                       RenderTableCell {TD} at (0,0) size 29x26 [color=#FFFF00] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                         RenderText {#text} at (1,0) size 27x26
                           text run at (1,0) width 27: "16."
-                      RenderTableCell {TD} at (28,0) size 57x22 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
-                        RenderTable {TABLE} at (1,1) size 54x20 [color=#000000]
-                          RenderTableSection {TBODY} at (0,0) size 54x20 [bgcolor=#FFFF00]
+                      RenderTableCell {TD} at (28,0) size 57x82 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=1 rs=1 cs=1]
+                        RenderTable {TABLE} at (1,1) size 54x80 [color=#000000]
+                          RenderTableSection {TBODY} at (0,0) size 54x80 [bgcolor=#FFFF00]
                             RenderTableRow {TR} at (0,0) size 54x20
                               RenderTableCell {TD} at (0,0) size 54x20 [color=#FFFFFF] [bgcolor=#404080] [r=0 c=0 rs=1 cs=1]
                                 RenderText {#text} at (1,1) size 8x18
@@ -478,34 +478,34 @@ layer at (0,0) size 785x1340
               RenderTableCell {TD} at (513,1066) size 93x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=3 c=6 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-            RenderTableRow {TR} at (0,1095) size 606x23
-              RenderTableCell {TD} at (0,1095) size 89x23 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=0 rs=1 cs=1]
+            RenderTableRow {TR} at (0,1152) size 606x22
+              RenderTableCell {TD} at (0,1152) size 89x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=0 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (88,1095) size 86x23 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=1 rs=1 cs=1]
+              RenderTableCell {TD} at (88,1152) size 86x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=1 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (173,1095) size 85x23 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=2 rs=1 cs=1]
+              RenderTableCell {TD} at (173,1152) size 85x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (257,1095) size 85x23 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=3 rs=1 cs=1]
+              RenderTableCell {TD} at (257,1152) size 85x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (341,1095) size 86x23 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=4 rs=1 cs=1]
+              RenderTableCell {TD} at (341,1152) size 86x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=4 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (426,1095) size 88x23 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=5 rs=1 cs=1]
+              RenderTableCell {TD} at (426,1152) size 88x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=5 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-              RenderTableCell {TD} at (513,1095) size 93x23 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=6 rs=1 cs=1]
+              RenderTableCell {TD} at (513,1152) size 93x22 [color=#FFFFFF] [bgcolor=#404080] [border: (1px inset #FFFFFF)] [r=4 c=6 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 6x18
                   text run at (2,2) width 6: "-"
-        RenderBlock (anonymous) at (0,1173) size 769x55
+        RenderBlock (anonymous) at (0,1230) size 769x54
           RenderBR {BR} at (384,0) size 1x18
           RenderText {#text} at (16,18) size 737x36
             text run at (16,18) width 737: "Notice the scrollbars, they are rendered outside of the table columns, and the yellow day numbers are hidden under"
             text run at (366,36) width 37: "them."
-        RenderBlock {P} at (0,1243) size 769x73
+        RenderBlock {P} at (0,1300) size 769x72
           RenderText {#text} at (1,0) size 767x72
             text run at (4,0) width 761: "This is probably another bug already covered, or fixed, but day 3 & 16 should have no scrollbar, but the area where the"
             text run at (1,18) width 424: "other scrollbars are drawn is drawn funny. They are not rendered. "

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug51000-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug51000-expected.txt
@@ -1,23 +1,23 @@
-layer at (0,0) size 800x600
-  RenderView at (0,0) size 800x600
-layer at (0,0) size 800x600
-  RenderBlock {HTML} at (0,0) size 800x600
-    RenderBody {BODY} at (8,8) size 784x584
-      RenderBlock {P} at (0,0) size 784x18
+layer at (0,0) size 785x952
+  RenderView at (0,0) size 785x600
+layer at (0,0) size 785x952
+  RenderBlock {HTML} at (0,0) size 785x952
+    RenderBody {BODY} at (8,8) size 769x936
+      RenderBlock {P} at (0,0) size 769x18
         RenderText {#text} at (0,0) size 371x18
           text run at (0,0) width 371: "300xp height value set on THEAD, TBODY, and TFOOT"
-      RenderTable {TABLE} at (0,34) size 250x76 [border: (1px outset #000000)]
-        RenderTableSection {THEAD} at (1,1) size 248x26
+      RenderTable {TABLE} at (0,34) size 250x902 [border: (1px outset #000000)]
+        RenderTableSection {THEAD} at (1,1) size 248x300
           RenderTableRow {TR} at (0,2) size 248x22
             RenderTableCell {TH} at (2,2) size 244x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 240x18
                 text run at (2,2) width 240: "This THEAD should be 300px high"
-        RenderTableSection {TFOOT} at (1,51) size 248x24
+        RenderTableSection {TFOOT} at (1,601) size 248x300
           RenderTableRow {TR} at (0,0) size 248x22
             RenderTableCell {TD} at (2,0) size 244x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 226x18
                 text run at (2,2) width 226: "This TFOOT should be 300px high"
-        RenderTableSection {TBODY} at (1,27) size 248x24
+        RenderTableSection {TBODY} at (1,301) size 248x300
           RenderTableRow {TR} at (0,0) size 248x22
             RenderTableCell {TD} at (2,0) size 244x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 234x18

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x2418
+layer at (0,0) size 785x2450
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x2418
-  RenderBlock {HTML} at (0,0) size 785x2419
-    RenderBody {BODY} at (8,8) size 769x2395
+layer at (0,0) size 785x2450
+  RenderBlock {HTML} at (0,0) size 785x2451
+    RenderBody {BODY} at (8,8) size 769x2427
       RenderBlock {H1} at (0,0) size 769x37
         RenderText {#text} at (0,0) size 432x37
           text run at (0,0) width 432: "Example 4: Some simple tables."
@@ -472,8 +472,8 @@ layer at (0,0) size 785x2418
         RenderBR {BR} at (0,0) size 0x18
         RenderText {#text} at (0,18) size 417x18
           text run at (0,18) width 417: "This is like the previous table plus the list's overflow property set"
-      RenderTable at (0,1362) size 225x19
-        RenderTableSection {UL} at (0,0) size 225x18
+      RenderTable at (0,1362) size 225x51
+        RenderTableSection {UL} at (0,0) size 225x50
           RenderTableRow (anonymous) at (0,0) size 225x18
             RenderTableCell {LI} at (0,0) size 33x18 [bgcolor=#FFA500] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (0,0) size 33x18
@@ -493,9 +493,9 @@ layer at (0,0) size 785x2418
             RenderTableCell {LI} at (199,0) size 26x18 [bgcolor=#FFA500] [r=0 c=5 rs=1 cs=1]
               RenderText {#text} at (0,0) size 26x18
                 text run at (0,0) width 26: "SIX"
-      RenderBlock (anonymous) at (0,1380) size 769x19
+      RenderBlock (anonymous) at (0,1412) size 769x19
         RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,1414) size 769x201
+      RenderBlock {P} at (0,1446) size 769x201
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 435x18
             text run at (0,0) width 435: "The following table will have its rows and columns in red collapsed"
@@ -582,7 +582,7 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (34,26) size 68x22 [border: (1px inset #000000)] [r=2 c=2 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C33"
-      RenderBlock {P} at (0,1630) size 769x245
+      RenderBlock {P} at (0,1662) size 769x245
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 756x18
             text run at (0,0) width 756: "The following table will have its 2nd row and 2nd col collapsed. A window resize may be necessary to see it properly."
@@ -698,7 +698,7 @@ layer at (0,0) size 785x2418
               RenderTableCell {TD} at (61,76) size 32x22 [border: (1px inset #000000)] [r=3 c=3 rs=1 cs=1]
                 RenderText {#text} at (2,2) size 27x18
                   text run at (2,2) width 27: "C44"
-      RenderBlock {P} at (0,1890) size 769x227
+      RenderBlock {P} at (0,1922) size 769x227
         RenderBlock (anonymous) at (0,0) size 769x18
           RenderText {#text} at (0,0) size 463x18
             text run at (0,0) width 463: "The following table will have its 1st row group collapsed (rows 1 and 2)"
@@ -825,7 +825,7 @@ layer at (0,0) size 785x2418
                   text run at (2,2) width 27: "C44"
         RenderBlock (anonymous) at (0,208) size 769x18
           RenderBR {BR} at (0,0) size 0x18
-      RenderBlock {P} at (0,2132) size 769x263
+      RenderBlock {P} at (0,2164) size 769x263
         RenderBlock (anonymous) at (0,0) size 769x36
           RenderText {#text} at (0,0) size 747x36
             text run at (0,0) width 571: "The following table is similar to a previous table except that the direction is right-to-left. "

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -684,6 +684,19 @@ void RenderTableSection::layoutRows()
 
     ASSERT(!needsLayout());
 
+    // Distribute any extra height from an explicit section height to the rows before
+    // committing the final logical height.
+    auto distributeExplicitSectionHeightToRows = [&] {
+        auto fixedHeight = style().logicalHeight().tryFixed();
+        if (!fixedHeight)
+            return;
+        LayoutUnit specifiedHeight = Style::evaluate<LayoutUnit>(*fixedHeight, style().usedZoomForLength());
+        if (specifiedHeight <= m_rowPos[numberOfRows])
+            return;
+        distributeExtraLogicalHeightToRows(specifiedHeight - m_rowPos[numberOfRows]);
+    };
+    distributeExplicitSectionHeightToRows();
+
     setLogicalHeight(m_rowPos[numberOfRows]);
 
     updateLayerTransform();


### PR DESCRIPTION
#### 3ef66918061f8ca7f977e0cd81c8e61ec7ff3018
<pre>
Table sections with explicit height should constrain contained rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=306592">https://bugs.webkit.org/show_bug.cgi?id=306592</a>
<a href="https://rdar.apple.com/169235210">rdar://169235210</a>

Reviewed by Alan Baradlay.

When a table section (tbody, thead, or tfoot) has an explicit height
that is larger than the natural height of its rows, the extra space
should be distributed among the rows. Previously, the section&apos;s own
height constraint was ignored, causing the section to collapse to
only the natural height of its rows.

According to the CSS Tables Level 3 specification for &quot;Computing row
measures&quot; [1], the table section&apos;s height should be max(section height,
sum of row heights).

This fix ensures that after calculating row heights in layoutRows(),
we check if the section has an explicit fixed height. If that height
exceeds the sum of row heights, we distribute the extra space to the
rows using the existing distributeExtraLogicalHeightToRows() method.

[1] <a href="https://drafts.csswg.org/css-tables-3/#computing-the-table-width">https://drafts.csswg.org/css-tables-3/#computing-the-table-width</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/computing-row-measure-0-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/table-height-redistribution-expected.txt: One test progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/tentative/tbody-height-redistribution-expected.txt: Rebaseline
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::layoutRows):

&gt; Rebaselines:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug51000-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug51000-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/other/test4-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug131020-3-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug14007-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug51000-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/other/test4-expected.txt:

Canonical link: <a href="https://commits.webkit.org/308540@main">https://commits.webkit.org/308540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f23687ae5f80da9d5259c6d0a42dbdb7c41d700c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155944 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100679 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daf71f5c-73c2-4798-a59c-a355fa19a406) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113502 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80953 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6beee56d-54de-4bf9-bbb2-77b903b5c41f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94255 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c171d38b-d3f0-46b6-a634-c4569bd5cf43) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12691 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3387 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158276 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121520 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121723 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31298 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131973 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75736 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8768 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19360 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83125 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19090 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19240 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->