### PR TITLE
[threaded-animations] several scroll-animations tests crash as a result of changing timelines with "Threaded Time-based Animations" enabled

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/timeline-update-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/timeline-update-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Changing timelines on a threaded animation updates the current time of the remote animation
+

--- a/LayoutTests/webanimations/threaded-animations/timeline-update.html
+++ b/LayoutTests/webanimations/threaded-animations/timeline-update.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ThreadedTimeBasedAnimationsEnabled=true ] -->
+<body>
+<style>
+
+html {
+    height: 2000px;
+}
+
+#target {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+
+    background-color: green;
+    opacity: 0;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+const assertRemoteAnimationProgress = async (expectedProgress, description) => {
+    const remoteAnimationStack = await UIHelper.remoteAnimationStackForElement(target);
+    assert_equals(remoteAnimationStack.animations.length, 1, `${description}, we have a single remote animation`);
+    const remoteAnimation = remoteAnimationStack.animations[0];
+    assert_approx_equals(remoteAnimation.progress, expectedProgress, 0.001, `${description}, the remote animation current time is ${expectedProgress}`);
+};
+
+promise_test(async t => {
+    const duration = 1000 * 1000;
+    const scroller = document.documentElement;
+    const timeline = new ScrollTimeline({ source : scroller });
+    const animation = target.animate({ opacity: 1 }, { timeline, duration });
+
+    const scrollProgress = 0.5;
+    const maxScrollTop = scroller.scrollHeight - window.innerHeight;
+    window.scrollTo(0, scrollProgress * maxScrollTop);
+    await Promise.all([UIHelper.renderingUpdate(), animationAcceleration(animation)]);
+    await assertRemoteAnimationProgress(scrollProgress, "After scrolling");
+
+    const monotonicProgress = 0.75;
+    animation.timeline = document.timeline;
+    animation.currentTime = monotonicProgress * duration;
+    await animationAcceleration(animation);
+    await assertRemoteAnimationProgress(monotonicProgress, "After changing the timeline to the document timeline");
+}, "Changing timelines on a threaded animation updates the current time of the remote animation");
+
+</script>
+</body>

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1522,10 +1522,6 @@ void KeyframeEffect::updateEffectStackMembership()
     if (!target)
         return;
 
-#if ENABLE(THREADED_ANIMATIONS)
-    StackMembershipMutationScope stackMembershipMutationScope(*this);
-#endif
-
     bool isRelevant = animation() && animation()->isRelevant();
     if (isRelevant && !m_inTargetEffectStack)
         target->ensureKeyframeEffectStack().addEffect(*this);


### PR DESCRIPTION
#### a26d2b5659691992a150d9e04b1015d54c7c189d
<pre>
[threaded-animations] several scroll-animations tests crash as a result of changing timelines with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306625">https://bugs.webkit.org/show_bug.cgi?id=306625</a>
<a href="https://rdar.apple.com/169284832">rdar://169284832</a>

Reviewed by Simon Fraser.

The following tests crash under `KeyframeEffect::~StackMembershipMutationScope()` when
running these three WPT tests:

- scroll-animations/css/timeline-offset-in-keyframe-change-timeline.tentative.html
- scroll-animations/scroll-timelines/setting-timeline.tentative.html
- scroll-animations/view-timelines/timeline-offset-in-keyframe.html

In each case, the crash occurs under the call to ``KeyframeEffect::updateEffectStackMembership()`
in `KeyframeEffect::animationTimelineDidChange()`. Removing that call does not regress any other
test, so it was probably not needed, likely because it was an accelerated stack update occurs via
another method called under `WebAnimation::setTimeline()`.

To make sure changing timelines still works as expected, we add a new test that checks the
state of remote animations is as expected.

Test: webanimations/threaded-animations/timeline-update.html

* LayoutTests/webanimations/threaded-animations/timeline-update-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/timeline-update.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::updateEffectStackMembership):

Canonical link: <a href="https://commits.webkit.org/306522@main">https://commits.webkit.org/306522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cf0d11eb31770e8c04fc0b8624651c22b65e9f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94664 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108780 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11320 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89684 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10880 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8529 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/213 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120180 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152533 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13638 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116878 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117209 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13249 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68847 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21843 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13681 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13418 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13617 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->