### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability in WebCore/animation

### DIFF
--- a/Source/WebCore/animation/CSSAnimationEvent.idl
+++ b/Source/WebCore/animation/CSSAnimationEvent.idl
@@ -36,9 +36,7 @@
 };
 
 // https://drafts.csswg.org/css-animations/#dictdef-animationeventinit
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary AnimationEventInit : EventInit {
+dictionary AnimationEventInit : EventInit {
     DOMString animationName = "";
     double elapsedTime = 0.0;
     DOMString pseudoElement = "";

--- a/Source/WebCore/animation/ComputedEffectTiming.h
+++ b/Source/WebCore/animation/ComputedEffectTiming.h
@@ -34,13 +34,15 @@
 namespace WebCore {
 
 struct ComputedEffectTiming : EffectTiming {
-    AnimationEffectPhase phase { AnimationEffectPhase::Idle };
-    std::optional<WebAnimationTime> localTime;
-    Markable<double> simpleIterationProgress;
-    Markable<double> progress;
-    Markable<double> currentIteration;
     WebAnimationTime endTime;
     WebAnimationTime activeDuration;
+    std::optional<WebAnimationTime> localTime;
+    Markable<double> progress;
+    Markable<double> currentIteration;
+
+    // FIXME: These are not part of the IDL.
+    AnimationEffectPhase phase { AnimationEffectPhase::Idle };
+    Markable<double> simpleIterationProgress;
     TimingFunction::Before before { TimingFunction::Before::No };
 };
 

--- a/Source/WebCore/animation/ComputedEffectTiming.idl
+++ b/Source/WebCore/animation/ComputedEffectTiming.idl
@@ -30,7 +30,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 // https://drafts.csswg.org/web-animations-2/#the-computedeffecttiming-dictionary
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary ComputedEffectTiming : EffectTiming {
     // FIXME: Add support for `startTime`.
     // CSSNumberish         startTime;

--- a/Source/WebCore/animation/CustomEffect.cpp
+++ b/Source/WebCore/animation/CustomEffect.cpp
@@ -52,14 +52,14 @@ ExceptionOr<Ref<CustomEffect>> CustomEffect::create(Document& document, Ref<Cust
                 return Exception { ExceptionCode::TypeError };
 
             return OptionalEffectTiming {
-                *convertedDuration,
-                effectTimingOptions.iterations,
                 effectTimingOptions.delay,
                 effectTimingOptions.endDelay,
-                effectTimingOptions.iterationStart,
-                effectTimingOptions.easing,
                 effectTimingOptions.fill,
-                effectTimingOptions.direction
+                effectTimingOptions.iterationStart,
+                effectTimingOptions.iterations,
+                *convertedDuration,
+                effectTimingOptions.direction,
+                effectTimingOptions.easing
             };
         }
     );

--- a/Source/WebCore/animation/KeyframeAnimationOptions.idl
+++ b/Source/WebCore/animation/KeyframeAnimationOptions.idl
@@ -28,9 +28,7 @@ typedef unsigned long FramesPerSecond;
 // https://drafts.csswg.org/web-animations-1/#dictdef-keyframeanimationoptions
 //   and then modified by
 // https://drafts.csswg.org/web-animations-2/#the-animatable-interface-mixin
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary KeyframeAnimationOptions : KeyframeEffectOptions {
+dictionary KeyframeAnimationOptions : KeyframeEffectOptions {
     DOMString id = "";
     AnimationTimeline? timeline;
     [EnabledBySetting=WebAnimationsCustomFrameRateEnabled] (FramesPerSecond or AnimationFrameRatePreset) frameRate = "auto";

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -791,14 +791,14 @@ ExceptionOr<Ref<KeyframeEffect>> KeyframeEffect::create(JSGlobalObject& lexicalG
             keyframeEffect->setIterationComposite(options.iterationComposite);
 
             return OptionalEffectTiming {
-                *convertedDuration,
-                options.iterations,
                 options.delay,
                 options.endDelay,
-                options.iterationStart,
-                options.easing,
                 options.fill,
-                options.direction
+                options.iterationStart,
+                options.iterations,
+                *convertedDuration,
+                options.direction,
+                options.easing
             };
         }
     );

--- a/Source/WebCore/animation/KeyframeEffect.idl
+++ b/Source/WebCore/animation/KeyframeEffect.idl
@@ -41,28 +41,21 @@ typedef (double? or TimelineRangeOffset or DOMString) KeyframeOffset;
     [CallWith=CurrentGlobalObject&CurrentDocument, ImplementedAs=setBindingsKeyframes] undefined setKeyframes(object? keyframes);
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary BasePropertyIndexedKeyframe {
+dictionary BasePropertyIndexedKeyframe {
     (sequence<KeyframeOffset> or KeyframeOffset) offset = [];
     (sequence<DOMString> or DOMString) easing = [];
     (sequence<CompositeOperationOrAuto> or CompositeOperationOrAuto) composite = [];
 };
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary BaseKeyframe {
+dictionary BaseKeyframe {
     KeyframeOffset offset = null;
     DOMString easing = "linear";
     CompositeOperationOrAuto composite = "auto";
 };
 
+// FIXME: The inheritance below is not yet standardized: https://github.com/w3c/csswg-drafts/issues/13423.
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary BaseComputedKeyframe {
-     KeyframeOffset offset = null;
+] dictionary BaseComputedKeyframe : BaseKeyframe {
      unrestricted double computedOffset;
-     DOMString easing = "linear";
-     CompositeOperationOrAuto composite = "auto";
 };

--- a/Source/WebCore/animation/KeyframeEffectOptions.idl
+++ b/Source/WebCore/animation/KeyframeEffectOptions.idl
@@ -28,9 +28,7 @@ typedef USVString CSSOMString;
 // https://drafts.csswg.org/web-animations-1/#dictdef-keyframeeffectoptions
 //   and then modified by
 // https://drafts.csswg.org/web-animations-2/#the-keyframeeffectoptions-dictionary
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary KeyframeEffectOptions : EffectTiming {
+dictionary KeyframeEffectOptions : EffectTiming {
     IterationCompositeOperation iterationComposite = "replace";
     CompositeOperation composite = "replace";
     CSSOMString? pseudoElement = null;

--- a/Source/WebCore/animation/OptionalEffectTiming.h
+++ b/Source/WebCore/animation/OptionalEffectTiming.h
@@ -33,14 +33,14 @@
 namespace WebCore {
 
 struct OptionalEffectTiming {
-    std::optional<Variant<double, String>> duration;
-    std::optional<double> iterations; // This value cannot be a Markable<double> since we need to check for a NaN value.
     Markable<double> delay;
     Markable<double> endDelay;
-    Markable<double> iterationStart;
-    String easing;
     OptionalFillMode fill;
+    Markable<double> iterationStart;
+    std::optional<double> iterations; // This value cannot be a Markable<double> since we need to check for a NaN value.
+    std::optional<Variant<double, String>> duration;
     OptionalPlaybackDirection direction;
+    String easing;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/OptionalEffectTiming.idl
+++ b/Source/WebCore/animation/OptionalEffectTiming.idl
@@ -26,9 +26,7 @@
 // https://drafts.csswg.org/web-animations-1/#dictdef-optionaleffecttiming
 //   and then modified by
 // https://drafts.csswg.org/web-animations-2/#the-effecttiming-dictionaries
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary OptionalEffectTiming {
+dictionary OptionalEffectTiming {
     double delay;
     double endDelay;
     FillMode fill;


### PR DESCRIPTION
#### 3c252ad0bf68a3a4578791d2fcb1e9a97666a25d
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability in WebCore/animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=306698">https://bugs.webkit.org/show_bug.cgi?id=306698</a>

Reviewed by Sam Weinig.

Canonical link: <a href="https://commits.webkit.org/306573@main">https://commits.webkit.org/306573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/243925f7897f00ed5947a45a00fd8846fae0c150

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150298 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/94845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/120a9d50-c0d4-4bda-b1a9-73fc0a70addd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108914 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/94845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fb2439f-324d-4d03-96d9-6b430fc08b9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89809 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0210551-c8f0-4942-9e06-4ccdb69fec7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11004 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8641 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/371 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152691 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117009 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117331 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13364 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123559 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69409 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21871 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13839 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2840 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13781 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->