### PR TITLE
[ITP] Crash in ResourceLoadStatisticsStore::ensureResourceStatisticsForRegistrableDomain due to unsafe std::optional access

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -1211,7 +1211,7 @@ bool ResourceLoadStatisticsStore::insertObservedDomain(const ResourceLoadStatist
     ASSERT(!RunLoop::isMain());
 
     if (domainID(loadStatistics.registrableDomain)) {
-        ITP_RELEASE_LOG_ERROR("insertObservedDomain: failed to find domain");
+        ITP_RELEASE_LOG_ERROR("insertObservedDomain: domain already exists");
         return false;
     }
     auto scopedStatement = this->scopedStatement(m_insertObservedDomainStatement, insertObservedDomainQuery, "insertObservedDomain"_s);
@@ -2528,7 +2528,12 @@ std::pair<ResourceLoadStatisticsStore::AddedRecord, std::optional<unsigned>> Res
         return { AddedRecord::No, std::nullopt };
     }
 
-    return { AddedRecord::Yes, domainID(domain).value() };
+    auto domainID = this->domainID(domain);
+    if (!domainID) {
+        ITP_RELEASE_LOG_ERROR("ensureResourceStatisticsForRegistrableDomain: reason %" PUBLIC_LOG_STRING ", failed to retrieve domain ID after successful insertion", reason.characters());
+        return { AddedRecord::No, std::nullopt };
+    }
+    return { AddedRecord::Yes, domainID.value() };
 }
 
 void ResourceLoadStatisticsStore::clearDatabaseContents()


### PR DESCRIPTION
#### 215b7246a62175d42d803158283bc89cbfd87e3a
<pre>
[ITP] Crash in ResourceLoadStatisticsStore::ensureResourceStatisticsForRegistrableDomain due to unsafe std::optional access
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306673">https://bugs.webkit.org/show_bug.cgi?id=306673</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/167532652">rdar://problem/167532652</a>&gt;

Reviewed by Matthew Finkel.

ResourceLoadStatisticsStore::ensureResourceStatisticsForRegistrableDomain()
crashes with std::bad_optional_access when calling .value() on an empty
std::optional&lt;unsigned&gt; returned by domainID(domain).  The crash occurs
when insertObservedDomain() successfully inserts a domain into the
database, but domainID(domain) immediately fails to find the
just-inserted domain, returning std::nullopt.

The fix replaces the unsafe .value() call with proper std::optional
checking and error recovery.  This prevents process termination and
provides diagnostic logging to help identify the underlying database
consistency issue.

Includes a drive-by fix to
ResourceLoadStatisticsStore::insertObservedDomain() to correct a
misleading error message that said &quot;failed to find domain&quot; when the
domain was actually found and already exists.

Unable to write a test since it would require removing a just-inserted
domain from the database caused by an unknown mechanism external to
ensureResourceStatisticsForRegistrableDomain().

* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::insertObservedDomain):
- Fix error message.
(WebKit::ResourceLoadStatisticsStore::ensureResourceStatisticsForRegistrableDomain):
- Fix crash by checking for value in std::optional before use.

Canonical link: <a href="https://commits.webkit.org/306672@main">https://commits.webkit.org/306672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/251489ffeb0305ac8577ffeb175ebb00128de823

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94789 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2a88317-54b1-4566-9348-b90c31ab385e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108861 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78734 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e04a20d-18c9-4c3c-8813-f6e4ecf31bf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89761 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aacc91e2-0876-40c4-8195-169552b6f3b3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8593 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/315 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120244 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116959 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117284 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13317 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69353 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21913 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13783 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2790 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77508 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13725 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13569 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->