### PR TITLE
[WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE under Source/WebKit/UIProcess/wpe/

### DIFF
--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp
@@ -49,9 +49,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h>
 #include <skia/core/SkStream.h>
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // Skia port
 #include <skia/encode/SkPngEncoder.h>
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebKit {


### PR DESCRIPTION
#### ef7a0c828acda77bc8684749ae71f53c148f2e3f
<pre>
[WPE] Drop WTF_ALLOW_UNSAFE_BUFFER_USAGE under Source/WebKit/UIProcess/wpe/
<a href="https://bugs.webkit.org/show_bug.cgi?id=306728">https://bugs.webkit.org/show_bug.cgi?id=306728</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/UIProcess/wpe/AcceleratedBackingStore.cpp: Remove
WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END} around Skia header includes,
as WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_{BEGIN,END} already prevents
the warnings.
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::preferredBufferFormats const): Use a std::span to
wrap the GArray retuned by wpe_buffer_formats_get_format_modifiers() and
use that to directly instantiate RendererBufferFormat::Format objects,
without needing an explicit loop.
* Source/WebKit/UIProcess/wpe/WebPasteboardProxyWPE.cpp:
(WebKit::clipboardFormats): Use a std::span to help convert a GStrv to
a Vector&lt;String&gt; by taking advantage of the Vector constructor that
takes a lambda as element generator.
(WebKit::WebPasteboardProxy::typesSafeForDOMToReadAndWrite): Use a

std::span to iterate over the GStrv of clipboard formats.
Canonical link: <a href="https://commits.webkit.org/306624@main">https://commits.webkit.org/306624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/513e682c71d317fe8c32b90fed152abc48b21079

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150462 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94991 "An unexpected error occured. Recent messages:Printed configuration") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109023 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/94991 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89919 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11115 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8759 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/524 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120431 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13939 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3584 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117107 "Found 1 new test failure: media/media-sources-selection.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117429 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13476 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123805 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69622 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13977 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3044 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77702 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->