### PR TITLE
Add `appearance: base-select` alias for `appearance: base`

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -311,6 +311,8 @@ constexpr CSSValueID toCSSValueID(StyleAppearance e)
         return CSSValueAuto;
     case StyleAppearance::Base:
         return CSSValueBase;
+    case StyleAppearance::BaseSelect:
+        return CSSValueBaseSelect;
     case StyleAppearance::Checkbox:
         return CSSValueCheckbox;
     case StyleAppearance::Radio:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9134,6 +9134,10 @@
                     "value": "base",
                     "settings-flag": "cssAppearanceBaseEnabled"
                 },
+                {
+                    "value": "base-select",
+                    "settings-flag": "htmlEnhancedSelectPseudoElementsEnabled"
+                },
                 "auto",
                 "none",
                 {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -909,8 +909,9 @@ anywhere
 
 // -webkit-appearance
 // The order here must match the order in the StyleAppearance enum in StyleAppearance.h.
-// All appearance values that should be accepted by the parser should be listed between 'base' and 'textarea':
+// All appearance values that should be accepted by the parser should be listed between 'base' and 'textfield':
 base
+base-select
 checkbox
 radio
 push-button
@@ -930,7 +931,6 @@ attachment enable-if=ENABLE_ATTACHMENT_ELEMENT
 borderless-attachment enable-if=ENABLE_ATTACHMENT_ELEMENT
 textarea
 textfield
--internal-auto-base
 
 //
 // CSS_PROP_BORDER_IMAGE
@@ -982,14 +982,11 @@ intersect
 exclude
 
 //
-// Variables Implementation
+// Global substitution functions
 //
 var
-
-//
-// Environment Variables
-//
 env
+-internal-auto-base
 
 //
 // CSS_PROP_BREAK_BEFORE/AFTER/INSIDE

--- a/Source/WebCore/platform/StyleAppearance.cpp
+++ b/Source/WebCore/platform/StyleAppearance.cpp
@@ -42,6 +42,9 @@ TextStream& operator<<(TextStream& ts, StyleAppearance appearance)
     case StyleAppearance::Base:
         ts << "base"_s;
         break;
+    case StyleAppearance::BaseSelect:
+        ts << "base-select"_s;
+        break;
     case StyleAppearance::Checkbox:
         ts << "checkbox"_s;
         break;

--- a/Source/WebCore/platform/StyleAppearance.h
+++ b/Source/WebCore/platform/StyleAppearance.h
@@ -36,6 +36,7 @@ enum class StyleAppearance : uint8_t {
     None,
     Auto,
     Base,
+    BaseSelect,
     Checkbox,
     Radio,
     PushButton,

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -130,6 +130,11 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
     }
 
     auto appearance = style.usedAppearance();
+    if (appearance == StyleAppearance::BaseSelect) {
+        style.setUsedAppearance(StyleAppearance::Base);
+        return StyleAppearance::Base;
+    }
+
     if (appearance == autoAppearance)
         return appearance;
 
@@ -629,6 +634,7 @@ RefPtr<ControlPart> RenderTheme::createControlPart(const RenderElement& renderer
     case StyleAppearance::None:
     case StyleAppearance::Auto:
     case StyleAppearance::Base:
+    case StyleAppearance::BaseSelect:
         break;
 
     case StyleAppearance::Checkbox:


### PR DESCRIPTION
#### 83b1795c2f993688b2e0e3786946fc51fa428e33
<pre>
Add `appearance: base-select` alias for `appearance: base`
<a href="https://bugs.webkit.org/show_bug.cgi?id=306709">https://bugs.webkit.org/show_bug.cgi?id=306709</a>
<a href="https://rdar.apple.com/169355684">rdar://169355684</a>

Reviewed by Antti Koivisto.

Implement `appearance: base-select` as an used-value time alias.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/platform/StyleAppearance.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/StyleAppearance.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):
(WebCore::RenderTheme::createControlPart const):

Canonical link: <a href="https://commits.webkit.org/306667@main">https://commits.webkit.org/306667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbdefb6d232159d1a52ee17fe02a01a8fc7b5588

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94937 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb1cdf43-8f16-4c81-8281-f827521eca4b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108976 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78810 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a54535a8-4e14-4c52-87af-b5ccce900090) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144761 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89872 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d385f890-4e9c-4d57-a0a7-423e9c86b36c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11078 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8718 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/472 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2949 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152794 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13887 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117067 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117389 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13438 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69545 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21910 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13925 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2917 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13664 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13867 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->