### PR TITLE
Drop `protected*()` getters in Node.h

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5845,7 +5845,7 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
 
     SpaceSplitString ids(value, SpaceSplitString::ShouldFoldCase::No);
     for (auto& id : ids) {
-        RefPtr target = origin.protectedTreeScope()->elementByIdResolvingReferenceTarget(id);
+        RefPtr target = protect(origin.treeScope())->elementByIdResolvingReferenceTarget(id);
         if (!target || target == &origin)
             continue;
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -117,7 +117,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
         bool hadElementChild = false;
         while (RefPtr child = m_firstChild.get()) {
             hadElementChild |= is<Element>(*child);
-            removeBetween(nullptr, child->protectedNextSibling().get(), *child);
+            removeBetween(nullptr, protect(child->nextSibling()).get(), *child);
         }
         document().incDOMTreeVersion();
         return { 0, hadElementChild ? DidRemoveElements::Yes : DidRemoveElements::No, CanDelayNodeDeletion::Unknown };
@@ -172,7 +172,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
             if (is<Element>(*child))
                 hadElementChild = true;
 
-            removeBetween(nullptr, child->protectedNextSibling().get(), *child);
+            removeBetween(nullptr, protect(child->nextSibling()).get(), *child);
             auto [subTreeSize, subtreeObservability, subtreeCanDelayNodeDeletion] = notifyChildNodeRemoved(*this, *child);
             treeSize += subTreeSize;
             ASSERT(subtreeCanDelayNodeDeletion != CanDelayNodeDeletion::Unknown);
@@ -1158,7 +1158,7 @@ static void dispatchChildInsertionEvents(Node& child)
 
     RefPtr c = child;
     if (c->parentNode() && document->hasListenerType(Document::ListenerType::DOMNodeInserted))
-        c->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeInsertedEvent, Event::CanBubble::Yes, c->protectedParentNode().get()));
+        c->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeInsertedEvent, Event::CanBubble::Yes, protect(c->parentNode()).get()));
 
     // dispatch the DOMNodeInsertedIntoDocument event to all descendants
     if (c->isConnected() && document->hasListenerType(Document::ListenerType::DOMNodeInsertedIntoDocument)) {
@@ -1178,7 +1178,7 @@ static void dispatchChildRemovalEvents(Ref<Node>& child)
 
     // dispatch pre-removal mutation events
     if (child->parentNode() && document->hasListenerType(Document::ListenerType::DOMNodeRemoved))
-        child->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeRemovedEvent, Event::CanBubble::Yes, child->protectedParentNode().get()));
+        child->dispatchScopedEvent(MutationEvent::create(eventNames().DOMNodeRemovedEvent, Event::CanBubble::Yes, protect(child->parentNode()).get()));
 
     // dispatch the DOMNodeRemovedFromDocument event to all descendants
     if (child->isConnected() && document->hasListenerType(Document::ListenerType::DOMNodeRemovedFromDocument)) {

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -41,10 +41,8 @@ public:
     virtual ~ContainerNode();
 
     Node* firstChild() const { return m_firstChild; }
-    RefPtr<Node> protectedFirstChild() const { return m_firstChild; }
     static constexpr ptrdiff_t firstChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_firstChild); }
     Node* lastChild() const { return m_lastChild; }
-    RefPtr<Node> protectedLastChild() const { return m_lastChild; }
     static constexpr ptrdiff_t lastChildMemoryOffset() { return OBJECT_OFFSETOF(ContainerNode, m_lastChild); }
     bool hasChildNodes() const { return m_firstChild; }
     bool hasOneChild() const { return m_firstChild && m_firstChild == m_lastChild; }
@@ -63,7 +61,6 @@ public:
     void replaceAll(Node*);
 
     inline ContainerNode& rootNode() const; // Defined in ContainerNodeInlines.h
-    inline Ref<ContainerNode> protectedRootNode() const; // Defined in ContainerNodeInlines.h
     ContainerNode& traverseToRootNode() const;
 
     // These methods are only used during parsing.

--- a/Source/WebCore/dom/ContainerNodeInlines.h
+++ b/Source/WebCore/dom/ContainerNodeInlines.h
@@ -37,11 +37,6 @@ inline ContainerNode& ContainerNode::rootNode() const
     return traverseToRootNode();
 }
 
-inline Ref<ContainerNode> ContainerNode::protectedRootNode() const
-{
-    return rootNode();
-}
-
 inline RenderElement* ContainerNode::renderer() const
 {
     return downcast<RenderElement>(Node::renderer());

--- a/Source/WebCore/dom/CustomElementDefaultARIA.cpp
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.cpp
@@ -48,7 +48,7 @@ void CustomElementDefaultARIA::setValueForAttribute(const QualifiedName& name, c
 
 static bool isElementVisible(const Element& element, const Element& thisElement)
 {
-    return !element.isConnected() || element.isInDocumentTree() || thisElement.isShadowIncludingDescendantOf(element.protectedRootNode());
+    return !element.isConnected() || element.isInDocumentTree() || thisElement.isShadowIncludingDescendantOf(protect(element.rootNode()));
 }
 
 const AtomString& CustomElementDefaultARIA::valueForAttribute(const Element& thisElement, const QualifiedName& name) const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2536,7 +2536,7 @@ void Document::setTitle(String&& title)
         if (!m_titleElement) {
             Ref titleElement = SVGTitleElement::create(SVGNames::titleTag, *this);
             m_titleElement = titleElement.copyRef();
-            svgElement->insertBefore(titleElement, svgElement->protectedFirstChild());
+            svgElement->insertBefore(titleElement, protect(svgElement->firstChild()));
         }
         // insertBefore above may have ran scripts which removed m_titleElement.
         if (RefPtr titleElement = m_titleElement)

--- a/Source/WebCore/dom/DocumentFragment.cpp
+++ b/Source/WebCore/dom/DocumentFragment.cpp
@@ -123,7 +123,7 @@ RefPtr<Element> DocumentFragment::getElementById(const AtomString& id) const
 
     // Fast path for ShadowRoot, where we are both a DocumentFragment and a TreeScope.
     if (isTreeScope())
-        return protectedTreeScope()->getElementById(id);
+        return protect(treeScope())->getElementById(id);
 
     // Otherwise, fall back to iterating all of the element descendants.
     for (Ref element : descendantsOfType<Element>(*const_cast<DocumentFragment*>(this))) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -6001,7 +6001,7 @@ ExceptionOr<Node*> Element::insertAdjacent(const String& where, Ref<Node>&& newC
     }
 
     if (equalLettersIgnoringASCIICase(where, "afterbegin"_s)) {
-        auto result = insertBefore(newChild, protectedFirstChild());
+        auto result = insertBefore(newChild, protect(firstChild()));
         if (result.hasException())
             return result.releaseException();
         return newChild.ptr();
@@ -6018,7 +6018,7 @@ ExceptionOr<Node*> Element::insertAdjacent(const String& where, Ref<Node>&& newC
         RefPtr parent = this->parentNode();
         if (!parent)
             return nullptr;
-        auto result = parent->insertBefore(newChild, protectedNextSibling());
+        auto result = parent->insertBefore(newChild, protect(nextSibling()));
         if (result.hasException())
             return result.releaseException();
         return newChild.ptr();

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -380,11 +380,6 @@ inline ShadowRoot* Element::shadowRoot() const
     return hasRareData() ? elementRareData()->shadowRoot() : nullptr;
 }
 
-inline RefPtr<ShadowRoot> Node::protectedShadowRoot() const
-{
-    return shadowRoot();
-}
-
 inline void Element::removeShadowRoot()
 {
     RefPtr shadowRoot = this->shadowRoot();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1287,19 +1287,9 @@ Element* Node::shadowHost() const
     return nullptr;
 }
 
-RefPtr<Element> Node::protectedShadowHost() const
-{
-    return shadowHost();
-}
-
 ShadowRoot* Node::containingShadowRoot() const
 {
     return dynamicDowncast<ShadowRoot>(treeScope().rootNode());
-}
-
-RefPtr<ShadowRoot> Node::protectedContainingShadowRoot() const
-{
-    return containingShadowRoot();
 }
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -165,21 +165,15 @@ public:
     NodeType nodeType() const { return nodeTypeFromBitFields(m_typeBitFields); }
     virtual size_t approximateMemoryCost() const { return sizeof(*this); }
     ContainerNode* parentNode() const;
-    inline RefPtr<ContainerNode> protectedParentNode() const;
     static constexpr ptrdiff_t parentNodeMemoryOffset() { return OBJECT_OFFSETOF(Node, m_parentNode); }
     inline Element* parentElement() const;
-    inline RefPtr<Element> protectedParentElement() const;
     Node* previousSibling() const { return m_previousSibling; }
-    RefPtr<Node> protectedPreviousSibling() const { return m_previousSibling; }
     static constexpr ptrdiff_t previousSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_previousSibling); }
     Node* nextSibling() const { return m_next; }
-    RefPtr<Node> protectedNextSibling() const { return m_next; }
     static constexpr ptrdiff_t nextSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_next); }
     WEBCORE_EXPORT Ref<NodeList> childNodes();
     inline Node* firstChild() const;
-    inline RefPtr<Node> protectedFirstChild() const;
     inline Node* lastChild() const;
-    inline RefPtr<Node> protectedLastChild() const;
     inline bool hasAttributes() const;
     inline NamedNodeMap* attributesMap() const;
     Node* pseudoAwareNextSibling() const;
@@ -286,11 +280,8 @@ public:
 
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
     WEBCORE_EXPORT Element* shadowHost() const;
-    RefPtr<Element> protectedShadowHost() const;
     ShadowRoot* containingShadowRoot() const;
-    RefPtr<ShadowRoot> protectedContainingShadowRoot() const;
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
-    inline RefPtr<ShadowRoot> protectedShadowRoot() const; // Defined in ElementRareData.h
     bool isClosedShadowHidden(const Node&) const;
 
     HTMLSlotElement* assignedSlot() const;
@@ -326,13 +317,11 @@ public:
 
     // Node's parent or shadow tree host.
     inline ContainerNode* parentOrShadowHostNode() const; // Defined in NodeInlines.h
-    inline RefPtr<ContainerNode> protectedParentOrShadowHostNode() const; // Defined in NodeInlines.h
     ContainerNode* parentInComposedTree() const;
     WEBCORE_EXPORT Element* parentElementInComposedTree() const;
     Element* parentOrShadowHostElement() const;
     inline void setParentNode(ContainerNode*);
     inline Node& rootNode() const;
-    inline Ref<Node> protectedRootNode() const;
     WEBCORE_EXPORT Node& traverseToRootNode() const;
     Node& shadowIncludingRoot() const;
 
@@ -448,7 +437,6 @@ public:
         ASSERT(m_treeScope);
         return *m_treeScope;
     }
-    inline Ref<TreeScope> protectedTreeScope() const; // Defined in NodeInlines.h
     inline void setTreeScopeRecursively(TreeScope&);
     static constexpr ptrdiff_t treeScopeMemoryOffset() { return OBJECT_OFFSETOF(Node, m_treeScope); }
 
@@ -567,7 +555,6 @@ public:
 
     enum EventTargetInterfaceType eventTargetInterface() const override;
     ScriptExecutionContext* scriptExecutionContext() const final;
-    inline RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
     using EventTarget::addEventListener;

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -48,16 +48,6 @@ inline ContainerNode* Node::parentOrShadowHostNode() const
     return parentNode();
 }
 
-inline RefPtr<ContainerNode> Node::protectedParentOrShadowHostNode() const
-{
-    return parentOrShadowHostNode();
-}
-
-inline RefPtr<ScriptExecutionContext> Node::protectedScriptExecutionContext() const
-{
-    return scriptExecutionContext();
-}
-
 inline WebCoreOpaqueRoot Node::opaqueRoot() const
 {
     if (isConnected()) {
@@ -66,11 +56,6 @@ inline WebCoreOpaqueRoot Node::opaqueRoot() const
     }
     // FIXME: Possible race?
     return traverseToOpaqueRoot();
-}
-
-inline Ref<TreeScope> Node::protectedTreeScope() const
-{
-    return treeScope();
 }
 
 inline RenderBox* Node::renderBox() const
@@ -117,11 +102,6 @@ inline void Node::setRenderer(RenderObject* renderer)
 inline Element* Node::parentElement() const
 {
     return dynamicDowncast<Element>(parentNode());
-}
-
-inline RefPtr<Element> Node::protectedParentElement() const
-{
-    return parentElement();
 }
 
 bool Node::isBeforePseudoElement() const
@@ -182,20 +162,10 @@ inline Node* Node::firstChild() const
     return containerNode ? containerNode->firstChild() : nullptr;
 }
 
-inline RefPtr<Node> Node::protectedFirstChild() const
-{
-    return firstChild();
-}
-
 inline Node* Node::lastChild() const
 {
     auto* containerNode = dynamicDowncast<ContainerNode>(*this);
     return containerNode ? containerNode->lastChild() : nullptr;
-}
-
-inline RefPtr<Node> Node::protectedLastChild() const
-{
-    return lastChild();
 }
 
 inline bool Node::hasChildNodes() const
@@ -210,21 +180,11 @@ inline Node& Node::rootNode() const
     return traverseToRootNode();
 }
 
-inline Ref<Node> Node::protectedRootNode() const
-{
-    return rootNode();
-}
-
 inline void Node::setParentNode(ContainerNode* parent)
 {
     ASSERT(isMainThread());
     m_parentNode = parent;
     m_refCountAndParentBit = (m_refCountAndParentBit & s_refCountMask) | !!parent;
-}
-
-inline RefPtr<ContainerNode> Node::protectedParentNode() const
-{
-    return parentNode();
 }
 
 ALWAYS_INLINE bool Node::hasOneRef() const

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -405,11 +405,11 @@ ExceptionOr<RefPtr<DocumentFragment>> Range::processContents(ActionType action)
         // Collapse the range, making sure that the result is not within a node that was partially selected.
         if (action == Extract || action == Delete) {
             if (partialStart && commonRoot->contains(*partialStart)) {
-                auto result = setStart(partialStart->protectedParentNode().releaseNonNull(), partialStart->computeNodeIndex() + 1);
+                auto result = setStart(protect(partialStart->parentNode()).releaseNonNull(), partialStart->computeNodeIndex() + 1);
                 if (result.hasException())
                     return result.releaseException();
             } else if (partialEnd && commonRoot->contains(*partialEnd)) {
-                auto result = setStart(partialEnd->protectedParentNode().releaseNonNull(), partialEnd->computeNodeIndex());
+                auto result = setStart(protect(partialEnd->parentNode()).releaseNonNull(), partialEnd->computeNodeIndex());
                 if (result.hasException())
                     return result.releaseException();
             }
@@ -634,7 +634,7 @@ ExceptionOr<RefPtr<Node>> processAncestorsAndTheirSiblings(Range::ActionType act
                     if (result.hasException())
                         return result.releaseException();
                 } else {
-                    auto result = clonedContainer->insertBefore(child.get(), clonedContainer->protectedFirstChild());
+                    auto result = clonedContainer->insertBefore(child.get(), protect(clonedContainer->firstChild()));
                     if (result.hasException())
                         return result.releaseException();
                 }
@@ -645,7 +645,7 @@ ExceptionOr<RefPtr<Node>> processAncestorsAndTheirSiblings(Range::ActionType act
                     if (result.hasException())
                         return result.releaseException();
                 } else {
-                    auto result = clonedContainer->insertBefore(child->cloneNode(true), clonedContainer->protectedFirstChild());
+                    auto result = clonedContainer->insertBefore(child->cloneNode(true), protect(clonedContainer->firstChild()));
                     if (result.hasException())
                         return result.releaseException();
                 }
@@ -1010,9 +1010,9 @@ void Range::textRemoved(Node& text, unsigned offset, unsigned length)
 static inline void boundaryTextNodesMerged(RangeBoundaryPoint& boundary, NodeWithIndex& oldNode, unsigned offset)
 {
     if (&boundary.container() == oldNode.node())
-        boundary.set(oldNode.node()->protectedPreviousSibling().releaseNonNull(), boundary.offset() + offset, nullptr);
+        boundary.set(protect(oldNode.node()->previousSibling()).releaseNonNull(), boundary.offset() + offset, nullptr);
     else if (&boundary.container() == oldNode.node()->parentNode() && boundary.offset() == static_cast<unsigned>(oldNode.index()))
-        boundary.set(oldNode.node()->protectedPreviousSibling().releaseNonNull(), offset, nullptr);
+        boundary.set(protect(oldNode.node()->previousSibling()).releaseNonNull(), offset, nullptr);
 }
 
 void Range::textNodesMerged(NodeWithIndex& oldNode, unsigned offset)
@@ -1036,7 +1036,7 @@ static inline void boundaryTextNodesSplit(RangeBoundaryPoint& boundary, Text& ol
         unsigned boundaryOffset = boundary.offset();
         if (boundaryOffset > splitOffset) {
             if (parent)
-                boundary.set(oldNode.protectedNextSibling().releaseNonNull(), boundaryOffset - splitOffset, nullptr);
+                boundary.set(protect(oldNode.nextSibling()).releaseNonNull(), boundaryOffset - splitOffset, nullptr);
             else
                 boundary.setOffset(splitOffset);
         }

--- a/Source/WebCore/dom/SerializedNode.cpp
+++ b/Source/WebCore/dom/SerializedNode.cpp
@@ -125,7 +125,7 @@ Ref<Node> SerializedNode::deserialize(SerializedNode&& serializedNode, WebCore::
             Ref content = TemplateContentDocumentFragment::create(Ref { document.ensureTemplateDocument() }.get(), result);
             for (auto&& child : std::exchange(element.content->children, { })) {
                 if (RefPtr childNode = deserialize(WTF::move(child), document)) {
-                    childNode->setTreeScopeRecursively(content->protectedTreeScope());
+                    childNode->setTreeScopeRecursively(protect(content->treeScope()));
                     content->appendChildCommon(*childNode);
                 }
             }
@@ -142,7 +142,7 @@ Ref<Node> SerializedNode::deserialize(SerializedNode&& serializedNode, WebCore::
     RefPtr containerNode = dynamicDowncast<WebCore::ContainerNode>(node);
     for (auto&& child : WTF::move(serializedChildren)) {
         Ref childNode = deserialize(WTF::move(child), document);
-        childNode->setTreeScopeRecursively(containerNode->protectedTreeScope());
+        childNode->setTreeScopeRecursively(protect(containerNode->treeScope()));
         containerNode->appendChildCommon(childNode);
     }
 

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -85,7 +85,7 @@ bool StaticRange::computeValidity() const
         return false;
     if (startContainer.ptr() == endContainer.ptr())
         return endOffset() > startOffset();
-    if (!connectedInSameTreeScope(startContainer->protectedRootNode().ptr(), endContainer->protectedRootNode().ptr()))
+    if (!connectedInSameTreeScope(protect(startContainer->rootNode()).ptr(), protect(endContainer->rootNode()).ptr()))
         return false;
     return !is_gt(treeOrder<ComposedTree>(startContainer, endContainer));
 }

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -67,7 +67,7 @@ ExceptionOr<Ref<Text>> Text::splitText(unsigned offset)
     dispatchModifiedEvent(oldData);
 
     if (RefPtr parent = parentNode()) {
-        auto insertResult = parent->insertBefore(newText, protectedNextSibling());
+        auto insertResult = parent->insertBefore(newText, protect(nextSibling()));
         if (insertResult.hasException())
             return insertResult.releaseException();
     }

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -507,7 +507,7 @@ RefPtr<HTMLElement> ApplyStyleCommand::splitAncestorsWithUnicodeBidi(Node* node,
     while (currentNode) {
         RefPtr parent = downcast<Element>(currentNode->parentNode());
         if (before ? currentNode->previousSibling() : currentNode->nextSibling())
-            splitElement(*parent, before ? *currentNode : *currentNode->protectedNextSibling());
+            splitElement(*parent, before ? *currentNode : *protect(currentNode->nextSibling()));
         if (parent == highestAncestorWithUnicodeBidi)
             break;
         currentNode = parent;

--- a/Source/WebCore/editing/ChangeListTypeCommand.cpp
+++ b/Source/WebCore/editing/ChangeListTypeCommand.cpp
@@ -90,7 +90,7 @@ void ChangeListTypeCommand::doApply()
     Ref listToReplace = WTF::move(typeAndElement->second);
     Ref newList = createNewList(listToReplace);
     insertNodeBefore(newList.copyRef(), listToReplace);
-    moveRemainingSiblingsToNewParent(listToReplace->protectedFirstChild().get(), nullptr, newList);
+    moveRemainingSiblingsToNewParent(protect(listToReplace->firstChild()).get(), nullptr, newList);
     removeNode(listToReplace);
     setEndingSelection({ Position { newList.ptr(), Position::PositionIsAfterChildren }});
 }

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1624,7 +1624,7 @@ bool CompositeEditCommand::breakOutOfEmptyListItem()
                 // If listNode does NOT appear at the end, then we should consider it as a regular paragraph.
                 // e.g. <ul><li> <ul><li><br></li></ul> hello</li></ul> should become <ul><li> <div><br></div> hello</li></ul> at the end
                 splitElement(*liElement, *listNode);
-                removeNodePreservingChildren(*listNode->protectedParentNode());
+                removeNodePreservingChildren(*protect(listNode->parentNode()));
                 newBlock = HTMLLIElement::create(document);
             }
             // If listNode does NOT appear at the end of the outer list item, then behave as if in a regular paragraph.

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -851,7 +851,7 @@ void EditingStyle::removeStyleAddedByNode(Node* node)
 {
     if (!node || !node->parentNode())
         return;
-    auto parentStyle = copyPropertiesFromComputedStyle(node->protectedParentNode().get(), PropertiesToInclude::EditingPropertiesInEffect);
+    auto parentStyle = copyPropertiesFromComputedStyle(protect(node->parentNode()).get(), PropertiesToInclude::EditingPropertiesInEffect);
     auto nodeStyle = copyPropertiesFromComputedStyle(node, PropertiesToInclude::EditingPropertiesInEffect);
     removeEquivalentProperties(parentStyle.get());
     removeEquivalentProperties(nodeStyle.get());
@@ -862,7 +862,7 @@ void EditingStyle::removeStyleConflictingWithStyleOfNode(Node& node)
     if (!node.parentNode() || !m_mutableStyle)
         return;
 
-    auto parentStyle = copyPropertiesFromComputedStyle(node.protectedParentNode().get(), PropertiesToInclude::EditingPropertiesInEffect);
+    auto parentStyle = copyPropertiesFromComputedStyle(protect(node.parentNode()).get(), PropertiesToInclude::EditingPropertiesInEffect);
     auto nodeStyle = EditingStyle::create(&node, PropertiesToInclude::EditingPropertiesInEffect);
     nodeStyle->removeEquivalentProperties(parentStyle.get());
 

--- a/Source/WebCore/editing/SplitTextNodeCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeCommand.cpp
@@ -103,7 +103,7 @@ void SplitTextNodeCommand::doReapply()
 void SplitTextNodeCommand::insertText1AndTrimText2()
 {
     Ref text2 = m_text2;
-    if (text2->protectedParentNode()->insertBefore(*protectedText1(), text2.copyRef()).hasException())
+    if (protect(text2->parentNode())->insertBefore(*protectedText1(), text2.copyRef()).hasException())
         return;
     text2->deleteData(0, m_offset);
 }

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -795,7 +795,7 @@ bool TextIterator::handleReplacedElement()
         return false;
 
     if (m_lastTextNodeEndedWithCollapsedSpace) {
-        emitCharacter(' ', m_lastTextNode->protectedParentNode(), m_lastTextNode.copyRef(), 1, 1);
+        emitCharacter(' ', protect(m_lastTextNode->parentNode()), m_lastTextNode.copyRef(), 1, 1);
         return false;
     }
 
@@ -837,7 +837,7 @@ bool TextIterator::handleReplacedElement()
     }();
 
     if (shouldEmitObjectReplacementCharacter) {
-        emitCharacter(objectReplacementCharacter, m_currentNode->protectedParentNode(), protectedCurrentNode(), 0, 1);
+        emitCharacter(objectReplacementCharacter, protect(m_currentNode->parentNode()), protectedCurrentNode(), 0, 1);
         // Don't process subtrees for embedded objects. If the text there is required,
         // it must be explicitly asked by specifying a range falling inside its boundaries.
         m_handledChildren = true;
@@ -845,10 +845,10 @@ bool TextIterator::handleReplacedElement()
     }
 
     if (m_behaviors.contains(TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions)) {
-        // We want replaced elements to behave like punctuation for boundary 
-        // finding, and to simply take up space for the selection preservation 
+        // We want replaced elements to behave like punctuation for boundary
+        // finding, and to simply take up space for the selection preservation
         // code in moveParagraphs, so we use a comma.
-        emitCharacter(',', m_currentNode->protectedParentNode(), protectedCurrentNode(), 0, 1);
+        emitCharacter(',', protect(m_currentNode->parentNode()), protectedCurrentNode(), 0, 1);
         return true;
     }
 
@@ -1151,14 +1151,14 @@ void TextIterator::exitNode(Node* exitedNode)
         // contain a VisiblePosition when doing selection preservation.
         if (m_lastCharacter != '\n') {
             // insert a newline with a position following this block's contents.
-            emitCharacter('\n', baseNode->protectedParentNode(), baseNode.copyRef(), 1, 1);
+            emitCharacter('\n', protect(baseNode->parentNode()), baseNode.copyRef(), 1, 1);
             // remember whether to later add a newline for the current node
             ASSERT(!m_nodeForAdditionalNewline);
             if (addNewline)
                 m_nodeForAdditionalNewline = baseNode.get();
         } else if (addNewline)
             // insert a newline with a position following this block's contents.
-            emitCharacter('\n', baseNode->protectedParentNode(), baseNode.copyRef(), 1, 1);
+            emitCharacter('\n', protect(baseNode->parentNode()), baseNode.copyRef(), 1, 1);
     }
     
     // If nothing was emitted, see if we need to emit a space.
@@ -1335,7 +1335,7 @@ void SimplifiedBackwardsTextIterator::advance()
 
             // Exit all other containers.
             while (!m_node->previousSibling()) {
-                if (!advanceRespectingRange(m_node->protectedParentOrShadowHostNode().get()))
+                if (!advanceRespectingRange(protect(m_node->parentOrShadowHostNode()).get()))
                     break;
                 m_fullyClippedStack.pop();
                 exitNode();
@@ -1347,7 +1347,7 @@ void SimplifiedBackwardsTextIterator::advance()
             }
 
             m_fullyClippedStack.pop();
-            if (advanceRespectingRange(m_node->protectedPreviousSibling().get()))
+            if (advanceRespectingRange(protect(m_node->previousSibling()).get()))
                 pushFullyClippedState(m_fullyClippedStack, *protectedNode(), m_behaviors);
             else
                 m_node = nullptr;
@@ -1437,11 +1437,11 @@ RenderText* SimplifiedBackwardsTextIterator::handleFirstLetter(int& startOffset,
 bool SimplifiedBackwardsTextIterator::handleReplacedElement()
 {
     unsigned index = m_node->computeNodeIndex();
-    // We want replaced elements to behave like punctuation for boundary 
-    // finding, and to simply take up space for the selection preservation 
+    // We want replaced elements to behave like punctuation for boundary
+    // finding, and to simply take up space for the selection preservation
     // code in moveParagraphs, so we use a comma. Unconditionally emit
     // here because this iterator is only used for boundary finding.
-    emitCharacter(',', m_node->protectedParentNode(), index, index + 1);
+    emitCharacter(',', protect(m_node->parentNode()), index, index + 1);
     return true;
 }
 
@@ -1450,14 +1450,14 @@ bool SimplifiedBackwardsTextIterator::handleNonTextNode()
     RefPtr currentNode = m_node;
     if (shouldEmitTabBeforeNode(*currentNode)) {
         unsigned index = currentNode->computeNodeIndex();
-        emitCharacter('\t', currentNode->protectedParentNode(), index + 1, index + 1);
+        emitCharacter('\t', protect(currentNode->parentNode()), index + 1, index + 1);
     } else if (shouldEmitNewlineForNode(currentNode.get(), m_behaviors.contains(TextIteratorBehavior::EmitsOriginalText)) || shouldEmitNewlineAfterNode(*m_node)) {
         if (m_lastCharacter != '\n') {
             // Corresponds to the same check in TextIterator::exitNode.
             unsigned index = currentNode->computeNodeIndex();
             // The start of this emitted range is wrong. Ensuring correctness would require
             // VisiblePositions and so would be slow. previousBoundary expects this.
-            emitCharacter('\n', currentNode->protectedParentNode(), index + 1, index + 1);
+            emitCharacter('\n', protect(currentNode->parentNode()), index + 1, index + 1);
         }
     }
     return true;

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -236,7 +236,7 @@ static bool hasAncestorQualifyingForWritingToolsPreservation(Element* ancestor, 
 
     auto entry = cache.find(*ancestor);
     if (entry == cache.end()) {
-        auto result = elementQualifiesForWritingToolsPreservation(ancestor) || hasAncestorQualifyingForWritingToolsPreservation(ancestor->protectedParentElement().get(), cache);
+        auto result = elementQualifiesForWritingToolsPreservation(ancestor) || hasAncestorQualifyingForWritingToolsPreservation(protect(ancestor->parentElement()).get(), cache);
 
         cache.set(*ancestor, result);
         return result;
@@ -336,7 +336,7 @@ static void updateAttributes(const Node* node, const RenderStyle& style, OptionS
 {
 #if ENABLE(WRITING_TOOLS)
     if (includedElements.contains(IncludedElement::PreservedContent)) {
-        if (hasAncestorQualifyingForWritingToolsPreservation(node->protectedParentElement().get(), elementQualifiesForWritingToolsPreservationCache))
+        if (hasAncestorQualifyingForWritingToolsPreservation(protect(node->parentElement()).get(), elementQualifiesForWritingToolsPreservationCache))
             [attributes setObject:@(1) forKey:WTWritingToolsPreservedAttributeName];
         else
             [attributes removeObjectForKey:WTWritingToolsPreservedAttributeName];

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -821,7 +821,7 @@ RefPtr<Node> StyledMarkupAccumulator::serializeNodes(const Position& start, cons
         m_highestNodeToBeSerialized = traverseNodesForSerialization(*startNode, pastEnd.get(), NodeTraversalMode::DoNotEmitString);
 
     if (m_highestNodeToBeSerialized && m_highestNodeToBeSerialized->parentNode())
-        m_wrappingStyle = EditingStyle::wrappingStyleForSerialization(*m_highestNodeToBeSerialized->protectedParentNode(), shouldAnnotate(), m_standardFontFamilySerializationMode);
+        m_wrappingStyle = EditingStyle::wrappingStyleForSerialization(*protect(m_highestNodeToBeSerialized->parentNode()), shouldAnnotate(), m_standardFontFamilySerializationMode);
 
     return traverseNodesForSerialization(*startNode, pastEnd.get(), NodeTraversalMode::EmitString);
 }
@@ -1377,8 +1377,8 @@ bool isPlainTextMarkup(Node* node)
     
     if (secondChild->nextSibling())
         return false;
-    
-    return parentTabSpanNode(firstChild->protectedFirstChild().get()) && is<Text>(secondChild);
+
+    return parentTabSpanNode(protect(firstChild->firstChild()).get()) && is<Text>(secondChild);
 }
 
 static bool contextPreservesNewline(const SimpleRange& context)

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -183,7 +183,7 @@ void FormAssociatedCustomElement::didUpgrade()
 
     setDataListAncestorState(TriState::Indeterminate);
     updateWillValidateAndValidity();
-    syncWithFieldsetAncestors(element->protectedParentNode().get());
+    syncWithFieldsetAncestors(protect(element->parentNode()).get());
     invalidateElementsCollectionCachesInAncestors();
     restoreFormControlStateIfNecessary();
 }

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -303,7 +303,7 @@ const AtomString& FormListedElement::name() const
 }
 
 FormAttributeTargetObserver::FormAttributeTargetObserver(const AtomString& id, FormListedElement& element)
-    : IdTargetObserver(element.asProtectedHTMLElement()->protectedTreeScope()->idTargetObserverRegistry(), id)
+    : IdTargetObserver(protect(element.asProtectedHTMLElement()->treeScope())->idTargetObserverRegistry(), id)
     , m_element(element)
 {
 }

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -151,7 +151,7 @@ bool HTMLDetailsElement::isActiveSummary(const HTMLSummaryElement& summary) cons
     if (summary.parentNode() != this)
         return false;
 
-    RefPtr slot = protectedShadowRoot()->findAssignedSlot(summary);
+    RefPtr slot = protect(shadowRoot())->findAssignedSlot(summary);
     return slot && slot == summarySlot.get();
 }
 

--- a/Source/WebCore/html/HTMLHRElement.cpp
+++ b/Source/WebCore/html/HTMLHRElement.cpp
@@ -62,7 +62,7 @@ auto HTMLHRElement::insertedIntoAncestor(InsertionType insertionType, ContainerN
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || m_ownerSelect)
         return result;
 
-    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protectedParentNode().get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
+    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protect(parentNode()).get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
         m_ownerSelect = select.get();
         select->setRecalcListItems();
     }
@@ -77,7 +77,7 @@ void HTMLHRElement::removedFromAncestor(RemovalType removalType, ContainerNode& 
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || !m_ownerSelect)
         return;
 
-    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protectedParentNode().get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
+    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protect(parentNode()).get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
         ASSERT_UNUSED(select, select == m_ownerSelect.get());
         return;
     }

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -536,7 +536,7 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
     Node::InsertedIntoAncestorResult insertNotificationRequest = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 
     if (insertionType.treeScopeChanged && !m_parsedUsemap.isNull())
-        protectedTreeScope()->addImageElementByUsemap(m_parsedUsemap, *this);
+        protect(treeScope())->addImageElementByUsemap(m_parsedUsemap, *this);
 
     if (auto* parentPicture = dynamicDowncast<HTMLPictureElement>(parentOfInsertedTree); parentPicture && &parentOfInsertedTree == parentElement()) {
         // FIXME: When the hack in HTMLConstructionSite::createHTMLElementOrFindCustomElementInterface to eagerly call setPictureElement is removed, we can just assert !pictureElement().
@@ -557,7 +557,7 @@ Node::InsertedIntoAncestorResult HTMLImageElement::insertedIntoAncestor(Insertio
 void HTMLImageElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     if (removalType.treeScopeChanged && !m_parsedUsemap.isNull())
-        oldParentOfRemovedTree.protectedTreeScope()->removeImageElementByUsemap(m_parsedUsemap, *this);
+        protect(oldParentOfRemovedTree.treeScope())->removeImageElementByUsemap(m_parsedUsemap, *this);
 
     if (is<HTMLPictureElement>(oldParentOfRemovedTree) && !parentElement()) {
         ASSERT(pictureElement() == &oldParentOfRemovedTree);
@@ -727,7 +727,7 @@ bool HTMLImageElement::matchesUsemap(const AtomString& name) const
 
 RefPtr<HTMLMapElement> HTMLImageElement::associatedMapElement() const
 {
-    return protectedTreeScope()->getImageMap(m_parsedUsemap);
+    return protect(treeScope())->getImageMap(m_parsedUsemap);
 }
 
 int HTMLImageElement::x() const

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -62,7 +62,7 @@ auto HTMLOptGroupElement::insertedIntoAncestor(InsertionType insertionType, Cont
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || m_ownerSelect)
         return result;
 
-    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protectedParentNode().get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
+    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protect(parentNode()).get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
         m_ownerSelect = select.get();
         select->setRecalcListItems();
     }
@@ -77,7 +77,7 @@ void HTMLOptGroupElement::removedFromAncestor(RemovalType removalType, Container
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || !m_ownerSelect)
         return;
 
-    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protectedParentNode().get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
+    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protect(parentNode()).get(), HTMLSelectElement::ExcludeOptGroup::Yes)) {
         ASSERT_UNUSED(select, select == m_ownerSelect.get());
         return;
     }

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -97,7 +97,7 @@ auto HTMLOptionElement::insertedIntoAncestor(InsertionType insertionType, Contai
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || m_ownerSelect)
         return result;
 
-    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protectedParentNode().get(), HTMLSelectElement::ExcludeOptGroup::No)) {
+    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protect(parentNode()).get(), HTMLSelectElement::ExcludeOptGroup::No)) {
         m_ownerSelect = select.get();
         select->setRecalcListItems();
     }
@@ -112,7 +112,7 @@ void HTMLOptionElement::removedFromAncestor(RemovalType removalType, ContainerNo
     if (!document().settings().htmlEnhancedSelectParsingEnabled() || !m_ownerSelect)
         return;
 
-    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protectedParentNode().get(), HTMLSelectElement::ExcludeOptGroup::No)) {
+    if (RefPtr select = HTMLSelectElement::findOwnerSelect(protect(parentNode()).get(), HTMLSelectElement::ExcludeOptGroup::No)) {
         ASSERT_UNUSED(select, select == m_ownerSelect.get());
         return;
     }

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -80,7 +80,7 @@ ExceptionOr<void> HTMLTableElement::setCaption(RefPtr<HTMLTableCaptionElement>&&
     deleteCaption();
     if (!newCaption)
         return { };
-    return insertBefore(*newCaption, protectedFirstChild());
+    return insertBefore(*newCaption, protect(firstChild()));
 }
 
 RefPtr<HTMLTableSectionElement> HTMLTableElement::tHead() const

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -536,7 +536,7 @@ void HTMLTextAreaElement::updatePlaceholderText()
     }
     if (!m_placeholder) {
         m_placeholder = TextControlPlaceholderElement::create(protect(document()));
-        protectedUserAgentShadowRoot()->insertBefore(*protectedPlaceholderElement(), innerTextElement()->protectedNextSibling());
+        protectedUserAgentShadowRoot()->insertBefore(*protectedPlaceholderElement(), protect(innerTextElement()->nextSibling()));
     }
     protectedPlaceholderElement()->setInnerText(String { placeholderText });
 }

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -183,7 +183,7 @@ void MediaDocument::replaceMediaElementTimerFired()
         if (RefPtr loader = this->loader())
             embedElement->setAttributeWithoutSynchronization(typeAttr, AtomString { loader->writer().mimeType() });
 
-        videoElement->protectedParentNode()->replaceChild(embedElement, *videoElement);
+        protect(videoElement->parentNode())->replaceChild(embedElement, *videoElement);
     }
 }
 

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -64,7 +64,7 @@ bool RadioInputType::valueMissing(const String&) const
 
     bool isRequired = false;
     bool foundCheckedRadio = false;
-    forEachButtonInDetachedGroup(element->protectedRootNode(), name, [&](auto& input) {
+    forEachButtonInDetachedGroup(protect(element->rootNode()), name, [&](auto& input) {
         if (input.checked()) {
             foundCheckedRadio = true;
             return false;

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -302,7 +302,7 @@ void SearchInputType::createShadowSubtree()
     m_resultsButton = WTF::move(resultsButton);
 
     Ref cancelButton = SearchFieldCancelButtonElement::create(document);
-    container->insertBefore(cancelButton, textWrapper->protectedNextSibling());
+    container->insertBefore(cancelButton, protect(textWrapper->nextSibling()));
     m_cancelButton = WTF::move(cancelButton);
 }
 

--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -208,7 +208,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
 #else
         glyphSpan->setIdAttribute("spatial-glyph"_s);
 #endif
-        bottomLabelText->insertBefore(glyphSpan, bottomLabelText->protectedFirstChild());
+        bottomLabelText->insertBefore(glyphSpan, protect(bottomLabelText->firstChild()));
 
         if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(element->renderer()))
             renderImage->setHasShadowControls(true);

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -210,7 +210,7 @@ void SpinButtonElement::releaseCapture()
 
 bool SpinButtonElement::matchesReadWritePseudoClass() const
 {
-    return protectedShadowHost()->matchesReadWritePseudoClass();
+    return protect(shadowHost())->matchesReadWritePseudoClass();
 }
 
 void SpinButtonElement::startRepeatingTimer()

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -251,7 +251,7 @@ std::optional<Style::UnadjustedStyle> TextControlPlaceholderElement::resolveCust
     }
 
     if (shadowHostStyle)
-        RenderTheme::singleton().adjustTextControlInnerPlaceholderStyle(styleStyle.get(), *shadowHostStyle, protectedShadowHost().get());
+        RenderTheme::singleton().adjustTextControlInnerPlaceholderStyle(styleStyle.get(), *shadowHostStyle, protect(shadowHost()).get());
 
     return style;
 }

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -169,7 +169,7 @@ ExceptionOr<void> DOMPatchSupport::innerPatchNode(Digest& oldDigest, Digest& new
     Ref newNode = *newDigest.node;
 
     if (newNode->nodeType() != oldNode->nodeType() || newNode->nodeName() != oldNode->nodeName())
-        return m_domEditor.replaceChild(*oldNode->protectedParentNode(), newNode.get(), oldNode);
+        return m_domEditor.replaceChild(*protect(oldNode->parentNode()), newNode.get(), oldNode);
 
     if (oldNode->nodeValue() != newNode->nodeValue()) {
         auto result = m_domEditor.setNodeValue(oldNode, newNode->nodeValue());
@@ -461,7 +461,7 @@ ExceptionOr<void> DOMPatchSupport::removeChildAndMoveToNew(Digest& oldDigest)
 {
     Ref<Node> oldNode = *oldDigest.node;
     ASSERT(oldNode->parentNode());
-    auto result = m_domEditor.removeChild(*oldNode->protectedParentNode(), oldNode);
+    auto result = m_domEditor.removeChild(*protect(oldNode->parentNode()), oldNode);
     if (result.hasException())
         return result.releaseException();
 
@@ -474,7 +474,7 @@ ExceptionOr<void> DOMPatchSupport::removeChildAndMoveToNew(Digest& oldDigest)
     if (it != m_unusedNodesMap.end()) {
         auto& newDigest = *it->value;
         Ref newNode = *newDigest.node;
-        auto result = m_domEditor.replaceChild(*newNode->protectedParentNode(), oldNode.get(), newNode);
+        auto result = m_domEditor.replaceChild(*protect(newNode->parentNode()), oldNode.get(), newNode);
         if (result.hasException())
             return result.releaseException();
         newDigest.node = oldNode.ptr();

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -941,7 +941,7 @@ Inspector::Protocol::ErrorStringOr<Inspector::Protocol::DOM::NodeId> InspectorDO
 
     // Replace the old node with the new node
     RefPtr<ContainerNode> parent = oldNode->parentNode();
-    if (!m_domEditor->insertBefore(*parent, newElement.copyRef(), oldNode->protectedNextSibling().get(), errorString))
+    if (!m_domEditor->insertBefore(*parent, newElement.copyRef(), protect(oldNode->nextSibling()).get(), errorString))
         return makeUnexpected(errorString);
     if (!m_domEditor->removeChild(*parent, *oldNode, errorString))
         return makeUnexpected(errorString);

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -376,7 +376,7 @@ Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(Variant<RefPtr<ShadowRo
 
     Ref startNode = range->startContainer();
     unsigned startOffset = range->startOffset();
-    while (startNode->isInShadowTree() && !shadowRootSet.contains(startNode->protectedContainingShadowRoot().get())) {
+    while (startNode->isInShadowTree() && !shadowRootSet.contains(protect(startNode->containingShadowRoot()).get())) {
         RefPtr host = startNode->shadowHost();
         ASSERT(host && host->parentNode());
         startNode = *host->parentNode();
@@ -385,7 +385,7 @@ Vector<Ref<StaticRange>> DOMSelection::getComposedRanges(Variant<RefPtr<ShadowRo
 
     Ref endNode = range->endContainer();
     unsigned endOffset = range->endOffset();
-    while (endNode->isInShadowTree() && !shadowRootSet.contains(endNode->protectedContainingShadowRoot().get())) {
+    while (endNode->isInShadowTree() && !shadowRootSet.contains(protect(endNode->containingShadowRoot()).get())) {
         RefPtr host = endNode->shadowHost();
         ASSERT(host && host->parentNode());
         endNode = *host->parentNode();

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1288,7 +1288,7 @@ void RenderThemeMac::createColorWellSwatchSubtree(HTMLElement& swatch)
 
 void RenderThemeMac::setColorWellSwatchBackground(HTMLElement& swatch, Color color)
 {
-    Ref swatchChild = *downcast<HTMLElement>(swatch.protectedFirstChild());
+    Ref swatchChild = *downcast<HTMLElement>(swatch.firstChild());
 
     auto backgroundColor = color.isOpaque() ? color : blendSourceOver(Color::white, color);
     auto foregroundColor = color.isOpaque() ? Color::transparentBlack : blendSourceOver(Color::black, color);

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp
@@ -78,7 +78,7 @@ void RenderSVGGradientStop::layout()
 
 SVGGradientElement* RenderSVGGradientStop::gradientElement()
 {
-    return dynamicDowncast<SVGGradientElement>(element().protectedParentElement().get());
+    return dynamicDowncast<SVGGradientElement>(protect(element().parentElement()).get());
 }
 
 }

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -149,7 +149,7 @@ void SVGTRefElement::updateReferencedText(Element* target)
         root->appendChild(Text::create(protect(document()), WTF::move(textContent)));
     else {
         ASSERT(root->firstChild()->isTextNode());
-        root->protectedFirstChild()->setTextContent(WTF::move(textContent));
+        protect(root->firstChild())->setTextContent(WTF::move(textContent));
     }
 }
 

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -573,7 +573,7 @@ void SVGUseElement::expandUseElementsInShadowTree() const
         if (target)
             originalClone->cloneTarget(replacementClone.get(), *target);
 
-        originalClone->protectedParentNode()->replaceChild(replacementClone, originalClone);
+        protect(originalClone->parentNode())->replaceChild(replacementClone, originalClone);
 
         // Resume iterating, starting just inside the replacement clone.
         it = descendants.from(replacementClone.get());
@@ -599,7 +599,7 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
 
         cloneDataAndChildren(replacementClone.get(), originalClone);
 
-        originalClone->protectedParentNode()->replaceChild(replacementClone, originalClone);
+        protect(originalClone->parentNode())->replaceChild(replacementClone, originalClone);
 
         // Resume iterating, starting just inside the replacement clone.
         it = descendants.from(replacementClone.get());

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -864,7 +864,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
     bool handledAttributes = handleNamespaceAttributes(prefixedAttributes, libxmlNamespaces, numNamespaces, shouldUseNullCustomElementRegistry);
     bool success = handledAttributes ? handleElementAttributes(prefixedAttributes, libxmlAttributes, numAttributes, shouldUseNullCustomElementRegistry) : false;
 
-    RefPtr registry = shouldUseNullCustomElementRegistry ? nullptr : CustomElementRegistry::registryForNodeOrTreeScope(*currentNode, currentNode->protectedTreeScope());
+    RefPtr registry = shouldUseNullCustomElementRegistry ? nullptr : CustomElementRegistry::registryForNodeOrTreeScope(*currentNode, protect(currentNode->treeScope()));
     auto newElement = document->createElement(qName, true, registry.get());
 
     if (!handledAttributes) {

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -848,7 +848,7 @@ void WebAutomationSessionProxy::computeElementLayout(WebCore::PageIdentifier pag
     }
 
     auto elementInViewCenterPoint = visiblePortionOfElementRect.center();
-    auto elementList = containerElement->protectedTreeScope()->elementsFromPoint(elementInViewCenterPoint.x(), elementInViewCenterPoint.y(), WebCore::HitTestSource::User);
+    auto elementList = protect(containerElement->treeScope())->elementsFromPoint(elementInViewCenterPoint.x(), elementInViewCenterPoint.y(), WebCore::HitTestSource::User);
     auto index = elementList.findIf([containerElement](auto& item) {
         return item.ptr() == containerElement;
     });

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -95,27 +95,27 @@ static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
 
 - (WKDOMNode *)parentNode
 {
-    return WebKit::toWKDOMNode(protectedImpl(self)->protectedParentNode().get());
+    return WebKit::toWKDOMNode(protect(protectedImpl(self)->parentNode()).get());
 }
 
 - (WKDOMNode *)firstChild
 {
-    return WebKit::toWKDOMNode(protectedImpl(self)->protectedFirstChild().get());
+    return WebKit::toWKDOMNode(protect(protectedImpl(self)->firstChild()).get());
 }
 
 - (WKDOMNode *)lastChild
 {
-    return WebKit::toWKDOMNode(protectedImpl(self)->protectedLastChild().get());
+    return WebKit::toWKDOMNode(protect(protectedImpl(self)->lastChild()).get());
 }
 
 - (WKDOMNode *)previousSibling
 {
-    return WebKit::toWKDOMNode(protectedImpl(self)->protectedPreviousSibling().get());
+    return WebKit::toWKDOMNode(protect(protectedImpl(self)->previousSibling()).get());
 }
 
 - (WKDOMNode *)nextSibling
 {
-    return WebKit::toWKDOMNode(protectedImpl(self)->protectedNextSibling().get());
+    return WebKit::toWKDOMNode(protect(protectedImpl(self)->nextSibling()).get());
 }
 
 - (NSArray *)textRects


### PR DESCRIPTION
#### b7056c34cbe99f896f0dd1016cd57f386e05e7ca
<pre>
Drop `protected*()` getters in Node.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=306718">https://bugs.webkit.org/show_bug.cgi?id=306718</a>

Reviewed by Anne van Kesteren.

Use `protect()` at call sites instead.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::dispatchChildInsertionEvents):
(WebCore::dispatchChildRemovalEvents):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::firstChild const):
(WebCore::ContainerNode::lastChild const):
(WebCore::ContainerNode::protectedFirstChild const): Deleted.
(WebCore::ContainerNode::protectedLastChild const): Deleted.
* Source/WebCore/dom/ContainerNodeInlines.h:
(WebCore::ContainerNode::protectedRootNode const): Deleted.
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::isElementVisible):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setTitle):
* Source/WebCore/dom/DocumentFragment.cpp:
(WebCore::DocumentFragment::getElementById const):
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::Node::protectedShadowRoot const): Deleted.
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::protectedShadowHost const): Deleted.
(WebCore::Node::protectedContainingShadowRoot const): Deleted.
* Source/WebCore/dom/Node.h:
(WebCore::Node::previousSibling const):
(WebCore::Node::nextSibling const):
(WebCore::Node::treeScope const):
(WebCore::Node::protectedPreviousSibling const): Deleted.
(WebCore::Node::protectedNextSibling const): Deleted.
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::protectedParentOrShadowHostNode const): Deleted.
(WebCore::Node::protectedScriptExecutionContext const): Deleted.
(WebCore::Node::protectedTreeScope const): Deleted.
(WebCore::Node::protectedParentElement const): Deleted.
(WebCore::Node::protectedFirstChild const): Deleted.
(WebCore::Node::protectedLastChild const): Deleted.
(WebCore::Node::protectedRootNode const): Deleted.
(WebCore::Node::protectedParentNode const): Deleted.
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::processContents):
(WebCore::processAncestorsAndTheirSiblings):
(WebCore::boundaryTextNodesMerged):
(WebCore::boundaryTextNodesSplit):
* Source/WebCore/dom/SerializedNode.cpp:
(WebCore::SerializedNode::deserialize):
* Source/WebCore/dom/StaticRange.cpp:
(WebCore::StaticRange::computeValidity const):
* Source/WebCore/dom/Text.cpp:
(WebCore::Text::splitText):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::splitAncestorsWithUnicodeBidi):
* Source/WebCore/editing/ChangeListTypeCommand.cpp:
(WebCore::ChangeListTypeCommand::doApply):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::removeStyleAddedByNode):
(WebCore::EditingStyle::removeStyleConflictingWithStyleOfNode):
* Source/WebCore/editing/SplitTextNodeCommand.cpp:
(WebCore::SplitTextNodeCommand::insertText1AndTrimText2):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleReplacedElement):
(WebCore::TextIterator::exitNode):
(WebCore::SimplifiedBackwardsTextIterator::advance):
(WebCore::SimplifiedBackwardsTextIterator::handleReplacedElement):
(WebCore::SimplifiedBackwardsTextIterator::handleNonTextNode):
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
(WebCore::hasAncestorQualifyingForWritingToolsPreservation):
(WebCore::updateAttributes):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::serializeNodes):
(WebCore::isPlainTextMarkup):
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::didUpgrade):
* Source/WebCore/html/FormListedElement.cpp:
(WebCore::FormAttributeTargetObserver::FormAttributeTargetObserver):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::isActiveSummary const):
* Source/WebCore/html/HTMLHRElement.cpp:
(WebCore::HTMLHRElement::insertedIntoAncestor):
(WebCore::HTMLHRElement::removedFromAncestor):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::insertedIntoAncestor):
(WebCore::HTMLImageElement::removedFromAncestor):
(WebCore::HTMLImageElement::associatedMapElement const):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::insertedIntoAncestor):
(WebCore::HTMLOptGroupElement::removedFromAncestor):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::insertedIntoAncestor):
(WebCore::HTMLOptionElement::removedFromAncestor):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::setCaption):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::updatePlaceholderText):
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::MediaDocument::replaceMediaElementTimerFired):
* Source/WebCore/html/RadioInputType.cpp:
(WebCore::RadioInputType::valueMissing const):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::createShadowSubtree):
* Source/WebCore/html/shadow/SpatialImageControls.cpp:
(WebCore::SpatialImageControls::ensureSpatialControls):
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
(WebCore::SpinButtonElement::matchesReadWritePseudoClass const):
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::TextControlPlaceholderElement::resolveCustomStyle):
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::DOMPatchSupport::innerPatchNode):
(WebCore::DOMPatchSupport::removeChildAndMoveToNew):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::setNodeName):
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::getComposedRanges):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::setColorWellSwatchBackground):
* Source/WebCore/rendering/svg/RenderSVGGradientStop.cpp:
(WebCore::RenderSVGGradientStop::gradientElement):
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::updateReferencedText):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::expandUseElementsInShadowTree const):
(WebCore::SVGUseElement::expandSymbolElementsInShadowTree const):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm:
(-[WKDOMNode parentNode]):
(-[WKDOMNode firstChild]):
(-[WKDOMNode lastChild]):
(-[WKDOMNode previousSibling]):
(-[WKDOMNode nextSibling]):

Canonical link: <a href="https://commits.webkit.org/306609@main">https://commits.webkit.org/306609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a43ca7175ef4685a3b044e7e33062befc474a1ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94911 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcdc68bf-94a3-419b-b87c-6e855aea7c97) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108955 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78791 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e64aa99d-3c53-45b0-8a22-02507e32f06d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89851 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf280e52-8edd-4636-9087-43b101dc1456) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11055 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8695 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/446 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152768 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13861 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117050 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13876 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12094 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13416 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123614 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69504 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13899 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2895 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13841 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->