### PR TITLE
Move RenderMenuList popup handling to HTMLSelectElement

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -32,6 +32,7 @@
 #include "AXObjectCache.h"
 #include "AccessibilityMenuListPopup.h"
 #include "FrameDestructionObserverInlines.h"
+#include "HTMLSelectElement.h"
 #include "RenderMenuList.h"
 #include "RenderObjectDocument.h"
 #include <wtf/Scope.h>
@@ -61,17 +62,17 @@ bool AccessibilityMenuList::press()
         return false;
 
 #if !PLATFORM(IOS_FAMILY)
-    RefPtr element = this->element();
+    RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(element());
     auto notification = AXNotification::PressDidFail;
-    if (CheckedPtr menuList = dynamicDowncast<RenderMenuList>(renderer()); menuList && element && !element->isDisabledFormControl()) {
-        if (menuList->popupIsVisible())
-            menuList->hidePopup();
+    if (selectElement && !selectElement->isDisabledFormControl()) {
+        if (selectElement->popupIsVisible())
+            selectElement->hidePopup();
         else
-            menuList->showPopup();
+            selectElement->showPopup();
         notification = AXNotification::PressDidSucceed;
     }
     if (CheckedPtr cache = axObjectCache())
-        cache->postNotification(element.get(), notification);
+        cache->postNotification(selectElement.get(), notification);
     return true;
 #endif
     return false;
@@ -108,8 +109,8 @@ bool AccessibilityMenuList::isCollapsed() const
         return true;
 
 #if !PLATFORM(IOS_FAMILY)
-    CheckedPtr menuList = dynamicDowncast<RenderMenuList>(renderer());
-    return !(menuList && menuList->popupIsVisible());
+    RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(element());
+    return !(selectElement && selectElement->usesMenuList() && selectElement->popupIsVisible());
 #else
     return true;
 #endif

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -32,7 +32,6 @@
 #include "HTMLOptionElement.h"
 #include "HTMLSelectElement.h"
 #include "PseudoClassChangeInvalidation.h"
-#include "RenderMenuList.h"
 #include "NodeRenderStyle.h"
 #include "StyleResolver.h"
 #include "TypedElementDescendantIteratorInlines.h"

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -40,7 +40,6 @@
 #include "NodeRenderStyle.h"
 #include "NodeTraversal.h"
 #include "PseudoClassChangeInvalidation.h"
-#include "RenderMenuList.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderTheme.h"
 #include "ScriptElement.h"

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -42,7 +42,11 @@ namespace WebCore {
 class HTMLOptionsCollection;
 class ShadowRoot;
 
-class HTMLSelectElement : public HTMLFormControlElement, public PopupMenuClient, private TypeAheadDataSource {
+#if !PLATFORM(IOS_FAMILY)
+class PopupMenu;
+#endif
+
+class HTMLSelectElement final : public HTMLFormControlElement, public PopupMenuClient, private TypeAheadDataSource {
     WTF_MAKE_TZONE_ALLOCATED(HTMLSelectElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSelectElement);
 public:
@@ -54,6 +58,7 @@ public:
 
     static Ref<HTMLSelectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
     static Ref<HTMLSelectElement> create(Document&);
+    ~HTMLSelectElement();
 
     enum class ExcludeOptGroup : bool { No, Yes };
     static HTMLSelectElement* findOwnerSelect(ContainerNode*, ExcludeOptGroup);
@@ -103,6 +108,12 @@ public:
     ExceptionOr<void> setLength(unsigned);
 
     ExceptionOr<void> showPicker();
+
+    void showPopup();
+#if !PLATFORM(IOS_FAMILY)
+    void hidePopup();
+    bool popupIsVisible() const { return m_popupIsVisible; }
+#endif
 
     // PopupMenuClient methods
     void valueChanged(unsigned listIndex, bool fireOnChange = true) override;
@@ -239,6 +250,8 @@ private:
 
     void childrenChanged(const ChildChange&) final;
 
+    void didDetachRenderers() final;
+
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
     // TypeAheadDataSource functions.
@@ -261,6 +274,11 @@ private:
     bool m_activeSelectionState;
     bool m_allowsNonContiguousSelection;
     mutable bool m_shouldRecalcListItems;
+
+#if !PLATFORM(IOS_FAMILY)
+    RefPtr<PopupMenu> m_popup;
+    bool m_popupIsVisible { false };
+#endif
 };
 
 } // namespace

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -38,7 +38,6 @@ class RenderMenuList final : public RenderFlexibleBox {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMenuList);
 public:
     RenderMenuList(HTMLSelectElement&, RenderStyle&&);
-    virtual ~RenderMenuList();
 
     HTMLSelectElement& selectElement() const;
 
@@ -48,13 +47,6 @@ public:
     void incrementCheckedPtrCount() const { RenderFlexibleBox::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const { RenderFlexibleBox::decrementCheckedPtrCount(); }
     void setDidBeginCheckedPtrDeletion() { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
-
-#if !PLATFORM(IOS_FAMILY)
-    bool popupIsVisible() const { return m_popupIsVisible; }
-#endif
-    void showPopup();
-    void hidePopup();
-    void popupDidHide();
 
     void setOptionsChanged(bool changed) { m_needsOptionsWidthUpdate = changed; }
 
@@ -66,17 +58,12 @@ public:
 
     void getItemBackgroundColor(unsigned listIndex, Color&, bool& itemHasCustomBackgroundColor) const;
 
-    PopupMenuStyle::Size popupMenuSize(const RenderStyle&);
-
     LayoutUnit clientPaddingLeft() const;
     LayoutUnit clientPaddingRight() const;
 
-    HostWindow* hostWindow() const;
     void setTextFromOption(int optionIndex);
 
 private:
-    void willBeDestroyed() override;
-
     void element() const = delete;
 
     void updateFromElement() override;
@@ -109,11 +96,6 @@ private:
     int m_optionsWidth;
 
     std::optional<int> m_lastActiveIndex;
-
-#if !PLATFORM(IOS_FAMILY)
-    RefPtr<PopupMenu> m_popup;
-    bool m_popupIsVisible;
-#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -205,7 +205,6 @@
 #include "RenderLayerCompositor.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderListBox.h"
-#include "RenderMenuList.h"
 #include "RenderObjectInlines.h"
 #include "RenderSearchField.h"
 #include "RenderTheme.h"
@@ -4820,8 +4819,7 @@ bool Internals::isSelectPopupVisible(HTMLSelectElement& element)
     element.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
 #if !PLATFORM(IOS_FAMILY)
-    auto* renderer = dynamicDowncast<RenderMenuList>(element.renderer());
-    return renderer && renderer->popupIsVisible();
+    return element.popupIsVisible();
 #else
     return false;
 #endif


### PR DESCRIPTION
#### c74593b7f29a219b0095c47e4b68906b85088d83
<pre>
Move RenderMenuList popup handling to HTMLSelectElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=306658">https://bugs.webkit.org/show_bug.cgi?id=306658</a>
<a href="https://rdar.apple.com/169307251">rdar://169307251</a>

Reviewed by Ryosuke Niwa.

Reduce the amount of logic that RenderMenuList handles with the eventual goal of removing RenderMenuList.

Split from Anne van Kesteren&apos;s PR: #57409

* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::press):
(WebCore::AccessibilityMenuList::isCollapsed const):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
* Source/WebCore/html/HTMLOptionElement.cpp:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::didDetachRenderers):
(WebCore::HTMLSelectElement::setOptionsChangedOnRenderer):
(WebCore::HTMLSelectElement::platformHandleKeydownEvent):
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::showPopup):
(WebCore::HTMLSelectElement::hidePopup):
(WebCore::HTMLSelectElement::showPicker):
(WebCore::HTMLSelectElement::itemStyle const):
(WebCore::HTMLSelectElement::menuStyle const):
(WebCore::HTMLSelectElement::popupDidHide):
* Source/WebCore/html/HTMLSelectElement.h:
(WebCore::HTMLSelectElement::size const): Deleted.
(WebCore::HTMLSelectElement::multiple const): Deleted.
(WebCore::HTMLSelectElement::allowsNonContiguousSelection const): Deleted.
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::RenderMenuList):
(WebCore::RenderMenuList::updateFromElement):
(WebCore::RenderMenuList::willBeDestroyed): Deleted.
(WebCore::RenderMenuList::popupMenuSize): Deleted.
(WebCore::RenderMenuList::hostWindow const): Deleted.
(WebCore::RenderMenuList::showPopup): Deleted.
(WebCore::RenderMenuList::hidePopup): Deleted.
(WebCore::RenderMenuList::popupDidHide): Deleted.
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isSelectPopupVisible):

Co-authored-by: Anne van Kesteren &lt;annevk@annevk.nl&gt;
Canonical link: <a href="https://commits.webkit.org/306546@main">https://commits.webkit.org/306546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e71585e42b375fad7fa90a18e7bf9447199b80d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14029 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150216 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/208f8e0a-8905-4d5e-bd60-30f490f15fb0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108838 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1845fa85-a4f1-4770-9029-fe7b2b070ea5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89738 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea39449d-0f15-4790-8033-cc4c3e2b12f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10946 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8571 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/289 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120231 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152609 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13719 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116937 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117263 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13293 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123499 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2780 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13496 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77482 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->