### PR TITLE
[JSC] Optimize `String#trim` with direct span access

### DIFF
--- a/JSTests/microbenchmarks/string-trim-end.js
+++ b/JSTests/microbenchmarks/string-trim-end.js
@@ -1,0 +1,15 @@
+(function() {
+    var shortAscii = "   hello   ";
+    var longAscii = "   " + "a".repeat(100) + "   ";
+    var noTrim = "hello";
+    var allSpaces = "          ";
+    var unicode = "   \u65e5\u672c\u8a9e   ";
+
+    for (var i = 0; i < 1e6; i++) {
+        shortAscii.trimEnd();
+        longAscii.trimEnd();
+        noTrim.trimEnd();
+        allSpaces.trimEnd();
+        unicode.trimEnd();
+    }
+})();

--- a/JSTests/microbenchmarks/string-trim-start.js
+++ b/JSTests/microbenchmarks/string-trim-start.js
@@ -1,0 +1,15 @@
+(function() {
+    var shortAscii = "   hello   ";
+    var longAscii = "   " + "a".repeat(100) + "   ";
+    var noTrim = "hello";
+    var allSpaces = "          ";
+    var unicode = "   \u65e5\u672c\u8a9e   ";
+
+    for (var i = 0; i < 1e6; i++) {
+        shortAscii.trimStart();
+        longAscii.trimStart();
+        noTrim.trimStart();
+        allSpaces.trimStart();
+        unicode.trimStart();
+    }
+})();

--- a/JSTests/microbenchmarks/string-trim.js
+++ b/JSTests/microbenchmarks/string-trim.js
@@ -1,0 +1,15 @@
+(function() {
+    var shortAscii = "   hello   ";
+    var longAscii = "   " + "a".repeat(100) + "   ";
+    var noTrim = "hello";
+    var allSpaces = "          ";
+    var unicode = "   \u65e5\u672c\u8a9e   ";
+
+    for (var i = 0; i < 1e6; i++) {
+        shortAscii.trim();
+        longAscii.trim();
+        noTrim.trim();
+        allSpaces.trim();
+        unicode.trim();
+    }
+})();


### PR DESCRIPTION
#### 73a97d320d4b5c30e9926e9a521eb0a9caf0baca
<pre>
[JSC] Optimize `String#trim` with direct span access
<a href="https://bugs.webkit.org/show_bug.cgi?id=306722">https://bugs.webkit.org/show_bug.cgi?id=306722</a>

Reviewed by Yusuke Suzuki.

This patch changes to optimize trimString() by replacing indirect str[i] character access
with direct pointer access via span8()/span16().

This pattern follows existing optimizations in WTF::StringImpl::trimMatchedCharacters
and JSC::JSONObject parsing.

                           TipOfTree                  Patched

string-trim             84.5490+-0.7410     ^     72.4870+-0.6489        ^ definitely 1.1664x faster
string-trim-end         94.2033+-25.1497    ^     66.1489+-1.4101        ^ definitely 1.4241x faster
string-trim-start       71.9005+-1.1854     ^     65.5192+-1.5173        ^ definitely 1.0974x faster

Tests: JSTests/microbenchmarks/string-trim-end.js
       JSTests/microbenchmarks/string-trim-start.js
       JSTests/microbenchmarks/string-trim.js

* JSTests/microbenchmarks/string-trim-end.js: Added.
* JSTests/microbenchmarks/string-trim-start.js: Added.
* JSTests/microbenchmarks/string-trim.js: Added.
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::trimString):

Canonical link: <a href="https://commits.webkit.org/306611@main">https://commits.webkit.org/306611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70fc2e1a6c934ccf2f85a8120d88e6a37df4876c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150378 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94915 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108957 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78793 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89853 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8698 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/450 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133774 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152772 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2594 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13865 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117052 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13880 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12097 "Found 1 new test failure: imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/047.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117374 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13419 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13903 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2898 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173079 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77628 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44818 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->