### PR TITLE
Add initial support for data URL references in paint servers

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -76,6 +76,7 @@
 #include "DOMCSSPaintWorklet.h"
 #include "DOMImplementation.h"
 #include "DOMTimer.h"
+#include "DataURLDecoder.h"
 #include "DateComponents.h"
 #include "DebugPageOverlays.h"
 #include "DeprecatedGlobalSettings.h"
@@ -219,6 +220,7 @@
 #include "PageSwapEvent.h"
 #include "PageTransitionEvent.h"
 #include "PaintWorkletGlobalScope.h"
+#include "ParserContentPolicy.h"
 #include "Performance.h"
 #include "PerformanceNavigationTiming.h"
 #include "PingLoader.h"
@@ -8250,6 +8252,90 @@ SVGDocumentExtensions& Document::svgExtensions()
 CheckedRef<SVGDocumentExtensions> Document::checkedSVGExtensions()
 {
     return svgExtensions();
+}
+
+RefPtr<SVGDocument> Document::svgDocumentFromDataURL(const URL& url)
+{
+    ASSERT(url.protocolIsData());
+
+    String dataURL = url.stringWithoutFragmentIdentifier();
+
+    auto it = m_dataURLSVGDocuments.find(dataURL);
+    if (it != m_dataURLSVGDocuments.end())
+        return it->value;
+
+    if (!ScriptDisallowedScope::InMainThread::isScriptAllowed()) {
+        eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }, url = url.isolatedCopy()] {
+            if (RefPtr document = weakThis.get()) {
+                if (RefPtr svgDoc = document->svgDocumentFromDataURL(url))
+                    document->clonePaintServersFromDataURLDocument(*svgDoc, url);
+            }
+        });
+        return nullptr;
+    }
+
+    auto result = DataURLDecoder::decode(url);
+    if (!result)
+        return nullptr;
+
+    if (!result->mimeType.startsWith("image/svg+xml"_s))
+        return nullptr;
+
+    Ref svgDoc = SVGDocument::create(nullptr, m_settings.copyRef(), url);
+
+    Ref decoder = TextResourceDecoder::create("application/xml"_s);
+    if (!result->charset.isEmpty())
+        decoder->setEncoding(result->charset, TextResourceDecoder::EncodingFromHTTPHeader);
+    String content = decoder->decodeAndFlush(result->data.span());
+
+
+    svgDoc->setParserContentPolicy({ ParserContentPolicy::AllowDeclarativeShadowRoots });
+    Ref<DocumentParser> parser = XMLDocumentParser::create(svgDoc, XMLDocumentParser::IsInFrameView::No, svgDoc->parserContentPolicy());
+    parser->append(content.releaseImpl());
+    parser->finish();
+    parser->detach();
+
+    m_dataURLSVGDocuments.set(dataURL, svgDoc.ptr());
+    return svgDoc;
+}
+
+void Document::clonePaintServersFromDataURLDocument(SVGDocument& svgDoc, const URL& dataURL)
+{
+    RefPtr docElement = documentElement();
+    if (!docElement)
+        return;
+
+    RefPtr<ContainerNode> targetContainer = docElement;
+
+    String dataURLKey = dataURL.stringWithoutFragmentIdentifier();
+
+    RefPtr svgDocElement = svgDoc.documentElement();
+    if (!svgDocElement)
+        return;
+
+    auto clonePaintServer = [&](SVGElement& element) {
+        auto originalID = element.getIdAttribute();
+        if (originalID.isEmpty())
+            return;
+
+        AtomString cloneID = dataURLCloneID(dataURLKey, originalID);
+
+        if (getElementById(cloneID))
+            return;
+
+        Ref clone = downcast<SVGElement>(element.cloneElementWithChildren(*this, nullptr));
+        clone->setAttributeWithoutSynchronization(HTMLNames::idAttr, cloneID);
+
+        ScriptDisallowedScope::EventAllowedScope eventAllowedScope { *targetContainer };
+        targetContainer->appendChild(clone);
+    };
+
+    for (auto& element : descendantsOfType<SVGElement>(*svgDocElement)) {
+        if (element.hasTagName(SVGNames::linearGradientTag)
+            || element.hasTagName(SVGNames::radialGradientTag)
+            || element.hasTagName(SVGNames::patternTag))
+            clonePaintServer(element);
+    }
 }
 
 bool Document::hasSVGRootNode() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -231,6 +231,7 @@ class RequestAnimationFrameCallback;
 class ResizeObserver;
 class ResourceMonitor;
 class FrameMemoryMonitor;
+class SVGDocument;
 class SVGDocumentExtensions;
 class SVGElement;
 class SVGSVGElement;
@@ -1429,6 +1430,9 @@ public:
     WEBCORE_EXPORT SVGDocumentExtensions& svgExtensions();
     WEBCORE_EXPORT CheckedRef<SVGDocumentExtensions> checkedSVGExtensions();
 
+    RefPtr<SVGDocument> svgDocumentFromDataURL(const URL&);
+    void clonePaintServersFromDataURLDocument(SVGDocument&, const URL&);
+
     void initSecurityContext();
     void initContentSecurityPolicy();
 
@@ -2418,6 +2422,7 @@ private:
     RefPtr<XPathEvaluator> m_xpathEvaluator;
 
     std::unique_ptr<SVGDocumentExtensions> m_svgExtensions;
+    HashMap<String, RefPtr<SVGDocument>> m_dataURLSVGDocuments;
 
     // Collection of canvas contexts that need periodic work in "PrepareCanvasesForDisplayOrFlush" phase of
     // render update. Hold canvases via rendering context, since there is no common base class that

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -37,6 +37,7 @@
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/TextResourceDecoder.h>
 #include <WebCore/UndoManager.h>
+#include <wtf/text/StringHash.h>
 
 namespace WebCore {
 
@@ -185,6 +186,11 @@ inline Ref<DocumentSyncData> Document::syncData()
 RefPtr<Document> FrameSelection::protectedDocument() const
 {
     return m_document.get();
+}
+
+inline AtomString dataURLCloneID(const String& dataURLKey, const AtomString& originalID)
+{
+    return makeAtomString("__datauri_"_s, String::number(StringHash::hash(dataURLKey)), "_"_s, originalID);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -20,6 +20,8 @@
 #include "config.h"
 #include "SVGResources.h"
 
+#include "ContainerNodeInlines.h"
+#include "DocumentInlines.h"
 #include "FilterOperation.h"
 #include "LegacyRenderSVGResourceClipperInlines.h"
 #include "LegacyRenderSVGResourceFilterInlines.h"
@@ -190,7 +192,34 @@ static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromS
     if (!paintURL)
         return nullptr;
 
-    id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, treeScope.protectedDocumentScope());
+    Ref document = treeScope.documentScope();
+
+    if (paintURL->resolved.protocolIsData()) {
+        auto result = SVGURIReference::targetElementFromIRIString(*paintURL, treeScope);
+
+        String dataURIKey = paintURL->resolved.stringWithoutFragmentIdentifier();
+        AtomString cloneID = dataURLCloneID(dataURIKey, result.identifier);
+
+        if (RefPtr existingClone = dynamicDowncast<SVGElement>(document->getElementById(cloneID))) {
+            if (auto* renderer = dynamicDowncast<LegacyRenderSVGResourceContainer>(existingClone->renderer())) {
+                RenderSVGResourceType resourceType = renderer->resourceType();
+                if (resourceType == PatternResourceType || resourceType == LinearGradientResourceType || resourceType == RadialGradientResourceType)
+                    return renderer;
+            }
+
+            hasPendingResource = true;
+            id = cloneID;
+            return nullptr;
+        }
+
+        if (!result.identifier.isEmpty()) {
+            hasPendingResource = true;
+            id = cloneID;
+        }
+        return nullptr;
+    }
+
+    id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, document);
     CheckedPtr container = getRenderSVGResourceContainerById(treeScope, id);
     if (!container) {
         hasPendingResource = true;

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -24,6 +24,7 @@
 
 #include "Document.h"
 #include "Element.h"
+#include "SVGDocument.h"
 #include "SVGElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGUseElement.h"
@@ -76,6 +77,10 @@ AtomString SVGURIReference::fragmentIdentifierFromIRIString(const String& url, c
 
     URL base = URL(document.baseURL(), url.left(start));
     String fragmentIdentifier = url.substring(start);
+
+    if (base.protocolIsData())
+        return StringView(fragmentIdentifier).substring(1).toAtomString();
+
     URL urlWithFragment(base, fragmentIdentifier);
     if (equalIgnoringFragmentIdentifier(urlWithFragment, document.url()))
         return StringView(fragmentIdentifier).substring(1).toAtomString();
@@ -117,9 +122,9 @@ auto SVGURIReference::targetElementFromIRIString(const String& iri, const TreeSc
     }
 
     if (url.protocolIsData()) {
-        // FIXME: We need to load the data url in a Document to be able to get the target element.
-        if (!equalIgnoringFragmentIdentifier(url, document->url()))
-            return { nullptr, WTF::move(id) };
+        if (RefPtr svgDoc = document->svgDocumentFromDataURL(url))
+            return { svgDoc->getElementById(id), WTF::move(id) };
+        return { nullptr, WTF::move(id) };
     }
 
     // Exit early if the referenced url is external, and we have no externalDocument given.

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -62,7 +62,10 @@ public:
 
         // If the URI matches our documents URL, we're dealing with a local reference.
         URL url = document.completeURL(uri);
-        ASSERT(!url.protocolIsData());
+
+        if (url.protocolIsData())
+            return false;
+
         return !equalIgnoringFragmentIdentifier(url, document.url());
     }
 


### PR DESCRIPTION
#### 5c1ed9bdd2d1
<pre>
Add initial support for data URL references in paint servers
<a href="https://bugs.webkit.org/show_bug.cgi?id=104169">https://bugs.webkit.org/show_bug.cgi?id=104169</a>
<a href="https://rdar.apple.com/97098436">rdar://97098436</a>

Reviewed by NOBODY (OOPS!).

This PR adds support for SVG data URLs:
e.g `fill=&quot;url(data:image/svg+xml;base64,...#gradientId)&quot;``

The current approach clones referenced paint servers into the main
document with computed IDs. Cloning is deferred via the event
loop because SVG resources appear to be built during style-resolution.

A few issues with this approach that I&apos;m working on addressing:
- The cloned elements are introspectable in the DOM and visible to authors
- It takes multiple render cycles to display the paint server

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::svgDocumentFromDataURL):
(WebCore::Document::clonePaintServersFromDataURLDocument):
* Source/WebCore/dom/Document.h:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::paintingResourceFromSVGPaint):
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::fragmentIdentifierFromIRIString):
(WebCore::SVGURIReference::targetElementFromIRIString):
* Source/WebCore/svg/SVGURIReference.h:
(WebCore::SVGURIReference::isExternalURIReference):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c1ed9bdd2d187ca9ecc45b9bfba4760baa4641a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150152 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94676 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0cf45c22-cc99-4381-b44f-abd1afb9b9d4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108788 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78712 "3 flakes 8 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144529 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11344 "Found 1 new test failure: svg/custom/object-data-href.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89692 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10901 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8530 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/225 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152545 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3213 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116896 "Found 2 new test failures: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html svg/custom/object-data-href.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13665 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11924 "Found 1 new test failure: svg/custom/object-data-href.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117220 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13259 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68856 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13693 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2729 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13431 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77418 "Found 2 new failures in dom/Document.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13640 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13477 "Failed to checkout and rebase branch from PR 57566") | | | | 
<!--EWS-Status-Bubble-End-->