### PR TITLE
[

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2451,8 +2451,6 @@ webkit.org/b/306629 [ Release arm64 ] imported/w3c/web-platform-tests/media-sour
 
 webkit.org/b/306301 [ x86_64 ] http/tests/webgpu/webgpu/api/validation/state/device_lost/destroy.html [ Failure ]
 
-webkit.org/b/306663 [ Debug arm64 ] webaudio/silent-audio-interrupted-in-background.html [ Pass Failure ]
-
 webkit.org/b/306670 [ Debug arm64 ] http/tests/webgpu/webgpu/api/validation/render_pipeline/resource_compatibility.html [ Pass Failure ]
 
 webkit.org/b/306785 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-insecure.sub.window.html [ Pass Failure ]

--- a/LayoutTests/webaudio/silent-audio-interrupted-in-background.html
+++ b/LayoutTests/webaudio/silent-audio-interrupted-in-background.html
@@ -24,6 +24,7 @@ function showPage()
 {
     debug("* Setting page visibility to visible");
     if (window.testRunner)
+    
         testRunner.setPageVisibility("visible");
 }
 

--- a/LayoutTests/webaudio/silent-audio-interrupted-in-background.html
+++ b/LayoutTests/webaudio/silent-audio-interrupted-in-background.html
@@ -7,7 +7,7 @@ description("Tests silent WebAudio rendering in hidden pages.");
 jsTestIsAsync = true;
 
 let counter = 0;
-document.onvisibilitychange = async function() {
+document.onvisibilitychange = function() {
     if (!counter) {
          counter = 1;
          shouldBeTrue("document.hidden");
@@ -23,15 +23,15 @@ document.onvisibilitychange = async function() {
 function showPage()
 {
     debug("* Setting page visibility to visible");
-    if (window.internals)
-        internals.setPageVisibility(true);
+    if (window.testRunner)
+        testRunner.setPageVisibility("visible");
 }
 
 function hidePage()
 {
     debug("* Setting page visibility to hidden");
-    if (window.internals)
-        internals.setPageVisibility(false);
+    if (window.testRunner)
+        testRunner.setPageVisibility("hidden");
 }
 
 onload = function() {


### PR DESCRIPTION
#### 76e0949482749c857b32944a088b6c5f28e09e28
<pre>
[MacOS Debug]webaudio/silent-audio-interrupted-in-background.html is a flaky text failure.
<a href="https://rdar.apple.com/169312061">rdar://169312061</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306663">https://bugs.webkit.org/show_bug.cgi?id=306663</a>

Reviewed by NOBODY (OOPS!).

Flaky test failure  was caused by the use of internals.setPageVisibility(false/true) which has a race condition where
the visibilitychange event can fire before document.hidden is updated. Changed to testRunner.setPageVisibility(&quot;hidden&quot;/&quot;visible&quot;)
which properly sets the visibility state synchronously before firing the event.

* LayoutTests/webaudio/silent-audio-interrupted-in-background.html:
</pre>
----------------------------------------------------------------------
#### fdc7703a9cb1fe369393cab7a8a6d8c2f44cc77d
<pre>
[block-in-inline] Incorrect inline content position when float and margin are present
<a href="https://bugs.webkit.org/show_bug.cgi?id=307608">https://bugs.webkit.org/show_bug.cgi?id=307608</a>

Reviewed by Antti Koivisto.

While floats need to know about margins on blocks, they are supposed to be transparent to margin collapsing.

Test: fast/inline/margin-with-float-and-block-in-inline.html

* LayoutTests/fast/inline/margin-with-float-and-block-in-inline-expected.html: Added.
* LayoutTests/fast/inline/margin-with-float-and-block-in-inline.html: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webaudio/silent-audio-interrupted-in-background.html:
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::initialize):
(WebCore::Layout::LineBuilder::applyMarginInBlockDirectionIfNeeded):

  Only reset margins when we see inline (inflow) content.

(WebCore::Layout::LineBuilder::tryPlacingFloatBox):
(WebCore::Layout::LineBuilder::handleInlineContent):
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h:

Canonical link: <a href="https://commits.webkit.org/307393@main">https://commits.webkit.org/307393@main</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76e0949482749c857b32944a088b6c5f28e09e28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144300 "Failed to checkout and rebase branch from PR 57600") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/8536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17461 "Failed to checkout and rebase branch from PR 57600") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16873 "Failed to checkout and rebase branch from PR 57600") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/152970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147263 "Failed to checkout and rebase branch from PR 57600") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/17461 "Failed to checkout and rebase branch from PR 57600") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/8536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/17461 "Failed to checkout and rebase branch from PR 57600") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/8536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/416 "Failed to checkout and rebase branch from PR 57600") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/17461 "Failed to checkout and rebase branch from PR 57600") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/8536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/155282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/8536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/155282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/16873 "Failed to checkout and rebase branch from PR 57600") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/155282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/8536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/8536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/16253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->