### PR TITLE
[GFC] Add some initial logic to support track sizing with auto track sizing functions

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -234,7 +234,7 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
             return root().style().alignItems().resolve();
         };
 
-        PlacedGridItem::ComputedSizes inlineAxisSizes {
+        ComputedSizes inlineAxisSizes {
             gridItemStyle->width(),
             gridItemStyle->minWidth(),
             gridItemStyle->maxWidth(),
@@ -242,7 +242,7 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
             gridItemStyle->marginRight()
         };
 
-        PlacedGridItem::ComputedSizes blockAxisSizes {
+        ComputedSizes blockAxisSizes {
             gridItemStyle->height(),
             gridItemStyle->minHeight(),
             gridItemStyle->maxHeight(),

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -403,6 +403,24 @@ GridItemSizingFunctions blockAxisGridItemSizingFunctions()
     return { blockAxisMinContentContribution, blockAxisMaxContentContribution };
 }
 
+bool preferredSizeBehavesAsAuto(const Style::PreferredSize& preferredSize)
+{
+    return WTF::switchOn(preferredSize,
+        [](const CSS::Keyword::Auto&) {
+            return true;
+        },
+        [](const auto&) {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return false;
+    });
+}
+
+bool preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize&)
+{
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return false;
+}
+
 }
 }
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -55,6 +55,9 @@ LayoutUnit blockAxisMinContentContribution(const ElementBox& gridItem, const Int
 LayoutUnit blockAxisMaxContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
 GridItemSizingFunctions blockAxisGridItemSizingFunctions();
 
+bool preferredSizeBehavesAsAuto(const Style::PreferredSize&);
+bool preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize&);
+
 } // namespace GridLayoutUtils
 } // namespace Layout
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
@@ -39,6 +39,7 @@ namespace Layout {
 class PlacedGridItem;
 class UnplacedGridItem;
 
+struct ComputedSizes;
 struct GridAreaLines;
 struct GridItemRect;
 struct TrackSizingFunctions;
@@ -49,6 +50,7 @@ using BorderBoxPositions = Vector<LayoutUnit>;
 using FlexTracks = Vector<FlexTrack>;
 using GridAreas = HashMap<UnplacedGridItem, GridAreaLines>;
 using GridCell = Vector<UnplacedGridItem, 1>;
+using ComputedSizesList = Vector<ComputedSizes>;
 using GridItemRects = Vector<GridItemRect>;
 using GridMatrix = Vector<Vector<GridCell>>;
 using PlacedGridItems = Vector<PlacedGridItem>;

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -39,17 +39,17 @@ namespace Layout {
 
 class UnplacedGridItem;
 
+struct ComputedSizes {
+    Style::PreferredSize preferredSize;
+    Style::MinimumSize minimumSize;
+    Style::MaximumSize maximumSize;
+
+    Style::MarginEdge marginStart;
+    Style::MarginEdge marginEnd;
+};
+
 class PlacedGridItem {
 public:
-    struct ComputedSizes {
-        Style::PreferredSize preferredSize;
-        Style::MinimumSize minimumSize;
-        Style::MaximumSize maximumSize;
-
-        Style::MarginEdge marginStart;
-        Style::MarginEdge marginEnd;
-    };
-
     PlacedGridItem(const UnplacedGridItem&, GridAreaLines, const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes,
     const StyleSelfAlignmentData& inlineAxisAlignment, const StyleSelfAlignmentData& blockAxisAlignment, const Style::ZoomFactor& usedZoom);
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -48,7 +48,8 @@ struct GridItemSizingFunctions {
 
 class TrackSizingAlgorithm {
 public:
-    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions&, FreeSpaceScenario, const IntegrationUtils&);
+    static TrackSizes sizeTracks(const PlacedGridItems&, const ComputedSizesList&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace,
+        const GridItemSizingFunctions&, const IntegrationUtils&, const FreeSpaceScenario&);
 
 private:
 


### PR DESCRIPTION
#### 9dcd118ed1fb13ed0fa436ff468814a52dffda41
<pre>
[GFC] Add some initial logic to support track sizing with auto track sizing functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306631">https://bugs.webkit.org/show_bug.cgi?id=306631</a>
<a href="https://rdar.apple.com/169291807">rdar://169291807</a>

Reviewed by Alan Baradlay.

With this patch, we should now have some basic logic for each step in the
&quot;Size tracks to fit non-spanning items,&quot; portion of the track sizing
algorithm.
<a href="https://drafts.csswg.org/css-grid-1/#algo-single-span-items">https://drafts.csswg.org/css-grid-1/#algo-single-span-items</a>

This does not mean we can call this section of the spec complete, but in
theory, we should be able to get some form of content running that goes
through this part of the spec (barring any bugs that need to be
resolved).

Similar to 306091@main and 306239@main, in which we added some support
for track sizing with min-content and max-content track sizing
functions, we basically translate the spec text into equivalent code.

One thing that may be notable is that this case is slightly more
complicated than just taking the min-content contribution or max-content
contribution like in the aforementioned patches. We may need to consider
the constraint the grid is being sized in or whether the grid item&apos;s
preferred size behaves as auto. For now, we just implement the simple
case where we take the minimum contribution of the items, which should
just come from the min-content contribution.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructPlacedGridItems const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
We need to start passing in the computed sizes in the appropriate
dimension of the grid items for this new scenario, so we can do a little
bit of refactoring here to accomplish this. Before, we were using
two calls to Vector::map to populate columnSpanList and rowSpanList.
Now, we can just have a single loop that populates the appropriate
structures.

* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h:
Move the ComputedSizes struct outside PlacedGridItem so we can forward
declare it in other places.

Canonical link: <a href="https://commits.webkit.org/306779@main">https://commits.webkit.org/306779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0855cb1dca2ac05e0e0ac54b5d3c9f7b2333b5e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150359 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94896 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b67ac358-dab1-496a-bd8b-1b3694d1bc93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108945 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78780 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f731f9b-4149-4c4b-813a-5429684ecade) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89841 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a6de433-8bf8-41db-9b23-39691ae08156) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11045 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8683 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/431 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120344 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152753 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13846 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117040 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13861 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12081 "Found 1 new test failure: imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/047.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13404 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69508 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13884 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2883 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13623 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77609 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13670 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->