### PR TITLE
[JSC] Implement RegExp SIMD path for x64 too

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -7829,6 +7829,12 @@ public:
         }
     }
 
+    void compareIntegerVector(RelationalCondition cond, SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest)
+    {
+        RELEASE_ASSERT(m_allowScratchRegister);
+        compareIntegerVector(cond, simdInfo, left, right, dest, fpTempRegister);
+    }
+
     void compareIntegerVector(RelationalCondition cond, SIMDInfo simdInfo, FPRegisterID left, FPRegisterID right, FPRegisterID dest, FPRegisterID scratch)
     {
         RELEASE_ASSERT(supportsAVX());
@@ -9290,6 +9296,13 @@ public:
     {
         ASSERT(supportsAVX());
         m_assembler.vpextrq_i8rm(imm.m_value, src, address.base, address.offset);
+    }
+
+    Jump branchTest128(ResultCondition cond, FPRegisterID vec)
+    {
+        RELEASE_ASSERT(supportsAVX());
+        m_assembler.vptest_rr(vec, vec);
+        return Jump(m_assembler.jCC(x86Condition(cond)));
     }
 
     void vectorAnyTrue(FPRegisterID vec, RegisterID dest)

--- a/Source/JavaScriptCore/yarr/YarrJITRegisters.h
+++ b/Source/JavaScriptCore/yarr/YarrJITRegisters.h
@@ -120,6 +120,22 @@ public:
 
     static constexpr GPRReg returnRegister = X86Registers::eax;
     static constexpr GPRReg returnRegister2 = X86Registers::edx;
+
+    // SIMD registers for Boyer-Moore SIMD lookahead (caller-saved, safe to use)
+    // Pattern constants (persistent across loop iterations)
+    static constexpr FPRReg vectorTemp0 = X86Registers::xmm0;
+    static constexpr FPRReg vectorTemp1 = X86Registers::xmm1;
+    static constexpr FPRReg vectorTemp2 = X86Registers::xmm2;
+    static constexpr FPRReg vectorTemp3 = X86Registers::xmm3;
+    static constexpr FPRReg vectorTemp4 = X86Registers::xmm4;
+    static constexpr FPRReg vectorInput0 = X86Registers::xmm5;
+    static constexpr FPRReg vectorInput1 = X86Registers::xmm6;
+    static constexpr FPRReg vectorInput2 = X86Registers::xmm7;
+    static constexpr FPRReg vectorInput3 = X86Registers::xmm8;
+    static constexpr FPRReg vectorScratch0 = X86Registers::xmm9;
+    static constexpr FPRReg vectorScratch1 = X86Registers::xmm10;
+    static constexpr FPRReg vectorScratch2 = X86Registers::xmm11;
+    static constexpr FPRReg vectorScratch3 = X86Registers::xmm12;
 #elif CPU(RISCV64)
     // Argument registers
     static constexpr GPRReg input = RISCV64Registers::x10;
@@ -196,7 +212,6 @@ public:
     GPRReg endOfStringAddress { InvalidGPRReg };
     GPRReg firstCharacterAdditionalReadSize { InvalidGPRReg };
 
-#if CPU(ARM64)
     // SIMD registers for Boyer-Moore SIMD lookahead
     // These are not used for inline JIT, but need to be present for template instantiation.
     static constexpr FPRReg vectorTemp0 = InvalidFPRReg;
@@ -212,7 +227,6 @@ public:
     static constexpr FPRReg vectorScratch1 = InvalidFPRReg;
     static constexpr FPRReg vectorScratch2 = InvalidFPRReg;
     static constexpr FPRReg vectorScratch3 = InvalidFPRReg;
-#endif
 };
 #endif
 


### PR DESCRIPTION
#### b7ed3dae4a6ad7bcdb51d747bce8e944b2a6d1ba
<pre>
[JSC] Implement RegExp SIMD path for x64 too
<a href="https://bugs.webkit.org/show_bug.cgi?id=306690">https://bugs.webkit.org/show_bug.cgi?id=306690</a>
<a href="https://rdar.apple.com/169336634">rdar://169336634</a>

Reviewed by Keith Miller.

This patch implements RegExp SIMD fast path for x64 too. Mostly the same
to ARM64, but using ptest for testing instead of vectorSwizzle2 since it
does not exist in x64.

* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::compareIntegerVector):
(JSC::MacroAssemblerX86_64::branchTest128):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrJITRegisters.h:

Canonical link: <a href="https://commits.webkit.org/306574@main">https://commits.webkit.org/306574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1f3a025ffdc415e458c33be3643226d3462350c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150287 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94834 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02b6f187-020d-4ded-9534-c1e89e3d2092) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108907 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9fa806a-5b84-4173-9a26-cd96661e99ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99736859-57a1-4842-8590-fc35893224aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/10993 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8632 "Found 1 new API test failure: TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/360 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133699 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152680 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2519 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117003 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117325 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13354 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123549 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69398 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21872 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13828 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2830 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173004 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77553 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44803 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13770 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13614 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->