### PR TITLE
Drop Node::protectedDocument()

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -259,7 +259,7 @@ void Clipboard::getType(ClipboardItem& item, const String& type, Ref<DeferredPro
     if (RefPtr page = frame->page())
         resultAsString = page->applyLinkDecorationFiltering(resultAsString, LinkDecorationFilteringTrigger::Paste);
 
-    promise->resolve<IDLInterface<Blob>>(ClipboardItem::blobFromString(frame->protectedDocument().get(), resultAsString, type));
+    promise->resolve<IDLInterface<Blob>>(ClipboardItem::blobFromString(protect(frame->document()).get(), resultAsString, type));
 }
 
 Clipboard::SessionIsValid Clipboard::updateSessionValidity()

--- a/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
+++ b/Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp
@@ -96,7 +96,7 @@ DOMCacheStorage* DOMWindowCaches::caches() const
     ASSERT(frame());
     ASSERT(frame()->document());
     if (!m_caches && frame()->page())
-        m_caches = DOMCacheStorage::create(*frame()->protectedDocument(), frame()->page()->cacheStorageProvider().createCacheStorageConnection());
+        m_caches = DOMCacheStorage::create(*protect(frame()->document()), frame()->page()->cacheStorageProvider().createCacheStorageConnection());
     return m_caches.get();
 }
 

--- a/Source/WebCore/Modules/gamepad/GamepadManager.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadManager.cpp
@@ -135,7 +135,7 @@ void GamepadManager::platformGamepadDisconnected(PlatformGamepad& platformGamepa
         navigatorGamepad.gamepadDisconnected(platformGamepad);
         notifiedNavigators.add(navigator.get());
 
-        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, WTF::move(gamepad)), window->protectedDocument().get());
+        window->dispatchEvent(GamepadEvent::create(eventNames().gamepaddisconnectedEvent, WTF::move(gamepad)), protect(window->document()).get());
     }
 
     // Notify all the Navigators that haven't already been notified.
@@ -187,7 +187,7 @@ void GamepadManager::makeGamepadVisible(PlatformGamepad& platformGamepad, WeakHa
 
         LOG(Gamepad, "(%u) GamepadManager::makeGamepadVisible - Dispatching gamepadconnected event for gamepad '%s'", (unsigned)getpid(), platformGamepad.id().utf8().data());
         UserGestureIndicator gestureIndicator(IsProcessingUserGesture::Yes, document.get());
-        window->dispatchEvent(GamepadEvent::create(eventNames().gamepadconnectedEvent, WTF::move(gamepad)), window->protectedDocument().get());
+        window->dispatchEvent(GamepadEvent::create(eventNames().gamepadconnectedEvent, WTF::move(gamepad)), protect(window->document()).get());
     }
 }
 

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -74,7 +74,7 @@ Ref<Gamepad> NavigatorGamepad::gamepadFromPlatformGamepad(PlatformGamepad& platf
 {
     unsigned index = platformGamepad.index();
     if (index >= m_gamepads.size() || !m_gamepads[index])
-        return Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad);
+        return Gamepad::create(protect(m_navigator->document()).get(), platformGamepad);
 
     return *m_gamepads[index];
 }
@@ -152,7 +152,7 @@ void NavigatorGamepad::gamepadsBecameVisible()
 
     for (size_t i = 0; i < platformGamepads.size(); ++i) {
         if (CheckedPtr gamepad = platformGamepads[i].get())
-            m_gamepads[i] = Gamepad::create(m_navigator->protectedDocument().get(), *gamepad);
+            m_gamepads[i] = Gamepad::create(protect(m_navigator->document()).get(), *gamepad);
     }
 }
 
@@ -171,9 +171,9 @@ void NavigatorGamepad::gamepadConnected(PlatformGamepad& platformGamepad)
     ASSERT(index <= m_gamepads.size());
 
     if (index < m_gamepads.size())
-        m_gamepads[index] = Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad);
+        m_gamepads[index] = Gamepad::create(protect(m_navigator->document()).get(), platformGamepad);
     else if (index == m_gamepads.size())
-        m_gamepads.append(Gamepad::create(m_navigator->protectedDocument().get(), platformGamepad));
+        m_gamepads.append(Gamepad::create(protect(m_navigator->document()).get(), platformGamepad));
 }
 
 void NavigatorGamepad::gamepadDisconnected(PlatformGamepad& platformGamepad)

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -199,7 +199,7 @@ static AppHighlightRangeData::NodePathComponent createNodePathComponent(const No
 static AppHighlightRangeData::NodePath makeNodePath(RefPtr<Node>&& node)
 {
     AppHighlightRangeData::NodePath components;
-    RefPtr body = node->protectedDocument()->body();
+    RefPtr body = protect(node->document())->body();
     for (RefPtr ancestor = node; ancestor && ancestor != body; ancestor = ancestor->parentNode())
         components.append(createNodePathComponent(*ancestor));
     components.reverse();

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -227,7 +227,7 @@ MediaControlTextTrackContainerElement* MediaControlsHost::ensureTextTrackContain
 {
     if (!m_textTrackContainer) {
         Ref mediaElement = m_mediaElement.get();
-        m_textTrackContainer = MediaControlTextTrackContainerElement::create(mediaElement->protectedDocument().get(), mediaElement);
+        m_textTrackContainer = MediaControlTextTrackContainerElement::create(protect(mediaElement->document()).get(), mediaElement);
     }
 
     return m_textTrackContainer.get();
@@ -340,7 +340,7 @@ bool MediaControlsHost::supportsRewind() const
 
 bool MediaControlsHost::needsChromeMediaControlsPseudoElement() const
 {
-    return protectedMediaElement()->protectedDocument()->quirks().needsChromeMediaControlsPseudoElement();
+    return protect(protectedMediaElement()->document())->quirks().needsChromeMediaControlsPseudoElement();
 }
 
 bool MediaControlsHost::isMediaControlsMacInlineSizeSpecsEnabled() const

--- a/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp
@@ -69,7 +69,7 @@ MediaDevices* NavigatorMediaDevices::mediaDevices(Navigator& navigator)
 MediaDevices* NavigatorMediaDevices::mediaDevices() const
 {
     if (!m_mediaDevices && frame())
-        m_mediaDevices = MediaDevices::create(*frame()->protectedDocument());
+        m_mediaDevices = MediaDevices::create(*protect(frame()->document()));
     return m_mediaDevices.get();
 }
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -130,7 +130,7 @@ HTMLModelElement::~HTMLModelElement()
     }
 #endif
 
-    LazyLoadModelObserver::unobserve(*this, protectedDocument());
+    LazyLoadModelObserver::unobserve(*this, protect(document()));
 
     m_loadModelTimer = nullptr;
 
@@ -441,7 +441,7 @@ RefPtr<GraphicsLayer> HTMLModelElement::graphicsLayer() const
 
 bool HTMLModelElement::isVisible() const
 {
-    bool isVisibleInline = !protectedDocument()->hidden() && m_isIntersectingViewport;
+    bool isVisibleInline = !protect(document())->hidden() && m_isIntersectingViewport;
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     return isVisibleInline || m_detachedForImmersive;
 #else
@@ -453,7 +453,7 @@ void HTMLModelElement::logWarning(ModelPlayer& modelPlayer, const String& warnin
 {
     ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
 
-    protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, warningMessage);
+    protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, warningMessage);
 }
 
 // MARK: - ModelPlayer support
@@ -618,7 +618,7 @@ void HTMLModelElement::reloadModelPlayer()
     ASSERT(animationState && transformState);
 
     if (!m_modelPlayerProvider)
-        m_modelPlayerProvider = protectedDocument()->protectedPage()->modelPlayerProvider();
+        m_modelPlayerProvider = protect(document())->protectedPage()->modelPlayerProvider();
     if (RefPtr modelPlayerProvider = m_modelPlayerProvider.get()) {
         modelPlayer = modelPlayerProvider->createModelPlayer(*this);
         m_modelPlayer = modelPlayer.copyRef();
@@ -1545,7 +1545,7 @@ void HTMLModelElement::stop()
 {
     RELEASE_LOG(ModelElement, "%p - HTMLModelElement::stop()", this);
 
-    LazyLoadModelObserver::unobserve(*this, protectedDocument());
+    LazyLoadModelObserver::unobserve(*this, protect(document()));
 
     m_loadModelTimer = nullptr;
 
@@ -1701,7 +1701,7 @@ void HTMLModelElement::sourceRequestResource()
         return triggerModelPlayerCreationCallbacksIfNeeded(Exception { ExceptionCode::AbortError, "The source URL is empty"_s });
 
     auto request = createResourceRequest(m_sourceURL, FetchOptions::Destination::Model);
-    auto resource = protectedDocument()->protectedCachedResourceLoader()->requestModelResource(WTF::move(request));
+    auto resource = protect(document())->protectedCachedResourceLoader()->requestModelResource(WTF::move(request));
     if (!resource.has_value()) {
         ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
         if (!m_readyPromise->isFulfilled())

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -285,7 +285,7 @@ static URL processAndCreateYouTubeURL(const URL& url, bool& isYouTubeShortenedUR
 
 AtomString YouTubePluginReplacement::youTubeURL(const AtomString& srcString)
 {
-    URL srcURL = m_parentElement->protectedDocument()->completeURL(srcString);
+    URL srcURL = protect(m_parentElement->document())->completeURL(srcString);
     return youTubeURLFromAbsoluteURL(srcURL, srcString);
 }
 

--- a/Source/WebCore/accessibility/AXListHelpers.cpp
+++ b/Source/WebCore/accessibility/AXListHelpers.cpp
@@ -61,7 +61,7 @@ bool AXListHelpers::childHasPseudoVisibleListItemMarkers(const Node& node)
     if (!beforePseudo)
         return false;
 
-    CheckedPtr cache = element->protectedDocument()->axObjectCache();
+    CheckedPtr cache = protect(element->document())->axObjectCache();
     RefPtr axBeforePseudo = cache ? cache->getOrCreate(*beforePseudo) : nullptr;
     if (!axBeforePseudo)
         return false;

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -119,7 +119,7 @@ AXTextMarker::AXTextMarker(const VisiblePosition& visiblePosition, TextMarkerOri
     if (!node)
         return;
 
-    CheckedPtr cache = node->protectedDocument()->axObjectCache();
+    CheckedPtr cache = protect(node->document())->axObjectCache();
     if (!cache)
         return;
 
@@ -134,7 +134,7 @@ AXTextMarker::AXTextMarker(const CharacterOffset& characterOffset, TextMarkerOri
     if (characterOffset.isNull())
         return;
 
-    if (CheckedPtr cache = characterOffset.node->protectedDocument()->axObjectCache())
+    if (CheckedPtr cache = protect(characterOffset.node->document())->axObjectCache())
         m_data = cache->textMarkerDataForCharacterOffset(characterOffset, origin);
 }
 
@@ -285,7 +285,7 @@ AXTextMarkerRange::AXTextMarkerRange(const std::optional<SimpleRange>& range)
     }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
-    if (CheckedPtr cache = range->start.protectedDocument()->axObjectCache()) {
+    if (CheckedPtr cache = protect(range->start.document())->axObjectCache()) {
         m_start = AXTextMarker(cache->startOrEndCharacterOffsetForRange(*range, true));
         m_end = AXTextMarker(cache->startOrEndCharacterOffsetForRange(*range, false));
     }

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2137,7 +2137,7 @@ static RenderObject* rendererForView(WAKView* view)
     if (!renderer)
         return nil;
 
-    CheckedPtr cache = renderer->protectedDocument()->axObjectCache();
+    CheckedPtr cache = protect(renderer->document())->axObjectCache();
     if (!cache)
         return nil;
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2652,7 +2652,7 @@ static RenderObject* rendererForView(NSView* view)
     if (!frame)
         return nullptr;
 
-    RefPtr<Node> node = frame->protectedDocument()->ownerElement();
+    RefPtr<Node> node = protect(frame->document())->ownerElement();
     if (!node)
         return nullptr;
 
@@ -2665,7 +2665,7 @@ static RenderObject* rendererForView(NSView* view)
     if (!renderer)
         return nil;
 
-    CheckedPtr cache = renderer->protectedDocument()->axObjectCache();
+    CheckedPtr cache = protect(renderer->document())->axObjectCache();
     RefPtr object = cache ? cache->getOrCreate(*renderer) : nil;
     RefPtr parent = object ? object->parentObjectUnignored() : nil;
     return parent ? parent->wrapper() : nil;

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -59,7 +59,7 @@ void AcceleratedEffectStackUpdater::update()
         Styleable target { *element, pseudoElementIdentifier };
 
         if (!page)
-            page = element->protectedDocument()->page();
+            page = protect(element->document())->page();
 
         CheckedPtr renderer = dynamicDowncast<RenderLayerModelObject>(target.renderer());
         if (!renderer || !renderer->isComposited())

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -75,7 +75,7 @@ Ref<ScrollTimeline> ScrollTimeline::create(Document& document, ScrollTimelineOpt
     timeline->setAxis(options.axis);
 
     if (auto source = timeline->m_source.element()) {
-        source->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+        protect(source->document())->updateLayoutIgnorePendingStylesheets();
         timeline->cacheCurrentTime();
     }
 
@@ -154,7 +154,7 @@ RefPtr<Element> ScrollTimeline::source() const
         return nullptr;
     }
     case Scroller::Root:
-        return source->element.protectedDocument()->scrollingElement();
+        return protect(source->element.document())->scrollingElement();
     case Scroller::Self:
         return &source->element;
     }
@@ -186,13 +186,13 @@ void ScrollTimeline::setSource(const Styleable& styleable)
 
     removeTimelineFromDocument(previousSource.get());
 
-    styleable.element.protectedDocument()->ensureTimelinesController().addTimeline(*this);
+    protect(styleable.element.document())->ensureTimelinesController().addTimeline(*this);
 }
 
 void ScrollTimeline::removeTimelineFromDocument(Element* element)
 {
     if (element) {
-        if (CheckedPtr timelinesController = element->protectedDocument()->timelinesController())
+        if (CheckedPtr timelinesController = protect(element->document())->timelinesController())
             timelinesController->removeTimeline(*this);
     }
 }
@@ -320,7 +320,7 @@ void ScrollTimeline::updateCurrentTimeIfStale()
     }
 
     if (needsStyleUpdate)
-        source->element.protectedDocument()->updateStyleIfNeeded();
+        protect(source->element.document())->updateStyleIfNeeded();
 }
 
 void ScrollTimeline::setTimelineScopeElement(const Element& element)
@@ -401,7 +401,7 @@ void ScrollTimeline::animationTimingDidChange(WebAnimation& animation)
     if (!source || !animation.pending() || animation.isEffectInvalidationSuspended())
         return;
 
-    if (RefPtr page = source->element.protectedDocument()->page())
+    if (RefPtr page = protect(source->element.document())->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::Animations);
 }
 
@@ -421,7 +421,7 @@ bool ScrollTimeline::computeCanBeAccelerated() const
 void ScrollTimeline::scheduleAcceleratedRepresentationUpdate()
 {
     if (RefPtr source = this->source()) {
-        if (RefPtr page = source->protectedDocument()->page()) {
+        if (RefPtr page = protect(source->document())->page()) {
             if (auto* acceleratedTimelinesUpdater = page->acceleratedTimelinesUpdater())
                 acceleratedTimelinesUpdater->scrollTimelineDidChange(*this);
         }

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -71,7 +71,7 @@ ExceptionOr<Ref<ViewTimeline>> ViewTimeline::create(Document& document, ViewTime
     viewTimeline->m_specifiedInsets = WTF::move(specifiedInsets);
     viewTimeline->setSubject(options.subject.get());
     if (auto subject = options.subject)
-        subject->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+        protect(subject->document())->updateLayoutIgnorePendingStylesheets();
     viewTimeline->cacheCurrentTime();
 
     return viewTimeline;
@@ -193,7 +193,7 @@ void ViewTimeline::setSubject(const Styleable& styleable)
 
     removeTimelineFromDocument(previousSubject.get());
 
-    styleable.element.protectedDocument()->ensureTimelinesController().addTimeline(*this);
+    protect(styleable.element.document())->ensureTimelinesController().addTimeline(*this);
 }
 
 AnimationTimelinesController* ViewTimeline::controller() const
@@ -435,7 +435,7 @@ Style::SingleAnimationRange ViewTimeline::defaultRange() const
 RefPtr<Element> ViewTimeline::bindingsSource() const
 {
     if (auto subject = m_subject.styleable())
-        subject->element.protectedDocument()->updateStyleIfNeeded();
+        protect(subject->element.document())->updateStyleIfNeeded();
     return ScrollTimeline::bindingsSource();
 }
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -905,7 +905,7 @@ void WebAnimation::enqueueAnimationEvent(Ref<AnimationEventBase>&& event)
         }
         if (RefPtr keyframeEffect = this->keyframeEffect()) {
             if (RefPtr target = keyframeEffect->target())
-                return target->protectedDocument()->existingTimeline();
+                return protect(target->document())->existingTimeline();
         }
         return nullptr;
     };
@@ -1788,7 +1788,7 @@ ExceptionOr<void> WebAnimation::commitStyles()
         return Exception { ExceptionCode::NoModificationAllowedError };
 
     // 2.2 If, after applying any pending style changes, target is not being rendered, throw an "InvalidStateError" DOMException and abort these steps.
-    styledElement->protectedDocument()->updateStyleIfNeeded();
+    protect(styledElement->document())->updateStyleIfNeeded();
     CheckedPtr renderer = styledElement->renderer();
     if (!renderer)
         return Exception { ExceptionCode::InvalidStateError };

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -112,7 +112,7 @@ const Settings* CSSComputedStyleDeclaration::settings() const
 
 const FixedVector<CSSPropertyID>& CSSComputedStyleDeclaration::exposedComputedCSSPropertyIDs() const
 {
-    return protectedElement()->protectedDocument()->exposedComputedCSSPropertyIDs();
+    return protect(protectedElement()->document())->exposedComputedCSSPropertyIDs();
 }
 
 String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) const

--- a/Source/WebCore/css/StyleMedia.cpp
+++ b/Source/WebCore/css/StyleMedia.cpp
@@ -35,7 +35,7 @@ StyleMedia::StyleMedia(LocalDOMWindow& window)
     : LocalDOMWindowProperty(&window)
 {
     if (window.document()) {
-        window.protectedDocument()->addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Warning,
+        protect(window.document())->addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Warning,
             "window.styleMedia is a deprecated draft version of window.matchMedia API, and it will be removed in the future."_s));
     }
 }

--- a/Source/WebCore/dom/CDATASection.cpp
+++ b/Source/WebCore/dom/CDATASection.cpp
@@ -58,7 +58,7 @@ SerializedNode CDATASection::serializeNode(CloningOperation) const
 
 Ref<Text> CDATASection::virtualCreate(String&& data)
 {
-    return create(protectedDocument(), WTF::move(data));
+    return create(protect(document()), WTF::move(data));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -234,7 +234,7 @@ void CharacterData::dispatchModifiedEvent(const String& oldData)
         dispatchSubtreeModifiedEvent();
     }
 
-    InspectorInstrumentation::characterDataModified(protectedDocument(), *this);
+    InspectorInstrumentation::characterDataModified(protect(document()), *this);
 }
 
 bool CharacterData::containsOnlyASCIIWhitespace() const

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -579,7 +579,7 @@ ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, RefPtr<Node>&& ref
         }
     }
 
-    InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
+    InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
     ChildListMutationScope mutation(*this);
     for (auto& child : targets) {
@@ -716,7 +716,7 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
         }
     }
 
-    InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
+    InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
     // Add the new child(ren).
     for (auto& child : targets) {
@@ -839,7 +839,7 @@ void ContainerNode::replaceAll(Node* node)
         ? ReplacedAllChildren::YesIncludingElements : ReplacedAllChildren::YesNotIncludingElements;
 
     executeNodeInsertionWithScriptAssertion(*this, *node, nullptr, ChildChange::Source::API, replacedAllChildren, [&] {
-        InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
+        InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
         node->setTreeScopeRecursively(treeScope());
         appendChildCommon(*node);
     });
@@ -913,7 +913,7 @@ ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Nod
         }
     }
 
-    InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
+    InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
     // Now actually add the child(ren)
     ChildListMutationScope mutation(*this);
@@ -958,7 +958,7 @@ ExceptionOr<void> ContainerNode::insertChildrenBeforeWithoutPreInsertionValidity
         }
     }
 
-    InspectorInstrumentation::willInsertDOMNode(protectedDocument(), *this);
+    InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
     ChildListMutationScope mutation(*this);
     for (auto& child : newChildren) {
@@ -1189,7 +1189,7 @@ static void dispatchChildRemovalEvents(Ref<Node>& child)
 
 ExceptionOr<Element*> ContainerNode::querySelector(const String& selectors)
 {
-    auto query = protectedDocument()->selectorQueryForString(selectors);
+    auto query = protect(document())->selectorQueryForString(selectors);
     if (query.hasException())
         return query.releaseException();
     return query.releaseReturnValue().queryFirst(*this);

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -240,8 +240,8 @@ void ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded(con
     if (RefPtr scrollAnchorRoot = findSkippedContentRoot(scrollAnchor)) {
         updateViewportProximity(*scrollAnchorRoot, ViewportProximity::Near);
         // Since we may not have determined initial visibility yet, force scheduling the content relevancy update.
-        scrollAnchorRoot->protectedDocument()->scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
-        scrollAnchorRoot->protectedDocument()->updateRelevancyOfContentVisibilityElements();
+        protect(scrollAnchorRoot->document())->scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
+        protect(scrollAnchorRoot->document())->updateRelevancyOfContentVisibilityElements();
     }
 }
 
@@ -250,7 +250,7 @@ void ContentVisibilityDocumentState::updateViewportProximity(const Element& elem
     // No need to schedule content relevancy update for first time call, since
     // that will be handled by determineInitialVisibleContentVisibility.
     if (m_elementViewportProximities.contains(element))
-        element.protectedDocument()->scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
+        protect(element.document())->scheduleContentRelevancyUpdate(ContentRelevancy::OnScreen);
     m_elementViewportProximities.ensure(element, [] {
         return ViewportProximity::Far;
     }).iterator->value = viewportProximity;

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -389,7 +389,7 @@ void CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue(Element
     ASSERT(element.reactionQueue());
     element.setIsInCustomElementReactionQueue();
     if (!CustomElementReactionStack::s_currentProcessingStack) {
-        element.protectedDocument()->protectedWindowEventLoop()->backupElementQueue().add(element);
+        protect(element.document())->protectedWindowEventLoop()->backupElementQueue().add(element);
         return;
     }
 

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -241,7 +241,7 @@ void CustomElementRegistry::addToScopedCustomElementRegistryMap(Element& element
     if (element.usesScopedCustomElementRegistryMap())
         return;
     element.setUsesScopedCustomElementRegistryMap();
-    registry.didAssociateWithDocument(element.protectedDocument().get());
+    registry.didAssociateWithDocument(protect(element.document()).get());
     auto result = scopedCustomElementRegistryMap().add(element, registry);
     ASSERT_UNUSED(result, result.isNewEntry);
 }

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -90,12 +90,12 @@ void DocumentImmersive::requestImmersive(HTMLModelElement* element, CompletionHa
         RELEASE_LOG_ERROR(Immersive, "%p - DocumentImmersive: %s", protectedThis.get(), message.utf8().data());
         if (emitErrorEvent == EmitErrorEvent::Yes) {
             protectedThis->queueImmersiveEventForElement(DocumentImmersive::EventType::Error, *protectedElement);
-            protectedThis->protectedDocument()->scheduleRenderingUpdate(RenderingUpdateStep::Immersive);
+            protect(protectedThis->document())->scheduleRenderingUpdate(RenderingUpdateStep::Immersive);
         }
         completionHandler(Exception { ExceptionCode::TypeError, message });
     };
 
-    if (!protectedDocument()->isFullyActive())
+    if (!protect(document())->isFullyActive())
         return handleError("Cannot request immersive on a document that is not fully active."_s, EmitErrorEvent::No, WTF::move(completionHandler));
 
     if (RefPtr window = document().window(); !window || !window->consumeTransientActivation())

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -918,17 +918,17 @@ std::tuple<float, float> DocumentMarkerController::markerYPositionAndHeightForFo
 
 void addMarker(const SimpleRange& range, DocumentMarkerType type, const DocumentMarker::Data& data)
 {
-    range.start.protectedDocument()->checkedMarkers()->addMarker(range, type, data);
+    protect(range.start.document())->checkedMarkers()->addMarker(range, type, data);
 }
 
 void addMarker(Node& node, unsigned startOffset, unsigned length, DocumentMarkerType type, DocumentMarker::Data&& data)
 {
-    node.protectedDocument()->checkedMarkers()->addMarker(node, startOffset, length, type, WTF::move(data));
+    protect(node.document())->checkedMarkers()->addMarker(node, startOffset, length, type, WTF::move(data));
 }
 
 void removeMarkers(const SimpleRange& range, OptionSet<DocumentMarkerType> types, RemovePartiallyOverlappingMarker policy)
 {
-    range.start.protectedDocument()->checkedMarkers()->removeMarkers(range, types, policy);
+    protect(range.start.document())->checkedMarkers()->removeMarkers(range, types, policy);
 }
 
 SimpleRange makeSimpleRange(Node& node, const DocumentMarker& marker)

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -418,7 +418,7 @@ void Element::hideNonceSlow()
     ASSERT(isConnected());
     ASSERT(hasAttributeWithoutSynchronization(nonceAttr));
 
-    if (!protectedDocument()->checkedContentSecurityPolicy()->isHeaderDelivered())
+    if (!protect(document())->checkedContentSecurityPolicy()->isHeaderDelivered())
         return;
 
     // Retain previous IDL nonce.
@@ -548,7 +548,7 @@ Element::DispatchMouseEventResult Element::dispatchMouseEvent(const PlatformMous
 #elif PLATFORM(MAC)
     isParentProcessAFullWebBrowser = WTF::MacApplication::isSafari();
 #endif
-    if (Quirks::StorageAccessResult::ShouldCancelEvent == protectedDocument()->quirks().triggerOptionalStorageAccessQuirk(*this, platformEvent, eventType, detail, relatedTarget, isParentProcessAFullWebBrowser, isSyntheticClick))
+    if (Quirks::StorageAccessResult::ShouldCancelEvent == protect(document())->quirks().triggerOptionalStorageAccessQuirk(*this, platformEvent, eventType, detail, relatedTarget, isParentProcessAFullWebBrowser, isSyntheticClick))
         return { Element::EventIsDispatched::No, eventIsDefaultPrevented };
 
     bool shouldNotDispatchMouseEvent = isAnyClick(mouseEvent) || mouseEvent->type() == eventNames().contextmenuEvent;
@@ -757,7 +757,7 @@ Ref<Attr> Element::detachAttribute(unsigned index)
     if (attrNode)
         detachAttrNodeFromElementWithValue(attrNode.get(), attribute.value());
     else
-        attrNode = Attr::create(protectedDocument(), attribute.name(), attribute.value());
+        attrNode = Attr::create(protect(document()), attribute.name(), attribute.value());
 
     removeAttributeInternal(index, InSynchronizationOfLazyAttribute::No);
     return attrNode.releaseNonNull();
@@ -927,37 +927,37 @@ bool Element::isFocusable() const
 bool Element::isUserActionElementInActiveChain() const
 {
     ASSERT(isUserActionElement());
-    return protectedDocument()->userActionElements().isInActiveChain(*this);
+    return protect(document())->userActionElements().isInActiveChain(*this);
 }
 
 bool Element::isUserActionElementActive() const
 {
     ASSERT(isUserActionElement());
-    return protectedDocument()->userActionElements().isActive(*this);
+    return protect(document())->userActionElements().isActive(*this);
 }
 
 bool Element::isUserActionElementFocused() const
 {
     ASSERT(isUserActionElement());
-    return protectedDocument()->userActionElements().isFocused(*this);
+    return protect(document())->userActionElements().isFocused(*this);
 }
 
 bool Element::isUserActionElementHovered() const
 {
     ASSERT(isUserActionElement());
-    return protectedDocument()->userActionElements().isHovered(*this);
+    return protect(document())->userActionElements().isHovered(*this);
 }
 
 bool Element::isUserActionElementDragged() const
 {
     ASSERT(isUserActionElement());
-    return protectedDocument()->userActionElements().isBeingDragged(*this);
+    return protect(document())->userActionElements().isBeingDragged(*this);
 }
 
 bool Element::isUserActionElementHasFocusVisible() const
 {
     ASSERT(isUserActionElement());
-    return protectedDocument()->userActionElements().hasFocusVisible(*this);
+    return protect(document())->userActionElements().hasFocusVisible(*this);
 }
 
 FormListedElement* Element::asFormListedElement()
@@ -980,7 +980,7 @@ AttachmentAssociatedElement* Element::asAttachmentAssociatedElement()
 bool Element::isUserActionElementHasFocusWithin() const
 {
     ASSERT(isUserActionElement());
-    return protectedDocument()->userActionElements().hasFocusWithin(*this);
+    return protect(document())->userActionElements().hasFocusWithin(*this);
 }
 
 void Element::setActive(bool value, Style::InvalidationScope invalidationScope)
@@ -1011,7 +1011,7 @@ void Element::setFocus(bool value, FocusVisibility visibility)
         return;
     
     Style::PseudoClassChangeInvalidation focusStyleInvalidation(*this, { { CSSSelector::PseudoClass::Focus, value }, { CSSSelector::PseudoClass::FocusVisible, value } });
-    protectedDocument()->userActionElements().setFocused(*this, value);
+    protect(document())->userActionElements().setFocused(*this, value);
 
     // Shadow host with a slot that contain focused element is not considered focused.
     for (RefPtr root = containingShadowRoot(); root; root = root->host()->containingShadowRoot()) {
@@ -1045,7 +1045,7 @@ void Element::setHasFocusWithin(bool value)
         return;
     {
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::FocusWithin, value);
-        protectedDocument()->userActionElements().setHasFocusWithin(*this, value);
+        protect(document())->userActionElements().setHasFocusWithin(*this, value);
     }
 }
 
@@ -1054,7 +1054,7 @@ void Element::setHasTentativeFocus(bool value)
     // Tentative focus is used when trying to set the focus on a new element.
     for (Ref ancestor : composedTreeAncestors(*this)) {
         ASSERT(ancestor->hasFocusWithin() != value);
-        protectedDocument()->userActionElements().setHasFocusWithin(ancestor, value);
+        protect(document())->userActionElements().setHasFocusWithin(ancestor, value);
     }
 }
 
@@ -1064,7 +1064,7 @@ void Element::setHovered(bool value, Style::InvalidationScope invalidationScope,
         return;
     {
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Hover, value, invalidationScope);
-        protectedDocument()->userActionElements().setHovered(*this, value);
+        protect(document())->userActionElements().setHovered(*this, value);
     }
 
     if (CheckedPtr style = renderStyle(); style && style->hasUsedAppearance()) {
@@ -1079,7 +1079,7 @@ void Element::setBeingDragged(bool value)
         return;
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::WebKitDrag, value);
-    protectedDocument()->userActionElements().setBeingDragged(*this, value);
+    protect(document())->userActionElements().setBeingDragged(*this, value);
 }
 
 inline ScrollAlignment toScrollAlignmentForInlineDirection(std::optional<ScrollLogicalPosition> position, WritingMode writingMode)
@@ -1253,7 +1253,7 @@ void Element::scrollIntoView(Variant<bool, ScrollIntoViewOptions>&& arg)
 
 void Element::scrollIntoView(bool alignToTop) 
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets(LayoutOptions::UpdateCompositingLayers);
+    protect(document())->updateLayoutIgnorePendingStylesheets(LayoutOptions::UpdateCompositingLayers);
 
     CheckedPtr renderer = this->renderer();
     if (!renderer)
@@ -1293,7 +1293,7 @@ void Element::scrollIntoViewIfNeeded(bool centerIfNeeded)
 
 void Element::scrollIntoViewIfNotVisible(bool centerIfNotVisible, AllowScrollingOverflowHidden allowScrollingOverflowHidden)
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets(LayoutOptions::UpdateCompositingLayers);
+    protect(document())->updateLayoutIgnorePendingStylesheets(LayoutOptions::UpdateCompositingLayers);
 
     CheckedPtr renderer = this->renderer();
     if (!renderer)
@@ -1489,7 +1489,7 @@ int Element::offsetLeftForBindings()
 
 int Element::offsetLeft()
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     if (CheckedPtr renderer = renderBoxModelObject())
         return adjustOffsetForZoomAndSubpixelLayout(*renderer, renderer->offsetLeft());
     return 0;
@@ -1518,7 +1518,7 @@ int Element::offsetTopForBindings()
 
 int Element::offsetTop()
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     if (CheckedPtr renderer = renderBoxModelObject())
         return adjustOffsetForZoomAndSubpixelLayout(*renderer, renderer->offsetTop());
     return 0;
@@ -1526,7 +1526,7 @@ int Element::offsetTop()
 
 int Element::offsetWidth()
 {
-    protectedDocument()->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
+    protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Width, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
     if (CheckedPtr renderer = renderBoxModelObject()) {
         auto offsetWidth = LayoutUnit { roundToInt(renderer->offsetWidth()) };
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(offsetWidth, *renderer).toDouble());
@@ -1536,7 +1536,7 @@ int Element::offsetWidth()
 
 int Element::offsetHeight()
 {
-    protectedDocument()->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
+    protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Height, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
     if (CheckedPtr renderer = renderBoxModelObject()) {
         auto offsetHeight = LayoutUnit { roundToInt(renderer->offsetHeight()) };
         return convertToNonSubpixelValue(adjustLayoutUnitForAbsoluteZoom(offsetHeight, *renderer).toDouble());
@@ -1556,7 +1556,7 @@ RefPtr<Element> Element::offsetParentForBindings()
 
 Element* Element::offsetParent()
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     CheckedPtr renderer = this->renderer();
     if (!renderer)
         return nullptr;
@@ -1566,7 +1566,7 @@ Element* Element::offsetParent()
 
 int Element::clientLeft()
 {
-    protectedDocument()->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Left, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
+    protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Left, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
 
     if (CheckedPtr renderer = renderBox()) {
         auto clientLeft = LayoutUnit { roundToInt(renderer->clientLeft()) };
@@ -1577,7 +1577,7 @@ int Element::clientLeft()
 
 int Element::clientTop()
 {
-    protectedDocument()->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Top, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
+    protect(document())->updateLayoutIfDimensionsOutOfDate(*this, DimensionsCheck::Top, { LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::IgnorePendingStylesheets });
 
     if (CheckedPtr renderer = renderBox()) {
         auto clientTop = LayoutUnit { roundToInt(renderer->clientTop()) };
@@ -1850,7 +1850,7 @@ IntRect Element::boundsInRootViewSpace()
 IntRect Element::boundingBoxInRootViewCoordinates() const
 {
     if (CheckedPtr renderer = this->renderer())
-        return protectedDocument()->view()->contentsToRootView(renderer->absoluteBoundingBoxRect());
+        return protect(document())->view()->contentsToRootView(renderer->absoluteBoundingBoxRect());
     return IntRect();
 }
 
@@ -1997,7 +1997,7 @@ static std::optional<std::pair<CheckedRef<RenderListBox>, LayoutRect>> listBoxEl
 
 Ref<DOMRectList> Element::getClientRects()
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     CheckedPtr renderer = this->renderer();
 
@@ -2017,7 +2017,7 @@ Ref<DOMRectList> Element::getClientRects()
     if (quads.isEmpty())
         return DOMRectList::create();
 
-    protectedDocument()->convertAbsoluteToClientQuads(quads, renderer->style());
+    protect(document())->convertAbsoluteToClientQuads(quads, renderer->style());
     return DOMRectList::create(quads);
 }
 
@@ -2364,7 +2364,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
         }
         break;
     case AttributeNames::accesskeyAttr:
-        protectedDocument()->invalidateAccessKeyCache();
+        protect(document())->invalidateAccessKeyCache();
         break;
     case AttributeNames::dirAttr:
         dirAttributeChanged(newValue);
@@ -3115,7 +3115,7 @@ Node::InsertedIntoAncestorResult Element::insertedIntoAncestor(InsertionType ins
 
     if (parentNode() == &parentOfInsertedTree && is<Document>(*parentNode())) {
         clearEffectiveLangStateOnNewDocumentElement();
-        protectedDocument()->setDocumentElementLanguage(langFromAttribute());
+        protect(document())->setDocumentElementLanguage(langFromAttribute());
     } else if (!hasLanguageAttribute())
         updateEffectiveLangStateFromParent();
 
@@ -3130,7 +3130,7 @@ void Element::clearEffectiveLangStateOnNewDocumentElement()
     ASSERT(parentNode() == &document());
 
     if (hasLangAttrKnownToMatchDocumentElement()) {
-        protectedDocument()->removeElementWithLangAttrMatchingDocumentElement(*this);
+        protect(document())->removeElementWithLangAttrMatchingDocumentElement(*this);
         setEffectiveLangKnownToMatchDocumentElement(false);
     }
 
@@ -3821,7 +3821,7 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNode(Attr& attrNode)
         if (oldAttrNode)
             detachAttrNodeFromElementWithValue(oldAttrNode.get(), attribute.value());
         else
-            oldAttrNode = Attr::create(protectedDocument(), attrNode.qualifiedName(), attribute.value());
+            oldAttrNode = Attr::create(protect(document()), attrNode.qualifiedName(), attribute.value());
 
         attachAttributeNodeIfNeeded(attrNode);
 
@@ -3877,7 +3877,7 @@ ExceptionOr<RefPtr<Attr>> Element::setAttributeNodeNS(Attr& attrNode)
             if (oldAttrNode)
                 detachAttrNodeFromElementWithValue(oldAttrNode.get(), elementData->attributeAt(index).value());
             else
-                oldAttrNode = Attr::create(protectedDocument(), attrNode.qualifiedName(), elementData->attributeAt(index).value());
+                oldAttrNode = Attr::create(protect(document()), attrNode.qualifiedName(), elementData->attributeAt(index).value());
         }
     }
 
@@ -4275,7 +4275,7 @@ void Element::blur()
         if (RefPtr frame = document().frame())
             frame->protectedPage()->focusController().setFocusedElement(nullptr, frame.get());
         else
-            protectedDocument()->setFocusedElement(nullptr);
+            protect(document())->setFocusedElement(nullptr);
     }
 }
 
@@ -4367,7 +4367,7 @@ void Element::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventIn
 {
     document().eventLoop().queueTask(TaskSource::DOMManipulation, [this, protectedThis = Ref { *this }, event = SecurityPolicyViolationEvent::create(eventNames().securitypolicyviolationEvent, WTF::move(eventInit), Event::IsTrusted::Yes)] {
         if (!isConnected())
-            protectedDocument()->dispatchEvent(event);
+            protect(document())->dispatchEvent(event);
         else
             dispatchEvent(event);
     });
@@ -4490,7 +4490,7 @@ ExceptionOr<void> Element::setInnerHTML(Variant<RefPtr<TrustedHTML>, String>&& h
 String Element::innerText()
 {
     // We need to update layout, since plainText uses line boxes in the render tree.
-    protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(document())->updateLayoutIgnorePendingStylesheets();
 
     if (!renderer())
         return textContent(true);
@@ -4875,7 +4875,7 @@ const AtomString& Element::langFromAttribute() const
 
 Locale& Element::locale() const
 {
-    return protectedDocument()->getCachedLocale(effectiveLang());
+    return protect(document())->getCachedLocale(effectiveLang());
 }
 
 void Element::normalizeAttributes()
@@ -5129,7 +5129,7 @@ void Element::requestFullscreen(FullscreenOptions&& options, RefPtr<DeferredProm
                 return;
 
             // Exit the fullscreen API when the hardware keyboard is detached.
-            protectedThis->protectedDocument()->postTask([weakThis](ScriptExecutionContext&) {
+            protect(protectedThis->document())->postTask([weakThis](ScriptExecutionContext&) {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
@@ -5141,7 +5141,7 @@ void Element::requestFullscreen(FullscreenOptions&& options, RefPtr<DeferredProm
         });
 #endif
         // Set the desired keyboard lock mode while entering fullscreen.
-        protectedDocument()->fullscreen().setKeyboardLockMode(options.keyboardLock);
+        protect(document())->fullscreen().setKeyboardLockMode(options.keyboardLock);
     }
     else {
         if (options.keyboardLock != FullscreenOptions::KeyboardLock::None) {
@@ -5150,7 +5150,7 @@ void Element::requestFullscreen(FullscreenOptions&& options, RefPtr<DeferredProm
         }
     }
 
-    protectedDocument()->fullscreen().requestFullscreen(*this, DocumentFullscreen::EnforceIFrameAllowFullscreenRequirement, [promise = WTF::move(promise)] (auto result) {
+    protect(document())->fullscreen().requestFullscreen(*this, DocumentFullscreen::EnforceIFrameAllowFullscreenRequirement, [promise = WTF::move(promise)] (auto result) {
         if (!promise)
             return;
         if (result.hasException())
@@ -5539,7 +5539,7 @@ bool Element::isWritingSuggestionsEnabled() const
     if (equalLettersIgnoringASCIICase(autocompleteValue, "off"_s))
         return false;
 
-    if (protectedDocument()->quirks().shouldDisableWritingSuggestionsByDefault())
+    if (protect(document())->quirks().shouldDisableWritingSuggestionsByDefault())
         return false;
 
     // Otherwise, return `true`.
@@ -5676,27 +5676,27 @@ void Element::willModifyAttribute(const QualifiedName& name, const AtomString& o
     if (auto recipients = MutationObserverInterestGroup::createForAttributesMutation(*this, name))
         recipients->enqueueMutationRecord(MutationRecord::createAttributes(*this, name, oldValue));
 
-    InspectorInstrumentation::willModifyDOMAttr(protectedDocument(), *this, oldValue, newValue);
+    InspectorInstrumentation::willModifyDOMAttr(protect(document()), *this, oldValue, newValue);
 }
 
 void Element::didAddAttribute(const QualifiedName& name, const AtomString& value)
 {
     notifyAttributeChanged(name, nullAtom(), value);
-    InspectorInstrumentation::didModifyDOMAttr(protectedDocument(), *this, name.toAtomString(), value);
+    InspectorInstrumentation::didModifyDOMAttr(protect(document()), *this, name.toAtomString(), value);
     dispatchSubtreeModifiedEvent();
 }
 
 void Element::didModifyAttribute(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue)
 {
     notifyAttributeChanged(name, oldValue, newValue);
-    InspectorInstrumentation::didModifyDOMAttr(protectedDocument(), *this, name.toAtomString(), newValue);
+    InspectorInstrumentation::didModifyDOMAttr(protect(document()), *this, name.toAtomString(), newValue);
     // Do not dispatch a DOMSubtreeModified event here; see bug 81141.
 }
 
 void Element::didRemoveAttribute(const QualifiedName& name, const AtomString& oldValue)
 {
     notifyAttributeChanged(name, oldValue, nullAtom());
-    InspectorInstrumentation::didRemoveDOMAttr(protectedDocument(), *this, name.toAtomString());
+    InspectorInstrumentation::didRemoveDOMAttr(protect(document()), *this, name.toAtomString());
     dispatchSubtreeModifiedEvent();
 }
 
@@ -6058,7 +6058,7 @@ static ExceptionOr<Ref<Element>> contextElementForInsertion(const String& where,
     CheckedRef contextNode = contextNodeResult.releaseReturnValue();
     RefPtr contextElement = dynamicDowncast<Element>(contextNode.get());
     if (!contextElement || (contextNode->document().isHTMLDocument() && is<HTMLHtmlElement>(contextNode.get())))
-        return Ref<Element> { HTMLBodyElement::create(contextNode->protectedDocument()) };
+        return Ref<Element> { HTMLBodyElement::create(protect(contextNode->document())) };
     return contextElement.releaseNonNull();
 }
 
@@ -6186,7 +6186,7 @@ Vector<Ref<WebAnimation>> Element::getAnimations(std::optional<GetAnimationsOpti
     // well since resolving layout-dependent media queries could yield animations.
     // FIXME: We might be able to use Style::Extractor which is more optimized.
     if (RefPtr owner = document->ownerElement())
-        owner->protectedDocument()->updateLayout();
+        protect(owner->document())->updateLayout();
     document->updateStyleIfNeeded();
 
     Vector<Ref<WebAnimation>> animations;

--- a/Source/WebCore/dom/ElementInlines.h
+++ b/Source/WebCore/dom/ElementInlines.h
@@ -113,7 +113,7 @@ inline const URL& Document::maskedURLForBindingsIfNeeded(const URL& url) const
 
 inline URL Element::getURLAttributeForBindings(const QualifiedName& name) const
 {
-    return protectedDocument()->maskedURLForBindingsIfNeeded(getURLAttribute(name));
+    return protect(document())->maskedURLForBindingsIfNeeded(getURLAttribute(name));
 }
 
 inline bool Element::hasAttributesWithoutUpdate() const

--- a/Source/WebCore/dom/ElementTextDirection.cpp
+++ b/Source/WebCore/dom/ElementTextDirection.cpp
@@ -88,7 +88,7 @@ static void updateHasDirAutoFlagForSubtree(Node& firstNode, TextDirectionState t
 static void updateElementHasDirAutoFlag(Element& element, TextDirectionState textDirectionState)
 {
     RefPtr parent = element.parentOrShadowHostElement();
-    element.protectedDocument()->setIsDirAttributeDirty();
+    protect(element.document())->setIsDirAttributeDirty();
 
     switch (textDirectionState) {
     case TextDirectionState::LTR:

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -123,7 +123,7 @@ static bool shouldSuppressEventDispatchInDOM(Node& node, Event& event)
     if (!event.isTrusted())
         return false;
 
-    RefPtr localMainFrame = node.protectedDocument()->localMainFrame();
+    RefPtr localMainFrame = protect(node.document())->localMainFrame();
     if (!localMainFrame)
         return false;
 

--- a/Source/WebCore/dom/FindRevealAlgorithms.cpp
+++ b/Source/WebCore/dom/FindRevealAlgorithms.cpp
@@ -47,7 +47,7 @@ enum class RevealType : bool {
 // https://html.spec.whatwg.org/#ancestor-revealing-algorithm
 bool revealClosedDetailsAndHiddenUntilFoundAncestors(Node& node)
 {
-    node.protectedDocument()->updateStyleIfNeeded();
+    protect(node.document())->updateStyleIfNeeded();
 
     // Bail out if there is neither a hidden=until-found or details ancestor.
     if (node.renderStyle() && !node.renderStyle()->autoRevealsWhenFound())

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -201,7 +201,7 @@ void removeOverlaySoonIfNeeded(HTMLElement& element)
     if (!hasOverlay(element))
         return;
 
-    element.protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
+    protect(element.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
         RefPtr element = weakElement.get();
         if (!element)
             return;
@@ -237,7 +237,7 @@ IntRect containerRect(HTMLElement& element)
 static void installImageOverlayStyleSheet(ShadowRoot& shadowRoot)
 {
     static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(imageOverlayUserAgentStyleSheet));
-    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, shadowRoot.protectedDocument(), false);
+    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, protect(shadowRoot.document()), false);
     style->setTextContent(String { shadowStyle });
     shadowRoot.appendChild(WTF::move(style));
 }

--- a/Source/WebCore/dom/LiveNodeListInlines.h
+++ b/Source/WebCore/dom/LiveNodeListInlines.h
@@ -58,7 +58,7 @@ ALWAYS_INLINE bool shouldInvalidateTypeOnAttributeChange(NodeListInvalidationTyp
 
 inline void LiveNodeList::invalidateCache() const
 {
-    invalidateCacheForDocument(protectedDocument().get());
+    invalidateCacheForDocument(protect(document()).get());
 }
 
 ALWAYS_INLINE void LiveNodeList::invalidateCacheForAttribute(const QualifiedName& attributeName) const
@@ -94,7 +94,7 @@ template <class NodeListType, CollectionTraversalType traversalType>
 CachedLiveNodeList<NodeListType, traversalType>::~CachedLiveNodeList()
 {
     if (m_indexCache.hasValidCache())
-        protectedDocument()->unregisterNodeListForInvalidation(*this);
+        protect(document())->unregisterNodeListForInvalidation(*this);
 }
 
 template <class NodeListType, CollectionTraversalType traversalType>
@@ -142,7 +142,7 @@ bool CachedLiveNodeList<NodeListType, traversalType>::collectionCanTraverseBackw
 template <class NodeListType, CollectionTraversalType traversalType>
 void CachedLiveNodeList<NodeListType, traversalType>::willValidateIndexCache() const
 {
-    protectedDocument()->registerNodeListForInvalidation(const_cast<CachedLiveNodeList&>(*this));
+    protect(document())->registerNodeListForInvalidation(const_cast<CachedLiveNodeList&>(*this));
 }
 
 template <class NodeListType, CollectionTraversalType traversalType>

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -226,7 +226,7 @@ void MouseRelatedEvent::computeRelativePosition()
     m_offsetLocation = m_pageLocation;
 
     // Must have an updated render tree for this math to work correctly.
-    targetNode->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(targetNode->document())->updateLayoutIgnorePendingStylesheets();
 
     // Adjust offsetLocation to be relative to the target's padding box.
     auto [renderer, adjustedNode] = findTargetRendererAndAdjustedNode(targetNode);

--- a/Source/WebCore/dom/MutationObserverRegistration.cpp
+++ b/Source/WebCore/dom/MutationObserverRegistration.cpp
@@ -76,7 +76,7 @@ void MutationObserverRegistration::observedSubtreeNodeWillDetach(Node& node)
         return;
 
     node.registerTransientMutationObserver(*this);
-    m_observer->setHasTransientRegistration(node.protectedDocument());
+    m_observer->setHasTransientRegistration(protect(node.document()));
 
     if (m_transientRegistrationNodes.isEmpty()) {
         ASSERT(!m_nodeKeptAlive);

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -442,7 +442,6 @@ public:
 
     // Returns the document associated with this node. A document node returns itself.
     inline Document& document() const; // Defined in NodeDocument.h
-    inline Ref<Document> protectedDocument() const; // Defined in NodeDocument.h
 
     TreeScope& treeScope() const
     {

--- a/Source/WebCore/dom/NodeDocument.h
+++ b/Source/WebCore/dom/NodeDocument.h
@@ -35,9 +35,4 @@ inline Document& Node::document() const
     return treeScope().documentScope();
 }
 
-inline Ref<Document> Node::protectedDocument() const
-{
-    return document();
-}
-
 }

--- a/Source/WebCore/dom/NodeIterator.cpp
+++ b/Source/WebCore/dom/NodeIterator.cpp
@@ -80,7 +80,7 @@ inline NodeIterator::NodeIterator(Node& rootNode, unsigned whatToShow, RefPtr<No
     : NodeIteratorBase(rootNode, whatToShow, WTF::move(filter))
     , m_referenceNode(rootNode, true)
 {
-    root().protectedDocument()->attachNodeIterator(*this);
+    protect(root().document())->attachNodeIterator(*this);
 }
 
 Ref<NodeIterator> NodeIterator::create(Node& rootNode, unsigned whatToShow, RefPtr<NodeFilter>&& filter)

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -270,7 +270,7 @@ Node::InsertedIntoAncestorResult ProcessingInstruction::insertedIntoAncestor(Ins
     CharacterData::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
         return InsertedIntoAncestorResult::Done;
-    protectedDocument()->styleScope().addStyleSheetCandidateNode(*this, m_createdByParser);
+    protect(document())->styleScope().addStyleSheetCandidateNode(*this, m_createdByParser);
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
 

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -219,7 +219,7 @@ void RadioButtonGroups::addButton(HTMLInputElement& element)
         group = makeUnique<RadioButtonGroup>();
     group->add(element);
 
-    if (CheckedPtr cache = element.protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(element.document())->existingAXObjectCache())
         cache->onRadioGroupMembershipChanged(element);
 }
 
@@ -296,7 +296,7 @@ void RadioButtonGroups::removeButton(HTMLInputElement& element)
     if (it->value->isEmpty())
         m_nameToGroupMap.remove(it);
 
-    if (CheckedPtr cache = element.protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(element.document())->existingAXObjectCache())
         cache->onRadioGroupMembershipChanged(element);
 }
 

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -756,7 +756,7 @@ ExceptionOr<Ref<DocumentFragment>> Range::createContextualFragment(Variant<RefPt
     else
         element = node->parentElement();
     if (!element || (element->document().isHTMLDocument() && is<HTMLHtmlElement>(*element)))
-        element = HTMLBodyElement::create(node->protectedDocument());
+        element = HTMLBodyElement::create(protect(node->document()));
     return WebCore::createContextualFragment(*element, stringValueHolder.releaseReturnValue(), { ParserContentPolicy::AllowScriptingContent, ParserContentPolicy::DoNotMarkAlreadyStarted });
 }
 
@@ -1094,7 +1094,7 @@ ExceptionOr<void> Range::expand(const String& unit)
 
 Ref<DOMRectList> Range::getClientRects() const
 {
-    startContainer().protectedDocument()->updateLayout();
+    protect(startContainer().document())->updateLayout();
     return DOMRectList::create(RenderObject::clientBorderAndTextRects(makeSimpleRange(*this)));
 }
 
@@ -1105,7 +1105,7 @@ Ref<DOMRect> Range::getBoundingClientRect() const
 
 Ref<DOMRect> Range::boundingClientRect(const SimpleRange& simpleRange)
 {
-    simpleRange.startContainer().protectedDocument()->updateLayout();
+    protect(simpleRange.startContainer().document())->updateLayout();
     return DOMRect::create(unionRectIgnoringZeroRects(RenderObject::clientBorderAndTextRects(simpleRange)));
 }
 

--- a/Source/WebCore/dom/RawDataDocumentParser.h
+++ b/Source/WebCore/dom/RawDataDocumentParser.h
@@ -40,7 +40,7 @@ protected:
     void finish() override
     {
         if (!isStopped())
-            protectedDocument()->finishedParsing();
+            protect(document())->finishedParsing();
     }
 
 private:

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -297,7 +297,7 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
     case ScriptType::SpeculationRules: {
         // If the element has a source attribute, queue a task to fire an event named error at the element, and return.
         if (hasSourceAttribute()) {
-            element->protectedDocument()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [protectedThis = Ref { *this }] {
+            protect(element->document())->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [protectedThis = Ref { *this }] {
                 protectedThis->dispatchErrorEvent();
             });
             return false;
@@ -567,7 +567,7 @@ void ScriptElement::executeScriptAndDispatchEvent(LoadableScript& loadableScript
             // When the script is "null" due to a fetch error, an error event
             // should be dispatched for the script element.
             if (std::optional<LoadableScript::ConsoleMessage> message = error->consoleMessage)
-                element().protectedDocument()->addConsoleMessage(message->source, message->level, message->message);
+                protect(element().document())->addConsoleMessage(message->source, message->level, message->message);
             dispatchErrorEvent();
             break;
         }

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -138,10 +138,10 @@ Node::InsertedIntoAncestorResult ShadowRoot::insertedIntoAncestor(InsertionType 
         }
     }
     if (insertionType.connectedToDocument) {
-        protectedDocument()->didInsertInDocumentShadowRoot(*this);
+        protect(document())->didInsertInDocumentShadowRoot(*this);
         if (m_hasScopedCustomElementRegistry) {
             if (RefPtr registry = customElementRegistry())
-                registry->didAssociateWithDocument(protectedDocument());
+                registry->didAssociateWithDocument(protect(document()));
         }
     }
     if (!adoptedStyleSheets().empty() && document().frame())
@@ -158,7 +158,7 @@ void ShadowRoot::removedFromAncestor(RemovalType removalType, ContainerNode& old
 {
     DocumentFragment::removedFromAncestor(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
-        protectedDocument()->didRemoveInDocumentShadowRoot(*this);
+        protect(document())->didRemoveInDocumentShadowRoot(*this);
 }
 
 void ShadowRoot::childrenChanged(const ChildChange& childChange)

--- a/Source/WebCore/dom/SpeculationRulesMatcher.cpp
+++ b/Source/WebCore/dom/SpeculationRulesMatcher.cpp
@@ -57,12 +57,12 @@ static bool matches(const SpeculationRules::DocumentPredicate&, Document&, HTMLA
 static bool matches(const SpeculationRules::URLPatternPredicate& predicate, HTMLAnchorElement& anchor)
 {
     for (const auto& patternString : predicate.patterns) {
-        ExceptionOr<Ref<URLPattern>> exceptionOrPattern = URLPattern::create(anchor.protectedDocument(), patternString, String(anchor.document().baseURL().string()), URLPatternOptions());
+        ExceptionOr<Ref<URLPattern>> exceptionOrPattern = URLPattern::create(protect(anchor.document()), patternString, String(anchor.document().baseURL().string()), URLPatternOptions());
         if (exceptionOrPattern.hasException())
             continue;
 
         Ref<URLPattern> pattern = exceptionOrPattern.returnValue();
-        auto result = pattern->test(anchor.protectedDocument(), anchor.href().string(), String(anchor.document().baseURL().string()));
+        auto result = pattern->test(protect(anchor.document()), anchor.href().string(), String(anchor.document().baseURL().string()));
         if (!result.hasException() && result.returnValue())
             return true;
     }
@@ -72,7 +72,7 @@ static bool matches(const SpeculationRules::URLPatternPredicate& predicate, HTML
 static bool matches(const SpeculationRules::CSSSelectorPredicate& predicate, Element& element)
 {
     for (const auto& selectorString : predicate.selectors) {
-        auto query = element.protectedDocument()->selectorQueryForString(selectorString);
+        auto query = protect(element.document())->selectorQueryForString(selectorString);
         if (query.hasException())
             continue;
         if (query.returnValue().matches(element))

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -137,12 +137,12 @@ void StyledElement::setInlineStyleFromString(const AtomString& newStyleString)
     // We reconstruct the property set instead of mutating if there is no CSSOM wrapper.
     // This makes wrapperless property sets immutable and so cacheable.
     if (RefPtr mutableStyleProperties = dynamicDowncast<MutableStyleProperties>(inlineStyle))
-        mutableStyleProperties->parseDeclaration(newStyleString, protectedDocument().get());
+        mutableStyleProperties->parseDeclaration(newStyleString, protect(document()).get());
     else
         inlineStyle = CSSParser::parseInlineStyleDeclaration(newStyleString, *this);
 
     if (usesStyleBasedEditability(*inlineStyle))
-        protectedDocument()->setHasElementUsingStyleBasedEditability();
+        protect(document())->setHasElementUsingStyleBasedEditability();
 }
 
 void StyledElement::styleAttributeChanged(const AtomString& newStyleString, AttributeModificationReason reason)
@@ -181,7 +181,7 @@ void StyledElement::invalidateStyleAttribute()
 {
     if (RefPtr inlineStyle = this->inlineStyle()) {
         if (usesStyleBasedEditability(*inlineStyle))
-            protectedDocument()->setHasElementUsingStyleBasedEditability();
+            protect(document())->setHasElementUsingStyleBasedEditability();
     }
 
     elementData()->setStyleAttributeIsDirty(true);
@@ -386,7 +386,7 @@ void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties&
     
 void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties& style, CSSPropertyID propertyID, const String& value)
 {
-    style.setProperty(propertyID, value, protectedDocument()->cssParserContext());
+    style.setProperty(propertyID, value, protect(document())->cssParserContext());
 }
 
 void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties& style, CSSPropertyID propertyID, Ref<CSSValue>&& value)

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -72,7 +72,7 @@ ExceptionOr<Ref<Text>> Text::splitText(unsigned offset)
             return insertResult.releaseException();
     }
 
-    protectedDocument()->textNodeSplit(*this);
+    protect(document())->textNodeSplit(*this);
 
     updateRendererAfterContentChange(0, oldData.length());
 
@@ -189,7 +189,7 @@ RenderPtr<RenderText> Text::createTextRenderer(const RenderStyle& style)
 
 Ref<Text> Text::virtualCreate(String&& data)
 {
-    return create(protectedDocument(), WTF::move(data));
+    return create(protect(document()), WTF::move(data));
 }
 
 void Text::updateRendererAfterContentChange(unsigned offsetOfReplacedData, unsigned lengthOfReplacedData)
@@ -200,7 +200,7 @@ void Text::updateRendererAfterContentChange(unsigned offsetOfReplacedData, unsig
     if (hasInvalidRenderer())
         return;
 
-    protectedDocument()->updateTextRenderer(*this, offsetOfReplacedData, lengthOfReplacedData);
+    protect(document())->updateTextRenderer(*this, offsetOfReplacedData, lengthOfReplacedData);
 }
 
 static void appendTextRepresentation(StringBuilder& builder, const Text& text)

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -426,7 +426,7 @@ LayoutRect ViewTransition::captureOverflowRect(RenderLayerModelObject& renderer)
         return containingBlockRect();
 
     auto bounds = renderer.layer()->calculateLayerBounds(renderer.layer(), LayoutSize(), { RenderLayer::IncludeFilterOutsets, RenderLayer::ExcludeHiddenDescendants, RenderLayer::IncludeCompositedDescendants, RenderLayer::PreserveAncestorFlags, RenderLayer::ExcludeViewTransitionCapturedDescendants });
-    return LayoutRect(encloseRectToDevicePixels(bounds, renderer.protectedDocument()->deviceScaleFactor()));
+    return LayoutRect(encloseRectToDevicePixels(bounds, protect(renderer.document())->deviceScaleFactor()));
 }
 
 // The computed local-to-absolute transform, and layer bounds don't include the position
@@ -946,7 +946,7 @@ void ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer,
             output.subpixelOffset = { };
         } else {
             transform.translate(transformState.accumulatedOffset().width(), transformState.accumulatedOffset().height());
-            output.subpixelOffset = snapTransformationTranslationToDevicePixels(transform, renderer.protectedDocument()->deviceScaleFactor());
+            output.subpixelOffset = snapTransformationTranslationToDevicePixels(transform, protect(renderer.document())->deviceScaleFactor());
         }
 
         output.layerToLayoutOffset = layerToLayoutOffset(renderer);

--- a/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
+++ b/Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
@@ -78,7 +78,7 @@ DOMWindowTrustedTypes* DOMWindowTrustedTypes::from(LocalDOMWindow& window)
 TrustedTypePolicyFactory* DOMWindowTrustedTypes::trustedTypes() const
 {
     if (!m_trustedTypes)
-        m_trustedTypes = TrustedTypePolicyFactory::create(*window()->protectedDocument());
+        m_trustedTypes = TrustedTypePolicyFactory::create(*protect(window()->document()));
     return m_trustedTypes.get();
 }
 

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -120,7 +120,7 @@ void createImageControls(HTMLElement& element)
     style->setTextContent(String { shadowStyle });
     shadowRoot->appendChild(WTF::move(style));
     
-    Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, element.protectedDocument(), nullptr);
+    Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, protect(element.document()), nullptr);
     button->setIdAttribute(imageControlsButtonIdentifier());
     controlLayer->appendChild(button);
     controlLayer->setUserAgentPart(UserAgentParts::appleAttachmentControlsContainer());
@@ -206,7 +206,7 @@ void updateImageControls(HTMLElement& element)
     if (!element.document().settings().imageControlsEnabled())
         return;
 
-    element.protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
+    protect(element.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
         RefPtr protectedElement = weakElement.get();
         if (!protectedElement)
             return;

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -1009,7 +1009,7 @@ RefPtr<HTMLElement> ApplyStyleCommand::highestAncestorWithConflictingInlineStyle
 
 void ApplyStyleCommand::applyInlineStyleToPushDown(Node& node, EditingStyle* style)
 {
-    node.protectedDocument()->updateStyleIfNeeded();
+    protect(node.document())->updateStyleIfNeeded();
 
     if (!style || style->isEmpty() || !node.renderer() || is<HTMLIFrameElement>(node))
         return;
@@ -1181,7 +1181,7 @@ void ApplyStyleCommand::removeInlineStyle(EditingStyle& style, const Position& s
 bool ApplyStyleCommand::nodeFullySelected(Element& element, const Position& start, const Position& end) const
 {
     // The tree may have changed and Position::upstream() relies on an up-to-date layout.
-    element.protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(element.document())->updateLayoutIgnorePendingStylesheets();
     return firstPositionInOrBeforeNode(&element) >= start && lastPositionInOrAfterNode(&element).upstream() <= end;
 }
 

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -913,7 +913,7 @@ RefPtr<Text> CompositeEditCommand::textNodeForRebalance(const Position& position
     if (!textNode || !textNode->length())
         return nullptr;
 
-    textNode->protectedDocument()->updateStyleIfNeeded();
+    protect(textNode->document())->updateStyleIfNeeded();
 
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 

--- a/Source/WebCore/editing/CustomUndoStep.cpp
+++ b/Source/WebCore/editing/CustomUndoStep.cpp
@@ -46,7 +46,7 @@ void CustomUndoStep::unapply()
     // FIXME: It's currently unclear how input events should be dispatched when unapplying or reapplying custom
     // edit commands. Should the page be allowed to specify a target in the DOM for undo and redo?
     Ref<UndoItem> protectedUndoItem(*m_undoItem);
-    protectedUndoItem->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(protectedUndoItem->document())->updateLayoutIgnorePendingStylesheets();
     protectedUndoItem->undoHandler().invoke();
 }
 
@@ -56,7 +56,7 @@ void CustomUndoStep::reapply()
         return;
 
     Ref<UndoItem> protectedUndoItem(*m_undoItem);
-    protectedUndoItem->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(protectedUndoItem->document())->updateLayoutIgnorePendingStylesheets();
     protectedUndoItem->redoHandler().invoke();
 }
 

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -475,7 +475,7 @@ VisiblePosition closestEditablePositionInElementForAbsolutePoint(const Element& 
         return { };
 
     Ref<const Element> protectedElement { element };
-    element.protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(element.document())->updateLayoutIgnorePendingStylesheets();
 
     CheckedPtr renderer = element.renderer();
     // Look at the inner element of a form control, not the control itself, as it is the editable part.

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1768,7 +1768,7 @@ RefPtr<EditingStyle> EditingStyle::styleAtSelectionStart(const VisibleSelection&
         return nullptr;
 
     Ref style = EditingStyle::create(element.get(), propertiesToInclude);
-    style->mergeTypingStyle(element->protectedDocument());
+    style->mergeTypingStyle(protect(element->document()));
 
     // If background color is transparent, traverse parent nodes until we hit a different value or document root
     // Also, if the selection is a range, ignore the background color at the start of selection,

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3895,7 +3895,7 @@ static inline void collapseCaretWidth(IntRect& rect)
 
 IntRect Editor::firstRectForRange(const SimpleRange& range) const
 {
-    range.start.protectedDocument()->updateLayout();
+    protect(range.start.document())->updateLayout();
 
     VisiblePosition start(makeDeprecatedLegacyPosition(range.start));
 

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2008,7 +2008,7 @@ Color CaretBase::computeCaretColor(const RenderStyle& elementStyle, const Node* 
 #else
         auto cssColorValue = CSSValueAppleSystemBlue;
 #endif
-        auto styleColorOptions = node->protectedDocument()->styleColorOptions(&elementStyle);
+        auto styleColorOptions = protect(node->document())->styleColorOptions(&elementStyle);
         auto systemAccentColor = RenderTheme::singleton().systemColor(cssColorValue, styleColorOptions | StyleColorOptions::UseSystemAppearance);
 
         Style::ColorResolver colorResolver { elementStyle };
@@ -2738,7 +2738,7 @@ void FrameSelection::setShouldShowBlockCursor(bool shouldShowBlockCursor)
 {
     m_shouldShowBlockCursor = shouldShowBlockCursor;
 
-    protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(document())->updateLayoutIgnorePendingStylesheets();
 
     updateAppearance();
 }

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -65,7 +65,7 @@ void ReplaceNodeWithSpanCommand::doApply()
     if (!m_elementToReplace->isConnected())
         return;
     if (!m_spanElement)
-        m_spanElement = HTMLSpanElement::create(m_elementToReplace->protectedDocument());
+        m_spanElement = HTMLSpanElement::create(protect(m_elementToReplace->document()));
     swapInNodePreservingAttributesAndChildren(protectedSpanElement().releaseNonNull(), m_elementToReplace);
 }
 

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -370,7 +370,7 @@ TextIterator::TextIterator(const SimpleRange& range, TextIteratorBehaviors behav
 {
     ASSERT(!m_behaviors.contains(TextIteratorBehavior::EmitsObjectReplacementCharacters) || !m_behaviors.contains(TextIteratorBehavior::EmitsObjectReplacementCharactersForImages));
 
-    range.start.protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(range.start.document())->updateLayoutIgnorePendingStylesheets();
 
     m_startContainer = range.start.container.ptr();
     m_startOffset = range.start.offset;
@@ -387,7 +387,7 @@ TextIterator::TextIterator(const SimpleRange& range, TextIteratorBehaviors behav
 void TextIterator::init()
 {
     RefPtr currentNode = m_currentNode;
-    if (isClippedByFrameAncestor(currentNode->protectedDocument(), m_behaviors))
+    if (isClippedByFrameAncestor(protect(currentNode->document()), m_behaviors))
         return;
 
     setUpFullyClippedStack(m_fullyClippedStack, *currentNode, m_behaviors);
@@ -1253,7 +1253,7 @@ void TextIterator::showTreeForThis() const
 
 SimplifiedBackwardsTextIterator::SimplifiedBackwardsTextIterator(const SimpleRange& range)
 {
-    range.start.protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(range.start.document())->updateLayoutIgnorePendingStylesheets();
 
     RefPtr startNode = range.start.container.ptr();
     RefPtr endNode = range.end.container.ptr();

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -950,7 +950,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
             for (RefPtr descendentNode = NodeTraversal::next(*originalNode, originalNode.get()); descendentNode; descendentNode = NodeTraversal::next(*descendentNode, originalNode.get()))
                 nodesToRemove.remove(*descendentNode);
         } else
-            replacementNode = Text::create(commonAncestor->protectedDocument(), WTF::move(replacementText));
+            replacementNode = Text::create(protect(commonAncestor->document()), WTF::move(replacementText));
 
         auto topDownPath = getPath(commonAncestor.get(), originalNode.get());
         updateInsertions(lastTopDownPath, topDownPath, replacementNode.get(), reusedOriginalNodes, insertions);

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -181,7 +181,7 @@ std::optional<SimpleRange> VisibleSelection::toNormalizedRange() const
     // in the course of running edit commands which modify the DOM.
     // Failing to call this can result in equivalentXXXPosition calls returning
     // incorrect results.
-    m_start.anchorNode()->protectedDocument()->updateLayout();
+    protect(m_start.anchorNode()->document())->updateLayout();
 
     // Check again, because updating layout can clear the selection.
     if (isNoneOrOrphaned())

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -968,7 +968,7 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
     if (!node)
         return VisiblePosition();
     
-    node->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(node->document())->updateLayoutIgnorePendingStylesheets();
     
     CheckedPtr renderer = node->renderer();
     if (!renderer)
@@ -1026,7 +1026,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
     if (!node)
         return VisiblePosition();
     
-    node->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(node->document())->updateLayoutIgnorePendingStylesheets();
 
     if (!node->renderer())
         return VisiblePosition();

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -637,7 +637,7 @@ bool WebContentMarkupReader::readWebArchive(SharedBuffer& buffer)
         return true;
     }
 
-    m_markup = sanitizeMarkupWithArchive(frame, *frame->protectedDocument(), *result, msoListQuirksForMarkup(), [&] (const String& type) {
+    m_markup = sanitizeMarkupWithArchive(frame, *protect(frame->document()), *result, msoListQuirksForMarkup(), [&] (const String& type) {
         return frame->loader().client().canShowMIMETypeAsHTML(type);
     });
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1595,7 +1595,7 @@ static inline bool hasMutationEventListeners(const Document& document)
 static inline bool canUseSetDataOptimization(const Text& containerChild, const ChildListMutationScope& mutationScope)
 {
     bool authorScriptMayHaveReference = containerChild.refCount();
-    return !authorScriptMayHaveReference && !mutationScope.canObserve() && !hasMutationEventListeners(containerChild.protectedDocument());
+    return !authorScriptMayHaveReference && !mutationScope.canObserve() && !hasMutationEventListeners(protect(containerChild.document()));
 }
 
 ExceptionOr<void> replaceChildrenWithFragment(ContainerNode& container, Ref<DocumentFragment>&& fragment)

--- a/Source/WebCore/html/BaseButtonInputType.cpp
+++ b/Source/WebCore/html/BaseButtonInputType.cpp
@@ -73,7 +73,7 @@ void BaseButtonInputType::setValue(const String& sanitizedValue, bool, TextField
     ASSERT(element);
     element->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
 
-    if (CheckedPtr cache = element->protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(element->document())->existingAXObjectCache())
         cache->valueChanged(*element);
 }
 

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -572,7 +572,7 @@ void BaseDateAndTimeInputType::didChangeValueFromControl()
     InputType::setValue(value, valueChanged, DispatchNoEvent, DoNotSet);
 
     if (!valueChanged) {
-        if (CheckedPtr cache = input->protectedDocument()->existingAXObjectCache()) {
+        if (CheckedPtr cache = protect(input->document())->existingAXObjectCache()) {
             // This method is called when a sub-field of a date or time input changes. An HTML input's DOM value
             // only changes when all fields are filled out, but accessibility needs to represent the partial value
             // for assistive technologies, so notify accessibility here so it can take the appropriate actions, e.g.

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -280,7 +280,7 @@ void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation)
     ASSERT(element());
     Ref element = *this->element();
     ASSERT(element->renderer());
-    if (RefPtr frame = element->protectedDocument()->frame()) {
+    if (RefPtr frame = protect(element->document())->frame()) {
         frame->eventHandler().setCapturingMouseEventsElement(element.ptr());
         m_isSwitchVisuallyOn = element->checked();
         m_switchPointerTrackingLogicalLeftPositionStart = switchPointerTrackingLogicalLeftPosition(element.get(), absoluteLocation);
@@ -293,7 +293,7 @@ void CheckboxInputType::stopSwitchPointerTracking()
     if (!isSwitchPointerTracking())
         return;
 
-    if (RefPtr frame = protectedElement()->protectedDocument()->frame())
+    if (RefPtr frame = protect(protectedElement()->document())->frame())
         frame->eventHandler().setCapturingMouseEventsElement(nullptr);
     m_hasSwitchVisuallyOnChanged = false;
     m_switchPointerTrackingLogicalLeftPositionStart = { };
@@ -342,7 +342,7 @@ void CheckboxInputType::willUpdateCheckedness(bool, WasSetByJavaScript wasChecke
 // ask a more knowledgable system for a refresh callback (perhaps passing a desired FPS).
 static Seconds switchAnimationUpdateInterval(HTMLInputElement& element)
 {
-    if (RefPtr page = element.protectedDocument()->page())
+    if (RefPtr page = protect(element.document())->page())
         return page->preferredRenderingUpdateInterval();
     return 0_s;
 }

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -239,7 +239,7 @@ void ColorInputType::attributeChanged(const QualifiedName& name)
         updateColorSwatch();
 
         Ref input = *element();
-        if (CheckedPtr cache = input->protectedDocument()->existingAXObjectCache())
+        if (CheckedPtr cache = protect(input->document())->existingAXObjectCache())
             cache->valueChanged(input);
     }
 
@@ -311,7 +311,7 @@ void ColorInputType::didChooseColor(const Color& color)
     updateColorSwatch();
     input->dispatchFormControlChangeEvent();
 
-    if (CheckedPtr cache = input->protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(input->document())->existingAXObjectCache())
         cache->valueChanged(input);
 }
 
@@ -355,12 +355,12 @@ IntRect ColorInputType::elementRectRelativeToRootView() const
     CheckedPtr renderer = element->renderer();
     if (!renderer)
         return IntRect();
-    return element->protectedDocument()->protectedView()->contentsToRootView(renderer->absoluteBoundingBoxRect());
+    return protect(element->document())->protectedView()->contentsToRootView(renderer->absoluteBoundingBoxRect());
 }
 
 std::optional<FrameIdentifier> ColorInputType::rootFrameID() const
 {
-    return element()->protectedDocument()->protectedView()->rootFrameID();
+    return protect(element()->document())->protectedView()->rootFrameID();
 }
 
 bool ColorInputType::supportsAlpha() const

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -211,7 +211,7 @@ ExceptionOr<bool> DOMTokenList::supports(StringView token)
 {
     if (!m_isSupportedToken)
         return Exception { ExceptionCode::TypeError };
-    return m_isSupportedToken(m_element->protectedDocument(), token);
+    return m_isSupportedToken(protect(m_element->document()), token);
 }
 
 // https://dom.spec.whatwg.org/#dom-domtokenlist-value

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -229,7 +229,7 @@ void FileInputType::createShadowSubtree()
     ASSERT(element()->shadowRoot());
 
     Ref element = *this->element();
-    Ref button = HTMLInputElement::create(inputTag, element->protectedDocument(), nullptr, false);
+    Ref button = HTMLInputElement::create(inputTag, protect(element->document()), nullptr, false);
     {
         ScriptDisallowedScope::EventAllowedScope eventAllowedScopeBeforeAppend { button };
         button->setAttributeWithoutSynchronization(typeAttr, InputTypeNames::button());
@@ -319,7 +319,7 @@ bool FileInputType::allowsDirectories() const
 {
     ASSERT(element());
     Ref element = *this->element();
-    if (!element->protectedDocument()->settings().directoryUploadEnabled())
+    if (!protect(element->document())->settings().directoryUploadEnabled())
         return false;
     return element->hasAttributeWithoutSynchronization(webkitdirectoryAttr);
 }

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -270,7 +270,7 @@ void FormAssociatedCustomElement::restoreFormControlState(const FormControlState
     if (savedState.size() == 1)
         restoredState.emplace<String>(savedState[0]);
     else {
-        auto formData = DOMFormData::create(&element->protectedDocument().get(), PAL::UTF8Encoding());
+        auto formData = DOMFormData::create(&protect(element->document()).get(), PAL::UTF8Encoding());
         for (size_t i = 0; i < savedState.size(); i += 2)
             formData->append(savedState[i], savedState[i + 1]);
         restoredState.emplace<RefPtr<DOMFormData>>(formData.ptr());

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -183,7 +183,7 @@ void FormListedElement::resetFormOwner()
     setForm(findAssociatedForm(element.get(), originalForm.get()));
     RefPtr newForm = form();
     if (newForm && newForm != originalForm && newForm->isConnected())
-        element->protectedDocument()->didAssociateFormControl(element.get());
+        protect(element->document())->didAssociateFormControl(element.get());
 }
 
 void FormListedElement::parseAttribute(const QualifiedName& name, const AtomString& value)
@@ -204,7 +204,7 @@ void FormListedElement::parseFormAttribute(const AtomString& value)
         setForm(HTMLFormElement::findClosestFormAncestor(element.get()));
         RefPtr newForm = form();
         if (newForm && newForm != originalForm && newForm->isConnected())
-            element->protectedDocument()->didAssociateFormControl(element.get());
+            protect(element->document())->didAssociateFormControl(element.get());
         m_formAttributeTargetObserver = nullptr;
     } else {
         resetFormOwner();

--- a/Source/WebCore/html/HTMLArticleElement.cpp
+++ b/Source/WebCore/html/HTMLArticleElement.cpp
@@ -62,7 +62,7 @@ auto HTMLArticleElement::insertedIntoAncestor(InsertionType insertionType, Conta
 void HTMLArticleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.disconnectedFromDocument)
-        oldParentOfRemovedTree.protectedDocument()->unregisterArticleElement(*this);
+        protect(oldParentOfRemovedTree.document())->unregisterArticleElement(*this);
 
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 }

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -314,7 +314,7 @@ private:
 template <typename ElementType>
 static Ref<ElementType> createContainedElement(HTMLElement& container, const AtomString& id, String&& textContent = { })
 {
-    Ref<ElementType> element = ElementType::create(container.protectedDocument());
+    Ref<ElementType> element = ElementType::create(protect(container.document()));
     element->setIdAttribute(id);
     if (!textContent.isEmpty())
         element->setTextContent(WTF::move(textContent));

--- a/Source/WebCore/html/HTMLBaseElement.cpp
+++ b/Source/WebCore/html/HTMLBaseElement.cpp
@@ -50,7 +50,7 @@ void HTMLBaseElement::attributeChanged(const QualifiedName& name, const AtomStri
 {
     if (name == hrefAttr || name == targetAttr) {
         if (isConnected())
-            protectedDocument()->processBaseElement();
+            protect(document())->processBaseElement();
     } else
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
@@ -59,7 +59,7 @@ Node::InsertedIntoAncestorResult HTMLBaseElement::insertedIntoAncestor(Insertion
 {
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
-        protectedDocument()->processBaseElement();
+        protect(document())->processBaseElement();
     return InsertedIntoAncestorResult::Done;
 }
 
@@ -67,7 +67,7 @@ void HTMLBaseElement::removedFromAncestor(RemovalType removalType, ContainerNode
 {
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
     if (removalType.disconnectedFromDocument)
-        protectedDocument()->processBaseElement();
+        protect(document())->processBaseElement();
 }
 
 bool HTMLBaseElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -88,7 +88,7 @@ void HTMLBodyElement::collectPresentationalHintsForAttribute(const QualifiedName
     case AttributeNames::backgroundAttr: {
         auto url = value.string().trim(isASCIIWhitespace);
         if (!url.isEmpty())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protectedDocument()->completeURL(url), localName())));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(url), localName())));
         break;
     }
     case AttributeNames::marginwidthAttr:
@@ -172,7 +172,7 @@ Node::InsertedIntoAncestorResult HTMLBodyElement::insertedIntoAncestor(Insertion
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
         return InsertedIntoAncestorResult::Done;
-    if (!is<HTMLFrameElementBase>(protectedDocument()->ownerElement()))
+    if (!is<HTMLFrameElementBase>(protect(document())->ownerElement()))
         return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
 }
@@ -214,7 +214,7 @@ void HTMLBodyElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protectedDocument()->completeURL(attributeWithoutSynchronization(backgroundAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -270,7 +270,7 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
         if (form()) {
             // Update layout before processing form actions in case the style changes
             // the Form or button relationships.
-            protectedDocument()->updateLayoutIgnorePendingStylesheets();
+            protect(document())->updateLayoutIgnorePendingStylesheets();
 
             if (RefPtr currentForm = form()) {
                 if (m_type == Type::Submit)

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -371,7 +371,7 @@ CanvasRenderingContext2D* HTMLCanvasElement::createContext2d(const String& type,
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F) && HAVE(SUPPORT_HDR_DISPLAY)
     if (m_context->pixelFormat() == PixelFormat::RGBA16F)
-        protectedDocument()->setHasHDRContent();
+        protect(document())->setHasHDRContent();
 #endif
 
 #if USE(CA) || USE(SKIA)
@@ -664,7 +664,7 @@ void HTMLCanvasElement::paint(GraphicsContext& context, const LayoutRect& r)
     m_context->clearAccumulatedDirtyRect();
 
     if (!context.paintingDisabled()) {
-        if (!usesContentsAsLayerContents() || protectedDocument()->printing() || m_isSnapshotting) {
+        if (!usesContentsAsLayerContents() || protect(document())->printing() || m_isSnapshotting) {
             if (m_context->compositingResultsNeedUpdating())
                 m_context->prepareForDisplay();
             if (m_context->isSurfaceBufferTransparentBlack(CanvasRenderingContext::SurfaceBuffer::DisplayBuffer)) {
@@ -798,7 +798,7 @@ ExceptionOr<Ref<OffscreenCanvas>> HTMLCanvasElement::transferControlToOffscreen(
         return Exception { ExceptionCode::InvalidStateError };
 
     std::unique_ptr placeholderContext = PlaceholderRenderingContext::create(*this);
-    Ref offscreen = OffscreenCanvas::create(protectedDocument().get(), *placeholderContext);
+    Ref offscreen = OffscreenCanvas::create(protect(document()).get(), *placeholderContext);
     m_context = WTF::move(placeholderContext);
     if (m_context->delegatesDisplay())
         invalidateStyleAndLayerComposition();
@@ -887,7 +887,7 @@ ExceptionOr<Ref<MediaStream>> HTMLCanvasElement::captureStream(std::optional<dou
 
 SecurityOrigin* HTMLCanvasElement::securityOrigin() const
 {
-    return &protectedDocument()->securityOrigin();
+    return &protect(document())->securityOrigin();
 }
 
 void HTMLCanvasElement::createImageBuffer() const
@@ -1046,7 +1046,7 @@ void HTMLCanvasElement::dispatchEvent(Event& event)
 
 std::unique_ptr<CSSParserContext> HTMLCanvasElement::createCSSParserContext() const
 {
-    return makeUnique<CSSParserContext>(protectedDocument().get());
+    return makeUnique<CSSParserContext>(protect(document()).get());
 }
 
 WebCoreOpaqueRoot root(HTMLCanvasElement* canvas)

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -127,7 +127,7 @@ HTMLCollection::HTMLCollection(ContainerNode& ownerNode, CollectionType type)
 HTMLCollection::~HTMLCollection()
 {
     if (hasNamedElementCache())
-        protectedDocument()->collectionWillClearIdNameMap(*this);
+        protect(document())->collectionWillClearIdNameMap(*this);
 
     // HTMLNameCollection & ClassCollection remove cache by themselves.
     // FIXME: We need a cleaner way to handle this.

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -75,7 +75,7 @@ void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElemen
         didChangeSlot(summarySlotName(), shadowRoot);
 
         if (RefPtr associatedDetails = dynamicDowncast<HTMLDetailsElement>(shadowRoot.host())) {
-            if (CheckedPtr cache = associatedDetails->protectedDocument()->existingAXObjectCache())
+            if (CheckedPtr cache = protect(associatedDetails->document())->existingAXObjectCache())
                 cache->onDetailsSummarySlotChange(*associatedDetails);
         }
     } else

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -278,7 +278,7 @@ void HTMLDialogElement::runFocusingSteps()
     if (control->isFocusable())
         control->runFocusingStepsForAutofocus();
     else if (m_isModal)
-        protectedDocument()->setFocusedElement(nullptr); // Focus fixup rule
+        protect(document())->setFocusedElement(nullptr); // Focus fixup rule
 
     RefPtr topDocument = controlDocument->sameOriginTopLevelTraversable();
     if (!topDocument)

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -501,7 +501,7 @@ ExceptionOr<void> HTMLElement::setInnerText(String&& text)
 
     // FIXME: This should use replaceAll(), after we fix that to work properly for DocumentFragment.
     // Add text nodes and <br> elements.
-    Ref fragment = textToFragment(protectedDocument(), WTF::move(text));
+    Ref fragment = textToFragment(protect(document()), WTF::move(text));
     // It's safe to dispatch events on the new fragment since author scripts have no access to it yet.
     ScriptDisallowedScope::EventAllowedScope allowedScope(fragment.get());
     return replaceChildrenWithFragment(*this, WTF::move(fragment));
@@ -519,9 +519,9 @@ ExceptionOr<void> HTMLElement::setOuterText(String&& text)
 
     // Convert text to fragment with <br> tags instead of linebreaks if needed.
     if (text.contains([](char16_t c) { return c == '\n' || c == '\r'; }))
-        newChild = textToFragment(protectedDocument(), WTF::move(text));
+        newChild = textToFragment(protect(document()), WTF::move(text));
     else
-        newChild = Text::create(protectedDocument(), WTF::move(text));
+        newChild = Text::create(protect(document()), WTF::move(text));
 
     if (!parentNode())
         return Exception { ExceptionCode::HierarchyRequestError };
@@ -965,7 +965,7 @@ void HTMLElement::setAutocorrect(bool autocorrect)
 InputMode HTMLElement::canonicalInputMode() const
 {
     auto mode = inputModeForAttributeValue(attributeWithoutSynchronization(inputmodeAttr));
-    if (mode == InputMode::None && protectedDocument()->quirks().shouldIgnoreInputModeNone())
+    if (mode == InputMode::None && protect(document())->quirks().shouldIgnoreInputModeNone())
         return InputMode::Unspecified;
     return mode;
 }
@@ -1073,7 +1073,7 @@ static ExceptionOr<bool> checkPopoverValidity(HTMLElement& element, PopoverVisib
     if (auto* dialog = dynamicDowncast<HTMLDialogElement>(element); dialog && dialog->isModal())
         return Exception { ExceptionCode::InvalidStateError, "Element is a modal <dialog> element"_s };
 
-    if (!element.protectedDocument()->isFullyActive())
+    if (!protect(element.document())->isFullyActive())
         return Exception { ExceptionCode::InvalidStateError, "Invalid for popovers within documents that are not fully active"_s };
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -219,7 +219,7 @@ void HTMLEmbedElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLPlugInElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protectedDocument()->completeURL(attributeWithoutSynchronization(srcAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(srcAttr)));
 }
 
 }

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -242,7 +242,7 @@ bool HTMLFormControlElement::isMouseFocusable() const
 #else
     // FIXME: We can remove needsFormControlToBeMouseFocusable if there are no more quirks
     // or if we decide to change the default behavior and make form control elements focusable
-    if (!!tabIndexSetExplicitly() || protectedDocument()->quirks().needsFormControlToBeMouseFocusable())
+    if (!!tabIndexSetExplicitly() || protect(document())->quirks().needsFormControlToBeMouseFocusable())
         return HTMLElement::isMouseFocusable();
     return false;
 #endif

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -320,7 +320,7 @@ ExceptionOr<void> HTMLFormElement::requestSubmit(HTMLElement* submitter)
 {
     // Update layout before processing form actions in case the style changes
     // the form or button relationships.
-    protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(document())->updateLayoutIgnorePendingStylesheets();
 
     RefPtr<HTMLFormControlElement> control;
     if (submitter) {
@@ -804,7 +804,7 @@ bool HTMLFormElement::reportValidity()
 
     // Update layout before processing form actions in case the style changes
     // the form or button relationships.
-    protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(document())->updateLayoutIgnorePendingStylesheets();
 
     return validateInteractively();
 }

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -70,7 +70,7 @@ bool HTMLFrameElementBase::canLoad() const
 
 bool HTMLFrameElementBase::canLoadURL(const String& relativeURL) const
 {
-    return canLoadURL(protectedDocument()->completeURL(relativeURL));
+    return canLoadURL(protect(document())->completeURL(relativeURL));
 }
 
 // Note that unlike HTMLPlugInElement::canLoadURL this uses ScriptController::canAccessFromCurrentOrigin.
@@ -78,7 +78,7 @@ bool HTMLFrameElementBase::canLoadURL(const URL& completeURL) const
 {
     if (completeURL.protocolIsJavaScript()) {
         RefPtr contentDocument = this->contentDocument();
-        if (contentDocument && !ScriptController::canAccessFromCurrentOrigin(contentDocument->protectedFrame().get(), protectedDocument().get()))
+        if (contentDocument && !ScriptController::canAccessFromCurrentOrigin(contentDocument->protectedFrame().get(), protect(document()).get()))
             return false;
     }
 
@@ -114,7 +114,7 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
             return;
         }
 
-        protectedThis->protectedDocument()->willLoadFrameElement(completeURL);
+        protect(protectedThis->document())->willLoadFrameElement(completeURL);
         parentFrame->loader().subframeLoader().requestFrame(*protectedThis, protectedThis->m_frameURL, frameName, lockHistory, lockBackForwardList);
     };
 

--- a/Source/WebCore/html/HTMLFrameOwnerElement.cpp
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.cpp
@@ -82,7 +82,7 @@ void HTMLFrameOwnerElement::disconnectContentFrame()
 {
     if (RefPtr frame = m_contentFrame.get()) {
         if (RefPtr innerDocument = contentDocument())
-            innerDocument->willBeDisconnectedFromFrame(protectedDocument());
+            innerDocument->willBeDisconnectedFromFrame(protect(document()));
         frame->frameDetached();
         if (frame == m_contentFrame.get())
             frame->disconnectOwnerElement();

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -87,7 +87,7 @@ void HTMLFrameSetElement::collectPresentationalHintsForAttribute(const Qualified
 void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (auto& eventName = HTMLBodyElement::eventNameForWindowEventHandlerAttribute(name); !eventName.isNull())
-        protectedDocument()->setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorldSingleton());
+        protect(document())->setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorldSingleton());
     else
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -133,7 +133,7 @@ void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomSt
         String invalidTokens;
         setSandboxFlags(newValue.isNull() ? SandboxFlags { } : SecurityContext::parseSandboxPolicy(newValue, invalidTokens));
         if (!invalidTokens.isNull())
-            protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Error while parsing the 'sandbox' attribute: "_s, invalidTokens));
+            protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Error while parsing the 'sandbox' attribute: "_s, invalidTokens));
         break;
     }
     case AttributeNames::allowAttr:
@@ -186,7 +186,7 @@ String HTMLIFrameElement::srcdoc() const
 
 ExceptionOr<void> HTMLIFrameElement::setSrcdoc(Variant<RefPtr<TrustedHTML>, String>&& value, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
 {
-    auto stringValueHolder = trustedTypeCompliantString(protectedDocument()->protectedContextDocument(), WTF::move(value), "HTMLIFrameElement srcdoc"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(document())->protectedContextDocument(), WTF::move(value), "HTMLIFrameElement srcdoc"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -250,7 +250,7 @@ void HTMLImageElement::setBestFitURLAndDPRFromImageCandidate(const ImageCandidat
 
     auto& sourceURL = imageSourceURL();
     // Only complete the URL if it's non-empty to avoid resolving "" to the document base URL.
-    m_currentURL = sourceURL.isEmpty() ? URL() : protectedDocument()->completeURL(sourceURL);
+    m_currentURL = sourceURL.isEmpty() ? URL() : protect(document())->completeURL(sourceURL);
 
     m_currentSrc = { };
     if (candidate.density >= 0)
@@ -332,7 +332,7 @@ void HTMLImageElement::setIsUserAgentShadowRootResource()
 void HTMLImageElement::evaluateDynamicMediaQueryDependencies()
 {
     RefPtr documentElement = document().documentElement();
-    MQ::MediaQueryEvaluator evaluator { protectedDocument()->printing() ? printAtom() : screenAtom(), document(), documentElement ? documentElement->computedStyle() : nullptr };
+    MQ::MediaQueryEvaluator evaluator { protect(document())->printing() ? printAtom() : screenAtom(), document(), documentElement ? documentElement->computedStyle() : nullptr };
 
     auto hasChanges = [&] {
         for (auto& results : m_dynamicMediaQueryResults) {
@@ -582,7 +582,7 @@ void HTMLImageElement::setPictureElement(HTMLPictureElement* pictureElement)
 unsigned HTMLImageElement::width()
 {
     if (inRenderedDocument())
-        protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+        protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
@@ -605,7 +605,7 @@ unsigned HTMLImageElement::width()
 unsigned HTMLImageElement::height()
 {
     if (inRenderedDocument())
-        protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+        protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     if (!renderer()) {
         // check the attribute first for an explicit pixel value
@@ -732,7 +732,7 @@ RefPtr<HTMLMapElement> HTMLImageElement::associatedMapElement() const
 
 int HTMLImageElement::x() const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     CheckedPtr renderer = this->renderer();
     if (!renderer)
         return 0;
@@ -743,7 +743,7 @@ int HTMLImageElement::x() const
 
 int HTMLImageElement::y() const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     CheckedPtr renderer = this->renderer();
     if (!renderer)
         return 0;
@@ -830,7 +830,7 @@ bool HTMLImageElement::isServerMap() const
     if (usemap.string()[0] == '#')
         return false;
 
-    return protectedDocument()->completeURL(usemap).isEmpty();
+    return protect(document())->completeURL(usemap).isEmpty();
 }
 
 String HTMLImageElement::crossOrigin() const

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1425,7 +1425,7 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     // https://github.com/whatwg/html/issues/6909#issuecomment-917138991
     if (!m_inputType->allowsShowPickerAcrossFrames()) {
         RefPtr localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
-        if (!localTopFrame || !frame->protectedDocument()->protectedSecurityOrigin()->isSameOriginAs(localTopFrame->protectedDocument()->protectedSecurityOrigin()))
+        if (!localTopFrame || !protect(frame->document())->protectedSecurityOrigin()->isSameOriginAs(protect(localTopFrame->document())->protectedSecurityOrigin()))
             return Exception { ExceptionCode::SecurityError, "Input showPicker() called from cross-origin iframe."_s };
     }
 

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -180,7 +180,7 @@ void HTMLLabelElement::defaultEventHandler(Event& event)
 
         control->dispatchSimulatedClick(&event);
 
-        protectedDocument()->updateLayoutIgnorePendingStylesheets();
+        protect(document())->updateLayoutIgnorePendingStylesheets();
         if (control->isMouseFocusable())
             control->focus({ { }, { }, { }, FocusTrigger::Click, { } });
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -495,7 +495,7 @@ void HTMLLinkElement::potentiallyBlockRendering()
 {
     bool explicitRenderBlocking = m_blockingList && m_blockingList->contains("render"_s);
     if (explicitRenderBlocking || isImplicitlyPotentiallyRenderBlocking()) {
-        protectedDocument()->blockRenderingOn(*this, explicitRenderBlocking ? Document::ImplicitRenderBlocking::No : Document::ImplicitRenderBlocking::Yes);
+        protect(document())->blockRenderingOn(*this, explicitRenderBlocking ? Document::ImplicitRenderBlocking::No : Document::ImplicitRenderBlocking::Yes);
         m_isRenderBlocking = true;
     }
 }
@@ -503,7 +503,7 @@ void HTMLLinkElement::potentiallyBlockRendering()
 void HTMLLinkElement::unblockRendering()
 {
     if (m_isRenderBlocking) {
-        protectedDocument()->unblockRenderingOn(*this);
+        protect(document())->unblockRenderingOn(*this);
         m_isRenderBlocking = false;
     }
 }
@@ -753,7 +753,7 @@ bool HTMLLinkElement::isURLAttribute(const Attribute& attribute) const
 
 URL HTMLLinkElement::href() const
 {
-    return protectedDocument()->completeURL(attributeWithoutSynchronization(hrefAttr));
+    return protect(document())->completeURL(attributeWithoutSynchronization(hrefAttr));
 }
 
 const AtomString& HTMLLinkElement::rel() const

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -112,7 +112,7 @@ void HTMLMetaElement::attributeChanged(const QualifiedName& name, const AtomStri
         process(oldValue);
         if (isInDocumentTree()) {
             if (equalLettersIgnoringASCIICase(oldValue, "theme-color"_s) && !equalLettersIgnoringASCIICase(newValue, "theme-color"_s))
-                protectedDocument()->metaElementThemeColorChanged(*this);
+                protect(document())->metaElementThemeColorChanged(*this);
         }
         break;
     case AttributeNames::contentAttr:
@@ -149,10 +149,10 @@ void HTMLMetaElement::removedFromAncestor(RemovalType removalType, ContainerNode
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument && equalLettersIgnoringASCIICase(name(), "theme-color"_s))
-        oldParentOfRemovedTree.protectedDocument()->metaElementThemeColorChanged(*this);
+        protect(oldParentOfRemovedTree.document())->metaElementThemeColorChanged(*this);
 #if ENABLE(DARK_MODE_CSS)
     else if (removalType.disconnectedFromDocument && isNameColorScheme(name()))
-        oldParentOfRemovedTree.protectedDocument()->metaElementColorSchemeChanged();
+        protect(oldParentOfRemovedTree.document())->metaElementColorSchemeChanged();
 #endif
 }
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -390,7 +390,7 @@ void HTMLObjectElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) cons
 {
     HTMLPlugInElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protectedDocument()->completeURL(attributeWithoutSynchronization(dataAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(dataAttr)));
 }
 
 void HTMLObjectElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -154,7 +154,7 @@ void HTMLOptGroupElement::recalcSelectOptions()
 
 String HTMLOptGroupElement::groupLabelText() const
 {
-    String itemText = protectedDocument()->displayStringModifiedByEncoding(attributeWithoutSynchronization(labelAttr));
+    String itemText = protect(document())->displayStringModifiedByEncoding(attributeWithoutSynchronization(labelAttr));
     
     // In WinIE, leading and trailing whitespace is ignored in options and optgroups. We match this behavior.
     itemText = itemText.trim(deprecatedIsSpaceOrNewline);

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -140,7 +140,7 @@ String HTMLOptionElement::text() const
 
     // FIXME: Is displayStringModifiedByEncoding helpful here?
     // If it's correct here, then isn't it needed in the value and label functions too?
-    return protectedDocument()->displayStringModifiedByEncoding(text).trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
+    return protect(document())->displayStringModifiedByEncoding(text).trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 void HTMLOptionElement::setText(String&& text)
@@ -280,7 +280,7 @@ void HTMLOptionElement::setSelectedState(bool selected, AllowStyleInvalidation a
 
     m_isSelected = selected;
 
-    if (CheckedPtr cache = protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(document())->existingAXObjectCache())
         cache->onSelectedOptionChanged(*this);
 }
 

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -117,7 +117,7 @@ HTMLPlugInElement::~HTMLPlugInElement()
     ASSERT(!m_pendingPDFTestCallback);
 
     if (m_needsDocumentActivationCallbacks)
-        protectedDocument()->unregisterForDocumentSuspensionCallbacks(*this);
+        protect(document())->unregisterForDocumentSuspensionCallbacks(*this);
 }
 
 bool HTMLPlugInElement::willRespondToMouseClickEventsWithEditability(Editability) const
@@ -314,7 +314,7 @@ RenderPtr<RenderElement> HTMLPlugInElement::createElementRenderer(RenderStyle&& 
     // inactive or reactivates so it can clear the renderer before going into the back/forward cache.
     if (!m_needsDocumentActivationCallbacks) {
         m_needsDocumentActivationCallbacks = true;
-        protectedDocument()->registerForDocumentSuspensionCallbacks(*this);
+        protect(document())->registerForDocumentSuspensionCallbacks(*this);
     }
 
     if (useFallbackContent())
@@ -537,7 +537,7 @@ RenderEmbeddedObject* HTMLPlugInElement::renderEmbeddedObject() const
 
 bool HTMLPlugInElement::canLoadURL(const String& relativeURL) const
 {
-    return canLoadURL(protectedDocument()->completeURL(relativeURL));
+    return canLoadURL(protect(document())->completeURL(relativeURL));
 }
 
 bool HTMLPlugInElement::canLoadURL(const URL& completeURL) const
@@ -546,7 +546,7 @@ bool HTMLPlugInElement::canLoadURL(const URL& completeURL) const
         if (is<RemoteFrame>(contentFrame()))
             return false;
         RefPtr contentDocument = this->contentDocument();
-        if (contentDocument && !protectedDocument()->protectedSecurityOrigin()->isSameOriginDomain(contentDocument->protectedSecurityOrigin().get()))
+        if (contentDocument && !protect(document())->protectedSecurityOrigin()->isSameOriginDomain(contentDocument->protectedSecurityOrigin().get()))
             return false;
     }
 
@@ -603,7 +603,7 @@ void HTMLPlugInElement::updateAfterStyleResolution()
     // Either way, clear the flag now, since we don't need to remember to try again.
     m_needsImageReload = false;
 
-    protectedDocument()->decrementLoadEventDelayCount();
+    protect(document())->decrementLoadEventDelayCount();
 }
 
 void HTMLPlugInElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -136,7 +136,7 @@ void HTMLProgressElement::didElementStateChange()
     if (CheckedPtr renderer = renderProgress())
         renderer->updateFromElement();
 
-    if (CheckedPtr cache = protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(document())->existingAXObjectCache())
         cache->valueChanged(*this);
 }
 

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -135,7 +135,7 @@ void HTMLScriptElement::potentiallyBlockRendering()
 {
     bool explicitRenderBlocking = m_blockingList && m_blockingList->contains("render"_s);
     if (explicitRenderBlocking || isImplicitlyPotentiallyRenderBlocking()) {
-        protectedDocument()->blockRenderingOn(*this, explicitRenderBlocking ? Document::ImplicitRenderBlocking::No : Document::ImplicitRenderBlocking::Yes);
+        protect(document())->blockRenderingOn(*this, explicitRenderBlocking ? Document::ImplicitRenderBlocking::No : Document::ImplicitRenderBlocking::Yes);
         m_isRenderBlocking = true;
     }
 }
@@ -143,7 +143,7 @@ void HTMLScriptElement::potentiallyBlockRendering()
 void HTMLScriptElement::unblockRendering()
 {
     if (m_isRenderBlocking) {
-        protectedDocument()->unblockRenderingOn(*this);
+        protect(document())->unblockRenderingOn(*this);
         m_isRenderBlocking = false;
     }
 }
@@ -219,7 +219,7 @@ void HTMLScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) cons
 {
     HTMLElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protectedDocument()->completeURL(sourceAttributeValue()));
+    addSubresourceURL(urls, protect(document())->completeURL(sourceAttributeValue()));
 }
 
 String HTMLScriptElement::sourceAttributeValue() const

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -292,7 +292,7 @@ void HTMLSelectElement::remove(int optionIndex)
 
 String HTMLSelectElement::value() const
 {
-    if (protectedDocument()->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::FormControls))
+    if (protect(document())->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::FormControls))
         return emptyString();
     for (auto& item : listItems()) {
         if (RefPtr option = dynamicDowncast<HTMLOptionElement>(item.get())) {
@@ -519,7 +519,7 @@ ExceptionOr<void> HTMLSelectElement::setItem(unsigned index, HTMLOptionElement* 
 
     // If we are adding options, we should check 'index > maxSelectItems' first to avoid integer overflow.
     if (index > length() && index >= maxSelectItems) {
-        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list and set an option at index. The maximum list length is "_s, maxSelectItems, '.'));
+        protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list and set an option at index. The maximum list length is "_s, maxSelectItems, '.'));
         return { };
     }
 
@@ -552,7 +552,7 @@ ExceptionOr<void> HTMLSelectElement::setLength(unsigned newLength)
 {
     // If we are adding options, we should check 'index > maxSelectItems' first to avoid integer overflow.
     if (newLength > length() && newLength > maxSelectItems) {
-        protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list to length "_s, newLength, " items. The maximum number of items allowed is "_s, maxSelectItems, '.'));
+        protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, makeString("Unable to expand the option list to length "_s, newLength, " items. The maximum number of items allowed is "_s, maxSelectItems, '.'));
         return { };
     }
 
@@ -560,7 +560,7 @@ ExceptionOr<void> HTMLSelectElement::setLength(unsigned newLength)
 
     if (diff < 0) { // Add dummy elements.
         do {
-            auto result = add(HTMLOptionElement::create(protectedDocument()).ptr(), std::nullopt);
+            auto result = add(HTMLOptionElement::create(protect(document())).ptr(), std::nullopt);
             if (result.hasException())
                 return result;
         } while (++diff);
@@ -1236,7 +1236,7 @@ bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
     if (!document().settings().spatialNavigationEnabled()) {
         if (event->keyIdentifier() == "Down"_s || event->keyIdentifier() == "Up"_s) {
             focus();
-            protectedDocument()->updateStyleIfNeeded();
+            protect(document())->updateStyleIfNeeded();
             // Calling focus() may cause us to lose our renderer. Return true so
             // that our caller doesn't process the event further, but don't set
             // the event as handled.
@@ -1335,7 +1335,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
         if (RenderTheme::singleton().popsMenuBySpaceOrReturn()) {
             if (keyCode == ' ' || keyCode == '\r') {
                 focus();
-                protectedDocument()->updateStyleIfNeeded();
+                protect(document())->updateStyleIfNeeded();
 
                 // Calling focus() may remove the renderer or change the renderer type.
                 if (!is<RenderMenuList>(renderer()))
@@ -1352,7 +1352,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
         } else if (RenderTheme::singleton().popsMenuByArrowKeys()) {
             if (keyCode == ' ') {
                 focus();
-                protectedDocument()->updateStyleIfNeeded();
+                protect(document())->updateStyleIfNeeded();
 
                 // Calling focus() may remove the renderer or change the renderer type.
                 if (!is<RenderMenuList>(renderer()))
@@ -1380,7 +1380,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
     if (RefPtr mouseEvent = dynamicDowncast<MouseEvent>(event); event.type() == eventNames.mousedownEvent && mouseEvent && mouseEvent->button() == MouseButton::Left) {
         focus();
 #if !PLATFORM(IOS_FAMILY)
-        protectedDocument()->updateStyleIfNeeded();
+        protect(document())->updateStyleIfNeeded();
 
         if (is<RenderMenuList>(renderer())) {
             ASSERT(!m_popupIsVisible);
@@ -1469,7 +1469,7 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
     RefPtr frame = document().frame();
     if (event.type() == eventNames.mousedownEvent && mouseEvent && mouseEvent->button() == MouseButton::Left) {
         focus();
-        protectedDocument()->updateStyleIfNeeded();
+        protect(document())->updateStyleIfNeeded();
 
         // Calling focus() may remove or change our renderer, in which case we don't want to handle the event further.
         CheckedPtr renderListBox = dynamicDowncast<RenderListBox>(this->renderer());
@@ -1814,7 +1814,7 @@ ExceptionOr<void> HTMLSelectElement::showPicker()
 
     // In cross-origin iframes it should throw a "SecurityError" DOMException. In same-origin iframes it should work fine.
     RefPtr localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
-    if (!localTopFrame || !frame->protectedDocument()->protectedSecurityOrigin()->isSameOriginAs(localTopFrame->protectedDocument()->protectedSecurityOrigin()))
+    if (!localTopFrame || !protect(frame->document())->protectedSecurityOrigin()->isSameOriginAs(protect(localTopFrame->document())->protectedSecurityOrigin()))
         return Exception { ExceptionCode::SecurityError, "Select showPicker() called from cross-origin iframe."_s };
 
     RefPtr window = frame->window();
@@ -2032,7 +2032,7 @@ LayoutUnit HTMLSelectElement::clientPaddingRight() const
 
 FontSelector* HTMLSelectElement::fontSelector() const
 {
-    return &protectedDocument()->fontSelector();
+    return &protect(document())->fontSelector();
 }
 
 HostWindow* HTMLSelectElement::hostWindow() const
@@ -2048,7 +2048,7 @@ void HTMLSelectElement::didUpdateActiveOption(int optionIndex)
     if (!AXObjectCache::accessibilityEnabled())
         return;
 
-    CheckedPtr axCache = protectedDocument()->existingAXObjectCache();
+    CheckedPtr axCache = protect(document())->existingAXObjectCache();
     if (!axCache)
         return;
 

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -239,7 +239,7 @@ void HTMLSlotElement::dispatchSlotChangeEvent()
 
 void HTMLSlotElement::updateAccessibilityOnSlotChange() const
 {
-    if (CheckedPtr cache = protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(document())->existingAXObjectCache())
         cache->onSlottedContentChange(*this);
 }
 

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -91,7 +91,7 @@ void HTMLStyleElement::attributeChanged(const QualifiedName& name, const AtomStr
     case AttributeNames::mediaAttr:
         m_styleSheetOwner.setMedia(newValue);
         if (RefPtr sheet = this->sheet()) {
-            sheet->setMediaQueries(MQ::MediaQueryParser::parse(newValue, protectedDocument()->cssParserContext()));
+            sheet->setMediaQueries(MQ::MediaQueryParser::parse(newValue, protect(document())->cssParserContext()));
             if (auto* scope = m_styleSheetOwner.styleScope())
                 scope->didChangeStyleSheetContents();
         } else

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -197,7 +197,7 @@ void HTMLTableCellElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) c
 {
     HTMLTablePartElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protectedDocument()->completeURL(attributeWithoutSynchronization(backgroundAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr)));
 }
 
 HTMLTableCellElement* HTMLTableCellElement::cellAbove() const

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -133,7 +133,7 @@ Ref<HTMLTableSectionElement> HTMLTableElement::createTHead()
 {
     if (RefPtr existingHead = tHead())
         return existingHead.releaseNonNull();
-    Ref head = HTMLTableSectionElement::create(theadTag, protectedDocument());
+    Ref head = HTMLTableSectionElement::create(theadTag, protect(document()));
     setTHead(head.copyRef());
     return head;
 }
@@ -148,7 +148,7 @@ Ref<HTMLTableSectionElement> HTMLTableElement::createTFoot()
 {
     if (RefPtr existingFoot = tFoot())
         return existingFoot.releaseNonNull();
-    Ref foot = HTMLTableSectionElement::create(tfootTag, protectedDocument());
+    Ref foot = HTMLTableSectionElement::create(tfootTag, protect(document()));
     setTFoot(foot.copyRef());
     return foot;
 }
@@ -161,7 +161,7 @@ void HTMLTableElement::deleteTFoot()
 
 Ref<HTMLTableSectionElement> HTMLTableElement::createTBody()
 {
-    Ref body = HTMLTableSectionElement::create(tbodyTag, protectedDocument());
+    Ref body = HTMLTableSectionElement::create(tbodyTag, protect(document()));
     RefPtr referenceElement = lastBody() ? lastBody()->nextSibling() : nullptr;
     insertBefore(body, WTF::move(referenceElement));
     return body;
@@ -171,7 +171,7 @@ Ref<HTMLTableCaptionElement> HTMLTableElement::createCaption()
 {
     if (RefPtr existingCaption = caption())
         return existingCaption.releaseNonNull();
-    Ref caption = HTMLTableCaptionElement::create(captionTag, protectedDocument());
+    Ref caption = HTMLTableCaptionElement::create(captionTag, protect(document()));
     setCaption(caption.copyRef());
     return caption;
 }
@@ -331,7 +331,7 @@ void HTMLTableElement::collectPresentationalHintsForAttribute(const QualifiedNam
         break;
     case AttributeNames::backgroundAttr:
         if (auto url = value.string().trim(isASCIIWhitespace); !url.isEmpty())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protectedDocument()->completeURL(url))));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(url))));
         break;
     case AttributeNames::valignAttr:
         if (!value.isEmpty())
@@ -606,7 +606,7 @@ void HTMLTableElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protectedDocument()->completeURL(attributeWithoutSynchronization(backgroundAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr)));
 }
 
 }

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -65,7 +65,7 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
         break;
     case AttributeNames::backgroundAttr:
         if (!StringView(value).containsOnly<isASCIIWhitespace<char16_t>>())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protectedDocument()->completeURL(value))));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(value))));
         break;
     case AttributeNames::valignAttr:
         if (equalLettersIgnoringASCIICase(value, "top"_s))

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -122,7 +122,7 @@ ExceptionOr<Ref<HTMLTableCellElement>> HTMLTableRowElement::insertCell(int index
     int numCells = children->length();
     if (index > numCells)
         return Exception { ExceptionCode::IndexSizeError };
-    Ref cell = HTMLTableCellElement::create(tdTag, protectedDocument());
+    Ref cell = HTMLTableCellElement::create(tdTag, protect(document()));
     ExceptionOr<void> result;
     if (numCells == index || index == -1)
         result = appendChild(cell);

--- a/Source/WebCore/html/HTMLTableSectionElement.cpp
+++ b/Source/WebCore/html/HTMLTableSectionElement.cpp
@@ -68,7 +68,7 @@ ExceptionOr<Ref<HTMLTableRowElement>> HTMLTableSectionElement::insertRow(int ind
     int numRows = children->length();
     if (index > numRows)
         return Exception { ExceptionCode::IndexSizeError };
-    Ref row = HTMLTableRowElement::create(trTag, protectedDocument());
+    Ref row = HTMLTableRowElement::create(trTag, protect(document()));
     ExceptionOr<void> result;
     if (numRows == index || index == -1)
         result = appendChild(row);

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -85,7 +85,7 @@ DocumentFragment& HTMLTemplateElement::content() const
 {
     ASSERT(!m_declarativeShadowRoot);
     if (!m_content)
-        lazyInitialize(m_content, TemplateContentDocumentFragment::create(protectedDocument()->ensureProtectedTemplateDocument(), *this));
+        lazyInitialize(m_content, TemplateContentDocumentFragment::create(protect(document())->ensureProtectedTemplateDocument(), *this));
     return *m_content;
 }
 
@@ -128,7 +128,7 @@ Ref<Node> HTMLTemplateElement::cloneNodeInternal(Document& document, CloningOper
     if (m_content) {
         auto& templateElement = downcast<HTMLTemplateElement>(*clone);
         Ref fragment = templateElement.content();
-        m_content->cloneChildNodes(fragment->protectedDocument(), nullptr, fragment);
+        m_content->cloneChildNodes(protect(fragment->document()), nullptr, fragment);
     }
     return clone.releaseNonNull();
 }

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -95,7 +95,7 @@ Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(Document& document)
 void HTMLTextAreaElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 {
     ScriptDisallowedScope::EventAllowedScope rootScope { root };
-    root.appendChild(TextControlInnerTextElement::create(protectedDocument(), isInnerTextElementEditable()));
+    root.appendChild(TextControlInnerTextElement::create(protect(document()), isInnerTextElementEditable()));
 }
 
 const AtomString& HTMLTextAreaElement::formControlType() const
@@ -214,7 +214,7 @@ bool HTMLTextAreaElement::appendFormData(DOMFormData& formData)
     if (name().isEmpty())
         return false;
 
-    protectedDocument()->updateLayout();
+    protect(document())->updateLayout();
 
     formData.append(name(), m_wrap == HardWrap ? valueWithHardLineBreaks() : value().get());
     if (auto& dirname = attributeWithoutSynchronization(dirnameAttr); !dirname.isNull())
@@ -535,7 +535,7 @@ void HTMLTextAreaElement::updatePlaceholderText()
         return;
     }
     if (!m_placeholder) {
-        m_placeholder = TextControlPlaceholderElement::create(protectedDocument());
+        m_placeholder = TextControlPlaceholderElement::create(protect(document()));
         protectedUserAgentShadowRoot()->insertBefore(*protectedPlaceholderElement(), innerTextElement()->protectedNextSibling());
     }
     protectedPlaceholderElement()->setInnerText(String { placeholderText });

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -350,7 +350,7 @@ bool HTMLTextFormControlElement::setSelectionRange(unsigned start, unsigned end,
             return cacheSelection(start, end, direction);
 
         // FIXME: Removing this synchronous layout requires fixing setSelectionWithoutUpdatingAppearance not needing up-to-date style.
-        protectedDocument()->updateLayoutIgnorePendingStylesheets();
+        protect(document())->updateLayoutIgnorePendingStylesheets();
 
         // Cache selection if renderer is invisible.
         if (CheckedPtr renderer = this->renderer()) {
@@ -966,7 +966,7 @@ void HTMLTextFormControlElement::adjustInnerTextStyle(const RenderStyle& parentS
 bool HTMLTextFormControlElement::shouldApplyScriptTrackingPrivacyProtection() const
 {
     return (wasEverChangedByUserEdit() || !wasCreatedByTaintedScript())
-        && protectedDocument()->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::FormControls);
+        && protect(document())->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::FormControls);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLTitleElement.cpp
+++ b/Source/WebCore/html/HTMLTitleElement.cpp
@@ -70,7 +70,7 @@ void HTMLTitleElement::didFinishInsertingNode()
     HTMLElement::didFinishInsertingNode();
 
     m_title = computedTextWithDirection();
-    protectedDocument()->titleElementAdded(*this);
+    protect(document())->titleElementAdded(*this);
 }
 
 void HTMLTitleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
@@ -78,7 +78,7 @@ void HTMLTitleElement::removedFromAncestor(RemovalType removalType, ContainerNod
     HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
 
     if (removalType.disconnectedFromDocument)
-        protectedDocument()->titleElementRemoved(*this);
+        protect(document())->titleElementRemoved(*this);
 }
 
 void HTMLTitleElement::childrenChanged(const ChildChange& change)
@@ -87,7 +87,7 @@ void HTMLTitleElement::childrenChanged(const ChildChange& change)
 
     if (isConnected()) {
         m_title = computedTextWithDirection();
-        protectedDocument()->titleElementTextChanged(*this);
+        protect(document())->titleElementTextChanged(*this);
     }
 }
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -349,7 +349,7 @@ void HTMLVideoElement::mediaPlayerFirstVideoFrameAvailable()
 
     if (CheckedPtr renderer = this->renderer()) {
         renderer->updateFromElement();
-        protectedDocument()->didPaintImage(*this, nullptr, renderer->videoBox());
+        protect(document())->didPaintImage(*this, nullptr, renderer->videoBox());
     }
 }
 
@@ -514,7 +514,7 @@ URL HTMLVideoElement::posterImageURL() const
     auto url = imageSourceURL().string().trim(isASCIIWhitespace);
     if (url.isEmpty())
         return URL();
-    return protectedDocument()->completeURL(url);
+    return protect(document())->completeURL(url);
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -99,7 +99,7 @@ void ImageInputType::handleDOMActivateEvent(Event& event)
 
     // Update layout before processing form actions in case the style changes
     // the Form or button relationships.
-    element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(element->document())->updateLayoutIgnorePendingStylesheets();
 
     if (RefPtr currentForm = element->form())
         currentForm->submitIfPossible(&event, element.ptr()); // Event handlers can run.
@@ -174,7 +174,7 @@ unsigned ImageInputType::height() const
     ASSERT(element());
     Ref element = *this->element();
 
-    element->protectedDocument()->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
+    protect(element->document())->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
 
     CheckedPtr renderer = element->renderer();
     if (renderer)
@@ -197,7 +197,7 @@ unsigned ImageInputType::width() const
     ASSERT(element());
     Ref element = *this->element();
 
-    element->protectedDocument()->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
+    protect(element->document())->updateLayout({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
 
     CheckedPtr renderer = element->renderer();
     if (renderer)

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -791,7 +791,7 @@ void InputType::setValue(const String& sanitizedValue, bool valueChanged, TextFi
         break;
     }
 
-    if (CheckedPtr cache = element->protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(element->document())->existingAXObjectCache())
         cache->valueChanged(*element);
 }
 
@@ -1013,7 +1013,7 @@ ExceptionOr<void> InputType::applyStep(int count, AnyStepHandling anyStepHandlin
     if (result.hasException() || !this->element())
         return result;
 
-    if (CheckedPtr cache = element->protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(element->document())->existingAXObjectCache())
         cache->valueChanged(element);
 
     return result;

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -84,7 +84,7 @@ LazyLoadFrameObserver::LazyLoadFrameObserver(HTMLIFrameElement& element)
 void LazyLoadFrameObserver::observe(const AtomString& frameURL, const ReferrerPolicy& referrerPolicy)
 {
     auto& frameObserver = m_element->lazyLoadFrameObserver();
-    RefPtr intersectionObserver = frameObserver.intersectionObserver(m_element->protectedDocument());
+    RefPtr intersectionObserver = frameObserver.intersectionObserver(protect(m_element->document()));
     if (!intersectionObserver)
         return;
     m_frameURL = frameURL;

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -77,7 +77,7 @@ private:
 void LazyLoadImageObserver::observe(Element& element)
 {
     auto& observer = element.document().lazyLoadImageObserver();
-    RefPtr intersectionObserver = observer.intersectionObserver(element.protectedDocument());
+    RefPtr intersectionObserver = observer.intersectionObserver(protect(element.document()));
     if (!intersectionObserver)
         return;
     intersectionObserver->observe(element);

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -676,7 +676,7 @@ bool MediaElementSession::canShowControlsManager(PlaybackControlsPurpose purpose
     if (purpose == MediaElementSession::PlaybackControlsPurpose::NowPlaying
         && hasBehaviorRestriction(RequirePageVisibilityForVideoToBeNowPlaying)
         && element->isVideo()
-        && !element->protectedDocument()->protectedPage()->isVisibleAndActive()) {
+        && !protect(element->document())->protectedPage()->isVisibleAndActive()) {
         INFO_LOG(LOGIDENTIFIER, "returning FALSE: NowPlaying restricted for video in a page that is not visible");
         return false;
     }
@@ -1216,7 +1216,7 @@ static bool isElementMainContentForPurposesOfAutoplay(const HTMLMediaElement& el
     OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent, HitTestRequest::Type::IgnoreClipping, HitTestRequest::Type::DisallowUserAgentShadowContent };
     HitTestResult result(rectRelativeToTopDocument.center());
 
-    localMainFrame->protectedDocument()->hitTest(hitType, result);
+    protect(localMainFrame->document())->hitTest(hitType, result);
     result.setToNonUserAgentShadowAncestor();
     return result.targetElement() == &element;
 }

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -371,7 +371,7 @@ static PermissionsPolicy::PolicyDirective parsePolicyDirective(StringView value,
 PermissionsPolicy::PolicyDirective PermissionsPolicy::processPermissionsPolicyAttribute(const HTMLIFrameElement& iframe)
 {
     auto allowAttributeValue = iframe.attributeWithoutSynchronization(allowAttr);
-    auto policyDirective = parsePolicyDirective(allowAttributeValue, iframe.protectedDocument()->securityOrigin().data(), declaredOrigin(iframe)->data());
+    auto policyDirective = parsePolicyDirective(allowAttributeValue, protect(iframe.document())->securityOrigin().data(), declaredOrigin(iframe)->data());
 
     if (iframe.hasAttributeWithoutSynchronization(allowfullscreenAttr) || iframe.hasAttributeWithoutSynchronization(webkitallowfullscreenAttr))
         policyDirective.add(Feature::Fullscreen, Allowlist::AllowAllOrigins { });

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -158,7 +158,7 @@ auto RadioInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
         if (inputElement->form() != element->form())
             break;
         if (inputElement->isRadioButton() && inputElement->name() == element->name() && inputElement->isFocusable()) {
-            inputElement->protectedDocument()->setFocusedElement(inputElement.get());
+            protect(inputElement->document())->setFocusedElement(inputElement.get());
             // If the focused radio button is not visible (e.g., during arrow key navigation), scroll it into view.
             inputElement->scrollIntoViewIfNotVisible(false);
             inputElement->dispatchSimulatedClick(&event, SendNoEvents, DoNotShowPressedLook);

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -164,7 +164,7 @@ LayoutUnit SearchInputType::clientPaddingRight() const
 
 FontSelector* SearchInputType::fontSelector() const
 {
-    return &protectedElement()->protectedDocument()->fontSelector();
+    return &protect(protectedElement()->document())->fontSelector();
 }
 
 HostWindow* SearchInputType::hostWindow() const

--- a/Source/WebCore/html/SubmitInputType.cpp
+++ b/Source/WebCore/html/SubmitInputType.cpp
@@ -81,7 +81,7 @@ void SubmitInputType::handleDOMActivateEvent(Event& event)
 
     // Update layout before processing form actions in case the style changes
     // the Form or button relationships.
-    element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(element->document())->updateLayoutIgnorePendingStylesheets();
 
     if (RefPtr currentForm = element->form())
         currentForm->submitIfPossible(&event, element.ptr()); // Event handlers can run.

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -474,7 +474,7 @@ void TextFieldInputType::createDataListDropdownIndicator()
         return;
     
     ScriptDisallowedScope::EventAllowedScope allowedScope(*m_container);
-    Ref dataListDropdownIndicator = DataListButtonElement::create(element()->protectedDocument().get(), *this);
+    Ref dataListDropdownIndicator = DataListButtonElement::create(protect(element()->document()).get(), *this);
     m_dataListDropdownIndicator = dataListDropdownIndicator.copyRef();
     RefPtr { m_container }->appendChild(dataListDropdownIndicator);
     dataListDropdownIndicator->setUserAgentPart(UserAgentParts::webkitListButton());
@@ -645,7 +645,7 @@ void TextFieldInputType::updatePlaceholderText()
         return;
     }
     if (!m_placeholder) {
-        Ref placeholder = TextControlPlaceholderElement::create(element->protectedDocument());
+        Ref placeholder = TextControlPlaceholderElement::create(protect(element->document()));
         m_placeholder = placeholder.copyRef();
         if (RefPtr container = m_container)
             element->protectedUserAgentShadowRoot()->insertBefore(placeholder, container);
@@ -851,7 +851,7 @@ void TextFieldInputType::createAutoFillButton(AutoFillButtonType autoFillButtonT
         return;
 
     ASSERT(element());
-    Ref autoFillButton = AutoFillButtonElement::create(element()->protectedDocument().get(), *this);
+    Ref autoFillButton = AutoFillButtonElement::create(protect(element()->document()).get(), *this);
     m_autoFillButton = autoFillButton.copyRef();
     RefPtr { m_container }->appendChild(autoFillButton);
 
@@ -934,7 +934,7 @@ IntRect TextFieldInputType::elementRectInRootViewCoordinates() const
     if (!element()->renderer())
         return IntRect();
     Ref element = *this->element();
-    return element->protectedDocument()->protectedView()->contentsToRootView(element->checkedRenderer()->absoluteBoundingBoxRect());
+    return protect(element->document())->protectedView()->contentsToRootView(element->checkedRenderer()->absoluteBoundingBoxRect());
 }
 
 Vector<DataListSuggestion> TextFieldInputType::suggestions()

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -146,7 +146,7 @@ bool ValidatedFormListedElement::reportValidity()
 
     // Needs to update layout now because we'd like to call isFocusable(),
     // which has !renderer()->needsLayout() assertion.
-    asHTMLElement().protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(asHTMLElement().document())->updateLayoutIgnorePendingStylesheets();
     if (auto validationAnchor = focusableValidationAnchorElement())
         focusAndShowValidationMessage(validationAnchor.releaseNonNull());
     else

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -165,7 +165,7 @@ void CanvasRenderingContext2D::drawFocusIfNeededInternal(const Path& path, Eleme
     Ref canvas = this->canvas();
     if (!element.focused() || !hasInvertibleTransform() || path.isEmpty() || !element.isDescendantOf(canvas.get()) || !context)
         return;
-    context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(element.protectedDocument()->styleColorOptions(canvas->computedStyle())));
+    context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(protect(element.document())->styleColorOptions(canvas->computedStyle())));
     didDrawEntireCanvas();
 }
 
@@ -252,7 +252,7 @@ inline TextDirection CanvasRenderingContext2D::toTextDirection(Direction directi
 CanvasDirection CanvasRenderingContext2D::direction() const
 {
     if (state().direction == Direction::Inherit)
-        canvas().protectedDocument()->updateStyleIfNeeded();
+        protect(canvas().document())->updateStyleIfNeeded();
     return toTextDirection(state().direction) == TextDirection::RTL ? CanvasDirection::Rtl : CanvasDirection::Ltr;
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1632,7 +1632,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLImageElement& imag
             orientation = Style::toPlatform(computedStyle->imageOrientation()).orientation();
     }
 
-    auto result = drawImage(imageElement.protectedDocument().get(), *cachedImage, imageElement.checkedRenderer().get(), imageRect, srcRect, dstRect, op, blendMode, orientation);
+    auto result = drawImage(protect(imageElement.document()).get(), *cachedImage, imageElement.checkedRenderer().get(), imageRect, srcRect, dstRect, op, blendMode, orientation);
 
     if (!result.hasException())
         checkOrigin(&imageElement);
@@ -1655,7 +1655,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(SVGImageElement& image
 
     auto imageRect = FloatRect(FloatPoint(), size(imageElement, ImageSizeType::BeforeDevicePixelRatio));
 
-    auto result = drawImage(imageElement.protectedDocument().get(), *cachedImage, imageElement.checkedRenderer().get(), imageRect, srcRect, dstRect, op, blendMode);
+    auto result = drawImage(protect(imageElement.document()).get(), *cachedImage, imageElement.checkedRenderer().get(), imageRect, srcRect, dstRect, op, blendMode);
 
     if (!result.hasException())
         checkOrigin(&imageElement);

--- a/Source/WebCore/html/canvas/CanvasStyle.cpp
+++ b/Source/WebCore/html/canvas/CanvasStyle.cpp
@@ -68,7 +68,7 @@ Color CanvasStyleColorResolutionDelegate::currentColor() const
         return Color::black;
 
     auto colorString = m_canvasElement->inlineStyle()->getPropertyValue(CSSPropertyColor);
-    auto color = CSSPropertyParserHelpers::parseColorRaw(colorString, m_canvasElement->cssParserContext(), m_canvasElement->protectedDocument().get());
+    auto color = CSSPropertyParserHelpers::parseColorRaw(colorString, m_canvasElement->cssParserContext(), protect(m_canvasElement->document()).get());
     if (color.isValid())
         return color;
     return Color::black;

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -439,7 +439,7 @@ void HTMLDocumentParser::append(RefPtr<StringImpl>&& inputSource, SynchronousMod
         } else {
             m_preloadScanner->appendToEnd(source);
             if (isWaitingForScripts())
-                m_preloadScanner->scan(*m_preloader, *protectedDocument());
+                m_preloadScanner->scan(*m_preloader, *protect(document()));
         }
     }
 
@@ -584,7 +584,7 @@ void HTMLDocumentParser::appendCurrentInputStreamToPreloadScannerAndScan()
 {
     ASSERT(m_preloadScanner);
     m_preloadScanner->appendToEnd(m_input.current());
-    m_preloadScanner->scan(*m_preloader, *protectedDocument());
+    m_preloadScanner->scan(*m_preloader, *protect(document()));
 }
 
 static ALWAYS_INLINE bool canChangeModuleScriptsExecutionTiming()

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -146,12 +146,12 @@ static bool isCachedPrefixMatch(const CachedSetInnerHTML& cache, std::span<const
 template<typename CharacterType>
 static FragmentReuseResult tryAvoidParsingByCloningExistingSubtree(std::span<const CharacterType> source, ContainerNode& destinationParent, Element& contextElement)
 {
-    auto& cache = destinationParent.protectedDocument()->cachedSetInnerHTML();
+    auto& cache = protect(destinationParent.document())->cachedSetInnerHTML();
     RefPtr cachedContainer = cache.cachedContainer.get();
     if (!cachedContainer)
         return FragmentReuseResult::CannotReuse;
     if (!isCachedSubtreeValid(*cachedContainer)) {
-        destinationParent.protectedDocument()->invalidateCachedSetInnerHTML();
+        protect(destinationParent.document())->invalidateCachedSetInnerHTML();
         return FragmentReuseResult::CannotReuse;
     }
 
@@ -177,9 +177,9 @@ static FragmentReuseResult cloneCachedPrefixAndParseSuffix(std::span<const Chara
     ASSERT(cachedContainer->hasChildNodes());
 
     for (RefPtr nodeToClone = cachedContainer->firstChild(); nodeToClone; nodeToClone = nodeToClone->nextSibling()) {
-        Ref<Node> clonedChild = nodeToClone->cloneNodeInternal(destinationParent.protectedDocument(), Node::CloningOperation::SelfOnly, nullptr);
+        Ref<Node> clonedChild = nodeToClone->cloneNodeInternal(protect(destinationParent.document()), Node::CloningOperation::SelfOnly, nullptr);
         if (RefPtr nodeToCloneAsContainer = dynamicDowncast<ContainerNode>(*nodeToClone))
-            nodeToCloneAsContainer->cloneSubtreeForFastParser(destinationParent.protectedDocument(), nullptr, downcast<ContainerNode>(clonedChild.get()), 0);
+            nodeToCloneAsContainer->cloneSubtreeForFastParser(protect(destinationParent.document()), nullptr, downcast<ContainerNode>(clonedChild.get()), 0);
         destinationParent.parserAppendChildIntoIsolatedTree(clonedChild.get());
     }
 

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -272,7 +272,7 @@ Ref<DateTimeEditElement> DateTimeEditElement::create(Document& document, DateTim
 void DateTimeEditElement::layout(const LayoutParameters& layoutParameters)
 {
     if (!firstChild()) {
-        Ref element = HTMLDivElement::create(protectedDocument().get());
+        Ref element = HTMLDivElement::create(protect(document()).get());
         appendChild(element);
         element->setUserAgentPart(UserAgentParts::webkitDatetimeEditFieldsWrapper());
     }

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -176,7 +176,7 @@ void DateTimeFieldElement::handleBlurEvent(Event& event)
 
 Locale& DateTimeFieldElement::localeForOwner() const
 {
-    return protectedDocument()->getCachedLocale(localeIdentifier());
+    return protect(document())->getCachedLocale(localeIdentifier());
 }
 
 AtomString DateTimeFieldElement::localeIdentifier() const
@@ -194,7 +194,7 @@ String DateTimeFieldElement::visibleValue() const
 void DateTimeFieldElement::updateVisibleValue(EventBehavior eventBehavior)
 {
     if (!firstChild())
-        appendChild(Text::create(protectedDocument().get(), String { emptyString() }));
+        appendChild(Text::create(protect(document()).get(), String { emptyString() }));
 
     Ref textNode = downcast<Text>(*firstChild());
     String newVisibleValue = visibleValue();

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -476,7 +476,7 @@ RefPtr<NativeImage> MediaControlTextTrackContainerElement::createTextTrackRepres
     if (!frame)
         return nullptr;
 
-    protectedDocument()->updateLayout();
+    protect(document())->updateLayout();
 
     CheckedPtr renderer = this->renderer();
     if (!renderer)
@@ -553,7 +553,7 @@ VTTCue& MediaControlTextTrackContainerElement::ensurePreviewCue() const
     }
 
     if (!m_previewCue) {
-        m_previewCue = VTTCue::create(protectedDocument(), 0, 0, { });
+        m_previewCue = VTTCue::create(protect(document()), 0, 0, { });
         m_previewCue->setSnapToLines(false);
         m_previewCue->setLine(25.);
         m_previewCue->setStartTime(MediaTime::zeroTime());
@@ -572,7 +572,7 @@ VTTCue& MediaControlTextTrackContainerElement::ensurePreviewCue() const
 const Logger& MediaControlTextTrackContainerElement::logger() const
 {
     if (!m_logger)
-        m_logger = protectedDocument()->logger();
+        m_logger = protect(document())->logger();
 
     return *m_logger;
 }

--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -116,7 +116,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
     if (!shouldHaveSpatialControls(imageElement) || hasSpatialImageControls(imageElement))
         return;
 
-    imageElement.protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { imageElement }] {
+    protect(imageElement.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { imageElement }] {
         RefPtr element = weakElement.get();
         if (!element)
             return;
@@ -248,7 +248,7 @@ bool handleEvent(HTMLElement& element, Event& event)
 
 void destroySpatialImageControls(HTMLElement& element)
 {
-    element.protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
+    protect(element.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
         RefPtr protectedElement = weakElement.get();
         if (!protectedElement)
             return;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -311,7 +311,7 @@ void SearchFieldResultsButtonElement::defaultEventHandler(Event& event)
             input->focus();
             input->select();
 #if !PLATFORM(IOS_FAMILY)
-            protectedDocument()->updateStyleIfNeeded();
+            protect(document())->updateStyleIfNeeded();
 
             if (CheckedPtr searchFieldRenderer = dynamicDowncast<RenderSearchField>(input->renderer())) {
                 if (searchFieldRenderer->popupIsVisible())

--- a/Source/WebCore/html/track/LoadableTextTrack.cpp
+++ b/Source/WebCore/html/track/LoadableTextTrack.cpp
@@ -94,7 +94,7 @@ void LoadableTextTrack::scheduleLoad(const URL& url)
         // 4. Download: If URL is not the empty string, perform a potentially CORS-enabled fetch of URL, with the
         // mode being the state of the media element's crossorigin content attribute, the origin being the
         // origin of the media element's Document, and the default origin behaviour set to fail.
-        loader = TextTrackLoader::create(static_cast<TextTrackLoaderClient&>(*this), trackElement->protectedDocument().get());
+        loader = TextTrackLoader::create(static_cast<TextTrackLoaderClient&>(*this), protect(trackElement->document()).get());
         m_loader = loader.copyRef();
         if (!loader->load(m_url, *trackElement))
             trackElement->didCompleteLoad(HTMLTrackElement::Failure);

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -494,7 +494,7 @@ static void copyWebVTTNodeToDOMTree(ContainerNode& webVTTNode, Node& parent)
     for (RefPtr node = webVTTNode.firstChild(); node; node = node->nextSibling()) {
         RefPtr<Node> clonedNode;
         if (RefPtr element = dynamicDowncast<WebVTTElement>(*node))
-            clonedNode = element->createEquivalentHTMLElement(parent.protectedDocument().get());
+            clonedNode = element->createEquivalentHTMLElement(protect(parent.document()).get());
         else
             clonedNode = node->cloneNode(false);
         parent.appendChild(*clonedNode);

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -329,7 +329,7 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
     page->setOpenedByDOMWithOpener(true);
 
     // FIXME: Why do we compute the absolute URL with respect to |frame| instead of |mainFrame|?
-    ResourceRequest resourceRequest { localFrame->protectedDocument()->completeURL(url) };
+    ResourceRequest resourceRequest { protect(localFrame->document())->completeURL(url) };
     FrameLoadRequest frameLoadRequest2 { *mainFrameDocument, mainFrameDocument->securityOrigin(), WTF::move(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
     localFrame->loader().changeLocation(WTF::move(frameLoadRequest2));
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -615,7 +615,7 @@ Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Node* nod
     // FIXME: <https://webkit.org/b/213499> Web Inspector: allow DOM nodes to be instrumented at any point, regardless of whether the main document has also been instrumented
 
     Inspector::Protocol::ErrorString ignored;
-    return pushNodeToFrontend(ignored, boundNodeId(nodeToPush->protectedDocument().ptr()), nodeToPush);
+    return pushNodeToFrontend(ignored, boundNodeId(protect(nodeToPush->document()).ptr()), nodeToPush);
 }
 
 Inspector::Protocol::DOM::NodeId InspectorDOMAgent::pushNodeToFrontend(Inspector::Protocol::ErrorString& errorString, Inspector::Protocol::DOM::NodeId documentNodeId, Node* nodeToPush)
@@ -851,7 +851,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAttributesAsText(
     if (!element)
         return makeUnexpected(errorString);
 
-    Ref parsedElement = createHTMLElement(element->protectedDocument(), spanTag);
+    Ref parsedElement = createHTMLElement(protect(element->document()), spanTag);
     auto result = parsedElement.get().setInnerHTML(makeString("<span "_s, text, "></span>"_s));
     if (result.hasException())
         return makeUnexpected(InspectorDOMAgent::toErrorString(result.releaseException()));
@@ -924,7 +924,7 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> InspectorDO
     if (!oldNode)
         return makeUnexpected(errorString);
 
-    auto createElementResult = oldNode->protectedDocument()->createElementForBindings(AtomString { tagName });
+    auto createElementResult = protect(oldNode->document())->createElementForBindings(AtomString { tagName });
     if (createElementResult.hasException())
         return makeUnexpected(InspectorDOMAgent::toErrorString(createElementResult.releaseException()));
 
@@ -2293,7 +2293,7 @@ Ref<Inspector::Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildO
     unsigned hierarchicalLevel = 0;
     unsigned level = 0;
 
-    if (auto* axObjectCache = node.protectedDocument()->axObjectCache()) {
+    if (auto* axObjectCache = protect(node.document())->axObjectCache()) {
         if (RefPtr axObject = axObjectCache->getOrCreate(node)) {
 
             if (RefPtr activeDescendant = axObject->activeDescendant())

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -169,7 +169,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
             error.setType(ResourceError::Type::AccessControl);
 
         if (!error.isTimeout())
-            loader.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "CORS-preflight request was blocked"_s);
+            protect(loader.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, "CORS-preflight request was blocked"_s);
 
         loader.preflightFailure(identifier, error);
         return;
@@ -179,7 +179,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
     bool isRedirect = preflightRequest.url().strippedForUseAsReferrer().string != response.url().strippedForUseAsReferrer().string;
     if (isRedirect || !response.isSuccessful()) {
         auto errorMessage = makeString("Preflight response is not successful. Status code: "_s, response.httpStatusCode());
-        loader.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
+        protect(loader.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
 
         loader.preflightFailure(identifier, ResourceError { errorDomainWebKitInternal, 0, request.url(), errorMessage, ResourceError::Type::AccessControl });
         return;

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -66,7 +66,7 @@ static inline bool canReferToParentFrameEncoding(const LocalFrame* frame, const 
     RefPtr document = frame->document();
     if (is<XMLDocument>(document))
         return false;
-    return parentFrame && parentFrame->protectedDocument()->protectedSecurityOrigin()->isSameOriginDomain(document->protectedSecurityOrigin());
+    return parentFrame && protect(parentFrame->document())->protectedSecurityOrigin()->isSameOriginDomain(document->protectedSecurityOrigin());
 }
     
 // This is only called by ScriptController::executeIfJavaScriptURL
@@ -94,7 +94,7 @@ void DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL(const Str
     if (!source.isNull()) {
         if (!m_hasReceivedSomeData) {
             m_hasReceivedSomeData = true;
-            frame->protectedDocument()->setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
+            protect(frame->document())->setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
         }
 
         if (RefPtr parser = frame->document()->parser())
@@ -187,7 +187,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
 
     Function<void()> handleDOMWindowCreation = [document, frame, shouldReuseDefaultView] {
         if (shouldReuseDefaultView)
-            document->takeDOMWindowFrom(*frame->protectedDocument());
+            document->takeDOMWindowFrom(*protect(frame->document()));
         else
             document->createDOMWindow();
     };
@@ -235,7 +235,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
             RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
             if (parentFrame && parentFrame->document()) {
                 document->inheritPolicyContainerFrom(parentFrame->document()->policyContainer());
-                document->checkedContentSecurityPolicy()->updateSourceSelf(parentFrame->protectedDocument()->protectedSecurityOrigin());
+                document->checkedContentSecurityPolicy()->updateSourceSelf(protect(parentFrame->document())->protectedSecurityOrigin());
             }
         } else if (triggeringAction && triggeringAction->requester() && !isLoadingBrowserControlledHTML()) {
             document->inheritPolicyContainerFrom(triggeringAction->requester()->policyContainer);
@@ -291,7 +291,7 @@ TextResourceDecoder& DocumentWriter::decoder()
             decoder->setEncoding(m_encoding,
                 m_encodingWasChosenByUser ? TextResourceDecoder::UserChosenEncoding : TextResourceDecoder::EncodingFromHTTPHeader);
         }
-        frame->protectedDocument()->setDecoder(WTF::move(decoder));
+        protect(frame->document())->setDecoder(WTF::move(decoder));
     }
     return *m_decoder;
 }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -287,7 +287,7 @@ void HistoryController::restoreDocumentState()
     documentLoader->setShouldOpenExternalURLsPolicy(currentItem->shouldOpenExternalURLsPolicy());
 
     LOG(Loading, "WebCoreLoading frame %" PRIu64 ": restoring form state from %p", m_frame->frameID().toUInt64(), currentItem.get());
-    m_frame->protectedDocument()->setStateForNewFormElements(currentItem->documentState());
+    protect(m_frame->document())->setStateForNewFormElements(currentItem->documentState());
 }
 
 void HistoryController::invalidateCurrentItemCachedPage()

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -372,7 +372,7 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, Cached
             // being queued to fire.
             newImage->addClient(*this);
         } else
-            resetLazyImageLoading(element().protectedDocument());
+            resetLazyImageLoading(protect(element().document()));
 
         if (oldImage) {
             oldImage->removeClient(*this);
@@ -448,7 +448,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
     m_pendingURL = { };
 
     if (isDeferred()) {
-        LazyLoadImageObserver::unobserve(protectedElement(), protectedDocument());
+        LazyLoadImageObserver::unobserve(protectedElement(), protect(document()));
         m_lazyImageLoadState = LazyImageLoadState::FullImage;
         LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " notifyFinished() for element " << element() << " setting lazy load state to " << m_lazyImageLoadState);
     }
@@ -468,7 +468,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
         loadEventSender().dispatchEventSoon(*this, eventNames().errorEvent);
 
         auto message = makeString("Cannot load image "_s, imageURL.string(), " due to access control checks."_s);
-        protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
+        protect(document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, message);
 
         if (hasPendingDecodePromises())
             rejectDecodePromises("Access control error."_s);
@@ -493,7 +493,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
         return;
     }
 
-    m_image->protectedImage()->subresourcesAreFinished(protectedDocument().ptr(), [this, protectedThis = Ref { *this }]() mutable {
+    m_image->protectedImage()->subresourcesAreFinished(protect(document()).ptr(), [this, protectedThis = Ref { *this }]() mutable {
         // It is technically possible state changed underneath us.
         if (!m_hasPendingLoadEvent)
             return;

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -327,7 +327,7 @@ void MediaResource::responseReceived(const CachedResource& resource, const Resou
     Ref protectedThis { *this };
     if (m_resource->resourceError().isAccessControl()) {
         static NeverDestroyed<const String> consoleMessage("Cross-origin media resource load denied by Cross-Origin Resource Sharing policy."_s);
-        m_loader->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage.get());
+        protect(m_loader->document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage.get());
         m_didPassAccessControlCheck.store(false);
         if (RefPtr client = this->client())
             client->accessControlCheckFailed(*this, ResourceError(errorDomainWebKitInternal, 0, response.url(), consoleMessage.get()));
@@ -337,7 +337,7 @@ void MediaResource::responseReceived(const CachedResource& resource, const Resou
 
     if (!m_loader->verifyMediaResponse(resource.url(), response, resource.protectedOrigin().get())) {
         static NeverDestroyed<const String> consoleMessage("Media response origin validation failed."_s);
-        m_loader->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage.get());
+        protect(m_loader->document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage.get());
         if (RefPtr client = this->client())
             client->loadFailed(*this, ResourceError(errorDomainWebKitInternal, 0, response.url(), consoleMessage.get()));
         ensureShutdown();

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -649,7 +649,7 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
     if (url.hasFragmentIdentifier()
         && localFrame
         && equalIgnoringFragmentIdentifier(localFrame->document()->url(), url)) {
-        ResourceRequest resourceRequest { localFrame->protectedDocument()->completeURL(url.string()), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
+        ResourceRequest resourceRequest { protect(localFrame->document())->completeURL(url.string()), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
         RefPtr frame = lexicalFrameFromCommonVM();
         auto initiatedByMainFrame = frame && frame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
         

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -262,7 +262,7 @@ void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTP
     }
 
     CachedResourceRequest cachedResourceRequest { ResourceRequest { request }, options };
-    std::ignore = frame.protectedDocument()->protectedCachedResourceLoader()->requestPingResource(WTF::move(cachedResourceRequest));
+    std::ignore = protect(frame.document())->protectedCachedResourceLoader()->requestPingResource(WTF::move(cachedResourceRequest));
 }
 
 // // https://html.spec.whatwg.org/multipage/origin.html#sanitize-url-report

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -88,8 +88,8 @@ static bool isAllowedByContentSecurityPolicy(const URL& url, const Element* owne
 
     ASSERT(ownerElement->document().contentSecurityPolicy());
     if (is<HTMLPlugInElement>(ownerElement))
-        return ownerElement->protectedDocument()->checkedContentSecurityPolicy()->allowObjectFromSource(url, redirectResponseReceived);
-    return ownerElement->protectedDocument()->checkedContentSecurityPolicy()->allowChildFrameFromSource(url, redirectResponseReceived);
+        return protect(ownerElement->document())->checkedContentSecurityPolicy()->allowObjectFromSource(url, redirectResponseReceived);
+    return protect(ownerElement->document())->checkedContentSecurityPolicy()->allowChildFrameFromSource(url, redirectResponseReceived);
 }
 
 static bool shouldExecuteJavaScriptURLSynchronously(const URL& url)
@@ -127,7 +127,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     NavigationAction action = loader->triggeringAction();
     Ref frame = m_frame.get();
     if (action.isEmpty()) {
-        action = NavigationAction { frame->protectedDocument().releaseNonNull(), request, InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), NavigationType::Other, loader->shouldOpenExternalURLsPolicyToPropagate() };
+        action = NavigationAction { protect(frame->document()).releaseNonNull(), request, InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), NavigationType::Other, loader->shouldOpenExternalURLsPolicyToPropagate() };
         action.setIsContentRuleListRedirect(loader->isContentRuleListRedirect());
         if (navigationAPIType)
             action.setNavigationAPIType(*navigationAPIType);
@@ -217,7 +217,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
     frameLoader->clearProvisionalLoadForPolicyCheck();
 
     RefPtr formState = formSubmission ? formSubmission->protectedState(): nullptr;
-    auto blobURLLifetimeExtension = extendBlobURLLifetimeIfNecessary(request, *frame->protectedDocument(), policyDecisionMode);
+    auto blobURLLifetimeExtension = extendBlobURLLifetimeIfNecessary(request, *protect(frame->document()), policyDecisionMode);
     bool requestIsJavaScriptURL = request.url().protocolIsJavaScript();
     bool isInitialEmptyDocumentLoad = !frameLoader->stateMachine().committedFirstRealDocumentLoad() && request.url().protocolIsAbout() && !substituteData.isValid();
     m_delegateIsDecidingNavigationPolicy = true;

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -184,7 +184,7 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
         if (RefPtr document = frame->document())
             clientRequest.setFirstPartyForCookies(document->firstPartyForCookies());
     }
-    FrameLoader::addSameSiteInfoToRequestIfNeeded(clientRequest, frame->protectedDocument().get());
+    FrameLoader::addSameSiteInfoToRequestIfNeeded(clientRequest, protect(frame->document()).get());
 
     willSendRequestInternal(WTF::move(clientRequest), ResourceResponse(), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](ResourceRequest&& request) mutable {
 
@@ -571,7 +571,7 @@ void ResourceLoader::didBlockAuthenticationChallenge()
         return;
     RefPtr frame = m_frame.get();
     if (frame && !shouldAllowResourceToAskForCredentials())
-        frame->protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked "_s, m_request.url().stringCenterEllipsizedToLength(), " from asking for credentials because it is a cross-origin request."_s));
+        protect(frame->document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Blocked "_s, m_request.url().stringCenterEllipsizedToLength(), " from asking for credentials because it is a cross-origin request."_s));
 }
 
 void ResourceLoader::didReceiveResponse(ResourceResponse&& r, CompletionHandler<void()>&& policyCompletionHandler)

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -75,7 +75,7 @@ using namespace HTMLNames;
 static bool canLoadJavaScriptURL(HTMLFrameOwnerElement& ownerElement, const URL& url)
 {
     ASSERT(url.protocolIsJavaScript());
-    if (!ownerElement.protectedDocument()->checkedContentSecurityPolicy()->allowJavaScriptURLs(aboutBlankURL().string(), { }, url.string(), &ownerElement))
+    if (!protect(ownerElement.document())->checkedContentSecurityPolicy()->allowJavaScriptURLs(aboutBlankURL().string(), { }, url.string(), &ownerElement))
         return false;
     if (!ownerElement.canLoadScriptURL(url))
         return false;
@@ -357,7 +357,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     if ((url.isAboutBlank() || url.isAboutSrcDoc()) && userContentProvider) {
         userContentProvider->userContentExtensionBackend().forEach([&] (const String& identifier, ContentExtensions::ContentExtension& extension) {
             if (RefPtr styleSheetContents = extension.globalDisplayNoneStyleSheet())
-                subFrame->protectedDocument()->extensionStyleSheets().maybeAddContentExtensionSheet(identifier, *styleSheetContents);
+                protect(subFrame->document())->extensionStyleSheets().maybeAddContentExtensionSheet(identifier, *styleSheetContents);
         });
     }
 #endif
@@ -455,7 +455,7 @@ bool FrameLoader::SubframeLoader::loadPlugin(HTMLPlugInElement& pluginElement, c
 URL FrameLoader::SubframeLoader::completeURL(const String& url) const
 {
     ASSERT(m_frame->document());
-    return m_frame->protectedDocument()->completeURL(url);
+    return protect(m_frame->document())->completeURL(url);
 }
 
 bool FrameLoader::SubframeLoader::shouldConvertInvalidURLsToBlank() const

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -92,7 +92,7 @@ void IconLoader::startLoading()
 
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().icon);
 
-    auto cachedResource = frame->protectedDocument()->protectedCachedResourceLoader()->requestIcon(WTF::move(request));
+    auto cachedResource = protect(frame->document())->protectedCachedResourceLoader()->requestIcon(WTF::move(request));
     m_resource = cachedResource.value_or(nullptr);
     if (CachedResourceHandle resource = m_resource)
         resource->addClient(*this);

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -274,11 +274,11 @@ static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event,
     if (!oldPage)
         return;
 
-    FrameLoadRequest frameLoadRequest { frame.protectedDocument().releaseNonNull(), frame.document()->protectedSecurityOrigin(), ResourceRequest(URL { urlToLoad }, frame.loader().outgoingReferrer()), { }, InitiatedByMainFrame::Unknown };
+    FrameLoadRequest frameLoadRequest { protect(frame.document()).releaseNonNull(), frame.document()->protectedSecurityOrigin(), ResourceRequest(URL { urlToLoad }, frame.loader().outgoingReferrer()), { }, InitiatedByMainFrame::Unknown };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
 
-    RefPtr newPage = oldPage->chrome().createWindow(frame, { }, { }, { *frame.protectedDocument(), frameLoadRequest.resourceRequest(), frameLoadRequest.initiatedByMainFrame(), frameLoadRequest.isRequestFromClientOrUserInput() });
+    RefPtr newPage = oldPage->chrome().createWindow(frame, { }, { }, { *protect(frame.document()), frameLoadRequest.resourceRequest(), frameLoadRequest.initiatedByMainFrame(), frameLoadRequest.isRequestFromClientOrUserInput() });
     if (!newPage)
         return;
     newPage->chrome().show();
@@ -295,7 +295,7 @@ static void insertUnicodeCharacter(char16_t character, LocalFrame& frame)
         return;
 
     ASSERT(frame.document());
-    TypingCommand::insertText(*frame.protectedDocument(), text, nullptr, { }, TypingCommand::TextCompositionType::None);
+    TypingCommand::insertText(*protect(frame.document()), text, nullptr, { }, TypingCommand::TextCompositionType::None);
 }
 
 #endif
@@ -528,7 +528,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
     case ContextMenuItemTagOpenLink:
         if (RefPtr targetFrame = m_context.hitTestResult().targetFrame()) {
             ResourceRequest resourceRequest { m_context.hitTestResult().absoluteLinkURL(), frame->loader().outgoingReferrer() };
-            FrameLoadRequest frameLoadRequest { frame->protectedDocument().releaseNonNull(), frame->document()->securityOrigin(), WTF::move(resourceRequest), { }, InitiatedByMainFrame::Unknown };
+            FrameLoadRequest frameLoadRequest { protect(frame->document()).releaseNonNull(), frame->document()->securityOrigin(), WTF::move(resourceRequest), { }, InitiatedByMainFrame::Unknown };
             frameLoadRequest.setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
             if (targetFrame->isMainFrame())
                 frameLoadRequest.setShouldOpenExternalURLsPolicy(ShouldOpenExternalURLsPolicy::ShouldAllow);

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -51,7 +51,7 @@ static RefPtr<Node> selectionShadowAncestor(LocalFrame& frame)
     RefPtr node = frame.selection().selection().base().anchorNode();
     if (!node || !node->isInShadowTree())
         return nullptr;
-    return node->protectedDocument()->ancestorNodeInThisScope(node.get());
+    return protect(node->document())->ancestorNodeInThisScope(node.get());
 }
 
 DOMSelection::DOMSelection(LocalDOMWindow& window)
@@ -424,7 +424,7 @@ String DOMSelection::toString() const
         return String();
 
     OptionSet<TextIteratorBehavior> options;
-    if (!frame->protectedDocument()->quirks().needsToCopyUserSelectNoneQuirk())
+    if (!protect(frame->document())->quirks().needsToCopyUserSelectNoneQuirk())
         options.add(TextIteratorBehavior::IgnoresUserSelectNone);
 
     auto range = frame->selection().selection().range();
@@ -437,7 +437,7 @@ RefPtr<Node> DOMSelection::shadowAdjustedNode(const Position& position) const
         return nullptr;
 
     RefPtr containerNode = position.containerNode();
-    RefPtr adjustedNode = frame()->protectedDocument()->ancestorNodeInThisScope(containerNode.get());
+    RefPtr adjustedNode = protect(frame()->document())->ancestorNodeInThisScope(containerNode.get());
     if (!adjustedNode)
         return nullptr;
 
@@ -453,7 +453,7 @@ unsigned DOMSelection::shadowAdjustedOffset(const Position& position) const
         return 0;
 
     RefPtr containerNode = position.containerNode();
-    RefPtr adjustedNode = frame()->protectedDocument()->ancestorNodeInThisScope(containerNode.get());
+    RefPtr adjustedNode = protect(frame()->document())->ancestorNodeInThisScope(containerNode.get());
     if (!adjustedNode)
         return 0;
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -966,7 +966,7 @@ String DOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow& activeWind
     // We can't figure anything out if we are operating on a RemoteDOMWindow and don't have a remote frame
     if (!localDocument && !remoteFrame)
         return String();
-    Ref activeOrigin = activeWindow.protectedDocument()->securityOrigin();
+    Ref activeOrigin = protect(activeWindow.document())->securityOrigin();
     const Ref targetOrigin = localDocument ? localDocument->securityOrigin() : remoteFrame->frameDocumentSecurityOriginOrOpaque();
     ASSERT(!activeOrigin->isSameOriginDomain(targetOrigin));
 
@@ -1033,7 +1033,7 @@ bool DOMWindow::isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const
 
         // This check only makes sense with LocalDOMWindows as RemoteDOMWindows necessarily have different origins
         RefPtr localDocument = documentIfLocal();
-        if (localDocument && activeWindow.protectedDocument()->protectedSecurityOrigin()->isSameOriginDomain(localDocument->protectedSecurityOrigin()))
+        if (localDocument && protect(activeWindow.document())->protectedSecurityOrigin()->isSameOriginDomain(localDocument->protectedSecurityOrigin()))
             return false;
     }
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -341,7 +341,7 @@ Variant<std::optional<DragOperation>, RemoteUserInputEventData> DragController::
         return std::nullopt;
     }
 
-    mouseMovedIntoDocument(hitTestResult.innerNode() ? RefPtr { hitTestResult.innerNode()->protectedDocument() } : nullptr);
+    mouseMovedIntoDocument(hitTestResult.innerNode() ? RefPtr { protect(hitTestResult.innerNode()->document()) } : nullptr);
 
     m_dragDestinationActionMask = dragData.dragDestinationActionMask();
     if (m_dragDestinationActionMask.isEmpty()) {
@@ -1038,7 +1038,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
 
     Ref dataTransfer = *state.dataTransfer;
     if (state.type == DragSourceAction::DHTML) {
-        dragImage = DragImage { dataTransfer->createDragImage(src.protectedDocument().get(), dragImageOffset) };
+        dragImage = DragImage { dataTransfer->createDragImage(protect(src.document()).get(), dragImageOffset) };
         // We allow DHTML/JS to set the drag image, even if its a link, image or text we're dragging.
         // This is in the spirit of the IE API, which allows overriding of pasteboard data and DragOp.
         if (dragImage) {
@@ -1136,7 +1136,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
     }
 
     if (!src.document()->protectedSecurityOrigin()->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton())) {
-        src.protectedDocument()->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Not allowed to drag local resource: "_s, linkURL.stringCenterEllipsizedToLength()));
+        protect(src.document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Not allowed to drag local resource: "_s, linkURL.stringCenterEllipsizedToLength()));
         return false;
     }
 
@@ -1584,7 +1584,7 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
 
 void DragController::finalizeDroppedImagePlaceholder(HTMLImageElement& placeholder, CompletionHandler<void()>&& completion)
 {
-    placeholder.protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [completion = WTF::move(completion), placeholder = Ref { placeholder }] () mutable {
+    protect(placeholder.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [completion = WTF::move(completion), placeholder = Ref { placeholder }] () mutable {
         if (placeholder->isDroppedImagePlaceholder()) {
             placeholder->removeAttribute(HTMLNames::heightAttr);
             placeholder->removeInlineStyleProperty(CSSPropertyBackgroundColor);

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -724,7 +724,7 @@ static HashSet<URL> collectMediaAndLinkURLs(const Element& element)
 enum class IsNearbyTarget : bool { No, Yes };
 static std::optional<TargetedElementInfo> targetedElementInfo(Element& element, IsNearbyTarget isNearbyTarget, ElementSelectorCache& cache, const WeakHashSet<Element, WeakPtrImplWithEventTargetData>& adjustedElements)
 {
-    element.protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(element.document())->updateLayoutIgnorePendingStylesheets();
 
     FloatRect boundsInClientCoordinates;
     RectEdges<bool> offsetEdges;
@@ -2087,7 +2087,7 @@ RefPtr<Image> ElementTargetingController::snapshotIgnoringVisibilityAdjustment(N
         return { };
 
     ClearVisibilityAdjustmentForScope clearAdjustmentScope { *element };
-    element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(element->document())->updateLayoutIgnorePendingStylesheets();
 
     CheckedPtr renderer = element->renderer();
     if (!renderer)

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -540,7 +540,7 @@ void FocusController::setFocusedInternal(bool focused)
     RefPtr focusedFrame = focusedLocalFrame();
     if (focusedFrame && focusedFrame->view()) {
         focusedFrame->checkedSelection()->setFocused(focused);
-        dispatchEventsOnWindowAndFocusedElement(focusedFrame->protectedDocument().get(), focused);
+        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()).get(), focused);
     }
 }
 
@@ -576,7 +576,7 @@ FocusableElementSearchResult FocusController::findFocusableElementDescendingInto
         auto* localContentFrame = dynamicDowncast<LocalFrame>(owner->contentFrame());
         if (!localContentFrame || !localContentFrame->document())
             break;
-        localContentFrame->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+        protect(localContentFrame->document())->updateLayoutIgnorePendingStylesheets();
         auto findResult = findFocusableElementWithinScope(direction, FocusNavigationScope::scopeOwnedByIFrame(*owner), nullptr, focusEventData, shouldFocusElement);
         if (!findResult.element)
             break;
@@ -1132,7 +1132,7 @@ void FocusController::setActiveInternal(bool active)
 
     RefPtr focusedFrame = focusedLocalFrame();
     if (focusedFrame && isFocused())
-        dispatchEventsOnWindowAndFocusedElement(focusedFrame->protectedDocument().get(), active);
+        dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()).get(), active);
 }
 
 static void contentAreaDidShowOrHide(ScrollableArea* scrollableArea, bool didShow)
@@ -1288,7 +1288,7 @@ bool FocusController::advanceFocusDirectionallyInContainer(const ContainerNode& 
         ASSERT(is<LocalFrame>(frameElement->contentFrame()));
 
         if (focusCandidate.isOffscreenAfterScrolling) {
-            scrollInDirection(focusCandidate.visibleNode->protectedDocument(), direction);
+            scrollInDirection(protect(focusCandidate.visibleNode->document()), direction);
             return true;
         }
         // Navigate into a new frame.
@@ -1297,7 +1297,7 @@ bool FocusController::advanceFocusDirectionallyInContainer(const ContainerNode& 
         RefPtr focusedElement = focusedOrMainFrame ? focusedOrMainFrame->document()->focusedElement() : nullptr;
         if (focusedElement && !hasOffscreenRect(*focusedElement))
             rect = nodeRectInAbsoluteCoordinates(*focusedElement, true /* ignore border */);
-        dynamicDowncast<LocalFrame>(frameElement->contentFrame())->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+        protect(dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document())->updateLayoutIgnorePendingStylesheets();
         if (!advanceFocusDirectionallyInContainer(*dynamicDowncast<LocalFrame>(frameElement->contentFrame())->document(), rect, direction, focusEventData)) {
             // The new frame had nothing interesting, need to find another candidate.
             RefPtr visibleNode = focusCandidate.visibleNode.get();

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -334,8 +334,8 @@ std::optional<OwnerPermissionsPolicyData> Frame::ownerPermissionsPolicy() const
     if (!owner)
         return std::nullopt;
 
-    auto documentOrigin = owner->protectedDocument()->securityOrigin().data();
-    auto documentPolicy = owner->protectedDocument()->permissionsPolicy();
+    auto documentOrigin = protect(owner->document())->securityOrigin().data();
+    auto documentPolicy = protect(owner->document())->permissionsPolicy();
 
     RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(owner);
     auto containerPolicy = iframe ? PermissionsPolicy::processPermissionsPolicyAttribute(*iframe) : PermissionsPolicy::PolicyDirective { };

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -197,7 +197,7 @@ RefPtr<Frame> FrameTree::scopedChild(unsigned index) const
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_thisFrame.get());
     if (!localFrame)
         return nullptr;
-    return scopedChild(index, localFrame->protectedDocument().get());
+    return scopedChild(index, protect(localFrame->document()).get());
 }
 
 RefPtr<Frame> FrameTree::scopedChildByUniqueName(const AtomString& uniqueName) const
@@ -207,7 +207,7 @@ RefPtr<Frame> FrameTree::scopedChildByUniqueName(const AtomString& uniqueName) c
         return nullptr;
     return scopedChild([&](auto& frameTree) {
         return frameTree.uniqueName() == uniqueName;
-    }, localFrame->protectedDocument().get());
+    }, protect(localFrame->document()).get());
 }
 
 RefPtr<Frame> FrameTree::scopedChildBySpecifiedName(const AtomString& specifiedName) const
@@ -217,14 +217,14 @@ RefPtr<Frame> FrameTree::scopedChildBySpecifiedName(const AtomString& specifiedN
         return childBySpecifiedName(specifiedName);
     return scopedChild([&](auto& frameTree) {
         return frameTree.specifiedName() == specifiedName;
-    }, localFrame->protectedDocument().get());
+    }, protect(localFrame->document()).get());
 }
 
 unsigned FrameTree::scopedChildCount() const
 {
     if (m_scopedChildCount == invalidCount) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_thisFrame.get()))
-            m_scopedChildCount = scopedChildCount(localFrame->protectedDocument().get());
+            m_scopedChildCount = scopedChildCount(protect(localFrame->document()).get());
     }
     return m_scopedChildCount;
 }

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -66,7 +66,7 @@ History::History(LocalDOMWindow& window)
 
 static bool isDocumentFullyActive(LocalFrame* frame)
 {
-    return frame && frame->protectedDocument()->isFullyActive();
+    return frame && protect(frame->document())->isFullyActive();
 }
 
 static Exception documentNotFullyActive()

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -66,7 +66,7 @@ LargestContentfulPaintData::~LargestContentfulPaintData() = default;
 // https://w3c.github.io/paint-timing/#exposed-for-paint-timing
 bool LargestContentfulPaintData::isExposedForPaintTiming(const Element& element)
 {
-    if (!element.protectedDocument()->isFullyActive())
+    if (!protect(element.document())->isFullyActive())
         return false;
 
     if (!element.isInDocumentTree()) // Also checks isConnected().

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -250,7 +250,7 @@ LocalFrame::~LocalFrame()
     if (!loader->isComplete())
         loader->closeURL();
 
-    loader->clear(protectedDocument(), false);
+    loader->clear(protect(document()), false);
     checkedScript()->updatePlatformScriptObjects();
 
     // FIXME: We should not be doing all this work inside the destructor
@@ -299,7 +299,7 @@ void LocalFrame::setView(RefPtr<LocalFrameView>&& view)
     // notified. If we wait until the view is destroyed, then things won't be hooked up enough for
     // these calls to work.
     if (!view && m_doc && m_doc->backForwardCacheState() != Document::InBackForwardCache)
-        protectedDocument()->willBeRemovedFromFrame();
+        protect(document())->willBeRemovedFromFrame();
     
     if (RefPtr view = m_view)
         view->checkedLayoutContext()->unscheduleLayout();
@@ -438,7 +438,7 @@ void LocalFrame::invalidateContentEventRegionsIfNeeded(InvalidateContentEventReg
         return;
 
     if (RefPtr ownerElement = this->ownerElement())
-        ownerElement->protectedDocument()->invalidateEventRegionsForFrame(*ownerElement);
+        protect(ownerElement->document())->invalidateEventRegionsForFrame(*ownerElement);
 }
 
 #if ENABLE(ORIENTATION_EVENTS)
@@ -878,7 +878,7 @@ void LocalFrame::clearTimers(LocalFrameView *view, Document *document)
 
 void LocalFrame::clearTimers()
 {
-    clearTimers(protectedView().get(), protectedDocument().get());
+    clearTimers(protectedView().get(), protect(document()).get());
 }
 
 CheckedRef<ScriptController> LocalFrame::checkedScript()
@@ -1351,7 +1351,7 @@ void LocalFrame::frameWasDisconnectedFromOwner() const
     if (RefPtr window = m_doc->window())
         window->willDetachDocumentFromFrame();
 
-    protectedDocument()->detachFromFrame();
+    protect(document())->detachFromFrame();
 }
 
 void LocalFrame::storageAccessExceptionReceivedForDomain(const RegistrableDomain& domain)

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3171,7 +3171,7 @@ void LocalFrameView::maintainScrollPositionAtScrollToTextFragmentRange(SimpleRan
 
 void LocalFrameView::scrollElementToRect(const Element& element, const IntRect& rect)
 {
-    m_frame->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(m_frame->document())->updateLayoutIgnorePendingStylesheets();
 
     LayoutRect bounds;
     if (RenderElement* renderer = element.renderer())
@@ -3452,7 +3452,7 @@ TemporarySelectionChange LocalFrameView::revealRangeWithTemporarySelection(const
         TemporarySelectionOption::UserTriggered,
         TemporarySelectionOption::ForceCenterScroll
     };
-    return { range.startContainer().protectedDocument(), { range }, defaultOptions | extraOptions };
+    return { protect(range.startContainer().document()), { range }, defaultOptions | extraOptions };
 }
 
 static ScrollPositionChangeOptions scrollPositionChangeOptionsForElement(const LocalFrameView& frameView, Element* element, const ScrollRectToVisibleOptions& options)
@@ -5322,7 +5322,7 @@ void LocalFrameView::updateScrollCorner()
         m_scrollCorner = nullptr;
     else {
         if (!m_scrollCorner) {
-            m_scrollCorner = createRenderer<RenderScrollbarPart>(renderer->protectedDocument(), WTF::move(*cornerStyle));
+            m_scrollCorner = createRenderer<RenderScrollbarPart>(protect(renderer->document()), WTF::move(*cornerStyle));
             m_scrollCorner->initializeStyle();
         } else
             m_scrollCorner->setStyle(WTF::move(*cornerStyle));

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -82,7 +82,7 @@ String Navigator::appVersion() const
     if (!frame)
         return String();
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::AppVersion);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*protect(frame->document()), NavigatorAPIsAccessed::AppVersion);
     return NavigatorBase::appVersion();
 }
 
@@ -92,7 +92,7 @@ const String& Navigator::userAgent() const
     if (!frame || !frame->page())
         return m_userAgent;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::UserAgent);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*protect(frame->document()), NavigatorAPIsAccessed::UserAgent);
 
 #if PLATFORM(IOS_FAMILY)
     if (RefPtr document = frame->document(); document && document->quirks().needsChromeOSNavigatorUserAgentQuirk(*document)) {
@@ -270,10 +270,10 @@ void Navigator::initializePluginAndMimeTypeArrays()
         return;
 
     RefPtr frame = this->frame();
-    bool needsEmptyNavigatorPluginsQuirk = frame && frame->document() && frame->protectedDocument()->quirks().shouldNavigatorPluginsBeEmpty();
+    bool needsEmptyNavigatorPluginsQuirk = frame && frame->document() && protect(frame->document())->quirks().shouldNavigatorPluginsBeEmpty();
     if (!frame || !frame->page() || needsEmptyNavigatorPluginsQuirk) {
         if (needsEmptyNavigatorPluginsQuirk)
-            frame->protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Info, "QUIRK: Navigator plugins / mimeTypes empty on marcus.com. More information at https://bugs.webkit.org/show_bug.cgi?id=248798"_s);
+            protect(frame->document())->addConsoleMessage(MessageSource::Other, MessageLevel::Info, "QUIRK: Navigator plugins / mimeTypes empty on marcus.com. More information at https://bugs.webkit.org/show_bug.cgi?id=248798"_s);
         m_plugins = DOMPluginArray::create(*this);
         m_mimeTypes = DOMMimeTypeArray::create(*this);
         return;
@@ -316,7 +316,7 @@ void Navigator::initializePluginAndMimeTypeArrays()
 DOMPluginArray& Navigator::plugins()
 {
     if (RefPtr frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::Plugins);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*protect(frame->document()), NavigatorAPIsAccessed::Plugins);
 
     initializePluginAndMimeTypeArrays();
     return *m_plugins;
@@ -325,7 +325,7 @@ DOMPluginArray& Navigator::plugins()
 DOMMimeTypeArray& Navigator::mimeTypes()
 {
     if (RefPtr frame = this->frame(); frame && frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::MimeTypes);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*protect(frame->document()), NavigatorAPIsAccessed::MimeTypes);
 
     initializePluginAndMimeTypeArrays();
     return *m_mimeTypes;
@@ -345,7 +345,7 @@ bool Navigator::cookieEnabled() const
         return false;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*frame->protectedDocument(), NavigatorAPIsAccessed::CookieEnabled);
+        ResourceLoadObserver::singleton().logNavigatorAPIAccessed(*protect(frame->document()), NavigatorAPIsAccessed::CookieEnabled);
 
     RefPtr page = frame->page();
     if (!page)
@@ -467,7 +467,7 @@ NavigatorUAData& Navigator::userAgentData() const
     RefPtr frame = this->frame();
     if (frame && frame->page()) {
         RefPtr client = frame->loader().client();
-        if (client->hasCustomUserAgent() || (frame->document() && frame->protectedDocument()->quirks().needsCustomUserAgentData())) {
+        if (client->hasCustomUserAgent() || (frame->document() && protect(frame->document())->quirks().needsCustomUserAgentData())) {
             auto userAgentString = frame->loader().userAgent({ });
             Ref parser = UserAgentStringParser::create(userAgentString);
             std::optional userAgentStringData = parser->parse();

--- a/Source/WebCore/page/PageGroupLoadDeferrer.cpp
+++ b/Source/WebCore/page/PageGroupLoadDeferrer.cpp
@@ -50,7 +50,7 @@ PageGroupLoadDeferrer::PageGroupLoadDeferrer(Page& page, bool deferSelf)
             RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
-            localFrame->protectedDocument()->suspendScheduledTasks(ReasonForSuspension::WillDeferLoading);
+            protect(localFrame->document())->suspendScheduledTasks(ReasonForSuspension::WillDeferLoading);
         }
     }
 
@@ -72,7 +72,7 @@ PageGroupLoadDeferrer::~PageGroupLoadDeferrer()
             RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
             if (!localFrame)
                 continue;
-            localFrame->protectedDocument()->resumeScheduledTasks(ReasonForSuspension::WillDeferLoading);
+            protect(localFrame->document())->resumeScheduledTasks(ReasonForSuspension::WillDeferLoading);
         }
     }
 }

--- a/Source/WebCore/page/PerformanceEventTiming.cpp
+++ b/Source/WebCore/page/PerformanceEventTiming.cpp
@@ -58,7 +58,7 @@ RefPtr<Node> PerformanceEventTiming::target() const
     if (!node || !node->isConnected())
         return nullptr;
 
-    if (!node->protectedDocument()->isFullyActive())
+    if (!protect(node->document())->isFullyActive())
         return nullptr;
 
     return node;

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -366,7 +366,7 @@ void PointerCaptureController::dispatchEventForTouchAtIndex(EventTarget& target,
     bool shouldWaitForSyntheticClick = [&] {
 #if PLATFORM(IOS_FAMILY)
         if (platformTouchEvent.isPotentialTap())
-            return currentTarget->protectedDocument()->quirks().shouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick();
+            return protect(currentTarget->document())->quirks().shouldDispatchPointerOutAndLeaveAfterHandlingSyntheticClick();
 #endif
         return false;
     }();

--- a/Source/WebCore/page/PointerLockController.cpp
+++ b/Source/WebCore/page/PointerLockController.cpp
@@ -265,7 +265,7 @@ void PointerLockController::didLosePointerLock()
     if (!m_unlockPending)
         m_documentAllowedToRelockWithoutUserGesture = nullptr;
 
-    enqueueEvent(eventNames().pointerlockchangeEvent, m_element ? m_element->protectedDocument().ptr() : RefPtr { m_documentOfRemovedElementWhileWaitingForUnlock.get() }.get());
+    enqueueEvent(eventNames().pointerlockchangeEvent, m_element ? protect(m_element->document()).ptr() : RefPtr { m_documentOfRemovedElementWhileWaitingForUnlock.get() }.get());
     clearElement();
     m_unlockPending = false;
     m_documentOfRemovedElementWhileWaitingForUnlock = nullptr;
@@ -308,7 +308,7 @@ void PointerLockController::clearElement()
 void PointerLockController::enqueueEvent(const AtomString& type, Element* element)
 {
     if (element)
-        enqueueEvent(type, element->protectedDocument().ptr());
+        enqueueEvent(type, protect(element->document()).ptr());
 }
 
 void PointerLockController::enqueueEvent(const AtomString& type, Document* document)

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -276,7 +276,7 @@ void PrintContext::spoolPage(GraphicsContext& ctx, int pageNumber, float width)
     ctx.translate(-pageRect.x(), -pageRect.y());
     ctx.clip(pageRect);
     frame->view()->paintContents(ctx, pageRect);
-    outputLinkedDestinations(ctx, *frame->protectedDocument(), pageRect);
+    outputLinkedDestinations(ctx, *protect(frame->document()), pageRect);
     ctx.restore();
 }
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1239,7 +1239,7 @@ void Quirks::triggerOptionalStorageAccessIframeQuirk(const URL& frameURL, Comple
         if (document->frame() && !m_document->frame()->isMainFrame()) {
             Ref mainFrame = document->frame()->mainFrame();
             if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(mainFrame); localMainFrame && localMainFrame->document()) {
-                localMainFrame->protectedDocument()->quirks().triggerOptionalStorageAccessIframeQuirk(frameURL, WTF::move(completionHandler));
+                protect(localMainFrame->document())->quirks().triggerOptionalStorageAccessIframeQuirk(frameURL, WTF::move(completionHandler));
                 return;
             }
         }

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -81,7 +81,7 @@ int Screen::height() const
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Height);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::Height);
 
     if (shouldFlipScreenDimensions(*frame))
         return static_cast<int>(frame->screenSize().width());
@@ -95,7 +95,7 @@ int Screen::width() const
     if (!frame)
         return 0;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::Width);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::Width);
 
     if (shouldFlipScreenDimensions(*frame))
         return static_cast<int>(frame->screenSize().height());
@@ -109,7 +109,7 @@ unsigned Screen::colorDepth() const
     if (!frame)
         return 24;
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::ColorDepth);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::ColorDepth);
     return static_cast<unsigned>(screenDepth(frame->protectedView().get()));
 }
 
@@ -120,7 +120,7 @@ int Screen::availLeft() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailLeft);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::AvailLeft);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
@@ -135,7 +135,7 @@ int Screen::availTop() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailTop);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::AvailTop);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
@@ -150,7 +150,7 @@ int Screen::availHeight() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailHeight);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::AvailHeight);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().height());
@@ -165,7 +165,7 @@ int Screen::availWidth() const
         return 0;
 
     if (frame->settings().webAPIStatisticsEnabled())
-        ResourceLoadObserver::singleton().logScreenAPIAccessed(*frame->protectedDocument(), ScreenAPIsAccessed::AvailWidth);
+        ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::AvailWidth);
 
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().width());
@@ -176,7 +176,7 @@ int Screen::availWidth() const
 ScreenOrientation& Screen::orientation()
 {
     if (!m_screenOrientation)
-        m_screenOrientation = ScreenOrientation::create(window() ? window()->protectedDocument().get() : nullptr);
+        m_screenOrientation = ScreenOrientation::create(window() ? protect(window()->document()).get() : nullptr);
     return *m_screenOrientation;
 }
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -332,7 +332,7 @@ bool scrollInDirection(LocalFrame* frame, FocusDirection direction)
 {
     ASSERT(frame);
 
-    if (frame && canScrollInDirection(*frame->protectedDocument(), direction)) {
+    if (frame && canScrollInDirection(*protect(frame->document()), direction)) {
         LayoutUnit dx;
         LayoutUnit dy;
         switch (direction) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -117,7 +117,7 @@ static inline bool checkFrameAncestors(ContentSecurityPolicySourceListDirective*
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*current);
         if (!localFrame)
             continue;
-        URL origin = urlFromOrigin(localFrame->protectedDocument()->protectedSecurityOrigin());
+        URL origin = urlFromOrigin(protect(localFrame->document())->protectedSecurityOrigin());
         if (!origin.isValid() || !directive->allows(origin, didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone::No))
             return false;
     }

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -450,7 +450,7 @@ void ContentChangeObserver::didAddMouseMoveRelatedEventListener(const AtomString
     if (!isObservingContentChanges())
         return;
 
-    if (!node.protectedDocument()->quirks().shouldTreatAddingMouseOutEventListenerAsContentChange())
+    if (!protect(node.document())->quirks().shouldTreatAddingMouseOutEventListenerAsContentChange())
         return;
 
     if (eventType != eventNames().mouseoutEvent)

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -117,7 +117,7 @@ void LocalFrame::setViewportArguments(const ViewportArguments& arguments)
 
 NSArray *LocalFrame::wordsInCurrentParagraph() const
 {
-    protectedDocument()->updateLayout();
+    protect(document())->updateLayout();
 
     if (!page() || !page()->selection().isCaret())
         return nil;
@@ -488,7 +488,7 @@ static inline NodeQualifier ancestorRespondingToClickEventsNodeQualifier(Securit
             *nodeBounds = IntRect();
 
         auto node = hitTestResult.innerNode();
-        if (!node || (securityOrigin && !securityOrigin->isSameOriginAs(node->protectedDocument()->protectedSecurityOrigin())))
+        if (!node || (securityOrigin && !securityOrigin->isSameOriginAs(protect(node->document())->protectedSecurityOrigin())))
             return nullptr;
 
         for (; node && node != terminationNode; node = node->parentInComposedTree()) {

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -431,7 +431,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
 
     if (element->isLink()) {
         if (auto href = element->attributeWithoutSynchronization(HTMLNames::hrefAttr); !href.isEmpty()) {
-            if (auto url = element->protectedDocument()->completeURL(href); !url.isEmpty()) {
+            if (auto url = protect(element->document())->completeURL(href); !url.isEmpty()) {
                 if (context.mergeParagraphs)
                     return { WTF::move(url) };
 
@@ -476,7 +476,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
 
         return { ContentEditableData {
             .isPlainTextOnly = !element->hasRichlyEditableStyle(),
-            .isFocused = element->protectedDocument()->activeElement() == element,
+            .isFocused = protect(element->document())->activeElement() == element,
         } };
     }
 
@@ -513,7 +513,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
             labelText(*control),
             input ? input->placeholder() : nullString(),
             shouldTreatAsPasswordField(element.get()),
-            element->protectedDocument()->activeElement() == control
+            protect(element->document())->activeElement() == control
         };
 
         if (context.mergeParagraphs && control->isTextField())
@@ -862,7 +862,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
 
         if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(node); iframe && item) {
             if (RefPtr frame = dynamicDowncast<LocalFrame>(iframe->contentFrame())) {
-                if (RefPtr document = frame->document(); document && areSameOrigin(*document, node.protectedDocument()))
+                if (RefPtr document = frame->document(); document && areSameOrigin(*document, protect(node.document())))
                     item->children.appendVector(extractItem(Request { context.originalRequest }, *frame).children);
             }
         }
@@ -1446,7 +1446,7 @@ static void dispatchSimulatedClick(Node& targetNode, const String& searchText, C
         return dispatchSimulatedClick(*frame, centerInRootView, WTF::move(completion));
     }
 
-    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, element->protectedDocument().ptr() };
+    UserGestureIndicator indicator { IsProcessingUserGesture::Yes, protect(element->document()).ptr() };
 
     // Fall back to dispatching a programmatic click.
     if (element->dispatchSimulatedClick(nullptr, SendMouseUpDownEvents))
@@ -1586,7 +1586,7 @@ static void simulateKeyPress(LocalFrame& targetFrame, std::optional<NodeIdentifi
         if (!focusTarget)
             return completion(false, makeString(identifier->loggingString()));
 
-        if (focusTarget != focusTarget->protectedDocument()->activeElement())
+        if (focusTarget != protect(focusTarget->document())->activeElement())
             focusTarget->focus();
     }
 

--- a/Source/WebCore/platform/DragImage.cpp
+++ b/Source/WebCore/platform/DragImage.cpp
@@ -85,7 +85,7 @@ struct ScopedNodeDragEnabler {
     {
         if (element)
             element->setBeingDragged(true);
-        frame.protectedDocument()->updateLayout();
+        protect(frame.document())->updateLayout();
     }
 
     ~ScopedNodeDragEnabler()
@@ -162,7 +162,7 @@ struct ScopedFrameSelectionState {
 
 DragImageRef createDragImageForRange(LocalFrame& frame, const SimpleRange& range, bool forceBlackText)
 {
-    frame.protectedDocument()->updateLayout();
+    protect(frame.document())->updateLayout();
     RenderView* view = frame.contentRenderer();
     if (!view)
         return nullptr;

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -61,7 +61,7 @@ OutlinePainter::OutlinePainter(const PaintInfo& paintInfo)
 
 static float deviceScaleFactor(const RenderElement& renderer)
 {
-    return renderer.protectedDocument()->deviceScaleFactor();
+    return protect(renderer.document())->deviceScaleFactor();
 }
 
 void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRect& paintRect) const
@@ -699,7 +699,7 @@ void OutlinePainter::addPDFURLAnnotationForLink(const RenderElement& renderer, c
             return;
         }
     }
-    m_paintInfo.context().setURLForRect(element->protectedDocument()->completeURL(href), urlRect);
+    m_paintInfo.context().setURLForRect(protect(element->document())->completeURL(href), urlRect);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1226,7 +1226,7 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
     }
 
     // 3. paint selection
-    if (!protectedDocument()->printing()) {
+    if (!protect(document())->printing()) {
         // Fill in gaps in selection on lines, between blocks and "empty space" when content is skipped.
         paintSelection(paintInfo, scrolledOffset);
     }
@@ -1670,7 +1670,7 @@ LayoutRect RenderBlock::blockSelectionGap(RenderBlock& rootBlock, const LayoutPo
 
     LayoutRect gapRect = rootBlock.logicalRectToPhysicalRect(rootBlockPhysicalPosition, LayoutRect(logicalLeft, logicalTop, logicalWidth, logicalHeight));
     if (paintInfo)
-        paintInfo->context().fillRect(snapRectToDevicePixels(gapRect, protectedDocument()->deviceScaleFactor()), selectionBackgroundColor());
+        paintInfo->context().fillRect(snapRectToDevicePixels(gapRect, protect(document())->deviceScaleFactor()), selectionBackgroundColor());
     return gapRect;
 }
 
@@ -1686,7 +1686,7 @@ LayoutRect RenderBlock::logicalLeftSelectionGap(RenderBlock& rootBlock, const La
 
     LayoutRect gapRect = rootBlock.logicalRectToPhysicalRect(rootBlockPhysicalPosition, LayoutRect(rootBlockLogicalLeft, rootBlockLogicalTop, rootBlockLogicalWidth, logicalHeight));
     if (paintInfo)
-        paintInfo->context().fillRect(snapRectToDevicePixels(gapRect, protectedDocument()->deviceScaleFactor()), selObj->selectionBackgroundColor());
+        paintInfo->context().fillRect(snapRectToDevicePixels(gapRect, protect(document())->deviceScaleFactor()), selObj->selectionBackgroundColor());
     return gapRect;
 }
 
@@ -1702,7 +1702,7 @@ LayoutRect RenderBlock::logicalRightSelectionGap(RenderBlock& rootBlock, const L
 
     LayoutRect gapRect = rootBlock.logicalRectToPhysicalRect(rootBlockPhysicalPosition, LayoutRect(rootBlockLogicalLeft, rootBlockLogicalTop, rootBlockLogicalWidth, logicalHeight));
     if (paintInfo)
-        paintInfo->context().fillRect(snapRectToDevicePixels(gapRect, protectedDocument()->deviceScaleFactor()), selObj->selectionBackgroundColor());
+        paintInfo->context().fillRect(snapRectToDevicePixels(gapRect, protect(document())->deviceScaleFactor()), selObj->selectionBackgroundColor());
     return gapRect;
 }
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -405,7 +405,7 @@ void RenderBlockFlow::computeColumnCountAndWidth()
     LayoutUnit desiredColumnWidth = contentBoxLogicalWidth();
 
     // For now, we don't support multi-column layouts when printing, since we have to do a lot of work for proper pagination.
-    if (protectedDocument()->paginated() || (style().columnCount().isAuto() && style().columnWidth().isAuto()) || !style().hasInlineColumnAxis()) {
+    if (protect(document())->paginated() || (style().columnCount().isAuto() && style().columnWidth().isAuto()) || !style().hasInlineColumnAxis()) {
         setComputedColumnCountAndWidth(desiredColumnCount, desiredColumnWidth);
         return;
     }
@@ -3921,7 +3921,7 @@ void RenderBlockFlow::invalidateLineLayout(InvalidationReason invalidationReason
 
     switch (invalidationReason) {
     case InvalidationReason::InternalMove:
-        if (AXObjectCache* cache = protectedDocument()->existingAXObjectCache())
+        if (AXObjectCache* cache = protect(document())->existingAXObjectCache())
             cache->deferRecomputeIsIgnored(protectedElement().get());
         break;
     case InvalidationReason::ContentChange: {
@@ -4114,7 +4114,7 @@ RenderBlockFlow::InlineContentStatus RenderBlockFlow::markInlineContentDirtyForL
             renderer.clearNeedsLayout();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-        if (CheckedPtr cache = protectedDocument()->existingAXObjectCache())
+        if (CheckedPtr cache = protect(document())->existingAXObjectCache())
             cache->onTextRunsChanged(renderer);
 #endif
 
@@ -4244,7 +4244,7 @@ void RenderBlockFlow::layoutInlineContent(RelayoutChildren relayoutChildren, Lay
     setLogicalHeight(borderBoxLogicalHeight);
     updateRepaintTopAndBottomAfterLayout(relayoutChildren, partialRepaintRect, oldContentTopAndBottomIncludingInkOverflow, repaintLogicalTop, repaintLogicalBottom);
 
-    if (CheckedPtr cache = protectedDocument()->existingAXObjectCache())
+    if (CheckedPtr cache = protect(document())->existingAXObjectCache())
         cache->onLaidOutInlineContent(*this);
 }
 
@@ -4434,7 +4434,7 @@ void RenderBlockFlow::adjustComputedFontSizes(float size, float visibleWidth)
             float candidateNewSize = roundf(std::min(minFontSize, specifiedSize * lineTextMultiplier));
 
             if (candidateNewSize > specifiedSize && candidateNewSize != fontDescription.computedSize() && text.textNode() && oldStyle.textSizeAdjust().isAuto())
-                protectedDocument()->textAutoSizing().addTextNode(*text.protectedTextNode(), candidateNewSize);
+                protect(document())->textAutoSizing().addTextNode(*text.protectedTextNode(), candidateNewSize);
         }
 
         descendant = RenderObjectTraversal::nextSkippingChildren(text, this);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2109,7 +2109,7 @@ void RenderBox::imageChanged(WrappedImagePtr image, const IntRect*)
     if (styleImage && isNonEmpty) {
         incrementVisuallyNonEmptyPixelCountIfNeeded(flooredIntSize(styleImage->imageSize(this, style().usedZoom())));
         if (auto styleable = Styleable::fromRenderer(*this))
-            protectedDocument()->didLoadImage(styleable->protectedElement().get(), styleImage->cachedImage());
+            protect(document())->didLoadImage(styleable->protectedElement().get(), styleImage->cachedImage());
     }
 
     if (!isComposited())

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -567,7 +567,7 @@ bool RenderElement::repaintBeforeStyleChange(Style::Difference diff, const Rende
 
 void RenderElement::initializeStyle()
 {
-    Style::loadPendingResources(m_style, protectedDocument(), protectedElement().get());
+    Style::loadPendingResources(m_style, protect(document()), protectedElement().get());
 
     styleWillChange(Style::DifferenceResult::NewStyle, style());
     m_hasInitializedStyle = true;
@@ -615,7 +615,7 @@ void RenderElement::setStyle(RenderStyle&& style, Style::DifferenceResult minima
     diff.result = std::max(diff.result, minimalStyleDifference);
     diff = adjustStyleDifference(diff);
 
-    Style::loadPendingResources(style, protectedDocument(), protectedElement().get());
+    Style::loadPendingResources(style, protect(document()), protectedElement().get());
 
     auto didRepaint = repaintBeforeStyleChange(diff, m_style, style);
     styleWillChange(diff, style);
@@ -943,7 +943,7 @@ void RenderElement::styleWillChange(Style::Difference diff, const RenderStyle& n
             || m_style.usedZIndex() != newStyle.usedZIndex();
 
         if (visibilityChanged)
-            protectedDocument()->invalidateRenderingDependentRegions();
+            protect(document())->invalidateRenderingDependentRegions();
 
         bool inertChanged = m_style.effectiveInert() != newStyle.effectiveInert();
 
@@ -1839,7 +1839,7 @@ std::unique_ptr<RenderStyle> RenderElement::getUncachedPseudoStyle(const Style::
     if (!resolvedStyle)
         return nullptr;
 
-    Style::loadPendingResources(*resolvedStyle->style, protectedDocument(), element.ptr());
+    Style::loadPendingResources(*resolvedStyle->style, protect(document()), element.ptr());
 
     return WTF::move(resolvedStyle->style);
 }

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -343,7 +343,7 @@ void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
 
     if (auto* image = cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protectedDocument()->didLoadImage(styleable->protectedElement().get(), image);
+            protect(document())->didLoadImage(styleable->protectedElement().get(), image);
     }
 }
 
@@ -699,7 +699,7 @@ void RenderImage::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
             if (auto styleable = Styleable::fromRenderer(*this)) {
                 auto localVisibleRect = visibleRect;
                 localVisibleRect.moveBy(-paintOffset);
-                protectedDocument()->didPaintImage(styleable->element, cachedImage(), localVisibleRect);
+                protect(document())->didPaintImage(styleable->element, cachedImage(), localVisibleRect);
             }
         }
     }

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -881,7 +881,7 @@ void RenderInline::imageChanged(WrappedImagePtr image, const IntRect*)
     RefPtr styleImage = Style::findLayerUsedImage(style().backgroundLayers(), image, isNonEmpty);
     if (styleImage && isNonEmpty) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protectedDocument()->didLoadImage(styleable->protectedElement().get(), styleImage->cachedImage());
+            protect(document())->didLoadImage(styleable->protectedElement().get(), styleImage->cachedImage());
     }
 
     // FIXME: We can do better.

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3604,7 +3604,7 @@ GraphicsLayer* RenderLayerBacking::childForSuperlayers() const
     if (m_owningLayer.isRenderViewLayer()) {
         // If the document element is captured, then the RenderView's layer will get attached
         // into the view-transition tree, and we instead want to attach the root of the VT tree to our ancestor.
-        if (m_owningLayer.renderer().protectedDocument()->activeViewTransitionCapturedDocumentElement()) {
+        if (protect(m_owningLayer.renderer().document())->activeViewTransitionCapturedDocumentElement()) {
             if (WeakPtr viewTransitionContainingBlock = m_owningLayer.renderer().view().viewTransitionContainingBlock(); viewTransitionContainingBlock && viewTransitionContainingBlock->hasLayer() && viewTransitionContainingBlock->layer()->backing())
                 return viewTransitionContainingBlock->layer()->backing()->childForSuperlayers();
         }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1032,7 +1032,7 @@ static std::optional<ScrollingNodeID> frameHostingNodeForFrame(LocalFrame& frame
         return { };
 
     // Find the frame's enclosing layer in our render tree.
-    RefPtr ownerElement = frame.protectedDocument()->ownerElement();
+    RefPtr ownerElement = protect(frame.document())->ownerElement();
     if (!ownerElement)
         return { };
 
@@ -1686,7 +1686,7 @@ void RenderLayerCompositor::collectViewTransitionNewContentLayers(RenderLayer& l
     if (!downcast<RenderViewTransitionCapture>(layer.renderer()).canUseExistingLayers())
         return;
 
-    RefPtr activeViewTransition = layer.renderer().protectedDocument()->activeViewTransition();
+    RefPtr activeViewTransition = protect(layer.renderer().document())->activeViewTransition();
     if (!activeViewTransition)
         return;
 
@@ -1703,7 +1703,7 @@ void RenderLayerCompositor::collectViewTransitionNewContentLayers(RenderLayer& l
         return;
 
     if (capturedRenderer->isDocumentElementRenderer()) {
-        ASSERT(capturedRenderer->protectedDocument()->activeViewTransitionCapturedDocumentElement());
+        ASSERT(protect(capturedRenderer->document())->activeViewTransitionCapturedDocumentElement());
         capturedRenderer = &capturedRenderer->view();
         ASSERT(capturedRenderer->hasLayer());
     }
@@ -1853,7 +1853,7 @@ void RenderLayerCompositor::updateBackingAndHierarchy(RenderLayer& layer, Vector
         // Layers that are captured in a view transition get manually parented to their pseudo in collectViewTransitionNewContentLayers.
         // The view transition root (when the document element is captured) gets parented in RenderLayerBacking::childForSuperlayers.
         bool skipAddToEnclosing = layer.renderer().capturedInViewTransition() && !layer.renderer().isDocumentElementRenderer();
-        if (layer.renderer().isViewTransitionContainingBlock() && layer.renderer().protectedDocument()->activeViewTransitionCapturedDocumentElement())
+        if (layer.renderer().isViewTransitionContainingBlock() && protect(layer.renderer().document())->activeViewTransitionCapturedDocumentElement())
             skipAddToEnclosing = true;
 
         if (!skipAddToEnclosing)
@@ -3907,7 +3907,7 @@ bool RenderLayerCompositor::requiresCompositingForBackfaceVisibility(RenderLayer
 
 bool RenderLayerCompositor::requiresCompositingForViewTransition(RenderLayerModelObject& renderer) const
 {
-    return renderer.effectiveCapturedInViewTransition() || renderer.isRenderViewTransitionCapture() || renderer.isViewTransitionContainingBlock() || (renderer.isRenderView() && renderer.protectedDocument()->activeViewTransition());
+    return renderer.effectiveCapturedInViewTransition() || renderer.isRenderViewTransitionCapture() || renderer.isViewTransitionContainingBlock() || (renderer.isRenderView() && protect(renderer.document())->activeViewTransition());
 }
 
 bool RenderLayerCompositor::requiresCompositingForVideo(RenderLayerModelObject& renderer) const
@@ -5251,7 +5251,7 @@ void RenderLayerCompositor::attachRootLayer(RootLayerAttachment attachment)
         case RootLayerAttachedViaEnclosingFrame: {
             // The layer will get hooked up via RenderLayerBacking::updateConfiguration()
             // for the frame's renderer in the parent document.
-            if (RefPtr ownerElement = m_renderView.protectedDocument()->ownerElement()) {
+            if (RefPtr ownerElement = protect(m_renderView.document())->ownerElement()) {
                 ownerElement->scheduleInvalidateStyleAndLayerComposition();
                 if (CheckedPtr renderer = ownerElement->renderer())
                     renderer->repaint();
@@ -5286,7 +5286,7 @@ void RenderLayerCompositor::detachRootLayer()
         else
             RefPtr { m_rootContentsLayer }->removeFromParent();
 
-        if (RefPtr ownerElement = m_renderView.protectedDocument()->ownerElement())
+        if (RefPtr ownerElement = protect(m_renderView.document())->ownerElement())
             ownerElement->scheduleInvalidateStyleAndLayerComposition();
 
         if (auto frameRootScrollingNodeID = m_renderView.frameView().scrollingNodeID()) {
@@ -5341,7 +5341,7 @@ void RenderLayerCompositor::notifyIFramesOfCompositingChange()
 {
     // Compositing affects the answer to RenderIFrame::requiresAcceleratedCompositing(), so
     // we need to schedule a style recalc in our parent document.
-    if (RefPtr ownerElement = m_renderView.protectedDocument()->ownerElement())
+    if (RefPtr ownerElement = protect(m_renderView.document())->ownerElement())
         ownerElement->scheduleInvalidateStyleAndLayerComposition();
 }
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -514,7 +514,7 @@ RenderSVGResourceMasker* RenderLayerModelObject::svgMaskerResourceFromStyle() co
     if (!maskImage)
         return nullptr;
 
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImage->url(), protectedDocument());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImage->url(), protect(document()));
 
     if (RefPtr referencedMaskElement = ReferencedSVGResources::referencedMaskElement(treeScopeForSVGReferences(), *maskImage)) {
         if (auto* referencedMaskerRenderer = dynamicDowncast<RenderSVGResourceMasker>(referencedMaskElement->renderer()))

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -389,7 +389,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
         }
 
         // Update regions, scrolling may change the clip of a particular region.
-        renderer.protectedDocument()->invalidateRenderingDependentRegions();
+        protect(renderer.document())->invalidateRenderingDependentRegions();
         DebugPageOverlays::didLayout(renderer.protectedFrame());
     }
 
@@ -433,7 +433,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     // Schedule the scroll and scroll-related DOM events.
     if (RefPtr element = renderer.element()) {
         setIsAwaitingScrollend(true);
-        element->protectedDocument()->addPendingScrollEventTarget(*element, ScrollEventType::Scroll);
+        protect(element->document())->addPendingScrollEventTarget(*element, ScrollEventType::Scroll);
     }
 
     if (scrollsOverflow())
@@ -449,7 +449,7 @@ void RenderLayerScrollableArea::scrollDidEnd()
         return;
     setIsAwaitingScrollend(false);
     if (RefPtr element = m_layer.renderer().element())
-        element->protectedDocument()->addPendingScrollEventTarget(*element, ScrollEventType::Scrollend);
+        protect(element->document())->addPendingScrollEventTarget(*element, ScrollEventType::Scrollend);
 }
 
 void RenderLayerScrollableArea::updateCompositingLayersAfterScroll()
@@ -1832,7 +1832,7 @@ void RenderLayerScrollableArea::updateScrollCornerStyle()
     }
 
     if (!m_scrollCorner) {
-        m_scrollCorner = createRenderer<RenderScrollbarPart>(renderer.protectedDocument(), WTF::move(*corner));
+        m_scrollCorner = createRenderer<RenderScrollbarPart>(protect(renderer.document()), WTF::move(*corner));
         // FIXME: A renderer should be a child of its parent!
         m_scrollCorner->setParent(&renderer);
         m_scrollCorner->initializeStyle();
@@ -1863,7 +1863,7 @@ void RenderLayerScrollableArea::updateResizerStyle()
     }
 
     if (!m_resizer) {
-        m_resizer = createRenderer<RenderScrollbarPart>(renderer.protectedDocument(), WTF::move(*resizer));
+        m_resizer = createRenderer<RenderScrollbarPart>(protect(renderer.document()), WTF::move(*resizer));
         // FIXME: A renderer should be a child of its parent!
         m_resizer->setParent(&renderer);
         m_resizer->initializeStyle();
@@ -2042,7 +2042,7 @@ bool RenderLayerScrollableArea::mockScrollbarsControllerEnabled() const
 
 void RenderLayerScrollableArea::logMockScrollbarsControllerMessage(const String& message) const
 {
-    m_layer.renderer().protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Debug, makeString("RenderLayer: "_s, message));
+    protect(m_layer.renderer().document())->addConsoleMessage(MessageSource::Other, MessageLevel::Debug, makeString("RenderLayer: "_s, message));
 }
 
 String RenderLayerScrollableArea::debugDescription() const
@@ -2067,7 +2067,7 @@ void RenderLayerScrollableArea::animatedScrollDidEnd()
 
 float RenderLayerScrollableArea::deviceScaleFactor() const
 {
-    return m_layer.renderer().protectedDocument()->deviceScaleFactor();
+    return protect(m_layer.renderer().document())->deviceScaleFactor();
 }
 
 void RenderLayerScrollableArea::updateAnchorPositionedAfterScroll()

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -1201,7 +1201,7 @@ void RenderListBox::scrollDidEnd()
 {
     if (ScrollAnimator* scrollAnimator = existingScrollAnimator(); scrollAnimator && !scrollAnimator->isUserScrollInProgress() && !isAwaitingScrollend()) {
         setIsAwaitingScrollend(false);
-        selectElement().protectedDocument()->addPendingScrollEventTarget(selectElement(), ScrollEventType::Scrollend);
+        protect(selectElement().document())->addPendingScrollEventTarget(selectElement(), ScrollEventType::Scrollend);
     }
 }
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2243,7 +2243,7 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
 {
     Vector<FloatRect> rects;
 
-    range.start.protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(range.start.document())->updateLayoutIgnorePendingStylesheets();
 
     bool useVisibleBounds = behavior.contains(RenderObject::BoundingRectBehavior::UseVisibleBounds);
 
@@ -2285,7 +2285,7 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
                         continue;
                     auto snappedBounds = snapRectToDevicePixels(rootClippedBounds->clippedOverflowRect, node->document().deviceScaleFactor());
                     if (space == CoordinateSpace::Client)
-                        node->protectedDocument()->convertAbsoluteToClientRect(snappedBounds, renderer->style());
+                        protect(node->document())->convertAbsoluteToClientRect(snappedBounds, renderer->style());
                     rects.append(snappedBounds);
                     continue;
                 }
@@ -2293,14 +2293,14 @@ static Vector<FloatRect> borderAndTextRects(const SimpleRange& range, Coordinate
                 Vector<FloatQuad> elementQuads;
                 renderer->absoluteQuads(elementQuads);
                 if (space == CoordinateSpace::Client)
-                    node->protectedDocument()->convertAbsoluteToClientQuads(elementQuads, renderer->style());
+                    protect(node->document())->convertAbsoluteToClientQuads(elementQuads, renderer->style());
                 rects.appendVector(boundingBoxes(elementQuads));
             }
         } else if (auto* textNode = dynamicDowncast<Text>(node.get())) {
             if (CheckedPtr renderer = textNode->renderer()) {
                 auto clippedRects = absoluteRectsForRangeInText(range, *textNode, behavior);
                 if (space == CoordinateSpace::Client)
-                    node->protectedDocument()->convertAbsoluteToClientRects(clippedRects, renderer->style());
+                    protect(node->document())->convertAbsoluteToClientRects(clippedRects, renderer->style());
                 rects.appendVector(clippedRects);
             }
         }
@@ -2446,7 +2446,7 @@ static bool usesVisuallyContiguousBidiTextSelection(const SimpleRange& range)
     UNUSED_PARAM(range);
     return false;
 #else
-    return range.protectedStartContainer()->protectedDocument()->settings().visuallyContiguousBidiTextSelectionEnabled();
+    return protect(range.protectedStartContainer()->document())->settings().visuallyContiguousBidiTextSelectionEnabled();
 #endif
 }
 

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -260,7 +260,7 @@ void RenderScrollbar::updateScrollbarPart(ScrollbarPart partType)
     if (auto& partRendererSlot = m_parts.add(partType, nullptr).iterator->value)
         partRendererSlot->setStyle(WTF::move(*partStyle));
     else {
-        partRendererSlot = createRenderer<RenderScrollbarPart>(owningRenderer()->protectedDocument(), WTF::move(*partStyle), this, partType);
+        partRendererSlot = createRenderer<RenderScrollbarPart>(protect(owningRenderer()->document()), WTF::move(*partStyle), this, partType);
         partRendererSlot->initializeStyle();
     }
 }

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -251,7 +251,7 @@ LayoutUnit RenderSearchField::clientPaddingRight() const
 
 FontSelector* RenderSearchField::fontSelector() const
 {
-    return &protectedDocument()->fontSelector();
+    return &protect(document())->fontSelector();
 }
 
 HostWindow* RenderSearchField::hostWindow() const

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -868,7 +868,7 @@ bool RenderTheme::paint(const RenderBox& box, ControlPart& part, const PaintInfo
 
     updateControlPartForRenderer(part, box);
 
-    float deviceScaleFactor = box.protectedDocument()->deviceScaleFactor();
+    float deviceScaleFactor = protect(box.document())->deviceScaleFactor();
     auto zoomedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
     auto borderShape = BorderShape::shapeForBorderRect(box.checkedStyle().get(), LayoutRect(zoomedRect));
     auto controlStyle = extractControlStyleForRenderer(box);
@@ -896,7 +896,7 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     if (!canPaint(paintInfo, box.settings(), appearance)) [[unlikely]]
         return false;
 
-    float deviceScaleFactor = box.protectedDocument()->deviceScaleFactor();
+    float deviceScaleFactor = protect(box.document())->deviceScaleFactor();
     FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, deviceScaleFactor);
 
     switch (appearance) {
@@ -1019,7 +1019,7 @@ void RenderTheme::paintDecorations(const RenderBox& box, const PaintInfo& paintI
     if (paintInfo.context().paintingDisabled())
         return;
 
-    FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, box.protectedDocument()->deviceScaleFactor());
+    FloatRect devicePixelSnappedRect = snapRectToDevicePixels(rect, protect(box.document())->deviceScaleFactor());
 
     // Call the appropriate paint method based off the appearance value.
     switch (box.style().usedAppearance()) {

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -261,7 +261,7 @@ void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
     if (paintInfo.phase == PaintPhase::Foreground) {
         page->addRelevantRepaintedObject(*this, rect);
         if (displayingPoster && !context.paintingDisabled())
-            protectedDocument()->didPaintImage(videoElement.get(), cachedImage(), videoBoxRect);
+            protect(document())->didPaintImage(videoElement.get(), cachedImage(), videoBoxRect);
     }
 
     LayoutRect contentRect = contentBoxRect();

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -174,7 +174,7 @@ bool RenderView::isChildAllowed(const RenderObject& child, const RenderStyle&) c
 void RenderView::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
-    if (!protectedDocument()->paginated())
+    if (!protect(document())->paginated())
         m_pageLogicalSize = { };
 
     if (shouldUsePrintingLayout()) {
@@ -219,7 +219,7 @@ void RenderView::layout()
 
 void RenderView::updateQuirksMode()
 {
-    m_layoutState->updateQuirksMode(protectedDocument());
+    m_layoutState->updateQuirksMode(protect(document()));
 }
 
 void RenderView::updateInitialContainingBlockSize()
@@ -369,7 +369,7 @@ RenderElement* RenderView::rendererForRootBackground() const
     if (documentRenderer.shouldApplyAnyContainment())
         return nullptr;
 
-    if (RefPtr body = protectedDocument()->body()) {
+    if (RefPtr body = protect(document())->body()) {
         if (auto* renderer = body->renderer()) {
             if (!renderer->shouldApplyAnyContainment())
                 return renderer;
@@ -414,7 +414,7 @@ void RenderView::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint&)
     // FIXME: This needs to be dynamic.  We should be able to go back to blitting if we ever stop being inside
     // a transform, transparency layer, etc.
     Ref document = this->document();
-    for (RefPtr element = document->ownerElement(); element && element->renderer(); element = element->protectedDocument()->ownerElement()) {
+    for (RefPtr element = document->ownerElement(); element && element->renderer(); element = protect(element->document())->ownerElement()) {
         CheckedPtr layer = element->renderer()->enclosingLayer();
         if (layer->cannotBlitToWindow()) {
             frameView().setCannotBlitToWindow();
@@ -582,7 +582,7 @@ void RenderView::flushAccumulatedRepaintRegion() const
     IntSize rectOffset;
 
     CheckedPtr<RenderBox> iframeOwnerRenderer;
-    if (RefPtr ownerElement = protectedDocument()->ownerElement()) {
+    if (RefPtr ownerElement = protect(document())->ownerElement()) {
         iframeOwnerRenderer = ownerElement->renderBox();
         if (!iframeOwnerRenderer) {
             m_accumulatedRepaintRegion = nullptr;
@@ -646,7 +646,7 @@ auto RenderView::computeVisibleRectsInContainer(const RepaintRects& rects, const
 
     // Apply our transform if we have one (because of full page zooming).
     if (!container && hasLayer() && layer()->transform())
-        adjustedRects.transform(*layer()->transform(), protectedDocument()->deviceScaleFactor());
+        adjustedRects.transform(*layer()->transform(), protect(document())->deviceScaleFactor());
 
     return adjustedRects;
 }
@@ -674,7 +674,7 @@ void RenderView::absoluteQuads(Vector<FloatQuad>& quads, bool* wasFixed) const
 
 bool RenderView::printing() const
 {
-    return protectedDocument()->printing();
+    return protect(document())->printing();
 }
 
 bool RenderView::shouldUsePrintingLayout() const

--- a/Source/WebCore/rendering/TextPaintStyle.cpp
+++ b/Source/WebCore/rendering/TextPaintStyle.cpp
@@ -117,7 +117,7 @@ TextPaintStyle computeTextPaintStyle(const RenderText& renderer, const RenderSty
     paintStyle.fillColor = lineStyle.visitedDependentTextFillColorApplyingColorFilter(paintInfo.paintBehavior);
 
     bool forceBackgroundToWhite = false;
-    if (frame->document() && frame->protectedDocument()->printing()) {
+    if (frame->document() && protect(frame->document())->printing()) {
         if (lineStyle.printColorAdjust() == PrintColorAdjust::Economy)
             forceBackgroundToWhite = true;
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1895,7 +1895,7 @@ static std::pair<RefPtr<Image>, float> createAttachmentPlaceholderImage(float de
 
 static void paintAttachmentIconPlaceholder(const RenderAttachment& attachment, GraphicsContext& context, AttachmentLayout& layout)
 {
-    auto [placeholderImage, imageScale] = createAttachmentPlaceholderImage(attachment.protectedDocument()->deviceScaleFactor(), layout);
+    auto [placeholderImage, imageScale] = createAttachmentPlaceholderImage(protect(attachment.document())->deviceScaleFactor(), layout);
 
     // Center the placeholder image where the icon would usually be.
     FloatRect placeholderRect(0, 0, placeholderImage->width() / imageScale, placeholderImage->height() / imageScale);
@@ -1948,7 +1948,7 @@ static void paintAttachmentProgress(const RenderAttachment& attachment, Graphics
 
         FloatRect progressRect = progressBounds;
         progressRect.setWidth(progressRect.width() * progress);
-        progressRect = encloseRectToDevicePixels(progressRect, attachment.protectedDocument()->deviceScaleFactor());
+        progressRect = encloseRectToDevicePixels(progressRect, protect(attachment.document())->deviceScaleFactor());
 
         context.fillRect(progressRect, attachmentProgressBarFillColor);
     }
@@ -2003,7 +2003,7 @@ bool RenderThemeMac::paintAttachment(const RenderElement& renderer, const PaintI
     GraphicsContextStateSaver saver(context);
 
     context.translate(toFloatSize(paintRect.location()));
-    context.translate(floorSizeToDevicePixels({ LayoutUnit((paintRect.width() - attachmentIconBackgroundSize) / 2), 0 }, renderer.protectedDocument()->deviceScaleFactor()));
+    context.translate(floorSizeToDevicePixels({ LayoutUnit((paintRect.width() - attachmentIconBackgroundSize) / 2), 0 }, protect(renderer.document())->deviceScaleFactor()));
 
     bool usePlaceholder = validProgress && !progress;
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -301,7 +301,7 @@ void RenderMathMLRoot::paint(PaintInfo& info, const LayoutPoint& paintOffset)
         horizontalOffset += horizontal.kernBeforeDegree + indexWidth + horizontal.kernAfterDegree;
     }
     radicalOperatorTopLeft.move(mirrorIfNeeded(horizontalOffset, m_radicalOperator.width()), m_radicalOperatorTop);
-    m_radicalOperator.paint(style(), info, radicalOperatorTopLeft, protectedDocument()->deviceScaleFactor());
+    m_radicalOperator.paint(style(), info, radicalOperatorTopLeft, protect(document())->deviceScaleFactor());
 
     // We draw the radical line.
     LayoutUnit ruleThickness = verticalParameters().ruleThickness;

--- a/Source/WebCore/rendering/style/StyleCachedImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCachedImage.cpp
@@ -126,7 +126,7 @@ LegacyRenderSVGResourceContainer* StyleCachedImage::uncheckedRenderSVGResource(c
     }
 
     if (!m_cachedImage) {
-        auto fragmentIdentifier = SVGURIReference::fragmentIdentifierFromIRIString(m_url, renderer->protectedDocument());
+        auto fragmentIdentifier = SVGURIReference::fragmentIdentifierFromIRIString(m_url, protect(renderer->document()));
         return uncheckedRenderSVGResource(renderer->treeScopeForSVGReferences(), fragmentIdentifier);
     }
 

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -230,7 +230,7 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 
         auto localVisibleRect = visibleRect;
         localVisibleRect.moveBy(-paintOffset);
-        protectedDocument()->didPaintImage(protectedImageElement().get(), cachedImage(), localVisibleRect);
+        protect(document())->didPaintImage(protectedImageElement().get(), cachedImage(), localVisibleRect);
     }
 }
 
@@ -368,7 +368,7 @@ void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
 
     if (auto* image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protectedDocument()->didLoadImage(styleable->protectedElement().get(), image);
+            protect(document())->didLoadImage(styleable->protectedElement().get(), image);
     }
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -267,7 +267,7 @@ bool RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
     auto fontDescription = style.fontDescription();
 
     // FIXME: We need to better handle the case when we compute very small fonts below (below 1pt).
-    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), scalingFactor, renderer.protectedDocument()));
+    fontDescription.setComputedSize(Style::computedFontSizeFromSpecifiedSizeForSVGInlineText(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), scalingFactor, protect(renderer.document())));
 
     // SVG controls its own glyph orientation, so don't allow writing-mode
     // to affect it.

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -261,7 +261,7 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
         if (!element)
             return;
 
-        auto fragment = SVGURIReference::fragmentIdentifierFromIRIString(value, element->protectedDocument());
+        auto fragment = SVGURIReference::fragmentIdentifierFromIRIString(value, protect(element->document()));
         writeIfNotEmpty(ts, name, fragment);
     };
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -234,7 +234,7 @@ void LegacyRenderSVGImage::paintForeground(PaintInfo& paintInfo)
 
     auto* cachedImage = imageResource().cachedImage();
     if (cachedImage && !context.paintingDisabled())
-        protectedDocument()->didPaintImage(imageElement(), cachedImage, destRect);
+        protect(document())->didPaintImage(imageElement(), cachedImage, destRect);
 }
 
 void LegacyRenderSVGImage::invalidateBufferedForeground()
@@ -298,7 +298,7 @@ void LegacyRenderSVGImage::imageChanged(WrappedImagePtr, const IntRect*)
 
     if (auto* image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protectedDocument()->didLoadImage(styleable->protectedElement().get(), image);
+            protect(document())->didLoadImage(styleable->protectedElement().get(), image);
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -166,7 +166,7 @@ static inline String targetReferenceFromResource(SVGElement& element)
     else
         ASSERT_NOT_REACHED();
 
-    return SVGURIReference::fragmentIdentifierFromIRIString(target, element.protectedDocument());
+    return SVGURIReference::fragmentIdentifierFromIRIString(target, protect(element.document()));
 }
 
 static inline bool isChainableResource(const SVGElement& element, const SVGElement& linkedResource)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -459,7 +459,7 @@ void RenderTreeBuilder::attachToRenderElement(RenderElement& parent, RenderPtr<R
         if (afterChild && afterChild->isAnonymous() && !afterChild->isBeforeContent())
             table = afterChild;
         else {
-            auto newTable = Table::createAnonymousTableWithStyle(parent.protectedDocument(), parent.style());
+            auto newTable = Table::createAnonymousTableWithStyle(protect(parent.document()), parent.style());
             table = newTable.get();
             attach(parent, WTF::move(newTable), beforeChild);
         }
@@ -783,7 +783,7 @@ void RenderTreeBuilder::createAnonymousWrappersForInlineContent(RenderBlock& par
 
         child = inlineRunEnd->nextSibling();
 
-        auto newBlock = Block::createAnonymousBlockWithStyle(parent.protectedDocument(), parent.style());
+        auto newBlock = Block::createAnonymousBlockWithStyle(protect(parent.document()), parent.style());
         auto& block = *newBlock;
         attachToRenderElementInternal(parent, WTF::move(newBlock), inlineRunStart);
         moveChildren(parent, block, inlineRunStart, child, RenderTreeBuilder::NormalizeAfterInsertion::No);
@@ -853,7 +853,7 @@ void RenderTreeBuilder::childFlowStateChangesAndAffectsParentBlock(RenderElement
     }
     // An anonymous block must be made to wrap this inline.
     auto* parent = child.parent();
-    auto newBlock = Block::createAnonymousBlockWithStyle(parent->protectedDocument(), parent->style());
+    auto newBlock = Block::createAnonymousBlockWithStyle(protect(parent->document()), parent->style());
     auto& block = *newBlock;
     attachToRenderElementInternal(*parent, WTF::move(newBlock), &child);
     auto thisToMove = detachFromRenderElement(*parent, child, WillBeDestroyed::No);
@@ -1176,19 +1176,19 @@ void RenderTreeBuilder::removeFloatingObjects(RenderBlock& renderer)
 RenderPtr<RenderBox> RenderTreeBuilder::createAnonymousBoxWithSameTypeAndWithStyle(const RenderBox& renderer, const RenderStyle& style)
 {
     if (is<RenderTableCell>(renderer))
-        return Table::createAnonymousTableCellWithStyle(renderer.protectedDocument(), style);
+        return Table::createAnonymousTableCellWithStyle(protect(renderer.document()), style);
 
     if (is<RenderTableRow>(renderer))
-        return Table::createAnonymousTableRowWithStyle(renderer.protectedDocument(), style);
+        return Table::createAnonymousTableRowWithStyle(protect(renderer.document()), style);
 
     if (is<RenderTableSection>(renderer))
-        return Table::createAnonymousTableSectionWithStyle(renderer.protectedDocument(), style);
+        return Table::createAnonymousTableSectionWithStyle(protect(renderer.document()), style);
 
     if (is<RenderTable>(renderer))
-        return Table::createAnonymousTableWithStyle(renderer.protectedDocument(), style);
+        return Table::createAnonymousTableWithStyle(protect(renderer.document()), style);
 
     if (is<RenderBlock>(renderer))
-        return Block::createAnonymousBlockWithStyle(renderer.protectedDocument(), style);
+        return Block::createAnonymousBlockWithStyle(protect(renderer.document()), style);
 
     ASSERT_NOT_REACHED();
     return { };

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -279,7 +279,7 @@ void RenderTreeBuilder::Block::attachIgnoringContinuation(RenderBlock& parent, R
     }
 
     // No suitable existing anonymous box - create a new one.
-    auto newBox = Block::createAnonymousBlockWithStyle(parent.protectedDocument(), parent.style());
+    auto newBox = Block::createAnonymousBlockWithStyle(protect(parent.document()), parent.style());
     auto& box = *newBox;
     m_builder.attachToRenderElement(parent, WTF::move(newBox), beforeChild);
     m_builder.attach(box, WTF::move(child));

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -67,7 +67,7 @@ RenderBlock& RenderTreeBuilder::FormControls::findOrCreateParentForChild(RenderB
     if (innerRenderer)
         return *innerRenderer;
 
-    auto wrapper = Block::createAnonymousBlockWithStyle(parent.protectedDocument(), parent.style());
+    auto wrapper = Block::createAnonymousBlockWithStyle(protect(parent.document()), parent.style());
     innerRenderer = wrapper.get();
     m_builder.blockBuilder().attach(parent, WTF::move(wrapper), nullptr);
     parent.setInnerRenderer(*innerRenderer);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -258,7 +258,7 @@ void RenderTreeBuilder::Inline::splitFlow(RenderInline& parent, RenderObject* be
         block = block->containingBlock();
     } else {
         // No anonymous block available for use. Make one.
-        createdPre = Block::createAnonymousBlockWithStyle(block->protectedDocument(), block->style());
+        createdPre = Block::createAnonymousBlockWithStyle(protect(block->document()), block->style());
         pre = createdPre.get();
         madeNewBeforeBlock = true;
     }
@@ -426,7 +426,7 @@ void RenderTreeBuilder::Inline::childBecameNonInline(RenderInline& parent, Rende
         return;
 
     // We have to split the parent flow.
-    auto newBox = Block::createAnonymousBlockWithStyle(parent.containingBlock()->protectedDocument(), parent.containingBlock()->style());
+    auto newBox = Block::createAnonymousBlockWithStyle(protect(parent.containingBlock()->document()), parent.containingBlock()->style());
     newBox->setIsContinuation();
     auto* oldContinuation = parent.continuation();
     if (oldContinuation)

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
@@ -59,7 +59,7 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableR
     }
 
     auto createAnonymousTableCell = [&] (auto& parent) -> RenderTableCell& {
-        auto newCell = createAnonymousTableCellWithStyle(parent.protectedDocument(), parent.style());
+        auto newCell = createAnonymousTableCellWithStyle(protect(parent.document()), parent.style());
         auto& cell = *newCell;
         m_builder.attach(parent, WTF::move(newCell), beforeChild);
         beforeChild = nullptr;
@@ -120,7 +120,7 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableS
     if (auto* tableRow = dynamicDowncast<RenderTableRow>(parentCandidate); tableRow && tableRow->isAnonymous() && !tableRow->isBeforeOrAfterContent())
         return *tableRow;
 
-    auto newRow = createAnonymousTableRowWithStyle(parent.protectedDocument(), parent.style());
+    auto newRow = createAnonymousTableRowWithStyle(protect(parent.document()), parent.style());
     auto& row = *newRow;
     m_builder.attach(parent, WTF::move(newRow), beforeChild);
     beforeChild = nullptr;
@@ -185,7 +185,7 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTable&
         && beforeChild->style().display() != DisplayType::TableColumnGroup)
         beforeChild = nullptr;
 
-    auto newSection = createAnonymousTableSectionWithStyle(parent.protectedDocument(), parent.style());
+    auto newSection = createAnonymousTableSectionWithStyle(protect(parent.document()), parent.style());
     auto& section = *newSection;
     m_builder.attach(parent, WTF::move(newSection), beforeChild);
     beforeChild = nullptr;

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -102,7 +102,7 @@ RefPtr<CSSPrimitiveValue> Extractor::getFontSizeCSSValuePreferringKeyword() cons
     if (!element)
         return nullptr;
 
-    element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+    protect(element->document())->updateLayoutIgnorePendingStylesheets();
 
     auto* style = element->computedStyle(m_pseudoElementIdentifier);
     if (!style)
@@ -426,7 +426,7 @@ const RenderStyle* Extractor::computeStyle(CSSPropertyID propertyID, UpdateLayou
             document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.get());
         else if (forcedLayout == ForcedLayout::ParentDocument) {
             if (RefPtr owner = document->ownerElement())
-                owner->protectedDocument()->updateLayout();
+                protect(owner->document())->updateLayout();
             else
                 forcedLayout = ForcedLayout::No;
         }
@@ -544,7 +544,7 @@ bool Extractor::propertyMatches(CSSPropertyID propertyID, const CSSValue* value)
         return false;
     if (propertyID == CSSPropertyFontSize) {
         if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(*value)) {
-            m_element->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+            protect(m_element->document())->updateLayoutIgnorePendingStylesheets();
             if (auto* style = m_element->computedStyle(m_pseudoElementIdentifier)) {
                 if (CSSValueID sizeIdentifier = style->fontDescription().keywordSizeAsIdentifier()) {
                     if (primitiveValue->isValueID() && primitiveValue->valueID() == sizeIdentifier)

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -809,7 +809,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
             styleable.updateCSSViewTimelines(oldStyle, *resolvedStyle.style);
 
         if ((oldStyle && oldStyle->timelineScope().type != NameScope::Type::None) || resolvedStyle.style->timelineScope().type != NameScope::Type::None) {
-            CheckedRef styleOriginatedTimelinesController = element->protectedDocument()->ensureStyleOriginatedTimelinesController();
+            CheckedRef styleOriginatedTimelinesController = protect(element->document())->ensureStyleOriginatedTimelinesController();
             styleOriginatedTimelinesController->updateNamedTimelineMapForTimelineScope(resolvedStyle.style->timelineScope(), styleable);
         }
 

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -299,7 +299,7 @@ void Styleable::animationWasRemoved(WebAnimation& animation) const
 void Styleable::elementWasRemoved() const
 {
     cancelStyleOriginatedAnimations();
-    if (CheckedPtr styleOriginatedTimelinesController = element.protectedDocument()->styleOriginatedTimelinesController())
+    if (CheckedPtr styleOriginatedTimelinesController = protect(element.document())->styleOriginatedTimelinesController())
         styleOriginatedTimelinesController->styleableWasRemoved(*this);
 }
 
@@ -321,11 +321,11 @@ void Styleable::cancelStyleOriginatedAnimations() const
     // It is important we don't cancel style-originated animations when entering the page cache
     // since any JS wrapper that is kept alive in the page cache could be associated with an animation
     // that itself has not been kept alive (or rather canceled) when entering the page cache.
-    if (element.protectedDocument()->backForwardCacheState() != Document::NotInBackForwardCache)
+    if (protect(element.document())->backForwardCacheState() != Document::NotInBackForwardCache)
         return;
 
     cancelStyleOriginatedAnimations({ });
-    if (CheckedPtr styleOriginatedTimelinesController = element.protectedDocument()->styleOriginatedTimelinesController())
+    if (CheckedPtr styleOriginatedTimelinesController = protect(element.document())->styleOriginatedTimelinesController())
         styleOriginatedTimelinesController->unregisterNamedTimelinesAssociatedWithElement(*this);
 }
 
@@ -866,7 +866,7 @@ void Styleable::updateCSSScrollTimelines(const RenderStyle* currentStyle, const 
         if (currentStyle && currentStyle->scrollTimelineNames() == afterChangeStyle.scrollTimelineNames() && currentStyle->scrollTimelineAxes() == afterChangeStyle.scrollTimelineAxes())
             return;
 
-        CheckedRef styleOriginatedTimelinesController = element.protectedDocument()->ensureStyleOriginatedTimelinesController();
+        CheckedRef styleOriginatedTimelinesController = protect(element.document())->ensureStyleOriginatedTimelinesController();
 
         auto& currentTimelineNames = afterChangeStyle.scrollTimelineNames();
         auto& currentTimelineAxes = afterChangeStyle.scrollTimelineAxes();
@@ -910,7 +910,7 @@ void Styleable::updateCSSViewTimelines(const RenderStyle* currentStyle, const Re
         if ((currentStyle && currentStyle->viewTimelineNames() == afterChangeStyle.viewTimelineNames()) && (currentStyle && currentStyle->viewTimelineAxes() == afterChangeStyle.viewTimelineAxes()) && (currentStyle && currentStyle->viewTimelineInsets() == afterChangeStyle.viewTimelineInsets()))
             return;
 
-        CheckedRef styleOriginatedTimelinesController = element.protectedDocument()->ensureStyleOriginatedTimelinesController();
+        CheckedRef styleOriginatedTimelinesController = protect(element.document())->ensureStyleOriginatedTimelinesController();
 
         auto& currentTimelineNames = afterChangeStyle.viewTimelineNames();
         auto& currentTimelineAxes = afterChangeStyle.viewTimelineAxes();

--- a/Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp
@@ -38,7 +38,7 @@ void FilterReference::loadExternalDocumentIfNeeded(CachedResourceLoader& cachedR
 {
     if (cachedSVGDocumentReference)
         return;
-    if (!SVGURIReference::isExternalURIReference(url.resolved.string(), *cachedResourceLoader.protectedDocument()))
+    if (!SVGURIReference::isExternalURIReference(url.resolved.string(), *protect(cachedResourceLoader.document())))
         return;
     lazyInitialize(cachedSVGDocumentReference, CachedSVGDocumentReference::create(url));
     cachedSVGDocumentReference->load(cachedResourceLoader, options);

--- a/Source/WebCore/style/values/primitives/StyleURL.cpp
+++ b/Source/WebCore/style/values/primitives/StyleURL.cpp
@@ -78,7 +78,7 @@ auto ToCSS<URL>::operator()(const URL& url, const RenderStyle&) -> CSS::URL
 
 auto ToStyle<CSS::URL>::operator()(const CSS::URL& url, const BuilderState& state) -> URL
 {
-    return toStyleWithScriptExecutionContext(url, state.protectedDocument());
+    return toStyleWithScriptExecutionContext(url, protect(state.document()));
 }
 
 Ref<CSSValue> CSSValueCreation<URL>::operator()(CSSValuePool&, const RenderStyle& style, const URL& value)

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -534,7 +534,7 @@ void SVGElement::attributeChanged(const QualifiedName& name, const AtomString& o
 
     switch (name.nodeName()) {
     case AttributeNames::idAttr:
-        protectedDocument()->checkedSVGExtensions()->rebuildAllElementReferencesForTarget(*this);
+        protect(document())->checkedSVGExtensions()->rebuildAllElementReferencesForTarget(*this);
         break;
     case AttributeNames::classAttr:
         m_className->setBaseValInternal(newValue);

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -79,7 +79,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             Ref { m_orderY }->setBaseValInternal(result->second);
 
             if (result->first < 1 || result->second < 1)
-                protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing order=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing order=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         }
         break;
     }
@@ -88,7 +88,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         if (propertyValue != EdgeModeType::Unknown)
             Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else
-            protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+            protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         break;
     }
     case AttributeNames::kernelMatrixAttr:
@@ -102,7 +102,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             Ref { m_divisor }->setBaseValInternal(*result);
 
             if (*result <= 0)
-                protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing divisor=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing divisor=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         }
         break;
     }
@@ -125,7 +125,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             Ref { m_kernelUnitLengthY }->setBaseValInternal(result->second);
 
             if (result->first < 0 || result->second < 0)
-                protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing kernelUnitLength=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing kernelUnitLength=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         }
         break;
     }
@@ -135,7 +135,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         else if (newValue == falseAtom())
             Ref { m_preserveAlpha }->setBaseValInternal(false);
         else
-            protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing preserveAlphaAttr=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+            protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing preserveAlphaAttr=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -80,7 +80,7 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
         if (propertyValue != EdgeModeType::Unknown)
             Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else
-            protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feGaussianBlur: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+            protect(document())->checkedSVGExtensions()->reportWarning(makeString("feGaussianBlur: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         break;
     }
     default:

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -89,7 +89,7 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
             Ref { m_numOctaves }->setBaseValInternal(*result);
 
             if (*result <= 0)
-                protectedDocument()->checkedSVGExtensions()->reportWarning(makeString("feTurbulence: problem parsing numOctaves=\""_s, newValue, "\". numOctaves must be > 0. Filtered element will not be displayed."_s));
+                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feTurbulence: problem parsing numOctaves=\""_s, newValue, "\". numOctaves must be > 0. Filtered element will not be displayed."_s));
         }
         break;
     }

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -296,7 +296,7 @@ void SVGFontFaceElement::rebuildFontFace()
         }
     }
 
-    protectedDocument()->styleScope().didChangeStyleSheetEnvironment();
+    protect(document())->styleScope().didChangeStyleSheetEnvironment();
 }
 
 Node::InsertedIntoAncestorResult SVGFontFaceElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
@@ -306,7 +306,7 @@ Node::InsertedIntoAncestorResult SVGFontFaceElement::insertedIntoAncestor(Insert
         ASSERT(!m_fontElement);
         return InsertedIntoAncestorResult::Done;
     }
-    protectedDocument()->svgExtensions().registerSVGFontFaceElement(*this);
+    protect(document())->svgExtensions().registerSVGFontFaceElement(*this);
 
     rebuildFontFace();
     return result;

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -104,7 +104,7 @@ void SVGForeignObjectElement::svgAttributeChanged(const QualifiedName& attrName)
 
 RenderPtr<RenderElement> SVGForeignObjectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    protectedDocument()->setMayHaveRenderedSVGForeignObjects();
+    protect(document())->setMayHaveRenderedSVGForeignObjects();
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGForeignObject>(*this, WTF::move(style));
     return createRenderer<LegacyRenderSVGForeignObject>(*this, WTF::move(style));

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -51,7 +51,7 @@ SVGGeometryElement::SVGGeometryElement(const QualifiedName& tagName, Document& d
 
 float SVGGeometryElement::getTotalLength() const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     auto* renderer = this->renderer();
     if (!renderer)
@@ -69,7 +69,7 @@ float SVGGeometryElement::getTotalLength() const
 
 ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     auto* renderer = this->renderer();
     // Spec: If current element is a non-rendered element, throw an InvalidStateError.
@@ -92,7 +92,7 @@ ExceptionOr<Ref<SVGPoint>> SVGGeometryElement::getPointAtLength(float distance) 
 
 bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     auto* renderer = this->renderer();
     if (!renderer)
@@ -111,7 +111,7 @@ bool SVGGeometryElement::isPointInFill(DOMPointInit&& pointInit)
 
 bool SVGGeometryElement::isPointInStroke(DOMPointInit&& pointInit)
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     auto* renderer = this->renderer();
     if (!renderer)
@@ -134,7 +134,7 @@ void SVGGeometryElement::attributeChanged(const QualifiedName& name, const AtomS
         Ref pathLength = m_pathLength;
         pathLength->setBaseValInternal(newValue.toFloat());
         if (pathLength->baseVal() < 0)
-            protectedDocument()->checkedSVGExtensions()->reportError("A negative value for path attribute <pathLength> is not allowed"_s);
+            protect(document())->checkedSVGExtensions()->reportError("A negative value for path attribute <pathLength> is not allowed"_s);
     }
 
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGLength.cpp
+++ b/Source/WebCore/svg/SVGLength.cpp
@@ -52,7 +52,7 @@ ExceptionOr<float> SVGLength::valueForBindings()
 
     if (requiresStyleUpdate(m_value.lengthType())) {
         if (element)
-            element->protectedDocument()->updateStyleIfNeeded();
+            protect(element->document())->updateStyleIfNeeded();
     }
 
     return m_value.valueForBindings(SVGLengthContext { element.get() });

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -78,7 +78,7 @@ FloatRect SVGLocatable::getBBox(SVGElement* element, StyleUpdateStrategy styleUp
 {
     ASSERT(element);
     if (styleUpdateStrategy == AllowStyleUpdate)
-        element->protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element);
+        protect(element->document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element);
 
     // FIXME: Eventually we should support getBBox for detached elements.
     if (!element->renderer())
@@ -91,7 +91,7 @@ AffineTransform SVGLocatable::computeCTM(SVGElement* element, CTMScope mode, Sty
 {
     ASSERT(element);
     if (styleUpdateStrategy == AllowStyleUpdate)
-        element->protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element);
+        protect(element->document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element);
 
     RefPtr stopAtElement = mode == CTMScope::NearestViewportScope ? nearestViewportElement(element) : nullptr;
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -124,7 +124,7 @@ void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomStrin
         else if (Ref { m_pathSegList }->baseVal()->parse(newValue))
             cache.add(newValue, m_pathSegList->baseVal()->existingPathByteStream().data());
         else
-            protectedDocument()->checkedSVGExtensions()->reportError(makeString("Problem parsing d=\""_s, newValue, "\""_s));
+            protect(document())->checkedSVGExtensions()->reportError(makeString("Problem parsing d=\""_s, newValue, "\""_s));
     }
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
@@ -183,14 +183,14 @@ void SVGPathElement::removedFromAncestor(RemovalType removalType, ContainerNode&
 
 float SVGPathElement::getTotalLength() const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     return getTotalLengthOfSVGPathByteStream(pathByteStream());
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGPathElement::getPointAtLength(float distance) const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     // Spec: If it is not able to compute the total length of path, then throw.
     if (pathByteStream().isEmpty())
@@ -205,7 +205,7 @@ ExceptionOr<Ref<SVGPoint>> SVGPathElement::getPointAtLength(float distance) cons
 
 unsigned SVGPathElement::getPathSegAtLength(float length) const
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     return getSVGPathSegAtLengthFromSVGPathByteStream(pathByteStream(), length);
 }
@@ -213,7 +213,7 @@ unsigned SVGPathElement::getPathSegAtLength(float length) const
 FloatRect SVGPathElement::getBBox(StyleUpdateStrategy styleUpdateStrategy)
 {
     if (styleUpdateStrategy == AllowStyleUpdate)
-        protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+        protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
 
     // FIXME: Eventually we should support getBBox for detached elements.
     // FIXME: If the path is null it means we're calling getBBox() before laying out this element,

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -52,7 +52,7 @@ void SVGPolyElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     if (name == SVGNames::pointsAttr) {
         if (!m_points->baseVal()->parse(newValue))
-            protectedDocument()->checkedSVGExtensions()->reportError(makeString("Problem parsing points=\""_s, newValue, "\""_s));
+            protect(document())->checkedSVGExtensions()->reportError(makeString("Problem parsing points=\""_s, newValue, "\""_s));
     }
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -107,7 +107,7 @@ SVGSVGElement::~SVGSVGElement()
 void SVGSVGElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
     oldDocument.unregisterForDocumentSuspensionCallbacks(*this);
-    protectedDocument()->registerForDocumentSuspensionCallbacks(*this);
+    protect(document())->registerForDocumentSuspensionCallbacks(*this);
     SVGGraphicsElement::didMoveToNewDocument(oldDocument, newDocument);
 }
 
@@ -170,7 +170,7 @@ void SVGSVGElement::updateCurrentTranslate()
 
     updateSVGRendererForElementChange();
     if (parentNode() == &document() && document().renderView())
-        protectedDocument()->checkedRenderView()->repaint();
+        protect(document())->checkedRenderView()->repaint();
 }
 
 void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -180,22 +180,22 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
         // setting certain event handlers directly on the window object.
         switch (name.nodeName()) {
         case AttributeNames::onunloadAttr:
-            protectedDocument()->setWindowAttributeEventListener(eventNames().unloadEvent, name, newValue, protectedMainThreadNormalWorld());
+            protect(document())->setWindowAttributeEventListener(eventNames().unloadEvent, name, newValue, protectedMainThreadNormalWorld());
             return;
         case AttributeNames::onresizeAttr:
-            protectedDocument()->setWindowAttributeEventListener(eventNames().resizeEvent, name, newValue, protectedMainThreadNormalWorld());
+            protect(document())->setWindowAttributeEventListener(eventNames().resizeEvent, name, newValue, protectedMainThreadNormalWorld());
             return;
         case AttributeNames::onscrollAttr:
-            protectedDocument()->setWindowAttributeEventListener(eventNames().scrollEvent, name, newValue, protectedMainThreadNormalWorld());
+            protect(document())->setWindowAttributeEventListener(eventNames().scrollEvent, name, newValue, protectedMainThreadNormalWorld());
             return;
         case AttributeNames::onzoomAttr:
-            protectedDocument()->setWindowAttributeEventListener(eventNames().zoomEvent, name, newValue, protectedMainThreadNormalWorld());
+            protect(document())->setWindowAttributeEventListener(eventNames().zoomEvent, name, newValue, protectedMainThreadNormalWorld());
             return;
         case AttributeNames::onabortAttr:
-            protectedDocument()->setWindowAttributeEventListener(eventNames().abortEvent, name, newValue, protectedMainThreadNormalWorld());
+            protect(document())->setWindowAttributeEventListener(eventNames().abortEvent, name, newValue, protectedMainThreadNormalWorld());
             return;
         case AttributeNames::onerrorAttr:
-            protectedDocument()->setWindowAttributeEventListener(eventNames().errorEvent, name, newValue, protectedMainThreadNormalWorld());
+            protect(document())->setWindowAttributeEventListener(eventNames().errorEvent, name, newValue, protectedMainThreadNormalWorld());
             return;
         default:
             break;
@@ -309,25 +309,25 @@ static bool checkEnclosureWithoutUpdatingLayout(SVGElement& element, SVGRect& re
 
 Ref<NodeList> SVGSVGElement::getIntersectionList(SVGRect& rect, SVGElement* referenceElement)
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     return collectIntersectionOrEnclosureList(rect, referenceElement, checkIntersectionWithoutUpdatingLayout);
 }
 
 Ref<NodeList> SVGSVGElement::getEnclosureList(SVGRect& rect, SVGElement* referenceElement)
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     return collectIntersectionOrEnclosureList(rect, referenceElement, checkEnclosureWithoutUpdatingLayout);
 }
 
 bool SVGSVGElement::checkIntersection(Ref<SVGElement>&& element, SVGRect& rect)
 {
-    element->protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
+    protect(element->document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
     return checkIntersectionWithoutUpdatingLayout(element, rect);
 }
 
 bool SVGSVGElement::checkEnclosure(Ref<SVGElement>&& element, SVGRect& rect)
 {
-    element->protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
+    protect(element->document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element.ptr());
     return checkEnclosureWithoutUpdatingLayout(element, rect);
 }
 
@@ -467,7 +467,7 @@ RenderPtr<RenderElement> SVGSVGElement::createElementRenderer(RenderStyle&& styl
 {
     if (isOutermostSVGSVGElement()) {
         if (document().settings().layerBasedSVGEngineEnabled()) {
-            protectedDocument()->setMayHaveRenderedSVGRootElements();
+            protect(document())->setMayHaveRenderedSVGRootElements();
             return createRenderer<RenderSVGRoot>(*this, WTF::move(style));
         }
         return createRenderer<LegacyRenderSVGRoot>(*this, WTF::move(style));
@@ -684,7 +684,7 @@ AffineTransform SVGSVGElement::viewBoxToViewTransform(float viewWidth, float vie
 
 RefPtr<SVGViewElement> SVGSVGElement::findViewAnchor(StringView fragmentIdentifier) const
 {
-    return dynamicDowncast<SVGViewElement>(protectedDocument()->findAnchor(fragmentIdentifier));
+    return dynamicDowncast<SVGViewElement>(protect(document())->findAnchor(fragmentIdentifier));
 }
 
 SVGSVGElement* SVGSVGElement::findRootAnchor(const SVGViewElement* viewElement) const

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -106,7 +106,7 @@ void SVGScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     SVGElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protectedDocument()->completeURL(href()));
+    addSubresourceURL(urls, protect(document())->completeURL(href()));
 }
 Ref<Element> SVGScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -147,7 +147,7 @@ void SVGTRefElement::updateReferencedText(Element* target)
     ASSERT(root);
     ScriptDisallowedScope::EventAllowedScope allowedScope(*root);
     if (!root->firstChild())
-        root->appendChild(Text::create(protectedDocument(), WTF::move(textContent)));
+        root->appendChild(Text::create(protect(document()), WTF::move(textContent)));
     else {
         ASSERT(root->firstChild()->isTextNode());
         root->protectedFirstChild()->setTextContent(WTF::move(textContent));
@@ -168,7 +168,7 @@ void SVGTRefElement::detachTarget()
         return;
 
     // Mark the referenced ID as pending.
-    auto target = SVGURIReference::targetElementFromIRIString(href(), protectedDocument());
+    auto target = SVGURIReference::targetElementFromIRIString(href(), protect(document()));
     if (!target.identifier.isEmpty())
         treeScopeForSVGReferences().addPendingSVGResource(target.identifier, *this);
 }

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -61,13 +61,13 @@ SVGTextContentElement::SVGTextContentElement(const QualifiedName& tagName, Docum
 
 unsigned SVGTextContentElement::getNumberOfChars()
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     return SVGTextQuery(checkedRenderer().get()).numberOfCharacters();
 }
 
 float SVGTextContentElement::getComputedTextLength()
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     return SVGTextQuery(checkedRenderer().get()).textLength();
 }
 
@@ -115,7 +115,7 @@ ExceptionOr<float> SVGTextContentElement::getRotationOfChar(unsigned charnum)
 
 int SVGTextContentElement::getCharNumAtPosition(DOMPointInit&& pointInit)
 {
-    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
+    protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     FloatPoint transformPoint {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
     return SVGTextQuery(checkedRenderer().get()).characterNumberAtPosition(transformPoint);
 }

--- a/Source/WebCore/svg/SVGTitleElement.cpp
+++ b/Source/WebCore/svg/SVGTitleElement.cpp
@@ -46,7 +46,7 @@ Node::InsertedIntoAncestorResult SVGTitleElement::insertedIntoAncestor(Insertion
 {
     auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument && parentNode() == document().documentElement())
-        protectedDocument()->titleElementAdded(*this);
+        protect(document())->titleElementAdded(*this);
     return result;
 }
 
@@ -72,7 +72,7 @@ void SVGTitleElement::childrenChanged(const ChildChange& change)
 {
     SVGElement::childrenChanged(change);
     if (isConnected() && parentNode() == document().documentElement())
-        protectedDocument()->titleElementTextChanged(*this);
+        protect(document())->titleElementTextChanged(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -142,9 +142,9 @@ bool SVGURIReference::haveLoadedRequiredResources() const
 {
     if (href().isEmpty())
         return true;
-    if (contextElement().protectedDocument()->completeURL(href()).protocolIsData())
+    if (protect(contextElement().document())->completeURL(href()).protocolIsData())
         return true;
-    if (!isExternalURIReference(href(), contextElement().protectedDocument()))
+    if (!isExternalURIReference(href(), protect(contextElement().document())))
         return true;
     return errorOccurred() || haveFiredLoadEvent();
 }

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -117,7 +117,7 @@ Node::InsertedIntoAncestorResult SVGUseElement::insertedIntoAncestor(InsertionTy
     auto result = SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument) {
         if (m_shadowTreeNeedsUpdate)
-            protectedDocument()->addElementWithPendingUserAgentShadowTreeUpdate(*this);
+            protect(document())->addElementWithPendingUserAgentShadowTreeUpdate(*this);
         invalidateShadowTree();
         // FIXME: Move back the call to updateExternalDocument() here once notifyFinished is made always async.
         return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
@@ -286,7 +286,7 @@ void SVGUseElement::updateUserAgentShadowTree()
 
     if (!isConnected())
         return;
-    protectedDocument()->removeElementWithPendingUserAgentShadowTreeUpdate(*this);
+    protect(document())->removeElementWithPendingUserAgentShadowTreeUpdate(*this);
 
     AtomString targetID;
     RefPtr target = findTarget(&targetID);
@@ -498,7 +498,7 @@ RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
         // The caller would use the target ID to wait for a pending resource on the wrong document.
         // If we ever want the change that and let the caller to wait on the external document,
         // we should change this function so it returns the appropriate document to go with the ID.
-        if (!targetID->isNull() && isExternalURIReference(original->href(), original->protectedDocument()))
+        if (!targetID->isNull() && isExternalURIReference(original->href(), protect(original->document())))
             *targetID = nullAtom();
     }
     RefPtr target = dynamicDowncast<SVGElement>(targetResult.element.get());
@@ -525,7 +525,7 @@ RefPtr<SVGElement> SVGUseElement::findTarget(AtomString* targetID) const
 
 void SVGUseElement::cloneTarget(ContainerNode& container, SVGElement& target) const
 {
-    Ref targetClone = downcast<SVGElement>(target.cloneElementWithChildren(protectedDocument(), nullptr));
+    Ref targetClone = downcast<SVGElement>(target.cloneElementWithChildren(protect(document()), nullptr));
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { targetClone };
     associateClonesWithOriginals(targetClone.get(), target);
     removeDisallowedElementsFromSubtree(targetClone.get());
@@ -558,7 +558,7 @@ void SVGUseElement::expandUseElementsInShadowTree() const
         // Spec: In the generated content, the 'use' will be replaced by 'g', where all attributes from the
         // 'use' element except for x, y, width, height and xlink:href are transferred to the generated 'g' element.
 
-        Ref replacementClone = SVGGElement::create(protectedDocument());
+        Ref replacementClone = SVGGElement::create(protect(document()));
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
 
         cloneDataAndChildren(replacementClone.get(), originalClone);
@@ -594,7 +594,7 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
         // the generated 'svg'. If attributes width and/or height are not specified, the generated
         // 'svg' element will use values of 100% for these attributes.
 
-        Ref replacementClone = SVGSVGElement::create(protectedDocument());
+        Ref replacementClone = SVGSVGElement::create(protect(document()));
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { replacementClone };
 
         cloneDataAndChildren(replacementClone.get(), originalClone);

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -97,7 +97,7 @@ RefPtr<SVGSVGElement> SVGImage::rootElement() const
     if (!localMainFrame)
         return nullptr;
 
-    return DocumentSVG::rootElement(*localMainFrame->protectedDocument());
+    return DocumentSVG::rootElement(*protect(localMainFrame->document()));
 }
 
 bool SVGImage::renderingTaintsOrigin() const
@@ -532,7 +532,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
         });
         activeDocumentLoader->writer().end();
 
-        localMainFrame->protectedDocument()->updateLayoutIgnorePendingStylesheets();
+        protect(localMainFrame->document())->updateLayoutIgnorePendingStylesheets();
 
         // Set the intrinsic size before a container size is available.
         m_intrinsicSize = containerSize();

--- a/Source/WebCore/xml/XPathExpression.cpp
+++ b/Source/WebCore/xml/XPathExpression.cpp
@@ -65,7 +65,7 @@ ExceptionOr<Ref<XPathResult>> XPathExpression::evaluate(Node& contextNode, unsig
     evaluationContext.size = 1;
     evaluationContext.position = 1;
     evaluationContext.hadTypeConversionError = false;
-    auto result = XPathResult::create(contextNode.protectedDocument().get(), m_topExpression->evaluate());
+    auto result = XPathResult::create(protect(contextNode.document()).get(), m_topExpression->evaluate());
     evaluationContext.node = nullptr; // Do not hold a reference to the context node, as this may prevent the whole document from being destroyed in time.
 
     if (evaluationContext.hadTypeConversionError)

--- a/Source/WebCore/xml/XPathNodeSet.cpp
+++ b/Source/WebCore/xml/XPathNodeSet.cpp
@@ -186,7 +186,7 @@ static inline RefPtr<Node> findRootNode(Node* node)
     if (RefPtr attr = dynamicDowncast<Attr>(*current))
         current = attr->ownerElement();
     if (current->isConnected())
-        return current->protectedDocument();
+        return protect(current->document());
     for (RefPtr parent = current->parentNode(); parent; parent = current->parentNode())
         current = WTF::move(parent);
     return current;

--- a/Source/WebCore/xml/XSLImportRule.cpp
+++ b/Source/WebCore/xml/XSLImportRule.cpp
@@ -101,7 +101,7 @@ void XSLImportRule::loadSheet()
 
     auto options = CachedResourceLoader::defaultCachedResourceOptions();
     options.mode = FetchOptions::Mode::SameOrigin;
-    m_cachedSheet = cachedResourceLoader->requestXSLStyleSheet({ ResourceRequest(cachedResourceLoader->protectedDocument()->completeURL(absHref)), options }).value_or(nullptr);
+    m_cachedSheet = cachedResourceLoader->requestXSLStyleSheet({ ResourceRequest(protect(cachedResourceLoader->document())->completeURL(absHref)), options }).value_or(nullptr);
 
     if (m_cachedSheet) {
         m_cachedSheet->addClient(*this);

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -134,7 +134,7 @@ void XMLDocumentParser::append(RefPtr<StringImpl>&& inputSource)
 void XMLDocumentParser::handleError(XMLErrors::Type type, const char* m, TextPosition position)
 {
     if (!m_xmlErrors)
-        m_xmlErrors = makeUnique<XMLErrors>(*protectedDocument());
+        m_xmlErrors = makeUnique<XMLErrors>(*protect(document()));
     m_xmlErrors->handleError(type, m, position);
     if (type != XMLErrors::Type::Warning)
         m_sawError = true;
@@ -149,7 +149,7 @@ void XMLDocumentParser::createLeafTextNode()
 
     ASSERT(m_bufferedText.size() == 0);
     ASSERT(!m_leafTextNode);
-    m_leafTextNode = Text::create(m_currentNode->protectedDocument(), String { emptyString() });
+    m_leafTextNode = Text::create(protect(m_currentNode->document()), String { emptyString() });
     if (RefPtr currentNode = m_currentNode.get())
         currentNode->parserAppendChild(*protectedLeafTextNode());
 }
@@ -211,9 +211,9 @@ void XMLDocumentParser::end()
 
     if (isParsing())
         prepareToStopParsing();
-    protectedDocument()->setReadyState(Document::ReadyState::Interactive);
+    protect(document())->setReadyState(Document::ReadyState::Interactive);
     clearCurrentNodeStack();
-    protectedDocument()->finishedParsing();
+    protect(document())->finishedParsing();
 }
 
 void XMLDocumentParser::finish()
@@ -297,7 +297,7 @@ bool XMLDocumentParser::parseDocumentFragment(const String& chunk, DocumentFragm
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-xhtml-syntax.html#xml-fragment-parsing-algorithm
     // For now we have a hack for script/style innerHTML support:
     if (contextElement && (contextElement->hasLocalName(HTMLNames::scriptTag->localName()) || contextElement->hasLocalName(HTMLNames::styleTag->localName()))) {
-        fragment.parserAppendChild(fragment.protectedDocument()->createTextNode(String { chunk }));
+        fragment.parserAppendChild(protect(fragment.document())->createTextNode(String { chunk }));
         return true;
     }
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -365,7 +365,7 @@ WebCore::AccessibilityObject* WebAutomationSessionProxy::getAccessibilityObjectF
     if (!WebCore::AXObjectCache::accessibilityEnabled())
         WebCore::AXObjectCache::enableAccessibility();
 
-    if (CheckedPtr axObjectCache = coreElement->protectedDocument()->axObjectCache()) {
+    if (CheckedPtr axObjectCache = protect(coreElement->document())->axObjectCache()) {
         // Force a layout and cache update. If we don't, and this request has come in before the render tree was built,
         // the accessibility object for this element will not be created (because it doesn't yet have its renderer).
         axObjectCache->performDeferredCacheUpdate(ForceLayout::Yes);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -90,7 +90,7 @@ static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
 
 - (WKDOMDocument *)document
 {
-    return WebKit::toWKDOMDocument(protectedImpl(self)->protectedDocument().ptr());
+    return WebKit::toWKDOMDocument(protect(protectedImpl(self)->document()).ptr());
 }
 
 - (WKDOMNode *)parentNode
@@ -121,7 +121,7 @@ static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
 - (NSArray *)textRects
 {
     Ref impl = *_impl;
-    impl->protectedDocument()->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
+    protect(impl->document())->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     if (!impl->renderer())
         return nil;
     return createNSArray(WebCore::RenderObject::absoluteTextRects(WebCore::makeRangeSelectingNodeContents(impl))).autorelease();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
@@ -124,7 +124,7 @@ static Ref<WebCore::Range> protectedImpl(WKDOMRange *range)
 - (NSString *)text
 {
     auto range = makeSimpleRange(protectedImpl(self));
-    range.start.protectedDocument()->updateLayout();
+    protect(range.start.document())->updateLayout();
     return plainText(range).createNSString().autorelease();
 }
 
@@ -136,7 +136,7 @@ static Ref<WebCore::Range> protectedImpl(WKDOMRange *range)
 - (NSArray *)textRects
 {
     auto range = makeSimpleRange(protectedImpl(self));
-    range.start.protectedDocument()->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
+    protect(range.start.document())->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     return createNSArray(WebCore::RenderObject::absoluteTextRects(range)).autorelease();
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -129,7 +129,7 @@ RefPtr<InjectedBundleNodeHandle> InjectedBundleNodeHandle::document()
     if (!m_node)
         return nullptr;
 
-    return getOrCreate(m_node->protectedDocument());
+    return getOrCreate(protect(m_node->document()));
 }
 
 // Additional DOM Operations
@@ -215,7 +215,7 @@ RefPtr<WebImage> InjectedBundleNodeHandle::renderedImage(SnapshotOptions options
     if (!frameView)
         return nullptr;
 
-    m_node->protectedDocument()->updateLayout();
+    protect(m_node->document())->updateLayout();
 
     CheckedPtr renderer = m_node->renderer();
     if (!renderer)

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -100,7 +100,7 @@ InjectedBundleRangeHandle::~InjectedBundleRangeHandle()
 
 Ref<InjectedBundleNodeHandle> InjectedBundleRangeHandle::document()
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_range->startContainer().protectedDocument());
+    return InjectedBundleNodeHandle::getOrCreate(protect(m_range->startContainer().document()));
 }
 
 WebCore::IntRect InjectedBundleRangeHandle::boundingRectInWindowCoordinates() const
@@ -175,7 +175,7 @@ RefPtr<WebImage> InjectedBundleRangeHandle::renderedImage(SnapshotOptions option
 String InjectedBundleRangeHandle::text() const
 {
     auto range = makeSimpleRange(m_range);
-    range.start.protectedDocument()->updateLayout();
+    protect(range.start.document())->updateLayout();
     return plainText(range);
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -102,7 +102,7 @@ PDFPluginAnnotation::~PDFPluginAnnotation()
 
     m_eventListener->setAnnotation(nullptr);
 
-    element->protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr<Node, WeakPtrImplWithEventTargetData> { element.get() }]() {
+    protect(element->document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr<Node, WeakPtrImplWithEventTargetData> { element.get() }]() {
         if (RefPtr element = weakElement.get())
             element->remove();
     });

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -134,7 +134,7 @@ PluginInfo PDFPluginBase::pluginInfo()
 }
 
 PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
-    : m_frame(*WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame()))
+    : m_frame(*WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame()))
     , m_element(element)
 #if HAVE(INCREMENTAL_PDF_APIS)
     , m_incrementalPDFLoadingEnabled(element.document().settings().incrementalPDFLoadingEnabled())

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1223,7 +1223,7 @@ void PluginView::updateDocumentForPluginSizingBehavior()
     if (!m_plugin->shouldSizeToFitContent())
         return;
     // The styles in PluginDocumentParser are constructed to respond to this class.
-    if (RefPtr documentElement = m_pluginElement->protectedDocument()->documentElement())
+    if (RefPtr documentElement = protect(m_pluginElement->document())->documentElement())
         documentElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "plugin-fits-content"_s);
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -454,7 +454,7 @@ void WebEditorClient::textFieldDidEndEditing(Element& element)
     if (!inputElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -469,7 +469,7 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
 
     bool initiatedByUserTyping = UserTypingGestureIndicator::processingUserTypingGesture() && UserTypingGestureIndicator::focusedElementAtGestureStart() == inputElement;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -485,7 +485,7 @@ void WebEditorClient::textDidChangeInTextArea(Element& element)
     if (!textAreaElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -562,7 +562,7 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     if (!getActionTypeForKeyEvent(event, actionType))
         return false;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
     ASSERT(webFrame);
 
     RefPtr page = m_page.get();
@@ -575,7 +575,7 @@ void WebEditorClient::textWillBeDeletedInTextField(Element& element)
     if (!inputElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*element.protectedDocument()->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -573,7 +573,7 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
         RefPtr element = fullScreenManager->element();
         fullScreenManager->exitFullScreenForElement(element.get(), [element] {
             if (element)
-                element->protectedDocument()->protectedFullscreen()->didExitFullscreen([](auto) { });
+                protect(element->document())->protectedFullscreen()->didExitFullscreen([](auto) { });
         });
     }
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -70,7 +70,7 @@ void WebRemoteFrameClient::frameDetached()
     m_frame->invalidate();
 
     if (ownerElement)
-        ownerElement->protectedDocument()->checkCompleted();
+        protect(ownerElement->document())->checkCompleted();
 }
 
 void WebRemoteFrameClient::frameRectDidChange(IntRect rect)

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -182,7 +182,7 @@ void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Eleme
             filename = downloadFilename;
     }
 
-    m_page->send(Messages::WebPageProxy::SetPromisedDataForImage(pasteboardName, WTF::move(*imageHandle), filename, extension, title, String([[response URL] absoluteString]), WTF::userVisibleString(url.createNSURL().get()), WTF::move(*archiveHandle), element.protectedDocument()->originIdentifierForPasteboard()));
+    m_page->send(Messages::WebPageProxy::SetPromisedDataForImage(pasteboardName, WTF::move(*imageHandle), filename, extension, title, String([[response URL] absoluteString]), WTF::userVisibleString(url.createNSURL().get()), WTF::move(*archiveHandle), protect(element.document())->originIdentifierForPasteboard()));
 }
 
 #else

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -246,7 +246,7 @@ void ViewGestureGeometryCollector::computeZoomInformationForNode(Node& node, Flo
 {
     absoluteBoundingRect = node.absoluteBoundingRect(&isReplaced);
     if (node.document().isImageDocument()) {
-        if (RefPtr imageElement = downcast<ImageDocument>(node.protectedDocument())->imageElement()) {
+        if (RefPtr imageElement = downcast<ImageDocument>(protect(node.document()))->imageElement()) {
             if (&node != imageElement.get()) {
                 absoluteBoundingRect = imageElement->absoluteBoundingRect(&isReplaced);
                 FloatPoint newOrigin = origin;

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -135,7 +135,7 @@ void WebFoundTextRangeController::findTextRangesForStringMatches(const String& s
     HashMap<WebCore::FrameIdentifier, Vector<WebFoundTextRange>> frameMatches;
     for (const auto& [foundTextRange, simpleRange] : WTF::zippedRange(webFoundTextRanges, validSimpleRanges)) {
         m_cachedFoundRanges.add(foundTextRange, simpleRange.makeWeakSimpleRange());
-        const auto frameID = simpleRange.startContainer().protectedDocument()->frame()->frameID();
+        const auto frameID = protect(simpleRange.startContainer().document())->frame()->frameID();
         auto& matches = frameMatches.ensure(frameID, createEmptyVector).iterator->value;
         matches.append(foundTextRange);
     }
@@ -191,10 +191,10 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
     if (auto simpleRange = simpleRangeFromFoundTextRange(range)) {
         switch (style) {
         case FindDecorationStyle::Normal:
-            simpleRange->start.protectedDocument()->checkedMarkers()->removeMarkers(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
+            protect(simpleRange->start.document())->checkedMarkers()->removeMarkers(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
             break;
         case FindDecorationStyle::Found: {
-            auto addedMarker = simpleRange->start.protectedDocument()->checkedMarkers()->addMarker(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
+            auto addedMarker = protect(simpleRange->start.document())->checkedMarkers()->addMarker(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
             if (!addedMarker)
                 m_unhighlightedFoundRanges.add(range);
             break;
@@ -213,7 +213,7 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
                 HashSet<WebFoundTextRange> rangesToRemove;
                 for (auto unhighlightedRange : m_unhighlightedFoundRanges) {
                     if (auto unhighlightedSimpleRange = simpleRangeFromFoundTextRange(unhighlightedRange)) {
-                        auto addedMarker = unhighlightedSimpleRange->start.protectedDocument()->checkedMarkers()->addMarker(*unhighlightedSimpleRange, WebCore::DocumentMarkerType::TextMatch);
+                        auto addedMarker = protect(unhighlightedSimpleRange->start.document())->checkedMarkers()->addMarker(*unhighlightedSimpleRange, WebCore::DocumentMarkerType::TextMatch);
                         if (addedMarker)
                             rangesToRemove.add(unhighlightedRange);
                     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8612,7 +8612,7 @@ void WebPage::insertAttachment(const String& identifier, std::optional<uint64_t>
 void WebPage::updateAttachmentAttributes(const String& identifier, std::optional<uint64_t>&& fileSize, const String& contentType, const String& fileName, const IPC::SharedBufferReference& associatedElementData, CompletionHandler<void()>&& callback)
 {
     if (RefPtr attachment = attachmentElementWithIdentifier(identifier)) {
-        attachment->protectedDocument()->updateLayout();
+        protect(attachment->document())->updateLayout();
         attachment->updateAttributes(WTF::move(fileSize), AtomString { contentType }, AtomString { fileName });
         attachment->updateAssociatedElementWithData(contentType, associatedElementData.isNull() ? WebCore::SharedBuffer::create() : associatedElementData.unsafeBuffer().releaseNonNull());
     }
@@ -9090,7 +9090,7 @@ void WebPage::requestTextRecognition(Element& element, TextRecognitionOptions&& 
         }
 
         auto cachedImage = renderImage->cachedImage();
-        auto imageURL = cachedImage ? weakElement->protectedDocument()->completeURL(cachedImage->url().string()) : URL { };
+        auto imageURL = cachedImage ? protect(weakElement->document())->completeURL(cachedImage->url().string()) : URL { };
         protectedPage->sendWithAsyncReply(Messages::WebPageProxy::RequestTextRecognition(WTF::move(imageURL), WTF::move(*bitmapHandle), options.sourceLanguageIdentifier, options.targetLanguageIdentifier), [webPage, weakElement, resolveAndRemoveHandlerFollowingError = WTF::move(resolveAndRemoveHandlerFollowingError)] (auto&& result) mutable {
             RefPtr protectedPage { webPage.get() };
             if (!protectedPage)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3472,7 +3472,7 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
                 return InteractionInformationAtPosition::Selectability::UnselectableDueToMediaControls;
         }
 
-        if (hitNode->protectedDocument()->quirks().shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(*hitNode))
+        if (protect(hitNode->document())->quirks().shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(*hitNode))
             return InteractionInformationAtPosition::Selectability::UnselectableDueToUserSelectNoneOrQuirk;
 
         return InteractionInformationAtPosition::Selectability::Selectable;

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -297,7 +297,7 @@ void PlaybackSessionManager::setUpPlaybackControlsManager(WebCore::HTMLMediaElem
 
     Ref page = *m_page;
     if (auto previousContextId = std::exchange(m_controlsManagerContextId, contextId)) {
-        if (mediaElement.protectedDocument()->quirks().needsNowPlayingFullscreenSwapQuirk()) {
+        if (protect(mediaElement.document())->quirks().needsNowPlayingFullscreenSwapQuirk()) {
             RefPtr previousElement = dynamicDowncast<HTMLVideoElement>(mediaElementWithContextId(*previousContextId));
             if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(mediaElement); videoElement && previousElement
                 && previousElement->fullscreenMode() != HTMLMediaElement::VideoFullscreenModeNone) {

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -288,13 +288,13 @@ bool VideoPresentationManager::canEnterVideoFullscreen(HTMLVideoElement& videoEl
     ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 
 #if ENABLE(FULLSCREEN_API)
-    if (videoElement.protectedDocument()->protectedFullscreen()->isAnimatingFullscreen())
+    if (protect(videoElement.document())->protectedFullscreen()->isAnimatingFullscreen())
         return false;
 #endif
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     if (m_currentVideoFullscreenMode == mode)
-        return videoElement.protectedDocument()->quirks().allowLayeredFullscreenVideos();
+        return protect(videoElement.document())->quirks().allowLayeredFullscreenVideos();
 #endif
     return true;
 }
@@ -472,7 +472,7 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
     auto setupFullscreen = [protectedThis = Ref { *this }, page = WeakPtr { m_page }, contextId = contextId, initialSize = initialSize, videoRect = videoRect, videoElement = WeakPtr { videoElement }, allowsPictureInPicture = allowsPictureInPicture, standby = standby, fullscreenMode = interface->fullscreenMode()] (HostingContext hostingContext, const FloatSize& size) {
         if (!page || !videoElement)
             return;
-        page->send(Messages::VideoPresentationManagerProxy::SetupFullscreenWithID(processQualify(contextId), hostingContext, videoRect, initialSize, size, page->deviceScaleFactor(), fullscreenMode, allowsPictureInPicture, standby, videoElement->protectedDocument()->quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
+        page->send(Messages::VideoPresentationManagerProxy::SetupFullscreenWithID(processQualify(contextId), hostingContext, videoRect, initialSize, size, page->deviceScaleFactor(), fullscreenMode, allowsPictureInPicture, standby, protect(videoElement->document())->quirks().blocksReturnToFullscreenFromPictureInPictureQuirk()));
 
         if (RefPtr player = videoElement->player()) {
             if (auto identifier = player->identifier())


### PR DESCRIPTION
#### 10e04877384c99cb616af10483fa22005992b920
<pre>
Drop Node::protectedDocument()
<a href="https://bugs.webkit.org/show_bug.cgi?id=306714">https://bugs.webkit.org/show_bug.cgi?id=306714</a>

Reviewed by Anne van Kesteren.

Use protect() at call sites instead.

* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::getType):
* Source/WebCore/Modules/cache/WindowOrWorkerGlobalScopeCaches.cpp:
(WebCore::DOMWindowCaches::caches const):
* Source/WebCore/Modules/gamepad/GamepadManager.cpp:
(WebCore::GamepadManager::platformGamepadDisconnected):
(WebCore::GamepadManager::makeGamepadVisible):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::gamepadFromPlatformGamepad):
(WebCore::NavigatorGamepad::gamepadsBecameVisible):
(WebCore::NavigatorGamepad::gamepadConnected):
* Source/WebCore/Modules/highlight/AppHighlightStorage.cpp:
(WebCore::makeNodePath):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::ensureTextTrackContainer):
(WebCore::MediaControlsHost::needsChromeMediaControlsPseudoElement const):
* Source/WebCore/Modules/mediastream/NavigatorMediaDevices.cpp:
(WebCore::NavigatorMediaDevices::mediaDevices const):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::~HTMLModelElement):
(WebCore::HTMLModelElement::isVisible const):
(WebCore::HTMLModelElement::logWarning):
(WebCore::HTMLModelElement::reloadModelPlayer):
(WebCore::HTMLModelElement::stop):
(WebCore::HTMLModelElement::sourceRequestResource):
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
(WebCore::YouTubePluginReplacement::youTubeURL):
* Source/WebCore/accessibility/AXListHelpers.cpp:
(WebCore::AXListHelpers::childHasPseudoVisibleListItemMarkers):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::focusedImageMapUIElement):
(WebCore::AXObjectCache::getOrCreateSlow):
(WebCore::AXObjectCache::handleTextChanged):
(WebCore::AXObjectCache::handleChildrenChanged):
(WebCore::AXObjectCache::postNotification):
(WebCore::AXObjectCache::handleTabPanelSelected):
(WebCore::AXObjectCache::onSelectedOptionChanged):
(WebCore::AXObjectCache::onRadioGroupMembershipChanged):
(WebCore::AXObjectCache::onTextCompositionChange):
(WebCore::AXObjectCache::liveRegionChangedNotificationPostTimerFired):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::previousBoundary):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _accessibilityParentForSubview:]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(rendererForView):
(-[WebAccessibilityObjectWrapper _accessibilityParentForSubview:]):
* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::update):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::create):
(WebCore::ScrollTimeline::source const):
(WebCore::ScrollTimeline::setSource):
(WebCore::ScrollTimeline::removeTimelineFromDocument):
(WebCore::ScrollTimeline::updateCurrentTimeIfStale):
(WebCore::ScrollTimeline::animationTimingDidChange):
(WebCore::ScrollTimeline::scheduleAcceleratedRepresentationUpdate):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::create):
(WebCore::ViewTimeline::setSubject):
(WebCore::ViewTimeline::bindingsSource const):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::enqueueAnimationEvent):
(WebCore::WebAnimation::commitStyles):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::eventHandlerPosition const):
(WebCore::ScriptController::executeScriptInWorld):
(WebCore::ScriptController::callInWorld):
(WebCore::ScriptController::canExecuteScripts):
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::exposedComputedCSSPropertyIDs const):
* Source/WebCore/css/StyleMedia.cpp:
(WebCore::StyleMedia::StyleMedia):
* Source/WebCore/dom/CDATASection.cpp:
(WebCore::CDATASection::virtualCreate):
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::dispatchModifiedEvent):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::insertBefore):
(WebCore::ContainerNode::replaceChild):
(WebCore::ContainerNode::replaceAll):
(WebCore::ContainerNode::appendChildWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::insertChildrenBeforeWithoutPreInsertionValidityCheck):
* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateContentRelevancyForScrollIfNeeded):
(WebCore::ContentVisibilityDocumentState::updateViewportProximity):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue):
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::addToScopedCustomElementRegistryMap):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayout):
(WebCore::Document::updateLayoutIfDimensionsOutOfDate):
(WebCore::Document::isFullyActive const):
(WebCore::Document::invalidateEventRegionsForFrame):
(WebCore::Document::initSecurityContext):
(WebCore::Document::initContentSecurityPolicy):
(WebCore::Document::updateLastHandledUserGestureTimestamp):
(WebCore::Document::matchingAnimations):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::enabledByPermissionsPolicy const):
(WebCore::fullscreenElementReadyCheck):
(WebCore::DocumentFullscreen::requestFullscreen):
(WebCore::DocumentFullscreen::willEnterFullscreen):
(WebCore::DocumentFullscreen::finishExitFullscreen):
(WebCore::DocumentFullscreen::fullyExitFullscreen):
(WebCore::DocumentFullscreen::dispatchPendingEvents):
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::requestImmersive):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::addMarker):
(WebCore::removeMarkers):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hideNonceSlow):
(WebCore::Element::dispatchMouseEvent):
(WebCore::Element::detachAttribute):
(WebCore::Element::isUserActionElementInActiveChain const):
(WebCore::Element::isUserActionElementActive const):
(WebCore::Element::isUserActionElementFocused const):
(WebCore::Element::isUserActionElementHovered const):
(WebCore::Element::isUserActionElementDragged const):
(WebCore::Element::isUserActionElementHasFocusVisible const):
(WebCore::Element::isUserActionElementHasFocusWithin const):
(WebCore::Element::setFocus):
(WebCore::Element::setHasFocusWithin):
(WebCore::Element::setHasTentativeFocus):
(WebCore::Element::setHovered):
(WebCore::Element::setBeingDragged):
(WebCore::Element::scrollIntoView):
(WebCore::Element::scrollIntoViewIfNotVisible):
(WebCore::Element::offsetLeft):
(WebCore::Element::offsetTop):
(WebCore::Element::offsetWidth):
(WebCore::Element::offsetHeight):
(WebCore::Element::offsetParent):
(WebCore::Element::clientLeft):
(WebCore::Element::clientTop):
(WebCore::Element::boundingBoxInRootViewCoordinates const):
(WebCore::Element::getClientRects):
(WebCore::Element::attributeChanged):
(WebCore::Element::insertedIntoAncestor):
(WebCore::Element::clearEffectiveLangStateOnNewDocumentElement):
(WebCore::Element::setAttributeNode):
(WebCore::Element::setAttributeNodeNS):
(WebCore::Element::blur):
(WebCore::Element::enqueueSecurityPolicyViolationEvent):
(WebCore::Element::innerText):
(WebCore::Element::locale const):
(WebCore::Element::requestFullscreen):
(WebCore::Element::isWritingSuggestionsEnabled const):
(WebCore::Element::willModifyAttribute):
(WebCore::Element::didAddAttribute):
(WebCore::Element::didModifyAttribute):
(WebCore::Element::didRemoveAttribute):
(WebCore::contextElementForInsertion):
(WebCore::Element::getAnimations):
* Source/WebCore/dom/ElementInlines.h:
(WebCore::Element::getURLAttributeForBindings const):
* Source/WebCore/dom/ElementTextDirection.cpp:
(WebCore::updateElementHasDirAutoFlag):
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::shouldSuppressEventDispatchInDOM):
* Source/WebCore/dom/FindRevealAlgorithms.cpp:
(WebCore::revealClosedDetailsAndHiddenUntilFoundAncestors):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::removeOverlaySoonIfNeeded):
(WebCore::ImageOverlay::installImageOverlayStyleSheet):
* Source/WebCore/dom/LiveNodeListInlines.h:
(WebCore::LiveNodeList::invalidateCache const):
(WebCore::traversalType&gt;::~CachedLiveNodeList):
(WebCore::traversalType&gt;::willValidateIndexCache const):
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::computeRelativePosition):
* Source/WebCore/dom/MutationObserverRegistration.cpp:
(WebCore::MutationObserverRegistration::observedSubtreeNodeWillDetach):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeDocument.h:
(WebCore::Node::protectedDocument const): Deleted.
* Source/WebCore/dom/NodeIterator.cpp:
(WebCore::NodeIterator::NodeIterator):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::insertedIntoAncestor):
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroups::addButton):
(WebCore::RadioButtonGroups::removeButton):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::createContextualFragment):
(WebCore::Range::getClientRects const):
(WebCore::Range::boundingClientRect):
* Source/WebCore/dom/RawDataDocumentParser.h:
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::executeScriptAndDispatchEvent):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::insertedIntoAncestor):
(WebCore::ShadowRoot::removedFromAncestor):
* Source/WebCore/dom/SpeculationRulesMatcher.cpp:
(WebCore::matches):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::setInlineStyleFromString):
(WebCore::StyledElement::invalidateStyleAttribute):
(WebCore::StyledElement::addPropertyToPresentationalHintStyle):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::splitText):
(WebCore::Text::virtualCreate):
(WebCore::Text::updateRendererAfterContentChange):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOverflowRect):
(WebCore::ViewTransition::copyElementBaseProperties):
* Source/WebCore/dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp:
(WebCore::DOMWindowTrustedTypes::trustedTypes const):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::createImageControls):
(WebCore::ImageControlsMac::updateImageControls):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyInlineStyleToPushDown):
(WebCore::ApplyStyleCommand::nodeFullySelected const):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::textNodeForRebalance const):
* Source/WebCore/editing/CustomUndoStep.cpp:
(WebCore::CustomUndoStep::unapply):
(WebCore::CustomUndoStep::reapply):
* Source/WebCore/editing/Editing.cpp:
(WebCore::closestEditablePositionInElementForAbsolutePoint):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::styleAtSelectionStart):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::firstRectForRange const):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::computeCaretColor):
(WebCore::FrameSelection::setShouldShowBlockCursor):
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp:
(WebCore::ReplaceNodeWithSpanCommand::doApply):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::TextIterator):
(WebCore::TextIterator::init):
(WebCore::SimplifiedBackwardsTextIterator::SimplifiedBackwardsTextIterator):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::toNormalizedRange const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::previousLinePosition):
(WebCore::nextLinePosition):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentMarkupReader::readWebArchive):
* Source/WebCore/editing/markup.cpp:
(WebCore::canUseSetDataOptimization):
* Source/WebCore/html/BaseButtonInputType.cpp:
(WebCore::BaseButtonInputType::setValue):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::startSwitchPointerTracking):
(WebCore::CheckboxInputType::stopSwitchPointerTracking):
(WebCore::switchAnimationUpdateInterval):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::attributeChanged):
(WebCore::ColorInputType::didChooseColor):
(WebCore::ColorInputType::elementRectRelativeToRootView const):
(WebCore::ColorInputType::rootFrameID const):
* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::DOMTokenList::supports):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::createShadowSubtree):
(WebCore::FileInputType::allowsDirectories const):
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::restoreFormControlState):
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::FormListedElement::resetFormOwner):
(WebCore::FormListedElement::parseFormAttribute):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::defaultEventHandler):
(WebCore::HTMLAnchorElement::attributeChanged):
(WebCore::HTMLAnchorElement::href const):
(WebCore::HTMLAnchorElement::attributionDestinationURLForPCM const):
(WebCore::HTMLAnchorElement::attributionSourceNonceForPCM const):
(WebCore::HTMLAnchorElement::parsePrivateClickMeasurement const):
(WebCore::HTMLAnchorElement::handleClick):
(WebCore::HTMLAnchorElement::insertedIntoAncestor):
(WebCore::HTMLAnchorElement::setShouldBePrefetched):
(WebCore::HTMLAnchorElement::checkForSpeculationRules):
* Source/WebCore/html/HTMLArticleElement.cpp:
(WebCore::HTMLArticleElement::removedFromAncestor):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
* Source/WebCore/html/HTMLBaseElement.cpp:
(WebCore::HTMLBaseElement::attributeChanged):
(WebCore::HTMLBaseElement::insertedIntoAncestor):
(WebCore::HTMLBaseElement::removedFromAncestor):
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLBodyElement::insertedIntoAncestor):
(WebCore::HTMLBodyElement::addSubresourceAttributeURLs const):
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::defaultEventHandler):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContext2d):
(WebCore::HTMLCanvasElement::paint):
(WebCore::HTMLCanvasElement::transferControlToOffscreen):
(WebCore::HTMLCanvasElement::securityOrigin const):
(WebCore::HTMLCanvasElement::createCSSParserContext const):
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::~HTMLCollection):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::DetailsSlotAssignment::hostChildElementDidChange):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::runFocusingSteps):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::setInnerText):
(WebCore::HTMLElement::setOuterText):
(WebCore::HTMLElement::canonicalInputMode const):
(WebCore::checkPopoverValidity):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::addSubresourceAttributeURLs const):
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::isMouseFocusable const):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::requestSubmit):
(WebCore::HTMLFormElement::reportValidity):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::canLoadURL const):
(WebCore::HTMLFrameElementBase::openURL):
* Source/WebCore/html/HTMLFrameOwnerElement.cpp:
(WebCore::HTMLFrameOwnerElement::disconnectContentFrame):
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::attributeChanged):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::attributeChanged):
(WebCore::HTMLIFrameElement::setSrcdoc):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::setBestFitURLAndDPRFromImageCandidate):
(WebCore::HTMLImageElement::evaluateDynamicMediaQueryDependencies):
(WebCore::HTMLImageElement::width):
(WebCore::HTMLImageElement::height):
(WebCore::HTMLImageElement::x const):
(WebCore::HTMLImageElement::y const):
(WebCore::HTMLImageElement::isServerMap const):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::showPicker):
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::defaultEventHandler):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::potentiallyBlockRendering):
(WebCore::HTMLLinkElement::unblockRendering):
(WebCore::HTMLLinkElement::href const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::invalidateMediaSession):
(WebCore::HTMLMediaElement::prepareForDocumentSuspension):
(WebCore::HTMLMediaElement::resumeFromDocumentSuspension):
(WebCore::HTMLMediaElement::pauseAfterDetachedTask):
(WebCore::HTMLMediaElement::load):
(WebCore::HTMLMediaElement::selectMediaResource):
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::speechSynthesis):
(WebCore::isAllowedToLoadMediaURL):
(WebCore::HTMLMediaElement::isSafeToLoadURL const):
(WebCore::HTMLMediaElement::dispatchPlayPauseEventsIfNeedsQuirks):
(WebCore::HTMLMediaElement::updateShouldContinueAfterNeedKey):
(WebCore::HTMLMediaElement::mediaPlayerKeyNeeded):
(WebCore::HTMLMediaElement::mediaPlayerMediaKeysStorageDirectory const):
(WebCore::HTMLMediaElement::mediaPlayerInitializationDataEncountered):
(WebCore::HTMLMediaElement::setAudioOutputDevice):
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::finishSeek):
(WebCore::HTMLMediaElement::setVolume):
(WebCore::HTMLMediaElement::setMutedInternal):
(WebCore::HTMLMediaElement::mediaPlayerDidAddTextTrack):
(WebCore::HTMLMediaElement::mediaPlayerDidReportGPUMemoryFootprint):
(WebCore::HTMLMediaElement::addTextTrack):
(WebCore::HTMLMediaElement::selectNextSourceChild):
(WebCore::HTMLMediaElement::mediaPlayerCharacteristicChanged):
(WebCore::HTMLMediaElement::updateVolume):
(WebCore::HTMLMediaElement::updatePlayState):
(WebCore::HTMLMediaElement::setPlaying):
(WebCore::HTMLMediaElement::clearMediaPlayer):
(WebCore::HTMLMediaElement::resume):
(WebCore::HTMLMediaElement::elementIsHidden const):
(WebCore::HTMLMediaElement::setTextTrackRepresentation):
(WebCore::HTMLMediaElement::dispatchEvent):
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::exitFullscreen):
(WebCore::HTMLMediaElement::setShouldDelayLoadEvent):
(WebCore::HTMLMediaElement::setMediaGroup):
(WebCore::HTMLMediaElement::updateSleepDisabling):
(WebCore::HTMLMediaElement::mediaPlayerCachedResourceLoader const):
(WebCore::HTMLMediaElement::mediaPlayerCreateResourceLoader):
(WebCore::HTMLMediaElement::mediaPlayerEngineFailedToLoad):
(WebCore::HTMLMediaElement::removeBehaviorRestrictionsAfterFirstUserGesture):
(WebCore::HTMLMediaElement::setControllerJSProperty):
(WebCore::HTMLMediaElement::ensureMediaControls):
(WebCore::HTMLMediaElement::supportsSeeking const):
(WebCore::HTMLMediaElement::processingUserGestureForMedia const):
(WebCore::HTMLMediaElement::updateMediaState):
(WebCore::HTMLMediaElement::documentSecurityOrigin const):
(WebCore::HTMLMediaElement::updateMediaPlayer):
(WebCore::HTMLMediaElement::mediaPlayerQueueTaskOnEventLoop):
(WebCore::HTMLMediaElement::setShowingStats):
(WebCore::HTMLMediaElement::watchtimeTimerFired):
(WebCore::HTMLMediaElement::limitedMatroskaSupportEnabled const):
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::HTMLMetaElement::attributeChanged):
(WebCore::HTMLMetaElement::removedFromAncestor):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::addSubresourceAttributeURLs const):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::groupLabelText const):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::text const):
(WebCore::HTMLOptionElement::setSelectedState):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::~HTMLPlugInElement):
(WebCore::HTMLPlugInElement::createElementRenderer):
(WebCore::HTMLPlugInElement::canLoadURL const):
(WebCore::HTMLPlugInElement::updateAfterStyleResolution):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::didElementStateChange):
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::potentiallyBlockRendering):
(WebCore::HTMLScriptElement::unblockRendering):
(WebCore::HTMLScriptElement::addSubresourceAttributeURLs const):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::value const):
(WebCore::HTMLSelectElement::setItem):
(WebCore::HTMLSelectElement::setLength):
(WebCore::HTMLSelectElement::platformHandleKeydownEvent):
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
(WebCore::HTMLSelectElement::listBoxDefaultEventHandler):
(WebCore::HTMLSelectElement::showPicker):
(WebCore::HTMLSelectElement::fontSelector const):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::updateAccessibilityOnSlotChange const):
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::attributeChanged):
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::addSubresourceAttributeURLs const):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::createTHead):
(WebCore::HTMLTableElement::createTFoot):
(WebCore::HTMLTableElement::createTBody):
(WebCore::HTMLTableElement::createCaption):
(WebCore::HTMLTableElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLTableElement::addSubresourceAttributeURLs const):
* Source/WebCore/html/HTMLTablePartElement.cpp:
(WebCore::HTMLTablePartElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLTableRowElement.cpp:
(WebCore::HTMLTableRowElement::insertCell):
* Source/WebCore/html/HTMLTableSectionElement.cpp:
(WebCore::HTMLTableSectionElement::insertRow):
* Source/WebCore/html/HTMLTemplateElement.cpp:
(WebCore::HTMLTemplateElement::content const):
(WebCore::HTMLTemplateElement::cloneNodeInternal const):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::didAddUserAgentShadowRoot):
(WebCore::HTMLTextAreaElement::appendFormData):
(WebCore::HTMLTextAreaElement::updatePlaceholderText):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setSelectionRange):
(WebCore::HTMLTextFormControlElement::shouldApplyScriptTrackingPrivacyProtection const):
* Source/WebCore/html/HTMLTitleElement.cpp:
(WebCore::HTMLTitleElement::didFinishInsertingNode):
(WebCore::HTMLTitleElement::removedFromAncestor):
(WebCore::HTMLTitleElement::childrenChanged):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::mediaPlayerFirstVideoFrameAvailable):
(WebCore::HTMLVideoElement::posterImageURL const):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::handleDOMActivateEvent):
(WebCore::ImageInputType::height const):
(WebCore::ImageInputType::width const):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::setValue):
(WebCore::InputType::applyStep):
* Source/WebCore/html/LazyLoadFrameObserver.cpp:
(WebCore::LazyLoadFrameObserver::observe):
* Source/WebCore/html/LazyLoadImageObserver.cpp:
(WebCore::LazyLoadImageObserver::observe):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::canShowControlsManager const):
(WebCore::isElementMainContentForPurposesOfAutoplay):
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::PermissionsPolicy::processPermissionsPolicyAttribute):
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::handleKeydownEvent):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::fontSelector const):
* Source/WebCore/html/SubmitInputType.cpp:
(WebCore::SubmitInputType::handleDOMActivateEvent):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createDataListDropdownIndicator):
(WebCore::TextFieldInputType::updatePlaceholderText):
(WebCore::TextFieldInputType::createAutoFillButton):
(WebCore::TextFieldInputType::elementRectInRootViewCoordinates const):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::reportValidity):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::drawFocusIfNeededInternal):
(WebCore::CanvasRenderingContext2D::direction const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):
* Source/WebCore/html/canvas/CanvasStyle.cpp:
(WebCore::CanvasStyleColorResolutionDelegate::currentColor const):
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::append):
(WebCore::HTMLDocumentParser::appendCurrentInputStreamToPreloadScannerAndScan):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::tryAvoidParsingByCloningExistingSubtree):
(WebCore::cloneCachedPrefixAndParseSuffix):
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditElement::layout):
* Source/WebCore/html/shadow/DateTimeFieldElement.cpp:
(WebCore::DateTimeFieldElement::localeForOwner const):
(WebCore::DateTimeFieldElement::updateVisibleValue):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::createTextTrackRepresentationImage):
(WebCore::MediaControlTextTrackContainerElement::ensurePreviewCue const):
(WebCore::MediaControlTextTrackContainerElement::logger const):
* Source/WebCore/html/shadow/SpatialImageControls.cpp:
(WebCore::SpatialImageControls::ensureSpatialControls):
(WebCore::SpatialImageControls::destroySpatialImageControls):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::SearchFieldResultsButtonElement::defaultEventHandler):
* Source/WebCore/html/track/LoadableTextTrack.cpp:
(WebCore::LoadableTextTrack::scheduleLoad):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::copyWebVTTNodeToDOMTree):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::openURLExternally):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::pushNodeToFrontend):
(WebCore::InspectorDOMAgent::setAttributesAsText):
(WebCore::InspectorDOMAgent::setNodeName):
(WebCore::InspectorDOMAgent::buildObjectForAccessibilityProperties):
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::doPreflight):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::matchRegistration):
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::checkLoadComplete):
(WebCore::DocumentLoader::loadMainResource):
(WebCore::DocumentLoader::addConsoleMessage):
(WebCore::DocumentLoader::enqueueSecurityPolicyViolationEvent):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::canReferToParentFrameEncoding):
(WebCore::DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL):
(WebCore::DocumentWriter::begin):
(WebCore::DocumentWriter::decoder):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::init):
(WebCore::FrameLoader::submitForm):
(WebCore::shouldClearWindowName):
(WebCore::FrameLoader::outgoingOrigin const):
(WebCore::FrameLoader::checkIfFormActionAllowedByCSP const):
(WebCore::FrameLoader::setFirstPartyForCookies):
(WebCore::FrameLoader::updateURLAndHistory):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::prepareForLoadStart):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::reportLocalLoadFailed):
(WebCore::FrameLoader::reportBlockedLoadFailed):
(WebCore::FrameLoader::reload):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::detachChildren):
(WebCore::FrameLoader::numPendingOrLoadingRequests const):
(WebCore::FrameLoader::frameDetached):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::shouldPerformFragmentNavigation):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::dispatchUnloadEvents):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::shouldTreatURLAsSameAsCurrent const):
(WebCore::FrameLoader::loadSameDocumentItem):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::createWindow):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::restoreDocumentState):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::notifyFinished):
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResource::responseReceived):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleLocationChange):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::isAllowedByContentSecurityPolicy):
(WebCore::PolicyChecker::checkNavigationPolicy):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::init):
(WebCore::ResourceLoader::didBlockAuthenticationChallenge):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::canLoadJavaScriptURL):
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
(WebCore::FrameLoader::SubframeLoader::completeURL const):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::SubresourceLoader):
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::didFail):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::computeFetchMetadataSiteInternal):
(WebCore::CachedResourceLoader::updateCachedResourceWithCurrentRequest):
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
(WebCore::CachedResourceLoader::revalidateResource):
(WebCore::CachedResourceLoader::loadResource):
(WebCore::CachedResourceLoader::visibleResourcesToPrioritize):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::startLoading):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::openNewWindow):
(WebCore::insertUnicodeCharacter):
(WebCore::ContextMenuController::contextMenuItemSelected):
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::selectionShadowAncestor):
(WebCore::DOMSelection::toString const):
(WebCore::DOMSelection::shadowAdjustedNode const):
(WebCore::DOMSelection::shadowAdjustedOffset const):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::crossDomainAccessErrorMessage):
(WebCore::DOMWindow::isInsecureScriptAccess):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::dragEnteredOrUpdated):
(WebCore::DragController::startDrag):
(WebCore::DragController::finalizeDroppedImagePlaceholder):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::snapshotIgnoringVisibilityAdjustment):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEventSingleClick):
(WebCore::EventHandler::canMouseDownStartSelect):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::handleMouseDraggedEvent):
(WebCore::EventHandler::hitTestResultAtPoint const):
(WebCore::EventHandler::scrollRecursively):
(WebCore::EventHandler::logicalScrollRecursively):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::findDropZone):
(WebCore::EventHandler::dispatchDragEnterOrDragOverEvent):
(WebCore::EventHandler::updateDragAndDrop):
(WebCore::EventHandler::cancelDragAndDrop):
(WebCore::EventHandler::performDragAndDrop):
(WebCore::EventHandler::prepareMouseEvent):
(WebCore::EventHandler::dispatchMouseEvent):
(WebCore::EventHandler::handleAccessKey):
(WebCore::EventHandler::keyEvent):
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::handleDrag):
(WebCore::EventHandler::handleTextInputEvent):
(WebCore::EventHandler::keyboardScrollRecursively):
(WebCore::EventHandler::keyboardScroll):
(WebCore::hitTestResultInFrame):
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedInternal):
(WebCore::FocusController::findFocusableElementDescendingIntoSubframes):
(WebCore::FocusController::setActiveInternal):
(WebCore::FocusController::advanceFocusDirectionallyInContainer):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::ownerPermissionsPolicy const):
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::scopedChild const):
(WebCore::FrameTree::scopedChildByUniqueName const):
(WebCore::FrameTree::scopedChildBySpecifiedName const):
(WebCore::FrameTree::scopedChildCount const):
* Source/WebCore/page/History.cpp:
(WebCore::isDocumentFullyActive):
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::isExposedForPaintTiming):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::focus):
(WebCore::LocalDOMWindow::innerHeight const):
(WebCore::LocalDOMWindow::innerWidth const):
(WebCore::LocalDOMWindow::scrollX const):
(WebCore::LocalDOMWindow::scrollY const):
(WebCore::LocalDOMWindow::getComputedStyle const):
(WebCore::LocalDOMWindow::getMatchedCSSRules const):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::createWindow):
(WebCore::LocalDOMWindow::open):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::setView):
(WebCore::LocalFrame::invalidateContentEventRegionsIfNeeded):
(WebCore::LocalFrame::clearTimers):
(WebCore::LocalFrame::frameWasDisconnectedFromOwner const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollElementToRect):
(WebCore::LocalFrameView::revealRangeWithTemporarySelection):
(WebCore::LocalFrameView::updateScrollCorner):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
(WebCore::Navigation::setActivation):
(WebCore::Navigation::createForPageswapEvent):
(WebCore::Navigation::reload):
(WebCore::Navigation::navigate):
(WebCore::Navigation::performTraversal):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::appVersion const):
(WebCore::Navigator::userAgent const):
(WebCore::Navigator::initializePluginAndMimeTypeArrays):
(WebCore::Navigator::plugins):
(WebCore::Navigator::mimeTypes):
(WebCore::Navigator::cookieEnabled const):
(WebCore::Navigator::userAgentData const):
* Source/WebCore/page/Page.cpp:
(WebCore::dispatchPrintEvent):
(WebCore::Page::didFinishLoadingImageForElement):
(WebCore::Page::updateElementsWithTextRecognitionResults):
(WebCore::Page::reloadExecutionContextsForOrigin const):
* Source/WebCore/page/PageGroupLoadDeferrer.cpp:
(WebCore::PageGroupLoadDeferrer::PageGroupLoadDeferrer):
(WebCore::PageGroupLoadDeferrer::~PageGroupLoadDeferrer):
* Source/WebCore/page/PerformanceEventTiming.cpp:
(WebCore::PerformanceEventTiming::target const):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::dispatchEventForTouchAtIndex):
* Source/WebCore/page/PointerLockController.cpp:
(WebCore::PointerLockController::didLosePointerLock):
(WebCore::PointerLockController::enqueueEvent):
* Source/WebCore/page/PrintContext.cpp:
(WebCore::PrintContext::spoolPage):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::triggerOptionalStorageAccessIframeQuirk const):
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::height const):
(WebCore::Screen::width const):
(WebCore::Screen::colorDepth const):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):
(WebCore::Screen::orientation):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::scrollInDirection):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkFrameAncestors):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::didAddMouseMoveRelatedEventListener):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::wordsInCurrentParagraph const):
(WebCore::ancestorRespondingToClickEventsNodeQualifier):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::dispatchSimulatedClick):
(WebCore::TextExtraction::simulateKeyPress):
* Source/WebCore/platform/DragImage.cpp:
(WebCore::ScopedNodeDragEnabler::ScopedNodeDragEnabler):
(WebCore::createDragImageForRange):
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::deviceScaleFactor):
(WebCore::OutlinePainter::addPDFURLAnnotationForLink const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintObject):
(WebCore::RenderBlock::blockSelectionGap):
(WebCore::RenderBlock::logicalLeftSelectionGap):
(WebCore::RenderBlock::logicalRightSelectionGap):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::computeColumnCountAndWidth):
(WebCore::RenderBlockFlow::invalidateLineLayout):
(WebCore::RenderBlockFlow::markInlineContentDirtyForLayout):
(WebCore::RenderBlockFlow::layoutInlineContent):
(WebCore::RenderBlockFlow::adjustComputedFontSizes):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::imageChanged):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::initializeStyle):
(WebCore::RenderElement::setStyle):
(WebCore::RenderElement::styleWillChange):
(WebCore::RenderElement::getUncachedPseudoStyle const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::imageChanged):
(WebCore::RenderImage::paintReplaced):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::imageChanged):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::childForSuperlayers const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::frameHostingNodeForFrame):
(WebCore::RenderLayerCompositor::collectViewTransitionNewContentLayers):
(WebCore::RenderLayerCompositor::updateBackingAndHierarchy):
(WebCore::RenderLayerCompositor::requiresCompositingForViewTransition const):
(WebCore::RenderLayerCompositor::attachRootLayer):
(WebCore::RenderLayerCompositor::detachRootLayer):
(WebCore::RenderLayerCompositor::notifyIFramesOfCompositingChange):
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::svgMaskerResourceFromStyle const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):
(WebCore::RenderLayerScrollableArea::scrollDidEnd):
(WebCore::RenderLayerScrollableArea::updateScrollCornerStyle):
(WebCore::RenderLayerScrollableArea::updateResizerStyle):
(WebCore::RenderLayerScrollableArea::logMockScrollbarsControllerMessage const):
(WebCore::RenderLayerScrollableArea::deviceScaleFactor const):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::scrollDidEnd):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::borderAndTextRects):
(WebCore::usesVisuallyContiguousBidiTextSelection):
* Source/WebCore/rendering/RenderScrollbar.cpp:
(WebCore::RenderScrollbar::updateScrollbarPart):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::fontSelector const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
(WebCore::RenderTheme::paintDecorations):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::paintReplaced):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::layout):
(WebCore::RenderView::updateQuirksMode):
(WebCore::RenderView::rendererForRootBackground const):
(WebCore::RenderView::paintBoxDecorations):
(WebCore::RenderView::flushAccumulatedRepaintRegion const):
(WebCore::RenderView::computeVisibleRectsInContainer const):
(WebCore::RenderView::printing const):
* Source/WebCore/rendering/TextPaintStyle.cpp:
(WebCore::computeTextPaintStyle):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::paintAttachmentIconPlaceholder):
(WebCore::paintAttachmentProgress):
(WebCore::RenderThemeMac::paintAttachment):
* Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp:
(WebCore::RenderMathMLRoot::paint):
* Source/WebCore/rendering/style/StyleCachedImage.cpp:
(WebCore::StyleCachedImage::uncheckedRenderSVGResource const):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintForeground):
(WebCore::RenderSVGImage::imageChanged):
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::computeNewScaledFontForStyle):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGPaintingFeatures):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::paintForeground):
(WebCore::LegacyRenderSVGImage::imageChanged):
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::targetReferenceFromResource):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::attachToRenderElement):
(WebCore::RenderTreeBuilder::createAnonymousWrappersForInlineContent):
(WebCore::RenderTreeBuilder::childFlowStateChangesAndAffectsParentBlock):
(WebCore::RenderTreeBuilder::createAnonymousBoxWithSameTypeAndWithStyle):
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
(WebCore::RenderTreeBuilder::Block::attachIgnoringContinuation):
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
(WebCore::RenderTreeBuilder::FormControls::findOrCreateParentForChild):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::RenderTreeBuilder::Inline::splitFlow):
(WebCore::RenderTreeBuilder::Inline::childBecameNonInline):
* Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp:
(WebCore::RenderTreeBuilder::Table::findOrCreateParentForChild):
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::Extractor::getFontSizeCSSValuePreferringKeyword const):
(WebCore::Style::Extractor::computeStyle const):
(WebCore::Style::Extractor::propertyMatches const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::elementWasRemoved const):
(WebCore::Styleable::cancelStyleOriginatedAnimations const):
(WebCore::Styleable::updateCSSScrollTimelines const):
(WebCore::Styleable::updateCSSViewTimelines const):
* Source/WebCore/style/values/filter-effects/StyleFilterReference.cpp:
(WebCore::Style::FilterReference::loadExternalDocumentIfNeeded):
* Source/WebCore/style/values/primitives/StyleURL.cpp:
(WebCore::Style::ToStyle&lt;CSS::URL&gt;::operator):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::attributeChanged):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::rebuildFontFace):
(WebCore::SVGFontFaceElement::insertedIntoAncestor):
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::createElementRenderer):
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::getTotalLength const):
(WebCore::SVGGeometryElement::getPointAtLength const):
(WebCore::SVGGeometryElement::isPointInFill):
(WebCore::SVGGeometryElement::isPointInStroke):
(WebCore::SVGGeometryElement::attributeChanged):
* Source/WebCore/svg/SVGLength.cpp:
(WebCore::SVGLength::valueForBindings):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::getBBox):
(WebCore::SVGLocatable::computeCTM):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):
(WebCore::SVGPathElement::getTotalLength const):
(WebCore::SVGPathElement::getPointAtLength const):
(WebCore::SVGPathElement::getPathSegAtLength const):
(WebCore::SVGPathElement::getBBox):
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::didMoveToNewDocument):
(WebCore::SVGSVGElement::updateCurrentTranslate):
(WebCore::SVGSVGElement::attributeChanged):
(WebCore::SVGSVGElement::getIntersectionList):
(WebCore::SVGSVGElement::getEnclosureList):
(WebCore::SVGSVGElement::checkIntersection):
(WebCore::SVGSVGElement::checkEnclosure):
(WebCore::SVGSVGElement::createElementRenderer):
(WebCore::SVGSVGElement::findViewAnchor const):
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::addSubresourceAttributeURLs const):
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::updateReferencedText):
(WebCore::SVGTRefElement::detachTarget):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::getNumberOfChars):
(WebCore::SVGTextContentElement::getComputedTextLength):
(WebCore::SVGTextContentElement::getCharNumAtPosition):
* Source/WebCore/svg/SVGTitleElement.cpp:
(WebCore::SVGTitleElement::insertedIntoAncestor):
(WebCore::SVGTitleElement::childrenChanged):
* Source/WebCore/svg/SVGURIReference.cpp:
(WebCore::SVGURIReference::haveLoadedRequiredResources const):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::insertedIntoAncestor):
(WebCore::SVGUseElement::updateUserAgentShadowTree):
(WebCore::SVGUseElement::findTarget const):
(WebCore::SVGUseElement::cloneTarget const):
(WebCore::SVGUseElement::expandUseElementsInShadowTree const):
(WebCore::SVGUseElement::expandSymbolElementsInShadowTree const):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::rootElement const):
(WebCore::SVGImage::dataChanged):
* Source/WebCore/xml/XPathExpression.cpp:
(WebCore::XPathExpression::evaluate):
* Source/WebCore/xml/XPathNodeSet.cpp:
(WebCore::XPath::findRootNode):
* Source/WebCore/xml/XSLImportRule.cpp:
(WebCore::XSLImportRule::loadSheet):
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::handleError):
(WebCore::XMLDocumentParser::createLeafTextNode):
(WebCore::XMLDocumentParser::end):
(WebCore::XMLDocumentParser::parseDocumentFragment):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::shouldAllowExternalLoad):
(WebCore::XMLDocumentParser::doWrite):
(WebCore::XMLDocumentParser::processingInstruction):
(WebCore::XMLDocumentParser::cdataBlock):
(WebCore::XMLDocumentParser::comment):
(WebCore::XMLDocumentParser::startDocument):
(WebCore::XMLDocumentParser::doEnd):
(WebCore::XMLDocumentParser::appendFragmentSource):

Canonical link: <a href="https://commits.webkit.org/306592@main">https://commits.webkit.org/306592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f489c3094604b39554bac566dcbc397c3a8f4942

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94907 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108951 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78787 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89847 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11052 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8691 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/442 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152764 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13857 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117046 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13872 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117368 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29899 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13412 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123610 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13895 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/2891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77620 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13681 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->