### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability in URL Pattern and Web Locks

### DIFF
--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -393,7 +393,7 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
         matchHelperAssignInputsFromURL(*inputURL, protocol, username, password, hostname, port, pathname, search, hash);
         result.inputs = Vector<URLPatternInput> { String { inputURL->string() } };
     } else {
-        URLPatternInput* inputPattern = std::get_if<URLPatternInput>(&input);
+        auto* inputPattern = std::get_if<URLPatternInput>(&input);
         result.inputs.append(*inputPattern);
 
         auto hasError = WTF::switchOn(*inputPattern, [&](const URLPatternInit& value) -> ExceptionOr<bool> {

--- a/Source/WebCore/Modules/url-pattern/URLPatternResult.idl
+++ b/Source/WebCore/Modules/url-pattern/URLPatternResult.idl
@@ -32,25 +32,23 @@
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
     ImplementedAs=URLPatternComponentResult,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary URLPatternComponentResult {
-    USVString input;
-    record<USVString, (undefined or USVString)> groups;
+    [ImplementationRequired] USVString input;
+    [ImplementationRequired] record<USVString, (undefined or USVString)> groups;
 };
 
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary URLPatternResult {
-    sequence<URLPatternInput> inputs;
+    [ImplementationRequired] sequence<URLPatternInput> inputs;
 
-    URLPatternComponentResult protocol;
-    URLPatternComponentResult username;
-    URLPatternComponentResult password;
-    URLPatternComponentResult hostname;
-    URLPatternComponentResult port;
-    URLPatternComponentResult pathname;
-    URLPatternComponentResult search;
-    URLPatternComponentResult hash;
+    [ImplementationRequired] URLPatternComponentResult protocol;
+    [ImplementationRequired] URLPatternComponentResult username;
+    [ImplementationRequired] URLPatternComponentResult password;
+    [ImplementationRequired] URLPatternComponentResult hostname;
+    [ImplementationRequired] URLPatternComponentResult port;
+    [ImplementationRequired] URLPatternComponentResult pathname;
+    [ImplementationRequired] URLPatternComponentResult search;
+    [ImplementationRequired] URLPatternComponentResult hash;
 };

--- a/Source/WebCore/Modules/web-locks/WebLockManagerSnapshot.idl
+++ b/Source/WebCore/Modules/web-locks/WebLockManagerSnapshot.idl
@@ -24,7 +24,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary WebLockManagerSnapshot {
     sequence<WebLockInfo> held;
     sequence<WebLockInfo> pending;
@@ -32,7 +31,6 @@
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary WebLockInfo {
     DOMString name;
     WebLockMode mode;

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -1928,7 +1928,8 @@ sub GetDictionaryMemberDefaultValueFunctor
 {
     my ($interface, $member) = @_;
 
-    if (!$member->isRequired && defined $member->default && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) {
+    my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
+    if (!$effectivelyRequired && defined $member->default && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) {
         my $IDLType = GetIDLType($interface, $member->type);
         my $defaultValue = GenerateDefaultValue($interface, $member, $member->type, $member->default);
         return "[&] -> ConversionResult<${IDLType}> { return ${defaultValue}; }";
@@ -2913,7 +2914,8 @@ sub GenerateDictionaryImplementationMemberConversion
     }
 
     my $defaultValueFunctor = GetDictionaryMemberDefaultValueFunctor($typeScope, $member);
-    my $optional = !$member->isRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
+    my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
+    my $optional = !$effectivelyRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
 
     my $conversion;
     if ($member->extendedAttributes->{PermissiveInvalidValue} && $codeGenerator->IsEnumType($type)) {
@@ -3222,7 +3224,8 @@ sub GenerateConvertDictionaryToJS
                 $indent = "    ";
             }
 
-            if (!$member->isRequired && not defined $member->default) {
+            my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
+            if (!$effectivelyRequired && not defined $member->default) {
                 my $IDLType = GetIDLType($typeScope, $member->type);
                 my $conversionExpression = NativeToJSValueUsingReferences($member, $typeScope, "${IDLType}::extractValueFromNullable(${valueExpression})", "globalObject");
 
@@ -3313,7 +3316,8 @@ sub GenerateConvertDictionaryToJSForLegacyNativeDictionaryRequiredInterfaceNulla
                 $indent = "    ";
             }
 
-            if (!$member->isRequired && not defined $member->default) {
+            my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
+            if (!$effectivelyRequired && not defined $member->default) {
                 my $IDLType = GetIDLType($typeScope, $member->type);
                 my $conversionExpression = NativeToJSValueUsingReferences($member, $typeScope, "${IDLType}::extractValueFromNullable(${valueExpression})", "globalObject");
 
@@ -8135,7 +8139,8 @@ sub GetIDLTypeForDictionaryMember
     my ($interface, $member) = @_;
 
     my $defaultValueFunctor = GetDictionaryMemberDefaultValueFunctor($interface, $member);
-    my $optional = !$member->isRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
+    my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
+    my $optional = !$effectivelyRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
 
     my $IDLType = GetIDLType($interface, $member->type);
     $IDLType = "IDLOptional<" . $IDLType . ">" if $optional && !$defaultValueFunctor;

--- a/Source/WebCore/bindings/scripts/IDLAttributes.json
+++ b/Source/WebCore/bindings/scripts/IDLAttributes.json
@@ -287,6 +287,10 @@
             "contextsAllowed": ["interface", "namespace", "dictionary", "dictionary-member", "attribute", "operation", "constant"],
             "values": ["*"]
         },
+        "ImplementationRequired": {
+            "contextsAllowed": ["dictionary-member"],
+            "notes": "Allows treating the dictionary member as required when the specification doesn't specify the required keyword but using it is unobservable."
+        },
         "InterfaceName": {
             "contextsAllowed": ["interface", "namespace"],
             "values": ["*"]


### PR DESCRIPTION
#### d9e504e9d9c7aa1934df8f10269372f202adfb4f
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability in URL Pattern and Web Locks
<a href="https://bugs.webkit.org/show_bug.cgi?id=306699">https://bugs.webkit.org/show_bug.cgi?id=306699</a>

Reviewed by Sam Weinig.

To keep the changes to C++ to a minimum we add [ImplementationRequired]
for dictionary members that are effectively required by the
specification, but currently do not use the required keyword due to a
standards community disagreement.

Canonical link: <a href="https://commits.webkit.org/306615@main">https://commits.webkit.org/306615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2206d27066b607ad07be5fce312f41230fefae0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94908 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33f3c6f7-d25b-4b2b-a1e4-ee23ee724e9b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108952 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78788 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f14e90a0-141f-487c-bb88-e7dae8614bab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89848 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a52ab42-55fa-436c-a245-1f6c464b351e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8692 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/443 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152765 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3387 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117047 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 19 flakes 7 failures; Uploaded test results; 2 flakes 3 failures; Compiled WebKit; 3 failures; Running analyze-layout-tests-results") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117369 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13413 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69501 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21888 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13896 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2892 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77621 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13838 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->