### PR TITLE
Remove unused code from ImageBitmapRenderingContext

### DIFF
--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -64,83 +64,25 @@ ImageBitmapCanvas ImageBitmapRenderingContext::canvas()
     return &downcast<HTMLCanvasElement>(base.get());
 }
 
-void ImageBitmapRenderingContext::setOutputBitmap(RefPtr<ImageBitmap> imageBitmap)
+ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<ImageBitmap> imageBitmap)
 {
-    // 1. If a bitmap argument was not provided, then:
-
     if (!imageBitmap) {
-        // 1.1. Set context's bitmap mode to blank.
-        // 1.2. Let canvas be the canvas element to which context is bound.
-        // 1.3. Set context's output bitmap to be transparent black with an
-        //      intrinsic width equal to the numeric value of canvas's width attribute
-        //      and an intrinsic height equal to the numeric value of canvas's height
-        //      attribute, those values being interpreted in CSS pixels.
         setBlank();
-        // 1.4. Set the output bitmap's origin-clean flag to true.
         canvasBase().setOriginClean();
-        return;
+        return { };
     }
-
-    // 2. If a bitmap argument was provided, then:
-
-    // 2.1. Set context's bitmap mode to valid.
-
-    m_bitmapMode = BitmapMode::Valid;
-
-    // 2.2. Set context's output bitmap to refer to the same underlying
-    //      bitmap data as bitmap, without making a copy.
-    //      Note: the origin-clean flag of bitmap is included in the
-    //      bitmap data to be referenced by context's output bitmap.
-
+    if (imageBitmap->isDetached())
+        return Exception { ExceptionCode::InvalidStateError };
     if (imageBitmap->originClean())
         canvasBase().setOriginClean();
     else
         canvasBase().setOriginTainted();
     canvasBase().setImageBufferAndMarkDirty(imageBitmap->takeImageBuffer());
-}
-
-ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<ImageBitmap> imageBitmap)
-{
-    // 1. Let bitmapContext be the ImageBitmapRenderingContext object on which
-    //    the transferFromImageBitmap() method was called.
-
-    // 2. If imageBitmap is null, then run the steps to set an ImageBitmapRenderingContext's
-    //    output bitmap, with bitmapContext as the context argument and no bitmap argument,
-    //    then abort these steps.
-
-    if (!imageBitmap) {
-        setOutputBitmap(nullptr);
-        return { };
-    }
-
-    // 3. If the value of imageBitmap's [[Detached]] internal slot is set to true,
-    //    then throw an "InvalidStateError" DOMException and abort these steps.
-
-    if (imageBitmap->isDetached())
-        return Exception { ExceptionCode::InvalidStateError };
-
-    // 4. Run the steps to set an ImageBitmapRenderingContext's output bitmap,
-    //    with the context argument equal to bitmapContext, and the bitmap
-    //    argument referring to imageBitmap's underlying bitmap data.
-
-    setOutputBitmap(imageBitmap);
-
-    // 5. Set the value of imageBitmap's [[Detached]] internal slot to true.
-    // 6. Unset imageBitmap's bitmap data.
-
-    // Note that the algorithm in the specification is currently a bit
-    // muddy here. The setOutputBitmap step above had to transfer ownership
-    // from the imageBitmap to this object, which requires a detach and unset,
-    // so this step isn't necessary, but we'll do it anyway.
-
-    imageBitmap->close();
-
     return { };
 }
 
 void ImageBitmapRenderingContext::setBlank()
 {
-    m_bitmapMode = BitmapMode::Blank;
     // FIXME: What is the point of creating a full size transparent buffer that
     // can never be changed? Wouldn't a 1x1 buffer give the same rendering? The
     // only reason I can think of is toDataURL(), but that doesn't seem like

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -48,19 +48,11 @@ class ImageBitmapRenderingContext final : public CanvasRenderingContext {
     WTF_MAKE_TZONE_ALLOCATED(ImageBitmapRenderingContext);
 public:
     static std::unique_ptr<ImageBitmapRenderingContext> create(CanvasBase&, ImageBitmapRenderingContextSettings&&);
-
-    enum class BitmapMode {
-        Valid,
-        Blank
-    };
-
     ~ImageBitmapRenderingContext();
 
     ImageBitmapCanvas canvas();
 
     ExceptionOr<void> transferFromImageBitmap(RefPtr<ImageBitmap>);
-
-    BitmapMode bitmapMode() { return m_bitmapMode; }
     bool hasAlpha() { return m_settings.alpha; }
 
 private:
@@ -68,10 +60,8 @@ private:
 
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
-    void setOutputBitmap(RefPtr<ImageBitmap>);
     void setBlank();
 
-    BitmapMode m_bitmapMode { BitmapMode::Blank };
     ImageBitmapRenderingContextSettings m_settings;
 };
 


### PR DESCRIPTION
#### dc5403ca9f85b4c28f4e6c07b4caddf6d2206d7b
<pre>
Remove unused code from ImageBitmapRenderingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=306613">https://bugs.webkit.org/show_bug.cgi?id=306613</a>
<a href="https://rdar.apple.com/169267153">rdar://169267153</a>

Reviewed by Anne van Kesteren.

Remove unused code and merge trivial functions that are used only once.
Remove stale comments. The spec text has changed, and the comments
make the trivial code more complex.

Makes future changes moving ImageBuffer out of CanvasBase more
reviewable.

* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::transferFromImageBitmap):
(WebCore::ImageBitmapRenderingContext::setBlank):
(WebCore::ImageBitmapRenderingContext::setOutputBitmap): Deleted.
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:

Canonical link: <a href="https://commits.webkit.org/306490@main">https://commits.webkit.org/306490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7197d65aa7fe60beafc9a12e8a1269a14bc2f07b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150100 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65dc2a8d-8151-4598-97cc-e76179d81e6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143395 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108746 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36554179-976b-4da9-b837-0eece059c31a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89651 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ad22880-e53d-4d03-9002-5f5e6cc78c07) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10851 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8475 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/172 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152493 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116849 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117179 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13213 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123329 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68795 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2642 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13378 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77355 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->