### PR TITLE
Minor scroll anchoring-related cleanup

### DIFF
--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1129,8 +1129,8 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
     }
 
     bool shouldCheckIfInAncestorChain = false;
-    if (frame().settings().cssScrollAnchoringEnabled() && (style().outOfFlowPositionStyleDidChange(oldStyle) || (shouldCheckIfInAncestorChain = style().scrollAnchoringSuppressionStyleDidChange(oldStyle)))) {
-        LOG_WITH_STREAM(ScrollAnchoring, stream << "RenderElement::styleDidChange() found node with style change: " << *this << " from: " << oldStyle->position() <<" to: " << style().position());
+    if (settings().cssScrollAnchoringEnabled() && (style().outOfFlowPositionStyleDidChange(oldStyle) || (shouldCheckIfInAncestorChain = style().scrollAnchoringSuppressionStyleDidChange(oldStyle)))) {
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "RenderElement::styleDidChange() " << diff << " found node with style change: " << *this << " from: " << oldStyle->position() <<" to: " << style().position());
         auto* controller = searchParentChainForScrollAnchoringController(*this);
         if (controller && (!shouldCheckIfInAncestorChain || (shouldCheckIfInAncestorChain && controller->isInScrollAnchoringAncestorChain(*this))))
             controller->notifyChildHadSuppressingStyleChange();

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -97,13 +97,11 @@ RenderLayerScrollableArea::RenderLayerScrollableArea(RenderLayer& layer)
     : m_layer(layer)
 {
     auto& renderer = m_layer.renderer();
-    if (renderer.document().settings().cssScrollAnchoringEnabled() && !is<HTMLHtmlElement>(renderer.element()) && !is<HTMLBodyElement>(renderer.element()))
+    if (renderer.settings().cssScrollAnchoringEnabled() && !is<HTMLHtmlElement>(renderer.element()) && !is<HTMLBodyElement>(renderer.element()))
         m_scrollAnchoringController = WTF::makeUnique<ScrollAnchoringController>(*this);
 }
 
-RenderLayerScrollableArea::~RenderLayerScrollableArea()
-{
-}
+RenderLayerScrollableArea::~RenderLayerScrollableArea() = default;
 
 void RenderLayerScrollableArea::clear()
 {

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -150,12 +150,14 @@ bool RenderStyle::scrollAnchoringSuppressionStyleDidChange(const RenderStyle* ot
         return false;
 
     if (m_computedStyle.m_nonInheritedData->boxData.ptr() != other->m_computedStyle.m_nonInheritedData->boxData.ptr()) {
-        if (m_computedStyle.m_nonInheritedData->boxData->width != other->m_computedStyle.m_nonInheritedData->boxData->width
-            || m_computedStyle.m_nonInheritedData->boxData->minWidth != other->m_computedStyle.m_nonInheritedData->boxData->minWidth
-            || m_computedStyle.m_nonInheritedData->boxData->maxWidth != other->m_computedStyle.m_nonInheritedData->boxData->maxWidth
-            || m_computedStyle.m_nonInheritedData->boxData->height != other->m_computedStyle.m_nonInheritedData->boxData->height
-            || m_computedStyle.m_nonInheritedData->boxData->minHeight != other->m_computedStyle.m_nonInheritedData->boxData->minHeight
-            || m_computedStyle.m_nonInheritedData->boxData->maxHeight != other->m_computedStyle.m_nonInheritedData->boxData->maxHeight)
+        auto& boxData = m_computedStyle.m_nonInheritedData->boxData.get();
+        auto& otherBoxData = other->m_computedStyle.m_nonInheritedData->boxData.get();
+        if (boxData.width != otherBoxData.width
+            || boxData.minWidth != otherBoxData.minWidth
+            || boxData.maxWidth != otherBoxData.maxWidth
+            || boxData.height != otherBoxData.height
+            || boxData.minHeight != otherBoxData.minHeight
+            || boxData.maxHeight != otherBoxData.maxHeight)
             return true;
     }
 
@@ -165,17 +167,19 @@ bool RenderStyle::scrollAnchoringSuppressionStyleDidChange(const RenderStyle* ot
     if (position() != other->position())
         return true;
 
-    if (m_computedStyle.m_nonInheritedData->surroundData.ptr() && other->m_computedStyle.m_nonInheritedData->surroundData.ptr() && m_computedStyle.m_nonInheritedData->surroundData != other->m_computedStyle.m_nonInheritedData->surroundData) {
-        if (m_computedStyle.m_nonInheritedData->surroundData->margin != other->m_computedStyle.m_nonInheritedData->surroundData->margin)
+    if (m_computedStyle.m_nonInheritedData->surroundData.ptr() && other->m_computedStyle.m_nonInheritedData->surroundData.ptr()) {
+        auto& surroundData = m_computedStyle.m_nonInheritedData->surroundData.get();
+        auto& otherSurroundData = other->m_computedStyle.m_nonInheritedData->surroundData.get();
+        if (surroundData.margin != otherSurroundData.margin)
             return true;
 
-        if (m_computedStyle.m_nonInheritedData->surroundData->padding != other->m_computedStyle.m_nonInheritedData->surroundData->padding)
+        if (surroundData.padding != otherSurroundData.padding)
             return true;
-    }
 
-    if (position() != PositionType::Static) {
-        if (m_computedStyle.m_nonInheritedData->surroundData->inset != other->m_computedStyle.m_nonInheritedData->surroundData->inset)
-            return true;
+        if (position() != PositionType::Static) {
+            if (surroundData.inset != otherSurroundData.inset)
+                return true;
+        }
     }
 
     if (hasTransformRelatedProperty() != other->hasTransformRelatedProperty() || transform() != other->transform())


### PR DESCRIPTION
#### 4e3ab311a0860db4a96297e9b4927c58d09253d4
<pre>
Minor scroll anchoring-related cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=306648">https://bugs.webkit.org/show_bug.cgi?id=306648</a>
<a href="https://rdar.apple.com/169302450">rdar://169302450</a>

Reviewed by Alan Baradlay.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange): Get `settings()` via the renderer; log the style diff.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::RenderLayerScrollableArea): Get `settings()` via the renderer.
(WebCore::RenderLayerScrollableArea::~RenderLayerScrollableArea): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::scrollAnchoringSuppressionStyleDidChange const): Put boxData etc. into local variables.

Canonical link: <a href="https://commits.webkit.org/306527@main">https://commits.webkit.org/306527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5024b3358d2f008a049b7ee3429e19b290c1e570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150178 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc9bfcd0-6882-4ca4-b9dd-565b41c9c9f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143473 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108813 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc636e29-0a64-41c1-a91e-a2af7bf19d9e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11363 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89714 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e05d809c-883f-4f06-9200-2603172137ae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8548 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/251 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152571 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13681 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116914 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117240 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29866 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13278 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123455 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/68882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13719 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2746 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13458 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13661 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13505 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->