### PR TITLE
Remove some LegacyNativeDictionaryRequiredInterfaceNullability from WebCore/dom

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1306,7 +1306,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/ActiveDOMCallback.h
     dom/ActiveDOMObject.h
     dom/AddEventListenerOptions.h
-    dom/AddEventListenerOptionsInlines.h
     dom/AsyncNodeDeletionQueue.h
     dom/AsyncNodeDeletionQueueInlines.h
     dom/Attr.h

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -143,6 +143,7 @@ public:
     void popErrorScope(ErrorScopePromise&&);
 
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
+    using EventTarget::addEventListener;
 
     using LostPromise = DOMPromiseProxy<IDLInterface<GPUDeviceLostInfo>>;
     LostPromise& lost();

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -29,7 +29,7 @@
 
 #include "MediaControlsHost.h"
 
-#include "AddEventListenerOptionsInlines.h"
+#include "AbortSignal.h"
 #include "AudioTrackList.h"
 #include "CaptionUserPreferences.h"
 #include "Chrome.h"
@@ -847,7 +847,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 #if USE(UICONTEXTMENU)
     page->chrome().client().showMediaControlsContextMenu(bounds, WTF::move(items), mediaElement.get(), WTF::move(handleItemSelected));
 #elif ENABLE(CONTEXT_MENUS) && USE(ACCESSIBILITY_CONTEXT_MENUS)
-    target.addEventListener(eventNames().contextmenuEvent, MediaControlsContextMenuEventListener::create(MediaControlsContextMenuProvider::create(mediaElement->identifier(), WTF::move(items), WTF::move(handleItemSelected))), { /*capture */ true, /* passive */ std::nullopt, /* once */ true });
+    target.addEventListener(eventNames().contextmenuEvent, MediaControlsContextMenuEventListener::create(MediaControlsContextMenuProvider::create(mediaElement->identifier(), WTF::move(items), WTF::move(handleItemSelected))), { { /*capture */ true }, /* passive */ std::nullopt, /* once */ true, nullptr, false });
     page->contextMenuController().showContextMenuAt(*target.document().protectedFrame(), bounds.center());
 #endif
 

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -105,6 +105,7 @@ private:
 
     void scheduledEventTimerFired();
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
+    using EventTarget::addEventListener;
 
     void exposeDevices(Vector<CaptureDeviceWithCapabilities>&&, MediaDeviceHashSalts&&, EnumerateDevicesPromise&&);
     void listenForDeviceChanges();

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1190,6 +1190,7 @@ dom/AbortSignal.cpp
 dom/AbstractRange.cpp
 dom/ActiveDOMCallback.cpp
 dom/ActiveDOMObject.cpp
+dom/AddEventListenerOptions.cpp
 dom/AllDescendantsCollection.cpp
 dom/Attr.cpp
 dom/BeforeTextInsertedEvent.cpp

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -8676,7 +8676,7 @@ sub WriteData
     }
 
     if ($name eq "AddEventListenerOptions" or $name eq "EventTarget") {
-        push @includes, "\"AddEventListenerOptionsInlines.h\"";
+        push @includes, "\"AbortSignal.h\"";
     }
 
     foreach my $include (sort @includes) {

--- a/Source/WebCore/css/MediaQueryList.cpp
+++ b/Source/WebCore/css/MediaQueryList.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "MediaQueryList.h"
 
-#include "AddEventListenerOptionsInlines.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DocumentQuirks.h"
 #include "EventNames.h"
@@ -80,7 +79,7 @@ void MediaQueryList::addListener(RefPtr<EventListener>&& listener)
     if (!listener)
         return;
 
-    addEventListener(eventNames().changeEvent, listener.releaseNonNull(), { });
+    addEventListener(eventNames().changeEvent, listener.releaseNonNull());
 }
 
 void MediaQueryList::removeListener(RefPtr<EventListener>&& listener)

--- a/Source/WebCore/dom/AddEventListenerOptions.cpp
+++ b/Source/WebCore/dom/AddEventListenerOptions.cpp
@@ -23,31 +23,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "AddEventListenerOptions.h"
 
-#include <WebCore/AbortSignal.h>
-#include <WebCore/AddEventListenerOptions.h>
-#include <optional>
+#include "AbortSignal.h"
 
 namespace WebCore {
 
-inline AddEventListenerOptions::AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, RefPtr<AbortSignal>&& signal, bool webkitTrustedOnly)
-    : EventListenerOptions(capture)
-    , passive(passive)
-    , once(once)
-    , signal(WTF::move(signal))
-    , webkitTrustedOnly(webkitTrustedOnly)
-{
-}
-
-inline AddEventListenerOptions::AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, bool webkitTrustedOnly)
-    : EventListenerOptions(capture)
-    , passive(passive)
-    , once(once)
-    , webkitTrustedOnly(webkitTrustedOnly)
-{
-}
-
-inline AddEventListenerOptions::~AddEventListenerOptions() = default;
+AddEventListenerOptions::~AddEventListenerOptions() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/dom/AddEventListenerOptions.h
+++ b/Source/WebCore/dom/AddEventListenerOptions.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #include <WebCore/EventListenerOptions.h>
+#include <WebCore/PlatformExportMacros.h>
 #include <optional>
-#include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {
@@ -35,11 +35,7 @@ namespace WebCore {
 class AbortSignal;
 
 struct AddEventListenerOptions : EventListenerOptions {
-    inline AddEventListenerOptions(bool capture = false, std::optional<bool> passive = std::nullopt, bool once = false, bool webkitTrustedOnly = false);
-
-    inline AddEventListenerOptions(bool capture, std::optional<bool> passive, bool once, RefPtr<AbortSignal>&&, bool webkitTrustedOnly);
-
-    inline ~AddEventListenerOptions();
+    WEBCORE_EXPORT ~AddEventListenerOptions();
 
     std::optional<bool> passive;
     bool once { false };

--- a/Source/WebCore/dom/AddEventListenerOptions.idl
+++ b/Source/WebCore/dom/AddEventListenerOptions.idl
@@ -24,9 +24,7 @@
  */
 
 // https://dom.spec.whatwg.org/#dictdef-addeventlisteneroptions
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary AddEventListenerOptions : EventListenerOptions {
+dictionary AddEventListenerOptions : EventListenerOptions {
     boolean passive;
     boolean once = false;
     AbortSignal signal;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6379,7 +6379,7 @@ void Document::adjustFocusedNodeOnNodeRemoval(Node& node, NodeRemoval nodeRemova
         // FIXME: We should avoid synchronously updating the style inside setFocusedElement.
         // FIXME: Object elements should avoid loading a frame synchronously in a post style recalc callback.
         SubframeLoadingDisabler disabler(dynamicDowncast<ContainerNode>(node));
-        setFocusedElement(nullptr, { { }, { }, FocusRemovalEventsMode::DoNotDispatch, { }, { } });
+        setFocusedElement(nullptr, { { }, { }, { }, { }, FocusRemovalEventsMode::DoNotDispatch, { }, { } });
         // Set the focus navigation starting node to the previous focused element so that
         // we can fallback to the siblings or parent node for the next search.
         // Also we need to call removeFocusNavigationNodeOfSubtree after this function because

--- a/Source/WebCore/dom/EventListenerMap.cpp
+++ b/Source/WebCore/dom/EventListenerMap.cpp
@@ -33,7 +33,7 @@
 #include "config.h"
 #include "EventListenerMap.h"
 
-#include "AddEventListenerOptionsInlines.h"
+#include "AbortSignal.h"
 #include "Event.h"
 #include "EventTarget.h"
 #include "JSEventListener.h"
@@ -203,7 +203,7 @@ static void copyListenersNotCreatedFromMarkupToTarget(const AtomString& eventTyp
         // Event listeners created from markup have already been transfered to the shadow tree during cloning.
         if (JSEventListener::wasCreatedFromMarkup(registeredListener->callback()))
             continue;
-        target->addEventListener(eventType, registeredListener->callback(), registeredListener->useCapture());
+        target->addEventListener(eventType, registeredListener->callback(), { { registeredListener->useCapture() }, std::nullopt, false, nullptr, false });
     }
 }
 

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -32,7 +32,7 @@
 #include "config.h"
 #include "EventTarget.h"
 
-#include "AddEventListenerOptionsInlines.h"
+#include "AbortSignal.h"
 #include "DOMWrapperWorld.h"
 #include "EventNames.h"
 #include "EventPath.h"
@@ -132,6 +132,11 @@ bool EventTarget::addEventListener(const AtomString& eventType, Ref<EventListene
     return true;
 }
 
+bool EventTarget::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener)
+{
+    return addEventListener(eventType, WTF::move(listener), { });
+}
+
 void EventTarget::addEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&& listener, AddEventListenerOptionsOrBoolean&& variant)
 {
     if (!listener)
@@ -142,7 +147,7 @@ void EventTarget::addEventListenerForBindings(const AtomString& eventType, RefPt
         SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE addEventListener(eventType, listener.releaseNonNull(), options);
     }, [&](bool capture) {
         // FIXME: Ideally we'd be able to mark the makeVisitor() lamdbas as NOESCAPE to avoid having to suppress.
-        SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE addEventListener(eventType, listener.releaseNonNull(), capture);
+        SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE addEventListener(eventType, listener.releaseNonNull(), { { capture }, std::nullopt, false, nullptr, false });
     });
 
     WTF::visit(visitor, variant);

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -106,6 +106,7 @@ public:
     ExceptionOr<bool> dispatchEventForBindings(Event&);
 
     virtual bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&);
+    bool addEventListener(const AtomString& eventType, Ref<EventListener>&&);
     virtual bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions& = { });
 
     virtual void removeAllEventListeners();

--- a/Source/WebCore/dom/FocusOptions.h
+++ b/Source/WebCore/dom/FocusOptions.h
@@ -38,13 +38,15 @@ enum class FocusTrigger : uint8_t { Other, Click, Bindings };
 enum class FocusVisibility : uint8_t { Invisible, Visible, ForceInvisible };
 
 struct FocusOptions {
+    bool preventScroll { false };
+    std::optional<bool> focusVisible { std::nullopt };
+
+    // Non-IDL members.
     SelectionRestorationMode selectionRestorationMode { SelectionRestorationMode::RestoreOrSelectAll };
     FocusDirection direction { FocusDirection::None };
     FocusRemovalEventsMode removalEventsMode { FocusRemovalEventsMode::Dispatch };
     FocusTrigger trigger { FocusTrigger::Other };
     FocusVisibility visibility { FocusVisibility::Invisible };
-    bool preventScroll { false };
-    std::optional<bool> focusVisible { std::nullopt };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/FocusOptions.idl
+++ b/Source/WebCore/dom/FocusOptions.idl
@@ -24,9 +24,7 @@
  */
 
 // https://html.spec.whatwg.org/multipage/interaction.html#focusoptions
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary FocusOptions {
+dictionary FocusOptions {
    boolean preventScroll = false;
    boolean focusVisible;
 };

--- a/Source/WebCore/dom/IdleRequestOptions.idl
+++ b/Source/WebCore/dom/IdleRequestOptions.idl
@@ -23,8 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary IdleRequestOptions {
-    unsigned long timeout;
+// https://w3c.github.io/requestidlecallback/#window_extensions
+
+dictionary IdleRequestOptions {
+    [ImplementationDefaultValue=0] unsigned long timeout;
 };

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -110,6 +110,7 @@ private:
     MessagePort(ScriptExecutionContext&, const MessagePortIdentifier& local, const MessagePortIdentifier& remote);
 
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
+    using EventTarget::addEventListener;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
 
     // ActiveDOMObject.

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -570,6 +570,7 @@ public:
     inline RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
+    using EventTarget::addEventListener;
     bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) override;
     void removeAllEventListeners() override;
 

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -28,7 +28,6 @@
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-#include "AddEventListenerOptionsInlines.h"
 #include "AttachmentAssociatedElement.h"
 #include "AttachmentElementClient.h"
 #include "ContainerNodeInlines.h"
@@ -286,8 +285,8 @@ public:
     static void addToImageForAttachment(HTMLImageElement& image, HTMLAttachmentElement& attachment)
     {
         auto listener = create(attachment);
-        image.addEventListener(eventNames().loadEvent, listener, { });
-        image.addEventListener(eventNames().errorEvent, listener, { });
+        image.addEventListener(eventNames().loadEvent, listener);
+        image.addEventListener(eventNames().errorEvent, listener);
     }
 
     void handleEvent(ScriptExecutionContext&, Event& event) final
@@ -490,8 +489,8 @@ void HTMLAttachmentElement::updateSaveButton(bool show)
 
         Ref saveButton = createContainedElement<HTMLButtonElement>(saveArea, attachmentSaveButtonIdentifier());
         m_saveButton = saveButton.copyRef();
-        saveButton->addEventListener(eventNames().clickEvent, AttachmentSaveEventListener::create(*this), { });
-        saveButton->addEventListener(eventNames().auxclickEvent, AttachmentSaveEventListener::create(*this), { });
+        saveButton->addEventListener(eventNames().clickEvent, AttachmentSaveEventListener::create(*this));
+        saveButton->addEventListener(eventNames().auxclickEvent, AttachmentSaveEventListener::create(*this));
     }
 }
 

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -250,7 +250,7 @@ bool HTMLFormControlElement::isMouseFocusable() const
 
 void HTMLFormControlElement::runFocusingStepsForAutofocus()
 {
-    focus({ SelectionRestorationMode::PlaceCaretAtStart });
+    focus({ { }, { }, SelectionRestorationMode::PlaceCaretAtStart });
 }
 
 void HTMLFormControlElement::dispatchBlurEvent(RefPtr<Element>&& newFocusedElement)

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -182,7 +182,7 @@ void HTMLLabelElement::defaultEventHandler(Event& event)
 
         protect(document())->updateLayoutIgnorePendingStylesheets();
         if (control->isMouseFocusable())
-            control->focus({ { }, { }, { }, FocusTrigger::Click, { } });
+            control->focus({ { }, { }, { }, { }, { }, FocusTrigger::Click, { } });
 
         event.setDefaultHandled();
     }
@@ -211,7 +211,7 @@ void HTMLLabelElement::focus(const FocusOptions& options)
 
     // To match other browsers, always restore previous selection.
     if (auto element = control())
-        element->focus({ SelectionRestorationMode::RestoreOrSelectAll, options.direction });
+        element->focus({ { }, { }, SelectionRestorationMode::RestoreOrSelectAll, options.direction });
 }
 
 bool HTMLLabelElement::accessKeyAction(bool sendMouseEvents)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -476,6 +476,7 @@ public:
     WEBCORE_EXPORT void hideCaptionDisplaySettingsPreview();
 
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) override;
+    using EventTarget::addEventListener;
     WEBCORE_EXPORT bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) override;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "ImageDocument.h"
 
-#include "AddEventListenerOptionsInlines.h"
 #include "CachedImage.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
@@ -285,7 +284,7 @@ void ImageDocument::createDocumentStructure()
         processViewport("width=device-width,viewport-fit=cover"_s, ViewportArguments::Type::ImageDocument);
 #else
         Ref listener = ImageEventListener::create(*this);
-        imageElement->addEventListener(eventNames().clickEvent, WTF::move(listener), false);
+        imageElement->addEventListener(eventNames().clickEvent, WTF::move(listener));
 #endif
     }
 

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -700,7 +700,7 @@ void InputType::handleBlurEvent()
 bool InputType::accessKeyAction(bool)
 {
     ASSERT(element());
-    protectedElement()->focus({ SelectionRestorationMode::SelectAll });
+    protectedElement()->focus({ { }, { }, SelectionRestorationMode::SelectAll });
     return false;
 }
 

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -27,7 +27,6 @@
 
 #if ENABLE(PDFJS)
 
-#include "AddEventListenerOptionsInlines.h"
 #include "DocumentLoader.h"
 #include "EventListener.h"
 #include "EventNames.h"
@@ -164,7 +163,7 @@ void PDFDocument::createDocumentStructure()
     m_iframe->setAttribute(styleAttr, "width: 100%; height: 100%; border: 0; display: block;"_s);
 
     m_listener = PDFDocumentEventListener::create(*this);
-    m_iframe->addEventListener(eventNames().loadEvent, *m_listener, false);
+    m_iframe->addEventListener(eventNames().loadEvent, *m_listener);
 
     body->appendChild(*m_iframe);
 }
@@ -253,7 +252,7 @@ void PDFDocument::injectStyleAndContentScript()
     ASSERT(contentDocument->body());
     m_script = HTMLScriptElement::create(scriptTag, *contentDocument, false);
     ASSERT(m_listener);
-    m_script->addEventListener(eventNames().loadEvent, *m_listener, false);
+    m_script->addEventListener(eventNames().loadEvent, *m_listener);
     m_script->setAttribute(srcAttr, "webkit-pdfjs-viewer://pdfjs/extras/content-script.js"_s);
     contentDocument->body()->appendChild(*m_script);
 

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -34,7 +34,6 @@
 #include "AXObjectCacheInlines.h"
 #include "AccessibilityNodeObject.h"
 #include "AccessibilityObjectInlines.h"
-#include "AddEventListenerOptionsInlines.h"
 #include "Attr.h"
 #include "AudioTrack.h"
 #include "AudioTrackConfiguration.h"
@@ -2665,8 +2664,8 @@ void InspectorDOMAgent::addEventListenersToNode(Node& node)
 #if ENABLE(VIDEO)
     auto callback = EventFiredCallback::create(*this);
 
-    auto createEventListener = [&] (const AtomString& eventName) {
-        node.addEventListener(eventName, callback.copyRef(), false);
+    auto createEventListener = [&](const AtomString& eventName) {
+        node.addEventListener(eventName, callback.copyRef());
     };
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -32,7 +32,6 @@
 #include "config.h"
 #include "InspectorIndexedDBAgent.h"
 
-#include "AddEventListenerOptionsInlines.h"
 #include "DOMStringList.h"
 #include "DocumentSecurityOrigin.h"
 #include "DocumentView.h"
@@ -149,7 +148,7 @@ void ExecutableWithDatabase::start(IDBFactory* idbFactory, SecurityOrigin*, cons
     }
 
     // FIXME: This is a safer cpp false positive (rdar://160082559).
-    SUPPRESS_UNCOUNTED_ARG result.releaseReturnValue()->addEventListener(eventNames().successEvent, OpenDatabaseCallback::create(*this), false);
+    SUPPRESS_UNCOUNTED_ARG result.releaseReturnValue()->addEventListener(eventNames().successEvent, OpenDatabaseCallback::create(*this));
 }
 
 
@@ -481,7 +480,7 @@ public:
         }
 
         auto openCursorCallback = OpenCursorCallback::create(m_injectedScript, m_requestCallback.copyRef(), m_skipCount, m_pageSize);
-        idbRequest->addEventListener(eventNames().successEvent, WTF::move(openCursorCallback), false);
+        idbRequest->addEventListener(eventNames().successEvent, WTF::move(openCursorCallback));
     }
 
     BackendDispatcher::CallbackBase& requestCallback() override { return m_requestCallback.get(); }
@@ -711,7 +710,7 @@ public:
             return;
         }
 
-        idbTransaction->addEventListener(eventNames().completeEvent, ClearObjectStoreListener::create(m_requestCallback.copyRef()), false);
+        idbTransaction->addEventListener(eventNames().completeEvent, ClearObjectStoreListener::create(m_requestCallback.copyRef()));
     }
 
     BackendDispatcher::CallbackBase& requestCallback() override { return m_requestCallback.get(); }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3374,7 +3374,7 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
 
     // If focus shift is blocked, we eat the event.
     RefPtr page = frame->page();
-    if (page && !page->focusController().setFocusedElement(element.get(), protectedFrame().ptr(), { { }, { }, { }, FocusTrigger::Click, { } }))
+    if (page && !page->focusController().setFocusedElement(element.get(), protectedFrame().ptr(), { { }, { }, { }, { }, { }, FocusTrigger::Click, { } }))
         return false;
 
     if (element && m_mouseDownDelegatedFocus)

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -742,7 +742,7 @@ FocusableElementSearchResult FocusController::findFocusableElementInDocumentOrde
         }
     }
 
-    element->focus({ SelectionRestorationMode::SelectAll, direction, { }, { }, FocusVisibility::Visible });
+    element->focus({ { }, { }, SelectionRestorationMode::SelectAll, direction, { }, { }, FocusVisibility::Visible });
 
     return findResult;
 }
@@ -1327,7 +1327,7 @@ bool FocusController::advanceFocusDirectionallyInContainer(const ContainerNode& 
 
     // We found a new focus node, navigate to it.
     RefPtr element = focusCandidate.focusableNode.get();
-    element->focus({ SelectionRestorationMode::SelectAll, direction });
+    element->focus({ { }, { }, SelectionRestorationMode::SelectAll, direction });
     return true;
 }
 

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -274,6 +274,7 @@ public:
     // Events
     // EventTarget API
     WEBCORE_EXPORT bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
+    using EventTarget::addEventListener;
     WEBCORE_EXPORT bool removeEventListener(const AtomString& eventType, EventListener&, const EventListenerOptions&) final;
     void removeAllEventListeners() final;
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3123,7 +3123,7 @@ bool LocalFrameView::scrollToAnchorFragment(StringView fragmentIdentifier)
     if (anchorElement) {
         // If the anchor accepts keyboard focus, move focus there to aid users relying on keyboard navigation.
         if (anchorElement->isFocusable())
-            document->setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, FocusVisibility::Visible });
+            document->setFocusedElement(anchorElement.get(), { { }, { }, { }, { }, { }, { }, FocusVisibility::Visible });
         else {
             document->setFocusedElement(nullptr);
             document->setFocusNavigationStartingNode(anchorElement.get());

--- a/Source/WebCore/page/VisualViewport.h
+++ b/Source/WebCore/page/VisualViewport.h
@@ -41,6 +41,7 @@ public:
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
+    using EventTarget::addEventListener;
 
     double offsetLeft() const;
     double offsetTop() const;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -28,7 +28,6 @@
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
 
-#import "AddEventListenerOptionsInlines.h"
 #import "AudioTrackList.h"
 #import "DocumentPage.h"
 #import "Event.h"
@@ -115,22 +114,22 @@ void PlaybackSessionModelMediaElement::setMediaElement(HTMLMediaElement* mediaEl
 
     if (newMediaElement) {
         for (auto& eventName : observedEventNames())
-            newMediaElement->addEventListener(eventName, *this, false);
+            newMediaElement->addEventListener(eventName, *this);
 
         Ref audioTracks = newMediaElement->ensureAudioTracks();
-        audioTracks->addEventListener(events.addtrackEvent, *this, false);
-        audioTracks->addEventListener(events.changeEvent, *this, false);
-        audioTracks->addEventListener(events.removetrackEvent, *this, false);
+        audioTracks->addEventListener(events.addtrackEvent, *this);
+        audioTracks->addEventListener(events.changeEvent, *this);
+        audioTracks->addEventListener(events.removetrackEvent, *this);
 
         Ref videoTracks = newMediaElement->ensureVideoTracks();
-        videoTracks->addEventListener(events.addtrackEvent, *this, false);
-        videoTracks->addEventListener(events.changeEvent, *this, false);
-        videoTracks->addEventListener(events.removetrackEvent, *this, false);
+        videoTracks->addEventListener(events.addtrackEvent, *this);
+        videoTracks->addEventListener(events.changeEvent, *this);
+        videoTracks->addEventListener(events.removetrackEvent, *this);
 
         Ref textTracks = newMediaElement->ensureTextTracks();
-        textTracks->addEventListener(events.addtrackEvent, *this, false);
-        textTracks->addEventListener(events.changeEvent, *this, false);
-        textTracks->addEventListener(events.removetrackEvent, *this, false);
+        textTracks->addEventListener(events.addtrackEvent, *this);
+        textTracks->addEventListener(events.changeEvent, *this);
+        textTracks->addEventListener(events.removetrackEvent, *this);
         m_isListening = true;
     }
 

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -28,7 +28,6 @@
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 
-#import "AddEventListenerOptionsInlines.h"
 #import "DocumentFullscreen.h"
 #import "Event.h"
 #import "EventListener.h"
@@ -110,10 +109,10 @@ void VideoPresentationModelVideoElement::setVideoElement(HTMLVideoElement* video
         videoElement->addClient(*this);
         m_document = videoElement->document();
         for (auto& eventName : observedEventNames())
-            videoElement->addEventListener(eventName, m_videoListener, false);
+            videoElement->addEventListener(eventName, m_videoListener);
         m_isListening = true;
         for (auto& eventName : documentObservedEventNames())
-            videoElement->document().addEventListener(eventName, m_videoListener, false);
+            videoElement->document().addEventListener(eventName, m_videoListener);
     }
 
     updateForEventName(eventNameAll());

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -23,7 +23,6 @@
 #include "config.h"
 #include "SVGTRefElement.h"
 
-#include "AddEventListenerOptionsInlines.h"
 #include "ElementRareData.h"
 #include "EventListener.h"
 #include "EventNames.h"
@@ -85,8 +84,8 @@ void SVGTRefTargetEventListener::attach(RefPtr<Element>&& target)
     ASSERT(target.get());
     ASSERT(target->isConnected());
 
-    target->addEventListener(eventNames().DOMSubtreeModifiedEvent, *this, false);
-    target->addEventListener(eventNames().DOMNodeRemovedFromDocumentEvent, *this, false);
+    target->addEventListener(eventNames().DOMSubtreeModifiedEvent, *this);
+    target->addEventListener(eventNames().DOMNodeRemovedFromDocumentEvent, *this);
     m_target = WTF::move(target);
 }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -27,7 +27,6 @@
 #include "config.h"
 #include "SVGSMILElement.h"
 
-#include "AddEventListenerOptionsInlines.h"
 #include "CSSPropertyNames.h"
 #include "Document.h"
 #include "Event.h"
@@ -580,7 +579,7 @@ void SVGSMILElement::connectConditions()
                 continue;
             ASSERT(!condition.m_eventListener);
             condition.m_eventListener = ConditionEventListener::create(this, &condition);
-            eventBase->addEventListener(condition.m_name, *condition.m_eventListener, false);
+            eventBase->addEventListener(condition.m_name, *condition.m_eventListener);
         } else if (condition.m_type == Condition::Syncbase) {
             ASSERT(!condition.m_baseID.isEmpty());
             condition.m_syncbase = treeScope().getElementById(condition.m_baseID);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -28,7 +28,6 @@
 #include "Internals.h"
 
 #include "AXObjectCacheInlines.h"
-#include "AddEventListenerOptionsInlines.h"
 #include "AnimationTimeline.h"
 #include "AnimationTimelinesController.h"
 #include "AudioSession.h"
@@ -7397,7 +7396,7 @@ void Internals::addPrefetchLoadEventListener(HTMLLinkElement& link, RefPtr<Event
 {
     if (link.document().settings().linkPrefetchEnabled() && equalLettersIgnoringASCIICase(link.rel(), "prefetch"_s)) {
         link.allowPrefetchLoadAndErrorForTesting();
-        link.addEventListener(eventNames().loadEvent, listener.releaseNonNull(), false);
+        link.addEventListener(eventNames().loadEvent, listener.releaseNonNull());
     }
 }
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "ServiceWorkerContainer.h"
 
-#include "AddEventListenerOptionsInlines.h"
 #include "ContentSecurityPolicy.h"
 #include "ContextDestructionObserverInlines.h"
 #include "CookieChangeSubscription.h"

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -124,7 +124,8 @@ public:
 private:
     ServiceWorkerContainer(ScriptExecutionContext*, NavigatorBase&);
 
-    bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions& = { }) final;
+    bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
+    using EventTarget::addEventListener;
 
     void scheduleJob(Ref<ServiceWorkerJob>&&);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9264,13 +9264,13 @@ header: <WebCore/FocusOptions.h>
 };
 
 struct WebCore::FocusOptions {
+    bool preventScroll;
+    std::optional<bool> focusVisible;
     WebCore::SelectionRestorationMode selectionRestorationMode;
     WebCore::FocusDirection direction;
     WebCore::FocusRemovalEventsMode removalEventsMode;
     WebCore::FocusTrigger trigger;
     WebCore::FocusVisibility visibility;
-    bool preventScroll;
-    std::optional<bool> focusVisible;
 };
 
 enum class WebKit::CommitTiming : bool;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -35,7 +35,7 @@
 #include "WebFrame.h"
 #include "WebFullScreenManagerProxyMessages.h"
 #include "WebPage.h"
-#include <WebCore/AddEventListenerOptionsInlines.h>
+#include <WebCore/AbortSignal.h>
 #include <WebCore/Color.h>
 #include <WebCore/ContainerNodeInlines.h>
 #include <WebCore/DocumentFullscreen.h>
@@ -219,7 +219,7 @@ void WebFullScreenManager::setElement(WebCore::Element& element)
     m_elementFrameIdentifier = element.document().frame()->frameID();
 
     for (auto& eventName : eventsToObserve())
-        element.addEventListener(eventName, *this, { true });
+        element.addEventListener(eventName, *this, { { true }, std::nullopt, false, nullptr, false });
 }
 
 void WebFullScreenManager::clearElement()
@@ -747,7 +747,7 @@ void WebFullScreenManager::setMainVideoElement(RefPtr<WebCore::HTMLVideoElement>
 
     if (element) {
         for (auto& eventName : eventsToObserve.get())
-            element->addEventListener(eventName, *this, { });
+            element->addEventListener(eventName, *this);
 
 #if ENABLE(IMAGE_ANALYSIS)
         if (element->paused())

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -61,7 +61,6 @@
 #include "WebProcess.h"
 #include <WebCore/AXCoreObject.h>
 #include <WebCore/AXObjectCache.h>
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSPropertyParserConsumer+Color.h>
 #include <WebCore/CaptionUserPreferences.h>
 #include <WebCore/CompositionHighlight.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMAttr.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMAttr.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMAttr.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMCharacterData.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMCharacterData.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMCharacterData.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDeprecated.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDeprecated.cpp
@@ -19,7 +19,6 @@
 #include "config.h"
 #include "WebKitDOMDeprecated.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include "ConvertToUTF8String.h"
 #include <WebCore/DOMException.h>
 #include <WebCore/Document.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMFileList.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMFileList.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMFileList.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/Document.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLCanvasElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLCanvasElement.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMHTMLCanvasElement.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLFieldSetElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLFieldSetElement.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMHTMLFieldSetElement.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLHtmlElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLHtmlElement.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMHTMLHtmlElement.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLMapElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLMapElement.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMHTMLMapElement.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOptionElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLOptionElement.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMHTMLOptionElement.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLSelectElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLSelectElement.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMHTMLSelectElement.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTextAreaElement.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLTextAreaElement.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMHTMLTextAreaElement.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeGtk.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMNodeGtk.cpp
@@ -29,7 +29,6 @@
 #include "WebKitDOMNodeListPrivate.h"
 #include "WebKitDOMNodePrivate.h"
 #include "WebKitDOMPrivate.h"
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include <WebCore/DOMException.h>
 #include <WebCore/Document.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMProcessingInstruction.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMProcessingInstruction.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMProcessingInstruction.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMText.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMText.cpp
@@ -20,7 +20,6 @@
 #include "config.h"
 #include "WebKitDOMText.h"
 
-#include <WebCore/AddEventListenerOptionsInlines.h>
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -34,7 +34,6 @@
 #import "PDFPluginTextAnnotation.h"
 #import <CoreGraphics/CoreGraphics.h>
 #import <PDFKit/PDFKit.h>
-#import <WebCore/AddEventListenerOptionsInlines.h>
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
 #import <WebCore/DocumentEventLoop.h>
@@ -78,8 +77,8 @@ void PDFPluginAnnotation::attach(Element* parent)
     if (!element->hasClass())
         element->setAttributeWithoutSynchronization(classAttr, "annotation"_s);
     element->setAttributeWithoutSynchronization(x_apple_pdf_annotationAttr, "true"_s);
-    element->addEventListener(eventNames().changeEvent, *m_eventListener, false);
-    element->addEventListener(eventNames().blurEvent, *m_eventListener, false);
+    element->addEventListener(eventNames().changeEvent, *m_eventListener);
+    element->addEventListener(eventNames().blurEvent, *m_eventListener);
 
     updateGeometry();
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
@@ -28,7 +28,6 @@
 
 #if ENABLE(PDF_PLUGIN)
 
-#import <WebCore/AddEventListenerOptionsInlines.h>
 #import <WebCore/EnterKeyHint.h>
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>
@@ -54,7 +53,7 @@ Ref<Element> PDFPluginPasswordField::createAnnotationElement()
     Ref element = PDFPluginTextAnnotation::createAnnotationElement();
     element->setAttribute(typeAttr, "password"_s);
     element->setAttribute(enterkeyhintAttr, AtomString { attributeValueForEnterKeyHint(EnterKeyHint::Go) });
-    element->addEventListener(eventNames().keyupEvent, *eventListener(), false);
+    element->addEventListener(eventNames().keyupEvent, *eventListener());
     return element;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -30,7 +30,6 @@
 
 #import "PDFAnnotationTypeHelpers.h"
 #import "PDFKitSPI.h"
-#import <WebCore/AddEventListenerOptionsInlines.h>
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
 #import <WebCore/ColorCocoa.h>
@@ -86,7 +85,7 @@ Ref<Element> PDFPluginTextAnnotation::createAnnotationElement()
     bool isMultiline = [textAnnotation isMultiline];
 
     Ref element = downcast<HTMLTextFormControlElement>(document->createElement(isMultiline ? textareaTag : inputTag, false));
-    element->addEventListener(eventNames().keydownEvent, *eventListener(), false);
+    element->addEventListener(eventNames().keydownEvent, *eventListener());
 
     if (!textAnnotation)
         return element;

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -33,7 +33,6 @@
 #import "DOMNodeListInternal.h"
 #import "ExceptionHandlers.h"
 #import "ObjCEventListener.h"
-#import <WebCore/AddEventListenerOptionsInlines.h>
 #import <WebCore/DOMImplementation.h>
 #import <WebCore/ElementInlines.h>
 #import <WebCore/JSExecState.h>


### PR DESCRIPTION
#### a908742cd775de5fa23dbf408618449db7f5fefb
<pre>
Remove some LegacyNativeDictionaryRequiredInterfaceNullability from WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=306721">https://bugs.webkit.org/show_bug.cgi?id=306721</a>

Reviewed by Sam Weinig.

This tackles AddEventListenerOptions, FocusOptions, and
IdleRequestOptions.

For AddEventListenerOptions we add an addEventListener() overload that
takes two arguments to avoid having to include AbortSignal.h all over.

Canonical link: <a href="https://commits.webkit.org/306596@main">https://commits.webkit.org/306596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a1481971f49d25f6135cb25cc32f287dac67fc7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150382 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94919 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/454b03bc-ca27-4873-98da-de0f546a59bf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143661 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108959 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78796 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a84a35b2-bb73-4198-ae02-df15c76520d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144743 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/11512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89855 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e283ee80-2dd3-49fd-aaac-a4851180b1e5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11063 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8702 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/454 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152776 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13869 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117054 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117376 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13423 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69521 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21880 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13907 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2902 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77632 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13849 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13693 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->