### PR TITLE
[Scroll anchoring] Eliminate the invalidateScrollAnchoringElement/updateScrollAnchoringElement pattern

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3204,7 +3204,7 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
 
     if (layoutOptions.contains(LayoutOptions::IgnorePendingStylesheets)) {
         if (RefPtr frameView = view())
-            frameView->updateScrollAnchoringPositionForScrollableAreas();
+            frameView->adjustScrollAnchoringPositionForScrollableAreas();
     }
 
     m_ignorePendingStylesheets = oldIgnore;
@@ -6009,7 +6009,7 @@ void Document::runScrollSteps()
             protectedPage()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
 
         frameView->updateScrollAnchoringElementsForScrollableAreas();
-        frameView->updateScrollAnchoringPositionForScrollableAreas();
+        frameView->adjustScrollAnchoringPositionForScrollableAreas();
     }
 
     // FIXME: The order of dispatching is not specified: https://github.com/WICG/visual-viewport/issues/66.

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -739,12 +739,8 @@ public:
     void dequeueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
     void queueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
     void updateScrollAnchoringElementsForScrollableAreas();
-    void updateScrollAnchoringPositionForScrollableAreas();
-
-    void updateScrollAnchoringElement() final;
-    void updateScrollPositionForScrollAnchoringController() final;
-    void invalidateScrollAnchoringElement() final;
-    ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
+    void adjustScrollAnchoringPositionForScrollableAreas();
+    ScrollAnchoringController* scrollAnchoringController() const final { return m_scrollAnchoringController.get(); }
 
     void updateAnchorPositionedAfterScroll() final;
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -29,6 +29,7 @@
 #include <WebCore/Element.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/ScrollTypes.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -42,23 +43,27 @@ enum class CandidateExaminationResult {
     Exclude, Select, Descend, Skip
 };
 
-class ScrollAnchoringController {
+class ScrollAnchoringController : public CanMakeCheckedPtr<ScrollAnchoringController> {
     WTF_MAKE_TZONE_ALLOCATED(ScrollAnchoringController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollAnchoringController);
 public:
     explicit ScrollAnchoringController(ScrollableArea&);
     ~ScrollAnchoringController();
-    void invalidateAnchorElement();
+
     void adjustScrollPositionForAnchoring();
-    void chooseAnchorElement(Document&);
     CandidateExaminationResult examineAnchorCandidate(Element&);
+
+    void invalidateAnchorElement();
     void updateAnchorElement();
+
     void notifyChildHadSuppressingStyleChange();
     bool isInScrollAnchoringAncestorChain(const RenderObject&);
 
     Element* anchorElement() const { return m_anchorElement.get(); }
 
-
 private:
+    void chooseAnchorElement(Document&);
+
     Element* findAnchorElementRecursive(Element*);
     bool didFindPriorityCandidate(Document&);
     FloatPoint computeOffsetFromOwningScroller(RenderObject&);

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -248,7 +248,6 @@ bool ScrollAnimator::handleTouchEvent(const PlatformTouchEvent&)
 
 static void notifyScrollAnchoringControllerOfScroll(ScrollableArea& scrollableArea)
 {
-    scrollableArea.invalidateScrollAnchoringElement();
     scrollableArea.updateScrollAnchoringElement();
 }
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -259,7 +259,7 @@ void ScrollableArea::scrollPositionChanged(const ScrollPosition& position)
 
     if (scrollPosition() != oldPosition) {
         scrollbarsController().notifyContentAreaScrolled(scrollPosition() - oldPosition);
-        invalidateScrollAnchoringElement();
+
         updateScrollAnchoringElement();
         updateAnchorPositionedAfterScroll();
     }
@@ -279,6 +279,24 @@ bool ScrollableArea::handleWheelEventForScrolling(const PlatformWheelEvent& whee
 void ScrollableArea::stopKeyboardScrollAnimation()
 {
     scrollAnimator().stopKeyboardScrollAnimation();
+}
+
+void ScrollableArea::updateScrollAnchoringElement(ComputeNewScrollAnchor computeNewScrollAnchor)
+{
+    CheckedPtr controller = scrollAnchoringController();
+    if (!controller)
+        return;
+
+    if (computeNewScrollAnchor == ComputeNewScrollAnchor::Yes)
+        controller->invalidateAnchorElement();
+
+    controller->updateAnchorElement();
+}
+
+void ScrollableArea::adjustScrollAnchoringPosition()
+{
+    if (CheckedPtr controller = scrollAnchoringController())
+        controller->adjustScrollPositionForAnchoring();
 }
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -423,12 +423,23 @@ public:
     bool overscrollBehaviorAllowsRubberBand() const { return horizontalOverscrollBehavior() != OverscrollBehavior::None || verticalOverscrollBehavior() != OverscrollBehavior::None; }
     bool shouldBlockScrollPropagation(const FloatSize&) const;
     FloatSize deltaForPropagation(const FloatSize&) const;
+
     WEBCORE_EXPORT virtual float adjustVerticalPageScrollStepForFixedContent(float step);
+
     virtual bool needsAnimatedScroll() const { return false; }
-    virtual void updateScrollAnchoringElement() { }
-    virtual void updateScrollPositionForScrollAnchoringController() { }
-    virtual void invalidateScrollAnchoringElement() { }
+
+    // Anchor positioning
     virtual void updateAnchorPositionedAfterScroll() { }
+
+    // Scroll anchoring
+    enum class ComputeNewScrollAnchor : bool {
+        No,
+        Yes
+    };
+    void updateScrollAnchoringElement(ComputeNewScrollAnchor = ComputeNewScrollAnchor::Yes);
+    void adjustScrollAnchoringPosition();
+    virtual ScrollAnchoringController* scrollAnchoringController() const { return nullptr; }
+
     virtual std::optional<FrameIdentifier> rootFrameID() const { return std::nullopt; }
 
     WEBCORE_EXPORT void setScrollbarsController(std::unique_ptr<ScrollbarsController>&&);

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -2069,24 +2069,6 @@ float RenderLayerScrollableArea::deviceScaleFactor() const
     return m_layer.renderer().protectedDocument()->deviceScaleFactor();
 }
 
-void RenderLayerScrollableArea::updateScrollAnchoringElement()
-{
-    if (m_scrollAnchoringController)
-        m_scrollAnchoringController->updateAnchorElement();
-}
-
-void RenderLayerScrollableArea::updateScrollPositionForScrollAnchoringController()
-{
-    if (m_scrollAnchoringController)
-        m_scrollAnchoringController->adjustScrollPositionForAnchoring();
-}
-
-void RenderLayerScrollableArea::invalidateScrollAnchoringElement()
-{
-    if (m_scrollAnchoringController)
-        m_scrollAnchoringController->invalidateAnchorElement();
-}
-
 void RenderLayerScrollableArea::updateAnchorPositionedAfterScroll()
 {
     Style::AnchorPositionEvaluator::updateScrollAdjustments(m_layer.renderer().view());

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -260,10 +260,8 @@ public:
     void animatedScrollDidEnd() final;
     LayoutRect scrollRectToVisible(const LayoutRect& absoluteRect, const ScrollRectToVisibleOptions&);
     std::optional<LayoutRect> updateScrollPositionForScrollIntoView(const ScrollPositionChangeOptions&, const LayoutRect& revealRect, const LayoutRect& localExposeRect);
-    void updateScrollAnchoringElement() final;
-    void updateScrollPositionForScrollAnchoringController() final;
-    void invalidateScrollAnchoringElement() final;
-    ScrollAnchoringController* scrollAnchoringController() { return m_scrollAnchoringController.get(); }
+
+    ScrollAnchoringController* scrollAnchoringController() const final { return m_scrollAnchoringController.get(); }
 
     void updateAnchorPositionedAfterScroll() final;
 
@@ -340,7 +338,7 @@ private:
     RenderPtr<RenderScrollbarPart> m_scrollCorner;
     RenderPtr<RenderScrollbarPart> m_resizer;
 
-    std::unique_ptr<RenderMarquee> m_marquee; // Used for <marquee>.
+    std::unique_ptr<RenderMarquee> m_marquee;
 
     std::unique_ptr<ScrollAnchoringController> m_scrollAnchoringController;
 };

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2328,14 +2328,14 @@ ScrollAnchoringController* RenderObject::searchParentChainForScrollAnchoringCont
 {
     if (renderer.hasLayer()) {
         if (auto* scrollableArea = downcast<RenderLayerModelObject>(renderer).layer()->scrollableArea()) {
-            auto controller = scrollableArea->scrollAnchoringController();
+            auto* controller = scrollableArea->scrollAnchoringController();
             if (controller && controller->anchorElement())
                 return controller;
         }
     }
     for (CheckedPtr enclosingLayer = renderer.enclosingLayer(); enclosingLayer; enclosingLayer = enclosingLayer->parent()) {
         if (RenderLayerScrollableArea* scrollableArea = enclosingLayer->scrollableArea()) {
-            auto controller = scrollableArea->scrollAnchoringController();
+            auto* controller = scrollableArea->scrollAnchoringController();
             if (controller && controller->anchorElement())
                 return controller;
         }


### PR DESCRIPTION
#### efdc94274152816082dc0b6183901c9a2728d8c3
<pre>
[Scroll anchoring] Eliminate the invalidateScrollAnchoringElement/updateScrollAnchoringElement pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=306650">https://bugs.webkit.org/show_bug.cgi?id=306650</a>
<a href="https://rdar.apple.com/169303894">rdar://169303894</a>

Reviewed by Tim Nguyen.

A repeating pattern in scroll anchoring code was this:

    invalidateScrollAnchoringElement();
    updateScrollAnchoringElement();

Fix this by adding a `ComputeNewScrollAnchor` argument which defaults to `Yes`.

We can also push code down into ScrollableArea by making scrollAnchoringController() be the virtual
function; other code is common between LocalFrameView and RenderLayerScrollableArea. Now only
ScrollableArea needs to call `invalidateAnchorElement()`.

Rename `updateScrollAnchoringPositionForScrollableAreas()` to `adjustScrollAnchoringPositionForScrollableAreas()`
because there are too many things with &quot;update&quot; in the name.

Make ScrollAnchoringController CheckedPtr compatible.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayout):
(WebCore::Document::runScrollSteps):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::LocalFrameView):
(WebCore::LocalFrameView::setLayoutViewportOverrideRect):
(WebCore::LocalFrameView::scrollOffsetChangedViaPlatformWidgetImpl):
(WebCore::LocalFrameView::updateScrollAnchoringElementsForScrollableAreas):
(WebCore::LocalFrameView::adjustScrollAnchoringPositionForScrollableAreas):
(WebCore::LocalFrameView::scheduleResizeEventIfNeeded):
(WebCore::LocalFrameView::updateScrollAnchoringPositionForScrollableAreas): Deleted.
(WebCore::LocalFrameView::updateScrollAnchoringElement): Deleted.
(WebCore::LocalFrameView::updateScrollPositionForScrollAnchoringController): Deleted.
(WebCore::LocalFrameView::invalidateScrollAnchoringElement): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::invalidateAnchorElement):
(WebCore::ScrollAnchoringController::examineAnchorCandidate):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::notifyScrollAnchoringControllerOfScroll):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollPositionChanged):
(WebCore::ScrollableArea::updateScrollAnchoringElement):
(WebCore::ScrollableArea::adjustScrollAnchoringPosition):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::scrollAnchoringController const):
(WebCore::ScrollableArea::updateScrollAnchoringElement): Deleted.
(WebCore::ScrollableArea::updateScrollPositionForScrollAnchoringController): Deleted.
(WebCore::ScrollableArea::invalidateScrollAnchoringElement): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollAnchoringElement): Deleted.
(WebCore::RenderLayerScrollableArea::updateScrollPositionForScrollAnchoringController): Deleted.
(WebCore::RenderLayerScrollableArea::invalidateScrollAnchoringElement): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::searchParentChainForScrollAnchoringController):

Canonical link: <a href="https://commits.webkit.org/306533@main">https://commits.webkit.org/306533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0a89b897974e0e7c2e21c654b7de96e719d2adb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150183 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20eb1994-9bfe-4416-9050-ed3c4fa7d053) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108821 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bfe4aa3-f3ec-407a-8832-6aba2fab9bb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89722 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10923 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8553 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/256 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120207 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152576 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116919 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13701 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/11947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117247 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13281 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68887 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2750 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13463 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77449 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13666 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->