### PR TITLE
Shrink containerNode by using first child's previous sibling pointer

### DIFF
--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -2699,6 +2699,9 @@ inline void SelectorCodeGenerator::generateWalkToNextAdjacentElement(Assembler::
 inline void SelectorCodeGenerator::generateWalkToPreviousAdjacentElement(Assembler::JumpList& failureCases, Assembler::RegisterID workRegister)
 {
     Assembler::Label loopStart = m_assembler.label();
+
+    failureCases.append(m_assembler.branchTest32(Assembler::NonZero, Assembler::Address(workRegister, Node::stateFlagsMemoryOffset()), Assembler::TrustedImm32(Node::flagIsFirstChild())));
+
     m_assembler.loadPtr(Assembler::Address(workRegister, Node::previousSiblingMemoryOffset()), workRegister);
     failureCases.append(m_assembler.branchTestPtr(Assembler::Zero, workRegister));
     DOMJIT::branchTestIsElementFlagOnNode(m_assembler, Assembler::Zero, workRegister).linkTo(loopStart, &m_assembler);

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -31,6 +31,7 @@
 #include "CommonAtomStrings.h"
 #include "CommonVM.h"
 #include "ContainerNodeAlgorithms.h"
+#include "ContainerNodeInlines.h"
 #include "DocumentInlines.h"
 #include "DocumentQuirks.h"
 #include "Editor.h"
@@ -77,7 +78,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ContainerNode);
 
 struct SameSizeAsContainerNode : public Node {
     void* firstChild;
-    void* lastChild;
 };
 
 static_assert(sizeof(ContainerNode) == sizeof(SameSizeAsContainerNode), "ContainerNode should stay small");
@@ -612,18 +612,20 @@ void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
     ASSERT(!newChild.isShadowRoot());
 
     RefPtr previousSibling = nextChild.previousSibling();
-    ASSERT(m_lastChild != previousSibling.get());
-    nextChild.setPreviousSibling(&newChild);
     if (previousSibling) {
         ASSERT(m_firstChild != &nextChild);
         ASSERT(previousSibling->nextSibling() == &nextChild);
+        nextChild.setPreviousSibling(&newChild);
         previousSibling->setNextSibling(&newChild);
+        newChild.setPreviousSibling(previousSibling.get());
     } else {
         ASSERT(m_firstChild == &nextChild);
-        m_firstChild = &newChild;
+        updateFirstChild(&newChild);
+        newChild.setIsFirstChild(true);
+        nextChild.setIsFirstChild(false);
+        nextChild.setPreviousSibling(&newChild);
     }
     newChild.setParentNode(this);
-    newChild.setPreviousSibling(previousSibling.get());
     newChild.setNextSibling(&nextChild);
 }
 
@@ -633,13 +635,15 @@ void ContainerNode::appendChildCommon(Node& child)
 
     child.setParentNode(this);
 
-    if (RefPtr lastChild = this->lastChild()) {
-        child.setPreviousSibling(lastChild.get());
-        lastChild->setNextSibling(&child);
-    } else
-        m_firstChild = &child;
+    if (RefPtr last = lastChild()) {
+        child.setPreviousSibling(last);
+        last->setNextSibling(&child);
+    } else {
+        child.setIsFirstChild(true);
+        updateFirstChild(&child);
+    }
 
-    m_lastChild = &child;
+    updateLastChild(&child);
 }
 
 void ContainerNode::parserInsertBefore(Node& newChild, Node& nextChild)
@@ -787,25 +791,26 @@ void ContainerNode::removeBetween(Node* previousChild, Node* nextChild, Node& ol
     if (hasShadowRootContainingSlots()) [[unlikely]]
         shadowRoot()->willRemoveAssignedNode(oldChild);
 
-    if (nextChild) {
+    if (nextChild)
         nextChild->setPreviousSibling(previousChild);
-        oldChild.setNextSibling(nullptr);
-    } else {
-        ASSERT(m_lastChild == &oldChild);
-        m_lastChild = previousChild;
-    }
-    if (previousChild) {
+    if (previousChild)
         previousChild->setNextSibling(nextChild);
-        oldChild.setPreviousSibling(nullptr);
-    } else {
-        ASSERT(m_firstChild == &oldChild);
-        m_firstChild = nextChild;
+
+    if (m_firstChild == &oldChild) {
+        updateFirstChild(nextChild);
+        if (nextChild)
+            nextChild->setIsFirstChild(true);
     }
 
+    if (lastChild() == &oldChild)
+        updateLastChild(previousChild);
+
+    oldChild.setIsFirstChild(false);
+    oldChild.setPreviousSibling(nullptr);
+    oldChild.setNextSibling(nullptr);
+
     ASSERT(m_firstChild != &oldChild);
-    ASSERT(m_lastChild != &oldChild);
-    ASSERT(!oldChild.previousSibling());
-    ASSERT(!oldChild.nextSibling());
+    ASSERT(lastChild() != &oldChild);
     oldChild.setParentNode(nullptr);
 
     oldChild.setTreeScopeRecursively(document());

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -42,10 +42,9 @@ public:
 
     Node* firstChild() const { return m_firstChild; }
     static constexpr ptrdiff_t firstChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_firstChild); }
-    Node* lastChild() const { return m_lastChild; }
-    static constexpr ptrdiff_t lastChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_lastChild); }
+    Node* lastChild() const { return m_firstChild ? m_firstChild->lastChildForParent() : nullptr; }
     bool hasChildNodes() const { return m_firstChild; }
-    bool hasOneChild() const { return m_firstChild && m_firstChild == m_lastChild; }
+    bool hasOneChild() const { return m_firstChild && m_firstChild == m_firstChild->lastChildForParent(); }
 
     bool directChildNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
     void setDirectChildNeedsStyleRecalc() { setStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
@@ -156,8 +155,8 @@ protected:
     friend void removeDetachedChildrenInContainer(ContainerNode&);
 
     void removeDetachedChildren();
-    void setFirstChild(Node* child) { m_firstChild = child; }
-    void setLastChild(Node* child) { m_lastChild = child; }
+    inline void updateFirstChild(Node*);
+    inline void updateLastChild(Node*);
 
     HTMLCollection* cachedHTMLCollection(CollectionType);
 
@@ -187,7 +186,6 @@ private:
     bool isContainerNode() const = delete;
 
     CheckedPtr<Node> m_firstChild;
-    CheckedPtr<Node> m_lastChild;
 };
 
 inline ContainerNode::ContainerNode(Document& document, NodeType type, OptionSet<TypeFlag> typeFlags)

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -27,6 +27,7 @@
 #include "ContainerNodeAlgorithms.h"
 
 #include "AsyncNodeDeletionQueueInlines.h"
+#include "ContainerNodeInlines.h"
 #include "ElementChildIteratorInlines.h"
 #include "ElementRareData.h"
 #include "HTMLFrameOwnerElement.h"
@@ -164,7 +165,8 @@ RemovedSubtreeResult notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTre
 
 void removeDetachedChildrenInContainer(ContainerNode& container)
 {
-    container.setLastChild(nullptr);
+    if (container.firstChild())
+        container.updateLastChild(nullptr);
 
     RefPtr<Node> next;
     for (RefPtr node = container.firstChild(); node; node = WTF::move(next)) {
@@ -173,7 +175,7 @@ void removeDetachedChildrenInContainer(ContainerNode& container)
         next = node->nextSibling();
         node->setNextSibling(nullptr);
         node->setParentNode(nullptr);
-        container.setFirstChild(next.get());
+        container.m_firstChild = next.get();
         if (next)
             next->setPreviousSibling(nullptr);
 

--- a/Source/WebCore/dom/ContainerNodeInlines.h
+++ b/Source/WebCore/dom/ContainerNodeInlines.h
@@ -47,4 +47,17 @@ inline CheckedPtr<RenderElement> ContainerNode::checkedRenderer() const
     return renderer();
 }
 
+inline void ContainerNode::updateFirstChild(Node* child)
+{
+    if (child)
+        child->setPreviousSibling(lastChild());
+    m_firstChild = child;
+}
+
+inline void ContainerNode::updateLastChild(Node* child)
+{
+    ASSERT(m_firstChild);
+    m_firstChild->setPreviousSibling(child);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -170,7 +170,12 @@ public:
     ContainerNode* parentNode() const;
     static constexpr ptrdiff_t parentNodeMemoryOffset() { return OBJECT_OFFSETOF(Node, m_parentNode); }
     inline Element* parentElement() const;
-    Node* previousSibling() const { return m_previousSibling; }
+    inline Node* previousSibling() const;
+    Node* lastChildForParent() const
+    {
+        ASSERT(hasStateFlag(StateFlag::IsFirstChild));
+        return m_previousSibling;
+    }
     static constexpr ptrdiff_t previousSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_previousSibling); }
     Node* nextSibling() const { return m_next; }
     static constexpr ptrdiff_t nextSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_next); }
@@ -375,6 +380,9 @@ public:
 
     bool isUserActionElement() const { return hasStateFlag(StateFlag::IsUserActionElement); }
     void setUserActionElement(bool flag) { setStateFlag(StateFlag::IsUserActionElement, flag); }
+
+    bool isFirstChild() const { return hasStateFlag(StateFlag::IsFirstChild); }
+    void setIsFirstChild(bool flag) { setStateFlag(StateFlag::IsFirstChild, flag); }
 
     bool inRenderedDocument() const;
     bool needsStyleRecalc() const { return styleValidity() != Style::Validity::Valid || hasInvalidRenderer(); }
@@ -622,6 +630,7 @@ public:
     static auto flagIsHTML() { return enumToUnderlyingType(TypeFlag::IsHTMLElement); }
     static auto flagIsLink() { return enumToUnderlyingType(StateFlag::IsLink); }
     static auto flagIsParsingChildren() { return enumToUnderlyingType(StateFlag::IsParsingChildren); }
+    static auto flagIsFirstChild() { return enumToUnderlyingType(StateFlag::IsFirstChild); }
 #endif // ENABLE(JIT)
 
 #if ASSERT_ENABLED
@@ -683,8 +692,9 @@ protected:
         InLargestContentfulPaintTextContentSet = 1 << 21,
         DidMutateSubtreeAfterSetInnerHTML = 1 << 22,
         WasParsedWithFastPath = 1 << 23,
-        HasShadowRoot = 1 << 24
-        // 7 bits free.
+        HasShadowRoot = 1 << 24,
+        IsFirstChild = 1 << 25
+        // 6 bits free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -276,4 +276,11 @@ inline void collectChildNodes(Node& node, NodeVector& children)
         children.append(*child);
 }
 
+inline Node* Node::previousSibling() const
+{
+    if (hasStateFlag(StateFlag::IsFirstChild))
+        return nullptr;
+    return m_previousSibling;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/RangeBoundaryPoint.h
+++ b/Source/WebCore/dom/RangeBoundaryPoint.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/BoundaryPoint.h>
 #include <WebCore/CharacterData.h>
+#include <WebCore/ContainerNodeInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/domjit/JSNodeDOMJIT.cpp
+++ b/Source/WebCore/domjit/JSNodeDOMJIT.cpp
@@ -93,8 +93,36 @@ Ref<JSC::DOMJIT::CallDOMGetterSnippet> compileNodeFirstChildAttribute()
 
 Ref<JSC::DOMJIT::CallDOMGetterSnippet> compileNodeLastChildAttribute()
 {
-    SUPPRESS_MEMORY_UNSAFE_CAST auto containerNodeOffset = CAST_OFFSET(Node*, ContainerNode*);
-    auto snippet = createCallDOMGetterForOffsetAccess<Node>(containerNodeOffset + ContainerNode::lastChildMemoryOffset(), DOMJIT::operationToJSNode, IsContainerGuardRequirement::Required);
+    Ref<JSC::DOMJIT::CallDOMGetterSnippet> snippet = JSC::DOMJIT::CallDOMGetterSnippet::create();
+    snippet->numGPScratchRegisters = 1;
+    snippet->setGenerator([=](CCallHelpers& jit, JSC::SnippetParams& params) {
+        JSValueRegs result = params[0].jsValueRegs();
+        GPRReg node = params[1].gpr();
+        GPRReg globalObject = params[2].gpr();
+        GPRReg scratch = params.gpScratch(0);
+        JSValue globalObjectValue = params[2].value();
+
+        CCallHelpers::JumpList nullCases;
+
+        jit.loadPtr(CCallHelpers::Address(node, JSNode::offsetOfWrapped()), scratch);
+        static_assert(!JSNode::hasCustomPtrTraits(), "Optimized JSNode wrapper access should not be using RawPtrTraits");
+
+        nullCases.append(jit.branchTest16(CCallHelpers::Zero, CCallHelpers::Address(scratch, Node::typeFlagsMemoryOffset()), CCallHelpers::TrustedImm32(Node::flagIsContainer())));
+
+        RELEASE_ASSERT_NOT_CAST_OFFSET(Node*, ContainerNode*);
+        jit.loadPtr(CCallHelpers::Address(scratch, ContainerNode::firstChildMemoryOffset()), scratch);
+        nullCases.append(jit.branchTestPtr(CCallHelpers::Zero, scratch));
+
+        jit.loadPtr(CCallHelpers::Address(scratch, Node::previousSiblingMemoryOffset()), scratch);
+
+        DOMJIT::toWrapper<Node>(jit, params, scratch, globalObject, result, DOMJIT::operationToJSNode, globalObjectValue);
+        CCallHelpers::Jump done = jit.jump();
+
+        nullCases.link(&jit);
+        jit.moveValue(jsNull(), result);
+        done.link(&jit);
+        return CCallHelpers::JumpList();
+    });
     snippet->effect = JSC::DOMJIT::Effect::forDef(DOMJIT::AbstractHeapRepository::Node_lastChild);
     return snippet;
 }
@@ -108,7 +136,36 @@ Ref<JSC::DOMJIT::CallDOMGetterSnippet> compileNodeNextSiblingAttribute()
 
 Ref<JSC::DOMJIT::CallDOMGetterSnippet> compileNodePreviousSiblingAttribute()
 {
-    auto snippet = createCallDOMGetterForOffsetAccess<Node>(Node::previousSiblingMemoryOffset(), DOMJIT::operationToJSNode, IsContainerGuardRequirement::NotRequired);
+    Ref<JSC::DOMJIT::CallDOMGetterSnippet> snippet = JSC::DOMJIT::CallDOMGetterSnippet::create();
+    snippet->numGPScratchRegisters = 2;
+    snippet->setGenerator([=](CCallHelpers& jit, JSC::SnippetParams& params) {
+        JSValueRegs result = params[0].jsValueRegs();
+        GPRReg node = params[1].gpr();
+        GPRReg globalObject = params[2].gpr();
+        GPRReg scratch = params.gpScratch(0);
+        GPRReg flagsReg = params.gpScratch(1);
+        JSValue globalObjectValue = params[2].value();
+
+        CCallHelpers::JumpList nullCases;
+
+        jit.loadPtr(CCallHelpers::Address(node, JSNode::offsetOfWrapped()), scratch);
+        static_assert(!JSNode::hasCustomPtrTraits(), "Optimized JSNode wrapper access should not be using RawPtrTraits");
+
+        jit.load32(CCallHelpers::Address(scratch, Node::stateFlagsMemoryOffset()), flagsReg);
+        jit.loadPtr(CCallHelpers::Address(scratch, Node::previousSiblingMemoryOffset()), scratch);
+
+        jit.moveConditionallyTest32(CCallHelpers::NonZero, flagsReg, CCallHelpers::TrustedImm32(Node::flagIsFirstChild()), CCallHelpers::TrustedImm32(0), scratch, scratch);
+
+        nullCases.append(jit.branchTestPtr(CCallHelpers::Zero, scratch));
+
+        DOMJIT::toWrapper<Node>(jit, params, scratch, globalObject, result, DOMJIT::operationToJSNode, globalObjectValue);
+        CCallHelpers::Jump done = jit.jump();
+
+        nullCases.link(&jit);
+        jit.moveValue(jsNull(), result);
+        done.link(&jit);
+        return CCallHelpers::JumpList();
+    });
     snippet->effect = JSC::DOMJIT::Effect::forDef(DOMJIT::AbstractHeapRepository::Node_previousSibling);
     return snippet;
 }


### PR DESCRIPTION
#### c8cd2e51be0af1d3ef23c5c8eb36a54842a9cd63
<pre>
Shrink containerNode by using first child&apos;s previous sibling pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=306641">https://bugs.webkit.org/show_bug.cgi?id=306641</a>
<a href="https://rdar.apple.com/168261386">rdar://168261386</a>

Reviewed by NOBODY (OOPS!).

Use a circular reference so that firstChild-&gt;previousSibling points to
lastChild, saving 16 bytes per ContainerNode. Update DOM JIT and CSS JIT
to handle the new previousSibling semantics.

ContainerNode was previously 104 bytes but took up 112 bytes due to
libpas byte alignment. With this change ContainerNode now needs 96 bytes.
This progresses SP3 by ~0.15% overall with +0.27% in ES6, +0.74% in
Lit-Complex-DOM, +0.56% in Svelte-Complex-DOM, and +0.60% in jQuery.

No tests included as there is no behavior change introduced here.
Correctness will be verified with the existing test suite.

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::SelectorCodeGenerator::generateWalkToPreviousAdjacentElement):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::insertBeforeCommon):
(WebCore::ContainerNode::appendChildCommon):
(WebCore::ContainerNode::removeBetween):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::lastChild const):
(WebCore::ContainerNode::hasOneChild const):
(WebCore::ContainerNode::lastChildMemoryOffset): Deleted.
(WebCore::ContainerNode::setFirstChild):
(WebCore::ContainerNode::setLastChild):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::removeDetachedChildrenInContainer):
* Source/WebCore/dom/ContainerNodeInlines.h:
(WebCore::ContainerNode::updateFirstChild):
(WebCore::ContainerNode::updateLastChild):
* Source/WebCore/dom/Node.h:
(WebCore::Node::lastChildForParent const):
(WebCore::Node::isFirstChild const):
(WebCore::Node::setIsFirstChild):
(WebCore::Node::flagIsFirstChild):
(WebCore::Node::previousSibling const): Deleted.
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::previousSibling const):
* Source/WebCore/dom/RangeBoundaryPoint.h:
* Source/WebCore/domjit/JSNodeDOMJIT.cpp:
(WebCore::compileNodeLastChildAttribute):
(WebCore::compileNodePreviousSiblingAttribute):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8cd2e51be0af1d3ef23c5c8eb36a54842a9cd63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15841 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8087 "Failed to checkout and rebase branch from PR 57580") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152037 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96607 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15928 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110265 "Found 54 new test failures: editing/text-iterator/find-string-on-flat-tree.html imported/w3c/web-platform-tests/dom/nodes/Node-compareDocumentPosition.html imported/w3c/web-platform-tests/dom/traversal/NodeIterator-removal.html imported/w3c/web-platform-tests/dom/traversal/TreeWalker.html imported/w3c/web-platform-tests/editing/run/bold.html?1-1000 imported/w3c/web-platform-tests/editing/run/bold.html?1001-2000 imported/w3c/web-platform-tests/editing/run/bold.html?2001-3000 imported/w3c/web-platform-tests/editing/run/bold.html?3001-last imported/w3c/web-platform-tests/editing/run/delete.html?1-1000 imported/w3c/web-platform-tests/editing/run/delete.html?1001-2000 ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79393 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12219 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9935 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2038 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154347 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6898 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118284 "Found 54 new test failures: editing/text-iterator/find-string-on-flat-tree.html imported/w3c/web-platform-tests/dom/nodes/Node-compareDocumentPosition.html imported/w3c/web-platform-tests/dom/traversal/NodeIterator-removal.html imported/w3c/web-platform-tests/dom/traversal/NodeIterator.html imported/w3c/web-platform-tests/dom/traversal/TreeWalker.html imported/w3c/web-platform-tests/editing/run/bold.html?1-1000 imported/w3c/web-platform-tests/editing/run/bold.html?1001-2000 imported/w3c/web-platform-tests/editing/run/bold.html?2001-3000 imported/w3c/web-platform-tests/editing/run/bold.html?3001-last imported/w3c/web-platform-tests/editing/run/delete.html?1-1000 ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118625 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14572 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71307 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15513 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5557 "Unable to confirm if test failures are introduced by change, retrying build") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15250 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79236 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->