### PR TITLE
Reduce the scope of some PopupMenu IPC

### DIFF
--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -2038,16 +2038,12 @@ bool HTMLSelectElement::itemIsSelected(unsigned listIndex) const
     return option && option->selected();
 }
 
+#if !PLATFORM(COCOA)
 void HTMLSelectElement::setTextFromItem(unsigned listIndex)
 {
-#if !PLATFORM(COCOA)
     downcast<SelectFallbackButtonElement>(*protect(userAgentShadowRoot())->firstChild()).setTextFromOption(listToOptionIndex(listIndex));
-#else
-    // FIXME: Remove the setTextFromItem() API and IPC call from Cocoa platforms entirely.
-    UNUSED_PARAM(listIndex);
-    ASSERT_NOT_REACHED();
-#endif
 }
+#endif
 
 void HTMLSelectElement::listBoxSelectItem(int listIndex, bool allowMultiplySelections, bool shift, bool fireOnChangeNow)
 {

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -140,7 +140,9 @@ public:
     bool itemIsLabel(unsigned listIndex) const override;
     bool itemIsSelected(unsigned listIndex) const override;
     bool shouldPopOver() const override { return !POPUP_MENU_PULLS_DOWN; }
+#if !PLATFORM(COCOA)
     void setTextFromItem(unsigned listIndex) override;
+#endif
     void listBoxSelectItem(int listIndex, bool allowMultiplySelections, bool shift, bool fireOnChangeNow = true) override;
     bool popupMultiple() const override { return multiple(); }
     FontSelector* fontSelector() const override;

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -208,10 +208,12 @@ bool SearchInputType::itemIsSelected(unsigned) const
     return false;
 }
 
+#if !PLATFORM(COCOA)
 void SearchInputType::setTextFromItem(unsigned listIndex)
 {
     protectedElement()->setValue(itemText(listIndex));
 }
+#endif
 
 FontSelector* SearchInputType::fontSelector() const
 {

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -77,7 +77,9 @@ public:
     bool itemIsLabel(unsigned listIndex) const override;
     bool itemIsSelected(unsigned listIndex) const override;
     bool shouldPopOver() const override { return false; }
+#if !PLATFORM(COCOA)
     void setTextFromItem(unsigned listIndex) override;
+#endif
     FontSelector* fontSelector() const override;
     HostWindow* hostWindow() const override;
     Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) override;

--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -62,7 +62,9 @@ public:
     virtual bool itemIsLabel(unsigned listIndex) const = 0;
     virtual bool itemIsSelected(unsigned listIndex) const = 0;
     virtual bool shouldPopOver() const = 0;
+#if !PLATFORM(COCOA)
     virtual void setTextFromItem(unsigned listIndex) = 0;
+#endif
 
     virtual void listBoxSelectItem(int /*listIndex*/, bool /*allowMultiplySelections*/, bool /*shift*/, bool /*fireOnChangeNow*/ = true) { ASSERT_NOT_REACHED(); }
     virtual bool popupMultiple() const

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -456,9 +456,13 @@ public:
 #endif
 
     // WebPopupMenuProxy::Client
+#if !PLATFORM(IOS_FAMILY)
     void valueChangedForPopupMenu(WebPopupMenuProxy*, int32_t newSelectedIndex) final;
-    void setTextFromItemForPopupMenu(WebPopupMenuProxy*, int32_t index) final;
     NativeWebMouseEvent* currentlyProcessedMouseDownEvent() final;
+#endif
+#if !PLATFORM(COCOA)
+    void setTextFromItemForPopupMenu(WebPopupMenuProxy*, int32_t index) final;
+#endif
 #if PLATFORM(GTK)
     void failedToShowPopupMenu() final;
 #endif

--- a/Source/WebKit/UIProcess/WebPopupMenuProxy.h
+++ b/Source/WebKit/UIProcess/WebPopupMenuProxy.h
@@ -50,9 +50,13 @@ protected:
     virtual ~WebPopupMenuProxyClient() = default;
 
 public:
+#if !PLATFORM(IOS_FAMILY)
     virtual void valueChangedForPopupMenu(WebPopupMenuProxy*, int32_t newSelectedIndex) = 0;
-    virtual void setTextFromItemForPopupMenu(WebPopupMenuProxy*, int32_t index) = 0;
     virtual NativeWebMouseEvent* currentlyProcessedMouseDownEvent() = 0;
+#endif
+#if !PLATFORM(COCOA)
+    virtual void setTextFromItemForPopupMenu(WebPopupMenuProxy*, int32_t index) = 0;
+#endif
 #if PLATFORM(GTK)
     virtual void failedToShowPopupMenu() = 0;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
@@ -56,6 +56,7 @@ void WebPopupMenu::disconnectClient()
     m_popupClient = nullptr;
 }
 
+#if !PLATFORM(IOS_FAMILY)
 void WebPopupMenu::didChangeSelectedIndex(int newIndex)
 {
     RefPtr popupClient = m_popupClient;
@@ -66,12 +67,15 @@ void WebPopupMenu::didChangeSelectedIndex(int newIndex)
     if (newIndex >= 0)
         popupClient->valueChanged(newIndex);
 }
+#endif
 
+#if !PLATFORM(COCOA)
 void WebPopupMenu::setTextForIndex(int index)
 {
     if (RefPtr popupClient = m_popupClient)
         popupClient->setTextFromItem(index);
 }
+#endif
 
 Vector<WebPopupItem> WebPopupMenu::populateItems()
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.h
@@ -19,8 +19,7 @@
  *
  */
 
-#ifndef WebPopupMenu_h
-#define WebPopupMenu_h
+#pragma once
 
 #include "WebPopupItem.h"
 #include <WebCore/PopupMenu.h>
@@ -45,8 +44,12 @@ public:
     WebPage* page();
 
     void disconnectFromPage() { m_page = nullptr; }
+#if !PLATFORM(IOS_FAMILY)
     void didChangeSelectedIndex(int newIndex);
+#endif
+#if !PLATFORM(COCOA)
     void setTextForIndex(int newIndex);
+#endif
 #if PLATFORM(GTK)
     WebCore::PopupMenuClient* client() const { return m_popupClient.get(); }
 #endif
@@ -67,5 +70,3 @@ private:
 };
 
 } // namespace WebKit
-
-#endif // WebPopupMenu_h

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5862,6 +5862,7 @@ void WebPage::replaceMatches(const Vector<uint32_t>& matchIndices, const String&
     completionHandler(numberOfReplacements);
 }
 
+#if !PLATFORM(IOS_FAMILY)
 void WebPage::didChangeSelectedIndexForActivePopupMenu(int32_t newIndex)
 {
     changeSelectedIndex(newIndex);
@@ -5873,6 +5874,7 @@ void WebPage::changeSelectedIndex(int32_t index)
     if (RefPtr menu = m_activePopupMenu)
         menu->didChangeSelectedIndex(index);
 }
+#endif
 
 #if PLATFORM(IOS_FAMILY)
 void WebPage::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vector<String>& files, const String& displayString, std::span<const uint8_t> iconData)
@@ -6075,11 +6077,13 @@ void WebPage::capitalizeWord(FrameIdentifier frameID)
 }
 #endif
 
+#if !PLATFORM(COCOA)
 void WebPage::setTextForActivePopupMenu(int32_t index)
 {
     if (RefPtr menu = m_activePopupMenu)
         menu->setTextForIndex(index);
 }
+#endif
 
 #if PLATFORM(GTK)
 void WebPage::failedToShowPopupMenu()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2434,8 +2434,12 @@ private:
     void addLayerForFindOverlay(CompletionHandler<void(std::optional<WebCore::PlatformLayerIdentifier>)>&&);
     void removeLayerForFindOverlay(CompletionHandler<void()>&&);
 
+#if !PLATFORM(IOS_FAMILY)
     void didChangeSelectedIndexForActivePopupMenu(int32_t newIndex);
+#endif
+#if !PLATFORM(COCOA)
     void setTextForActivePopupMenu(int32_t index);
+#endif
 
 #if PLATFORM(GTK)
     void failedToShowPopupMenu();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -398,8 +398,12 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
 
     # Popup menu.
+#if !PLATFORM(IOS_FAMILY)
     DidChangeSelectedIndexForActivePopupMenu(int32_t newIndex)
+#endif
+#if !PLATFORM(COCOA)
     SetTextForActivePopupMenu(int32_t index)
+#endif
 #if PLATFORM(GTK)
     FailedToShowPopupMenu()
 #endif


### PR DESCRIPTION
#### 7550dda8fc2b8a811f851573a7dc8152003f59ba
<pre>
Reduce the scope of some PopupMenu IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=306697">https://bugs.webkit.org/show_bug.cgi?id=306697</a>

Reviewed by Chris Dumez.

DidChangeSelectedIndexForActivePopupMenu is not used by iOS family and
SetTextForActivePopupMenu is not used by Cocoa.

Canonical link: <a href="https://commits.webkit.org/306565@main">https://commits.webkit.org/306565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cac68d4a34966bfb66ff44b70e5c04ff83acbd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150295 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a5e5efa-0fec-4407-a122-b8e48dc473de) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108911 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d75e0a52-6c3b-40bb-8b47-ea9929eba873) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89806 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11001 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8638 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/368 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152688 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13798 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117006 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117328 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13361 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123557 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21866 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13836 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2838 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77561 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13622 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->