### PR TITLE
[JSC] Extend SIHeap to support arbitrary number of compiler threads

### DIFF
--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -89,13 +89,9 @@ bool SequesteredImmortalHeap::scavengeImpl(void* /*userdata*/)
     dataLogLnIf(verbose, "SequesteredImmortalHeap: scavenging");
     {
         Locker listLocker { m_scavengerLock };
-        auto bound = m_nextFreeIndex;
-        ASSERT(bound <= m_allocatorSlots.size());
+        auto bound = m_slotManager.allocatedCount();
         for (size_t i = 0; i < bound; i++) {
-            // FIXME: Refactor the SeqImmortalHeap <-> SeqArenaAllocator
-            // relationship so that we don't have to assume data layouts
-            // here
-            auto& queue = *reinterpret_cast<ConcurrentDecommitQueue*>(&m_allocatorSlots[i]);
+            auto& queue = *reinterpret_cast<ConcurrentDecommitQueue*>(&m_slotManager[i]);
             queue.decommit();
         }
     }


### PR DESCRIPTION
#### af95d936795d777165e058757baebbbf669767df
<pre>
[JSC] Extend SIHeap to support arbitrary number of compiler threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=306654">https://bugs.webkit.org/show_bug.cgi?id=306654</a>
<a href="https://rdar.apple.com/169305352">rdar://169305352</a>

Reviewed by Yusuke Suzuki.

Before a thread uses SequesteredArenaMalloc, it must be allocated a
thread-local handle that manages its arena + decommit queue.
Previously, there was a fixed limit to the number of these handles that
can be allocated, imposing upper bound to the number of compiler threads
that can run within a single VM.
This limit was not encountered in practice, as we would not spin up &gt;100
compiler threads in the web use-case where this is currently enabled,
but it was still untidy, and furthermore meant that increasing the size
of the handles (e.g. from 128B to 256B) would have been fraught.
This patch fixes that by providing a fallback for when the base pool of
these handles is exhausted. Further &apos;blocks&apos; of handles will be
allocated from the immortal allocator, forming a linked list that can be
traversed as necessary. Since these &apos;blocks&apos; are allocated with 64
handles at a time, we still preserve locality in accessing their
contents, but regardless this list only ever needs to be traversed for
debugging (e.g. logging the index of a given arena), and so is not
performance sensitive in any case.

Canonical link: <a href="https://commits.webkit.org/306659@main">https://commits.webkit.org/306659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/488a9c026749e687d6befae8cec26da0cca5edd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150567 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/815e70bc-a844-40ec-b498-a03e08df7d8c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f928d706-e297-467f-858d-09d376f46399) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11654 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127092 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90010 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dc06d29-ac53-4f5c-834f-b5bb3da03dd0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11198 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8846 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/621 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133945 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120523 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152943 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2765 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14036 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117194 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117511 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29944 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13560 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69730 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14074 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3236 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173250 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77799 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44853 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->