### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from crypto

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1078,6 +1078,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/CryptoAlgorithm.h
     crypto/CryptoAlgorithmIdentifier.h
     crypto/CryptoAlgorithmParameters.h
+    crypto/CryptoAlgorithmParametersInit.h
     crypto/CryptoKey.h
     crypto/CryptoKeyData.h
     crypto/CryptoKeyFormat.h
@@ -1105,6 +1106,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     crypto/keys/CryptoRsaKeyAlgorithm.h
 
     crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
+    crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h
 
     css/CSSAttrValue.h
     css/CSSColorValue.h

--- a/Source/WebCore/crypto/CryptoAlgorithmParameters.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmParameters.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/CryptoAlgorithmIdentifier.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
 
@@ -53,6 +54,24 @@ public:
         RsaPssParams,
         X25519Params,
     };
+
+    CryptoAlgorithmParameters(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmParametersInit init)
+        : name { WTF::move(init.name) }
+        , identifier { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmParameters(CryptoAlgorithmIdentifier identifier)
+        : name { }
+        , identifier { identifier }
+    {
+    }
+
+    CryptoAlgorithmParameters()
+        : name { }
+        , identifier { 0 }
+    {
+    }
 
     // FIXME: Consider merging name and identifier.
     String name;

--- a/Source/WebCore/crypto/CryptoAlgorithmParameters.idl
+++ b/Source/WebCore/crypto/CryptoAlgorithmParameters.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmParametersInit
 ] dictionary CryptoAlgorithmParameters {
     required DOMString name;
 };

--- a/Source/WebCore/crypto/CryptoAlgorithmParametersInit.h
+++ b/Source/WebCore/crypto/CryptoAlgorithmParametersInit.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmParametersInit {
+    String name;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/JsonWebKey.h
+++ b/Source/WebCore/crypto/JsonWebKey.h
@@ -32,12 +32,12 @@
 namespace WebCore {
 
 struct JsonWebKey {
-    JsonWebKey isolatedCopy() && {
+    JsonWebKey isolatedCopy() &&
+    {
         return {
             crossThreadCopy(WTF::move(kty)),
             crossThreadCopy(WTF::move(use)),
             key_ops,
-            usages,
             crossThreadCopy(WTF::move(alg)),
             ext,
             crossThreadCopy(WTF::move(crv)),
@@ -52,15 +52,14 @@ struct JsonWebKey {
             crossThreadCopy(WTF::move(dq)),
             crossThreadCopy(WTF::move(qi)),
             crossThreadCopy(WTF::move(oth)),
-            crossThreadCopy(WTF::move(k))
+            crossThreadCopy(WTF::move(k)),
+            usages,
         };
     }
 
     String kty;
     String use;
-    // FIXME: Consider merging key_ops and usages.
     std::optional<Vector<CryptoKeyUsage>> key_ops;
-    CryptoKeyUsageBitmap usages;
     String alg;
 
     std::optional<bool> ext;
@@ -78,6 +77,9 @@ struct JsonWebKey {
     String qi;
     std::optional<Vector<RsaOtherPrimesInfo>> oth;
     String k;
+
+    // Not part of exposed dictionary.
+    CryptoKeyUsageBitmap usages = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/JsonWebKey.idl
+++ b/Source/WebCore/crypto/JsonWebKey.idl
@@ -26,7 +26,6 @@
 [
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary JsonWebKey {
     // The following fields are defined in Section 3.1 of JSON Web Key
     DOMString kty;

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
@@ -103,7 +103,7 @@ void CryptoAlgorithmAESCBC::generateKey(const CryptoAlgorithmParameters& paramet
         return;
     }
 
-    callback(WTF::move(result));
+    callback(result.releaseNonNull());
 }
 
 void CryptoAlgorithmAESCBC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
@@ -103,7 +103,7 @@ void CryptoAlgorithmAESCFB::generateKey(const CryptoAlgorithmParameters& paramet
         return;
     }
 
-    callback(WTF::move(result));
+    callback(result.releaseNonNull());
 }
 
 void CryptoAlgorithmAESCFB::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
@@ -113,7 +113,7 @@ void CryptoAlgorithmAESCTR::generateKey(const CryptoAlgorithmParameters& paramet
         return;
     }
 
-    callback(WTF::move(result));
+    callback(result.releaseNonNull());
 }
 
 void CryptoAlgorithmAESCTR::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
@@ -149,7 +149,7 @@ void CryptoAlgorithmAESGCM::generateKey(const CryptoAlgorithmParameters& paramet
         return;
     }
 
-    callback(WTF::move(result));
+    callback(result.releaseNonNull());
 }
 
 void CryptoAlgorithmAESGCM::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
@@ -66,7 +66,7 @@ void CryptoAlgorithmAESKW::generateKey(const CryptoAlgorithmParameters& paramete
         return;
     }
 
-    callback(WTF::move(result));
+    callback(result.releaseNonNull());
 }
 
 void CryptoAlgorithmAESKW::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
@@ -91,7 +91,7 @@ void CryptoAlgorithmHMAC::generateKey(const CryptoAlgorithmParameters& parameter
         return;
     }
 
-    callback(WTF::move(result));
+    callback(result.releaseNonNull());
 }
 
 void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)

--- a/Source/WebCore/crypto/parameters/AesCbcCfbParams.idl
+++ b/Source/WebCore/crypto/parameters/AesCbcCfbParams.idl
@@ -27,8 +27,7 @@
 // https://www.w3.org/TR/WebCryptoAPI/#dfn-AesCbcParams, and
 // https://www.w3.org/TR/2014/CR-WebCryptoAPI-20141211/#dfn-AesCfbParams
 [
-    ImplementedAs=CryptoAlgorithmAesCbcCfbParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmAesCbcCfbParamsInit
 ] dictionary AesCbcCfbParams : CryptoAlgorithmParameters {
     // The initialization vector. MUST be 16 bytes.
     required BufferSource iv;

--- a/Source/WebCore/crypto/parameters/AesCtrParams.idl
+++ b/Source/WebCore/crypto/parameters/AesCtrParams.idl
@@ -23,8 +23,7 @@
 */
 
 [
-    ImplementedAs=CryptoAlgorithmAesCtrParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmAesCtrParamsInit
 ] dictionary AesCtrParams : CryptoAlgorithmParameters {
     // The initial value of the counter block. counter MUST be 16 bytes
     // (the AES block size). The counter bits are the rightmost length

--- a/Source/WebCore/crypto/parameters/AesGcmParams.idl
+++ b/Source/WebCore/crypto/parameters/AesGcmParams.idl
@@ -23,8 +23,7 @@
  */
 
 [
-    ImplementedAs=CryptoAlgorithmAesGcmParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmAesGcmParamsInit
 ] dictionary AesGcmParams : CryptoAlgorithmParameters {
     // The initialization vector to use. May be up to 2^64-1 bytes long.
     required BufferSource iv;

--- a/Source/WebCore/crypto/parameters/AesKeyParams.idl
+++ b/Source/WebCore/crypto/parameters/AesKeyParams.idl
@@ -27,8 +27,7 @@
 // https://www.w3.org/TR/WebCryptoAPI/#aes-derivedkey-params, and
 // https://www.w3.org/TR/WebCryptoAPI/#aes-keygen-params
 [
-    ImplementedAs=CryptoAlgorithmAesKeyParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmAesKeyParamsInit
 ] dictionary AesKeyParams : CryptoAlgorithmParameters {
     // The length, in bits, of the key.
     required [EnforceRange] unsigned short length;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmAesCbcCfbParamsInit.h>
 #include <WebCore/CryptoAlgorithmParameters.h>
 #include <wtf/Vector.h>
 
@@ -34,23 +35,39 @@ namespace WebCore {
 class CryptoAlgorithmAesCbcCfbParams final : public CryptoAlgorithmParameters {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(CryptoAlgorithmAesCbcCfbParams, WEBCORE_EXPORT);
 public:
-    BufferSource iv;
+    std::optional<BufferSource> iv;
+
+    CryptoAlgorithmAesCbcCfbParams()
+        : CryptoAlgorithmParameters { }
+    {
+    }
+
+    CryptoAlgorithmAesCbcCfbParams(CryptoAlgorithmIdentifier identifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmAesCbcCfbParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmAesCbcCfbParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , iv { WTF::move(init.iv) }
+    {
+    }
 
     Class parametersClass() const final { return Class::AesCbcCfbParams; }
 
     const Vector<uint8_t>& ivVector() const
     {
-        if (!m_ivVector.isEmpty() || !iv.length())
+        if (!m_ivVector.isEmpty() || !iv || !iv->length())
             return m_ivVector;
 
-        m_ivVector.append(iv.span());
+        if (iv)
+            m_ivVector.append(iv->span());
         return m_ivVector;
     }
 
     CryptoAlgorithmAesCbcCfbParams isolatedCopy() const
     {
-        CryptoAlgorithmAesCbcCfbParams result;
-        result.identifier = identifier;
+        CryptoAlgorithmAesCbcCfbParams result { identifier };
         result.m_ivVector = ivVector();
 
         return result;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BufferSource.h"
+#include "CryptoAlgorithmParametersInit.h"
+
+namespace WebCore {
+
+struct CryptoAlgorithmAesCbcCfbParamsInit : CryptoAlgorithmParametersInit {
+    BufferSource iv;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BufferSource.h"
+#include "CryptoAlgorithmParametersInit.h"
+
+namespace WebCore {
+
+struct CryptoAlgorithmAesCtrParamsInit : CryptoAlgorithmParametersInit {
+    BufferSource counter;
+    uint8_t length;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BufferSource.h"
+#include "CryptoAlgorithmParametersInit.h"
+
+namespace WebCore {
+
+struct CryptoAlgorithmAesGcmParamsInit : CryptoAlgorithmParametersInit {
+    BufferSource iv;
+    std::optional<BufferSource> additionalData;
+    std::optional<uint8_t> tagLength;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CryptoAlgorithmAesKeyParamsInit.h"
 #include "CryptoAlgorithmParameters.h"
 
 namespace WebCore {
@@ -33,6 +34,12 @@ class CryptoAlgorithmAesKeyParams final : public CryptoAlgorithmParameters {
     WTF_MAKE_TZONE_ALLOCATED(CryptoAlgorithmAesKeyParams);
 public:
     unsigned short length;
+
+    CryptoAlgorithmAesKeyParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmAesKeyParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , length { WTF::move(init.length) }
+    {
+    }
 
     Class parametersClass() const final { return Class::AesKeyParams; }
 };

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+
+namespace WebCore {
+
+struct CryptoAlgorithmAesKeyParamsInit : CryptoAlgorithmParametersInit {
+    unsigned short length;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CryptoAlgorithmEcKeyParamsInit.h"
 #include "CryptoAlgorithmParameters.h"
 
 namespace WebCore {
@@ -34,12 +35,22 @@ class CryptoAlgorithmEcKeyParams final : public CryptoAlgorithmParameters {
 public:
     String namedCurve;
 
+    CryptoAlgorithmEcKeyParams(CryptoAlgorithmIdentifier identifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmEcKeyParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmEcKeyParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , namedCurve { WTF::move(init.namedCurve) }
+    {
+    }
+
     Class parametersClass() const final { return Class::EcKeyParams; }
 
     CryptoAlgorithmEcKeyParams isolatedCopy() const
     {
-        CryptoAlgorithmEcKeyParams result;
-        result.identifier = identifier;
+        CryptoAlgorithmEcKeyParams result { identifier };
         result.namedCurve = namedCurve.isolatedCopy();
 
         return result;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+
+namespace WebCore {
+
+struct CryptoAlgorithmEcKeyParamsInit : CryptoAlgorithmParametersInit {
+    String namedCurve;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CryptoAlgorithmEcdhKeyDeriveParamsInit.h"
 #include "CryptoAlgorithmParameters.h"
 
 namespace WebCore {
@@ -35,6 +36,12 @@ class CryptoAlgorithmEcdhKeyDeriveParams final : public CryptoAlgorithmParameter
     WTF_MAKE_TZONE_ALLOCATED(CryptoAlgorithmEcdhKeyDeriveParams);
 public:
     RefPtr<CryptoKey> publicKey;
+
+    CryptoAlgorithmEcdhKeyDeriveParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmEcdhKeyDeriveParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , publicKey { WTF::move(init.publicKey) }
+    {
+    }
 
     Class parametersClass() const final { return Class::EcdhKeyDeriveParams; }
 };

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+
+namespace WebCore {
+
+class CryptoKey;
+
+struct CryptoAlgorithmEcdhKeyDeriveParamsInit : CryptoAlgorithmParametersInit {
+    Ref<CryptoKey> publicKey;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CryptoAlgorithmEcdsaParamsInit.h"
 #include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
@@ -38,12 +39,23 @@ public:
     Variant<JSC::Strong<JSC::JSObject>, String> hash;
     CryptoAlgorithmIdentifier hashIdentifier;
 
+    CryptoAlgorithmEcdsaParams(CryptoAlgorithmIdentifier identifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmEcdsaParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmEcdsaParamsInit init, CryptoAlgorithmIdentifier hashIdentifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , hash { WTF::move(init.hash) }
+        , hashIdentifier { WTF::move(hashIdentifier) }
+    {
+    }
+
     Class parametersClass() const final { return Class::EcdsaParams; }
 
     CryptoAlgorithmEcdsaParams isolatedCopy() const
     {
-        CryptoAlgorithmEcdsaParams result;
-        result.identifier = identifier;
+        CryptoAlgorithmEcdsaParams result { identifier };
         result.hashIdentifier = hashIdentifier;
 
         return result;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmEcdsaParamsInit : CryptoAlgorithmParametersInit {
+    Variant<JSC::Strong<JSC::JSObject>, String> hash;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParamsInit.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BufferSource.h"
+#include "CryptoAlgorithmParametersInit.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmHkdfParamsInit : CryptoAlgorithmParametersInit {
+    Variant<JSC::Strong<JSC::JSObject>, String> hash;
+    BufferSource salt;
+    BufferSource info;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CryptoAlgorithmHmacKeyParamsInit.h"
 #include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
@@ -39,12 +40,24 @@ public:
     CryptoAlgorithmIdentifier hashIdentifier;
     std::optional<size_t> length;
 
+    CryptoAlgorithmHmacKeyParams(CryptoAlgorithmIdentifier identifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmHmacKeyParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmHmacKeyParamsInit init, CryptoAlgorithmIdentifier hashIdentifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , hash { WTF::move(init.hash) }
+        , hashIdentifier { WTF::move(hashIdentifier) }
+        , length { WTF::move(init.length) }
+    {
+    }
+
     Class parametersClass() const final { return Class::HmacKeyParams; }
 
     CryptoAlgorithmHmacKeyParams isolatedCopy() const
     {
-        CryptoAlgorithmHmacKeyParams result;
-        result.identifier = identifier;
+        CryptoAlgorithmHmacKeyParams result { identifier };
         result.hashIdentifier = hashIdentifier;
         result.length = length;
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+#include <optional>
+
+namespace WebCore {
+
+struct CryptoAlgorithmHmacKeyParamsInit : CryptoAlgorithmParametersInit {
+    Variant<JSC::Strong<JSC::JSObject>, String> hash;
+    std::optional<size_t> length;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BufferSource.h"
+#include "CryptoAlgorithmParametersInit.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmPbkdf2ParamsInit : CryptoAlgorithmParametersInit {
+    BufferSource salt;
+    unsigned long iterations;
+    Variant<JSC::Strong<JSC::JSObject>, String> hash;
+};
+
+} // namespace WebCore
+

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmRsaHashedImportParamsInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
 
@@ -38,12 +39,23 @@ public:
     Variant<JSC::Strong<JSC::JSObject>, String> hash;
     CryptoAlgorithmIdentifier hashIdentifier;
 
+    CryptoAlgorithmRsaHashedImportParams(CryptoAlgorithmIdentifier identifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmRsaHashedImportParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmRsaHashedImportParamsInit init, CryptoAlgorithmIdentifier hashIdentifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , hash { WTF::move(init.hash) }
+        , hashIdentifier { WTF::move(hashIdentifier) }
+    {
+    }
+
     Class parametersClass() const final { return Class::RsaHashedImportParams; }
 
     CryptoAlgorithmRsaHashedImportParams isolatedCopy() const
     {
-        CryptoAlgorithmRsaHashedImportParams result;
-        result.identifier = identifier;
+        CryptoAlgorithmRsaHashedImportParams result { identifier };
         result.hashIdentifier = hashIdentifier;
 
         return result;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmRsaHashedImportParamsInit : CryptoAlgorithmParametersInit {
+    Variant<JSC::Strong<JSC::JSObject>, String> hash;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CryptoAlgorithmRsaHashedKeyGenParamsInit.h"
 #include "CryptoAlgorithmRsaKeyGenParams.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
@@ -36,6 +37,13 @@ public:
     // FIXME: Consider merging hash and hashIdentifier.
     Variant<JSC::Strong<JSC::JSObject>, String> hash;
     CryptoAlgorithmIdentifier hashIdentifier;
+
+    CryptoAlgorithmRsaHashedKeyGenParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmRsaHashedKeyGenParamsInit init, CryptoAlgorithmIdentifier hashIdentifier)
+        : CryptoAlgorithmRsaKeyGenParams { WTF::move(identifier), WTF::move(init) }
+        , hash { WTF::move(init.hash) }
+        , hashIdentifier { WTF::move(hashIdentifier) }
+    {
+    }
 
     Class parametersClass() const final { return Class::RsaHashedKeyGenParams; }
 };

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmRsaKeyGenParamsInit.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmRsaHashedKeyGenParamsInit : CryptoAlgorithmRsaKeyGenParamsInit {
+    Variant<JSC::Strong<JSC::JSObject>, String> hash;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmRsaKeyGenParamsInit.h"
 #include <JavaScriptCore/Uint8Array.h>
 #include <wtf/Vector.h>
 
@@ -36,6 +37,13 @@ class CryptoAlgorithmRsaKeyGenParams : public CryptoAlgorithmParameters {
 public:
     size_t modulusLength;
     RefPtr<Uint8Array> publicExponent;
+
+    CryptoAlgorithmRsaKeyGenParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmRsaKeyGenParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , modulusLength { WTF::move(init.modulusLength) }
+        , publicExponent { WTF::move(init.publicExponent) }
+    {
+    }
 
     Class parametersClass() const override { return Class::RsaKeyGenParams; }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+#include <JavaScriptCore/Uint8Array.h>
+#include <wtf/Ref.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmRsaKeyGenParamsInit : CryptoAlgorithmParametersInit {
+    size_t modulusLength;
+    Ref<Uint8Array> publicExponent;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
@@ -27,6 +27,7 @@
 
 #include "BufferSource.h"
 #include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmRsaOaepParamsInit.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -35,7 +36,18 @@ class CryptoAlgorithmRsaOaepParams final : public CryptoAlgorithmParameters {
     WTF_MAKE_TZONE_ALLOCATED(CryptoAlgorithmRsaOaepParams);
 public:
     // Use labelVector() instead of label. The label will be gone once labelVector() is called.
-    mutable std::optional<BufferSource::VariantType> label;
+    mutable std::optional<BufferSource> label;
+
+    CryptoAlgorithmRsaOaepParams(CryptoAlgorithmIdentifier identifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmRsaOaepParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmRsaOaepParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , label { WTF::move(init.label) }
+    {
+    }
 
     Class parametersClass() const final { return Class::RsaOaepParams; }
 
@@ -54,8 +66,7 @@ public:
 
     CryptoAlgorithmRsaOaepParams isolatedCopy() const
     {
-        CryptoAlgorithmRsaOaepParams result;
-        result.identifier = identifier;
+        CryptoAlgorithmRsaOaepParams result { identifier };
         result.m_labelVector = labelVector();
 
         return result;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "BufferSource.h"
+#include "CryptoAlgorithmParametersInit.h"
+#include <optional>
+
+namespace WebCore {
+
+struct CryptoAlgorithmRsaOaepParamsInit : CryptoAlgorithmParametersInit {
+    std::optional<BufferSource> label;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmRsaPssParamsInit.h"
 
 namespace WebCore {
 
@@ -34,12 +35,22 @@ class CryptoAlgorithmRsaPssParams final : public CryptoAlgorithmParameters {
 public:
     size_t saltLength;
 
+    CryptoAlgorithmRsaPssParams(CryptoAlgorithmIdentifier identifier)
+        : CryptoAlgorithmParameters { WTF::move(identifier) }
+    {
+    }
+
+    CryptoAlgorithmRsaPssParams(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmRsaPssParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , saltLength { WTF::move(init.saltLength) }
+    {
+    }
+
     Class parametersClass() const final { return Class::RsaPssParams; }
 
     CryptoAlgorithmRsaPssParams isolatedCopy() const
     {
-        CryptoAlgorithmRsaPssParams result;
-        result.identifier = identifier;
+        CryptoAlgorithmRsaPssParams result { identifier };
         result.saltLength = saltLength;
 
         return result;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+
+namespace WebCore {
+
+struct CryptoAlgorithmRsaPssParamsInit : CryptoAlgorithmParametersInit {
+    size_t saltLength;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "CryptoAlgorithmParameters.h"
+#include "CryptoAlgorithmX25519ParamsInit.h"
 #include "CryptoKey.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
@@ -31,6 +32,13 @@ class CryptoAlgorithmX25519Params final : public CryptoAlgorithmParameters {
     WTF_MAKE_TZONE_ALLOCATED(CryptoAlgorithmX25519Params);
 public:
     RefPtr<CryptoKey> publicKey;
+
+    CryptoAlgorithmX25519Params(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmX25519ParamsInit init)
+        : CryptoAlgorithmParameters { WTF::move(identifier), WTF::move(init) }
+        , publicKey { WTF::move(init.publicKey) }
+    {
+    }
+
     Class parametersClass() const final { return Class::X25519Params; }
 };
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2,1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "CryptoAlgorithmParametersInit.h"
+#include "CryptoKey.h"
+#include <wtf/Ref.h>
+
+namespace WebCore {
+
+struct CryptoAlgorithmX25519ParamsInit : CryptoAlgorithmParametersInit {
+    Ref<CryptoKey> publicKey;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/crypto/parameters/EcKeyParams.idl
+++ b/Source/WebCore/crypto/parameters/EcKeyParams.idl
@@ -27,8 +27,7 @@
 // https://www.w3.org/TR/WebCryptoAPI/#EcKeyImportParams-dictionary, and
 // https://www.w3.org/TR/WebCryptoAPI/#EcKeyGenParams-dictionary
 [
-    ImplementedAs=CryptoAlgorithmEcKeyParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmEcKeyParamsInit
 ] dictionary EcKeyParams : CryptoAlgorithmParameters {
     required DOMString namedCurve;
 };

--- a/Source/WebCore/crypto/parameters/EcdhKeyDeriveParams.idl
+++ b/Source/WebCore/crypto/parameters/EcdhKeyDeriveParams.idl
@@ -24,8 +24,7 @@
  */
 
 [
-    ImplementedAs=CryptoAlgorithmEcdhKeyDeriveParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmEcdhKeyDeriveParamsInit,
 ] dictionary EcdhKeyDeriveParams : CryptoAlgorithmParameters {
     // We should rename this to public once https://bugs.webkit.org/show_bug.cgi?id=169333 is fixed.
     // The peer's EC public key.

--- a/Source/WebCore/crypto/parameters/EcdsaParams.idl
+++ b/Source/WebCore/crypto/parameters/EcdsaParams.idl
@@ -26,8 +26,7 @@
 typedef (object or DOMString) HashAlgorithmIdentifier;
 
 [
-    ImplementedAs=CryptoAlgorithmEcdsaParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmEcdsaParamsInit
 ] dictionary EcdsaParams : CryptoAlgorithmParameters {
     // The hash algorithm to use
     required HashAlgorithmIdentifier hash;

--- a/Source/WebCore/crypto/parameters/HkdfParams.idl
+++ b/Source/WebCore/crypto/parameters/HkdfParams.idl
@@ -26,8 +26,7 @@
 typedef (object or DOMString) HashAlgorithmIdentifier;
 
 [
-    ImplementedAs=CryptoAlgorithmHkdfParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmHkdfParamsInit,
 ] dictionary HkdfParams : CryptoAlgorithmParameters {
     // The algorithm to use with HMAC (e.g.: SHA-256)
     required HashAlgorithmIdentifier hash;

--- a/Source/WebCore/crypto/parameters/HmacKeyParams.idl
+++ b/Source/WebCore/crypto/parameters/HmacKeyParams.idl
@@ -29,8 +29,7 @@ typedef (object or DOMString) HashAlgorithmIdentifier;
 // https://www.w3.org/TR/WebCryptoAPI/#hmac-importparams, and
 // https://www.w3.org/TR/WebCryptoAPI/#hmac-keygen-params
 [
-    ImplementedAs=CryptoAlgorithmHmacKeyParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmHmacKeyParamsInit
 ] dictionary HmacKeyParams : CryptoAlgorithmParameters {
     // The inner hash function to use.
     required HashAlgorithmIdentifier hash;

--- a/Source/WebCore/crypto/parameters/Pbkdf2Params.idl
+++ b/Source/WebCore/crypto/parameters/Pbkdf2Params.idl
@@ -26,8 +26,7 @@
 typedef (object or DOMString) HashAlgorithmIdentifier;
 
 [
-    ImplementedAs=CryptoAlgorithmPbkdf2Params,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmPbkdf2ParamsInit,
 ] dictionary Pbkdf2Params : CryptoAlgorithmParameters {
     required BufferSource salt;
     required [EnforceRange] unsigned long iterations;

--- a/Source/WebCore/crypto/parameters/RsaHashedImportParams.idl
+++ b/Source/WebCore/crypto/parameters/RsaHashedImportParams.idl
@@ -26,8 +26,7 @@
 typedef (object or DOMString) HashAlgorithmIdentifier;
 
 [
-    ImplementedAs=CryptoAlgorithmRsaHashedImportParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmRsaHashedImportParamsInit
 ] dictionary RsaHashedImportParams : CryptoAlgorithmParameters {
     // The hash algorithm to use
     required HashAlgorithmIdentifier hash;

--- a/Source/WebCore/crypto/parameters/RsaHashedKeyGenParams.idl
+++ b/Source/WebCore/crypto/parameters/RsaHashedKeyGenParams.idl
@@ -26,8 +26,7 @@
 typedef (object or DOMString) HashAlgorithmIdentifier;
 
 [
-    ImplementedAs=CryptoAlgorithmRsaHashedKeyGenParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmRsaHashedKeyGenParamsInit
 ] dictionary RsaHashedKeyGenParams : RsaKeyGenParams {
     // The hash algorithm to use
     required HashAlgorithmIdentifier hash;

--- a/Source/WebCore/crypto/parameters/RsaKeyGenParams.idl
+++ b/Source/WebCore/crypto/parameters/RsaKeyGenParams.idl
@@ -24,8 +24,7 @@
  */
 
 [
-    ImplementedAs=CryptoAlgorithmRsaKeyGenParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmRsaKeyGenParamsInit
 ] dictionary RsaKeyGenParams : CryptoAlgorithmParameters {
     // The length, in bits, of the RSA modulus
     required [EnforceRange] unsigned long modulusLength;

--- a/Source/WebCore/crypto/parameters/RsaOaepParams.idl
+++ b/Source/WebCore/crypto/parameters/RsaOaepParams.idl
@@ -24,8 +24,7 @@
 */
 
 [
-    ImplementedAs=CryptoAlgorithmRsaOaepParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmRsaOaepParamsInit
 ] dictionary RsaOaepParams : CryptoAlgorithmParameters {
     // The optional label/application data to associate with the message
     BufferSource label;

--- a/Source/WebCore/crypto/parameters/RsaPssParams.idl
+++ b/Source/WebCore/crypto/parameters/RsaPssParams.idl
@@ -24,8 +24,7 @@
  */
 
 [
-    ImplementedAs=CryptoAlgorithmRsaPssParams,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmRsaPssParamsInit
 ] dictionary RsaPssParams : CryptoAlgorithmParameters {
     // The desired length of the random salt
     required [EnforceRange] unsigned long saltLength;

--- a/Source/WebCore/crypto/parameters/X25519Params.idl
+++ b/Source/WebCore/crypto/parameters/X25519Params.idl
@@ -1,7 +1,30 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 [
-    ImplementedAs=CryptoAlgorithmX25519Params,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
+    ImplementedAs=CryptoAlgorithmX25519ParamsInit,
 ] dictionary X25519Params : CryptoAlgorithmParameters {
     required CryptoKey publicKey;
-
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8878,7 +8878,6 @@ struct WebCore::JsonWebKey {
     String kty;
     String use
     std::optional<Vector<WebCore::CryptoKeyUsage>> key_ops;
-    int usages;
     String alg;
     std::optional<bool> ext;
     String crv;
@@ -8894,6 +8893,7 @@ struct WebCore::JsonWebKey {
     String qi;
     std::optional<Vector<WebCore::RsaOtherPrimesInfo>> oth;
     String k;
+    int usages;
 };
 
 enum class WebCore::CryptoAlgorithmIdentifier : uint8_t {


### PR DESCRIPTION
#### f685275922572d7f7236b2672b37a04264b4c707
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from crypto
<a href="https://bugs.webkit.org/show_bug.cgi?id=306715">https://bugs.webkit.org/show_bug.cgi?id=306715</a>

Reviewed by Chris Dumez.

Remove LegacyNativeDictionaryRequiredInterfaceNullability from crypto IDL files.

This was done by adding new types for the param dictionaries, using the suffix
&quot;Init&quot; to differentiate them. The existing param types have uses beyond the
just being a bindings dictionary (including mutability in some cases) so using
a new type was necessary.

* Source/WebCore/Headers.cmake
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/crypto/CryptoAlgorithmParameters.h:
* Source/WebCore/crypto/CryptoAlgorithmParameters.idl:
* Source/WebCore/crypto/CryptoAlgorithmParametersInit.h: Copied from Source/WebCore/crypto/CryptoAlgorithmParameters.idl.
* Source/WebCore/crypto/JsonWebKey.h:
* Source/WebCore/crypto/JsonWebKey.idl:
* Source/WebCore/crypto/SubtleCrypto.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp:
* Source/WebCore/crypto/parameters/AesCbcCfbParams.idl:
* Source/WebCore/crypto/parameters/AesCtrParams.idl:
* Source/WebCore/crypto/parameters/AesGcmParams.idl:
* Source/WebCore/crypto/parameters/AesKeyParams.idl:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h: Copied from Source/WebCore/crypto/CryptoAlgorithmParameters.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h: Copied from Source/WebCore/crypto/parameters/RsaPssParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h: Copied from Source/WebCore/crypto/parameters/EcdsaParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h: Copied from Source/WebCore/crypto/CryptoAlgorithmParameters.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h: Copied from Source/WebCore/crypto/parameters/RsaPssParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h: Copied from Source/WebCore/crypto/parameters/RsaPssParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h: Copied from Source/WebCore/crypto/parameters/EcdsaParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParamsInit.h: Copied from Source/WebCore/crypto/parameters/EcdsaParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h: Copied from Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h.
* Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h: Copied from Source/WebCore/crypto/parameters/EcdsaParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h: Copied from Source/WebCore/crypto/CryptoAlgorithmParameters.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h: Copied from Source/WebCore/crypto/CryptoAlgorithmParameters.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h: Copied from Source/WebCore/crypto/CryptoAlgorithmParameters.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h: Copied from Source/WebCore/crypto/CryptoAlgorithmParameters.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h: Copied from Source/WebCore/crypto/parameters/RsaPssParams.idl.
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519ParamsInit.h: Copied from Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h.
* Source/WebCore/crypto/parameters/EcKeyParams.idl:
* Source/WebCore/crypto/parameters/EcdhKeyDeriveParams.idl:
* Source/WebCore/crypto/parameters/EcdsaParams.idl:
* Source/WebCore/crypto/parameters/HkdfParams.idl:
* Source/WebCore/crypto/parameters/HmacKeyParams.idl:
* Source/WebCore/crypto/parameters/Pbkdf2Params.idl:
* Source/WebCore/crypto/parameters/RsaHashedImportParams.idl:
* Source/WebCore/crypto/parameters/RsaHashedKeyGenParams.idl:
* Source/WebCore/crypto/parameters/RsaKeyGenParams.idl:
* Source/WebCore/crypto/parameters/RsaOaepParams.idl:
* Source/WebCore/crypto/parameters/RsaPssParams.idl:
* Source/WebCore/crypto/parameters/X25519Params.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/306676@main">https://commits.webkit.org/306676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/776cd43db9edc0d3f7d4a07e59dda98d91f47824

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141798 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108963 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78800 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8707 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/458 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152780 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117058 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13888 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12105 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/range-restore-oninput-onchange-event.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117380 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29959 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13427 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123625 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69527 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13911 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2906 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13650 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77636 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->