### PR TITLE
[GFC] Specified size suggestion of a grid item with fixed size is that size

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -61,11 +61,18 @@ static bool spansFlexMaxTrackSizingFunction(WTF::Range<size_t> spannedTrackIndex
     return false;
 }
 
-static std::optional<LayoutUnit> inlineSpecifiedSizeSuggestion(const PlacedGridItem&, LayoutUnit borderAndPadding)
+static std::optional<LayoutUnit> inlineSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding)
 {
-    UNUSED_VARIABLE(borderAndPadding);
-    ASSERT_NOT_IMPLEMENTED_YET();
-    return { };
+    auto& preferredSize = gridItem.inlineAxisSizes().preferredSize;
+    return WTF::switchOn(preferredSize,
+        [&](const Style::PreferredSize::Fixed fixedSize) -> std::optional<LayoutUnit> {
+            return Style::evaluate<LayoutUnit>(fixedSize, gridItem.usedZoom()) + borderAndPadding;
+        },
+        [](const auto&) -> std::optional<LayoutUnit> {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+    );
 }
 
 static std::optional<LayoutUnit> inlineTransferredSizeSuggestion(const PlacedGridItem&)
@@ -80,11 +87,17 @@ static LayoutUnit inlineContentSizeSuggestion(const PlacedGridItem& gridItem, co
     return integrationUtils.minContentWidth(gridItem.layoutBox());
 }
 
-static std::optional<LayoutUnit> blockSpecifiedSizeSuggestion(const PlacedGridItem&, LayoutUnit borderAndPadding)
+static std::optional<LayoutUnit> blockSpecifiedSizeSuggestion(const PlacedGridItem& gridItem, LayoutUnit borderAndPadding)
 {
-    UNUSED_VARIABLE(borderAndPadding);
-    ASSERT_NOT_IMPLEMENTED_YET();
-    return { };
+    auto& preferredSize = gridItem.blockAxisSizes().preferredSize;
+    return WTF::switchOn(preferredSize,
+        [&](const Style::PreferredSize::Fixed fixedSize) -> std::optional<LayoutUnit> {
+            return Style::evaluate<LayoutUnit>(fixedSize, gridItem.usedZoom()) + borderAndPadding;
+        },
+        [](const auto&) -> std::optional<LayoutUnit> {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+    });
 }
 
 static std::optional<LayoutUnit> blockTransferredSizeSuggestion(const PlacedGridItem&)


### PR DESCRIPTION
#### 7846430552742ff8602fdd4a855ee9981eb8a354
<pre>
[GFC] Specified size suggestion of a grid item with fixed size is that size
<a href="https://bugs.webkit.org/show_bug.cgi?id=306655">https://bugs.webkit.org/show_bug.cgi?id=306655</a>
<a href="https://rdar.apple.com/169306049">rdar://169306049</a>

Reviewed by Alan Baradlay and Brandon Stewart.

Fill in {inline,block}specifiedSizeSuggestion by checking the preferred
size and returning the size + borderAndPadding directly if it is fixed.
All other cases will go into the auto&amp; case to be caught as
ASSERT_NOT_IMPLEMENTED which will hopefully be reduced down over time to
get rid of this &quot;catch all,&quot; case.

Canonical link: <a href="https://commits.webkit.org/306788@main">https://commits.webkit.org/306788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f64f578e7d6043bfa0c70d0b4ff98297a85b3cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151005 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c877c1bd-c93b-47ac-9f97-01b292038971) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14909 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d9ed035-28ee-4707-8c51-c41de366cd06) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145308 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/11999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90375 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c9ddf91-3f59-48eb-a1ea-f26e0cd4a9d6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1025 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153342 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4532 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14456 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30042 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/13883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70143 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14483 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78199 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14420 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->