### PR TITLE
Iframe history not restored on back navigation with BFCache off.

### DIFF
--- a/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache-expected.txt
@@ -1,0 +1,28 @@
+Nested iframe history navigation works correctly when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Popup loaded
+Popup pageshow: not-persisted
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other displayed.
+Popup loaded
+Popup pageshow: not-persisted
+Page2 loaded
+PASS Page2 displayed twice.
+Page1 loaded
+PASS Page1 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.
+Navigate iframe to page2.
+Navigate main frame to other.
+Go back. (back-iframe-popup.html with iframe showing page2)
+Go back again. (back-iframe-popup.html with iframe showing page1)
+... and ensures the nested iframe content is correctly restored to page1.

--- a/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
+++ b/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
@@ -1,0 +1,95 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=false dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/navigation-utils.js"></script>
+<script>
+
+description("Nested iframe history navigation works correctly when back/forward cache is disabled.");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("resources/back-iframe-popup.html");
+}
+
+var page1ShowCount = 0;
+var page2ShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        load: () => debug("Popup loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Popup should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+            debug("Popup pageshow: " + arg);
+        },
+    },
+    page1: {
+        load: () => debug("Page1 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page1 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page1ShowCount++;
+            if (page1ShowCount == 1) {
+                debug("Page1 displayed first time.");
+                sendMessageToPopup("navigate-to-page2");
+            } else if (page1ShowCount == 2) {
+                if (window.testRunner) {
+                    testPassed("Page1 displayed twice.");
+                    finishJSTest();
+                }
+            }
+        }
+    },
+    page2: {
+        load: () => debug("Page2 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page2 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page2ShowCount++;
+            if (page2ShowCount == 1) {
+                debug("Page2 displayed first time.");
+                sendMessageToPopup("navigate-to-other");
+            } else if (page2ShowCount == 2) {
+                testPassed("Page2 displayed twice.");
+                sendMessageToPopup("back2");
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: ({arg}) => {
+            debug("Other displayed.");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to page2.</li>
+    <li>Navigate main frame to other.</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing page2)</li>
+    <li>Go back again. (back-iframe-popup.html with iframe showing page1)</li>
+</ul>
+<p>... and ensures the nested iframe content is correctly restored to page1.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-1.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-1.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "page1";
+
+window.onload = () => sendMessageToTop("load");
+window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+</script>
+</head>
+<body>
+<h1>Page 1</h1>
+<p>PASS: iframe content: Page 1</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-2.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-2.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "page2";
+
+window.onload = () => sendMessageToTop("load");
+window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+</script>
+</head>
+<body>
+<h1>Page 2</h1>
+<p>FAIL: iframe content: Page 2 (After navigation)</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-other.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-other.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "other";
+
+window.onload = () => sendMessageToOpener("load");
+window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    opener: {
+        back1: () => history.back(),
+    },
+});
+
+</script>
+</head>
+<body>
+<h1>Other page</h1>
+<p>FAIL: This page should not be displayed at the end.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "popup";
+const iframeId = "test-iframe"
+
+window.onload = () => sendMessageToOpener("load");
+window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    opener: {
+        'navigate-to-page2': () => navigateIframeTo("back-iframe-2.html"),
+        'navigate-to-other': () => navigateTo("back-iframe-other.html"),
+        back2: () => history.back(),
+    },
+    page1: () => forwardMessageToOpener(event.data),
+    page2: () => forwardMessageToOpener(event.data),
+});
+
+
+</script>
+</head>
+<body>
+<h1>Popup page</h1>
+<iframe src="back-iframe-1.html" id="test-iframe"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/navigation-utils.js
+++ b/LayoutTests/http/tests/navigation/resources/navigation-utils.js
@@ -1,0 +1,90 @@
+/* `page` must be defined in embedding HTML files */
+function makeMessage(action, arg = "") {
+    if (page === null || page === undefined) {
+        console.error("makeMessage: page is not defined");
+        return "";
+    }
+    return `${page}:${action}:${arg}:${location.search}`;
+}
+
+function parseMessage(message) {
+    const [sender, action, arg, search] = message.split(":", 4);
+    return {sender, action, arg, search};
+}
+
+function sendMessageTo(action, arg, target) {
+    const message = makeMessage(action, arg);
+    console.log(`${page}: Sending message: ${message}`);
+    target.postMessage(message, "*");
+}
+
+function dispatchMessage(message, senderHandler) {
+    console.log(`${page}: Received message: ${message}`);
+    const {sender, action, arg, search} = parseMessage(message);
+    const actionHandlers = senderHandler[sender];
+    if (actionHandlers) {
+        if (typeof actionHandlers === "function") {
+            actionHandlers({action, arg, search});
+        } else {
+            const handler = actionHandlers[action];
+            if (handler) {
+                handler({arg, search});
+            }
+        }
+    }
+}
+
+function forwardMessageToOpener(message) {
+    if (!window.opener) {
+        console.error("forwardMessageToOpener: window.opener is not defined");
+        return;
+    }
+    window.opener.postMessage(message, "*");
+}
+
+/* `popup` must be defined in embedding HTML files */
+function sendMessageToPopup(action, arg = "") {
+    if (popup === null || popup === undefined) {
+        console.error("sendMessageToPopup: popup is not defined");
+        return;
+    }
+    sendMessageTo(action, arg, popup);
+}
+
+function sendMessageToOpener(action, arg = "") {
+    if (!window.opener) {
+        console.error("sendMessageToOpener: window.opener is not defined");
+        return;
+    }
+    sendMessageTo(action, arg, window.opener);
+}
+
+function sendMessageToTop(action, arg = "") {
+    if (!window.top) {
+        console.error("sendMessageToTop: window.top is not defined");
+        return;
+    }
+    sendMessageTo(action, arg, window.top);
+}
+
+/* `iframeId` must be defined in embedding HTML files */
+function iframeContentWindow() {
+    if (iframeId === null || iframeId === undefined) {
+        console.error("getIframe: iframeId is not defined");
+        return;
+    }
+    return document.getElementById(iframeId).contentWindow;
+
+}
+
+function sendMessageToIframe(action, arg = "") {
+    sendMessageTo(action, arg, iframeContentWindow());
+}
+
+function navigateTo(url) {
+    window.location.href = url;
+}
+
+function navigateIframeTo(url) {
+    iframeContentWindow().location.href = url;
+}

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -143,6 +143,11 @@ void WebBackForwardListFrameItem::setFrameState(Ref<FrameState>&& frameState)
     m_frameState->children.clear();
 }
 
+void WebBackForwardListFrameItem::updateFrameID(FrameIdentifier newFrameID)
+{
+    m_frameState->frameID = newFrameID;
+}
+
 Ref<FrameState> WebBackForwardListFrameItem::copyFrameStateWithChildren()
 {
     Ref frameState = protect(this->frameState())->copy();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -66,6 +66,8 @@ public:
     void setChild(Ref<FrameState>&&);
     void clearChildren() { m_children.clear(); }
 
+    void updateFrameID(WebCore::FrameIdentifier);
+
     void setWasRestoredFromSession();
 
     String loggingString();

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -217,4 +217,12 @@ String WebBackForwardListItem::loggingString()
     return m_mainFrameItem->loggingString();
 }
 
+void WebBackForwardListItem::updateFrameID(FrameIdentifier oldFrameID, FrameIdentifier newFrameID)
+{
+    if (RefPtr frameItem = m_mainFrameItem->childItemForFrameID(oldFrameID))
+        frameItem->updateFrameID(newFrameID);
+    if (m_navigatedFrameID && *m_navigatedFrameID == oldFrameID)
+        m_navigatedFrameID = newFrameID;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -104,6 +104,8 @@ public:
     void setEnhancedSecurity(EnhancedSecurity state) { m_enhancedSecurity = state; }
     EnhancedSecurity enhancedSecurity() const { return m_enhancedSecurity; }
 
+    void updateFrameID(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
+
 private:
     WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, BrowsingContextGroup*);
 
@@ -116,7 +118,7 @@ private:
 
     const WebCore::BackForwardItemIdentifier m_identifier;
     const Ref<WebBackForwardListFrameItem> m_mainFrameItem;
-    const Markable<WebCore::FrameIdentifier> m_navigatedFrameID;
+    Markable<WebCore::FrameIdentifier> m_navigatedFrameID;
     URL m_resourceDirectoryURL;
     const WebPageProxyIdentifier m_pageID;
     WebCore::ProcessIdentifier m_lastProcessIdentifier;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -706,8 +706,19 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
             protect(webPageProxy->backForwardCache())->removeEntry(*item);
         }
 
+        auto oldFrameID = frameItem->frameID();
         frameItem->setFrameState(WTF::move(frameState));
+        auto newFrameID = frameItem->frameID();
+
+        if (oldFrameID && newFrameID && oldFrameID != newFrameID)
+            updateAllFrameIDs(*oldFrameID, *newFrameID);
     }
+}
+
+void WebBackForwardList::updateAllFrameIDs(FrameIdentifier oldFrameID, FrameIdentifier newFrameID)
+{
+    for (auto& entry : m_entries)
+        entry->updateFrameID(oldFrameID, newFrameID);
 }
 
 void WebBackForwardList::backForwardGoToItem(BackForwardItemIdentifier itemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -109,6 +109,8 @@ private:
     WebBackForwardListCounts counts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
 
+    void updateAllFrameIDs(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
+
     // IPC messages
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);
     void backForwardSetChildItem(WebCore::BackForwardFrameItemIdentifier, Ref<FrameState>&&);


### PR DESCRIPTION
#### 667fcac3eb769a6538493ddddea064a41650069f
<pre>
Iframe history not restored on back navigation with BFCache off.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306554">https://bugs.webkit.org/show_bug.cgi?id=306554</a>
<a href="https://rdar.apple.com/169197828">rdar://169197828</a>

Reviewed by Sihui Liu.

When navigating back through browser history with iframes (BFCache OFF), the iframe&apos;s
content is not restored to its previous state. The browser&apos;s loading indicator continues
spinning indefinitely.

When WebBackForwardListFrameItem is updated with new FrameState, other frame ID stored in
WebBackForwardList should be updated accordingly. This patch implements the necessary
mechanism to propagate frame state updates to all relevant back-forward list items.

New tests: http/tests/navigation/back-iframe-no-bf-cache.html

* LayoutTests/http/tests/navigation/back-iframe-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html: Added.
* LayoutTests/http/tests/navigation/resources/back-iframe-1.html: Added.
* LayoutTests/http/tests/navigation/resources/back-iframe-2.html: Added.
* LayoutTests/http/tests/navigation/resources/back-iframe-other.html: Added.
* LayoutTests/http/tests/navigation/resources/back-iframe-popup.html: Added.
* LayoutTests/http/tests/navigation/resources/navigation-utils.js: Added.
(makeMessage):
(parseMessage):
(sendMessageTo):
(dispatchMessage):
(forwardMessageToOpener):
(sendMessageToPopup):
(sendMessageToOpener):
(sendMessageToTop):
(iframeContentWindow):
(sendMessageToIframe):
(navigateTo):
(navigateIframeTo):
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::updateFrameID):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::updateFrameID):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardUpdateItem):
(WebKit::WebBackForwardList::updateAllFrameIDs):
* Source/WebKit/UIProcess/WebBackForwardList.h:

Canonical link: <a href="https://commits.webkit.org/306580@main">https://commits.webkit.org/306580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb0bf92ba41f8d652a009c0e366e150bc6b46129

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150303 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94850 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6144753b-7af4-4506-ab0d-b5c1ac2493f6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108918 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/927641e1-f49e-4cb9-bc90-fa4c0d7e032d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126858 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89813 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99d67b18-3449-4813-b367-05b2542c64da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11008 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8646 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/376 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152696 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117013 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117335 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13371 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69414 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13844 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2845 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13583 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13630 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->