### PR TITLE
Focusing a cross-origin iFrame on iOS results in an unintended focus on iframe.

### DIFF
--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -713,21 +713,24 @@ FocusableElementSearchResult FocusController::findFocusableElementInDocumentOrde
         if (!owner->contentFrame())
             return findResult;
 
-        document->setFocusedElement(nullptr);
-        setFocusedFrame(owner->protectedContentFrame().get());
+        if (shouldFocusElement == ShouldFocusElement::Yes) {
+            document->setFocusedElement(nullptr);
+            setFocusedFrame(owner->protectedContentFrame().get());
+        }
         return findResult;
     }
-    
+
     // FIXME: It would be nice to just be able to call setFocusedElement(node) here, but we can't do
     // that because some elements (e.g. HTMLInputElement and HTMLTextAreaElement) do extra work in
     // their focus() methods.
 
     Ref newDocument = element->document();
 
-    if (newDocument.ptr() != document) {
-        // Focus is going away from this document, so clear the focused node.
+    if (newDocument.ptr() != document && shouldFocusElement == ShouldFocusElement::Yes)
         document->setFocusedElement(nullptr);
-    }
+
+    if (shouldFocusElement == ShouldFocusElement::No)
+        return findResult;
 
     setFocusedFrame(newDocument->protectedFrame().get());
 
@@ -738,8 +741,9 @@ FocusableElementSearchResult FocusController::findFocusableElementInDocumentOrde
             frame->selection().setSelection(newSelection, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes), intent);
         }
     }
-    if (shouldFocusElement == ShouldFocusElement::Yes)
-        element->focus({ SelectionRestorationMode::SelectAll, direction, { }, { }, FocusVisibility::Visible });
+
+    element->focus({ SelectionRestorationMode::SelectAll, direction, { }, { }, FocusVisibility::Visible });
+
     return findResult;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm
@@ -349,25 +349,18 @@ void CrossOriginIframeRelinquishToChromeTests::runTest()
         const char* activeElementID;
         bool hasFocus;
     };
-    auto checkFocusState = [webView, this](FrameFocusState mainFrame, FrameFocusState innerFrame) {
+    auto checkFocusState = [webView](FrameFocusState mainFrame, FrameFocusState innerFrame) {
         // FIXME: <rdar://161283373> This IPC round trip should not be necessary.
-#if !PLATFORM(IOS_FAMILY)
-        UNUSED_PARAM(this);
-#endif
 
         [webView waitForNextPresentationUpdate];
 
         EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.activeElement.id"], mainFrame.activeElementID);
+
         EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"document.hasFocus()"] boolValue], mainFrame.hasFocus);
 
         EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.activeElement.id" inFrame:[webView firstChildFrame]], innerFrame.activeElementID);
 
-#if PLATFORM(IOS_FAMILY)
-        // FIXME: Fix the fact that the iFrame is focued when it should not be on iOS.
-        if (!siteIsolationEnabled())
-#endif
-            EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"document.hasFocus()" inFrame:[webView firstChildFrame]] boolValue], innerFrame.hasFocus);
-
+        EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"document.hasFocus()" inFrame:[webView firstChildFrame]] boolValue], innerFrame.hasFocus);
     };
 
     checkFocusState({ "mainFrameBody", true }, { "iframeBody", false });


### PR DESCRIPTION
#### c5a53c2a96c1bd48c7e0ec52fb362a1475f3f244
<pre>
Focusing a cross-origin iFrame on iOS results in an unintended focus on iframe.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306660">https://bugs.webkit.org/show_bug.cgi?id=306660</a>
<a href="https://rdar.apple.com/169310024">rdar://169310024</a>

Reviewed by Alex Christensen.

This is a continuation of 306434@main.
I should have had more guards for side effects
in findFocusableElementInDocumentOrderStartingWithFrame.

Adding the guard for all side-effects fixes the
test, and is more logically sound, since we can
get here when we are only looking for the next
or previous element, that should not result in focus,
selection or focused frame changing.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm

* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::findFocusableElementInDocumentOrderStartingWithFrame):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FocusWebView.mm:

Canonical link: <a href="https://commits.webkit.org/306566@main">https://commits.webkit.org/306566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd4f5051c8bda12edc2e77e6cbe9c79f61616fb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150244 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94791 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89984dd1-94b4-4fe3-a2de-5c77635d1f88) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108867 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/929dddf2-0775-455b-924d-879736a94a1d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89767 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2030546-bfd2-442f-9026-05e69f4b561a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8596 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/317 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2824 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152637 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13747 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116965 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117290 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29884 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13319 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69355 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13785 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2792 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->