### PR TITLE
Remove unnecessary remote frame navigation pruning from BackForwardList.

### DIFF
--- a/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache-expected.txt
@@ -10,7 +10,7 @@ Page1 displayed first time.
 Page2 loaded
 Page2 displayed first time.
 Other page loaded
-Other displayed.
+Other page displayed.
 Popup loaded
 Popup pageshow: not-persisted
 Page2 loaded

--- a/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
+++ b/LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html
@@ -45,10 +45,8 @@ window.onmessage = (event) => dispatchMessage(event.data, {
                 debug("Page1 displayed first time.");
                 sendMessageToPopup("navigate-to-page2");
             } else if (page1ShowCount == 2) {
-                if (window.testRunner) {
-                    testPassed("Page1 displayed twice.");
-                    finishJSTest();
-                }
+                testPassed("Page1 displayed twice.");
+                finishJSTest();
             }
         }
     },
@@ -74,7 +72,7 @@ window.onmessage = (event) => dispatchMessage(event.data, {
     other: {
         load: () => debug("Other page loaded"),
         pageshow: ({arg}) => {
-            debug("Other displayed.");
+            debug("Other page displayed.");
             sendMessageToPopup("back1");
         }
     },

--- a/LayoutTests/http/tests/navigation/cross-site-iframe-nav-expected.txt
+++ b/LayoutTests/http/tests/navigation/cross-site-iframe-nav-expected.txt
@@ -1,0 +1,28 @@
+Cross-site iframe history is preserved when the main frame navigates (back/forward cache is disabled).
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Popup loaded
+Popup pageshow: not-persisted
+Same-site iframe loaded
+Same-site iframe displayed first time.
+Cross-site iframe loaded
+Cross-site iframe displayed first time.
+Other page loaded
+Other page displayed.
+Popup loaded
+Popup pageshow: not-persisted
+Cross-site iframe loaded
+PASS Cross-site iframe displayed twice.
+Same-site iframe loaded
+PASS Same-site iframe displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with cross-site-iframe-nav-popup.html. It has an same-site iframe initially.
+Navigate iframe to cross-site.
+Navigate main frame to other.
+Go back. (cross-site-iframe-nav-popup.html with cross-site iframe)
+Go back again. (cross-site-iframe-nav-popup.html with same-site iframe)
+... and ensures the cross-site iframe history is preserved in the BackForwardList.

--- a/LayoutTests/http/tests/navigation/cross-site-iframe-nav.html
+++ b/LayoutTests/http/tests/navigation/cross-site-iframe-nav.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=false dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/navigation-utils.js"></script>
+<script>
+
+description("Cross-site iframe history is preserved when the main frame navigates (back/forward cache is disabled).");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("resources/cross-site-iframe-nav-popup.html");
+}
+
+var sameSiteShowCount = 0;
+var crossSiteShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        load: () => debug("Popup loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Popup should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+            debug("Popup pageshow: " + arg);
+        },
+    },
+    samesite: {
+        load: () => debug("Same-site iframe loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Same-site iframe should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            sameSiteShowCount++;
+            if (sameSiteShowCount == 1) {
+                debug("Same-site iframe displayed first time.");
+                sendMessageToPopup("navigate-to-cross-site");
+            } else if (sameSiteShowCount == 2) {
+                testPassed("Same-site iframe displayed twice.");
+                finishJSTest();
+            }
+        }
+    },
+    crosssite: {
+        load: () => debug("Cross-site iframe loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Cross-site iframe should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            crossSiteShowCount++;
+            if (crossSiteShowCount == 1) {
+                debug("Cross-site iframe displayed first time.");
+                sendMessageToPopup("navigate-to-other");
+            } else if (crossSiteShowCount == 2) {
+                testPassed("Cross-site iframe displayed twice.");
+                sendMessageToPopup("back2");
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: () => {
+            debug("Other page displayed.");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with cross-site-iframe-nav-popup.html. It has an same-site iframe initially.</li>
+    <li>Navigate iframe to cross-site.</li>
+    <li>Navigate main frame to other.</li>
+    <li>Go back. (cross-site-iframe-nav-popup.html with cross-site iframe)</li>
+    <li>Go back again. (cross-site-iframe-nav-popup.html with same-site iframe)</li>
+</ul>
+<p>... and ensures the cross-site iframe history is preserved in the BackForwardList.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-other.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-other.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "other";
+
+window.onload = () => sendMessageToOpener("load");
+window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    opener: {
+        back1: () => history.back(),
+    },
+});
+
+</script>
+</head>
+<body>
+<h1>Other Page</h1>
+<p>This is the other page (no iframe).</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+
+window.onload = () => sendMessageToTop("load");
+window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+</script>
+</head>
+<body>
+<h1>Iframe Page</h1>
+<script>
+document.getElementById("host").textContent = location.hostname + ":" + location.port;
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "popup";
+const iframeId = "test-iframe"
+
+window.onload = () => sendMessageToOpener("load");
+window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    opener: {
+        'navigate-to-cross-site': () => navigateIframeTo(`http://${crossSiteHostname}:8000/navigation/resources/cross-site-iframe-nav-page.html`),
+        'navigate-to-other': () => navigateTo("cross-site-iframe-nav-other.html"),
+        back2: () => history.back(),
+    },
+    samesite: () => forwardMessageToOpener(event.data),
+    crosssite: () => forwardMessageToOpener(event.data),
+    other: () => forwardMessageToOpener(event.data),
+});
+
+
+</script>
+</head>
+<body>
+<h1>Popup page</h1>
+<iframe src="cross-site-iframe-nav-page.html" id="test-iframe"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/navigation-utils.js
+++ b/LayoutTests/http/tests/navigation/resources/navigation-utils.js
@@ -1,3 +1,6 @@
+const sameSiteHostname = "127.0.0.1";
+const crossSiteHostname = "localhost";
+
 /* `page` must be defined in embedding HTML files */
 function makeMessage(action, arg = "") {
     if (page === null || page === undefined) {

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -169,22 +169,16 @@ Ref<FrameState> WebBackForwardListItem::mainFrameState() const
 
 const String& WebBackForwardListItem::originalURL() const
 {
-    if (m_isRemoteFrameNavigation)
-        return emptyString();
     return mainFrameItem().frameState().originalURLString;
 }
 
 const String& WebBackForwardListItem::url() const
 {
-    if (m_isRemoteFrameNavigation)
-        return emptyString();
     return mainFrameItem().frameState().urlString;
 }
 
 const String& WebBackForwardListItem::title() const
 {
-    if (m_isRemoteFrameNavigation)
-        return emptyString();
     return mainFrameItem().frameState().title;
 }
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -94,9 +94,6 @@ public:
 
     WebBackForwardListFrameItem& mainFrameItem() const SWIFT_RETURNS_INDEPENDENT_VALUE;
 
-    void setIsRemoteFrameNavigation(bool isRemoteFrameNavigation) { m_isRemoteFrameNavigation = isRemoteFrameNavigation; }
-    bool isRemoteFrameNavigation() const { return m_isRemoteFrameNavigation; }
-
     void setWasRestoredFromSession();
 
     String loggingString();
@@ -127,7 +124,6 @@ private:
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     RefPtr<ViewSnapshot> m_snapshot;
 #endif
-    bool m_isRemoteFrameNavigation { false };
     EnhancedSecurity m_enhancedSecurity { EnhancedSecurity::Disabled };
 } SWIFT_SHARED_REFERENCE(refBackForwardListItem, derefBackForwardListItem);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3931,7 +3931,7 @@ TEST(SiteIsolation, ValidateSessionRestoreWithoutNavigating)
     EXPECT_TRUE([newIsolatedSessionState isEqualForTesting:normalSessionState.get()]);
 }
 
-TEST(SiteIsolation, DiscardUncachedBackItemForNavigatedOverIframe)
+TEST(SiteIsolation, BackNavigationOverCrossSiteIframeWithoutBFCache)
 {
     HTTPServer server({
         { "/example"_s, { "<iframe src='https://webkit.org/a'></iframe>"_s } },
@@ -3956,7 +3956,7 @@ TEST(SiteIsolation, DiscardUncachedBackItemForNavigatedOverIframe)
     EXPECT_WK_STREQ("c", [webView _test_waitForAlert]);
 
     [webView goBack];
-    EXPECT_WK_STREQ("a", [webView _test_waitForAlert]);
+    EXPECT_WK_STREQ("b", [webView _test_waitForAlert]);
 }
 
 TEST(SiteIsolation, ProtocolProcessSeparation)


### PR DESCRIPTION
#### cf1683ccb688cf4a2a8429b3edc15943febef46a
<pre>
Remove unnecessary remote frame navigation pruning from BackForwardList.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306679">https://bugs.webkit.org/show_bug.cgi?id=306679</a>
<a href="https://rdar.apple.com/169328011">rdar://169328011</a>

Reviewed by Charlie Wolfe.

r288281@main (bug 285096) introduced logic to prune remote frame navigation items from
the BackForwardList when the parent frame navigated. This was intended to handle the
case where BFCache is disabled and iframe state cannot be preserved.

However, this pruning logic is no longer necessary because:

1. The FrameState.children mechanism preserves iframe navigation history in
   BackForwardList items, even without BFCache.

2. When navigating back, recursiveGoToItem() uses the children array to restore
   iframe navigation state by calling loadItem() on each child frame.

3. r306554@main added updateFrameID() to handle frame ID changes when iframes
   are recreated, making the history restoration work correctly across multiple
   back navigations.

The pruning logic also had the unintended side effect of causing different
behavior depending on whether Site Isolation is enabled, which is inconsistent.

This patch removes:
- The isRemoteFrameNavigation flag and associated pruning logic
- The sharesAncestor() check that was incorrectly deleting valid history items

Tests:
- http/tests/navigation/cross-site-iframe-nav.html:
New test verifying cross-site iframe history is preserved across main frame navigations.

- API test BackNavigationOverCrossSiteIframeWithoutBFCache (was DiscardUncachedBackItemForNavigatedOverIframe):
Updated to verify iframe history is NOT pruned.

* LayoutTests/http/tests/navigation/back-iframe-no-bf-cache-expected.txt:
* LayoutTests/http/tests/navigation/back-iframe-no-bf-cache.html:
* LayoutTests/http/tests/navigation/cross-site-iframe-nav-expected.txt: Added.
* LayoutTests/http/tests/navigation/cross-site-iframe-nav.html: Added.
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-other.html: Added.
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html: Added.
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html: Added.
* LayoutTests/http/tests/navigation/resources/navigation-utils.js:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::originalURL const):
(WebKit::WebBackForwardListItem::url const):
(WebKit::WebBackForwardListItem::title const):
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::setIsRemoteFrameNavigation): Deleted.
(WebKit::WebBackForwardListItem::isRemoteFrameNavigation const): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::addItem):
(WebKit::WebBackForwardList::backForwardAddItemShared):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, BackNavigationOverCrossSiteIframeWithoutBFCache)):
(TestWebKitAPI::TEST(SiteIsolation, DiscardUncachedBackItemForNavigatedOverIframe)): Deleted.

Canonical link: <a href="https://commits.webkit.org/306664@main">https://commits.webkit.org/306664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abe2e4ce4f66962e16163dd4e5436b2e8cd0c093

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150573 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2efdf58f-2140-479b-a9f2-5cee4d89ab53) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109117 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90013 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41d6f61e-7c5d-4d10-a431-7f7b46a68053) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11202 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8851 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3319 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152949 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14042 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117198 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29949 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13561 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69736 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14089 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3241 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14027 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->