### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from RTCStatsReport

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -96,52 +96,43 @@ public:
     };
 
     struct Stats {
-#if USE(LIBWEBRTC)
-        Stats(Type, const webrtc::RTCStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        Stats(Type, const GstStructure*);
-#endif
-
         double timestamp { 0 };
         Type type;
         String id;
+
+#if USE(LIBWEBRTC)
+        static Stats convert(Type, const webrtc::RTCStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static Stats convert(Type, const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<Stats>);
 
     struct RtpStreamStats : Stats {
-#if USE(LIBWEBRTC)
-        RtpStreamStats(Type, const webrtc::RTCRtpStreamStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        RtpStreamStats(Type, const GstStructure*);
-#endif
-
         uint32_t ssrc { 0 };
         String kind;
         String transportId;
         String codecId;
+
+#if USE(LIBWEBRTC)
+        static RtpStreamStats convert(Type, const webrtc::RTCRtpStreamStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static RtpStreamStats convert(Type, const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<RtpStreamStats>);
 
     struct ReceivedRtpStreamStats : RtpStreamStats {
-#if USE(LIBWEBRTC)
-        ReceivedRtpStreamStats(Type, const webrtc::RTCReceivedRtpStreamStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        ReceivedRtpStreamStats(Type, const GstStructure*);
-#endif
-
         std::optional<uint64_t> packetsReceived;
         std::optional<int64_t> packetsLost;
         std::optional<double> jitter;
+
+#if USE(LIBWEBRTC)
+        static ReceivedRtpStreamStats convert(Type, const webrtc::RTCReceivedRtpStreamStats&, std::optional<uint64_t> packetsReceived);
+#elif USE(GSTREAMER_WEBRTC)
+        static ReceivedRtpStreamStats convert(Type, const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<ReceivedRtpStreamStats>);
 
     struct InboundRtpStreamStats : ReceivedRtpStreamStats {
-#if USE(LIBWEBRTC)
-        InboundRtpStreamStats(const webrtc::RTCInboundRtpStreamStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        InboundRtpStreamStats(const GstStructure*);
-#endif
-
         String trackIdentifier;
         String mid;
         String remoteId;
@@ -167,8 +158,6 @@ public:
         std::optional<uint64_t> fecPacketsReceived;
         std::optional<uint64_t> fecPacketsDiscarded;
         std::optional<uint64_t> bytesReceived;
-        std::optional<uint64_t> packetsFailedDecryption;
-        std::optional<uint64_t> packetsDuplicated;
         std::optional<uint32_t> nackCount;
         std::optional<uint32_t> firCount;
         std::optional<uint32_t> pliCount;
@@ -179,8 +168,6 @@ public:
         std::optional<uint64_t> jitterBufferEmittedCount;
         std::optional<double> jitterBufferMinimumDelay;
         std::optional<uint64_t> totalSamplesReceived;
-        std::optional<uint64_t> samplesDecodedWithSilk;
-        std::optional<uint64_t> samplesDecodedWithCelt;
         std::optional<uint64_t> concealedSamples;
         std::optional<uint64_t> silentConcealedSamples;
         std::optional<uint64_t> concealmentEvents;
@@ -199,35 +186,38 @@ public:
         std::optional<uint64_t> retransmittedBytesReceived;
         std::optional<uint32_t> rtxSsrc;
         std::optional<uint32_t> fecSsrc;
+
+#if USE(LIBWEBRTC)
+        static InboundRtpStreamStats convert(const webrtc::RTCInboundRtpStreamStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static InboundRtpStreamStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<InboundRtpStreamStats>);
 
     struct RemoteInboundRtpStreamStats : ReceivedRtpStreamStats {
-#if USE(LIBWEBRTC)
-        RemoteInboundRtpStreamStats(const webrtc::RTCRemoteInboundRtpStreamStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        RemoteInboundRtpStreamStats(const GstStructure*);
-#endif
-
         String localId;
         std::optional<double> roundTripTime;
         std::optional<double> totalRoundTripTime;
         std::optional<double> fractionLost;
         std::optional<uint64_t> roundTripTimeMeasurements;
+
+#if USE(LIBWEBRTC)
+        static RemoteInboundRtpStreamStats convert(const webrtc::RTCRemoteInboundRtpStreamStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static RemoteInboundRtpStreamStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<RemoteInboundRtpStreamStats>);
 
     struct SentRtpStreamStats : RtpStreamStats {
-#if USE(LIBWEBRTC)
-        SentRtpStreamStats(Type, const webrtc::RTCSentRtpStreamStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        SentRtpStreamStats(Type, const GstStructure*);
-#endif
-
         std::optional<uint32_t> packetsSent;
         std::optional<uint64_t> bytesSent;
+
+#if USE(LIBWEBRTC)
+        static SentRtpStreamStats convert(Type, const webrtc::RTCSentRtpStreamStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static SentRtpStreamStats convert(Type, const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<SentRtpStreamStats>);
 
     enum class QualityLimitationReason {
         None,
@@ -237,12 +227,6 @@ public:
     };
 
     struct OutboundRtpStreamStats : SentRtpStreamStats {
-#if USE(LIBWEBRTC)
-        OutboundRtpStreamStats(const webrtc::RTCOutboundRtpStreamStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        OutboundRtpStreamStats(const GstStructure*);
-#endif
-
         String mid;
         String mediaSourceId;
         String remoteId;
@@ -271,32 +255,30 @@ public:
         std::optional<uint32_t> pliCount;
         std::optional<bool> active;
         String scalabilityMode;
+
+#if USE(LIBWEBRTC)
+        static OutboundRtpStreamStats convert(const webrtc::RTCOutboundRtpStreamStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static OutboundRtpStreamStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<OutboundRtpStreamStats>);
 
     struct RemoteOutboundRtpStreamStats : SentRtpStreamStats {
-#if USE(LIBWEBRTC)
-        RemoteOutboundRtpStreamStats(const webrtc::RTCRemoteOutboundRtpStreamStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        RemoteOutboundRtpStreamStats(const GstStructure*);
-#endif
-
         String localId;
         std::optional<double> remoteTimestamp;
         std::optional<uint64_t> reportsSent;
         std::optional<double> roundTripTime;
         std::optional<double> totalRoundTripTime;
         std::optional<uint64_t> roundTripTimeMeasurements;
+
+#if USE(LIBWEBRTC)
+        static RemoteOutboundRtpStreamStats convert(const webrtc::RTCRemoteOutboundRtpStreamStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static RemoteOutboundRtpStreamStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<RemoteOutboundRtpStreamStats>);
 
     struct DataChannelStats : Stats {
-#if USE(LIBWEBRTC)
-        DataChannelStats(const webrtc::RTCDataChannelStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        DataChannelStats(const GstStructure*);
-#endif
-
         String label;
         String protocol;
         std::optional<int> dataChannelIdentifier;
@@ -305,8 +287,13 @@ public:
         std::optional<uint64_t> bytesSent;
         std::optional<uint32_t> messagesReceived;
         std::optional<uint64_t> bytesReceived;
+
+#if USE(LIBWEBRTC)
+        static DataChannelStats convert(const webrtc::RTCDataChannelStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static DataChannelStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<DataChannelStats>);
 
     enum class IceCandidatePairState {
         Frozen,
@@ -317,12 +304,6 @@ public:
     };
 
     struct IceCandidatePairStats : Stats {
-#if USE(LIBWEBRTC)
-        IceCandidatePairStats(const webrtc::RTCIceCandidatePairStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        IceCandidatePairStats(const GstStructure*);
-#endif
-
         String transportId;
         String localCandidateId;
         String remoteCandidateId;
@@ -345,16 +326,15 @@ public:
         std::optional<uint64_t> consentRequestsSent;
         std::optional<uint32_t> packetsDiscardedOnSend;
         std::optional<uint64_t> bytesDiscardedOnSend;
+
+#if USE(LIBWEBRTC)
+        static IceCandidatePairStats convert(const webrtc::RTCIceCandidatePairStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static IceCandidatePairStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<IceCandidatePairStats>);
 
     struct IceCandidateStats : Stats {
-#if USE(LIBWEBRTC)
-        IceCandidateStats(const webrtc::RTCIceCandidateStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        IceCandidateStats(GstWebRTCStatsType, const GstStructure*);
-#endif
-
         String transportId;
         std::optional<String> address;
         std::optional<int32_t> port;
@@ -368,22 +348,26 @@ public:
         std::optional<int32_t> relatedPort;
         String usernameFragment;
         std::optional<RTCIceTcpCandidateType> tcpType;
+
+#if USE(LIBWEBRTC)
+        static IceCandidateStats convert(const webrtc::RTCIceCandidateStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static IceCandidateStats convert(GstWebRTCStatsType, const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<IceCandidateStats>);
 
     struct CertificateStats : Stats {
-#if USE(LIBWEBRTC)
-        CertificateStats(const webrtc::RTCCertificateStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        CertificateStats(const GstStructure*);
-#endif
-
         String fingerprint;
         String fingerprintAlgorithm;
         String base64Certificate;
         String issuerCertificateId;
+
+#if USE(LIBWEBRTC)
+        static CertificateStats convert(const webrtc::RTCCertificateStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static CertificateStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<CertificateStats>);
 
     enum class CodecType {
         Encode,
@@ -391,21 +375,19 @@ public:
     };
 
     struct CodecStats : Stats {
-#if USE(LIBWEBRTC)
-        CodecStats(const webrtc::RTCCodecStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        CodecStats(const GstStructure*);
-#endif
-
         uint32_t payloadType { 0 };
         String transportId;
         String mimeType;
         std::optional<uint32_t> clockRate;
         std::optional<uint32_t> channels;
         String sdpFmtpLine;
-        String implementation;
+
+#if USE(LIBWEBRTC)
+        static CodecStats convert(const webrtc::RTCCodecStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static CodecStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<CodecStats>);
 
     enum class DtlsRole : uint8_t {
         Client,
@@ -414,12 +396,6 @@ public:
     };
 
     struct TransportStats : Stats {
-#if USE(LIBWEBRTC)
-        TransportStats(const webrtc::RTCTransportStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        TransportStats(const GstStructure*);
-#endif
-
         std::optional<uint64_t> packetsSent;
         std::optional<uint64_t> packetsReceived;
         std::optional<uint64_t> bytesSent;
@@ -436,78 +412,78 @@ public:
         std::optional<DtlsRole> dtlsRole;
         String srtpCipher;
         std::optional<uint32_t> selectedCandidatePairChanges;
+
+#if USE(LIBWEBRTC)
+        static TransportStats convert(const webrtc::RTCTransportStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static TransportStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<TransportStats>);
 
     struct AudioPlayoutStats : Stats {
-#if USE(LIBWEBRTC)
-        AudioPlayoutStats(const webrtc::RTCAudioPlayoutStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        AudioPlayoutStats(const GstStructure*);
-#endif
-
         String kind;
         std::optional<double> synthesizedSamplesDuration;
         std::optional<uint32_t> synthesizedSamplesEvents;
         std::optional<double> totalSamplesDuration;
         std::optional<double> totalPlayoutDelay;
         std::optional<uint64_t> totalSamplesCount;
+
+#if USE(LIBWEBRTC)
+        static AudioPlayoutStats convert(const webrtc::RTCAudioPlayoutStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static AudioPlayoutStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<AudioPlayoutStats>);
 
     struct PeerConnectionStats : Stats {
-#if USE(LIBWEBRTC)
-        PeerConnectionStats(const webrtc::RTCPeerConnectionStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        PeerConnectionStats(const GstStructure*);
-#endif
-
         std::optional<uint32_t> dataChannelsOpened;
         std::optional<uint32_t> dataChannelsClosed;
+
+#if USE(LIBWEBRTC)
+        static PeerConnectionStats convert(const webrtc::RTCPeerConnectionStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static PeerConnectionStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<PeerConnectionStats>);
 
     struct MediaSourceStats : Stats {
-#if USE(LIBWEBRTC)
-        MediaSourceStats(Type, const webrtc::RTCMediaSourceStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        MediaSourceStats(Type, const GstStructure*);
-#endif
-
         String trackIdentifier;
         String kind;
-        std::optional<bool> relayedSource;
+
+#if USE(LIBWEBRTC)
+        static MediaSourceStats convert(Type, const webrtc::RTCMediaSourceStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static MediaSourceStats convert(Type, const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<MediaSourceStats>);
 
     struct AudioSourceStats : MediaSourceStats {
-#if USE(LIBWEBRTC)
-        AudioSourceStats(const webrtc::RTCAudioSourceStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        AudioSourceStats(const GstStructure*);
-#endif
-
         std::optional<double> audioLevel;
         std::optional<double> totalAudioEnergy;
         std::optional<double> totalSamplesDuration;
         std::optional<double> echoReturnLoss;
         std::optional<double> echoReturnLossEnhancement;
+
+#if USE(LIBWEBRTC)
+        static AudioSourceStats convert(const webrtc::RTCAudioSourceStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static AudioSourceStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<AudioSourceStats>);
+
 
     struct VideoSourceStats : MediaSourceStats {
-#if USE(LIBWEBRTC)
-        VideoSourceStats(const webrtc::RTCVideoSourceStats&);
-#elif USE(GSTREAMER_WEBRTC)
-        VideoSourceStats(const GstStructure*);
-#endif
-
         std::optional<unsigned long> width;
         std::optional<unsigned long> height;
         std::optional<unsigned long> frames;
         std::optional<double> framesPerSecond;
+
+#if USE(LIBWEBRTC)
+        static VideoSourceStats convert(const webrtc::RTCVideoSourceStats&);
+#elif USE(GSTREAMER_WEBRTC)
+        static VideoSourceStats convert(const GstStructure*);
+#endif
     };
-    static_assert(!std::is_default_constructible_v<VideoSourceStats>);
 
 private:
     explicit RTCStatsReport(MapInitializer&&);

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
@@ -52,7 +52,6 @@ typedef double DOMHighResTimeStamp;
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCStats {
     required DOMHighResTimeStamp timestamp;
     required RTCStatsType type;
@@ -62,7 +61,6 @@ typedef double DOMHighResTimeStamp;
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRtpStreamStats : RTCStats {
     required unsigned long ssrc;
     required DOMString kind;
@@ -72,7 +70,6 @@ typedef double DOMHighResTimeStamp;
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCReceivedRtpStreamStats : RTCRtpStreamStats {
     unsigned long long packetsReceived;
     long long packetsLost;
@@ -81,7 +78,6 @@ typedef double DOMHighResTimeStamp;
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCInboundRtpStreamStats : RTCReceivedRtpStreamStats {
     required DOMString trackIdentifier;
     DOMString mid;
@@ -138,7 +134,6 @@ typedef double DOMHighResTimeStamp;
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRemoteInboundRtpStreamStats : RTCReceivedRtpStreamStats {
     DOMString localId;
     double roundTripTime;
@@ -149,7 +144,6 @@ typedef double DOMHighResTimeStamp;
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCSentRtpStreamStats : RTCRtpStreamStats {
     unsigned long packetsSent;
     unsigned long long bytesSent;
@@ -164,7 +158,6 @@ enum RTCQualityLimitationReason {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCOutboundRtpStreamStats : RTCSentRtpStreamStats {
     DOMString mid;
     DOMString mediaSourceId;
@@ -198,7 +191,6 @@ enum RTCQualityLimitationReason {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCRemoteOutboundRtpStreamStats : RTCSentRtpStreamStats {
     DOMString localId;
     DOMHighResTimeStamp remoteTimestamp;
@@ -217,7 +209,6 @@ enum RTCCodecType {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCCodecStats : RTCStats {
     required unsigned long payloadType;
     required DOMString transportId;
@@ -229,7 +220,6 @@ enum RTCCodecType {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCMediaSourceStats : RTCStats {
     required DOMString  trackIdentifier;
     required DOMString  kind;
@@ -239,7 +229,6 @@ enum RTCCodecType {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCAudioSourceStats : RTCMediaSourceStats {
     double audioLevel;
     double totalAudioEnergy;
@@ -250,7 +239,6 @@ enum RTCCodecType {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCVideoSourceStats : RTCMediaSourceStats {
     unsigned long width;
     unsigned long height;
@@ -260,7 +248,6 @@ enum RTCCodecType {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCAudioPlayoutStats : RTCStats {
     required DOMString kind;
     double synthesizedSamplesDuration;
@@ -272,7 +259,6 @@ enum RTCCodecType {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCPeerConnectionStats : RTCStats {
     unsigned long dataChannelsOpened;
     unsigned long dataChannelsClosed;
@@ -280,7 +266,6 @@ enum RTCCodecType {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCDataChannelStats : RTCStats {
     DOMString label;
     DOMString protocol;
@@ -300,7 +285,6 @@ enum RTCDtlsRole {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCTransportStats : RTCStats {
     unsigned long long packetsSent;
     unsigned long long packetsReceived;
@@ -322,7 +306,6 @@ enum RTCDtlsRole {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCIceCandidateStats : RTCStats {
     required DOMString transportId;
     DOMString? address;
@@ -349,7 +332,6 @@ enum RTCStatsIceCandidatePairState {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCIceCandidatePairStats : RTCStats {
     required DOMString transportId;
     required DOMString localCandidateId;
@@ -377,7 +359,6 @@ enum RTCStatsIceCandidatePairState {
 
 [
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary RTCCertificateStats : RTCStats {
     required DOMString fingerprint;
     required DOMString fingerprintAlgorithm;


### PR DESCRIPTION
#### e900c1a9b18a7d142cb05dae9d0c7746a1dc58fd
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from RTCStatsReport
<a href="https://bugs.webkit.org/show_bug.cgi?id=306711">https://bugs.webkit.org/show_bug.cgi?id=306711</a>

Reviewed by Anne van Kesteren.

Remove LegacyNativeDictionaryRequiredInterfaceNullability from RTCStatsReport.

* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/RTCStatsReport.idl:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:

Canonical link: <a href="https://commits.webkit.org/306632@main">https://commits.webkit.org/306632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e846e9b5b0aca1140893fedaf65baa0a397a084

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141796 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108961 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78797 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11067 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8704 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/456 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2936 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13871 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13886 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12103 "Too many flaky failures: fast/dom/Geolocation/window-close-crash.html, imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-self-allowed-target-blank.html, imported/w3c/web-platform-tests/css/css-view-transitions/navigation/with-types/navigation-supersedes-types-same-rule.html, imported/w3c/web-platform-tests/fetch/connection-pool/network-partition-key.html, imported/w3c/web-platform-tests/fetch/http-cache/split-cache.html, imported/w3c/web-platform-tests/html/browsers/the-window-object/BarProp.window.html, imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html, imported/w3c/web-platform-tests/page-lifecycle/freeze.html, imported/w3c/web-platform-tests/streams/piping/crashtests/cross-piping.html, imported/w3c/web-platform-tests/wasm/jsapi/functions/entry-different-function-realm.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13424 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123623 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69524 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13909 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2904 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13648 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77634 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->