### PR TITLE
SpeculationRules - JSON rules with no charset interpreted as UTF-8

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html
@@ -13,6 +13,7 @@
 <meta name="variant" content="?include=RelativeUrlForSpeculationRulesSet">
 <meta name="variant" content="?include=RelativeUrlForCandidate">
 <meta name="variant" content="?include=UseNonUTF8EncodingForSpeculationRulesSet">
+<meta name="variant" content="?include=OmitCharsetFromSpeculationRulesSet">
 <meta name="variant" content="?include=FailCORS">
 <meta name="variant" content="?include=FailToParseSpeculationRulesHeader">
 <meta name="variant" content="?include=InnerListInSpeculationRulesHeader">
@@ -41,6 +42,8 @@
       useRelativeUrlForSpeculationRulesSet: false,
       // Whether to use UTF-8 encoding for the rule set.
       useUtf8EncodingForSpeculationRulesSet: true,
+      // Whether to omit the charset from the Content-Type header.
+      omitCharsetFromSpeculationRulesSet: false,
       // Whether to force the response to cause a CORS failure.
       failCors: false,
       // Whether to use a valid SpeculationRules header format.
@@ -66,7 +69,7 @@
     if (options.useRelativeUrlForCandidate) {
       executor_url = `executor.sub.html`;
     }
-    let speculation_rule_set_url = `ruleset.py?url=${executor_url}&uuid=${uuid}&page=${page}&status=${options.status}&valid_mime=${options.useValidMimeTypeForSpeculationRulesSet}&valid_json=${options.useValidJsonForSpeculationRulesSet}&empty_json=${options.useEmptySpeculationRulesSet}&fail_cors=${options.failCors}&valid_encoding=${options.useUtf8EncodingForSpeculationRulesSet}&redirect=${options.redirect}`;
+    let speculation_rule_set_url = `ruleset.py?url=${executor_url}&uuid=${uuid}&page=${page}&status=${options.status}&valid_mime=${options.useValidMimeTypeForSpeculationRulesSet}&valid_json=${options.useValidJsonForSpeculationRulesSet}&empty_json=${options.useEmptySpeculationRulesSet}&fail_cors=${options.failCors}&valid_encoding=${options.useUtf8EncodingForSpeculationRulesSet}&omit_charset=${options.omitCharsetFromSpeculationRulesSet}&redirect=${options.redirect}`;
     if (!options.useRelativeUrlForSpeculationRulesSet) {
       let base_url = new URL(SR_PREFETCH_UTILS_URL);
       base_url.hostname = get_host_info().NOTSAMESITE_HOST;
@@ -121,6 +124,10 @@
   subsetTestByKey('UseNonUTF8EncodingForSpeculationRulesSet', promise_test, async t => {
     return runSpeculationRulesFetchTest(t, {useUtf8EncodingForSpeculationRulesSet: false, shouldPrefetch: false});
   }, "The speculation rules set should always be encoded using UTF-8.");
+
+  subsetTestByKey('OmitCharsetFromSpeculationRulesSet', promise_test, async t => {
+    return runSpeculationRulesFetchTest(t, {omitCharsetFromSpeculationRulesSet: true, shouldPrefetch: true});
+  }, "The speculation rules set should be decoded as UTF-8 even when no charset is declared.");
 
   subsetTestByKey('FailCORS', promise_test, async t => {
     return runSpeculationRulesFetchTest(t, {failCors: true, shouldPrefetch: false});

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=OmitCharsetFromSpeculationRulesSet-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=OmitCharsetFromSpeculationRulesSet-expected.txt
@@ -1,0 +1,3 @@
+
+PASS The speculation rules set should be decoded as UTF-8 even when no charset is declared.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/ruleset.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/ruleset.py
@@ -6,6 +6,7 @@ def main(request, response):
     empty_json = request.GET[b"empty_json"].decode("utf-8")
     fail_cors = request.GET[b"fail_cors"].decode("utf-8")
     valid_encoding = request.GET[b"valid_encoding"].decode("utf-8")
+    omit_charset = request.GET.get(b"omit_charset", b"false").decode("utf-8")
     redirect = request.GET[b"redirect"].decode("utf-8")
     sec_fetch_dest = request.headers[b"Sec-Fetch-Dest"].decode(
         "utf-8").lower() if b"Sec-Fetch-Dest" in request.headers else None
@@ -20,7 +21,8 @@ def main(request, response):
                      (b'Access-Control-Allow-Origin', b'*')], b""
 
     encoding = "utf-8" if valid_encoding == "true" else "windows-1250"
-    content_type += f'; charset={encoding}'.encode('utf-8')
+    if omit_charset != "true":
+        content_type += f'; charset={encoding}'.encode('utf-8')
     strparam = b'\xc3\xb7'.decode('utf-8')
 
     content = f'''

--- a/Source/WebCore/dom/LoadableSpeculationRules.cpp
+++ b/Source/WebCore/dom/LoadableSpeculationRules.cpp
@@ -100,7 +100,7 @@ bool LoadableSpeculationRules::load(Document& document, const URL& url)
     return true;
 }
 
-// https://html.spec.whatwg.org/C#the-speculation-rules-header
+// https://html.spec.whatwg.org/C#process-the-speculation-rules-header
 // 3.4.2.2. processResponseConsumeBody
 void LoadableSpeculationRules::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
 {
@@ -124,12 +124,7 @@ void LoadableSpeculationRules::notifyFinished(CachedResource& resource, const Ne
     }
 
     // 4. Let bodyText be the result of UTF-8 decoding bodyBytes.
-    if (resource.encoding() != "UTF-8"_s) {
-        document->addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Invalid speculation rules encoding "_s, m_url.string()));
-        return;
-    }
-
-    String speculationRulesText = m_cachedScript->script().toString();
+    String speculationRulesText = m_cachedScript->script(CachedScript::ShouldDecodeAsUTF8Only::Yes).toString();
     if (speculationRulesText.isEmpty())
         return;
 


### PR DESCRIPTION
#### 9b44ce96b044b2cc5ac189b470b8cdcd46a3f1fb
<pre>
SpeculationRules - JSON rules with no charset interpreted as UTF-8
<a href="https://bugs.webkit.org/show_bug.cgi?id=306605">https://bugs.webkit.org/show_bug.cgi?id=306605</a>

Reviewed by Alex Christensen.

This PR aligns the implementation with the spec and enforces UTF-8 encoding on external JSON rules.
This resolves the issue, as resources without explicit encoding will now be properly processed.

No new test files, but added new test cases.

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https.html: Add a new test case.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/out-of-document-rule-set.https_include=OmitCharsetFromSpeculationRulesSet-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/resources/ruleset.py: Add a new test case.
(main):
* Source/WebCore/dom/LoadableSpeculationRules.cpp:
(WebCore::LoadableSpeculationRules::notifyFinished): Enforce UTF-8 encoding instead of bailing.

Canonical link: <a href="https://commits.webkit.org/306513@main">https://commits.webkit.org/306513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6868b6c32de318af9d08053877d9b0005f3be9a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150073 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108721 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78674 "2 flakes 12 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10823 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8449 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/145 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152466 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13571 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3046 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116824 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117155 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29851 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13191 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68768 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13614 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2596 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77328 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->