### PR TITLE
Remove ShadowRoot::checkedStyleScope

### DIFF
--- a/Source/WebCore/css/StyleSheetList.cpp
+++ b/Source/WebCore/css/StyleSheetList.cpp
@@ -50,7 +50,7 @@ inline const Vector<Ref<StyleSheet>>& StyleSheetList::styleSheets() const
     if (RefPtr document = m_document.get())
         return document->styleScope().styleSheetsForStyleSheetList();
     if (RefPtr shadowRoot = m_shadowRoot.get())
-        return shadowRoot->checkedStyleScope()->styleSheetsForStyleSheetList();
+        return protect(shadowRoot->styleScope())->styleSheetsForStyleSheetList();
     return m_detachedStyleSheets;
 }
 
@@ -69,7 +69,7 @@ void StyleSheetList::detach()
         m_document = nullptr;
     } else if (RefPtr shadowRoot = m_shadowRoot.get()) {
         ASSERT(!m_document);
-        m_detachedStyleSheets = shadowRoot->checkedStyleScope()->styleSheetsForStyleSheetList();
+        m_detachedStyleSheets = protect(shadowRoot->styleScope())->styleSheetsForStyleSheetList();
         m_shadowRoot = nullptr;
     } else
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -145,13 +145,8 @@ Node::InsertedIntoAncestorResult ShadowRoot::insertedIntoAncestor(InsertionType 
         }
     }
     if (!adoptedStyleSheets().empty() && document().frame())
-        checkedStyleScope()->didChangeActiveStyleSheetCandidates();
+        protect(styleScope())->didChangeActiveStyleSheetCandidates();
     return InsertedIntoAncestorResult::Done;
-}
-
-CheckedRef<Style::Scope> ShadowRoot::checkedStyleScope() const
-{
-    return *m_styleScope;
 }
 
 void ShadowRoot::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -81,7 +81,6 @@ public:
     using TreeScope::rootNode;
 
     Style::Scope& styleScope() { return *m_styleScope; }
-    CheckedRef<Style::Scope> checkedStyleScope() const;
     StyleSheetList& styleSheets();
 
     bool delegatesFocus() const { return m_delegatesFocus; }


### PR DESCRIPTION
#### 117ea5c2cd59670324664ec175f01596c68c8f43
<pre>
Remove ShadowRoot::checkedStyleScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=306677">https://bugs.webkit.org/show_bug.cgi?id=306677</a>
<a href="https://rdar.apple.com/169323246">rdar://169323246</a>

Reviewed by Anne van Kesteren and Tim Nguyen.

We can remove ShadowRoot::checkedStyleScope and its usages because we are using the protect function() instead of dedicated checked &amp; protected getters.

No new tests needed.

* Source/WebCore/css/StyleSheetList.cpp:
(WebCore::StyleSheetList::styleSheets const):
(WebCore::StyleSheetList::detach):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::insertedIntoAncestor):
(WebCore::ShadowRoot::checkedStyleScope const): Deleted.
* Source/WebCore/dom/ShadowRoot.h:

Canonical link: <a href="https://commits.webkit.org/306610@main">https://commits.webkit.org/306610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b196ed3a2a3df7d052f30295b44475266e17b21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150246 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94793 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e942890-dcdf-433d-86cc-eb05ad92dbbe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108865 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78736 "3 flakes 11 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d91ecec-8a31-43bd-89d6-74198e797f48) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89765 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11d174c7-7cb7-4735-99bc-a4a003cb7e2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10959 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8598 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/319 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152639 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116966 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13764 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/11995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117291 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13323 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69357 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21886 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13787 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2794 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13729 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13573 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->