### PR TITLE
Make HTMLSelectElement::usesMenuList() match HTMLSelectElement::createElementRenderer()

### DIFF
--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -173,7 +173,7 @@ void HTMLSelectElement::optionSelectedByUser(int optionIndex, bool fireOnChangeN
 {
     // User interaction such as mousedown events can cause list box select elements to send change events.
     // This produces that same behavior for changes triggered by other code running on behalf of the user.
-    if (!usesMenuList()) {
+    if (!m_multiple) {
         updateSelectedState(optionToListIndex(optionIndex), allowMultipleSelection, false);
         updateValidity();
         if (CheckedPtr renderer = this->renderer())
@@ -244,7 +244,7 @@ bool HTMLSelectElement::usesMenuList() const
 #if !PLATFORM(IOS_FAMILY)
     return !m_multiple && m_size <= 1;
 #else
-    return !m_multiple;
+    return true;
 #endif
 }
 
@@ -386,13 +386,9 @@ bool HTMLSelectElement::canSelectAll() const
 
 RenderPtr<RenderElement> HTMLSelectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-#if !PLATFORM(IOS_FAMILY)
     if (usesMenuList())
         return createRenderer<RenderMenuList>(*this, WTF::move(style));
     return createRenderer<RenderListBox>(*this, WTF::move(style));
-#else
-    return createRenderer<RenderMenuList>(*this, WTF::move(style));
-#endif
 }
 
 bool HTMLSelectElement::childShouldCreateRenderer(const Node& child) const
@@ -692,7 +688,7 @@ void HTMLSelectElement::selectAll()
 
 void HTMLSelectElement::saveLastSelection()
 {
-    if (usesMenuList()) {
+    if (!m_multiple) {
         m_lastOnChangeIndex = selectedIndex();
         return;
     }


### PR DESCRIPTION
#### 90105076097cd2dd55008faf5e20d0597a9e200a
<pre>
Make HTMLSelectElement::usesMenuList() match HTMLSelectElement::createElementRenderer()

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionSelectedByUser):
(WebCore::HTMLSelectElement::usesMenuList const):
(WebCore::HTMLSelectElement::createElementRenderer):
(WebCore::HTMLSelectElement::saveLastSelection):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90105076097cd2dd55008faf5e20d0597a9e200a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95975 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70a2ec9d-1354-4951-82a3-903e49c00afc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15339 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109806 "Found 1 new test failure: fast/forms/select/listbox-drag-in-non-multiple.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79133 "2 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40de2043-a62b-4575-844b-2bbdb5927456) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145735 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12265 "Found 5 new test failures: fast/dom/HTMLSelectElement/select-selectedOptions.html fast/forms/ios/form-control-refresh/select/select-multiple-picker.html fast/forms/ios/select-multiple-options-after-optgroup.html fast/forms/ios/select-multiple-options-with-hr.html fast/forms/select/select-state-restore.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127738 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90715 "Found 2 new API test failures: WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-select, WPE/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a3c3cbb-fea4-4a83-9cd7-c20e63d3a29a) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11768 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/resetting-a-form/reset-form-2.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9444 "Found 1 new API test failure: TestWebKitAPI.TextExtractionTests.SelectPopupMenu (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1459 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153773 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4852 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117821 "Found 2 new test failures: fast/forms/select/listbox-drag-in-non-multiple.html platform/gtk/fast/forms/menulist-typeahead-find.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14921 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12924 "Found 33 new test failures: fast/forms/select/listbox-drag-in-non-multiple.html fast/forms/select/mac-wk2/blur-dismisses-select-popup.html fast/forms/select/mac-wk2/open-select-popup-after-dismissing-by-blur.html fast/forms/select/select-state-restore.html imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has.html imported/w3c/web-platform-tests/css/selectors/open-pseudo.html imported/w3c/web-platform-tests/html/semantics/forms/input-change-event-properties.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-and-base-select.tentative.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/nested-options.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118154 "Found 2 new API test failures: WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-select, WebKitGTK/TestOptionMenu:/webkit/WebKitWebView/option-menu-activate (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14141 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125025 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14927 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3986 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78636 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14870 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->