### PR TITLE
Avoid using CanvasBase::allocateImageBuffer() in WebGL, WebGPU transferToImageBuffer()

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,7 +1,5 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d
@@ -26,10 +24,10 @@ Got context: "[object OffscreenCanvasRenderingContext2D]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: webgl
 Got context: "[object WebGLRenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgpu
 Got context: "null"
 Got exception: "InvalidStateError: The object is in an invalid state."

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,8 +1,5 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d
@@ -27,10 +24,10 @@ Got context: "[object OffscreenCanvasRenderingContext2D]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: webgl
 Got context: "[object WebGLRenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x8192
 Testing height: 100000000 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x8192
 Testing height: 100000000 type: webgpu
 Got context: "[object GPUCanvasContext]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."

--- a/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,8 +1,5 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d
@@ -27,10 +24,10 @@ Got context: "[object OffscreenCanvasRenderingContext2D]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: webgl
 Got context: "[object WebGLRenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
-Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Got result with size: 100x16384
 Testing height: 100000000 type: webgpu
 Got context: "[object GPUCanvasContext]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -32,6 +32,7 @@
 #include "GPUPresentationContext.h"
 #include "GPUPresentationContextDescriptor.h"
 #include "GPUTextureDescriptor.h"
+#include "GraphicsClient.h"
 #include "GraphicsLayerContentsDisplayDelegate.h"
 #include "GraphicsLayerEnums.h"
 #include "ImageBitmap.h"
@@ -339,7 +340,13 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
 
 RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
 {
-    auto buffer = canvasBase().allocateImageBuffer();
+    RefPtr scriptExecutionContext = canvasBase().scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return nullptr;
+    const auto size = canvasBase().size();
+    if (size.isEmpty())
+        return nullptr;
+    RefPtr buffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
     if (!buffer)
         return nullptr;
     Ref<ImageBuffer> bufferRef = buffer.releaseNonNull();

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -833,7 +833,13 @@ RefPtr<VideoFrame> WebGLRenderingContextBase::surfaceBufferToVideoFrame(SurfaceB
 
 RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
 {
-    auto buffer = protectedCanvasBase()->allocateImageBuffer();
+    RefPtr scriptExecutionContext = this->scriptExecutionContext();
+    if (!scriptExecutionContext)
+        return nullptr;
+    const auto size = m_defaultFramebuffer->size();
+    if (size.isEmpty())
+        return nullptr;
+    RefPtr buffer = ImageBuffer::create(size, RenderingMode::Accelerated, RenderingPurpose::Canvas, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, scriptExecutionContext->graphicsClient());
     if (!buffer)
         return nullptr;
     if (compositingResultsNeedUpdating())


### PR DESCRIPTION
#### 163003d0cfa23e228d68f6e0af966c3ff06b8f4a
<pre>
Avoid using CanvasBase::allocateImageBuffer() in WebGL, WebGPU transferToImageBuffer()
<a href="https://bugs.webkit.org/show_bug.cgi?id=306617">https://bugs.webkit.org/show_bug.cgi?id=306617</a>
<a href="https://rdar.apple.com/169276497">rdar://169276497</a>

Reviewed by Mike Wyrzykowski.

The allocation function is related to how 2D context backing store is
allocated. transferToImageBuffer needs a general purpose ImageBuffer,
where the WebGL, WebGPU backing store is transferred to.

This makes it simpler to move 2D context related ImageBuffer code to
2D rendering context classes.

* LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
Example of failure being fixed here:
Previously transferToImageBitmap of a giant WebGL context failed due to
canvas area limitations.

* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::transferToImageBuffer):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::transferToImageBuffer):

Canonical link: <a href="https://commits.webkit.org/306772@main">https://commits.webkit.org/306772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/226a688a5ded7f07709ee35e73f00063f62f4729

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95267 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109221 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78943 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d9e4f43-c5c1-45e4-a06a-eb38f222c71f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90118 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dee21c73-764c-463e-a7ee-9ba986644551) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11296 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8956 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/757 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153074 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14166 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117293 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117613 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30028 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13663 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69866 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14215 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3410 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77931 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13992 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->