### PR TITLE
Remove SizeAndAlignment class in TZone code.

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeapManager.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.h
@@ -197,10 +197,10 @@ private:
 
     BINLINE pas_heap_ref* heapRefForTZoneType(const TZoneSpecification&, LockHolder&);
 
-    inline static unsigned bucketCountForSizeClass(TZoneDescriptor);
+    inline static unsigned bucketCountForSizeClass(unsigned sizeClass);
 
     inline unsigned bucketForKey(const TZoneSpecification&, unsigned bucketCountForSize, LockHolder&);
-    Group* populateGroupBuckets(LockHolder&, TZoneDescriptor);
+    Group* populateGroupBuckets(LockHolder&, const TZoneSpecification&);
 
     static TZoneHeapManager::State s_state;
     Mutex m_mutex;


### PR DESCRIPTION
#### 24c117bd1a2ea6c01ba6a423f5d75f92780e4011
<pre>
Remove SizeAndAlignment class in TZone code.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306717">https://bugs.webkit.org/show_bug.cgi?id=306717</a>
<a href="https://rdar.apple.com/169370644">rdar://169370644</a>

Reviewed by Keith Miller.

The SizeAndAlignment logic belongs in TZoneSpecification which defines a TZone type&apos;s
sorting algorithm / criteria.  This refactoring paves the way to add alternate TZone
categories that use different sorting algorithms for heap selection.

Also added some debugging info (file and line number) to TZoneSpecification because
classname alone is insufficient as there can be many classes with the same name.
Also enhanced TZoneHeapManager::dumpRegisteredTypes(0 to also print the pid to
distinguish between processes.

No new tests because this is a refactoring patch.  There is no behavior change..

* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::TZoneDescriptorHashTrait::hash):
(bmalloc::api::TZoneSpecification::sizeClass const):
(bmalloc::api::TZoneSpecification::encodeSize):
(bmalloc::api::TZoneSpecification::encodeAlignment):
(bmalloc::api::TZoneSpecification::encodeDescriptor):
(bmalloc::api::SizeAndAlignment::encode): Deleted.
(bmalloc::api::SizeAndAlignment::decodeSize): Deleted.
(bmalloc::api::SizeAndAlignment::decodeAlignment): Deleted.
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneDescriptorDecoder::TZoneDescriptorDecoder):
(bmalloc::api::TZoneDescriptorDecoder::value const):
(bmalloc::api::TZoneDescriptorDecoder::sizeClass const):
(bmalloc::api::TZoneDescriptorDecoder::alignment const):
(bmalloc::api::TZoneHeapManager::dumpRegisteredTypes):
(bmalloc::api::TZoneHeapManager::bucketCountForSizeClass):
(bmalloc::api::TZoneHeapManager::bucketForKey):
(bmalloc::api::TZoneHeapManager::populateGroupBuckets):
(bmalloc::api::TZoneHeapManager::heapRefForTZoneType):
(bmalloc::api::TZoneHeapManager::TZoneHeapManager::heapRefForTZoneTypeDifferentSize):
* Source/bmalloc/bmalloc/TZoneHeapManager.h:

Canonical link: <a href="https://commits.webkit.org/306630@main">https://commits.webkit.org/306630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dd3d22205523b44db02d99989c9d34916e351e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141778 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94903 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/add51933-96f8-44bf-ba1e-ead93a74251d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108950 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78786 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9646e74-01df-4bd6-b822-d2635ed3c683) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89846 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6090e371-85e5-43b1-8440-ded7401a819e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11051 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8690 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/438 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133762 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152760 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2582 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117045 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117367 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13411 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69510 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21893 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13891 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2890 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173067 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13630 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44816 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13833 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13677 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->