### PR TITLE
[Cocoa] Subtitles language label shows "Not available" for some videos

### DIFF
--- a/Source/WebCore/page/CaptionUserPreferences.cpp
+++ b/Source/WebCore/page/CaptionUserPreferences.cpp
@@ -240,6 +240,8 @@ MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(const 
     auto legibleType = MediaSelectionOption::LegibleType::Regular;
     if (&track == &TextTrack::captionMenuOffItemSingleton())
         legibleType = MediaSelectionOption::LegibleType::LegibleOff;
+    else if (&track == &TextTrack::captionMenuOnItemSingleton())
+        legibleType = MediaSelectionOption::LegibleType::LegibleOn;
     else if (&track == &TextTrack::captionMenuAutomaticItemSingleton())
         legibleType = MediaSelectionOption::LegibleType::LegibleAuto;
 
@@ -261,7 +263,7 @@ MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(const 
         break;
     }
 
-    return { mediaType, displayNameForTrack(track), legibleType };
+    return { mediaType, displayNameForTrack(track), legibleType, track.validBCP47Language() };
 }
     
 Vector<Ref<TextTrack>> CaptionUserPreferences::sortedTrackListForMenu(TextTrackList* trackList, HashSet<TextTrack::Kind> kinds)
@@ -306,7 +308,7 @@ String CaptionUserPreferences::displayNameForTrack(const AudioTrack& track) cons
 
 MediaSelectionOption CaptionUserPreferences::mediaSelectionOptionForTrack(const AudioTrack& track) const
 {
-    return { MediaSelectionOption::MediaType::Audio, displayNameForTrack(track), MediaSelectionOption::LegibleType::Regular };
+    return { MediaSelectionOption::MediaType::Audio, displayNameForTrack(track), MediaSelectionOption::LegibleType::Regular, track.validBCP47Language() };
 }
 
 Vector<Ref<AudioTrack>> CaptionUserPreferences::sortedTrackListForMenu(AudioTrackList* trackList)

--- a/Source/WebCore/platform/MediaSelectionOption.h
+++ b/Source/WebCore/platform/MediaSelectionOption.h
@@ -41,23 +41,34 @@ struct MediaSelectionOption {
     enum class LegibleType : uint8_t {
         Regular,
         LegibleOff,
+        LegibleOn,
         LegibleAuto,
     };
 
     MediaSelectionOption() = default;
-    MediaSelectionOption(MediaType mediaType, const String& displayName, LegibleType legibleType)
+    MediaSelectionOption(MediaType mediaType, const String& displayName, LegibleType legibleType, const String& languageTag)
         : mediaType { mediaType }
         , displayName { displayName }
         , legibleType { legibleType }
+        , languageTag { languageTag }
     {
     }
 
-    MediaSelectionOption isolatedCopy() const & { return { mediaType, displayName.isolatedCopy(), legibleType }; }
-    MediaSelectionOption isolatedCopy() && { return { mediaType, WTF::move(displayName).isolatedCopy(), legibleType }; }
+    MediaSelectionOption(MediaType mediaType, String&& displayName, LegibleType legibleType, String&& languageTag)
+        : mediaType { mediaType }
+        , displayName { WTF::move(displayName) }
+        , legibleType { legibleType }
+        , languageTag { WTF::move(languageTag) }
+    {
+    }
+
+    MediaSelectionOption isolatedCopy() const & { return { mediaType, displayName.isolatedCopy(), legibleType, languageTag.isolatedCopy() }; }
+    MediaSelectionOption isolatedCopy() && { return { mediaType, WTF::move(displayName).isolatedCopy(), legibleType, WTF::move(languageTag).isolatedCopy() }; }
 
     MediaType mediaType { MediaType::Unknown };
     String displayName;
     LegibleType legibleType { LegibleType::Regular };
+    String languageTag;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm
@@ -181,7 +181,7 @@ static RetainPtr<NSArray> mediaSelectionOptions(const Vector<MediaSelectionOptio
         if (option.legibleType != MediaSelectionOption::LegibleType::Regular)
             return nil;
 #endif
-        return adoptNS([[WebAVMediaSelectionOption alloc] initWithMediaType:toAVMediaType(option.mediaType) displayName:option.displayName.createNSString().get()]);
+        return adoptNS([[WebAVMediaSelectionOption alloc] initWithMediaType:toAVMediaType(option.mediaType) displayName:option.displayName.createNSString().get() extendedLanguageTag:option.languageTag.createNSString().get()]);
     });
 }
 

--- a/Source/WebCore/platform/ios/WebAVPlayerController.h
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.h
@@ -39,12 +39,12 @@ class PlaybackSessionInterfaceIOS;
 @class AVTimeRange;
 
 @interface WebAVMediaSelectionOption : NSObject
-- (instancetype)initWithMediaType:(AVMediaType)type displayName:(NSString *)displayName;
+- (instancetype)initWithMediaType:(AVMediaType)type displayName:(NSString *)displayName extendedLanguageTag:(NSString *)extendedLanguageTag;
 
 @property (nonatomic, readonly) NSString *displayName;
 @property (nonatomic, readonly) NSString *localizedDisplayName;
 @property (nonatomic, readonly) AVMediaType mediaType;
-
+@property (nonatomic, readonly, nullable) NSString *extendedLanguageTag;
 @end
 
 @interface WebAVPlayerController : NSObject

--- a/Source/WebCore/platform/ios/WebAVPlayerController.mm
+++ b/Source/WebCore/platform/ios/WebAVPlayerController.mm
@@ -1195,9 +1195,11 @@ Class webAVPlayerControllerClassSingleton()
 @implementation WebAVMediaSelectionOption {
     RetainPtr<NSString> _localizedDisplayName;
     RetainPtr<AVMediaType> _mediaType;
+    RetainPtr<NSString> _extendedLanguageTag;
+    RetainPtr<NSLocale> _locale;
 }
 
-- (instancetype)initWithMediaType:(AVMediaType)mediaType displayName:(NSString *)displayName
+- (instancetype)initWithMediaType:(AVMediaType)mediaType displayName:(NSString *)displayName extendedLanguageTag:(NSString *)extendedLanguageTag
 {
     self = [super init];
     if (!self)
@@ -1205,6 +1207,8 @@ Class webAVPlayerControllerClassSingleton()
 
     _mediaType = mediaType;
     _localizedDisplayName = displayName;
+    _extendedLanguageTag = extendedLanguageTag;
+    _locale = adoptNS([[NSLocale alloc] initWithLocaleIdentifier:_extendedLanguageTag.get()]);
 
     return self;
 }
@@ -1212,7 +1216,7 @@ Class webAVPlayerControllerClassSingleton()
 - (id)copyWithZone:(NSZone *)zone
 {
     RetainPtr displayName = adoptNS([_localizedDisplayName copyWithZone:zone]);
-    SUPPRESS_RETAINPTR_CTOR_ADOPT return [[WebAVMediaSelectionOption allocWithZone:zone] initWithMediaType:_mediaType.get() displayName:displayName.get()];
+    SUPPRESS_RETAINPTR_CTOR_ADOPT return [[WebAVMediaSelectionOption allocWithZone:zone] initWithMediaType:_mediaType.get() displayName:displayName.get() extendedLanguageTag:_extendedLanguageTag.get()];
 }
 
 - (NSString *)displayName
@@ -1253,16 +1257,12 @@ Class webAVPlayerControllerClassSingleton()
 
 - (NSString *)extendedLanguageTag
 {
-    ASSERT_NOT_REACHED();
-    WTFLogAlways("ERROR: -[WebAVMediaSelectionOption extendedLanguageTag] unimplemented");
-    return nil;
+    return _extendedLanguageTag.get();
 }
 
 - (NSLocale *)locale
 {
-    ASSERT_NOT_REACHED();
-    WTFLogAlways("ERROR: -[WebAVMediaSelectionOption locale] unimplemented");
-    return nil;
+    return _locale.get();
 }
 
 - (NSArray<AVMetadataItem *> *)commonMetadata
@@ -1337,9 +1337,7 @@ Class webAVPlayerControllerClassSingleton()
 
 - (NSString *)languageCode
 {
-    ASSERT_NOT_REACHED();
-    WTFLogAlways("ERROR: -[WebAVMediaSelectionOption languageCode] unimplemented");
-    return nil;
+    return _extendedLanguageTag.get();
 }
 
 - (AVAssetTrack *)track

--- a/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
+++ b/Source/WebCore/platform/mac/WebPlaybackControlsManager.mm
@@ -252,6 +252,7 @@ using WebCore::PlaybackSessionInterfaceMac;
 static AVTouchBarMediaSelectionOptionType toAVTouchBarMediaSelectionOptionType(MediaSelectionOption::LegibleType type)
 {
     switch (type) {
+    case MediaSelectionOption::LegibleType::LegibleOn:
     case MediaSelectionOption::LegibleType::Regular:
         return AVTouchBarMediaSelectionOptionTypeRegular;
     case MediaSelectionOption::LegibleType::LegibleOff:

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4366,6 +4366,7 @@ struct WebCore::MediaSelectionOption {
     WebCore::MediaSelectionOption::MediaType mediaType;
     String displayName;
     WebCore::MediaSelectionOption::LegibleType legibleType;
+    String languageTag;
 };
 
 [Nested] enum class WebCore::MediaSelectionOption::MediaType : uint8_t {
@@ -4379,6 +4380,7 @@ struct WebCore::MediaSelectionOption {
 [Nested] enum class WebCore::MediaSelectionOption::LegibleType : uint8_t {
     Regular,
     LegibleOff,
+    LegibleOn,
     LegibleAuto,
 };
 


### PR DESCRIPTION
#### 3e6b56ba17b7d642a8427e055928104c23f6ce22
<pre>
[Cocoa] Subtitles language label shows &quot;Not available&quot; for some videos
<a href="https://rdar.apple.com/168726531">rdar://168726531</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306623">https://bugs.webkit.org/show_bug.cgi?id=306623</a>

Reviewed by Eric Carlson.

AVKit needs locale information in order to correctly build the track
list UI, which means WebKit needs to pipe the language code provided
by the track up to the UIProcess as part of the synthetic
WebAVMediaSelectionOption we pass to the AVPlayerViewController.

* Source/WebCore/page/CaptionUserPreferences.cpp:
(WebCore::CaptionUserPreferences::mediaSelectionOptionForTrack const):
* Source/WebCore/platform/MediaSelectionOption.h:
(WebCore::MediaSelectionOption::MediaSelectionOption):
(WebCore::MediaSelectionOption::isolatedCopy const):
(WebCore::MediaSelectionOption::isolatedCopy):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKitLegacy.mm:
(WebCore::mediaSelectionOptions):
* Source/WebCore/platform/ios/WebAVPlayerController.h:
* Source/WebCore/platform/ios/WebAVPlayerController.mm:
(-[WebAVMediaSelectionOption initWithMediaType:displayName:extendedLanguageTag:]):
(-[WebAVMediaSelectionOption copyWithZone:]):
(-[WebAVMediaSelectionOption extendedLanguageTag]):
(-[WebAVMediaSelectionOption locale]):
(-[WebAVMediaSelectionOption languageCode]):
(-[WebAVMediaSelectionOption initWithMediaType:displayName:]): Deleted.
* Source/WebCore/platform/mac/WebPlaybackControlsManager.mm:
(toAVTouchBarMediaSelectionOptionType):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/306658@main">https://commits.webkit.org/306658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d1cd728e5b0da598fb2c425e68d2174bf232a0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14374 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/4402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150585 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5d463bb-a9a1-4c94-8cbf-53e365fa46c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14527 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9adae1c9-d2e4-4e5a-860c-39c1bef9259c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11663 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90022 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06537ac3-d115-4a63-997f-3c06eed1575d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/644 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/3332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152961 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14053 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/3950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14075 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12257 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117523 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29946 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13571 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14102 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77818 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->