### PR TITLE
Move memory cost reporting to canvas rendering contexts

### DIFF
--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -79,11 +79,6 @@ public:
 
     RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
 
-    size_t memoryCost() const;
-#if ENABLE(RESOURCE_USAGE)
-    size_t externalMemoryCost() const;
-#endif
-
     void setOriginClean() { m_originClean = true; }
     void setOriginTainted() { m_originClean = false; }
     bool originClean() const { return m_originClean; }
@@ -160,7 +155,6 @@ private:
 
     mutable IntSize m_size;
     mutable RefPtr<ImageBuffer> m_imageBuffer;
-    mutable std::atomic<size_t> m_imageBufferMemoryCost { 0 };
     mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 
     String m_lastFillText;

--- a/Source/WebCore/html/HTMLCanvasElement.idl
+++ b/Source/WebCore/html/HTMLCanvasElement.idl
@@ -38,8 +38,6 @@ typedef (
     ActiveDOMObject,
     JSCustomMarkFunction,
     JSGenerateToNativeObject,
-    ReportExtraMemoryCost,
-    ReportExternalMemoryCost,
     Exposed=Window
 ] interface HTMLCanvasElement : HTMLElement {
     [CEReactions=NotNeeded, CallTracer=InspectorCanvasCallTracer] attribute unsigned long width;

--- a/Source/WebCore/html/OffscreenCanvas.idl
+++ b/Source/WebCore/html/OffscreenCanvas.idl
@@ -56,8 +56,6 @@ enum OffscreenRenderingContextType {
     Conditional=OFFSCREEN_CANVAS,
     ConditionalForWorker=OFFSCREEN_CANVAS_IN_WORKERS,
     EnabledForContext,
-    ReportExtraMemoryCost,
-    ReportExternalMemoryCost,
     Exposed=(Window,Worker)
 ] interface OffscreenCanvas : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor([EnforceRange] unsigned long width, [EnforceRange] unsigned long height);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -129,6 +129,12 @@ public:
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 
+    void updateMemoryCostOnAllocation(bool hasNewBuffer);
+    size_t memoryCost() const;
+#if ENABLE(RESOURCE_USAGE)
+    size_t externalMemoryCost() const;
+#endif
+
 protected:
     enum class Type : uint8_t {
         CanvasElement2D,
@@ -159,6 +165,8 @@ protected:
     void checkOrigin(const URL&);
     void checkOrigin(const CSSStyleImageValue&);
 
+    mutable std::atomic<size_t> m_memoryCost { 0 };
+
     bool m_isInPreparationForDisplayOrFlush { false };
     bool m_hasActiveInspectorCanvasCallTracer { false };
 
@@ -167,6 +175,7 @@ private:
 
     WeakRef<CanvasBase> m_canvas;
     const Type m_type;
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.idl
@@ -34,6 +34,8 @@ enum RenderingMode {
     CustomIsReachable,
     JSCustomMarkFunction,
     CallTracer=InspectorCanvasCallTracer,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=Window
 ] interface CanvasRenderingContext2D {
     // back-reference to the canvas

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -28,6 +28,8 @@
 [
     ActiveDOMObject,
     EnabledBySetting=WebGPUEnabled,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     SecureContext,
     SkipVTableValidation,

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl
@@ -30,6 +30,8 @@ typedef (HTMLCanvasElement) ImageBitmapCanvas;
 #endif
 
 [
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,
 ] interface ImageBitmapRenderingContext {

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
@@ -29,6 +29,8 @@
     Conditional=OFFSCREEN_CANVAS,
     ConditionalForWorker=OFFSCREEN_CANVAS_IN_WORKERS,
     EnabledForContext,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     JSCustomMarkFunction,
     TaggedWrapper,

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -63,6 +63,8 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     GenerateIsReachable=ImplCanvasBase,
     JSCustomMarkFunction,
     DoNotCheckConstants,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,
 ] interface WebGL2RenderingContext {

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.idl
@@ -47,6 +47,8 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     JSCustomMarkFunction,
     DoNotCheckConstants,
     ExportMacro=WEBCORE_EXPORT,
+    ReportExtraMemoryCost,
+    ReportExternalMemoryCost,
     Exposed=(Window,Worker),
     CallTracer=InspectorCanvasCallTracer,
 ] interface WebGLRenderingContext {

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -428,7 +428,7 @@ Ref<Inspector::Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(b
     if (auto attributes = buildObjectForCanvasContextAttributes(m_context.get()))
         canvas->setContextAttributes(attributes.releaseNonNull());
 
-    if (size_t memoryCost = m_context->canvasBase().memoryCost())
+    if (size_t memoryCost = m_context->memoryCost())
         canvas->setMemoryCost(memoryCost);
 
     if (captureBacktrace) {

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -377,7 +377,7 @@ void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context
     if (!inspectorCanvas)
         return;
 
-    m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().canvasBase().memoryCost());
+    m_frontendDispatcher->canvasMemoryChanged(inspectorCanvas->identifier(), inspectorCanvas->canvasContext().memoryCost());
 }
 
 void InspectorCanvasAgent::canvasChanged(CanvasBase& canvasBase, const FloatRect&)


### PR DESCRIPTION
#### 3c05c29f69e0c89d4a75f6e64ccf1152e494390b
<pre>
Move memory cost reporting to canvas rendering contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=306608">https://bugs.webkit.org/show_bug.cgi?id=306608</a>
<a href="https://rdar.apple.com/169256162">rdar://169256162</a>

Reviewed by Simon Fraser.

Before, the canvas element or offscreen canvas object would report the
memory cost The rendering context holds the resources and the cost is
per rendering context type.

This simplifies moving the ImageBuffer to CanvasRenderingContext2DBase.
The current memory cost is bound to the image buffer size, and this is
wildly inaccurate for WebGL and WebGPU. This will be fixed later.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::setImageBuffer const):
(WebCore::CanvasBase::memoryCost const): Deleted.
(WebCore::CanvasBase::externalMemoryCost const): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/HTMLCanvasElement.idl:
* Source/WebCore/html/OffscreenCanvas.idl:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::updateMemoryCostOnAllocation):
(WebCore::CanvasRenderingContext::memoryCost const):
(WebCore::CanvasRenderingContext::externalMemoryCost const):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2D.idl:
* Source/WebCore/html/canvas/GPUCanvasContext.idl:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.idl:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl:
* Source/WebCore/html/canvas/WebGL2RenderingContext.idl:
* Source/WebCore/html/canvas/WebGLRenderingContext.idl:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildObjectForCanvas):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::didChangeCanvasMemory):

Canonical link: <a href="https://commits.webkit.org/306625@main">https://commits.webkit.org/306625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ba3f347e020e893383efec709af02d88d412b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150438 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94969 "Failed to compile WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d201873-8bdd-45d7-95d3-bca4e632ca24) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109002 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/94969 "Failed to compile WebKit") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34afabd3-4a34-4dfc-920c-9ab39aa18804) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89898 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d68da90-3485-4316-adf3-2e4482498c24) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11105 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8749 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/504 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152826 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117090 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13463 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69598 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13957 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2990 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->