### PR TITLE
Add RuleSet bucket for fullscreen rules

### DIFF
--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -37,6 +37,7 @@
 #include "CSSValueKeywords.h"
 #include "ContainerQueryEvaluator.h"
 #include "DeclarationOrigin.h"
+#include "DocumentFullscreen.h"
 #include "ElementInlines.h"
 #include "ElementRareData.h"
 #include "ElementTextDirection.h"
@@ -249,6 +250,10 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
         collectMatchingRulesForList(ruleSet.focusPseudoClassRules(), matchRequest);
     if (matchesFocusVisiblePseudoClass(element))
         collectMatchingRulesForList(ruleSet.focusVisiblePseudoClassRules(), matchRequest);
+#if ENABLE(FULLSCREEN_API)
+    if (auto* fullscreen = element.document().fullscreenIfExists(); fullscreen && fullscreen->isFullscreen())
+        collectMatchingRulesForList(ruleSet.fullscreenPseudoClassRules(), matchRequest);
+#endif
     if (&element == element.document().documentElement())
         collectMatchingRulesForList(ruleSet.rootElementRules(), matchRequest);
     collectMatchingRulesForList(ruleSet.tagRules(element.localName(), isCaseInsensitiveForHTML), matchRequest);

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -185,6 +185,7 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
     const CSSSelector* focusVisibleSelector = nullptr;
     const CSSSelector* rootElementSelector = nullptr;
     const CSSSelector* hostPseudoClassSelector = nullptr;
+    const CSSSelector* fullscreenPseudoClassSelector = nullptr;
     const CSSSelector* customPseudoElementSelector = nullptr;
     const CSSSelector* slottedPseudoElementSelector = nullptr;
     const CSSSelector* partPseudoElementSelector = nullptr;
@@ -275,6 +276,14 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             case CSSSelector::PseudoClass::Root:
                 rootElementSelector = selector;
                 break;
+#if ENABLE(FULLSCREEN_API)
+            case CSSSelector::PseudoClass::Fullscreen:
+            case CSSSelector::PseudoClass::InternalInWindowFullscreen:
+            case CSSSelector::PseudoClass::InternalFullscreenDocument:
+            case CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition:
+                fullscreenPseudoClassSelector = selector;
+                break;
+#endif
             case CSSSelector::PseudoClass::Scope:
                 m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
                 break;
@@ -396,6 +405,11 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
         return;
     }
 
+    if (fullscreenPseudoClassSelector) {
+        m_fullscreenPseudoClassRules.append(ruleData);
+        return;
+    }
+
     if (namedPseudoElementSelector) {
         addToRuleSet(namedPseudoElementSelector->stringList()->first(), m_namedPseudoElementRules, ruleData);
         return;
@@ -498,6 +512,7 @@ void RuleSet::traverseRuleDatas(Function&& function)
     traverseVector(m_partPseudoElementRules);
     traverseVector(m_focusPseudoClassRules);
     traverseVector(m_focusVisiblePseudoClassRules);
+    traverseVector(m_fullscreenPseudoClassRules);
     traverseVector(m_rootElementRules);
     traverseVector(m_universalRules);
     traverseVector(m_universalPseudoElementRules);
@@ -602,6 +617,7 @@ void RuleSet::shrinkToFit()
     m_partPseudoElementRules.shrinkToFit();
     m_focusPseudoClassRules.shrinkToFit();
     m_focusVisiblePseudoClassRules.shrinkToFit();
+    m_fullscreenPseudoClassRules.shrinkToFit();
     m_rootElementRules.shrinkToFit();
     m_universalRules.shrinkToFit();
     m_universalPseudoElementRules.shrinkToFit();

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -111,6 +111,7 @@ public:
     const RuleDataVector& partPseudoElementRules() const { return m_partPseudoElementRules; }
     const RuleDataVector& focusPseudoClassRules() const { return m_focusPseudoClassRules; }
     const RuleDataVector& focusVisiblePseudoClassRules() const { return m_focusVisiblePseudoClassRules; }
+    const RuleDataVector& fullscreenPseudoClassRules() const { return m_fullscreenPseudoClassRules; }
     const RuleDataVector& rootElementRules() const { return m_rootElementRules; }
     const RuleDataVector& universalRules() const { return m_universalRules; }
     // For pseudo-element rules that apply to all elements or all HTML elements like "::marker".
@@ -222,6 +223,7 @@ private:
     RuleDataVector m_partPseudoElementRules;
     RuleDataVector m_focusPseudoClassRules;
     RuleDataVector m_focusVisiblePseudoClassRules;
+    RuleDataVector m_fullscreenPseudoClassRules;
     RuleDataVector m_rootElementRules;
     RuleDataVector m_universalRules;
     RuleDataVector m_universalPseudoElementRules;


### PR DESCRIPTION
#### 2d31810f4477543bc3dabf55d4cb64cbec0c6dd6
<pre>
Add RuleSet bucket for fullscreen rules
<a href="https://bugs.webkit.org/show_bug.cgi?id=306614">https://bugs.webkit.org/show_bug.cgi?id=306614</a>
<a href="https://rdar.apple.com/169270208">rdar://169270208</a>

Reviewed by Tim Nguyen.

Fullscreen pseduo-class rules can&apos;t match unless we are in fullscreen state.
Some of these exist in the user-agent stylesheet so they are worth optimizing.

* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):
(WebCore::Style::RuleSet::traverseRuleDatas):
(WebCore::Style::RuleSet::shrinkToFit):
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet::fullscreenPseudoClassRules const):

Canonical link: <a href="https://commits.webkit.org/306577@main">https://commits.webkit.org/306577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d3080994be8710d437f8c6c42469e19ac87af27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150114 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94635 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a5fb316-a695-43b6-a145-5dc2e3b2475d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14635 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14085 "Failed to checkout and rebase branch from PR 57555") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108758 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78696 "1 flakes 6 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1b10cb8-1e7f-4fe3-9dfa-1485e2a71273) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89663 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4eba3e5d-a106-401d-b33b-336d1d1f9903) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10863 "Passed tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/186 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152507 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13612 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116859 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13627 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/14085 "Failed to checkout and rebase branch from PR 57555") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117189 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29889 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13225 "Failed to checkout and rebase branch from PR 57555") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123386 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68811 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13655 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2681 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13392 "Failed to checkout and rebase branch from PR 57555") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77369 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13591 "Failed to checkout and rebase branch from PR 57555") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13439 "Failed to checkout and rebase branch from PR 57555") | | | | 
<!--EWS-Status-Bubble-End-->