### PR TITLE
`protect()` overload for CF types is too permissive

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -626,6 +626,7 @@
 		DDF306FD27C086CC006A526F /* TypeCastsCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3070627C086CC006A526F /* WeakLinking.h in Headers */ = {isa = PBXBuildFile; fileRef = 37C7CC291EA40A73007BD956 /* WeakLinking.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3070C27C086CC006A526F /* TypeCastsCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AFDE647195201C300C48FFA /* TypeCastsCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2A0CF001302E77880086000B /* CFTypeTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0CF001302E77880086000A /* CFTypeTraits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3070E27C086CC006A526F /* NSURLExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CC0EE872162BC2200A1A842 /* NSURLExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3071127C086CC006A526F /* CrashReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA072A8236FFBF70018839C /* CrashReporter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DDF3071327C086CC006A526F /* CFURLExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1F05922164356B0039302C /* CFURLExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1245,6 +1246,7 @@
 		1A944F461C3D8814005BD28C /* BlockPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockPtr.h; sourceTree = "<group>"; };
 		1AEA88E11D6BBCF400E5AD64 /* EnumTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumTraits.h; sourceTree = "<group>"; };
 		1AFDE647195201C300C48FFA /* TypeCastsCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeCastsCF.h; sourceTree = "<group>"; };
+		2A0CF001302E77880086000A /* CFTypeTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFTypeTraits.h; sourceTree = "<group>"; };
 		1C08E3662985D7D300CAE594 /* IOReturnSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IOReturnSPI.h; sourceTree = "<group>"; };
 		1C08E3672985D7D400CAE594 /* IOTypesSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IOTypesSPI.h; sourceTree = "<group>"; };
 		1C181C7D1D3078DA00F5FA16 /* TextBreakIterator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextBreakIterator.cpp; sourceTree = "<group>"; };
@@ -2172,6 +2174,7 @@
 		2CDED0F018115C3F004DBA70 /* cf */ = {
 			isa = PBXGroup;
 			children = (
+				2A0CF001302E77880086000A /* CFTypeTraits.h */,
 				5C1F05912164356B0039302C /* CFURLExtras.cpp */,
 				5C1F05922164356B0039302C /* CFURLExtras.h */,
 				A331D95C21F249E4009F02AA /* FileSystemCF.cpp */,
@@ -3505,6 +3508,7 @@
 				63F9BED42898D96400371416 /* CFPrivSPI.h in Headers */,
 				DDF306D927C08654006A526F /* CFRunLoopSPI.h in Headers */,
 				DDF306D827C08654006A526F /* CFStringSPI.h in Headers */,
+				2A0CF001302E77880086000B /* CFTypeTraits.h in Headers */,
 				DDF3071327C086CC006A526F /* CFURLExtras.h in Headers */,
 				DDF306DF27C08654006A526F /* CFXPCBridgeSPI.h in Headers */,
 				DDF307F027C086EA006A526F /* CharacterNames.h in Headers */,

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -65,6 +65,7 @@ list(APPEND WTF_SOURCES
 )
 
 list(APPEND WTF_PUBLIC_HEADERS
+    cf/CFTypeTraits.h
     cf/CFURLExtras.h
     cf/NotificationCenterCF.h
     cf/TypeCastsCF.h

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -31,6 +31,7 @@
 
 #if USE(CF)
 #include <CoreFoundation/CoreFoundation.h>
+#include <wtf/cf/CFTypeTraits.h>
 #endif
 
 #ifdef __OBJC__
@@ -320,7 +321,7 @@ template<typename T> inline RetainPtr<RetainPtrType<T>> retainPtr(T ptr)
 
 #if USE(CF)
 template<typename T>
-    requires (std::is_pointer_v<T> && std::is_convertible_v<T, CFTypeRef> && !IsNSType<T>)
+    requires IsCFType<T>
 ALWAYS_INLINE CLANG_POINTER_CONVERSION RetainPtr<RetainPtrType<T>> protect(T ptr)
 {
     return ptr;

--- a/Source/WTF/wtf/cf/CFTypeTraits.h
+++ b/Source/WTF/wtf/cf/CFTypeTraits.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if USE(CF)
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <type_traits>
+
+namespace WTF {
+
+// CFTypeTrait primary template - specializations provide typeID() for specific CF types.
+template <typename> struct CFTypeTrait;
+
+} // namespace WTF
+
+// Macro to declare CFTypeTrait specializations.
+#define WTF_DECLARE_CF_TYPE_TRAIT(ClassName) \
+template <> \
+struct WTF::CFTypeTrait<ClassName##Ref> { \
+    static inline CFTypeID typeID() { return ClassName##GetTypeID(); } \
+};
+
+#define WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(ClassName, MutableClassName) \
+template <> \
+struct WTF::CFTypeTrait<MutableClassName##Ref> { \
+    static inline CFTypeID typeID() { return ClassName##GetTypeID(); } \
+};
+
+// Standard CF type specializations.
+WTF_DECLARE_CF_TYPE_TRAIT(CFArray);
+WTF_DECLARE_CF_TYPE_TRAIT(CFBoolean);
+WTF_DECLARE_CF_TYPE_TRAIT(CFData);
+WTF_DECLARE_CF_TYPE_TRAIT(CFDictionary);
+WTF_DECLARE_CF_TYPE_TRAIT(CFNumber);
+WTF_DECLARE_CF_TYPE_TRAIT(CFRunLoop);
+WTF_DECLARE_CF_TYPE_TRAIT(CFRunLoopSource);
+WTF_DECLARE_CF_TYPE_TRAIT(CFRunLoopTimer);
+WTF_DECLARE_CF_TYPE_TRAIT(CFString);
+WTF_DECLARE_CF_TYPE_TRAIT(CFURL);
+
+// Mutable CF type specializations.
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFArray, CFMutableArray);
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFData, CFMutableData);
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFDictionary, CFMutableDictionary);
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFString, CFMutableString);
+
+namespace WTF {
+
+namespace detail {
+
+template<typename T, typename = void>
+inline constexpr bool HasCFTypeTraitHelper = false;
+
+template<typename T>
+inline constexpr bool HasCFTypeTraitHelper<T, std::void_t<decltype(CFTypeTrait<T>::typeID())>> = true;
+
+} // namespace detail
+
+template<typename T>
+inline constexpr bool HasCFTypeTrait = detail::HasCFTypeTraitHelper<T>;
+
+// IsCFType: true for CFTypeRef or any type with a CFTypeTrait specialization.
+template<typename T>
+concept IsCFType = std::is_pointer_v<T> && (
+    std::is_same_v<std::remove_cv_t<T>, CFTypeRef> || HasCFTypeTrait<T>
+);
+
+} // namespace WTF
+
+using WTF::HasCFTypeTrait;
+using WTF::IsCFType;
+
+#endif // USE(CF)

--- a/Source/WTF/wtf/cf/TypeCastsCF.h
+++ b/Source/WTF/wtf/cf/TypeCastsCF.h
@@ -30,14 +30,13 @@
 #include <objc/objc.h>
 #include <wtf/Assertions.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/cf/CFTypeTraits.h>
 
 #ifndef CF_BRIDGED_TYPE
 #define CF_BRIDGED_TYPE(T)
 #endif
 
 namespace WTF {
-
-template <typename> struct CFTypeTrait;
 
 // Use dynamic_cf_cast<> instead of checked_cf_cast<> when actively checking CF types,
 // similar to dynamic_cast<> in C++. Be sure to include a nullptr check.
@@ -100,33 +99,8 @@ inline id bridge_id_cast(CFTypeRef object)
 
 } // namespace WTF
 
-#define WTF_DECLARE_CF_TYPE_TRAIT(ClassName) \
-template <> \
-struct WTF::CFTypeTrait<ClassName##Ref> { \
-    static inline CFTypeID typeID(void) { return ClassName##GetTypeID(); } \
-};
-
-WTF_DECLARE_CF_TYPE_TRAIT(CFArray);
-WTF_DECLARE_CF_TYPE_TRAIT(CFBoolean);
-WTF_DECLARE_CF_TYPE_TRAIT(CFData);
-WTF_DECLARE_CF_TYPE_TRAIT(CFDictionary);
-WTF_DECLARE_CF_TYPE_TRAIT(CFNumber);
-WTF_DECLARE_CF_TYPE_TRAIT(CFString);
-WTF_DECLARE_CF_TYPE_TRAIT(CFURL);
+// CTFontDescriptor requires CoreText, so we declare its trait here rather than in CFTypeTraits.h
 WTF_DECLARE_CF_TYPE_TRAIT(CTFontDescriptor);
-
-#define WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(ClassName, MutableClassName) \
-template <> \
-struct WTF::CFTypeTrait<MutableClassName##Ref> { \
-    static inline CFTypeID typeID(void) { return ClassName##GetTypeID(); } \
-};
-
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFArray, CFMutableArray);
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFData, CFMutableData);
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFDictionary, CFMutableDictionary);
-WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFString, CFMutableString);
-
-#undef WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT
 
 using WTF::bridgeCFCast;
 using WTF::bridge_id_cast;


### PR DESCRIPTION
#### a3054e0f9369e1342d1e67d81f6cde44f1598198
<pre>
`protect()` overload for CF types is too permissive
<a href="https://bugs.webkit.org/show_bug.cgi?id=306615">https://bugs.webkit.org/show_bug.cgi?id=306615</a>

Reviewed by Geoffrey Garen.

`protect()` overload for CF types is too permissive and can get called
for non-CFTypes. This is because `CFTypeRef` is a typedef to `void*`.

To address the issue, I am introduced a new `IsCFType` (Similar to the
existing `IsNSType`) which matches CFTypes based on whether or not
CFTypeTrait exists for the type.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/PlatformMac.cmake:
* Source/WTF/wtf/RetainPtr.h:
* Source/WTF/wtf/cf/CFTypeTraits.h: Copied from Source/WTF/wtf/cf/TypeCastsCF.h.
* Source/WTF/wtf/cf/TypeCastsCF.h:

Canonical link: <a href="https://commits.webkit.org/306493@main">https://commits.webkit.org/306493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a6522498fbfab925c04907d359074e08124b5a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13915 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94625 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8e815a2-7e3d-48de-b146-08d1b47f9185) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108750 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac32de1a-8248-4adb-8999-7114d6701ce3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89655 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da055188-b33d-404e-91b3-d7a1180cb348) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10856 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8478 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/176 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133512 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152497 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2332 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116852 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29835 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13219 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68799 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13645 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2667 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172821 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77359 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44766 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13581 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13429 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->