### PR TITLE
[YARR] Fix capture group reset in JIT-compiled fixed-count non-capturing parentheses

### DIFF
--- a/JSTests/stress/regexp-fixed-count-nested-captures-reset.js
+++ b/JSTests/stress/regexp-fixed-count-nested-captures-reset.js
@@ -1,0 +1,74 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "expected: " + JSON.stringify(expected) + ", actual: " + JSON.stringify(actual));
+}
+
+function shouldBeArray(actual, expected, message) {
+    if (actual === null && expected !== null)
+        throw new Error((message ? message + ": " : "") + "expected: " + JSON.stringify(expected) + ", actual: null");
+    if (actual === null || expected === null) {
+        if (actual !== expected)
+            throw new Error((message ? message + ": " : "") + "expected: " + JSON.stringify(expected) + ", actual: " + JSON.stringify(actual));
+        return;
+    }
+    if (actual.length !== expected.length)
+        throw new Error((message ? message + ": " : "") + "expected length: " + expected.length + ", actual length: " + actual.length);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error((message ? message + ": " : "") + "at index " + i + ", expected: " + JSON.stringify(expected[i]) + ", actual: " + JSON.stringify(actual[i]));
+    }
+}
+
+(function testBackreferenceWithCaptureReset() {
+    let re = /(?:^(a)|\1(a)|(ab)){2}/;
+    let str = 'aab';
+    let actual = re.exec(str);
+
+    shouldBeArray(actual, ['aa', undefined, 'a', undefined], "backreference with capture reset");
+    shouldBe(actual.index, 0, "match index");
+    shouldBe(actual.input, str, "input string");
+})();
+
+(function testDuplicateNamedGroupsWithFixedCount() {
+    let result1 = /(?:(?:(?<a>x)|(?<a>y))\k<a>){2}/.exec('xxyy');
+    shouldBeArray(result1, ['xxyy', undefined, 'y'], "duplicate named groups - simple case");
+
+    let result2 = /(?:(?:(?<a>x)|(?<a>y)|(a)|(?<b>b)|(?<a>z))\k<a>){3}/.exec('xzzyyxxy');
+    shouldBeArray(result2, ['zzyyxx', 'x', undefined, undefined, undefined, undefined], "duplicate named groups - complex case");
+
+    let result3 = 'xxyy'.match(/(?:(?:(?<a>x)|(?<a>y))\k<a>){2}/);
+    shouldBeArray(result3, ['xxyy', undefined, 'y'], "duplicate named groups - String.match");
+})();
+
+(function testCaptureResetInVariousPatterns() {
+    let re1 = /(?:(a)|\1b){2}/;
+    let result1 = re1.exec('ab');
+    shouldBeArray(result1, ['ab', undefined], "backreference reset to empty string");
+
+    let re2 = /(?:(a)|b){2}/;
+    let result2 = re2.exec('ab');
+    shouldBeArray(result2, ['ab', undefined], "capture reset - alternation without backreference");
+
+    let re3 = /(?:(a)|b){3}/;
+    let result3 = re3.exec('aba');
+    shouldBeArray(result3, ['aba', 'a'], "capture reset - three iterations ending with capture");
+
+    let result4 = re3.exec('abb');
+    shouldBeArray(result4, ['abb', undefined], "capture reset - three iterations ending without capture");
+})();
+
+(function testNestedNonCapturingWithCaptures() {
+    let re = /(?:(a)(b)){2}/;
+    let result = re.exec('abab');
+    shouldBeArray(result, ['abab', 'a', 'b'], "nested capturing groups in fixed count");
+})();
+
+(function testNonCapturingWithoutNestedCaptures() {
+    let re = /(?:ab){3}/;
+    let result = re.exec('ababab');
+    shouldBeArray(result, ['ababab'], "non-capturing without nested captures");
+
+    let re2 = /(?:a|b){4}/;
+    let result2 = re2.exec('abba');
+    shouldBeArray(result2, ['abba'], "non-capturing alternation without captures");
+})();

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3827,6 +3827,14 @@ class YarrGenerator final : public YarrJITInfo {
                 // Set the reentry label for looping.
                 op.m_reentry = m_jit.label();
 
+                // Clear nested captures at the start of each iteration.
+                // This is required by ECMAScript spec - capture groups are reset to undefined
+                // at the beginning of each iteration of a quantified group.
+                if (m_compileMode == JITCompileMode::IncludeSubpatterns && term->containsAnyCaptures()) {
+                    for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                        clearSubpatternStart(subpattern);
+                }
+
                 // Store the current index for empty match detection.
                 storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
                 break;


### PR DESCRIPTION
#### 7c8968c2ec20b0c7e94513704ce4773ae6c0e134
<pre>
[YARR] Fix capture group reset in JIT-compiled fixed-count non-capturing parentheses
<a href="https://bugs.webkit.org/show_bug.cgi?id=306593">https://bugs.webkit.org/show_bug.cgi?id=306593</a>

Reviewed by Yusuke Suzuki.

The recent optimization for non-capturing parentheses with fixed-count quantifiers
(bug 305284) introduced a regression where nested capture groups were not being
reset to undefined at the start of each iteration.

ECMAScript specification requires that capture groups within a quantified group
are reset to undefined at the beginning of each iteration. The existing
ParenthesesSubpatternBegin implementation handles this via saveParenContext()
which calls clearSubpatternStart() for each nested capture. However, the new
ParenthesesSubpatternFixedCountBegin was missing this logic.

This patch adds the capture group clearing code to ParenthesesSubpatternFixedCountBegin,
matching the behavior of the interpreter and the existing JIT implementation for
non-fixed-count quantifiers.

Test: JSTests/stress/regexp-fixed-count-nested-captures-reset.js

* JSTests/stress/regexp-fixed-count-nested-captures-reset.js: Added.
(shouldBe):
(testDuplicateNamedGroupsWithFixedCount):
(testCaptureResetInVariousPatterns):
(testNestedNonCapturingWithCaptures):
(testNonCapturingWithoutNestedCaptures):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/306476@main">https://commits.webkit.org/306476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d110b25c3a99898d230cf23497538e1af0cb100c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150050 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108699 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8428 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/122 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133458 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152443 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2278 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116800 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117130 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13172 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68745 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13591 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2578 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172766 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13327 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44753 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->