### PR TITLE
[YARR] Fix incorrect matching for fixed-count non-capturing groups with multiple alternatives

### DIFF
--- a/JSTests/stress/regexp-fixed-count-multiple-alternatives-backtrack.js
+++ b/JSTests/stress/regexp-fixed-count-multiple-alternatives-backtrack.js
@@ -1,0 +1,37 @@
+// Regression test for fixed-count non-capturing parentheses with multiple alternatives.
+// These patterns require backtracking across iterations, which the FixedCount JIT
+// optimization does not support. They should fall back to the interpreter.
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// Pattern: (?:aa|a){2}b
+// Input: "aab"
+// Correct: "a" + "a" + "b" = match "aab"
+// Bug: "aa" consumed too much, second iteration fails, no backtrack to try "a"
+shouldBe(/(?:aa|a){2}b/.exec("aab"), ["aab"], "(?:aa|a){2}b should match 'aab'");
+
+// Pattern: (?:aaa|aa|a){3}b
+// Input: "aaab"
+// Correct: "a" + "a" + "a" + "b" = match "aaab"
+shouldBe(/(?:aaa|aa|a){3}b/.exec("aaab"), ["aaab"], "(?:aaa|aa|a){3}b should match 'aaab'");
+
+// More complex backtracking scenarios
+shouldBe(/(?:ab|a){2}c/.exec("aac"), ["aac"], "(?:ab|a){2}c should match 'aac'");
+shouldBe(/(?:abc|ab|a){3}d/.exec("abaad"), ["abaad"], "(?:abc|ab|a){3}d should match 'abaad'");
+
+// Verify patterns still work in non-backtracking cases
+shouldBe(/(?:aa|a){2}b/.exec("aaab"), ["aaab"], "(?:aa|a){2}b should match 'aaab'");
+shouldBe(/(?:aa|a){2}/.exec("aaa"), ["aaa"], "(?:aa|a){2} should match 'aaa'");
+
+// Verify single-alternative patterns still use JIT optimization (should be fast)
+shouldBe(/(?:ab){3}/.exec("ababab"), ["ababab"], "(?:ab){3} should match 'ababab'");
+shouldBe(/(?:a){5}b/.exec("aaaaab"), ["aaaaab"], "(?:a){5}b should match 'aaaaab'");
+
+// Edge cases
+shouldBe(/(?:aa|a){2}b/.exec("ab"), null, "(?:aa|a){2}b should not match 'ab'");
+shouldBe(/(?:aa|a){3}b/.exec("aab"), null, "(?:aa|a){3}b should not match 'aab'");
+
+print("All tests passed!");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4815,11 +4815,13 @@ class YarrGenerator final : public YarrJITInfo {
                     parenthesesBeginOpCode = YarrOpCode::ParenthesesSubpatternFixedCountBegin;
                     parenthesesEndOpCode = YarrOpCode::ParenthesesSubpatternFixedCountEnd;
 
-                    // If there is more than one alternative we cannot use the 'simple' nodes.
+                    // If there is more than one alternative, we cannot use FixedCount optimization
+                    // because backtracking across iterations requires state preservation that
+                    // ParenthesesSubpatternFixedCount does not support.
+                    // FIXME: Add JIT support for backtracking across iterations with multiple alternatives.
                     if (term->parentheses.disjunction->m_alternatives.size() != 1) {
-                        alternativeBeginOpCode = YarrOpCode::NestedAlternativeBegin;
-                        alternativeNextOpCode = YarrOpCode::NestedAlternativeNext;
-                        alternativeEndOpCode = YarrOpCode::NestedAlternativeEnd;
+                        m_failureReason = JITFailureReason::FixedCountParenthesizedSubpattern;
+                        return;
                     }
                 } else {
                     // FIXME: Add JIT support for capturing FixedCount parentheses.


### PR DESCRIPTION
#### 56d7e9d4db479f5f86672a86438d1c265adc06d0
<pre>
[YARR] Fix incorrect matching for fixed-count non-capturing groups with multiple alternatives
<a href="https://bugs.webkit.org/show_bug.cgi?id=306683">https://bugs.webkit.org/show_bug.cgi?id=306683</a>

Reviewed by NOBODY (OOPS!).

The optimization for non-capturing parentheses with fixed-count quantifiers
 (305284) introduced a regression where patterns like (?:aa|a){2}b fail
to match strings like &quot;aab&quot;.

This patch changes to fix it by falling back to the interpreter for fixed-count
non-capturing parentheses with multiple alternatives. Single-alternative patterns
continue to use the JIT optimization.

* JSTests/stress/regexp-fixed-count-multiple-alternatives-backtrack.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56d7e9d4db479f5f86672a86438d1c265adc06d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150265 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108884 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11426 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10978 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8613 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/338 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133677 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120266 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/2846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152658 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2497 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13768 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/3309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/116981 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12010 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117305 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13337 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/123533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13806 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/172982 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13545 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44797 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->