### PR TITLE
Remove CanvasBase::m_contextStateSaver, it is not useful

### DIFF
--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -45,7 +45,6 @@ class CanvasRenderingContext;
 class Element;
 class Event;
 class GraphicsContext;
-class GraphicsContextStateSaver;
 class Image;
 class ImageBuffer;
 class IntRect;
@@ -129,8 +128,6 @@ public:
     bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;
     void recordLastFillText(const String&);
 
-    void resetGraphicsContextState() const;
-
     void setNoiseInjectionSalt(NoiseInjectionHashSalt salt) { m_canvasNoiseHashSalt = salt; }
     bool havePendingCanvasNoiseInjection() const { return m_canvasNoiseInjection.haveDirtyRects(); }
 
@@ -164,7 +161,6 @@ private:
     mutable IntSize m_size;
     mutable RefPtr<ImageBuffer> m_imageBuffer;
     mutable std::atomic<size_t> m_imageBufferMemoryCost { 0 };
-    mutable std::unique_ptr<GraphicsContextStateSaver> m_contextStateSaver;
     mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 
     String m_lastFillText;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -615,8 +615,6 @@ void HTMLCanvasElement::didUpdateSizeProperties()
 
     if (RefPtr context = dynamicDowncast<CanvasRenderingContext2D>(m_context.get()))
         context->reset();
-    else
-        resetGraphicsContextState();
 
     IntSize oldSize = size();
     IntSize newSize(w, h);

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -153,7 +153,6 @@ void OffscreenCanvas::setHeight(unsigned newHeight)
 
 void OffscreenCanvas::didUpdateSizeProperties()
 {
-    resetGraphicsContextState();
     if (RefPtr context = dynamicDowncast<OffscreenCanvasRenderingContext2D>(m_context.get()))
         context->reset();
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -262,14 +262,12 @@ void CanvasRenderingContext2DBase::unwindStateStack()
     size_t stackSize = m_stateStack.size();
     if (stackSize <= 1)
         return;
-
-    // We need to keep the last state because it is tracked by CanvasBase::m_contextStateSaver.
+    m_stateStack.shrink(1);
     auto* context = existingDrawingContext();
-    while (m_stateStack.size() > 1) {
-        m_stateStack.removeLast();
-        if (context)
-            context->restore();
-    }
+    if (!context)
+        return;
+    for (;stackSize > 1; --stackSize)
+        context->restore();
 }
 
 CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
@@ -330,7 +328,8 @@ void CanvasRenderingContext2DBase::reset()
     m_hasDeferredOperations = false;
     clearAccumulatedDirtyRect();
     if (auto* c = existingDrawingContext()) {
-        canvasBase().resetGraphicsContextState();
+        c->restore();
+        c->save();
         c->clearRect(FloatRect { { }, canvasBase().size() });
     }
 }


### PR DESCRIPTION
#### 8d32ab8d183e71c3b32349fcc3f5a6436786b643
<pre>
Remove CanvasBase::m_contextStateSaver, it is not useful
<a href="https://bugs.webkit.org/show_bug.cgi?id=306603">https://bugs.webkit.org/show_bug.cgi?id=306603</a>
<a href="https://rdar.apple.com/169252451">rdar://169252451</a>

Reviewed by Simon Fraser.

GraphicsContextStateSaver is a RAII class, it&apos;s not more useful than
explicit save/restore useful when managed explicitly. Having the state
saver in CanvasBase makes it harder to move the ImageBuffer from
CanvasBase to 2DCanvasRenderingContextBase.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::setImageBuffer const):
(WebCore::CanvasBase::resetGraphicsContextState const): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::didUpdateSizeProperties):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::didUpdateSizeProperties):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::unwindStateStack):
(WebCore::CanvasRenderingContext2DBase::reset):

Canonical link: <a href="https://commits.webkit.org/306511@main">https://commits.webkit.org/306511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9abae38dc5aa3557bfff39af2ad7163cf5fc44f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94592 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0599b928-b4a9-49bd-8cbd-aa8a777119a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108720 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78670 "10 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8614ad2b-7497-4447-944a-9909bf247974) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89625 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a41f9d5-b35b-4cc6-8679-a64569da956e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8447 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/143 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152464 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13569 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116821 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29848 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13194 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68766 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13612 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2594 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77326 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13548 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->