### PR TITLE
Add a generic `adopt()` function to WTF

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 		DDF306FD27C086CC006A526F /* TypeCastsCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3070627C086CC006A526F /* WeakLinking.h in Headers */ = {isa = PBXBuildFile; fileRef = 37C7CC291EA40A73007BD956 /* WeakLinking.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3070C27C086CC006A526F /* TypeCastsCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AFDE647195201C300C48FFA /* TypeCastsCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2A0CF001302E77880086000B /* CFTypeTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0CF001302E77880086000A /* CFTypeTraits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3070E27C086CC006A526F /* NSURLExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CC0EE872162BC2200A1A842 /* NSURLExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3071127C086CC006A526F /* CrashReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA072A8236FFBF70018839C /* CrashReporter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3071327C086CC006A526F /* CFURLExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1F05922164356B0039302C /* CFURLExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1249,6 +1250,7 @@
 		1A944F461C3D8814005BD28C /* BlockPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockPtr.h; sourceTree = "<group>"; };
 		1AEA88E11D6BBCF400E5AD64 /* EnumTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumTraits.h; sourceTree = "<group>"; };
 		1AFDE647195201C300C48FFA /* TypeCastsCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCastsCF.h; sourceTree = "<group>"; };
+		2A0CF001302E77880086000A /* CFTypeTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFTypeTraits.h; sourceTree = "<group>"; };
 		1C08E3662985D7D300CAE594 /* IOReturnSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IOReturnSPI.h; sourceTree = "<group>"; };
 		1C08E3672985D7D400CAE594 /* IOTypesSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IOTypesSPI.h; sourceTree = "<group>"; };
 		1C181C7D1D3078DA00F5FA16 /* TextBreakIterator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextBreakIterator.cpp; sourceTree = "<group>"; };

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -85,8 +85,8 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
 
 #if USE(CF)
     if (contains(formatSpan, "%@"_span)) {
-        auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
-        auto result = adoptCF(CFStringCreateWithFormatAndArguments(kCFAllocatorDefault, nullptr, cfFormat.get(), args));
+        auto cfFormat = adopt(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, format, kCFStringEncodingUTF8, kCFAllocatorNull));
+        auto result = adopt(CFStringCreateWithFormatAndArguments(kCFAllocatorDefault, nullptr, cfFormat.get(), args));
         va_end(argsCopy);
         return result.get();
     }
@@ -159,9 +159,9 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
 
 #if USE(CF)
     if (contains(formatSpan, "%@"_span)) {
-        auto cfFormat = adoptCF(CFStringCreateWithCStringNoCopy(nullptr, format, kCFStringEncodingUTF8, kCFAllocatorNull));
+        auto cfFormat = adopt(CFStringCreateWithCStringNoCopy(nullptr, format, kCFStringEncodingUTF8, kCFAllocatorNull));
 
-        auto str = adoptCF(CFStringCreateWithFormatAndArguments(nullptr, nullptr, cfFormat.get(), args));
+        auto str = adopt(CFStringCreateWithFormatAndArguments(nullptr, nullptr, cfFormat.get(), args));
         CFIndex length = CFStringGetMaximumSizeForEncoding(CFStringGetLength(str.get()), kCFStringEncodingUTF8);
         constexpr unsigned InitialBufferSize { 256 };
         Vector<char, InitialBufferSize> buffer(length + 1);

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -179,6 +179,9 @@ public:
 
 private:
     friend Ref adoptRef<T>(T&);
+    template<typename U, typename V, typename W>
+        requires HasRefPtrMemberFunctions<U>::value
+    friend Ref<U, V, W> adopt(U&);
     template<typename X, typename Y, typename Z> friend class Ref;
 
     template<typename X, typename Y, typename Z, typename U, typename V, typename W>
@@ -348,6 +351,14 @@ inline Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T& reference)
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
     requires HasRefPtrMemberFunctions<T>::value
+inline Ref<T, PtrTraits, RefDerefTraits> adopt(T& reference)
+{
+    adopted(&reference);
+    return Ref<T, PtrTraits, RefDerefTraits>(reference, Ref<T, PtrTraits, RefDerefTraits>::Adopt);
+}
+
+template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
+    requires HasRefPtrMemberFunctions<T>::value
 ALWAYS_INLINE CLANG_POINTER_CONVERSION Ref<T, PtrTraits, RefDerefTraits> protect(T& reference)
 {
     return Ref<T, PtrTraits, RefDerefTraits>(reference);
@@ -402,6 +413,7 @@ inline bool arePointingToEqualData(const Ref<T, PtrTraits, RefDerefTraits>& a, c
 } // namespace WTF
 
 using WTF::Ref;
+using WTF::adopt;
 using WTF::adoptRef;
 using WTF::arePointingToEqualData;
 using WTF::protect;

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -97,6 +97,9 @@ public:
 
 private:
     friend RefPtr adoptRef<T, PtrTraits, RefDerefTraits>(T*);
+    template<typename U, typename V, typename W>
+        requires HasRefPtrMemberFunctions<U>::value
+    friend RefPtr<U, V, W> adopt(U*);
     template<typename X, typename Y, typename Z> friend class RefPtr;
 
     template<typename T1, typename U, typename V, typename X, typename Y, typename Z>
@@ -224,6 +227,14 @@ inline RefPtr<T, U, V> adoptRef(T* p)
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
     requires HasRefPtrMemberFunctions<T>::value
+inline RefPtr<T, PtrTraits, RefDerefTraits> adopt(T* p)
+{
+    adopted(p);
+    return RefPtr<T, PtrTraits, RefDerefTraits>(p, RefPtr<T, PtrTraits, RefDerefTraits>::Adopt);
+}
+
+template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
+    requires HasRefPtrMemberFunctions<T>::value
 ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, PtrTraits, RefDerefTraits> protect(T* ptr)
 {
     return RefPtr<T, PtrTraits, RefDerefTraits>(ptr);
@@ -318,6 +329,7 @@ ALWAYS_INLINE void lazyInitialize(const RefPtr<T>& ptr, Ref<U>&& obj)
 } // namespace WTF
 
 using WTF::RefPtr;
+using WTF::adopt;
 using WTF::adoptRef;
 using WTF::protect;
 using WTF::upcast;

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -147,6 +147,18 @@ public:
 
     template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptNS(U NS_RELEASES_ARGUMENT);
 
+#if USE(CF)
+    template<typename U>
+        requires IsCFType<U>
+    friend constexpr RetainPtr<RetainPtrType<U>> adopt(U CF_RELEASES_ARGUMENT);
+#endif
+
+#ifdef __OBJC__
+    template<typename U>
+        requires IsNSType<U>
+    friend constexpr RetainPtr<RetainPtrType<U>> adopt(U NS_RELEASES_ARGUMENT);
+#endif
+
 private:
     enum AdoptTag { Adopt };
     constexpr RetainPtr(PtrType ptr, AdoptTag) : m_ptr(ptr) { }
@@ -314,6 +326,24 @@ template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES
     return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
 }
 
+#if USE(CF)
+template<typename T>
+    requires IsCFType<T>
+constexpr RetainPtr<RetainPtrType<T>> adopt(T CF_RELEASES_ARGUMENT ptr)
+{
+    return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
+}
+#endif
+
+#ifdef __OBJC__
+template<typename T>
+    requires IsNSType<T>
+constexpr RetainPtr<RetainPtrType<T>> adopt(T NS_RELEASES_ARGUMENT ptr)
+{
+    return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
+}
+#endif
+
 template<typename T> inline RetainPtr<RetainPtrType<T>> retainPtr(T ptr)
 {
     return ptr;
@@ -402,6 +432,7 @@ ALWAYS_INLINE void lazyInitialize(const RetainPtr<T>& ptr, RetainPtr<U>&& obj)
 } // namespace WTF
 
 using WTF::RetainPtr;
+using WTF::adopt;
 using WTF::adoptCF;
 using WTF::lazyInitialize;
 using WTF::protect;

--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -44,7 +44,7 @@ class RunLoop::Holder {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(RunLoop);
 public:
     Holder()
-        : m_runLoop(adoptRef(*new RunLoop))
+        : m_runLoop(adopt(*new RunLoop))
     {
     }
 
@@ -171,7 +171,7 @@ void RunLoop::dispatch(Function<void()>&& function)
 Ref<RunLoop::DispatchTimer> RunLoop::dispatchAfter(Seconds delay, Function<void()>&& function)
 {
     RELEASE_ASSERT(function);
-    Ref<DispatchTimer> timer = adoptRef(*new DispatchTimer(*this));
+    Ref<DispatchTimer> timer = adopt(*new DispatchTimer(*this));
     timer->setFunction([timer = timer.copyRef(), function = WTF::move(function)]() mutable {
         Ref<DispatchTimer> protectedTimer { WTF::move(timer) };
         function();

--- a/Source/WTF/wtf/ThreadGroup.h
+++ b/Source/WTF/wtf/ThreadGroup.h
@@ -42,7 +42,7 @@ public:
 
     static Ref<ThreadGroup> create()
     {
-        return adoptRef(*new ThreadGroup());
+        return adopt(*new ThreadGroup());
     }
 
     WTF_EXPORT_PRIVATE ThreadGroupAddResult add(Thread&);

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -231,7 +231,7 @@ void Thread::entryPoint(NewThreadContext* newThreadContext)
     Function<void()> function;
     {
         // Ref is already incremented by Thread::create.
-        Ref context = adoptRef(*newThreadContext);
+        Ref context = adopt(*newThreadContext);
         // Block until our creating thread has completed any extra setup work, including establishing ThreadIdentifier.
         MutexLocker locker(context->mutex);
 
@@ -262,9 +262,9 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
 {
     WTF::initialize();
 
-    Ref thread = adoptRef(*new Thread(schedulingPolicy));
+    Ref thread = adopt(*new Thread(schedulingPolicy));
 
-    Ref context = adoptRef(*new NewThreadContext { name, WTF::move(entryPoint), thread.get() });
+    Ref context = adopt(*new NewThreadContext { name, WTF::move(entryPoint), thread.get() });
     {
         MutexLocker locker(context->mutex);
         context->ref(); // Adopted by Thread::entryPoint

--- a/Source/WTF/wtf/WorkerPool.h
+++ b/Source/WTF/wtf/WorkerPool.h
@@ -48,7 +48,7 @@ public:
     static Ref<WorkerPool> create(ASCIILiteral name, unsigned numberOfWorkers  = WTF::numberOfProcessorCores(), Seconds timeout = Seconds::infinity())
     {
         ASSERT(numberOfWorkers >= 1);
-        return adoptRef(*new WorkerPool(name, numberOfWorkers, timeout));
+        return adopt(*new WorkerPool(name, numberOfWorkers, timeout));
     }
 
     ASCIILiteral name() const { return m_name; }

--- a/Source/WTF/wtf/cf/CFURLExtras.cpp
+++ b/Source/WTF/wtf/cf/CFURLExtras.cpp
@@ -35,7 +35,7 @@ namespace WTF {
 
 RetainPtr<CFDataRef> bytesAsCFData(std::span<const uint8_t> bytes)
 {
-    return adoptCF(CFDataCreate(nullptr, bytes.data(), bytes.size()));
+    return adopt(CFDataCreate(nullptr, bytes.data(), bytes.size()));
 }
 
 RetainPtr<CFDataRef> bytesAsCFData(CFURLRef url)

--- a/Source/WTF/wtf/cf/RunLoopCF.cpp
+++ b/Source/WTF/wtf/cf/RunLoopCF.cpp
@@ -37,7 +37,7 @@ static RetainPtr<CFRunLoopTimerRef> createTimer(Seconds interval, bool repeat, v
 {
     CFRunLoopTimerContext context = { 0, info, 0, 0, 0 };
     Seconds repeatInterval = repeat ? interval : 0_s;
-    return adoptCF(CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + interval.seconds(), repeatInterval.seconds(), 0, 0, timerFired, &context));
+    return adopt(CFRunLoopTimerCreate(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent() + interval.seconds(), repeatInterval.seconds(), 0, 0, timerFired, &context));
 }
 
 void RunLoop::performWork(void* context)
@@ -50,7 +50,7 @@ RunLoop::RunLoop()
     : m_runLoop(CFRunLoopGetCurrent())
 {
     CFRunLoopSourceContext context = { 0, this, 0, 0, 0, 0, 0, 0, 0, performWork };
-    lazyInitialize(m_runLoopSource, adoptCF(CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &context)));
+    lazyInitialize(m_runLoopSource, adopt(CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &context)));
     CFRunLoopAddSource(m_runLoop.get(), m_runLoopSource.get(), kCFRunLoopCommonModes);
 }
 

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -32,6 +32,9 @@
 #import <wtf/darwin/XPCObjectPtr.h>
 #import <wtf/text/WTFString.h>
 
+// Declare CFTypeTrait for SecTaskRef so adopt() works with it.
+WTF_DECLARE_CF_TYPE_TRAIT(SecTask);
+
 namespace WTF {
 
 bool hasEntitlement(SecTaskRef task, ASCIILiteral entitlement)
@@ -40,54 +43,54 @@ bool hasEntitlement(SecTaskRef task, ASCIILiteral entitlement)
         return false;
     auto savedErrno = errno;
     auto string = entitlement.createCFString();
-    auto result = adoptCF(SecTaskCopyValueForEntitlement(task, string.get(), nullptr)) == kCFBooleanTrue;
+    auto result = adopt(SecTaskCopyValueForEntitlement(task, string.get(), nullptr)) == kCFBooleanTrue;
     errno = savedErrno;
     return result;
 }
 
 bool hasEntitlement(audit_token_t token, ASCIILiteral entitlement)
 {
-    return hasEntitlement(adoptCF(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token)).get(), entitlement);
+    return hasEntitlement(adopt(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token)).get(), entitlement);
 }
 
 bool hasEntitlement(xpc_connection_t connection, StringView entitlement)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adopt(xpc_connection_copy_entitlement_value(connection, entitlement.utf8().data()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 
 bool hasEntitlement(xpc_connection_t connection, ASCIILiteral entitlement)
 {
     // FIXME: This is a false positive. <rdar://164843889>
-    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adoptOSObject(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto value = adopt(xpc_connection_copy_entitlement_value(connection, entitlement.characters()));
     return value && xpc_get_type(value.get()) == XPC_TYPE_BOOL && xpc_bool_get_value(value.get());
 }
 
 bool processHasEntitlement(ASCIILiteral entitlement)
 {
-    return hasEntitlement(adoptCF(SecTaskCreateFromSelf(kCFAllocatorDefault)).get(), entitlement);
+    return hasEntitlement(adopt(SecTaskCreateFromSelf(kCFAllocatorDefault)).get(), entitlement);
 }
 
 bool hasEntitlementValue(audit_token_t token, ASCIILiteral entitlement, ASCIILiteral value)
 {
-    auto secTaskForToken = adoptCF(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token));
+    auto secTaskForToken = adopt(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token));
     if (!secTaskForToken)
         return false;
 
     auto string = entitlement.createCFString();
-    String entitlementValue = dynamic_cf_cast<CFStringRef>(adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get());
+    String entitlementValue = dynamic_cf_cast<CFStringRef>(adopt(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get());
     return entitlementValue == value;
 }
 
 bool hasEntitlementValueInArray(audit_token_t token, ASCIILiteral entitlement, ASCIILiteral value)
 {
-    auto secTaskForToken = adoptCF(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token));
+    auto secTaskForToken = adopt(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token));
     if (!secTaskForToken)
         return false;
 
     auto string = entitlement.createCFString();
-    RetainPtr array = adoptCF(dynamic_cf_cast<CFArrayRef>(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)));
+    RetainPtr array = adopt(dynamic_cf_cast<CFArrayRef>(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)));
     if (!array)
         return false;
 

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -76,7 +76,7 @@ String createTemporaryZipArchive(const String& path)
 {
     String temporaryFile;
 
-    RetainPtr coordinator = adoptNS([[NSFileCoordinator alloc] initWithFilePresenter:nil]);
+    RetainPtr coordinator = adopt([[NSFileCoordinator alloc] initWithFilePresenter:nil]);
     [coordinator coordinateReadingItemAtURL:[NSURL fileURLWithPath:path.createNSString().get()] options:NSFileCoordinatorReadingWithoutChanges error:nullptr byAccessor:[&](NSURL *newURL) mutable {
         CString archivePath([NSTemporaryDirectory() stringByAppendingPathComponent:@"WebKitGeneratedFileXXXXXX"].fileSystemRepresentation);
         int fd = mkostemp(archivePath.mutableSpanIncludingNullTerminator().data(), O_CLOEXEC);
@@ -106,7 +106,7 @@ String extractTemporaryZipArchive(const String& path)
     if (!temporaryDirectory)
         return nullString();
 
-    RetainPtr coordinator = adoptNS([[NSFileCoordinator alloc] initWithFilePresenter:nil]);
+    RetainPtr coordinator = adopt([[NSFileCoordinator alloc] initWithFilePresenter:nil]);
     [coordinator coordinateReadingItemAtURL:[NSURL fileURLWithPath:path.createNSString().get()] options:NSFileCoordinatorReadingWithoutChanges error:nullptr byAccessor:[&](NSURL *newURL) mutable {
         auto *options = @{
             bridge_id_cast(kBOMCopierOptionExtractPKZipKey): @YES,

--- a/Source/WTF/wtf/cocoa/LanguageCocoa.mm
+++ b/Source/WTF/wtf/cocoa/LanguageCocoa.mm
@@ -89,7 +89,7 @@ void overrideUserPreferredLanguages(const Vector<String>& override)
 {
     LOG_WITH_STREAM(Language, stream << "Languages are being overridden to: " << override);
     NSDictionary *existingArguments = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSArgumentDomain];
-    auto newArguments = adoptNS([existingArguments mutableCopy]);
+    auto newArguments = adopt([existingArguments mutableCopy]);
     [newArguments setValue:createNSArray(override).get() forKey:@"AppleLanguages"];
     [[NSUserDefaults standardUserDefaults] setVolatileDomain:newArguments.get() forName:NSArgumentDomain];
     languageDidChange();

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -85,7 +85,7 @@ void MemoryPressureHandler::install()
     dispatch_async(m_dispatchQueue.get(), ^{
         auto memoryStatusFlags = DISPATCH_MEMORYPRESSURE_NORMAL | DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_WARN | DISPATCH_MEMORYPRESSURE_PROC_LIMIT_CRITICAL;
         // FIXME: This is a false positive. rdar://160931336
-        SUPPRESS_RETAINPTR_CTOR_ADOPT memoryPressureEventSource() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, memoryStatusFlags, m_dispatchQueue.get()));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT memoryPressureEventSource() = adopt(dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, memoryStatusFlags, m_dispatchQueue.get()));
 
         dispatch_source_set_event_handler(memoryPressureEventSource().get(), ^{
             auto status = dispatch_source_get_data(memoryPressureEventSource().get());
@@ -199,7 +199,7 @@ void MemoryPressureHandler::holdOff(Seconds seconds)
 {
     dispatch_async(m_dispatchQueue.get(), ^{
         // FIXME: This is a false positive. rdar://160931336
-        SUPPRESS_RETAINPTR_CTOR_ADOPT timerEventSource() = adoptOSObject(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_dispatchQueue.get()));
+        SUPPRESS_RETAINPTR_CTOR_ADOPT timerEventSource() = adopt(dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, m_dispatchQueue.get()));
         if (timerEventSource()) {
             dispatch_set_context(timerEventSource().get(), this);
             // FIXME: The final argument `s_minimumHoldOffTime.seconds()` seems wrong.

--- a/Source/WTF/wtf/cocoa/UUIDCocoa.mm
+++ b/Source/WTF/wtf/cocoa/UUIDCocoa.mm
@@ -33,7 +33,7 @@ namespace WTF {
 
 RetainPtr<NSUUID> UUID::createNSUUID() const
 {
-    return adoptNS([[NSUUID alloc] initWithUUIDString:toString().createNSString().get()]);
+    return adopt([[NSUUID alloc] initWithUUIDString:toString().createNSString().get()]);
 }
 
 std::optional<UUID> UUID::fromNSUUID(NSUUID *nsUUID)

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -85,7 +85,7 @@ void WorkQueueBase::platformInitialize(ASCIILiteral name, Type type, QOS qos)
     dispatch_queue_attr_t attr = type == Type::Concurrent ? DISPATCH_QUEUE_CONCURRENT : DISPATCH_QUEUE_SERIAL;
     attr = dispatch_queue_attr_make_with_qos_class(attr, Thread::dispatchQOSClass(qos), 0);
     // FIXME: This is a false positive. rdar://160931336
-    SUPPRESS_RETAINPTR_CTOR_ADOPT lazyInitialize(m_dispatchQueue, adoptOSObject(dispatch_queue_create(name, attr)));
+    SUPPRESS_RETAINPTR_CTOR_ADOPT lazyInitialize(m_dispatchQueue, adopt(dispatch_queue_create(name, attr)));
     dispatch_set_context(m_dispatchQueue.get(), this);
     // We use &s_uid for the key, since it's convenient. Dispatch does not dereference it.
     // We use s_uid to generate the id so that WorkQueues and Threads share the id namespace.

--- a/Source/WTF/wtf/darwin/DispatchOSObject.h
+++ b/Source/WTF/wtf/darwin/DispatchOSObject.h
@@ -69,6 +69,15 @@ ALWAYS_INLINE CLANG_POINTER_CONVERSION OSObjectPtr<TypeName##_t> protect(TypeNam
 WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_DISPATCH_PROTECT)
 #undef WTF_DECLARE_DISPATCH_PROTECT
 
+// Dispatch adopt() functions.
+#define WTF_DECLARE_DISPATCH_ADOPT(TypeName) \
+[[nodiscard]] ALWAYS_INLINE OSObjectPtr<TypeName##_t> adopt(TypeName##_t ptr) \
+{ \
+    return adoptOSObject(ptr); \
+}
+WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_DISPATCH_ADOPT)
+#undef WTF_DECLARE_DISPATCH_ADOPT
+
 #if !__has_feature(objc_arc)
 // Template specializations for dispatch retain/release traits (non-ARC only).
 #define WTF_DECLARE_DISPATCH_OSOBJECT_RETAIN_TRAITS(TypeName) \
@@ -90,4 +99,5 @@ WTF_OS_OBJECT_DISPATCH_TYPES(WTF_DECLARE_DISPATCH_OSOBJECT_RETAIN_TRAITS)
 
 } // namespace WTF
 
+using WTF::adopt;
 using WTF::protect;

--- a/Source/WTF/wtf/darwin/NetworkOSObject.h
+++ b/Source/WTF/wtf/darwin/NetworkOSObject.h
@@ -65,6 +65,15 @@ ALWAYS_INLINE CLANG_POINTER_CONVERSION OSObjectPtr<TypeName##_t> protect(TypeNam
 WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_NETWORK_PROTECT)
 #undef WTF_DECLARE_NETWORK_PROTECT
 
+// Network adopt() functions.
+#define WTF_DECLARE_NETWORK_ADOPT(TypeName) \
+[[nodiscard]] ALWAYS_INLINE OSObjectPtr<TypeName##_t> adopt(TypeName##_t ptr) \
+{ \
+    return adoptOSObject(ptr); \
+}
+WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_NETWORK_ADOPT)
+#undef WTF_DECLARE_NETWORK_ADOPT
+
 #if !__has_feature(objc_arc)
 // Template specializations for network retain/release traits (non-ARC only).
 #define WTF_DECLARE_NETWORK_OSOBJECT_RETAIN_TRAITS(TypeName) \
@@ -86,4 +95,5 @@ WTF_OS_OBJECT_NETWORK_TYPES(WTF_DECLARE_NETWORK_OSOBJECT_RETAIN_TRAITS)
 
 } // namespace WTF
 
+using WTF::adopt;
 using WTF::protect;

--- a/Source/WTF/wtf/darwin/XPCObjectPtr.h
+++ b/Source/WTF/wtf/darwin/XPCObjectPtr.h
@@ -62,6 +62,15 @@ ALWAYS_INLINE CLANG_POINTER_CONVERSION OSObjectPtr<TypeName##_t> protect(TypeNam
 WTF_OS_OBJECT_XPC_TYPES(WTF_DECLARE_XPC_PROTECT)
 #undef WTF_DECLARE_XPC_PROTECT
 
+// XPC adopt() functions.
+#define WTF_DECLARE_XPC_ADOPT(TypeName) \
+[[nodiscard]] ALWAYS_INLINE OSObjectPtr<TypeName##_t> adopt(TypeName##_t ptr) \
+{ \
+    return adoptOSObject(ptr); \
+}
+WTF_OS_OBJECT_XPC_TYPES(WTF_DECLARE_XPC_ADOPT)
+#undef WTF_DECLARE_XPC_ADOPT
+
 #if !__has_feature(objc_arc)
 // Template specializations for XPC retain/release traits (non-ARC only).
 #define WTF_DECLARE_XPC_OSOBJECT_RETAIN_TRAITS(TypeName) \
@@ -83,4 +92,5 @@ WTF_OS_OBJECT_XPC_TYPES(WTF_DECLARE_XPC_OSOBJECT_RETAIN_TRAITS)
 
 } // namespace WTF
 
+using WTF::adopt;
 using WTF::protect;

--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -110,6 +110,7 @@ typedef struct CF_BRIDGED_TYPE(id) __SecTrust *SecTrustRef;
 
 WTF_EXTERN_C_BEGIN
 
+CFTypeID SecTaskGetTypeID(void);
 SecTaskRef SecTaskCreateWithAuditToken(CFAllocatorRef, audit_token_t);
 SecTaskRef SecTaskCreateFromSelf(CFAllocatorRef);
 CFStringRef SecTaskCopySigningIdentifier(SecTaskRef, CFErrorRef *);


### PR DESCRIPTION
#### 6b84eb51e39089170b582c150016a67a12668931
<pre>
Add a generic `adopt()` function to WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=306597">https://bugs.webkit.org/show_bug.cgi?id=306597</a>

Reviewed by NOBODY (OOPS!).

Add a generic `adopt()` function to WTF that replaces `adoptRef()` / `adoptNS()`
/ `adoptCF()` / `adoptOSObject()`. It is able to detect the input type and
return the adequate smart pointer type.

One issue was to accurately detect CF types (other types were already
easy to recognize). I addressed this issue by matching CFTypeRef or
concrete CF types that have CFTypeTrait traits. This PR introduces
`IsCFType` for convenience and to match the pre-existing `IsNSType`.

This PR does some adoption of `adopt()` in Source/WTF to show that it
works. Once this lands, I will proceed with wider adoption and we can
get rid of `adoptRef()` and others.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Assertions.cpp:
(WTF::createWithFormatAndArguments):
* Source/WTF/wtf/PlatformMac.cmake:
* Source/WTF/wtf/Ref.h:
(WTF::adopt):
* Source/WTF/wtf/RefPtr.h:
(WTF::adopt):
* Source/WTF/wtf/RetainPtr.h:
(WTF::adopt):
* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::Holder::Holder):
(WTF::RunLoop::dispatchAfter):
* Source/WTF/wtf/ThreadGroup.h:
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::entryPoint):
(WTF::Thread::create):
* Source/WTF/wtf/WorkerPool.h:
* Source/WTF/wtf/cf/CFTypeTraits.h: Copied from Source/WTF/wtf/cf/TypeCastsCF.h.
* Source/WTF/wtf/cf/CFURLExtras.cpp:
(WTF::bytesAsCFData):
* Source/WTF/wtf/cf/RunLoopCF.cpp:
(WTF::createTimer):
(WTF::RunLoop::RunLoop):
* Source/WTF/wtf/cf/TypeCastsCF.h:
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlement):
(WTF::processHasEntitlement):
(WTF::hasEntitlementValue):
(WTF::hasEntitlementValueInArray):
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::createTemporaryZipArchive):
(WTF::FileSystemImpl::extractTemporaryZipArchive):
* Source/WTF/wtf/cocoa/LanguageCocoa.mm:
(WTF::overrideUserPreferredLanguages):
* Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm:
(WTF::MemoryPressureHandler::install):
(WTF::MemoryPressureHandler::holdOff):
* Source/WTF/wtf/cocoa/UUIDCocoa.mm:
(WTF::UUID::createNSUUID const):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::platformInitialize):
* Source/WTF/wtf/darwin/DispatchOSObject.h:
* Source/WTF/wtf/darwin/NetworkOSObject.h:
* Source/WTF/wtf/darwin/XPCObjectPtr.h:
* Source/WTF/wtf/spi/cocoa/SecuritySPI.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b84eb51e39089170b582c150016a67a12668931

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94784 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/764c1171-64ab-45e4-b29d-77ce794b33c1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108863 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78731 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86e099c5-5cf6-4c78-b249-ebf09784ff3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126798 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a06d03ed-2e68-4900-a4df-60156471d664) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10956 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8595 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/310 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133649 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152630 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2469 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13740 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116962 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117287 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13314 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69348 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13778 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2785 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172954 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13517 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77503 "Found 38 new failures in wtf/ThreadGroup.h, wtf/cf/RunLoopCF.cpp, wtf/WorkerPool.h, usr/local/include/wtf/darwin/XPCObjectPtr.h, wtf/Threading.cpp, usr/local/include/wtf/darwin/DispatchOSObject.h, wtf/cocoa/Entitlements.mm, wtf/cf/CFURLExtras.cpp, wtf/RunLoop.cpp, wtf/Assertions.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44789 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13564 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->