### PR TITLE
[threaded-animations] WPT test `scroll-animations/view-timelines/timeline-offset-in-keyframe.html` crashes with "Threaded Time-based Animations" enabled

### DIFF
--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -413,6 +413,15 @@ void BlendingKeyframes::updatedComputedOffsets(NOESCAPE const Function<double(co
     std::ranges::stable_sort(m_keyframes, { }, &BlendingKeyframe::offset);
 }
 
+bool BlendingKeyframes::hasKeyframeWithUnresolvedComputedOffset() const
+{
+    for (auto& keyframe : m_keyframes) {
+        if (std::isnan(keyframe.offset()))
+            return true;
+    }
+    return false;
+}
+
 uint64_t BlendingKeyframes::nextAnonymousIdentifier()
 {
     // Start from a random number so acceleratedAnimationName() won't ever collide with an author specified one.

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -162,6 +162,7 @@ public:
     bool hasKeyframeNotUsingRangeOffset() const { return m_hasKeyframeNotUsingRangeOffset; }
 
     void updatedComputedOffsets(NOESCAPE const Function<double(const BlendingKeyframe::Offset&)>&);
+    bool hasKeyframeWithUnresolvedComputedOffset() const;
 
 private:
     void analyzeKeyframe(const BlendingKeyframe&);

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1940,6 +1940,9 @@ bool KeyframeEffect::canBeAccelerated() const
     if (m_blendingKeyframes.hasDiscreteTransformInterval())
         return false;
 
+    if (!m_needsComputedKeyframeOffsetsUpdate && m_blendingKeyframes.hasKeyframeWithUnresolvedComputedOffset())
+        return false;
+
     if (RefPtr document = this->document()) {
         if (document->quirks().shouldPreventKeyframeEffectAcceleration(*this))
             return false;


### PR DESCRIPTION
#### 9b966716d8fae77ba2bbac9bb97a56e7fe03bc91
<pre>
[threaded-animations] WPT test `scroll-animations/view-timelines/timeline-offset-in-keyframe.html` crashes with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306652">https://bugs.webkit.org/show_bug.cgi?id=306652</a>
<a href="https://rdar.apple.com/169304641">rdar://169304641</a>

Reviewed by Simon Fraser.

One of the subtests in the WPT test `scroll-animations/view-timelines/timeline-offset-in-keyframe.html`
sets up an animation as follows:

```
const anim = target.animate([
    { offset: &quot;cover 0%&quot;, opacity: 0 },
    { offset: &quot;cover 100%&quot;, opacity: 1 }
], {
    rangeStart: { rangeName: &apos;contain&apos;, offset: CSS.percent(0) },
    rangeEnd: { rangeName: &apos;contain&apos;, offset: CSS.percent(100) },
    duration: 10000, fill: &apos;both&apos;
});
```

Notice the `offset` keys on the keyframes object using view progress timelines ranges [0]
which makes it so that the computed keyframes for this animation&apos;s effect will have unresolved
computed offsets if the timeline is not a view timeline, such as the default document timeline.

Running this test we would fail `ASSERT(!std::isnan(srcKeyframe.offset()))` in the `AcceleratedEffect`
constructor. Since an effect with a keyframe with an unresolved computed offset will not yield
interpolated values and thus, it makes no sense to accelerate it, so we update `KeyframeEffect::canBeAccelerated()`
to disable acceleration if any such keyframe exists. To aid that, we add a new `hasKeyframeWithUnresolvedComputedOffset()`
method on `BlendingKeyframes`.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedTimeBasedAnimationsEnabled=true`.

[0] <a href="https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges">https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges</a>

* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::hasKeyframeWithUnresolvedComputedOffset const):
* Source/WebCore/animation/BlendingKeyframes.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canBeAccelerated const):

Canonical link: <a href="https://commits.webkit.org/306553@main">https://commits.webkit.org/306553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ab3130dc1ab4b667f0fa208a67079489d607976

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/13999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94711 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108820 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78721 "6 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89721 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10920 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8554 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/260 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152580 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13690 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3230 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116921 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117249 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13280 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/68891 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21855 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13728 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2745 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13514 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->