### PR TITLE
[JSC] Convert simple `Object.defineProperty` to `DefineDataProperty` in DFG StrengthReduction

### DIFF
--- a/JSTests/stress/object-define-property-value-only-dfg.js
+++ b/JSTests/stress/object-define-property-value-only-dfg.js
@@ -1,0 +1,211 @@
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "expected " + expected + " but got " + actual);
+}
+
+function shouldBeTrue(actual, message) {
+    shouldBe(actual, true, message);
+}
+
+function shouldBeFalse(actual, message) {
+    shouldBe(actual, false, message);
+}
+
+function checkDescriptor(obj, key, expectedValue, expectedWritable, expectedEnumerable, expectedConfigurable) {
+    const desc = Object.getOwnPropertyDescriptor(obj, key);
+    shouldBe(desc.value, expectedValue, "value");
+    shouldBe(desc.writable, expectedWritable, "writable");
+    shouldBe(desc.enumerable, expectedEnumerable, "enumerable");
+    shouldBe(desc.configurable, expectedConfigurable, "configurable");
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "prop", { value: 42 });
+        shouldBe(obj.prop, 42);
+        checkDescriptor(obj, "prop", 42, false, false, false);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        let obj = {};
+        Object.defineProperty(obj, "num", { value: 123 });
+        shouldBe(obj.num, 123);
+
+        obj = {};
+        Object.defineProperty(obj, "str", { value: "hello" });
+        shouldBe(obj.str, "hello");
+
+        obj = {};
+        Object.defineProperty(obj, "bool", { value: true });
+        shouldBe(obj.bool, true);
+
+        obj = {};
+        Object.defineProperty(obj, "undef", { value: undefined });
+        shouldBe(obj.undef, undefined);
+        shouldBeTrue("undef" in obj);
+
+        obj = {};
+        Object.defineProperty(obj, "nul", { value: null });
+        shouldBe(obj.nul, null);
+
+        const innerObj = { inner: true };
+        obj = {};
+        Object.defineProperty(obj, "obj", { value: innerObj });
+        shouldBe(obj.obj, innerObj);
+        shouldBe(obj.obj.inner, true);
+
+        const fn = function() { return 99; };
+        obj = {};
+        Object.defineProperty(obj, "fn", { value: fn });
+        shouldBe(obj.fn, fn);
+        shouldBe(obj.fn(), 99);
+    }
+}
+
+{
+    const sym = Symbol("test");
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, sym, { value: "symbol value" });
+        shouldBe(obj[sym], "symbol value");
+        checkDescriptor(obj, sym, "symbol value", false, false, false);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "prop", { value: 42, writable: true });
+        shouldBe(obj.prop, 42);
+        checkDescriptor(obj, "prop", 42, true, false, false);
+        obj.prop = 100;
+        shouldBe(obj.prop, 100);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "prop", { value: 42, enumerable: true });
+        shouldBe(obj.prop, 42);
+        checkDescriptor(obj, "prop", 42, false, true, false);
+        const keys = Object.keys(obj);
+        shouldBe(keys.length, 1);
+        shouldBe(keys[0], "prop");
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "prop", { value: 42, configurable: true });
+        shouldBe(obj.prop, 42);
+        checkDescriptor(obj, "prop", 42, false, false, true);
+        delete obj.prop;
+        shouldBeFalse("prop" in obj);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        let storage = 0;
+        const obj = {};
+        Object.defineProperty(obj, "prop", {
+            get: function() { return storage; },
+            set: function(v) { storage = v; }
+        });
+        shouldBe(obj.prop, 0);
+        obj.prop = 42;
+        shouldBe(obj.prop, 42);
+        shouldBe(storage, 42);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "prop", {
+            get: function() { return 99; }
+        });
+        shouldBe(obj.prop, 99);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        let captured = null;
+        const obj = {};
+        Object.defineProperty(obj, "prop", {
+            set: function(v) { captured = v; }
+        });
+        obj.prop = "test";
+        shouldBe(captured, "test");
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "prop", { value: 1, configurable: true });
+        shouldBe(obj.prop, 1);
+        Object.defineProperty(obj, "prop", { value: 2 });
+        shouldBe(obj.prop, 2);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "prop", { value: 42, configurable: false });
+        let threw = false;
+        try {
+            Object.defineProperty(obj, "prop", { value: 100 });
+        } catch (e) {
+            threw = true;
+        }
+        shouldBeTrue(threw);
+        shouldBe(obj.prop, 42);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        const desc = { value: i };
+        Object.defineProperty(obj, "prop", desc);
+        shouldBe(obj.prop, i);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const obj = {};
+        Object.defineProperty(obj, "a", { value: 1 });
+        Object.defineProperty(obj, "b", { value: 2 });
+        Object.defineProperty(obj, "c", { value: 3 });
+        shouldBe(obj.a, 1);
+        shouldBe(obj.b, 2);
+        shouldBe(obj.c, 3);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        function Ctor() {}
+        Object.defineProperty(Ctor.prototype, "prop", { value: 42 });
+        const instance = new Ctor();
+        shouldBe(instance.prop, 42);
+    }
+}
+
+{
+    for (let i = 0; i < testLoopCount; i++) {
+        const exports = {};
+        Object.defineProperty(exports, "__esModule", { value: true });
+        shouldBe(exports.__esModule, true);
+        checkDescriptor(exports, "__esModule", true, false, false, false);
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -35,6 +35,7 @@
 #include "DFGInsertionSet.h"
 #include "DFGJITCode.h"
 #include "DFGPhase.h"
+#include "DefinePropertyAttributes.h"
 #include "JSBoundFunctionInlines.h"
 #include "JSObjectInlines.h"
 #include "JSWebAssemblyInstance.h"
@@ -1846,11 +1847,82 @@ private:
             break;
         }
 
+        case ObjectDefineProperty: {
+            // Detect pattern like Object.defineProperty(obj, "key", { value: x }) and convert it to DefineDataProperty.
+            // FIXME: Support descriptors with writable/enumerable/configurable attributes.
+            // FIXME: When key is a constant identifier and target's structure is known, inline
+            // the　structure transition directly (PutByOffset + PutStructure) instead of DefineDataProperty.
+            Node* target = m_node->child1().node();
+            Node* descriptor = m_node->child3().node();
+            if (descriptor->op() != NewObject)
+                break;
+
+            Structure* finalStructure = nullptr;
+            for (unsigned i = m_nodeIndex; i--;) {
+                Node* node = m_block->at(i);
+                if (node == descriptor)
+                    break;
+                if (node->op() == PutStructure && node->child1().node() == descriptor) {
+                    finalStructure = node->transition()->next.get();
+                    break;
+                }
+            }
+            if (!finalStructure)
+                break;
+
+            if (finalStructure->inlineSize() + finalStructure->outOfLineSize() != 1)
+                break;
+            VM& vm = m_graph.m_vm;
+            PropertyOffset valueOffset = finalStructure->getConcurrently(vm.propertyNames->value.impl());
+            if (!isValidOffset(valueOffset))
+                break;
+
+            DefinePropertyAttributes defineAttrs;
+            defineAttrs.setValue();
+
+            NodeOrigin origin = m_node->origin;
+            m_insertionSet.insertNode(m_nodeIndex, SpecNone, CheckStructure, origin, OpInfo(m_graph.addStructureSet(finalStructure)), Edge(descriptor, CellUse));
+            StorageAccessData* data = m_graph.m_storageAccessData.add();
+            data->offset = valueOffset;
+            data->identifierNumber = m_graph.identifiers().ensure(vm.propertyNames->value.impl());
+
+            Node* propertyStorage;
+            if (isInlineOffset(valueOffset))
+                propertyStorage = descriptor;
+            else
+                propertyStorage = m_insertionSet.insertNode(m_nodeIndex, SpecNone, GetButterfly, origin, Edge(descriptor, CellUse));
+
+            Node* value = m_insertionSet.insertNode(m_nodeIndex, SpecBytecodeTop, GetByOffset, origin, OpInfo(data), OpInfo(SpecBytecodeTop), Edge(propertyStorage, KnownStorageUse), Edge(descriptor));
+            Node* attributes = m_insertionSet.insertConstant(m_nodeIndex, origin, jsNumber(static_cast<int32_t>(defineAttrs.rawRepresentation())));
+
+            Node* key = m_node->child2().node();
+            UseKind keyUseKind = UntypedUse;
+            if (key->shouldSpeculateSymbol())
+                keyUseKind = SymbolUse;
+            else if (!m_graph.hasExitSite(m_node->origin.semantic, BadStringType) && key->shouldSpeculateStringIdent())
+                keyUseKind = StringIdentUse;
+            else if (key->shouldSpeculateString())
+                keyUseKind = StringUse;
+
+            size_t firstChild = m_graph.m_varArgChildren.size();
+            m_graph.m_varArgChildren.append(Edge(target, CellUse));
+            m_graph.m_varArgChildren.append(Edge(key, keyUseKind));
+            m_graph.m_varArgChildren.append(Edge(value, UntypedUse));
+            m_graph.m_varArgChildren.append(Edge(attributes, KnownInt32Use));
+
+            m_insertionSet.insertNode(m_nodeIndex, SpecNone, Node::VarArg, DefineDataProperty, origin, OpInfo(0), OpInfo(0), firstChild, m_graph.m_varArgChildren.size() - firstChild);
+
+            m_node->convertToIdentityOn(target);
+            m_node->origin = m_node->origin.withInvalidExit();
+            m_changed = true;
+            break;
+        }
+
         default:
             break;
         }
     }
-            
+
     void convertToIdentityOverChild(unsigned childIndex)
     {
         ASSERT(!(m_node->flags() & NodeHasVarArgs));


### PR DESCRIPTION
#### e2e2e5e428dbe9c6f0eb30b93cd0bd8b00417bd6
<pre>
[JSC] Convert simple `Object.defineProperty` to `DefineDataProperty` in DFG StrengthReduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=306604">https://bugs.webkit.org/show_bug.cgi?id=306604</a>

Reviewed by NOBODY (OOPS!).

This patch adds an optimization in DFG StrengthReductionPhase that detects
the pattern Object.defineProperty(obj, key, { value: x }) and converts the
ObjectDefineProperty node to a DefineDataProperty node.

DefineDataProperty is more efficient because it doesn&apos;t need to handle
accessor descriptors or property attribute flags at runtime.

Currently, this optimization only handles the simplest case where the
descriptor is a NewObject with exactly one property named &quot;value&quot;.

                                           TipOfTree                  Patched

object-define-property-value-only       29.9240+-1.3542     ^     16.6579+-0.5853        ^ definitely 1.7964x faster

* JSTests/stress/object-define-property-value-only-dfg.js: Added.
(shouldBe):
(shouldBeFalse):
(checkDescriptor):
(checkDescriptor.const.fn):
(shouldBeFalse.):
(shouldBeFalse.set get shouldBe):
(get shouldBe):
(set obj):
(shouldBe.):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2e2e5e428dbe9c6f0eb30b93cd0bd8b00417bd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94593 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108719 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78671 "2 flakes 10 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89624 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10825 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8453 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/144 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133480 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120098 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152465 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2300 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13570 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116822 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117153 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13189 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68767 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13613 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2606 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172789 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13350 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77327 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44759 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13397 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->