### PR TITLE
Use protect() pattern in ViewTransition.cpp

### DIFF
--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -203,7 +203,6 @@ public:
     const OrderedNamedElementsMap& namedElements() const { return m_namedElements; };
 
     Document* document() const;
-    RefPtr<Document> protectedDocument() const { return document(); }
 
     bool documentElementIsCaptured() const;
 


### PR DESCRIPTION
#### ca7e844a5ed3efc69516589bb10fde00df8c7ae4
<pre>
Use protect() pattern in ViewTransition.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=306674">https://bugs.webkit.org/show_bug.cgi?id=306674</a>
<a href="https://rdar.apple.com/169318527">rdar://169318527</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::resolveInboundCrossDocumentViewTransition):
(WebCore::ViewTransition::setupCrossDocumentViewTransition):
(WebCore::ViewTransition::skipViewTransition):
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::updatePropertiesForGroupPseudo):
(WebCore::ViewTransition::setupDynamicStyleSheet):
(WebCore::ViewTransition::setupTransitionPseudoElements):
(WebCore::ViewTransition::checkForViewportSizeChange):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::ViewTransition::viewTransitionNewPseudoForCapturedElement):
(WebCore::ViewTransition::visibilityStateChanged):
(WebCore::ViewTransition::stop):
* Source/WebCore/dom/ViewTransition.h:
(WebCore::ViewTransition::protectedDocument const): Deleted.

Canonical link: <a href="https://commits.webkit.org/306547@main">https://commits.webkit.org/306547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f2c366299adc6221c24e0c290cd4fe24098b27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150238 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57e35f8f-1e22-4234-adbd-0bf2b77dc831) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14210 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108858 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5b36175-1bd4-402d-8c4b-71118f5ed6fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126800 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89758 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65434eb4-2484-46b0-8e4a-61bccfd70514) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8589 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/311 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152631 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13741 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116956 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13315 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123506 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13779 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2787 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13518 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/13721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13565 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->