### PR TITLE
Fix outstanding safer C++ issues in Source/WebKit

### DIFF
--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -60,6 +60,12 @@ void Connection::sendWithReply(xpc_object_t message, CompletionHandler<void(xpc_
     }).get());
 }
 
+// Workaround a bug in clang static analyer that [[clang::suppress]] doesn't work in some template function.
+static void logMachServiceInterrupted(const CString& machServiceName)
+{
+    RELEASE_LOG(IPC, "Connection to mach service %s is interrupted", machServiceName.data());
+}
+
 template<typename Traits>
 void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
 {
@@ -79,7 +85,7 @@ void ConnectionToMachService<Traits>::initializeConnectionIfNeeded() const
 #endif
         }
         if (event == XPC_ERROR_CONNECTION_INTERRUPTED) {
-            RELEASE_LOG(IPC, "Connection to mach service %s is interrupted", weakThis->m_machServiceName.data());
+            logMachServiceInterrupted(weakThis->m_machServiceName);
             // Daemon crashed, we will need to make a new connection to a new instance of the daemon.
             weakThis->m_connection = nullptr;
         }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm
@@ -107,14 +107,14 @@
     return YES;
 }
 
-static NSString *identifierObjectKey = @"a";
-static NSString *identifierProcessIdentifierKey = @"b";
-static NSString *worldIdentifierObjectKey = @"c";
-static NSString *worldIdentifierProcessIdentifierKey = @"d";
-static NSString *frameIdentifierKey = @"e";
-static NSString *documentIDProcessIdentifierKey = @"f";
-static NSString *worldIdentifierHighBitsKey = @"g";
-static NSString *worldIdentifierLowBitsKey = @"h";
+static NSString* const identifierObjectKey = @"a";
+static NSString* const identifierProcessIdentifierKey = @"b";
+static NSString* const worldIdentifierObjectKey = @"c";
+static NSString* const worldIdentifierProcessIdentifierKey = @"d";
+static NSString* const frameIdentifierKey = @"e";
+static NSString* const documentIDProcessIdentifierKey = @"f";
+static NSString* const worldIdentifierHighBitsKey = @"g";
+static NSString* const worldIdentifierLowBitsKey = @"h";
 
 - (id)initWithCoder:(NSCoder *)decoder
 {


### PR DESCRIPTION
#### bdc25953d3d249e3ba8d54868c385fe683166252
<pre>
Fix outstanding safer C++ issues in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=306656">https://bugs.webkit.org/show_bug.cgi?id=306656</a>

Reviewed by Wenson Hsieh.

Make global variables in _WKJSHandle.mm const to suppress warnings.

Also extracted the code to call RELEASE_LOG in DaemonConnectionCocoa.mm to workaround a bug
in clang static analyzer that [[clang::suppress]] doesn&apos;t work in some template functions.

* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::logMachServiceInterrupted):
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::initializeConnectionIfNeeded const):
* Source/WebKit/UIProcess/API/Cocoa/_WKJSHandle.mm:

Canonical link: <a href="https://commits.webkit.org/306578@main">https://commits.webkit.org/306578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8a07e5afc574492020f0dfc6c66a6fda80f6aa5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3597 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150284 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94831 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b444835c-335c-421b-a3bb-ad80aabaa04a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108901 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78748 "5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d9b4492-34b6-4062-8c97-7a8bfeb83237) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f3ca5f9-99e6-4ac5-b718-7712453ac62f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8627 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/357 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120287 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152677 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116996 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117319 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13347 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123548 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69395 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21874 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13825 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2829 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13564 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13611 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->