### PR TITLE
Add defaultLanguage to list of preheated functions

### DIFF
--- a/Source/WebCore/page/ProcessWarming.cpp
+++ b/Source/WebCore/page/ProcessWarming.cpp
@@ -43,6 +43,7 @@
 #include "XLinkNames.h"
 #include "XMLNSNames.h"
 #include "XMLNames.h"
+#include <wtf/Language.h>
 
 namespace WebCore {
 
@@ -79,6 +80,8 @@ void ProcessWarming::prewarmGlobally()
 #if ENABLE(TELEPHONE_NUMBER_DETECTION)
     TelephoneNumberDetector::prewarm();
 #endif
+
+    defaultLanguage();
 }
 
 WebCore::PrewarmInformation ProcessWarming::collectPrewarmInformation()

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -715,6 +715,12 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 #if PLATFORM(COCOA)
     if (m_processType == ProcessType::PrewarmedWebContent)
         prewarmGlobally();
+    else {
+        // Prewarm some commonly used caches soon even for non-prewarmed web content.
+        RunLoop::currentSingleton().dispatch([]() {
+            defaultLanguage();
+        });
+    }
 #endif
 
     updateStorageAccessUserAgentStringQuirks(WTF::move(parameters.storageAccessUserAgentStringQuirksData));


### PR DESCRIPTION
#### 1dfd460b7bf9c9c9b4ac07c82f19eb47040a5e43
<pre>
Add defaultLanguage to list of preheated functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306599">https://bugs.webkit.org/show_bug.cgi?id=306599</a>
<a href="https://rdar.apple.com/169017664">rdar://169017664</a>

Reviewed by Per Arne Vollan.

I was assigned a JetStream regression caused by not using the injected bundle. The first iteration
of a particular subtest was a couple of milliseconds slower, which had a small but consistently
measurable impact on the overall benchmark score.

The first regression was slower due to faulting in code and data related to computing the user&apos;s
default language. Previously, the injected bundle happened to do this as a side effect of its
initialization. When we run without the injected bundle, that side effect wasn&apos;t happening anymore,
so instead we were paying for the faults and computation in the middle of the benchmark.

To fix this, add defaultLanguage to the list of functions in prewarmGlobally.

Unfortunately even that is not quite enough to appease the benchmark runner, as it runs in a
non-prewarmed WebProcess. So we additionally call defaultLanguage shortly after process
initialization in non-prewarmed processes.

* Source/WebCore/page/ProcessWarming.cpp:
(WebCore::ProcessWarming::prewarmGlobally):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/306496@main">https://commits.webkit.org/306496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db3e86675d91ef3415de48ccd18995841256fb79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150061 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94582 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1739acf3-a3a8-4c43-a806-ac639286f5ec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108709 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78666 "10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4b43811-7629-40e6-a3a8-e01bdf570213) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89614 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/084ee737-ed71-4a5e-ad47-7aeffaf9942a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10814 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8440 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/133 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152454 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13559 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116812 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117143 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13181 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68756 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13338 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77316 "Failed to checkout and rebase branch from PR 57534") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13538 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13386 "Failed to checkout and rebase branch from PR 57534") | | | | 
<!--EWS-Status-Bubble-End-->