### PR TITLE
[Skia] System fallback font selection shouldn't take style into account

### DIFF
--- a/LayoutTests/platform/glib/fast/forms/visual-hebrew-text-field-expected.txt
+++ b/LayoutTests/platform/glib/fast/forms/visual-hebrew-text-field-expected.txt
@@ -10,10 +10,10 @@ layer at (0,0) size 800x600
           RenderInline {A} at (274,1) size 426x17 [color=#0000EE]
             RenderText {#text} at (274,1) size 426x17
               text run at (274,1) width 426: "http://bugzilla.opendarwin.org/show_bug.cgi?id=8076"
-          RenderText {#text} at (0,20) size 563x17
-            text run at (0,20) width 563: "REGRESSION: native text fields are reversed on \"visual Hebrew\" pages"
-        RenderText {#text} at (562,20) size 6x17
-          text run at (562,20) width 6: "."
+          RenderText {#text} at (0,20) size 562x17
+            text run at (0,20) width 562: "REGRESSION: native text fields are reversed on \"visual Hebrew\" pages"
+        RenderText {#text} at (561,20) size 6x17
+          text run at (561,20) width 6: "."
       RenderBlock {P} at (0,72) size 784x19
         RenderText {#text} at (0,1) size 333x17
           text run at (0,1) width 333: "Text in the field should look like this: \x{5E8}\x{5D5}\x{5EA}\x{5E4}\x{5DB}"

--- a/LayoutTests/platform/glib/fast/text/in-rendered-text-rtl-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/in-rendered-text-rtl-expected.txt
@@ -6,15 +6,15 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 65x17
           text run at (0,1) width 65: "Test for "
-        RenderInline {I} at (0,1) size 776x36
-          RenderInline {A} at (64,1) size 426x17 [color=#0000EE]
-            RenderText {#text} at (64,1) size 426x17
-              text run at (64,1) width 426: "http://bugzilla.opendarwin.org/show_bug.cgi?id=7433"
-          RenderText {#text} at (0,1) size 776x36
-            text run at (489,1) width 287: " REGRESSION (r12789): Second RTL"
+        RenderInline {I} at (0,1) size 775x36
+          RenderInline {A} at (64,1) size 425x17 [color=#0000EE]
+            RenderText {#text} at (64,1) size 425x17
+              text run at (64,1) width 425: "http://bugzilla.opendarwin.org/show_bug.cgi?id=7433"
+          RenderText {#text} at (0,1) size 775x36
+            text run at (489,1) width 286: " REGRESSION (r12789): Second RTL"
             text run at (0,20) width 293: "text run on a line cannot be selected"
-        RenderText {#text} at (293,20) size 5x17
-          text run at (293,20) width 5: "."
+        RenderText {#text} at (292,20) size 6x17
+          text run at (292,20) width 6: "."
       RenderBlock {P} at (0,54) size 784x38
         RenderText {#text} at (0,1) size 766x36
           text run at (0,1) width 766: "The rightmost two words in the Hebrew text should be selectable by dragging or double-clicking"

--- a/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-CSS-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-CSS-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x573
   RenderBlock {HTML} at (0,0) size 800x573
     RenderBody {BODY} at (8,21) size 784x536
       RenderBlock {H1} at (0,0) size 784x38
-        RenderText {#text} at (0,1) size 538x36
-          text run at (0,1) width 538: "Bidirectional Text Test 2 - CSS"
+        RenderText {#text} at (0,1) size 476x36
+          text run at (0,1) width 476: "Bidirectional Text Test 2 - CSS"
       RenderBlock {P} at (0,59) size 784x20
         RenderText {#text} at (0,1) size 167x17
           text run at (0,1) width 167: "This test is based on "

--- a/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-HTML-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-HTML-expected.txt
@@ -4,8 +4,8 @@ layer at (0,0) size 800x519
   RenderBlock {HTML} at (0,0) size 800x519
     RenderBody {BODY} at (8,21) size 784x482
       RenderBlock {H1} at (0,0) size 784x38
-        RenderText {#text} at (0,1) size 571x36
-          text run at (0,1) width 571: "Bidirectional Text Test 2 - HTML"
+        RenderText {#text} at (0,1) size 504x36
+          text run at (0,1) width 504: "Bidirectional Text Test 2 - HTML"
       RenderBlock {P} at (0,59) size 784x20
         RenderText {#text} at (0,1) size 167x17
           text run at (0,1) width 167: "This test is based on "

--- a/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-formatting-characters-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-formatting-characters-expected.txt
@@ -4,9 +4,9 @@ layer at (0,0) size 785x654
   RenderBlock {HTML} at (0,0) size 785x654
     RenderBody {BODY} at (8,21) size 769x617
       RenderBlock {H1} at (0,0) size 769x76
-        RenderText {#text} at (0,1) size 671x74
-          text run at (0,1) width 671: "Bidirectional Text Test 2 - Formatting"
-          text run at (0,39) width 197: "Characters"
+        RenderText {#text} at (0,1) size 590x74
+          text run at (0,1) width 590: "Bidirectional Text Test 2 - Formatting"
+          text run at (0,39) width 176: "Characters"
       RenderBlock {P} at (0,97) size 769x20
         RenderText {#text} at (0,1) size 167x17
           text run at (0,1) width 167: "This test is based on "

--- a/LayoutTests/platform/glib/fast/text/international/bidi-european-terminators-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/international/bidi-european-terminators-expected.txt
@@ -10,8 +10,8 @@ layer at (0,0) size 785x615
           RenderText {#text} at (0,1) size 731x36
             text run at (108,1) width 623: "http://bugzilla.opendarwin.org/show_bug.cgi?id=6014 Bidi algorithm: incorrect"
             text run at (0,20) width 410: "resolved levels for neutrals between R and ET ON L"
-        RenderText {#text} at (410,20) size 5x17
-          text run at (410,20) width 5: "."
+        RenderText {#text} at (409,20) size 6x17
+          text run at (409,20) width 6: "."
       RenderBlock {P} at (0,54) size 769x57
         RenderText {#text} at (0,1) size 747x55
           text run at (0,1) width 126: "The characters "

--- a/LayoutTests/platform/glib/fast/text/international/bidi-ignored-for-first-child-inline-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/international/bidi-ignored-for-first-child-inline-expected.txt
@@ -10,8 +10,8 @@ layer at (0,0) size 800x600
           RenderText {#text} at (0,1) size 771x36
             text run at (132,1) width 639: "http://bugzilla.opendarwin.org/show_bug.cgi?id=5980 Bidi properties of an inline"
             text run at (0,20) width 478: "container whose first child is an inline container are ignored"
-        RenderText {#text} at (478,20) size 5x17
-          text run at (478,20) width 5: "."
+        RenderText {#text} at (477,20) size 6x17
+          text run at (477,20) width 6: "."
       RenderBlock {P} at (0,72) size 784x19
         RenderText {#text} at (0,1) size 363x17
           text run at (0,1) width 363: "The following lines should read \x{201C}ABCDEFGHI\x{201D}:"

--- a/LayoutTests/platform/glib/fast/text/international/rtl-caret-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/international/rtl-caret-expected.txt
@@ -6,16 +6,16 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 221x17
           text run at (0,1) width 221: "This is a regression test for "
-        RenderInline {I} at (0,1) size 759x36
+        RenderInline {I} at (0,1) size 760x36
           RenderInline {A} at (220,1) size 426x17 [color=#0000EE]
             RenderText {#text} at (220,1) size 426x17
               text run at (220,1) width 426: "http://bugzilla.opendarwin.org/show_bug.cgi?id=8866"
-          RenderText {#text} at (0,1) size 759x36
+          RenderText {#text} at (0,1) size 760x36
             text run at (645,1) width 6: " "
-            text run at (650,1) width 109: "REGRESSION:"
-            text run at (0,20) width 277: "Incorrect caret position in RTL text"
-        RenderText {#text} at (277,20) size 5x17
-          text run at (277,20) width 5: "."
+            text run at (650,1) width 110: "REGRESSION:"
+            text run at (0,20) width 275: "Incorrect caret position in RTL text"
+        RenderText {#text} at (274,20) size 6x17
+          text run at (274,20) width 6: "."
       RenderBlock {P} at (0,54) size 784x19
         RenderText {#text} at (0,1) size 437x17
           text run at (0,1) width 437: "The caret should be in the middle of the Hebrew word."

--- a/LayoutTests/platform/glib/fast/text/midword-break-after-breakable-char-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/midword-break-after-breakable-char-expected.txt
@@ -6,16 +6,16 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x38
         RenderText {#text} at (0,1) size 65x17
           text run at (0,1) width 65: "Test for "
-        RenderInline {I} at (0,1) size 771x36
-          RenderInline {A} at (64,1) size 372x17 [color=#0000EE]
-            RenderText {#text} at (64,1) size 372x17
-              text run at (64,1) width 372: "http://bugs.webkit.org/show_bug.cgi?id=13156"
-          RenderText {#text} at (0,1) size 771x36
-            text run at (435,1) width 6: " "
-            text run at (440,1) width 331: "REGRESSION (r19621): Pasting breakable"
-            text run at (0,20) width 736: "content where wrapped line is too long to fit in a textarea fails to draw a horizontal scrollbar"
-        RenderText {#text} at (736,20) size 5x17
-          text run at (736,20) width 5: "."
+        RenderInline {I} at (0,1) size 770x36
+          RenderInline {A} at (64,1) size 371x17 [color=#0000EE]
+            RenderText {#text} at (64,1) size 371x17
+              text run at (64,1) width 371: "http://bugs.webkit.org/show_bug.cgi?id=13156"
+          RenderText {#text} at (0,1) size 770x36
+            text run at (435,1) width 5: " "
+            text run at (440,1) width 330: "REGRESSION (r19621): Pasting breakable"
+            text run at (0,20) width 735: "content where wrapped line is too long to fit in a textarea fails to draw a horizontal scrollbar"
+        RenderText {#text} at (734,20) size 6x17
+          text run at (734,20) width 6: "."
       RenderBlock {P} at (0,54) size 784x57
         RenderText {#text} at (0,1) size 770x55
           text run at (0,1) width 761: "This tests that a line break will occur in the middle of the first word on a line if it\x{2019}s too long to fit"

--- a/LayoutTests/platform/gtk/fast/forms/select-writing-direction-natural-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/select-writing-direction-natural-expected.txt
@@ -7,15 +7,15 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,1) size 65x17
           text run at (0,1) width 65: "Test for "
         RenderInline {I} at (0,1) size 754x36
-          RenderInline {A} at (64,1) size 372x17 [color=#0000EE]
-            RenderText {#text} at (64,1) size 372x17
-              text run at (64,1) width 372: "http://bugs.webkit.org/show_bug.cgi?id=13775"
+          RenderInline {A} at (64,1) size 371x17 [color=#0000EE]
+            RenderText {#text} at (64,1) size 371x17
+              text run at (64,1) width 371: "http://bugs.webkit.org/show_bug.cgi?id=13775"
           RenderText {#text} at (0,1) size 754x36
-            text run at (435,1) width 6: " "
+            text run at (435,1) width 5: " "
             text run at (440,1) width 314: "REGRESSION: Popup button text should"
             text run at (0,20) width 525: "use \"natural\" directionality to match the items in the popup menu"
-        RenderText {#text} at (525,20) size 5x17
-          text run at (525,20) width 5: "."
+        RenderText {#text} at (524,20) size 6x17
+          text run at (524,20) width 6: "."
       RenderBlock {DIV} at (0,54) size 784x60
         RenderBlock {DIV} at (0,0) size 784x30
           RenderMenuList {SELECT} at (0,0) size 70x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]

--- a/LayoutTests/platform/wpe/fast/forms/select-writing-direction-natural-expected.txt
+++ b/LayoutTests/platform/wpe/fast/forms/select-writing-direction-natural-expected.txt
@@ -7,15 +7,15 @@ layer at (0,0) size 800x600
         RenderText {#text} at (0,1) size 65x17
           text run at (0,1) width 65: "Test for "
         RenderInline {I} at (0,1) size 754x36
-          RenderInline {A} at (64,1) size 372x17 [color=#0000EE]
-            RenderText {#text} at (64,1) size 372x17
-              text run at (64,1) width 372: "http://bugs.webkit.org/show_bug.cgi?id=13775"
+          RenderInline {A} at (64,1) size 371x17 [color=#0000EE]
+            RenderText {#text} at (64,1) size 371x17
+              text run at (64,1) width 371: "http://bugs.webkit.org/show_bug.cgi?id=13775"
           RenderText {#text} at (0,1) size 754x36
-            text run at (435,1) width 6: " "
+            text run at (435,1) width 5: " "
             text run at (440,1) width 314: "REGRESSION: Popup button text should"
             text run at (0,20) width 525: "use \"natural\" directionality to match the items in the popup menu"
-        RenderText {#text} at (525,20) size 5x17
-          text run at (525,20) width 5: "."
+        RenderText {#text} at (524,20) size 6x17
+          text run at (524,20) width 6: "."
       RenderBlock {DIV} at (0,54) size 784x62
         RenderBlock {DIV} at (0,0) size 784x31
           RenderMenuList {SELECT} at (0,0) size 70x31 [bgcolor=#FFFFFF] [border: (1px solid #000000)]

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -138,9 +138,9 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     Vector<const char*, 1> bcp47;
     if (isEmoji)
         bcp47.append("und-Zsye");
-    auto typeface = fontManager().matchFamilyStyleCharacter(nullptr, skiaFontStyle(description), bcp47.mutableSpan().data(), bcp47.size(), baseCharacter);
+    auto typeface = fontManager().matchFamilyStyleCharacter(nullptr, { }, bcp47.mutableSpan().data(), bcp47.size(), baseCharacter);
 #else
-    auto typeface = m_skiaSystemFallbackFontCache.fontForCharacterCluster(skiaFontStyle(description), isEmoji ? "und-Zsye"_s : description.computedLocale(), stringView);
+    auto typeface = m_skiaSystemFallbackFontCache.fontForCharacterCluster(isEmoji ? "und-Zsye"_s : description.computedLocale(), stringView);
 #endif
     if (!typeface)
         return nullptr;

--- a/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.h
@@ -42,7 +42,7 @@ public:
     SkiaSystemFallbackFontCache();
     ~SkiaSystemFallbackFontCache();
 
-    sk_sp<SkTypeface> fontForCharacterCluster(const SkFontStyle&, const String& locale, StringView);
+    sk_sp<SkTypeface> fontForCharacterCluster(const String& locale, StringView);
     void clear();
 private:
     HashMap<String, std::unique_ptr<FontSetCache>> m_cache;


### PR DESCRIPTION
#### ce075d61e972d89d1dc3b22ae60164276d6c0a8f
<pre>
[Skia] System fallback font selection shouldn&apos;t take style into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=295962">https://bugs.webkit.org/show_bug.cgi?id=295962</a>

Reviewed by Carlos Garcia Campos.

WebKit has WebCore::SystemFallbackFontCache class which caches system fallback
fonts. The cache key is a tuple of a string, locale and emoji policy. But, the
weight, width and slant are&apos;t involved into the cache key. However, Skia
backend looked for a system fallback font with the font style. This resulted in
mixed fonts for a text.

* LayoutTests/platform/glib/fast/forms/visual-hebrew-text-field-expected.txt:
* LayoutTests/platform/glib/fast/text/in-rendered-text-rtl-expected.txt:
* LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-CSS-expected.txt:
* LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-HTML-expected.txt:
* LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-formatting-characters-expected.txt:
* LayoutTests/platform/glib/fast/text/international/bidi-european-terminators-expected.txt:
* LayoutTests/platform/glib/fast/text/international/bidi-ignored-for-first-child-inline-expected.txt:
* LayoutTests/platform/glib/fast/text/international/rtl-caret-expected.txt:
* LayoutTests/platform/glib/fast/text/midword-break-after-breakable-char-expected.txt:
* LayoutTests/platform/gtk/fast/forms/select-writing-direction-natural-expected.txt:
* LayoutTests/platform/wpe/fast/forms/select-writing-direction-natural-expected.txt:
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::FontCache::systemFallbackForCharacterCluster):
* Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.cpp:
(WebCore::FontSetCache::FontSetCache):
(WebCore::FontSetCache::create):
(WebCore::FontSetCache::fontForCharacterCluster):
(WebCore::FontSetCache::FontSet::create):
(WebCore::SkiaSystemFallbackFontCache::fontForCharacterCluster):
(WebCore::fontconfigStyle):
(WebCore::FontSetCacheKey::FontSetCacheKey): Deleted.
(WebCore::FontSetCacheKey::isHashTableDeletedValue const): Deleted.
(WebCore::add): Deleted.
(WebCore::FontSetCacheKeyHash::hash): Deleted.
(WebCore::FontSetCacheKeyHash::equal): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaSystemFallbackFontCache.h:

Canonical link: <a href="https://commits.webkit.org/307565@main">https://commits.webkit.org/307565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a06afc71981875e433d9313e521b64e591cfe2f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111130 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79747 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147482 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129779 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92041 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10657 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/635 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17050 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119133 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119487 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15308 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72591 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22338 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16672 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6085 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16408 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80451 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->