### PR TITLE
Implement SetUpCrossRealTransformWritable

### DIFF
--- a/LayoutTests/streams/transfer-internal-expected.txt
+++ b/LayoutTests/streams/transfer-internal-expected.txt
@@ -1,5 +1,8 @@
 
-PASS Validate default behavior
-PASS Validate invalid type
-PASS Validate invalid object messages
+PASS Validate readable default behavior
+PASS Validate readable invalid type
+PASS Validate readable invalid object messages
+PASS Validate writable default behavior
+PASS Validate writable invalid type
+PASS Validate writable invalid object messages
 

--- a/LayoutTests/streams/transfer-internal.html
+++ b/LayoutTests/streams/transfer-internal.html
@@ -12,6 +12,30 @@ function createReadableStreamAndPort()
     return { stream, port: channel.port1 };
 }
 
+function createReadableStreamReaderFromMessage(message)
+{
+    const { stream, port } = createReadableStreamAndPort();
+    port.postMessage(message);
+    return stream.getReader();
+}
+
+function createWritableStreamAndPort()
+{
+    const channel = new MessageChannel();
+    channel.port1.start();
+    channel.port2.start();
+
+    const stream = internals.writableStreamFromMessagePort(channel.port2);
+    return { stream, port: channel.port1 };
+}
+
+function createWritableStreamWriterFromMessage(message)
+{
+    const { stream, port } = createWritableStreamAndPort();
+    port.postMessage(message);
+    return stream.getWriter();
+}
+
 promise_test(async t => {
     if (!window.internals)
         return;
@@ -26,7 +50,7 @@ promise_test(async t => {
 
     port.postMessage({ type:"close" });
     await reader.closed;
-}, 'Validate default behavior');
+}, 'Validate readable default behavior');
 
 promise_test(async t => {
     if (!window.internals)
@@ -37,14 +61,7 @@ promise_test(async t => {
 
     port.postMessage({ type:"ee" });
     await promise_rejects_js(t, TypeError, reader.closed);
-}, 'Validate invalid type');
-
-function createReadableStreamReaderFromMessage(message)
-{
-    const { stream, port } = createReadableStreamAndPort();
-    port.postMessage(message);
-    return stream.getReader();
-}
+}, 'Validate readable invalid type');
 
 promise_test(async t => {
     if (!window.internals)
@@ -62,5 +79,54 @@ promise_test(async t => {
     reader = createReadableStreamReaderFromMessage(null);
     await promise_rejects_dom(t, "DataCloneError", reader.closed);
 
-}, 'Validate invalid object messages');
+}, 'Validate readable invalid object messages');
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const { stream, port } = createWritableStreamAndPort();
+    const writer = stream.getWriter();
+
+    let promise = new Promise(resolve => port.onmessage = e => resolve(e.data));
+    writer.write("test");
+    port.postMessage({ type:"pull" });
+    let result = await promise;
+    assert_equals(result.type, "chunk");
+    assert_equals(result.value, "test");
+
+    promise = new Promise(resolve => port.onmessage = e => resolve(e.data));
+    writer.close();
+    result = await promise;
+    assert_equals(result.type, "close");
+}, 'Validate writable default behavior');
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const { stream, port } = createWritableStreamAndPort();
+    const writer = stream.getWriter();
+
+    port.postMessage({ type:"ee" });
+    await promise_rejects_js(t, TypeError, writer.closed);
+}, 'Validate writable invalid type');
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    let writer = createWritableStreamWriterFromMessage({ });
+    await promise_rejects_dom(t, "DataCloneError", writer.closed);
+
+    writer = createWritableStreamWriterFromMessage(1);
+    await promise_rejects_dom(t, "DataCloneError", writer.closed);
+
+    writer = createWritableStreamWriterFromMessage(undefined);
+    await promise_rejects_dom(t, "DataCloneError", writer.closed);
+
+    writer = createWritableStreamWriterFromMessage(null);
+    await promise_rejects_dom(t, "DataCloneError", writer.closed);
+
+}, 'Validate writable invalid object messages');
 </script>

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.cpp
@@ -173,7 +173,7 @@ void FileSystemWritableFileStreamSink::write(ScriptExecutionContext& context, JS
     }
 }
 
-void FileSystemWritableFileStreamSink::close()
+void FileSystemWritableFileStreamSink::close(JSDOMGlobalObject&)
 {
     ASSERT(!m_isClosed);
 
@@ -181,12 +181,13 @@ void FileSystemWritableFileStreamSink::close()
     protectedSource()->closeWritable(m_identifier, FileSystemWriteCloseReason::Completed);
 }
 
-void FileSystemWritableFileStreamSink::abort(JSC::JSValue)
+void FileSystemWritableFileStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&& promise)
 {
     ASSERT(!m_isClosed);
 
     m_isClosed = true;
     protectedSource()->closeWritable(m_identifier, FileSystemWriteCloseReason::Aborted);
+    promise.resolve();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemWritableFileStreamSink.h
@@ -42,8 +42,8 @@ private:
 
     // WritableStreamSink
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close() final;
-    void abort(JSC::JSValue) final;
+    void close(JSDOMGlobalObject&) final;
+    void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
 
     FileSystemWritableFileStreamIdentifier m_identifier;
     const Ref<FileSystemFileHandle> m_source;

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -208,16 +208,17 @@ void VideoTrackGenerator::Sink::write(ScriptExecutionContext&, JSC::JSValue valu
     promise.resolve();
 }
 
-void VideoTrackGenerator::Sink::close()
+void VideoTrackGenerator::Sink::close(JSDOMGlobalObject&)
 {
     callOnMainThread([source = m_source] {
         source->endImmediatly();
     });
 }
 
-void VideoTrackGenerator::Sink::abort(JSC::JSValue)
+void VideoTrackGenerator::Sink::abort(JSDOMGlobalObject& globalObject, JSC::JSValue, DOMPromiseDeferred<void>&& promise)
 {
-    close();
+    close(globalObject);
+    promise.resolve();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.h
@@ -89,8 +89,8 @@ private:
         explicit Sink(Ref<Source>&&);
 
         void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-        void close() final;
-        void abort(JSC::JSValue) final;
+        void close(JSDOMGlobalObject&) final;
+        void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
 
         bool m_muted { false };
         const Ref<Source> m_source;

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.h
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.h
@@ -36,5 +36,7 @@ class WritableStream;
 
 // https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformreadable
 WEBCORE_EXPORT ExceptionOr<Ref<ReadableStream>> setupCrossRealmTransformReadable(JSDOMGlobalObject&, MessagePort&);
+// https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable
+WEBCORE_EXPORT ExceptionOr<Ref<WritableStream>> setupCrossRealmTransformWritable(JSDOMGlobalObject&, MessagePort&);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/WritableStream.idl
+++ b/Source/WebCore/Modules/streams/WritableStream.idl
@@ -29,6 +29,7 @@
  */
 
 [
+    ExportMacro=WEBCORE_EXPORT,
     Exposed=*,
     PrivateIdentifier,
     PublicIdentifier,

--- a/Source/WebCore/Modules/streams/WritableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "config.h"
+#include "WritableStreamSink.h"
+
+#include "JSWritableStreamDefaultController.h"
+#include "JSWritableStreamSink.h"
+#include "WebCoreJSClientData.h"
+#include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/IdentifierInlines.h>
+#include <JavaScriptCore/JSObjectInlines.h>
+#include <JavaScriptCore/TopExceptionScope.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+class WritableStreamDefaultController {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WritableStreamDefaultController);
+public:
+    explicit WritableStreamDefaultController(JSWritableStreamDefaultController* controller)
+        : m_jsController(controller)
+    {
+    }
+
+    void errorIfNeeded(JSC::JSGlobalObject&, JSC::JSValue);
+    JSWritableStreamDefaultController* jsController() { return m_jsController; }
+
+private:
+    // The owner of WritableStreamDefaultController is responsible to keep uncollected the JSWritableStreamDefaultController.
+    JSWritableStreamDefaultController* m_jsController { nullptr };
+};
+
+static bool invokeWritableStreamDefaultControllerFunction(JSC::JSGlobalObject& lexicalGlobalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
+{
+    JSC::VM& vm = lexicalGlobalObject.vm();
+    JSC::JSLockHolder lock(vm);
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto function = lexicalGlobalObject.get(&lexicalGlobalObject, identifier);
+
+    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    RETURN_IF_EXCEPTION(scope, false);
+
+    ASSERT(function.isCallable());
+
+    auto callData = JSC::getCallData(function);
+    call(&lexicalGlobalObject, function, callData, JSC::jsUndefined(), arguments);
+    EXCEPTION_ASSERT(!scope.exception() || vm.hasPendingTerminationException());
+    return !scope.exception();
+}
+
+WritableStreamSink::WritableStreamSink() = default;
+WritableStreamSink::~WritableStreamSink() = default;
+
+void WritableStreamSink::start(std::unique_ptr<WritableStreamDefaultController>&& controller)
+{
+    m_controller = WTF::move(controller);
+}
+
+void WritableStreamSink::errorIfNeeded(JSC::JSGlobalObject& globalObject, JSC::JSValue error)
+{
+    Ref vm = globalObject.vm();
+    JSC::JSLockHolder lock(vm.get());
+
+    JSC::MarkedArgumentBuffer arguments;
+    arguments.append(m_controller->jsController());
+    arguments.append(error);
+    ASSERT(!arguments.hasOverflowed());
+
+    auto* clientData = downcast<JSVMClientData>(vm->clientData);
+    auto& privateName = clientData->builtinFunctions().writableStreamInternalsBuiltins().writableStreamDefaultControllerErrorIfNeededPrivateName();
+
+    invokeWritableStreamDefaultControllerFunction(globalObject, privateName, arguments);
+}
+
+JSC::JSValue JSWritableStreamSink::start(JSC::JSGlobalObject& globalObject, JSC::CallFrame& callFrame)
+{
+    Ref vm = globalObject.vm();
+
+    ASSERT(callFrame.argumentCount());
+    JSWritableStreamDefaultController* controller = jsDynamicCast<JSWritableStreamDefaultController*>(callFrame.uncheckedArgument(0));
+    ASSERT(controller);
+
+    m_controller.set(vm, this, controller);
+
+    Ref { wrapped() }->start(makeUnique<WritableStreamDefaultController>(controller));
+
+    return JSC::jsUndefined();
+}
+
+JSC::JSValue JSWritableStreamSink::controller(JSC::JSGlobalObject&) const
+{
+    ASSERT_NOT_REACHED();
+    return JSC::jsUndefined();
+}
+
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/streams/WritableStreamSink.idl
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.idl
@@ -28,7 +28,11 @@
     LegacyNoInterfaceObject,
     SkipVTableValidation
 ] interface WritableStreamSink {
+    [Custom] undefined start(WritableStreamDefaultController controller);
     [CallWith=CurrentScriptExecutionContext] Promise<undefined> write(any value);
-    undefined close();
-    undefined abort(any reason);
+    [CallWith=CurrentGlobalObject] undefined close();
+    [CallWith=CurrentGlobalObject] Promise<undefined> abort(any reason);
+
+    // Place holder to keep the controller linked to the source.
+    [CachedAttribute, CustomGetter, PrivateIdentifier] readonly attribute any controller;
 };

--- a/Source/WebCore/Modules/webtransport/DatagramSink.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.h
@@ -44,8 +44,7 @@ private:
     DatagramSink(WebTransportSession*);
 
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close() final { m_isClosed = true; }
-    void abort(JSC::JSValue) final { }
+    void close(JSDOMGlobalObject&) final { m_isClosed = true; }
 
     ThreadSafeWeakPtr<WebTransportSession> m_session;
     WeakPtr<WebTransportDatagramsWritable> m_datagrams;

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.cpp
@@ -106,7 +106,7 @@ void WebTransportSendStreamSink::write(ScriptExecutionContext& context, JSC::JSV
     });
 }
 
-void WebTransportSendStreamSink::close()
+void WebTransportSendStreamSink::close(JSDOMGlobalObject&)
 {
     if (m_isClosed)
         return;
@@ -119,8 +119,12 @@ void WebTransportSendStreamSink::close()
     }
 }
 
-void WebTransportSendStreamSink::abort(JSC::JSValue value)
+void WebTransportSendStreamSink::abort(JSDOMGlobalObject&, JSC::JSValue value, DOMPromiseDeferred<void>&& promise)
 {
+    auto scope = makeScopeExit([&promise] {
+        promise.resolve();
+    });
+
     if (m_isCancelled)
         return;
     m_isCancelled = true;

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
@@ -49,8 +49,8 @@ private:
     WEBCORE_EXPORT WebTransportSendStreamSink(WebTransport&, WebTransportStreamIdentifier);
 
     void write(ScriptExecutionContext&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
-    void close() final;
-    void abort(JSC::JSValue) final;
+    void close(JSDOMGlobalObject&) final;
+    void abort(JSDOMGlobalObject&, JSC::JSValue, DOMPromiseDeferred<void>&&) final;
 
     const ThreadSafeWeakPtr<WebTransport> m_transport;
     const WebTransportStreamIdentifier m_identifier;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -389,6 +389,7 @@ Modules/streams/StreamTeeUtilities.cpp
 Modules/streams/StreamTransferUtilities.cpp
 Modules/streams/TransformStream.cpp
 Modules/streams/WritableStream.cpp
+Modules/streams/WritableStreamSink.cpp
 Modules/url-pattern/URLPattern.cpp
 Modules/url-pattern/URLPatternCanonical.cpp
 Modules/url-pattern/URLPatternComponent.cpp

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -270,6 +270,7 @@
 #include "WindowProxy.h"
 #include "WorkerThread.h"
 #include "WorkletGlobalScope.h"
+#include "WritableStream.h"
 #include "WritingDirection.h"
 #include "XMLHttpRequest.h"
 #include <JavaScriptCore/CodeBlock.h>
@@ -8357,6 +8358,11 @@ void Internals::testAsyncIterator(JSDOMGlobalObject& globalObject, JSC::JSValue 
 ExceptionOr<Ref<ReadableStream>> Internals::readableStreamFromMessagePort(JSDOMGlobalObject& globalObject, MessagePort& port)
 {
     return setupCrossRealmTransformReadable(globalObject, port);
+}
+
+ExceptionOr<Ref<WritableStream>> Internals::writableStreamFromMessagePort(JSDOMGlobalObject& globalObject, MessagePort& port)
+{
+    return setupCrossRealmTransformWritable(globalObject, port);
 }
 
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -149,6 +149,7 @@ class VoidCallback;
 class WebAnimation;
 class WebGLRenderingContext;
 class WindowProxy;
+class WritableStream;
 class XMLHttpRequest;
 
 struct VideoConfiguration;
@@ -1683,6 +1684,7 @@ public:
 #endif // ENABLE(DAMAGE_TRACKING)
 
     ExceptionOr<Ref<ReadableStream>> readableStreamFromMessagePort(JSDOMGlobalObject&, MessagePort&);
+    ExceptionOr<Ref<WritableStream>> writableStreamFromMessagePort(JSDOMGlobalObject&, MessagePort&);
 
 #if ENABLE(MODEL_ELEMENT)
     void disableModelLoadDelaysForTesting();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1506,6 +1506,7 @@ enum ContentsFormat {
 #endif
 
     [CallWith=CurrentGlobalObject] ReadableStream readableStreamFromMessagePort(MessagePort port);
+    [CallWith=CurrentGlobalObject] WritableStream writableStreamFromMessagePort(MessagePort port);
 
     [Conditional=MODEL_ELEMENT] undefined disableModelLoadDelaysForTesting();
     [Conditional=MODEL_ELEMENT] DOMString modelElementState(HTMLModelElement element);


### PR DESCRIPTION
#### 50359d9c2caefaf74470bb65798b902460ee4376
<pre>
Implement SetUpCrossRealTransformWritable
<a href="https://rdar.apple.com/169174026">rdar://169174026</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306518">https://bugs.webkit.org/show_bug.cgi?id=306518</a>

Reviewed by Chris Dumez.

Follow the spec by introducing <a href="https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable">https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable</a> and related methods.
This will be useful to implement transferring of readable and writable streams.

To add sufficient support, we have to beef up WritableStreamSink.
In particular, we have to be able to support asynchronous aborting.
We do this by updating WritableStreamSink IDL.

We also have to expose a way to error the writable from the sink.
We add support for exposing the controller given by WritableStream to its sink at start time.
We can then call errorIfNeeded on the controller whenever the WritableStreamSink is start.

We implement this support like we do for ReadableStreamSource.
The controller is kept alive for the lifetime of the JSWritableStreamSink.
The JSWritableStreamSink is kept alive for the lifetime of its InternalWritableStream, which is kept alive by its WritableStream as a DOMGuarded object.

Covered by added API test, using new internal API.

Canonical link: <a href="https://commits.webkit.org/306689@main">https://commits.webkit.org/306689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0274ebbad8a4f3883288c40baba0961568e1fdd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95092 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/350af7d0-eceb-4696-880b-41b86b05dc97) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109077 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78866 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fcc4928-b10b-466d-aa85-0079d32e6972) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89974 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40d18829-799c-47c8-b33f-e4d63ef3fe6c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11161 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8807 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/577 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152899 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13992 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117157 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117478 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29969 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13521 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69687 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14030 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3180 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77755 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13972 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->