### PR TITLE
Haiku upstreaming; WebCore part 1

### DIFF
--- a/Source/WebCore/PlatformHaiku.cmake
+++ b/Source/WebCore/PlatformHaiku.cmake
@@ -1,0 +1,66 @@
+include(platform/ImageDecoders.cmake)
+include(platform/OpenSSL.cmake)
+
+list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
+  "${WEBCORE_DIR}/platform/glib"
+)
+
+list(APPEND WebCore_SOURCES
+  accessibility/playstation/AXObjectCachePlayStation.cpp
+  accessibility/playstation/AccessibilityObjectPlayStation.cpp
+
+  editing/glib/EditorGLib.cpp
+
+  page/PointerLockController.cpp
+
+  page/haiku/DragControllerHaiku.cpp
+  page/haiku/EventHandlerHaiku.cpp
+
+  platform/audio/FFTFrameStub.cpp
+
+  platform/graphics/PlatformDisplay.cpp
+  platform/graphics/WOFFFileFormat.cpp
+
+  platform/mock/GeolocationClientMock.cpp
+
+  platform/text/Hyphenation.cpp
+  platform/text/LocaleICU.cpp
+
+  platform/unix/LoggingUnix.cpp
+  platform/unix/SharedMemoryUnix.cpp
+)
+
+list(APPEND WebCore_USER_AGENT_STYLE_SHEETS
+    ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.css
+)
+
+set(WebCore_USER_AGENT_SCRIPTS
+    ${WebCore_DERIVED_SOURCES_DIR}/ModernMediaControls.js
+)
+
+list(APPEND WebCore_LIBRARIES
+  be
+  bsd
+  execinfo
+  ${JPEG_LIBRARY}
+  network
+  ${PNG_LIBRARY}
+  psl
+  shared
+  textencoding
+  translation
+  ${WEBP_LIBRARIES}
+  ${LIBXSLT_LIBRARIES}
+)
+
+list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
+  ${GNUTLS_INCLUDE_DIRS}
+  ${ICU_INCLUDE_DIRS}
+  ${LIBXML2_INCLUDE_DIR}
+  ${LIBXSLT_INCLUDE_DIR}
+  ${SQLITE_INCLUDE_DIR}
+  ${WEBP_INCLUDE_DIRS}
+  ${ZLIB_INCLUDE_DIRS}
+)
+
+set(CSS_VALUE_PLATFORM_DEFINES "HAVE_OS_DARK_MODE_SUPPORT=1")

--- a/Source/WebCore/editing/glib/EditorGLib.cpp
+++ b/Source/WebCore/editing/glib/EditorGLib.cpp
@@ -27,7 +27,7 @@
 #include "config.h"
 #include "Editor.h"
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(HAIKU)
 #include "CachedImage.h"
 #include "ContainerNodeInlines.h"
 #include "DocumentFragment.h"
@@ -134,4 +134,4 @@ RefPtr<DocumentFragment> Editor::webContentFromPasteboard(Pasteboard& pasteboard
 
 } // namespace WebCore
 
-#endif // PLATFORM(GTK) || PLATFORM(WPE)
+#endif // PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(HAIKU)

--- a/Source/WebCore/page/haiku/DragControllerHaiku.cpp
+++ b/Source/WebCore/page/haiku/DragControllerHaiku.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2007 Apple Inc.  All rights reserved.
+ * Copyright (C) 2007 Ryan Leavengood <leavengood@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "DragController.h"
+
+#include "Document.h"
+#include "DragData.h"
+#include "NotImplemented.h"
+#include "Pasteboard.h"
+
+#include <InterfaceDefs.h>
+
+
+namespace WebCore {
+
+// FIXME: These values are straight out of DragControllerMac, so probably have
+// little correlation with Haiku standards...
+const int DragController::MaxOriginalImageArea = 1500 * 1500;
+const int DragController::DragIconRightInset = 7;
+const int DragController::DragIconBottomInset = 3;
+
+const float DragController::DragImageAlpha = 0.75f;
+
+
+bool DragController::isCopyKeyDown(const DragData& /* dragData */)
+{
+    if (modifiers() & B_COMMAND_KEY)
+        return true;
+
+    return false;
+}
+
+std::optional<DragOperation> DragController::dragOperation(const DragData& dragData)
+{
+    // FIXME: This logic is incomplete
+    if (dragData.containsURL())
+        return DragOperation::Copy;
+
+    return std::nullopt;
+}
+
+const IntSize& DragController::maxDragImageSize()
+{
+    static const IntSize maxDragImageSize(400, 400);
+
+    return maxDragImageSize;
+}
+
+void DragController::cleanupAfterSystemDrag()
+{
+    notImplemented();
+}
+
+void DragController::declareAndWriteDragImage(DataTransfer& /*clipboard*/, Element&, const URL&, const String& /*label*/)
+{
+    notImplemented();
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/page/haiku/EventHandlerHaiku.cpp
+++ b/Source/WebCore/page/haiku/EventHandlerHaiku.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2006 Zack Rusin <zack@kde.org>
+ * Copyright (C) 2007 Ryan Leavengood <leavengood@gmail.com>
+ * Copyright (C) 2009 Maxime Simon <simon.maxime@gmail.com>
+ * Copyright (C) 2010 Stephan Aßmus <superstippi@gmx.de>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "EventHandler.h"
+
+#include "DataTransfer.h"
+#include "EventNames.h"
+#include "FocusController.h"
+#include "Frame.h"
+#include "FrameView.h"
+#include "HandleUserInputEventResult.h"
+#include "HitTestResult.h"
+#include "KeyboardEvent.h"
+#include "MouseEventWithHitTestResults.h"
+#include "NotImplemented.h"
+#include "Page.h"
+#include "PlatformKeyboardEvent.h"
+#include "PlatformWheelEvent.h"
+#include "RenderWidget.h"
+
+#include <interface/View.h>
+
+
+namespace WebCore {
+
+void EventHandler::focusDocumentView()
+{
+    BView* view = m_frame->view()->platformWidget();
+    if (view && view->LockLooperWithTimeout(5000) == B_OK) {
+        view->MakeFocus(true);
+        view->UnlockLooper();
+    }
+
+    Page* page = m_frame->page();
+    if (page)
+        page->focusController().setFocusedFrame(&m_frame.get());
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -102,7 +102,7 @@ struct PasteboardWebContent {
     HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> localFrameArchives;
     Vector<WebCore::FrameIdentifier> remoteFrameIdentifiers;
 #endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(HAIKU)
     String contentOrigin;
     bool canSmartCopyOrDelete;
     String text;
@@ -119,7 +119,7 @@ struct PasteboardURL {
 #if PLATFORM(MAC)
     String userVisibleForm;
 #endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(HAIKU)
     String markup;
 #endif
 };

--- a/Source/WebKit/Shared/Pasteboard.serialization.in
+++ b/Source/WebKit/Shared/Pasteboard.serialization.in
@@ -59,7 +59,7 @@ header: <WebCore/Pasteboard.h>
     HashMap<WebCore::FrameIdentifier, Ref<WebCore::LegacyWebArchive>> localFrameArchives;
     Vector<WebCore::FrameIdentifier> remoteFrameIdentifiers;
 #endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(HAIKU)
     String contentOrigin;
     bool canSmartCopyOrDelete;
     String text;
@@ -78,7 +78,7 @@ header: <WebCore/Pasteboard.h>
 #if PLATFORM(MAC)
     String userVisibleForm
 #endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(GTK) || PLATFORM(WPE) || PLATFORM(HAIKU)
     String markup
 #endif
 };


### PR DESCRIPTION
#### 1fa52a4b701b0d5f4eeb876658de1aeea822af4b
<pre>
Haiku upstreaming; WebCore part 1
<a href="https://bugs.webkit.org/show_bug.cgi?id=306612">https://bugs.webkit.org/show_bug.cgi?id=306612</a>

Reviewed by Nikolas Zimmermann.

Continue upstreaming files from the Haiku port.

Reuse EditorGLib.cpp since it is not actually GLib specific.

No new tests: no changes to existing platforms
* Source/WebCore/PlatformHaiku.cmake: Added with files shared with other platforms.
* Source/WebCore/editing/glib/EditorGLib.cpp: Enable usage on Haiku.
* Source/WebCore/platform/Pasteboard.h: Enable fields needed for Haiku.
* Source/WebCore/page/haiku/DragControllerHaiku.cpp: Added.
* Source/WebCore/page/haiku/EventHandlerHaiku.cpp: Added.
* Source/WebKit/Shared/Pasteboard.serialization.in: Enable fields needed for Haiku.

Canonical link: <a href="https://commits.webkit.org/312133@main">https://commits.webkit.org/312133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a01e19e7b2a4bb23c8543a0d413a55f17b6d5801

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115141 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81925 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16394 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14274 "Found 1 new API test failure: TestWebKitAPI.DeviceScaleFactorOnBack.WebKit2 (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5866 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160500 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3494 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123183 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123399 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35559 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21847 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133721 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78052 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10467 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21449 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85262 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->