### PR TITLE
Rebase resource-timing-cross-origin.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -411,7 +411,6 @@ media/video-element-fullscreen-not-in-dom-accelerated-iphone.html [ Skip ]
 # Per specification, if the scripts are identical, we do not install the new script and return the existing registration.
 imported/w3c/web-platform-tests/service-workers/service-worker/import-scripts-redirect.https.html [ Skip ]
 
-imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https.html [ Failure ]
 imported/w3c/web-platform-tests/service-workers/service-worker/svg-target-reftest.https.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/service-workers/service-worker/partitioned-cookies.tentative.https.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https-expected.txt
@@ -1,5 +1,4 @@
 
-
-FAIL Test that timing allow check fails when service worker changes origin from same to cross origin (cors). assert_equals: domainLookupStart should be 0 in cross-origin request. expected 7 but got 0
-FAIL Test that timing allow check fails when service worker changes origin from same to cross origin (no-cors). assert_equals: domainLookupStart should be 0 in cross-origin request. expected 7 but got 0
+PASS Test that timing allow check fails when service worker changes origin from same to cross origin (cors).
+PASS Test that timing allow check fails when service worker changes origin from same to cross origin (no-cors).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https.html
@@ -32,7 +32,7 @@ function test_sw_resource_timing({ mode }) {
       assert_equals(entry.responseStart, 0, 'responseStart should be 0 in cross-origin request.');
       assert_equals(entry.secureConnectionStart, 0, 'secureConnectionStart should be 0 in cross-origin request.');
       assert_equals(entry.decodedBodySize, 0, 'decodedBodySize should be 0 in cross-origin request.');
-      assert_equals(entry.ecodedBodySize, 0, 'encodedBodySize should be 0 in cross-origin request.');
+      assert_equals(entry.encodedBodySize, 0, 'encodedBodySize should be 0 in cross-origin request.');
       assert_equals(entry.transferSize, 0, 'transferSize should be 0 in cross-origin request.');
       frame.remove();
       await registration.unregister();


### PR DESCRIPTION
#### f6afa06b69b98c51c61b46fa2c03e772021b966d
<pre>
Rebase resource-timing-cross-origin.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=306665">https://bugs.webkit.org/show_bug.cgi?id=306665</a>
<a href="https://rdar.apple.com/169313412">rdar://169313412</a>

Reviewed by Anne van Kesteren.

resource-timing-cross-origin.https.html was fixed by <a href="https://github.com/WebKit/WebKit/pull/57523.">https://github.com/WebKit/WebKit/pull/57523.</a>
I rebased the test. There was also a small typo in the test, so I fixed it.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/resource-timing-cross-origin.https.html:

Canonical link: <a href="https://commits.webkit.org/306644@main">https://commits.webkit.org/306644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bdbac94b70dec1aa3d20896efd424c7f30525b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150219 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94759 "Build was cancelled. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13660719-8f9f-4074-83fa-a6b01e051718) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108840 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94759 "Build was cancelled. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/942e38ec-3b39-4f18-9910-4d25ac4e380e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89740 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e345881b-4b2c-4e8c-8a0a-731d2ee6a1fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8576 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152612 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13722 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116940 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117266 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29934 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13298 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123491 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69329 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13760 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2772 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13499 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13546 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->