### PR TITLE
Add missing `CLANG_POINTER_CONVERSION` annotation on some protect() functions

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -374,14 +374,14 @@ template<typename T, typename U, typename WeakPtrImpl, typename PtrTraits> inlin
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits, typename RefPtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
     requires HasRefPtrMemberFunctions<T>::value
-ALWAYS_INLINE RefPtr<T, RefPtrTraits, RefDerefTraits> protect(const WeakPtr<T, WeakPtrImpl, PtrTraits>& weakPtr)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, RefPtrTraits, RefDerefTraits> protect(const WeakPtr<T, WeakPtrImpl, PtrTraits>& weakPtr)
 {
     return RefPtr<T, RefPtrTraits, RefDerefTraits>(weakPtr.get());
 }
 
 template<typename T, typename WeakPtrImpl, typename WeakPtrPtrTraits, typename CheckedPtrTraits = RawPtrTraits<T>>
     requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
-ALWAYS_INLINE CheckedPtr<T, CheckedPtrTraits> protect(const WeakPtr<T, WeakPtrImpl, WeakPtrPtrTraits>& weakPtr)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedPtr<T, CheckedPtrTraits> protect(const WeakPtr<T, WeakPtrImpl, WeakPtrPtrTraits>& weakPtr)
 {
     return CheckedPtr<T, CheckedPtrTraits>(weakPtr.get());
 }

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -219,14 +219,14 @@ inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl> dynamicDowncast(W
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits = RawPtrTraits<T>>
     requires HasRefPtrMemberFunctions<T>::value
-ALWAYS_INLINE Ref<T, PtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION Ref<T, PtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
 {
     return Ref<T, PtrTraits>(*weakRef.ptr());
 }
 
 template<typename T, typename WeakPtrImpl, typename CheckedPtrTraits = RawPtrTraits<T>>
     requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
-ALWAYS_INLINE CheckedRef<T, CheckedPtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
+ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedRef<T, CheckedPtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
 {
     return CheckedRef<T, CheckedPtrTraits>(*weakRef.ptr());
 }

--- a/Source/WTF/wtf/darwin/DispatchOSObject.h
+++ b/Source/WTF/wtf/darwin/DispatchOSObject.h
@@ -62,7 +62,7 @@ WTF_OS_OBJECT_DISPATCH_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_DISPATCH)
 
 // Dispatch protect() functions.
 #define WTF_DECLARE_DISPATCH_PROTECT(TypeName) \
-ALWAYS_INLINE OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
+ALWAYS_INLINE CLANG_POINTER_CONVERSION OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
 { \
     return ptr; \
 }

--- a/Source/WTF/wtf/darwin/NetworkOSObject.h
+++ b/Source/WTF/wtf/darwin/NetworkOSObject.h
@@ -58,7 +58,7 @@ WTF_OS_OBJECT_NETWORK_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_NETWORK)
 
 // Network protect() functions.
 #define WTF_DECLARE_NETWORK_PROTECT(TypeName) \
-ALWAYS_INLINE OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
+ALWAYS_INLINE CLANG_POINTER_CONVERSION OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
 { \
     return ptr; \
 }

--- a/Source/WTF/wtf/darwin/XPCObjectPtr.h
+++ b/Source/WTF/wtf/darwin/XPCObjectPtr.h
@@ -55,7 +55,7 @@ WTF_OS_OBJECT_XPC_TYPES(WTF_IMPLEMENT_IS_OS_OBJECT_FUNCTIONS_XPC)
 
 // XPC protect() functions.
 #define WTF_DECLARE_XPC_PROTECT(TypeName) \
-ALWAYS_INLINE OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
+ALWAYS_INLINE CLANG_POINTER_CONVERSION OSObjectPtr<TypeName##_t> protect(TypeName##_t ptr) \
 { \
     return ptr; \
 }


### PR DESCRIPTION
#### 4441c520603a13dc5ba6f7be7ff5495e7bf0de14
<pre>
Add missing `CLANG_POINTER_CONVERSION` annotation on some protect() functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306602">https://bugs.webkit.org/show_bug.cgi?id=306602</a>

Reviewed by Ryosuke Niwa.

Add missing `CLANG_POINTER_CONVERSION` annotation on some
protect() functions to silence some Safer CPP warnings.

* Source/WTF/wtf/WeakPtr.h:
(WTF::protect):
* Source/WTF/wtf/WeakRef.h:
(WTF::protect):
* Source/WTF/wtf/darwin/DispatchOSObject.h:
* Source/WTF/wtf/darwin/NetworkOSObject.h:
* Source/WTF/wtf/darwin/XPCObjectPtr.h:

Canonical link: <a href="https://commits.webkit.org/306479@main">https://commits.webkit.org/306479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83267b6d00d7967ebcc13de9e851693e9006f17b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141494 "Failed to checkout and rebase branch from PR 57538") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150070 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca41a4e9-8fc9-43fa-9832-8836708254e6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108717 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d658d8c9-f85c-4982-8f83-d424cb09cf37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11265 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89622 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba9d3cc8-eb92-46d9-8b65-e7922960c501) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/10827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/142 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133478 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152463 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2298 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13568 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/3056 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116820 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117151 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29822 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/13196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123286 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13611 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172787 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77325 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44758 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13395 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->