### PR TITLE
[JSC] Optimize ReadWriteLock and use it in Wasm::TypeDefinition repository

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -962,7 +962,7 @@ RefPtr<FunctionSignature> TypeInformation::typeDefinitionForFunction(const Vecto
         ASSERT(!args.contains(Wasm::Types::Void));
     }
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     auto addResult = info.m_typeSet.template add<FunctionParameterTypes>(FunctionParameterTypes { results, args });
     return addResult.iterator->key->as<FunctionSignature>();
@@ -971,7 +971,7 @@ RefPtr<FunctionSignature> TypeInformation::typeDefinitionForFunction(const Vecto
 RefPtr<StructType> TypeInformation::typeDefinitionForStruct(const Vector<FieldType>& fields)
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     auto addResult = info.m_typeSet.template add<StructParameterTypes>(StructParameterTypes { fields });
     return addResult.iterator->key->as<StructType>();
@@ -980,7 +980,7 @@ RefPtr<StructType> TypeInformation::typeDefinitionForStruct(const Vector<FieldTy
 RefPtr<ArrayType> TypeInformation::typeDefinitionForArray(FieldType elementType)
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     auto addResult = info.m_typeSet.template add<ArrayParameterTypes>(ArrayParameterTypes { elementType });
     return addResult.iterator->key->as<ArrayType>();
@@ -989,7 +989,7 @@ RefPtr<ArrayType> TypeInformation::typeDefinitionForArray(FieldType elementType)
 RefPtr<RecursionGroup> TypeInformation::typeDefinitionForRecursionGroup(const Vector<TypeIndex>& types)
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     auto addResult = info.m_typeSet.template add<RecursionGroupParameterTypes>(RecursionGroupParameterTypes { types });
     return addResult.iterator->key->as<RecursionGroup>();
@@ -998,7 +998,7 @@ RefPtr<RecursionGroup> TypeInformation::typeDefinitionForRecursionGroup(const Ve
 RefPtr<Projection> TypeInformation::typeDefinitionForProjection(TypeIndex recursionGroup, ProjectionIndex projectionIndex)
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     auto addResult = info.m_typeSet.template add<ProjectionParameterTypes>(ProjectionParameterTypes { recursionGroup, projectionIndex });
     return addResult.iterator->key->as<Projection>();
@@ -1007,7 +1007,7 @@ RefPtr<Projection> TypeInformation::typeDefinitionForProjection(TypeIndex recurs
 RefPtr<Subtype> TypeInformation::typeDefinitionForSubtype(const Vector<TypeIndex>& superTypes, TypeIndex underlyingType, bool isFinal)
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     auto addResult = info.m_typeSet.template add<SubtypeParameterTypes>(SubtypeParameterTypes { superTypes, underlyingType, isFinal });
     return addResult.iterator->key->as<Subtype>();
@@ -1019,7 +1019,7 @@ RefPtr<Projection> TypeInformation::getPlaceholderProjection(ProjectionIndex pro
     auto projection = typeDefinitionForProjection(Projection::PlaceholderGroup, projectionIndex);
 
     {
-        Locker locker { info.m_lock };
+        Locker locker { info.m_lock.write() };
         info.m_placeholders.add(projection);
     }
 
@@ -1029,7 +1029,7 @@ RefPtr<Projection> TypeInformation::getPlaceholderProjection(ProjectionIndex pro
 void TypeInformation::addCachedUnrolling(TypeIndex type, const TypeDefinition& unrolled)
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     info.m_unrollingCache.add(type, RefPtr { &unrolled });
 }
@@ -1037,7 +1037,7 @@ void TypeInformation::addCachedUnrolling(TypeIndex type, const TypeDefinition& u
 std::optional<TypeIndex> TypeInformation::tryGetCachedUnrolling(TypeIndex type)
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.read() };
 
     const auto iterator = info.m_unrollingCache.find(type);
     if (iterator == info.m_unrollingCache.end())
@@ -1163,7 +1163,7 @@ bool TypeInformation::isReferenceValueAssignable(JSValue refValue, bool allowNul
 void TypeInformation::tryCleanup()
 {
     TypeInformation& info = singleton();
-    Locker locker { info.m_lock };
+    Locker locker { info.m_lock.write() };
 
     bool changed;
     do {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -42,6 +42,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/HashTraits.h>
 #include <wtf/Lock.h>
+#include <wtf/ReadWriteLock.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -1014,7 +1015,7 @@ private:
     RefPtr<FunctionSignature> m_Void_I32AnyrefI32;
     RefPtr<FunctionSignature> m_Void_I32AnyrefI32I32I32I32;
     RefPtr<FunctionSignature> m_Void_I32AnyrefI32I32AnyrefI32I32;
-    Lock m_lock;
+    ReadWriteLock m_lock;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h
@@ -79,7 +79,7 @@ inline TypeIndex TypeInformation::get(const TypeDefinition& type)
 {
     if (ASSERT_ENABLED) {
         TypeInformation& info = singleton();
-        Locker locker { info.m_lock };
+        Locker locker { info.m_lock.read() };
         ASSERT_UNUSED(info, info.m_typeSet.contains(TypeHash { const_cast<TypeDefinition&>(type) }));
     }
     return type.index();

--- a/Source/WTF/wtf/ReadWriteLock.cpp
+++ b/Source/WTF/wtf/ReadWriteLock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,49 +20,212 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
 #include <wtf/ReadWriteLock.h>
 
-#include <wtf/Locker.h>
+#include <wtf/ParkingLot.h>
+#include <wtf/Threading.h>
 
 namespace WTF {
 
-void ReadWriteLock::readLock()
-{
-    Locker locker { m_lock };
-    while (m_isWriteLocked || m_numWaitingWriters)
-        m_cond.wait(m_lock);
-    m_numReaders++;
-}
+// This magic number turns out to be optimal based on past JikesRVM experiments.
+// Same value used by WTF::Lock.
+static constexpr unsigned spinLimit = 40;
 
-void ReadWriteLock::readUnlock()
+void ReadWriteLock::readLockSlow()
 {
-    Locker locker { m_lock };
-    m_numReaders--;
-    if (!m_numReaders)
-        m_cond.notifyAll();
-}
+    unsigned spinCount = 0;
 
-void ReadWriteLock::writeLock()
-{
-    Locker locker { m_lock };
-    while (m_isWriteLocked || m_numReaders) {
-        m_numWaitingWriters++;
-        m_cond.wait(m_lock);
-        m_numWaitingWriters--;
+    for (;;) {
+        uint32_t state = m_state.load(std::memory_order_relaxed);
+
+        // If no writer is held and no writer is waiting, try to acquire read lock.
+        if (!(state & (WriterHeldBit | WriterWaitingBit))) {
+            if (m_state.compareExchangeWeak(state, state + ReaderCountUnit, std::memory_order_acquire))
+                return;
+            continue;
+        }
+
+        // Writer is active or waiting. Spin first if no parked readers and under spin limit.
+        if (!(state & HasParkedReadersBit) && spinCount < spinLimit) {
+            spinCount++;
+            Thread::yield();
+            continue;
+        }
+
+        // Set HasParkedReadersBit before parking.
+        if (!(state & HasParkedReadersBit)) {
+            if (!m_state.compareExchangeWeak(state, state | HasParkedReadersBit, std::memory_order_relaxed))
+                continue;
+            state |= HasParkedReadersBit;
+        }
+
+        // Park on the reader queue.
+        ParkingLot::parkConditionally(
+            readerParkingAddress(),
+            [&]() -> bool {
+                // Validate: still need to wait if writer is held or waiting.
+                uint32_t currentState = m_state.load(std::memory_order_relaxed);
+                return currentState & (WriterHeldBit | WriterWaitingBit);
+            },
+            []() { },
+            ParkingLot::Time::infinity());
+
+        // After waking, loop around and try again.
     }
-    m_isWriteLocked = true;
 }
 
-void ReadWriteLock::writeUnlock()
+void ReadWriteLock::readUnlockSlow()
 {
-    Locker locker { m_lock };
-    m_isWriteLocked = false;
-    m_cond.notifyAll();
+    for (;;) {
+        uint32_t state = m_state.load(std::memory_order_relaxed);
+        ASSERT(state >> ReaderCountShift); // Must have at least one reader.
+
+        uint32_t newState = state - ReaderCountUnit;
+        uint32_t newReaderCount = newState >> ReaderCountShift;
+
+        // If this is the last reader and there are parked writers, wake one.
+        if (!newReaderCount && (state & HasParkedWritersBit)) {
+            if (!m_state.compareExchangeWeak(state, newState, std::memory_order_release))
+                continue;
+
+            // Wake one writer.
+            ParkingLot::unparkOne(
+                writerParkingAddress(),
+                [&](ParkingLot::UnparkResult result) -> intptr_t {
+                    if (!result.mayHaveMoreThreads) {
+                        // Clear HasParkedWritersBit since there are no more parked writers.
+                        m_state.transactionRelaxed([](uint32_t& value) -> bool {
+                            value &= ~HasParkedWritersBit;
+                            return true;
+                        });
+                    }
+                    return 0;
+                });
+            return;
+        }
+
+        // Not the last reader or no waiting writers, just decrement.
+        if (m_state.compareExchangeWeak(state, newState, std::memory_order_release))
+            return;
+    }
+}
+
+void ReadWriteLock::writeLockSlow()
+{
+    unsigned spinCount = 0;
+    bool setWaiting = false;
+
+    for (;;) {
+        uint32_t state = m_state.load(std::memory_order_relaxed);
+
+        // If completely free (or only WriterWaitingBit is set by us), try to acquire.
+        if (state == 0 || (setWaiting && state == WriterWaitingBit)) {
+            uint32_t expected = setWaiting ? WriterWaitingBit : 0;
+            if (m_state.compareExchangeWeak(expected, WriterHeldBit, std::memory_order_acquire))
+                return;
+            continue;
+        }
+
+        // Set WriterWaitingBit to block new readers (for fairness).
+        if (!setWaiting && !(state & WriterWaitingBit)) {
+            if (m_state.compareExchangeWeak(state, state | WriterWaitingBit, std::memory_order_relaxed)) {
+                setWaiting = true;
+                state |= WriterWaitingBit;
+            }
+            continue;
+        }
+
+        // Spin if under limit and no parked writers.
+        if (!(state & HasParkedWritersBit) && spinCount < spinLimit) {
+            spinCount++;
+            Thread::yield();
+            continue;
+        }
+
+        // Set HasParkedWritersBit before parking.
+        if (!(state & HasParkedWritersBit)) {
+            if (!m_state.compareExchangeWeak(state, state | HasParkedWritersBit, std::memory_order_relaxed))
+                continue;
+            state |= HasParkedWritersBit;
+        }
+
+        // Park on the writer queue.
+        ParkingLot::ParkResult parkResult = ParkingLot::parkConditionally(
+            writerParkingAddress(),
+            [&]() -> bool {
+                // Validate: still blocked if readers exist or writer is held.
+                uint32_t currentState = m_state.load(std::memory_order_relaxed);
+                return (currentState & ReaderCountMask) || (currentState & WriterHeldBit);
+            },
+            []() { },
+            ParkingLot::Time::infinity());
+
+        // Check for direct handoff.
+        if (parkResult.wasUnparked && parkResult.token == DirectHandoff) {
+            // The lock was handed directly to us.
+            ASSERT(m_state.load(std::memory_order_relaxed) & WriterHeldBit);
+            return;
+        }
+
+        // Otherwise, loop around and try again (barging opportunity).
+    }
+}
+
+void ReadWriteLock::writeUnlockSlow()
+{
+    for (;;) {
+        uint32_t state = m_state.load(std::memory_order_relaxed);
+        ASSERT(state & WriterHeldBit);
+
+        // Check for parked writers first (writer preference to avoid starvation).
+        if (state & HasParkedWritersBit) {
+            ParkingLot::unparkOne(
+                writerParkingAddress(),
+                [&](ParkingLot::UnparkResult result) -> intptr_t {
+                    if (result.didUnparkThread && result.timeToBeFair) {
+                        // Direct handoff: keep WriterHeldBit set, transfer lock to waiting writer.
+                        if (!result.mayHaveMoreThreads) {
+                            m_state.transactionRelaxed([](uint32_t& value) -> bool {
+                                value &= ~HasParkedWritersBit;
+                                return true;
+                            });
+                        }
+                        return DirectHandoff;
+                    }
+
+                    // Barging opportunity: release the lock, unparked thread competes.
+                    m_state.transactionRelaxed([&](uint32_t& value) -> bool {
+                        value &= ~WriterHeldBit;
+                        if (!result.mayHaveMoreThreads)
+                            value &= ~HasParkedWritersBit;
+                        return true;
+                    });
+                    return BargingOpportunity;
+                });
+            return;
+        }
+
+        // Check for parked readers.
+        if (state & HasParkedReadersBit) {
+            // Release the writer lock.
+            uint32_t newState = (state & ~WriterHeldBit) & ~HasParkedReadersBit;
+            if (!m_state.compareExchangeWeak(state, newState, std::memory_order_release))
+                continue;
+
+            // Wake ALL parked readers.
+            ParkingLot::unparkAll(readerParkingAddress());
+            return;
+        }
+
+        // No parked threads, just release the writer lock.
+        uint32_t newState = state & ~WriterHeldBit;
+        if (m_state.compareExchangeWeak(state, newState, std::memory_order_release))
+            return;
+    }
 }
 
 } // namespace WTF
-

--- a/Source/WTF/wtf/ReadWriteLock.h
+++ b/Source/WTF/wtf/ReadWriteLock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,40 +20,72 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
 
-#include <wtf/Condition.h>
-#include <wtf/Lock.h>
+#include <wtf/Atomics.h>
+#include <wtf/Noncopyable.h>
 
 namespace WTF {
 
-// This is a traditional read-write lock implementation that enables concurrency between readers so long as
-// the read critical section is long. Concurrent readers will experience contention on read().lock() and
-// read().unlock() if the work inside the critical section is short. The more cores participate in reading,
-// the longer the read critical section has to be for this locking scheme to be profitable.
+// This is a high-performance read-write lock implementation that uses ParkingLot directly,
+// following the same patterns as WTF::Lock. It enables concurrency between readers while
+// providing efficient fast paths for uncontended operations.
+//
+// Compared to the traditional Lock+Condition implementation:
+// - Fast paths use a single CAS operation (no internal lock acquisition)
+// - No thundering herd: uses selective wakeup via unparkOne/unparkAll
+// - Writer fairness: waiting writers block new readers to prevent starvation
+//
+// It's easiest to read lock like this:
+//     Locker locker { rwLock.read() };
+//
+// It's easiest to write lock like this:
+//     Locker locker { rwLock.write() };
 
 class ReadWriteLock {
     WTF_MAKE_NONCOPYABLE(ReadWriteLock);
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(ReadWriteLock);
 public:
-    ReadWriteLock() = default;
+    constexpr ReadWriteLock() = default;
 
-    // It's easiest to read lock like this:
-    // 
-    //     Locker locker { rwLock.read() };
-    //
-    // It's easiest to write lock like this:
-    // 
-    //     Locker locker { rwLock.write() };
-    //
-    WTF_EXPORT_PRIVATE void readLock();
-    WTF_EXPORT_PRIVATE void readUnlock();
-    WTF_EXPORT_PRIVATE void writeLock();
-    WTF_EXPORT_PRIVATE void writeUnlock();
-    
+    void readLock()
+    {
+        uint32_t state = m_state.load(std::memory_order_relaxed);
+        if (!(state & (WriterHeldBit | WriterWaitingBit))) [[likely]] {
+            if (m_state.compareExchangeWeak(state, state + ReaderCountUnit, std::memory_order_acquire)) [[likely]]
+                return;
+        }
+        readLockSlow();
+    }
+
+    void readUnlock()
+    {
+        uint32_t state = m_state.load(std::memory_order_relaxed);
+        uint32_t readerCount = state >> ReaderCountShift;
+        if (readerCount > 1 && !(state & HasParkedWritersBit)) [[likely]] {
+            if (m_state.compareExchangeWeak(state, state - ReaderCountUnit, std::memory_order_release)) [[likely]]
+                return;
+        }
+        readUnlockSlow();
+    }
+
+    void writeLock()
+    {
+        if (m_state.compareExchangeWeak(0u, WriterHeldBit, std::memory_order_acquire)) [[likely]]
+            return;
+        writeLockSlow();
+    }
+
+    void writeUnlock()
+    {
+        if (m_state.compareExchangeWeak(WriterHeldBit, 0u, std::memory_order_release)) [[likely]]
+            return;
+        writeUnlockSlow();
+    }
+
     class ReadLock;
     class WriteLock;
 
@@ -61,11 +93,39 @@ public:
     WriteLock& write();
 
 private:
-    Lock m_lock;
-    Condition m_cond;
-    bool m_isWriteLocked WTF_GUARDED_BY_LOCK(m_lock) { false };
-    unsigned m_numReaders WTF_GUARDED_BY_LOCK(m_lock) { 0 };
-    unsigned m_numWaitingWriters WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+    // State encoding in a 32-bit word:
+    // Bits 31-16 (16 bits): Reader count (up to 65535 concurrent readers)
+    // Bit      3:           Writer waiting bit (blocks new readers for fairness)
+    // Bit      2:           Writer held bit
+    // Bit      1:           Has parked writers bit
+    // Bit      0:           Has parked readers bit
+    static constexpr uint32_t ReaderCountShift = 16;
+    static constexpr uint32_t ReaderCountUnit = 1u << ReaderCountShift;
+    static constexpr uint32_t ReaderCountMask = 0xFFFF0000;
+    static constexpr uint32_t WriterWaitingBit = 1u << 3;
+    static constexpr uint32_t WriterHeldBit = 1u << 2;
+    static constexpr uint32_t HasParkedWritersBit = 1u << 1;
+    static constexpr uint32_t HasParkedReadersBit = 1u << 0;
+
+    // Tokens for ParkingLot handoff (matching Lock pattern)
+    enum Token : intptr_t {
+        BargingOpportunity = 0,
+        DirectHandoff = 1
+    };
+
+    WTF_EXPORT_PRIVATE NEVER_INLINE void readLockSlow();
+    WTF_EXPORT_PRIVATE NEVER_INLINE void readUnlockSlow();
+    WTF_EXPORT_PRIVATE NEVER_INLINE void writeLockSlow();
+    WTF_EXPORT_PRIVATE NEVER_INLINE void writeUnlockSlow();
+
+    // Separate parking addresses for readers and writers to enable selective wakeup.
+    // ParkingLot uses the address as a key, so different addresses create separate queues.
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    void* readerParkingAddress() { return std::bit_cast<void*>(std::bit_cast<uint8_t*>(this)); }
+    void* writerParkingAddress() { return std::bit_cast<void*>((std::bit_cast<uint8_t*>(this) + 1)); }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+    Atomic<uint32_t> m_state { 0 };
 };
 
 class ReadWriteLock::ReadLock : public ReadWriteLock {
@@ -81,7 +141,7 @@ public:
     void lock() { writeLock(); }
     void unlock() { writeUnlock(); }
 };
-    
+
 inline ReadWriteLock::ReadLock& ReadWriteLock::read() { return *static_cast<ReadLock*>(this); }
 inline ReadWriteLock::WriteLock& ReadWriteLock::write() { return *static_cast<WriteLock*>(this); }
 


### PR DESCRIPTION
#### a41cd8ca10b297c24d8450736d61d9eb487c2d6f
<pre>
[JSC] Optimize ReadWriteLock and use it in Wasm::TypeDefinition repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=306662">https://bugs.webkit.org/show_bug.cgi?id=306662</a>
<a href="https://rdar.apple.com/169311734">rdar://169311734</a>

Reviewed by NOBODY (OOPS!).

This patch adds efficient ReadWriteLock implementation by using
ParkingLot. Previous one was using Lock and Condition, which was
dramatically inefficient compared to this one. And we start using this
in Wasm TypeDefinition repository.

* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::TypeInformation::typeDefinitionForFunction):
(JSC::Wasm::TypeInformation::typeDefinitionForStruct):
(JSC::Wasm::TypeInformation::typeDefinitionForArray):
(JSC::Wasm::TypeInformation::typeDefinitionForRecursionGroup):
(JSC::Wasm::TypeInformation::typeDefinitionForProjection):
(JSC::Wasm::TypeInformation::typeDefinitionForSubtype):
(JSC::Wasm::TypeInformation::getPlaceholderProjection):
(JSC::Wasm::TypeInformation::addCachedUnrolling):
(JSC::Wasm::TypeInformation::tryGetCachedUnrolling):
(JSC::Wasm::TypeInformation::tryCleanup):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
* Source/JavaScriptCore/wasm/WasmTypeDefinitionInlines.h:
(JSC::Wasm::TypeInformation::get):
* Source/WTF/wtf/ReadWriteLock.cpp:
(WTF::ReadWriteLock::readLockSlow):
(WTF::ReadWriteLock::readUnlockSlow):
(WTF::ReadWriteLock::writeLockSlow):
(WTF::ReadWriteLock::writeUnlockSlow):
(WTF::ReadWriteLock::readLock): Deleted.
(WTF::ReadWriteLock::readUnlock): Deleted.
(WTF::ReadWriteLock::writeLock): Deleted.
(WTF::ReadWriteLock::writeUnlock): Deleted.
* Source/WTF/wtf/ReadWriteLock.h:
(WTF::ReadWriteLock::readLock):
(WTF::ReadWriteLock::readUnlock):
(WTF::ReadWriteLock::writeLock):
(WTF::ReadWriteLock::writeUnlock):
(WTF::ReadWriteLock::readerParkingAddress):
(WTF::ReadWriteLock::writerParkingAddress):
(WTF::ReadWriteLock::WTF_GUARDED_BY_LOCK): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41cd8ca10b297c24d8450736d61d9eb487c2d6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141842 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94967 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdb4f1e9-8b9c-4233-ba44-6d6ec2b67e87) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78830 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4432106e-cb36-4e1b-8a3e-2b4d83723df7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89896 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cba81ee-f330-4b40-b482-b047b1a7e3c2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11103 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8745 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/502 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133826 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152824 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2646 "Found 1 jsc stress test failure: wasm.yaml/wasm/gc-spec-tests/br_on_cast_fail.wast.js.wasm-omg") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117088 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117410 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13465 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69595 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13955 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2987 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173131 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13694 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77680 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44834 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13897 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13741 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->