### PR TITLE
Refactor TZoneHeap and TZoneHeapManager to better express the concepts.

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -130,29 +130,31 @@ enum class TZoneMallocFallback : uint8_t {
 extern BEXPORT TZoneMallocFallback tzoneMallocFallback;
 
 using HeapRef = void*;
+using TZoneDescriptor = uint64_t;
 
 struct SizeAndAlignment {
-    using Value = uint64_t;
 
-    static constexpr Value encode(unsigned size, unsigned alignment)
+    static constexpr TZoneDescriptor encode(unsigned size, unsigned alignment)
     {
         return (static_cast<uint64_t>(alignment) << 32) | size;
     }
 
     template<typename T>
-    static constexpr Value encode()
+    static constexpr TZoneDescriptor encode()
     {
         size_t size = ::bmalloc::TZone::sizeClass<T>();
         size_t alignment = ::bmalloc::TZone::alignment<T>();
         return encode(size, alignment);
     }
 
-    static unsigned decodeSize(Value value) { return value; }
-    static unsigned decodeAlignment(Value value) { return value >> 32; }
+    static unsigned decodeSize(TZoneDescriptor value) { return value; }
+    static unsigned decodeAlignment(TZoneDescriptor value) { return value >> 32; }
+};
 
-    static constexpr unsigned long hash(Value value)
+struct TZoneDescriptorHashTrait {
+    static constexpr unsigned long hash(TZoneDescriptor descriptor)
     {
-        return (decodeSize(value) ^ decodeAlignment(value)) >> 3;
+        return (SizeAndAlignment::decodeSize(descriptor) ^ SizeAndAlignment::decodeAlignment(descriptor)) >> 3;
     }
 };
 
@@ -160,7 +162,7 @@ struct TZoneSpecification {
     HeapRef* addressOfHeapRef;
     unsigned size;
     CompactAllocationMode allocationMode;
-    SizeAndAlignment::Value sizeAndAlignment;
+    TZoneDescriptor descriptor;
 #if BUSE_TZONE_SPEC_NAME_ARG
     const char* name;
 #endif


### PR DESCRIPTION
#### 8936a255410e4f7e56028fc8f759a8040c1a0489
<pre>
Refactor TZoneHeap and TZoneHeapManager to better express the concepts.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306696">https://bugs.webkit.org/show_bug.cgi?id=306696</a>
<a href="https://rdar.apple.com/169338245">rdar://169338245</a>

Reviewed by Keith Miller.

This change only contains renaming of labels (i.e. type, field, and local variable names).
The only changes not related to label renaming are:
  a. the re-factoring out of TZoneDescriptorHashTrait (see (4) below).
  b. the replacement of one print string that says &quot;size classes&quot; with &quot;descriptors&quot;.

Details:

1. Renamed the following:

   SizeAndAlignment::Value -&gt; TZoneDescriptor
     - this will allow us to add more / alternate attributes into how we sort TZone types
       later in a subsequent patch (and not just be limited to size and alignment).
       See comment about Category in the organization of TZones heaps in TZoneHeapManager.h.

   TZoneHeapManager::TZoneBucket -&gt; TZoneHeapManager::Bucket
   TZoneHeapManager::TZoneTypeBuckets -&gt; TZoneHeapManager::Group
   TZoneHeapManager::TZoneTypeBuckets::numberOfTypesThisSizeClass -&gt; TZoneHeapManager::Group::numberOfTypesInGroup
   TZoneHeapManager::m_typeSizes -&gt; TZoneHeapManager::m_registeredDescriptors
   TZoneHeapManager::m_heapRefsBySizeAndAlignment -&gt; TZoneHeapManager::m_groupByDescriptor
   SIZE_TZONE_TYPE_BUCKETS -&gt; TZONE_GROUP_SIZE
    - the previous names were unnecessarily long, or were not easy to grok (e.g. what exactly
      are TypeBuckets?).  So, here we remove unnecessary the &quot;TZone&quot; prefix for embedded classes,
      and gave the group of Buckets concept a better name i.e. Group.  The rest of the renaming
      fall out from these.

2. Added a comment in TZoneHeapManager.h to better describe the way TZone heaps are organized.

3. In TZoneHeapManager::dumpRegisteredTypes(), renamed some local variables to say what they
   actually mean, and also to be more consistent with other local variable naming in the same
   function:

   largestSizeClassCount -&gt; typeCountHighWatermark
   largestSizeClass -&gt; typeCountHighWatermarkDescriptor
    - largestSizeClass is actually the type / descriptor (refered to as &quot;SizeClass&quot;) that
      corresponds to the high watermark count.  The old names read like largestSizeClassCount
      is the number of instances of the largestSizeClass.  This is misleading, and fails to
      communicate the true intent of these variables.

   numBucketsThisSizeClass -&gt; bucketCount
    - there&apos;s also a re-computation of this same value but stored in a local named bucketCount
      later in the function.  So, I just renamed numBucketsThisSizeClass, and removed the
      duplicate local.

4. Broke the SizeAndAlignment::hash() method out into a TZoneDescriptorHashTrait class where
   it belongs.

No new tests because this is only a refactoring change with no behavior change.

* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::SizeAndAlignment::encode):
(bmalloc::api::SizeAndAlignment::decodeSize):
(bmalloc::api::SizeAndAlignment::decodeAlignment):
(bmalloc::api::TZoneDescriptorHashTrait::hash):
(bmalloc::api::SizeAndAlignment::hash): Deleted.
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneHeapManager::dumpRegisteredTypes):
(bmalloc::api::TZoneHeapManager::bucketCountForSizeClass):
(bmalloc::api::TZoneHeapManager::bucketForKey):
(bmalloc::api::TZoneHeapManager::populateGroupBuckets):
(bmalloc::api::TZoneHeapManager::heapRefForTZoneType):
(bmalloc::api::TZoneHeapManager::TZoneHeapManager::heapRefForTZoneTypeDifferentSize):
(bmalloc::api::TZoneHeapManager::tzoneBucketForKey): Deleted.
(bmalloc::api::TZoneHeapManager::populateBucketsForSizeClass): Deleted.
* Source/bmalloc/bmalloc/TZoneHeapManager.h:

Canonical link: <a href="https://commits.webkit.org/306589@main">https://commits.webkit.org/306589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d65f59852bf5a71339028c68d194f69903e317a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141722 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150294 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94841 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09a4db0b-ab20-4d19-9cf3-06bd385c46d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108910 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78752 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b2dfa25-8341-449f-a4a2-4e427e505242) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126849 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89805 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0bcbe1a-44c9-4c08-96b4-c5f7715583da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11000 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8637 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/367 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133706 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120290 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152687 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2526 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13797 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117005 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117327 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13360 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69405 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21879 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13835 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2836 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173011 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13574 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44806 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13777 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->