### PR TITLE
If completeSyntheticClick provides a non-root frameID, resolve to root frame.

### DIFF
--- a/LayoutTests/http/tests/events/touch/ios/resources/iframe-with-content-change.html
+++ b/LayoutTests/http/tests/events/touch/ios/resources/iframe-with-content-change.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="target">Click this element</div>
+<div id="popup"></div>
+
+<script>
+    let target = document.getElementById("target");
+    let popup = document.getElementById("popup");
+
+    target.addEventListener("mousemove", () => {
+        popup.textContent = "Trigger a content change";
+        window.parent.postMessage('content changed', '*');
+    });
+
+    target.addEventListener("click", () => {
+        window.parent.postMessage('clicked', '*');
+    });
+
+    window.parent.postMessage('iframe loaded', '*');
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/events/touch/ios/synthetic-click-iframe-content-observation-expected.txt
+++ b/LayoutTests/http/tests/events/touch/ios/synthetic-click-iframe-content-observation-expected.txt
@@ -1,0 +1,11 @@
+Test that synthetic click completes successfully when content change observation finishes in a iframe
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Synthetic click completed successfully in iframe.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/http/tests/events/touch/ios/synthetic-click-iframe-content-observation.html
+++ b/LayoutTests/http/tests/events/touch/ios/synthetic-click-iframe-content-observation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/resources/js-test-pre.js"></script>
+<script>
+    description("Test that synthetic click completes successfully when content change observation finishes in a iframe");
+    window.jsTestIsAsync = true;
+
+    var iframeClickReceived = false;
+    var iframeContentChanged = false;
+    var iframeLoaded = false;
+
+    window.onmessage = (event) => {
+        if (event.data === 'clicked')
+            iframeClickReceived = true;
+        else if (event.data === 'content changed')
+            iframeContentChanged = true;
+        else if (event.data === 'iframe loaded')
+            iframeLoaded = true;
+    };
+
+    addEventListener("DOMContentLoaded", () => {
+        (async () => {
+            if (window.internals)
+                internals.settings.setContentChangeObserverEnabled(true);
+
+            let iframe = document.getElementById("iframe");
+            await UIHelper.waitForCondition(() => iframeLoaded);
+
+            let target = iframe.contentDocument.getElementById("target");
+            let targetX = iframe.offsetLeft + target.offsetLeft + target.offsetWidth / 2;
+            let targetY = iframe.offsetTop + target.offsetTop + target.offsetHeight / 2;
+            await UIHelper.activateAt(targetX, targetY);
+
+            await UIHelper.waitForCondition(() => iframeContentChanged);
+            await UIHelper.waitForCondition(() => iframeClickReceived);
+
+            testPassed("Synthetic click completed successfully in iframe.");
+
+            finishJSTest();
+        })();
+    });
+</script>
+</head>
+<body>
+<iframe id="iframe" src="resources/iframe-with-content-change.html" style="border: none;"></iframe>
+<p id="description"></p>
+<script src="/resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1012,7 +1012,15 @@ void WebPage::completeSyntheticClick(std::optional<WebCore::FrameIdentifier> fra
 {
     SetForScope completeSyntheticClickScope { m_completingSyntheticClick, true };
     IntPoint roundedAdjustedPoint = roundedIntPoint(location);
-    RefPtr localRootFrame = this->localRootFrame(frameID);
+
+    // FIXME: Make this function take a root frame's ID instead of taking a frame ID of a non-root frame and replacing it with the root frame.
+    auto rootFrameID = frameID;
+    if (RefPtr webFrame = WebProcess::singleton().webFrame(frameID)) {
+        if (RefPtr frame = webFrame->coreLocalFrame(); frame && !frame->isRootFrame())
+            rootFrameID = WebFrame::fromCoreFrame(frame->rootFrame())->frameID();
+    }
+
+    RefPtr localRootFrame = this->localRootFrame(rootFrameID);
     if (!localRootFrame) {
         invokePendingSyntheticClickCallback(SyntheticClickResult::PageInvalid);
         return;


### PR DESCRIPTION
#### cbb65e5cfe2d540739f02fdd1ce6588ea73a0549
<pre>
If completeSyntheticClick provides a non-root frameID, resolve to root frame.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306672">https://bugs.webkit.org/show_bug.cgi?id=306672</a>
<a href="https://rdar.apple.com/168161516">rdar://168161516</a>

Reviewed by Ryosuke Niwa.

Sometimes, completeSyntheticClick receives a frameID that may not be a root frame. Previously, we
passed the frameID directly to localRootFrame() which always expects a root frame identifier. Now
we always ensure that completeSyntheticClick resolves the frameID to a root frame before calling
localRootFrame().

Test: http/tests/events/touch/ios/synthetic-click-iframe-content-observation.html

* LayoutTests/http/tests/events/touch/ios/resources/iframe-with-content-change.html: Added.
* LayoutTests/http/tests/events/touch/ios/synthetic-click-iframe-content-observation-expected.txt: Added.
* LayoutTests/http/tests/events/touch/ios/synthetic-click-iframe-content-observation.html: Added.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::completeSyntheticClick):

Canonical link: <a href="https://commits.webkit.org/306757@main">https://commits.webkit.org/306757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/018fb450dbd4a67371551ef1df674053555d7df0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150863 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109349 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11a18a24-fde1-4f79-8b9c-6e296019cc20) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90249 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbce396f-bd8e-4e06-a7fc-44b68d39de1d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11398 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9064 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/898 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153215 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4336 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117406 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117729 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13773 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124512 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70007 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21943 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14356 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3544 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14293 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->