### PR TITLE
Add Delegated Merchant Session properties to CoreIPC Serialization

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.h
@@ -50,6 +50,10 @@ struct CoreIPCPKPaymentMerchantSessionData {
     RetainPtr<NSData> ampEnrollmentPinning;
     RetainPtr<NSString> operationalAnalyticsIdentifier;
     std::optional<Vector<RetainPtr<NSString>>> signedFields;
+#if ENABLE(APPLE_PAY_DELEGATED_REQUEST)
+    std::optional<bool> isDelegatedSession;
+    RetainPtr<NSString> delegateDisplayName;
+#endif
 };
 
 class CoreIPCPKPaymentMerchantSession {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in
@@ -40,6 +40,10 @@ webkit_platform_headers: "CoreIPCPKPaymentMerchantSession.h"
     RetainPtr<NSData> ampEnrollmentPinning;
     RetainPtr<NSString> operationalAnalyticsIdentifier;
     std::optional<Vector<RetainPtr<NSString>>> signedFields;
+#if ENABLE(APPLE_PAY_DELEGATED_REQUEST)
+    std::optional<bool> isDelegatedSession;
+    RetainPtr<NSString> delegateDisplayName;
+#endif
 }
 
 [WebKitPlatform] class WebKit::CoreIPCPKPaymentMerchantSession {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -54,6 +54,10 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     ampEnrollmentPinning: Data
     operationalAnalyticsIdentifier: String
     signedFields: Array<String>?
+#if ENABLE(APPLE_PAY_DELEGATED_REQUEST)
+    isDelegatedSession: Number
+    delegateDisplayName: String
+#endif
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1767,6 +1767,21 @@ TEST(IPCSerialization, DDScannerResultPlist)
                                displayName:(NSString *)displayName
             operationalAnalyticsIdentifier:(NSString *)operationalAnalyticsIdentifier
                                  signature:(NSData *)signature;
+
+#if HAVE(PASSKIT_DELEGATED_REQUEST)
+- (instancetype)initWithDelegateDisplayName:(NSString *)delegateDisplayName
+                         merchantIdentifier:(NSString *)merchantIdentifier
+                                displayName:(NSString *)displayName
+                                 initiative:(NSString *)initiative
+                          initiativeContext:(NSString *)initiativeContext
+                  merchantSessionIdentifier:(NSString *)merchantSessionIdentifier
+                                      nonce:(NSString *)nonce
+                             epochTimestamp:(NSUInteger)epochTimestamp
+                                  expiresAt:(NSUInteger)expiresAt
+             operationalAnalyticsIdentifier:(NSString *)operationalAnalyticsIdentifier
+                               signedFields:(NSArray<NSString *> *)signedFields
+                                  signature:(NSData *)signature;
+#endif
 @end
 
 TEST(IPCSerialization, DataDetectors)
@@ -1818,6 +1833,24 @@ TEST(IPCSerialization, SecureCoding)
         operationalAnalyticsIdentifier:@"WebKitOperations42"
         signature:[NSData new]]);
     runTestNS({ session.get() });
+
+#if HAVE(PASSKIT_DELEGATED_REQUEST)
+    // This initializer adopts delegate fields, but retryNonce and domain are unexercised
+    session = adoptNS([[PAL::getPKPaymentMerchantSessionClassSingleton() alloc]
+        initWithDelegateDisplayName:@"WebKit (Delegate)"
+        merchantIdentifier:@"WebKit Open Source Project"
+        displayName:@"WebKit"
+        initiative:@"WebKit Regression Test Suite"
+        initiativeContext:@"WebKit IPC Testing"
+        merchantSessionIdentifier:@"WebKitMerchantSession"
+        nonce:@"WebKitNonce"
+        epochTimestamp:1000000000
+        expiresAt:2000000000
+        operationalAnalyticsIdentifier:@"WebKitOperations42"
+        signedFields:@[ @"FirstField", @"AndTheSecond" ]
+        signature:[NSData new]]);
+    runTestNS({ session.get() });
+#endif
 
     RetainPtr<CNPostalAddress> address = postalAddressForTesting();
     RetainPtr<CNLabeledValue> labeledPostalAddress = adoptNS([[PAL::getCNLabeledValueClassSingleton() alloc] initWithLabel:@"Work" value:address.get()]);


### PR DESCRIPTION
#### b21311b392dc28a147a002685b9240359a3ac0ba
<pre>
Add Delegated Merchant Session properties to CoreIPC Serialization
<a href="https://rdar.apple.com/169044345">rdar://169044345</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306611">https://bugs.webkit.org/show_bug.cgi?id=306611</a>

Reviewed by Abrar Rahman Protyasha.

CoreIPC Serialisation in WebKit was missing the new delegated
session properties, meaning when PassKit received the Session
object, isDelegatedSession and delegateDisplayName were
missing, causing signature validation to fail. This adds the relevant
fields to ensure IPC Serialization now works as intended.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm

* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.mm:
(WebKit::CoreIPCPKPaymentMerchantSession::CoreIPCPKPaymentMerchantSession):
(WebKit::CoreIPCPKPaymentMerchantSession::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, SecureCoding)):

Canonical link: <a href="https://commits.webkit.org/306634@main">https://commits.webkit.org/306634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e90be5a678ac42893e5a53165b0e63098ad2514

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141730 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150302 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94849 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108917 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78756 "6 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11007 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8645 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/375 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152695 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13805 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117334 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29927 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13368 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123562 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69413 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13843 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2843 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77568 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13785 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->