### PR TITLE
Reduce use of protected functions in Source/WebCore/Modules

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp
@@ -46,12 +46,12 @@ String GPUCommandEncoder::label() const
 
 void GPUCommandEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
+    protect(backing())->setLabel(WTF::move(label));
 }
 
 ExceptionOr<Ref<GPURenderPassEncoder>> GPUCommandEncoder::beginRenderPass(const GPURenderPassDescriptor& renderPassDescriptor)
 {
-    RefPtr encoder = protectedBacking()->beginRenderPass(renderPassDescriptor.convertToBacking());
+    RefPtr encoder = protect(backing())->beginRenderPass(renderPassDescriptor.convertToBacking());
     RefPtr device = m_device.get();
     if (!encoder || !device)
         return Exception { ExceptionCode::InvalidStateError, "GPUCommandEncoder.beginRenderPass: Unable to begin render pass."_s };
@@ -60,7 +60,7 @@ ExceptionOr<Ref<GPURenderPassEncoder>> GPUCommandEncoder::beginRenderPass(const 
 
 ExceptionOr<Ref<GPUComputePassEncoder>> GPUCommandEncoder::beginComputePass(const std::optional<GPUComputePassDescriptor>& computePassDescriptor)
 {
-    RefPtr computePass = protectedBacking()->beginComputePass(computePassDescriptor ? std::optional { computePassDescriptor->convertToBacking() } : std::nullopt);
+    RefPtr computePass = protect(backing())->beginComputePass(computePassDescriptor ? std::optional { computePassDescriptor->convertToBacking() } : std::nullopt);
     RefPtr device = m_device.get();
     if (!computePass || !device)
         return Exception { ExceptionCode::InvalidStateError, "GPUCommandEncoder.beginComputePass: Unable to begin compute pass."_s };
@@ -82,7 +82,7 @@ void GPUCommandEncoder::copyBufferToBuffer(
     GPUSize64 destinationOffset,
     std::optional<GPUSize64> size)
 {
-    protectedBacking()->copyBufferToBuffer(source.backing(), sourceOffset, destination.backing(), destinationOffset, size.value_or(sourceOffset < source.size() ? source.size() - sourceOffset : 0u));
+    protect(backing())->copyBufferToBuffer(source.backing(), sourceOffset, destination.backing(), destinationOffset, size.value_or(sourceOffset < source.size() ? source.size() - sourceOffset : 0u));
 }
 
 void GPUCommandEncoder::copyBufferToTexture(
@@ -90,7 +90,7 @@ void GPUCommandEncoder::copyBufferToTexture(
     const GPUImageCopyTexture& destination,
     const GPUExtent3D& copySize)
 {
-    protectedBacking()->copyBufferToTexture(source.convertToBacking(), destination.convertToBacking(), convertToBacking(copySize));
+    protect(backing())->copyBufferToTexture(source.convertToBacking(), destination.convertToBacking(), convertToBacking(copySize));
 }
 
 void GPUCommandEncoder::copyTextureToBuffer(
@@ -98,7 +98,7 @@ void GPUCommandEncoder::copyTextureToBuffer(
     const GPUImageCopyBuffer& destination,
     const GPUExtent3D& copySize)
 {
-    protectedBacking()->copyTextureToBuffer(source.convertToBacking(), destination.convertToBacking(), convertToBacking(copySize));
+    protect(backing())->copyTextureToBuffer(source.convertToBacking(), destination.convertToBacking(), convertToBacking(copySize));
 }
 
 void GPUCommandEncoder::copyTextureToTexture(
@@ -106,7 +106,7 @@ void GPUCommandEncoder::copyTextureToTexture(
     const GPUImageCopyTexture& destination,
     const GPUExtent3D& copySize)
 {
-    protectedBacking()->copyTextureToTexture(source.convertToBacking(), destination.convertToBacking(), convertToBacking(copySize));
+    protect(backing())->copyTextureToTexture(source.convertToBacking(), destination.convertToBacking(), convertToBacking(copySize));
 }
 
 
@@ -115,27 +115,27 @@ void GPUCommandEncoder::clearBuffer(
     GPUSize64 offset,
     std::optional<GPUSize64> size)
 {
-    protectedBacking()->clearBuffer(buffer.backing(), offset, size);
+    protect(backing())->clearBuffer(buffer.backing(), offset, size);
 }
 
 void GPUCommandEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
+    protect(backing())->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void GPUCommandEncoder::popDebugGroup()
 {
-    protectedBacking()->popDebugGroup();
+    protect(backing())->popDebugGroup();
 }
 
 void GPUCommandEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
+    protect(backing())->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void GPUCommandEncoder::writeTimestamp(const GPUQuerySet& querySet, GPUSize32 queryIndex)
 {
-    protectedBacking()->writeTimestamp(querySet.backing(), queryIndex);
+    protect(backing())->writeTimestamp(querySet.backing(), queryIndex);
 }
 
 void GPUCommandEncoder::resolveQuerySet(
@@ -145,7 +145,7 @@ void GPUCommandEncoder::resolveQuerySet(
     const GPUBuffer& destination,
     GPUSize64 destinationOffset)
 {
-    protectedBacking()->resolveQuerySet(querySet.backing(), firstQuery, queryCount, destination.backing(), destinationOffset);
+    protect(backing())->resolveQuerySet(querySet.backing(), firstQuery, queryCount, destination.backing(), destinationOffset);
 }
 
 static WebGPU::CommandBufferDescriptor convertToBacking(const std::optional<GPUCommandBufferDescriptor>& commandBufferDescriptor)
@@ -158,7 +158,7 @@ static WebGPU::CommandBufferDescriptor convertToBacking(const std::optional<GPUC
 
 ExceptionOr<Ref<GPUCommandBuffer>> GPUCommandEncoder::finish(const std::optional<GPUCommandBufferDescriptor>& commandBufferDescriptor)
 {
-    RefPtr buffer = protectedBacking()->finish(convertToBacking(commandBufferDescriptor));
+    RefPtr buffer = protect(backing())->finish(convertToBacking(commandBufferDescriptor));
     if (!buffer)
         return Exception { ExceptionCode::InvalidStateError, "GPUCommandEncoder.finish: Unable to finish."_s };
     auto result = GPUCommandBuffer::create(buffer.releaseNonNull(), *this);

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h
@@ -117,8 +117,6 @@ public:
 private:
     GPUCommandEncoder(Ref<WebGPU::CommandEncoder>&&, WebGPU::Device&);
 
-    Ref<WebGPU::CommandEncoder> protectedBacking() { return m_backing; }
-
     Ref<WebGPU::CommandEncoder> m_backing;
     WeakPtr<WebGPU::Device> m_device;
     std::optional<String> m_overrideLabel;

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp
@@ -47,27 +47,27 @@ String GPUComputePassEncoder::label() const
 
 void GPUComputePassEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
+    protect(backing())->setLabel(WTF::move(label));
 }
 
 void GPUComputePassEncoder::setPipeline(const GPUComputePipeline& computePipeline)
 {
-    protectedBacking()->setPipeline(computePipeline.backing());
+    protect(backing())->setPipeline(computePipeline.backing());
 }
 
 void GPUComputePassEncoder::dispatchWorkgroups(GPUSize32 workgroupCountX, GPUSize32 workgroupCountY, GPUSize32 workgroupCountZ)
 {
-    protectedBacking()->dispatch(workgroupCountX, workgroupCountY, workgroupCountZ);
+    protect(backing())->dispatch(workgroupCountX, workgroupCountY, workgroupCountZ);
 }
 
 void GPUComputePassEncoder::dispatchWorkgroupsIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
-    protectedBacking()->dispatchIndirect(indirectBuffer.backing(), indirectOffset);
+    protect(backing())->dispatchIndirect(indirectBuffer.backing(), indirectOffset);
 }
 
 void GPUComputePassEncoder::end()
 {
-    protectedBacking()->end();
+    protect(backing())->end();
     if (RefPtr device = m_device.get()) {
         m_overrideLabel = label();
         m_backing = device->invalidComputePassEncoder();
@@ -77,7 +77,7 @@ void GPUComputePassEncoder::end()
 void GPUComputePassEncoder::setBindGroup(GPUIndex32 index, const GPUBindGroup* bindGroup,
     std::optional<Vector<GPUBufferDynamicOffset>>&& dynamicOffsets)
 {
-    protectedBacking()->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, WTF::move(dynamicOffsets));
+    protect(backing())->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, WTF::move(dynamicOffsets));
 }
 
 ExceptionOr<void> GPUComputePassEncoder::setBindGroup(GPUIndex32 index, const GPUBindGroup* bindGroup,
@@ -89,23 +89,23 @@ ExceptionOr<void> GPUComputePassEncoder::setBindGroup(GPUIndex32 index, const GP
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    protectedBacking()->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, dynamicOffsetsData.typedSpan(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    protect(backing())->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, dynamicOffsetsData.typedSpan(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 
 void GPUComputePassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
+    protect(backing())->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void GPUComputePassEncoder::popDebugGroup()
 {
-    protectedBacking()->popDebugGroup();
+    protect(backing())->popDebugGroup();
 }
 
 void GPUComputePassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
+    protect(backing())->insertDebugMarker(WTF::move(markerLabel));
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h
@@ -80,8 +80,6 @@ public:
 private:
     GPUComputePassEncoder(Ref<WebGPU::ComputePassEncoder>&&, WebGPU::Device&);
 
-    Ref<WebGPU::ComputePassEncoder> protectedBacking() { return m_backing; }
-
     Ref<WebGPU::ComputePassEncoder> m_backing;
     WeakPtr<WebGPU::Device> m_device;
     std::optional<String> m_overrideLabel;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -48,28 +48,28 @@ String GPURenderPassEncoder::label() const
 
 void GPURenderPassEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
+    protect(backing())->setLabel(WTF::move(label));
 }
 
 void GPURenderPassEncoder::setPipeline(const GPURenderPipeline& renderPipeline)
 {
-    protectedBacking()->setPipeline(renderPipeline.backing());
+    protect(backing())->setPipeline(renderPipeline.backing());
 }
 
 void GPURenderPassEncoder::setIndexBuffer(const GPUBuffer& buffer, GPUIndexFormat indexFormat, GPUSize64 offset, std::optional<GPUSize64> size)
 {
-    protectedBacking()->setIndexBuffer(buffer.backing(), convertToBacking(indexFormat), offset, size);
+    protect(backing())->setIndexBuffer(buffer.backing(), convertToBacking(indexFormat), offset, size);
 }
 
 void GPURenderPassEncoder::setVertexBuffer(GPUIndex32 slot, const GPUBuffer* buffer, GPUSize64 offset, std::optional<GPUSize64> size)
 {
-    protectedBacking()->setVertexBuffer(slot, buffer ? &buffer->backing() : nullptr, offset, size);
+    protect(backing())->setVertexBuffer(slot, buffer ? &buffer->backing() : nullptr, offset, size);
 }
 
 void GPURenderPassEncoder::draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
     GPUSize32 firstVertex, GPUSize32 firstInstance)
 {
-    protectedBacking()->draw(vertexCount, instanceCount, firstVertex, firstInstance);
+    protect(backing())->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
 void GPURenderPassEncoder::drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
@@ -77,23 +77,23 @@ void GPURenderPassEncoder::drawIndexed(GPUSize32 indexCount, GPUSize32 instanceC
     GPUSignedOffset32 baseVertex,
     GPUSize32 firstInstance)
 {
-    protectedBacking()->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+    protect(backing())->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }
 
 void GPURenderPassEncoder::drawIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
-    protectedBacking()->drawIndirect(indirectBuffer.backing(), indirectOffset);
+    protect(backing())->drawIndirect(indirectBuffer.backing(), indirectOffset);
 }
 
 void GPURenderPassEncoder::drawIndexedIndirect(const GPUBuffer& indirectBuffer, GPUSize64 indirectOffset)
 {
-    protectedBacking()->drawIndexedIndirect(indirectBuffer.backing(), indirectOffset);
+    protect(backing())->drawIndexedIndirect(indirectBuffer.backing(), indirectOffset);
 }
 
 void GPURenderPassEncoder::setBindGroup(GPUIndex32 index, const GPUBindGroup* bindGroup,
     std::optional<Vector<GPUBufferDynamicOffset>>&& dynamicOffsets)
 {
-    protectedBacking()->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, WTF::move(dynamicOffsets));
+    protect(backing())->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, WTF::move(dynamicOffsets));
 }
 
 ExceptionOr<void> GPURenderPassEncoder::setBindGroup(GPUIndex32 index, const GPUBindGroup* bindGroup,
@@ -105,56 +105,56 @@ ExceptionOr<void> GPURenderPassEncoder::setBindGroup(GPUIndex32 index, const GPU
     if (offset.hasOverflowed() || offset > dynamicOffsetsData.length())
         return Exception { ExceptionCode::RangeError, "dynamic offsets overflowed"_s };
 
-    protectedBacking()->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, dynamicOffsetsData.typedSpan(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
+    protect(backing())->setBindGroup(index, bindGroup ? &bindGroup->backing() : nullptr, dynamicOffsetsData.typedSpan(), dynamicOffsetsDataStart, dynamicOffsetsDataLength);
     return { };
 }
 
 void GPURenderPassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
+    protect(backing())->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void GPURenderPassEncoder::popDebugGroup()
 {
-    protectedBacking()->popDebugGroup();
+    protect(backing())->popDebugGroup();
 }
 
 void GPURenderPassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
+    protect(backing())->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void GPURenderPassEncoder::setViewport(float x, float y,
     float width, float height,
     float minDepth, float maxDepth)
 {
-    protectedBacking()->setViewport(x, y, width, height, minDepth, maxDepth);
+    protect(backing())->setViewport(x, y, width, height, minDepth, maxDepth);
 }
 
 void GPURenderPassEncoder::setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
     GPUIntegerCoordinate width, GPUIntegerCoordinate height)
 {
-    protectedBacking()->setScissorRect(x, y, width, height);
+    protect(backing())->setScissorRect(x, y, width, height);
 }
 
 void GPURenderPassEncoder::setBlendConstant(GPUColor color)
 {
-    protectedBacking()->setBlendConstant(convertToBacking(color));
+    protect(backing())->setBlendConstant(convertToBacking(color));
 }
 
 void GPURenderPassEncoder::setStencilReference(GPUStencilValue stencilValue)
 {
-    protectedBacking()->setStencilReference(stencilValue);
+    protect(backing())->setStencilReference(stencilValue);
 }
 
 void GPURenderPassEncoder::beginOcclusionQuery(GPUSize32 queryIndex)
 {
-    protectedBacking()->beginOcclusionQuery(queryIndex);
+    protect(backing())->beginOcclusionQuery(queryIndex);
 }
 
 void GPURenderPassEncoder::endOcclusionQuery()
 {
-    protectedBacking()->endOcclusionQuery();
+    protect(backing())->endOcclusionQuery();
 }
 
 void GPURenderPassEncoder::executeBundles(Vector<Ref<GPURenderBundle>>&& bundles)
@@ -162,12 +162,12 @@ void GPURenderPassEncoder::executeBundles(Vector<Ref<GPURenderBundle>>&& bundles
     auto result = WTF::map(bundles, [](auto& bundle) -> Ref<WebGPU::RenderBundle> {
         return bundle->backing();
     });
-    protectedBacking()->executeBundles(WTF::move(result));
+    protect(backing())->executeBundles(WTF::move(result));
 }
 
 void GPURenderPassEncoder::end()
 {
-    protectedBacking()->end();
+    protect(backing())->end();
     if (RefPtr device = m_device.get()) {
         m_overrideLabel = label();
         m_backing = device->invalidRenderPassEncoder();

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
@@ -109,8 +109,6 @@ public:
 private:
     GPURenderPassEncoder(Ref<WebGPU::RenderPassEncoder>&& backing, WebGPU::Device&);
 
-    Ref<WebGPU::RenderPassEncoder> protectedBacking() { return m_backing; }
-
     Ref<WebGPU::RenderPassEncoder> m_backing;
     WeakPtr<WebGPU::Device> m_device;
     std::optional<String> m_overrideLabel;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -345,7 +345,7 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
         .label = label.data(),
         .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*descriptor.protectedLayout().get()) : nullptr,
         .compute = WGPUProgrammableStageDescriptor {
-            .module = convertToBackingContext.convertToBacking(descriptor.compute.protectedModule().get()),
+            .module = convertToBackingContext.convertToBacking(protect(descriptor.compute.module.get()).get()),
             .entryPoint = entryPoint ? entryPoint->data() : nullptr,
             .constantCount = backingConstantEntries.size(),
             .constants = backingConstantEntries.size() ? backingConstantEntries.span().data() : nullptr,
@@ -498,7 +498,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
     }
 
     WGPUFragmentState fragmentState {
-        .module = descriptor.fragment ? convertToBackingContext.convertToBacking(descriptor.fragment->protectedModule().get()) : nullptr,
+        .module = descriptor.fragment ? convertToBackingContext.convertToBacking(protect(descriptor.fragment->module.get()).get()) : nullptr,
         .entryPoint = fragmentEntryPoint ? fragmentEntryPoint->data() : nullptr,
         .constantCount = fragmentConstantEntries.size(),
         .constants = fragmentConstantEntries.size() ? fragmentConstantEntries.span().data() : nullptr,
@@ -510,7 +510,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
         .label = label.data(),
         .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*descriptor.protectedLayout()) : nullptr,
         .vertex = {
-            .module = convertToBackingContext.convertToBacking(descriptor.vertex.protectedModule().get()),
+            .module = convertToBackingContext.convertToBacking(protect(descriptor.vertex.module.get()).get()),
             .entryPoint = vertexEntryPoint ? vertexEntryPoint->data() : nullptr,
             .constantCount = vertexConstantEntries.size(),
             .constants = vertexConstantEntries.size() ? vertexConstantEntries.span().data() : nullptr,

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h
@@ -39,8 +39,6 @@ struct ProgrammableStage {
     WeakRef<ShaderModule> module;
     String entryPoint;
     Vector<KeyValuePair<String, PipelineConstantValue>> constants;
-
-    Ref<ShaderModule> protectedModule() const { return module.get(); }
 };
 
 } // namespace WebCore::WebGPU

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp
@@ -129,17 +129,12 @@ LegacyCDM::~LegacyCDM() = default;
 
 bool LegacyCDM::supportsMIMEType(const String& mimeType) const
 {
-    return protectedCDMPrivate()->supportsMIMEType(mimeType);
-}
-
-RefPtr<CDMPrivateInterface> LegacyCDM::protectedCDMPrivate() const
-{
-    return cdmPrivate();
+    return protect(cdmPrivate())->supportsMIMEType(mimeType);
 }
 
 RefPtr<LegacyCDMSession> LegacyCDM::createSession(LegacyCDMSessionClient& client)
 {
-    RefPtr session = protectedCDMPrivate()->createSession(client);
+    RefPtr session = protect(cdmPrivate())->createSession(client);
     if (mediaPlayer())
         mediaPlayer()->setCDMSession(session.get());
     return session;

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h
@@ -77,7 +77,6 @@ public:
 
     RefPtr<MediaPlayer> mediaPlayer() const;
     CDMPrivateInterface* cdmPrivate() const { return m_private.get(); }
-    RefPtr<CDMPrivateInterface> protectedCDMPrivate() const;
 
 private:
     explicit LegacyCDM(const String& keySystem);

--- a/Source/WebCore/Modules/fetch/FetchBody.h
+++ b/Source/WebCore/Modules/fetch/FetchBody.h
@@ -98,8 +98,6 @@ public:
     bool hasReadableStream() const { return !!m_readableStream; }
     const ReadableStream* readableStream() const { return m_readableStream.get(); }
     ReadableStream* readableStream() { return m_readableStream.get(); }
-    RefPtr<const ReadableStream> protectedReadableStream() const { return readableStream(); }
-    RefPtr<ReadableStream> protectedReadableStream() { return readableStream(); }
     void setReadableStream(Ref<ReadableStream>&& stream)
     {
         ASSERT(!m_readableStream);
@@ -135,19 +133,13 @@ private:
     bool isText() const { return std::holds_alternative<String>(m_data); }
 
     const Blob& blobBody() const { return std::get<Ref<const Blob>>(m_data).get(); }
-    Ref<const Blob> protectedBlobBody() const { return blobBody(); }
     FormData& formDataBody() { return std::get<Ref<FormData>>(m_data).get(); }
-    Ref<FormData> protectedFormDataBody() { return formDataBody(); }
     const FormData& formDataBody() const { return std::get<Ref<FormData>>(m_data).get(); }
-    Ref<const FormData> protectedFormDataBody() const { return formDataBody(); }
     const ArrayBuffer& arrayBufferBody() const { return std::get<Ref<const ArrayBuffer>>(m_data).get(); }
-    Ref<const ArrayBuffer> protectedArrayBufferBody() const { return arrayBufferBody(); }
     const ArrayBufferView& arrayBufferViewBody() const { return std::get<Ref<const ArrayBufferView>>(m_data).get(); }
-    Ref<const ArrayBufferView> protectedArrayBufferViewBody() const { return arrayBufferViewBody(); }
     String& textBody() { return std::get<String>(m_data); }
     const String& textBody() const { return std::get<String>(m_data); }
     const URLSearchParams& urlSearchParamsBody() const { return std::get<Ref<const URLSearchParams>>(m_data).get(); }
-    Ref<const URLSearchParams> protectedURLSearchParamsBody() const { return urlSearchParamsBody(); }
 
     using Data = Variant<std::nullptr_t, Ref<const Blob>, Ref<FormData>, Ref<const ArrayBuffer>, Ref<const ArrayBufferView>, Ref<const URLSearchParams>, String, Ref<ReadableStream>>;
     Data m_data { nullptr };

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -392,7 +392,7 @@ ExceptionOr<void> FetchBodyOwner::createReadableStream(JSC::JSGlobalObject& stat
         if (streamOrException.hasException()) [[unlikely]]
             return streamOrException.releaseException();
         m_body->setReadableStream(streamOrException.releaseReturnValue());
-        m_body->protectedReadableStream()->lock();
+        protect(m_body->readableStream())->lock();
         return { };
     }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -499,7 +499,7 @@ void FetchResponse::consumeBodyReceivedByChunk(ConsumeDataByChunkCallback&& call
     m_isDisturbed = true;
 
     if (hasReadableStreamBody()) {
-        m_body->checkedConsumer()->extract(*m_body->protectedReadableStream(), [callback = WTF::move(callback), weakThis = WeakPtr { *this }](auto&& result) {
+        m_body->checkedConsumer()->extract(*protect(m_body->readableStream()), [callback = WTF::move(callback), weakThis = WeakPtr { *this }](auto&& result) {
             WTF::switchOn(WTF::move(result), [&](std::nullptr_t) {
                 callback(nullptr);
             }, [&](std::span<const uint8_t> chunk) {
@@ -576,7 +576,7 @@ void FetchResponse::closeStream()
 void FetchResponse::cancelStream()
 {
     if (isAllowedToRunScript() && hasReadableStreamBody()) {
-        body().protectedReadableStream()->cancel(Exception { ExceptionCode::AbortError, "load is cancelled"_s });
+        protect(body().readableStream())->cancel(Exception { ExceptionCode::AbortError, "load is cancelled"_s });
         return;
     }
     cancel();

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -160,11 +160,6 @@ SecurityOrigin* Geolocation::securityOrigin() const
     return scriptExecutionContext()->securityOrigin();
 }
 
-RefPtr<SecurityOrigin> Geolocation::protectedSecurityOrigin() const
-{
-    return securityOrigin();
-}
-
 Page* Geolocation::page() const
 {
     RefPtr document = this->document();
@@ -379,7 +374,7 @@ bool Geolocation::shouldBlockGeolocationRequests()
             return false;
     }
 
-    logError(protectedSecurityOrigin()->toString(), isSecure, document.get());
+    logError(protect(securityOrigin())->toString(), isSecure, document.get());
     return true;
 }
 

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -99,7 +99,6 @@ private:
 
     Page* page() const;
     SecurityOrigin* securityOrigin() const;
-    RefPtr<SecurityOrigin> protectedSecurityOrigin() const;
 
     typedef Vector<Ref<GeoNotifier>> GeoNotifierVector;
     typedef HashSet<Ref<GeoNotifier>> GeoNotifierSet;

--- a/Source/WebCore/Modules/geolocation/GeolocationController.cpp
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.cpp
@@ -66,11 +66,6 @@ GeolocationClient& GeolocationController::client()
     return *m_client;
 }
 
-Ref<GeolocationClient> GeolocationController::protectedClient()
-{
-    return client();
-}
-
 void GeolocationController::addObserver(Geolocation& observer, bool enableHighAccuracy)
 {
     bool highAccuracyWasRequired = needsHighAccuracy();
@@ -81,7 +76,7 @@ void GeolocationController::addObserver(Geolocation& observer, bool enableHighAc
 
     if (m_isUpdating) {
         if (!highAccuracyWasRequired && enableHighAccuracy)
-            protectedClient()->setEnableHighAccuracy(true);
+            protect(client())->setEnableHighAccuracy(true);
     } else
         startUpdatingIfNecessary();
 }
@@ -102,12 +97,12 @@ void GeolocationController::removeObserver(Geolocation& observer)
     if (m_observers.isEmpty())
         stopUpdatingIfNecessary();
     else if (highAccuracyWasRequired && !needsHighAccuracy())
-        protectedClient()->setEnableHighAccuracy(false);
+        protect(client())->setEnableHighAccuracy(false);
 }
 
 void GeolocationController::revokeAuthorizationToken(const String& authorizationToken)
 {
-    protectedClient()->revokeAuthorizationToken(authorizationToken);
+    protect(client())->revokeAuthorizationToken(authorizationToken);
 }
 
 void GeolocationController::requestPermission(Geolocation& geolocation)
@@ -117,7 +112,7 @@ void GeolocationController::requestPermission(Geolocation& geolocation)
         return;
     }
 
-    protectedClient()->requestPermission(geolocation);
+    protect(client())->requestPermission(geolocation);
 }
 
 void GeolocationController::cancelPermissionRequest(Geolocation& geolocation)
@@ -125,7 +120,7 @@ void GeolocationController::cancelPermissionRequest(Geolocation& geolocation)
     if (m_pendingPermissionRequest.remove(geolocation))
         return;
 
-    protectedClient()->cancelPermissionRequest(geolocation);
+    protect(client())->cancelPermissionRequest(geolocation);
 }
 
 void GeolocationController::positionChanged(const std::optional<GeolocationPositionData>& position)
@@ -146,7 +141,7 @@ std::optional<GeolocationPositionData> GeolocationController::lastPosition()
     if (m_lastPosition)
         return m_lastPosition.value();
 
-    return protectedClient()->lastPosition();
+    return protect(client())->lastPosition();
 }
 
 void GeolocationController::activityStateDidChange(OptionSet<ActivityState> oldActivityState, OptionSet<ActivityState> newActivityState)
@@ -174,7 +169,7 @@ void GeolocationController::startUpdatingIfNecessary()
     if (m_isUpdating || !m_page->isVisible() || m_observers.isEmpty())
         return;
 
-    protectedClient()->startUpdating((*m_observers.random())->authorizationToken(), needsHighAccuracy());
+    protect(client())->startUpdating((*m_observers.random())->authorizationToken(), needsHighAccuracy());
     m_isUpdating = true;
 }
 
@@ -183,7 +178,7 @@ void GeolocationController::stopUpdatingIfNecessary()
     if (!m_isUpdating)
         return;
 
-    protectedClient()->stopUpdating();
+    protect(client())->stopUpdating();
     m_isUpdating = false;
 }
 

--- a/Source/WebCore/Modules/geolocation/GeolocationController.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.h
@@ -62,7 +62,6 @@ public:
     std::optional<GeolocationPositionData> lastPosition();
 
     GeolocationClient& client();
-    Ref<GeolocationClient> protectedClient();
 
     WEBCORE_EXPORT static ASCIILiteral supplementName();
     static GeolocationController* from(Page* page) { return downcast<GeolocationController>(Supplement<Page>::from(page, supplementName())); }

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.h
@@ -56,9 +56,7 @@ public:
     IDBCursorDirection direction() const;
 
     IDBKey* key() { return m_key.get(); }
-    RefPtr<IDBKey> protectedKey() { return m_key; }
     IDBKey* primaryKey() { return m_primaryKey.get(); }
-    RefPtr<IDBKey> protectedPrimaryKey() { return m_primaryKey; }
     IDBValue value() { return m_value; }
     const std::optional<IDBKeyPath>& primaryKeyPath() { return m_keyPath; }
     JSValueInWrappedObject& keyWrapper() { return m_keyWrapper; }
@@ -94,9 +92,7 @@ protected:
 private:
     bool sourcesDeleted() const;
     IDBObjectStore& effectiveObjectStore() const;
-    Ref<IDBObjectStore> protectedEffectiveObjectStore() const;
     IDBTransaction& transaction() const;
-    Ref<IDBTransaction> protectedTransaction() const;
 
     void uncheckedIterateCursor(const IDBKeyData&, unsigned count);
     void uncheckedIterateCursor(const IDBKeyData&, const IDBKeyData&);

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
@@ -102,7 +102,7 @@ void IDBOpenDBRequest::fireSuccessAfterVersionChangeCommit()
 
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
     ASSERT(hasPendingActivity());
-    protectedTransaction()->addRequest(*this);
+    protect(transaction())->addRequest(*this);
 
     Ref event = IDBRequestCompletionEvent::create(eventNames().successEvent, Event::CanBubble::No, Event::IsCancelable::No, *this);
     m_openDatabaseSuccessEvent = event.get();
@@ -121,7 +121,7 @@ void IDBOpenDBRequest::fireErrorAfterVersionChangeCompletion()
     m_domError = DOMException::create(ExceptionCode::AbortError);
     setResultToUndefined();
 
-    protectedTransaction()->addRequest(*this);
+    protect(transaction())->addRequest(*this);
     enqueueEvent(IDBRequestCompletionEvent::create(eventNames().errorEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes, *this));
 }
 

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -94,7 +94,8 @@ public:
 
     ExceptionOr<DOMException*> error() const;
 
-    RefPtr<IDBTransaction> transaction() const;
+    IDBTransaction* transaction() const;
+    IDBTransaction* transactionForBindings() const;
     
     enum class ReadyState { Pending, Done };
     ReadyState readyState() const { return m_readyState; }
@@ -178,8 +179,6 @@ private:
     void clearWrappers();
 
 protected:
-    RefPtr<IDBTransaction> protectedTransaction() const;
-
     // FIXME: Protected data members aren't great for maintainability.
     // Consider adding protected helper functions and making these private.
     RefPtr<IDBTransaction> m_transaction;

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.idl
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.idl
@@ -38,7 +38,7 @@
     [CustomGetter] readonly attribute (IDBCursor or IDBDatabase or any) result;
     readonly attribute DOMException? error;
     readonly attribute (IDBObjectStore or IDBIndex or IDBCursor)? source;
-    readonly attribute IDBTransaction? transaction;
+    [ImplementedAs=transactionForBindings] readonly attribute IDBTransaction? transaction;
     readonly attribute IDBRequestReadyState readyState;
 
     // Event handlers:

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -227,7 +227,7 @@ void MemoryBackingStoreTransaction::abort()
 
     for (auto& index : m_deletedIndexes) {
         RELEASE_ASSERT(m_backingStore->hasObjectStore(index->info().objectStoreIdentifier()));
-        index->protectedObjectStore()->maybeRestoreDeletedIndex(index.copyRef());
+        protect(index->objectStore())->maybeRestoreDeletedIndex(index.copyRef());
     }
     m_deletedIndexes.clear();
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -58,11 +58,6 @@ MemoryObjectStore* MemoryIndex::objectStore()
     return m_objectStore.get();
 }
 
-RefPtr<MemoryObjectStore> MemoryIndex::protectedObjectStore()
-{
-    return m_objectStore.get();
-}
-
 void MemoryIndex::cursorDidBecomeClean(MemoryIndexCursor& cursor)
 {
     m_cleanCursors.add(cursor);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -84,7 +84,6 @@ public:
     IndexValueStore* valueStore() { return m_records.get(); }
 
     MemoryObjectStore* objectStore();
-    RefPtr<MemoryObjectStore> protectedObjectStore();
 
     void cursorDidBecomeClean(MemoryIndexCursor&);
     void cursorDidBecomeDirty(MemoryIndexCursor&);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp
@@ -80,8 +80,9 @@ void MemoryIndexCursor::currentData(IDBGetResult& getResult)
     if (info().cursorType() == IndexedDB::CursorType::KeyOnly)
         getResult = { m_currentKey, m_currentPrimaryKey };
     else {
-        IDBValue value = { m_index->protectedObjectStore()->valueForKey(m_currentPrimaryKey), { }, { } };
-        getResult = { m_currentKey, m_currentPrimaryKey, WTF::move(value), m_index->protectedObjectStore()->info().keyPath() };
+        RefPtr objectStore = m_index->objectStore();
+        IDBValue value = { objectStore->valueForKey(m_currentPrimaryKey), { }, { } };
+        getResult = { m_currentKey, m_currentPrimaryKey, WTF::move(value), objectStore->info().keyPath() };
     }
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -410,11 +410,6 @@ Document* MediaSession::document() const
     return m_navigator->window()->document();
 }
 
-RefPtr<Document> MediaSession::protectedDocument() const
-{
-    return document();
-}
-
 RefPtr<MediaSessionManagerInterface> MediaSession::sessionManager() const
 {
     RefPtr document = this->document();
@@ -554,7 +549,7 @@ void MediaSession::updateNowPlayingInfo(NowPlayingInfo& info)
 
     if (!m_defaultArtworkAttempted && (!m_metadata || m_metadata->artwork().isEmpty())) {
         m_defaultArtworkAttempted = true;
-        if (auto images = fallbackArtwork(protectedDocument() ? protectedDocument()->loader() : nullptr); images.size())
+        if (auto images = fallbackArtwork(protect(document()) ? protect(document())->loader() : nullptr); images.size())
             m_defaultMetadata = MediaMetadata::create(*this, WTF::move(images));
     }
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -105,7 +105,6 @@ public:
     void willPausePlayback();
 
     WEBCORE_EXPORT Document* document() const;
-    RefPtr<Document> protectedDocument() const;
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
     MediaSessionReadyState readyState() const { return m_readyState; };

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -261,21 +261,6 @@ RefPtr<MediaSource> SourceBuffer::protectedSource() const
     return m_source.get();
 }
 
-RefPtr<VideoTrackList> SourceBuffer::protectedVideoTracks() const
-{
-    return m_videoTracks;
-}
-
-RefPtr<AudioTrackList> SourceBuffer::protectedAudioTracks() const
-{
-    return m_audioTracks;
-}
-
-RefPtr<TextTrackList> SourceBuffer::protectedTextTracks() const
-{
-    return m_textTracks;
-}
-
 double SourceBuffer::appendWindowStart() const
 {
     return m_appendWindowStart.toDouble();
@@ -1099,9 +1084,9 @@ bool SourceBuffer::validateInitializationSegment(const SourceBufferPrivateClient
 
     // Note: those are checks from step 3.1
     //   * The number of audio, video, and text tracks match what was in the first initialization segment.
-    return segment.audioTracks.size() == protectedAudioTracks()->length()
-        && segment.videoTracks.size() == protectedVideoTracks()->length()
-        && segment.textTracks.size() == protectedTextTracks()->length();
+    return segment.audioTracks.size() == protect(audioTracksIfExists())->length()
+        && segment.videoTracks.size() == protect(videoTracksIfExists())->length()
+        && segment.textTracks.size() == protect(textTracksIfExists())->length();
 }
 
 void SourceBuffer::appendError(bool decodeError)
@@ -1129,12 +1114,12 @@ void SourceBuffer::appendError(bool decodeError)
 
 bool SourceBuffer::hasAudio() const
 {
-    return m_audioTracks && protectedAudioTracks()->length();
+    return m_audioTracks && protect(audioTracksIfExists())->length();
 }
 
 bool SourceBuffer::hasVideo() const
 {
-    return m_videoTracks && protectedVideoTracks()->length();
+    return m_videoTracks && protect(videoTracksIfExists())->length();
 }
 
 ScriptExecutionContext* SourceBuffer::scriptExecutionContext() const
@@ -1149,9 +1134,9 @@ void SourceBuffer::videoTrackSelectedChanged(VideoTrack& track)
     // 1. If the SourceBuffer associated with the previously selected video track is not associated with
     // any other enabled tracks, run the following steps:
     if (!track.selected()
-        && (!m_videoTracks || !protectedVideoTracks()->isAnyTrackEnabled())
-        && (!m_audioTracks || !protectedAudioTracks()->isAnyTrackEnabled())
-        && (!m_textTracks || !protectedTextTracks()->isAnyTrackEnabled())) {
+        && (!m_videoTracks || !protect(videoTracksIfExists())->isAnyTrackEnabled())
+        && (!m_audioTracks || !protect(audioTracksIfExists())->isAnyTrackEnabled())
+        && (!m_textTracks || !protect(textTracksIfExists())->isAnyTrackEnabled())) {
         // 1.1 Remove the SourceBuffer from activeSourceBuffers.
         // 1.2 Queue a task to fire a simple event named removesourcebuffer at activeSourceBuffers
         setActive(false);
@@ -1191,9 +1176,9 @@ void SourceBuffer::audioTrackEnabledChanged(AudioTrack& track)
     // If an audio track becomes disabled and the SourceBuffer associated with this track is not
     // associated with any other enabled or selected track, then run the following steps:
     if (!track.enabled()
-        && (!m_videoTracks || !protectedVideoTracks()->isAnyTrackEnabled())
-        && (!m_audioTracks || !protectedAudioTracks()->isAnyTrackEnabled())
-        && (!m_textTracks || !protectedTextTracks()->isAnyTrackEnabled())) {
+        && (!m_videoTracks || !protect(videoTracksIfExists())->isAnyTrackEnabled())
+        && (!m_audioTracks || !protect(audioTracksIfExists())->isAnyTrackEnabled())
+        && (!m_textTracks || !protect(textTracksIfExists())->isAnyTrackEnabled())) {
         // 1. Remove the SourceBuffer associated with the audio track from activeSourceBuffers
         // 2. Queue a task to fire a simple event named removesourcebuffer at activeSourceBuffers
         setActive(false);
@@ -1233,9 +1218,9 @@ void SourceBuffer::textTrackModeChanged(TextTrack& track)
     // If a text track mode becomes "disabled" and the SourceBuffer associated with this track is not
     // associated with any other enabled or selected track, then run the following steps:
     if (track.mode() == TextTrack::Mode::Disabled
-        && (!m_videoTracks || !protectedVideoTracks()->isAnyTrackEnabled())
-        && (!m_audioTracks || !protectedAudioTracks()->isAnyTrackEnabled())
-        && (!m_textTracks || !protectedTextTracks()->isAnyTrackEnabled())) {
+        && (!m_videoTracks || !protect(videoTracksIfExists())->isAnyTrackEnabled())
+        && (!m_audioTracks || !protect(audioTracksIfExists())->isAnyTrackEnabled())
+        && (!m_textTracks || !protect(textTracksIfExists())->isAnyTrackEnabled())) {
         // 1. Remove the SourceBuffer associated with the audio track from activeSourceBuffers
         // 2. Queue a task to fire a simple event named removesourcebuffer at activeSourceBuffers
         setActive(false);
@@ -1549,9 +1534,9 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidAttach(SourceBufferPrivate
 
     RefPtr source = m_source.get();
     // 3.2 Add the appropriate track descriptions from this initialization segment to each of the track buffers.
-    ASSERT(segment.audioTracks.size() == protectedAudioTracks()->length());
+    ASSERT(segment.audioTracks.size() == protect(audioTracksIfExists())->length());
     for (auto& audioTrackInfo : segment.audioTracks) {
-        auto audioTrack = protectedAudioTracks()->getTrackById(RefPtr { audioTrackInfo.track }->id());
+        auto audioTrack = protect(audioTracksIfExists())->getTrackById(RefPtr { audioTrackInfo.track }->id());
         ASSERT(audioTrack);
         audioTrack->setPrivate(Ref { *audioTrackInfo.track });
         if (isMainThread())

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -213,9 +213,6 @@ private:
 
     void rangeRemoval(const MediaTime&, const MediaTime&);
     RefPtr<MediaSource> protectedSource() const;
-    RefPtr<VideoTrackList> protectedVideoTracks() const;
-    RefPtr<AudioTrackList> protectedAudioTracks() const;
-    RefPtr<TextTrackList> protectedTextTracks() const;
 
     friend class Internals;
     using SamplesPromise = NativePromise<Vector<String>, PlatformMediaError>;

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -397,11 +397,6 @@ bool MediaStream::virtualHasPendingActivity() const
     return m_isActive && m_allowEventTracks == AllowEventTracks::Yes && hasEventListeners();
 }
 
-Ref<MediaStreamPrivate> MediaStream::protectedPrivateStream()
-{
-    return m_private;
-}
-
 ScriptExecutionContext* MediaStream::scriptExecutionContext() const
 {
     return ContextDestructionObserver::scriptExecutionContext();

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -94,7 +94,6 @@ public:
     template<typename Function> bool hasMatchingTrack(Function&& function) const { return std::ranges::any_of(m_trackMap.values(), std::forward<Function>(function)); }
 
     MediaStreamPrivate& privateStream() { return m_private.get(); }
-    Ref<MediaStreamPrivate> protectedPrivateStream();
 
     void startProducingData();
     void stopProducingData();

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -458,11 +458,6 @@ void PaymentRequest::abortWithException(Exception&& exception)
         settleShowPromise(WTF::move(exception));
 }
 
-RefPtr<PaymentHandler> PaymentRequest::protectedActivePaymentHandler()
-{
-    return activePaymentHandler();
-}
-
 void PaymentRequest::settleShowPromise(ExceptionOr<PaymentResponse&>&& result)
 {
     if (auto showPromise = std::exchange(m_showPromise, nullptr))
@@ -523,7 +518,7 @@ void PaymentRequest::abort(AbortPromise&& promise)
         return;
     }
 
-    if (m_activePaymentHandler && !protectedActivePaymentHandler()->canAbortSession()) {
+    if (m_activePaymentHandler && !protect(activePaymentHandler())->canAbortSession()) {
         promise.reject(Exception { ExceptionCode::InvalidStateError });
         return;
     }

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.h
@@ -127,7 +127,6 @@ private:
     void whenDetailsSettled(std::function<void()>&&);
     void abortWithException(Exception&&);
     PaymentHandler* activePaymentHandler() { return m_activePaymentHandler ? m_activePaymentHandler->paymentHandler.ptr() : nullptr; }
-    RefPtr<PaymentHandler> protectedActivePaymentHandler();
     void settleShowPromise(ExceptionOr<PaymentResponse&>&&);
     void closeActivePaymentHandler();
 

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -66,9 +66,7 @@ public:
     void close(DOMPromiseDeferred<void>&&);
 
     DefaultAudioDestinationNode& destination() final { return m_destinationNode.get(); }
-    Ref<DefaultAudioDestinationNode> protectedDestination() { return destination(); }
     const DefaultAudioDestinationNode& destination() const final { return m_destinationNode.get(); }
-    Ref<const DefaultAudioDestinationNode> protectedDestination() const { return destination(); }
 
     double baseLatency();
     double outputLatency();

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -186,7 +186,7 @@ void BaseAudioContext::lazyInitialize()
     if (m_isAudioThreadFinished)
         return;
 
-    protectedDestination()->initialize();
+    protect(destination())->initialize();
 
     m_isInitialized = true;
 }
@@ -212,7 +212,7 @@ void BaseAudioContext::uninitialize()
         return;
 
     // This stops the audio thread and all audio rendering.
-    protectedDestination()->uninitialize();
+    protect(destination())->uninitialize();
 
     // Don't allow the context to initialize a second time after it's already been explicitly uninitialized.
     m_isAudioThreadFinished = true;
@@ -278,7 +278,7 @@ void BaseAudioContext::stop()
     m_isStopScheduled = true;
 
     ASSERT(document());
-    protectedDocument()->updateIsPlayingMedia();
+    protect(document())->updateIsPlayingMedia();
 
     uninitialize();
     clear();
@@ -287,11 +287,6 @@ void BaseAudioContext::stop()
 Document* BaseAudioContext::document() const
 {
     return downcast<Document>(scriptExecutionContext());
-}
-
-RefPtr<Document> BaseAudioContext::protectedDocument() const
-{
-    return document();
 }
 
 bool BaseAudioContext::wouldTaintOrigin(const URL& url) const
@@ -989,7 +984,7 @@ void BaseAudioContext::workletIsReady()
 
     // If we're already rendering when the worklet becomes ready, we need to restart
     // rendering in order to switch to the audio worklet thread.
-    protectedDestination()->restartRendering();
+    protect(destination())->restartRendering();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -107,14 +107,11 @@ public:
     uint64_t contextID() const { return m_contextID; }
 
     Document* document() const;
-    RefPtr<Document> protectedDocument() const;
     bool isInitialized() const { return m_isInitialized; }
     
     virtual bool isOfflineContext() const = 0;
     virtual AudioDestinationNode& destination() = 0;
-    Ref<AudioDestinationNode> protectedDestination() { return destination(); }
     virtual const AudioDestinationNode& destination() const = 0;
-    Ref<const AudioDestinationNode> protectedDestination() const { return destination(); }
 #if PLATFORM(IOS_FAMILY)
     virtual const String& sceneIdentifier() const { return nullString(); }
 #endif

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp
@@ -146,7 +146,7 @@ void OfflineAudioContext::startRendering(Ref<DeferredPromise>&& promise)
 
     lazyInitialize();
 
-    protectedDestination()->startRendering([promise = WTF::move(promise), pendingActivity = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
+    protect(destination())->startRendering([promise = WTF::move(promise), pendingActivity = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
         if (exception) {
             promise->reject(WTF::move(*exception));
             return;
@@ -207,7 +207,7 @@ void OfflineAudioContext::resumeRendering(Ref<DeferredPromise>&& promise)
     }
     ASSERT(state() == AudioContextState::Suspended);
 
-    protectedDestination()->startRendering([promise = WTF::move(promise), pendingActivity = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
+    protect(destination())->startRendering([promise = WTF::move(promise), pendingActivity = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
         if (exception) {
             promise->reject(WTF::move(*exception));
             return;

--- a/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioContext.h
@@ -51,9 +51,7 @@ public:
     bool shouldSuspend();
 
     OfflineAudioDestinationNode& destination() final { return m_destinationNode.get(); }
-    Ref<OfflineAudioDestinationNode> protectedDestination() { return destination(); }
     const OfflineAudioDestinationNode& destination() const final { return m_destinationNode.get(); }
-    Ref<const OfflineAudioDestinationNode> protectedDestination() const { return destination(); }
 
 private:
     OfflineAudioContext(Document&, const OfflineAudioContextOptions&);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2020,7 +2020,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, const ContentType& in
 #if ENABLE(MEDIA_STREAM)
         if (RefPtr mediaStreamSrcObject = protectedThis->m_mediaStreamSrcObject; mediaStreamSrcObject && !protectedThis->m_remotePlaybackConfiguration) {
             ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "loading media stream blob ", mediaStreamSrcObject->logIdentifier());
-            if (!player->load(mediaStreamSrcObject->protectedPrivateStream()))
+            if (!player->load(protect(mediaStreamSrcObject->privateStream())))
                 protectedThis->mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
             else
                 protectedThis->mediaPlayerRenderingModeChanged();

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -387,11 +387,11 @@ public:
 
         auto* lexicalGlobalObject = context.globalObject();
 
-        auto key = m_injectedScript.wrapObject(toJS(*lexicalGlobalObject, *lexicalGlobalObject, cursor->protectedKey().get()), String(), true);
+        auto key = m_injectedScript.wrapObject(toJS(*lexicalGlobalObject, *lexicalGlobalObject, protect(cursor->key()).get()), String(), true);
         if (!key)
             return;
 
-        auto primaryKey = m_injectedScript.wrapObject(toJS(*lexicalGlobalObject, *lexicalGlobalObject, cursor->protectedPrimaryKey().get()), String(), true);
+        auto primaryKey = m_injectedScript.wrapObject(toJS(*lexicalGlobalObject, *lexicalGlobalObject, protect(cursor->primaryKey()).get()), String(), true);
         if (!primaryKey)
             return;
 

--- a/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp
@@ -37,7 +37,7 @@ namespace WebKit::WebGPU {
 
 std::optional<ProgrammableStage> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::ProgrammableStage& programmableStage)
 {
-    auto module = convertToBacking(programmableStage.protectedModule().get());
+    auto module = convertToBacking(protect(programmableStage.module).get());
 
     return { { module, programmableStage.entryPoint, programmableStage.constants } };
 }

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1434,7 +1434,7 @@ void MediaPlayerPrivateRemote::setCDM(LegacyCDM* cdm)
     if (!cdm)
         return;
 
-    if (RefPtr remoteCDM = protect(WebProcess::singleton().legacyCDMFactory())->findCDM(cdm->protectedCDMPrivate().get()))
+    if (RefPtr remoteCDM = protect(WebProcess::singleton().legacyCDMFactory())->findCDM(protect(cdm->cdmPrivate()).get()))
         remoteCDM->setPlayerId(m_id);
 }
 


### PR DESCRIPTION
#### 16c4470446cbeb8e4d6cb6899099858fb3bfc022
<pre>
Reduce use of protected functions in Source/WebCore/Modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=306601">https://bugs.webkit.org/show_bug.cgi?id=306601</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.cpp:
(WebCore::GPUCommandEncoder::setLabel):
(WebCore::GPUCommandEncoder::beginRenderPass):
(WebCore::GPUCommandEncoder::beginComputePass):
(WebCore::GPUCommandEncoder::copyBufferToBuffer):
(WebCore::GPUCommandEncoder::copyBufferToTexture):
(WebCore::GPUCommandEncoder::copyTextureToBuffer):
(WebCore::GPUCommandEncoder::copyTextureToTexture):
(WebCore::GPUCommandEncoder::clearBuffer):
(WebCore::GPUCommandEncoder::pushDebugGroup):
(WebCore::GPUCommandEncoder::popDebugGroup):
(WebCore::GPUCommandEncoder::insertDebugMarker):
(WebCore::GPUCommandEncoder::writeTimestamp):
(WebCore::GPUCommandEncoder::resolveQuerySet):
(WebCore::GPUCommandEncoder::finish):
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.h:
(WebCore::GPUCommandEncoder::protectedBacking): Deleted.
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.cpp:
(WebCore::GPUComputePassEncoder::setLabel):
(WebCore::GPUComputePassEncoder::setPipeline):
(WebCore::GPUComputePassEncoder::dispatchWorkgroups):
(WebCore::GPUComputePassEncoder::dispatchWorkgroupsIndirect):
(WebCore::GPUComputePassEncoder::end):
(WebCore::GPUComputePassEncoder::setBindGroup):
(WebCore::GPUComputePassEncoder::pushDebugGroup):
(WebCore::GPUComputePassEncoder::popDebugGroup):
(WebCore::GPUComputePassEncoder::insertDebugMarker):
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.h:
(WebCore::GPUComputePassEncoder::protectedBacking): Deleted.
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::setLabel):
(WebCore::GPURenderPassEncoder::setPipeline):
(WebCore::GPURenderPassEncoder::setIndexBuffer):
(WebCore::GPURenderPassEncoder::setVertexBuffer):
(WebCore::GPURenderPassEncoder::draw):
(WebCore::GPURenderPassEncoder::drawIndexed):
(WebCore::GPURenderPassEncoder::drawIndirect):
(WebCore::GPURenderPassEncoder::drawIndexedIndirect):
(WebCore::GPURenderPassEncoder::setBindGroup):
(WebCore::GPURenderPassEncoder::pushDebugGroup):
(WebCore::GPURenderPassEncoder::popDebugGroup):
(WebCore::GPURenderPassEncoder::insertDebugMarker):
(WebCore::GPURenderPassEncoder::setViewport):
(WebCore::GPURenderPassEncoder::setScissorRect):
(WebCore::GPURenderPassEncoder::setBlendConstant):
(WebCore::GPURenderPassEncoder::setStencilReference):
(WebCore::GPURenderPassEncoder::beginOcclusionQuery):
(WebCore::GPURenderPassEncoder::endOcclusionQuery):
(WebCore::GPURenderPassEncoder::executeBundles):
(WebCore::GPURenderPassEncoder::end):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h:
(WebCore::GPURenderPassEncoder::protectedBacking): Deleted.
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::convertToBacking):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUProgrammableStage.h:
(WebCore::WebGPU::ProgrammableStage::protectedModule const): Deleted.
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.cpp:
(WebCore::LegacyCDM::supportsMIMEType const):
(WebCore::LegacyCDM::createSession):
(WebCore::LegacyCDM::protectedCDMPrivate const): Deleted.
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDM.h:
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::consume):
(WebCore::FetchBody::consumeAsStream):
(WebCore::FetchBody::consumeArrayBuffer):
(WebCore::FetchBody::consumeArrayBufferView):
(WebCore::FetchBody::consumeBlob):
(WebCore::FetchBody::consumeFormData):
(WebCore::FetchBody::bodyAsFormData const):
(WebCore::FetchBody::convertReadableStreamToArrayBuffer):
(WebCore::FetchBody::take):
(WebCore::FetchBody::clone):
* Source/WebCore/Modules/fetch/FetchBody.h:
(WebCore::FetchBody::readableStream):
(WebCore::FetchBody::blobBody const):
(WebCore::FetchBody::formDataBody):
(WebCore::FetchBody::formDataBody const):
(WebCore::FetchBody::arrayBufferBody const):
(WebCore::FetchBody::arrayBufferViewBody const):
(WebCore::FetchBody::urlSearchParamsBody const):
(WebCore::FetchBody::protectedReadableStream const): Deleted.
(WebCore::FetchBody::protectedReadableStream): Deleted.
(WebCore::FetchBody::protectedBlobBody const): Deleted.
(WebCore::FetchBody::protectedFormDataBody): Deleted.
(WebCore::FetchBody::protectedFormDataBody const): Deleted.
(WebCore::FetchBody::protectedArrayBufferBody const): Deleted.
(WebCore::FetchBody::protectedArrayBufferViewBody const): Deleted.
(WebCore::FetchBody::protectedURLSearchParamsBody const): Deleted.
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::createReadableStream):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::consumeBodyReceivedByChunk):
(WebCore::FetchResponse::cancelStream):
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::shouldBlockGeolocationRequests):
(WebCore::Geolocation::protectedSecurityOrigin const): Deleted.
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/geolocation/GeolocationController.cpp:
(WebCore::GeolocationController::addObserver):
(WebCore::GeolocationController::removeObserver):
(WebCore::GeolocationController::revokeAuthorizationToken):
(WebCore::GeolocationController::requestPermission):
(WebCore::GeolocationController::cancelPermissionRequest):
(WebCore::GeolocationController::lastPosition):
(WebCore::GeolocationController::startUpdatingIfNecessary):
(WebCore::GeolocationController::stopUpdatingIfNecessary):
(WebCore::GeolocationController::protectedClient): Deleted.
* Source/WebCore/Modules/geolocation/GeolocationController.h:
* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
(WebCore::IDBCursor::transaction const):
(WebCore::IDBCursor::uncheckedIterateCursor):
(WebCore::IDBCursor::deleteFunction):
(WebCore::IDBCursor::iterateWithPrefetchedRecords):
(WebCore::IDBCursor::protectedEffectiveObjectStore const): Deleted.
(WebCore::IDBCursor::protectedTransaction const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBCursor.h:
(WebCore::IDBCursor::key):
(WebCore::IDBCursor::primaryKey):
(WebCore::IDBCursor::protectedKey): Deleted.
(WebCore::IDBCursor::protectedPrimaryKey): Deleted.
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp:
(WebCore::IDBOpenDBRequest::fireSuccessAfterVersionChangeCommit):
(WebCore::IDBOpenDBRequest::fireErrorAfterVersionChangeCompletion):
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::transactionForBindings const):
(WebCore::IDBRequest::transaction const):
(WebCore::IDBRequest::dispatchEvent):
(WebCore::IDBRequest::uncaughtExceptionInEventHandler):
(WebCore::IDBRequest::protectedTransaction const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBRequest.idl:
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::protectedObjectStore): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndexCursor.cpp:
(WebCore::IDBServer::MemoryIndexCursor::currentData):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::updateNowPlayingInfo):
(WebCore::MediaSession::protectedDocument const): Deleted.
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::validateInitializationSegment):
(WebCore::SourceBuffer::hasAudio const):
(WebCore::SourceBuffer::hasVideo const):
(WebCore::SourceBuffer::videoTrackSelectedChanged):
(WebCore::SourceBuffer::audioTrackEnabledChanged):
(WebCore::SourceBuffer::textTrackModeChanged):
(WebCore::SourceBuffer::sourceBufferPrivateDidAttach):
(WebCore::SourceBuffer::protectedVideoTracks const): Deleted.
(WebCore::SourceBuffer::protectedAudioTracks const): Deleted.
(WebCore::SourceBuffer::protectedTextTracks const): Deleted.
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::protectedPrivateStream): Deleted.
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::abort):
(WebCore::PaymentRequest::protectedActivePaymentHandler): Deleted.
* Source/WebCore/Modules/paymentrequest/PaymentRequest.h:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::baseLatency):
(WebCore::AudioContext::outputLatency):
(WebCore::AudioContext::close):
(WebCore::AudioContext::suspendRendering):
(WebCore::AudioContext::resumeRendering):
(WebCore::AudioContext::startRendering):
(WebCore::AudioContext::mayResumePlayback):
(WebCore::AudioContext::suspend):
(WebCore::AudioContext::resume):
(WebCore::AudioContext::suspendPlayback):
(WebCore::AudioContext::isNowPlayingEligible const):
(WebCore::AudioContext::shouldOverrideBackgroundPlaybackRestriction const):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::lazyInitialize):
(WebCore::BaseAudioContext::uninitialize):
(WebCore::BaseAudioContext::stop):
(WebCore::BaseAudioContext::workletIsReady):
(WebCore::BaseAudioContext::protectedDocument const): Deleted.
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::protectedDestination): Deleted.
(WebCore::BaseAudioContext::protectedDestination const): Deleted.
* Source/WebCore/Modules/webaudio/OfflineAudioContext.cpp:
(WebCore::OfflineAudioContext::startRendering):
(WebCore::OfflineAudioContext::resumeRendering):
* Source/WebCore/Modules/webaudio/OfflineAudioContext.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
* Source/WebKit/Shared/WebGPU/WebGPUProgrammableStage.cpp:
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::setCDM):

Canonical link: <a href="https://commits.webkit.org/306543@main">https://commits.webkit.org/306543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3a12cdcf8b15ecb7c18839d7b17491ca0966c7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14053 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/3530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150239 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4cc770b5-1a9b-46ad-8da4-d33af9389c8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0f40cfe-6802-4fe7-9a2a-a841dae42845) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11402 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89759 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/824e1974-b3ab-4731-98eb-0441f6728158) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8592 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/312 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152632 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13742 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/3284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116957 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117282 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29871 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13311 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/123508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13780 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13519 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13566 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->