### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability from mediacapabilities

### DIFF
--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.idl
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.idl
@@ -23,12 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/audio-session/#enumdef-audiosessionstate
 enum DOMAudioSessionState {
     "inactive",
     "active",
     "interrupted"
 };
 
+// https://w3c.github.io/audio-session/#enumdef-audiosessiontype
 enum DOMAudioSessionType {
     "auto",
     "playback",
@@ -38,6 +40,7 @@ enum DOMAudioSessionType {
     "play-and-record"
 };
 
+// https://w3c.github.io/audio-session/#audiosession
 [
     ActiveDOMObject,
     Conditional=DOM_AUDIO_SESSION,

--- a/Source/WebCore/Modules/mediacapabilities/AudioConfiguration.idl
+++ b/Source/WebCore/Modules/mediacapabilities/AudioConfiguration.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#dictdef-audioconfiguration
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,

--- a/Source/WebCore/Modules/mediacapabilities/ColorGamut.idl
+++ b/Source/WebCore/Modules/mediacapabilities/ColorGamut.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#enumdef-colorgamut
 enum ColorGamut {
     "srgb",
     "p3",

--- a/Source/WebCore/Modules/mediacapabilities/HdrMetadataType.idl
+++ b/Source/WebCore/Modules/mediacapabilities/HdrMetadataType.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#enumdef-hdrmetadatatype
 enum HdrMetadataType {
     "smpteSt2086",
     "smpteSt2094-10",

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#media-capabilities-interface
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     Exposed=(Window,DedicatedWorker)

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#dictdef-mediacapabilitiesdecodinginfo
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#dictdef-mediacapabilitiesencodinginfo
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesInfo.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesInfo.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#dictdef-mediacapabilitiesinfo
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,

--- a/Source/WebCore/Modules/mediacapabilities/MediaConfiguration.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaConfiguration.idl
@@ -23,9 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    LegacyNativeDictionaryRequiredInterfaceNullability,
-] dictionary MediaConfiguration {
+// https://w3c.github.io/media-capabilities/#dictdef-mediaconfiguration
+dictionary MediaConfiguration {
   VideoConfiguration video;
   AudioConfiguration audio;
 };

--- a/Source/WebCore/Modules/mediacapabilities/MediaDecodingConfiguration.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaDecodingConfiguration.idl
@@ -23,11 +23,13 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#dictdef-mediadecodingconfiguration
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaDecodingConfiguration : MediaConfiguration {
   required MediaDecodingType type;
+  // FIXME: Add support for `keySystemConfiguration`.
+  // MediaCapabilitiesKeySystemConfiguration keySystemConfiguration;
 };

--- a/Source/WebCore/Modules/mediacapabilities/MediaDecodingType.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaDecodingType.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#enumdef-mediadecodingtype
 enum MediaDecodingType {
   "file",
   "media-source",

--- a/Source/WebCore/Modules/mediacapabilities/MediaEncodingConfiguration.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaEncodingConfiguration.idl
@@ -23,11 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#dictdef-mediaencodingconfiguration
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MediaEncodingConfiguration : MediaConfiguration {
   required MediaEncodingType type;
 };

--- a/Source/WebCore/Modules/mediacapabilities/MediaEncodingType.idl
+++ b/Source/WebCore/Modules/mediacapabilities/MediaEncodingType.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#enumdef-mediaencodingtype
 enum MediaEncodingType {
   "record",
   "webrtc"

--- a/Source/WebCore/Modules/mediacapabilities/TransferFunction.idl
+++ b/Source/WebCore/Modules/mediacapabilities/TransferFunction.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#enumdef-transferfunction
 enum TransferFunction {
     "srgb",
     "pq",

--- a/Source/WebCore/Modules/mediacapabilities/VideoConfiguration.idl
+++ b/Source/WebCore/Modules/mediacapabilities/VideoConfiguration.idl
@@ -23,6 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/media-capabilities/#dictdef-videoconfiguration
 [
     EnabledBySetting=MediaCapabilitiesEnabled,
     ExportMacro=WEBCORE_EXPORT,
@@ -38,4 +39,8 @@
   HdrMetadataType hdrMetadataType;
   ColorGamut colorGamut;
   TransferFunction transferFunction;
+  // FIXME: Add support for `scalabilityMode`.
+  // DOMString scalabilityMode;
+  // FIXME: Add support for `spatialScalability`.
+  // boolean spatialScalability;
 };


### PR DESCRIPTION
#### 877fd22540a79643cc69eda1f72a936d9d027664
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability from mediacapabilities
<a href="https://bugs.webkit.org/show_bug.cgi?id=306730">https://bugs.webkit.org/show_bug.cgi?id=306730</a>

Reviewed by Anne van Kesteren.

Remove remaining uses of LegacyNativeDictionaryRequiredInterfaceNullability from
Modules/mediacapabilities. Also adds missing spec references.

* Source/WebCore/Modules/audiosession/DOMAudioSession.idl:
* Source/WebCore/Modules/mediacapabilities/AudioConfiguration.idl:
* Source/WebCore/Modules/mediacapabilities/ColorGamut.idl:
* Source/WebCore/Modules/mediacapabilities/HdrMetadataType.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesDecodingInfo.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesEncodingInfo.idl:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilitiesInfo.idl:
* Source/WebCore/Modules/mediacapabilities/MediaConfiguration.idl:
* Source/WebCore/Modules/mediacapabilities/MediaDecodingConfiguration.idl:
* Source/WebCore/Modules/mediacapabilities/MediaDecodingType.idl:
* Source/WebCore/Modules/mediacapabilities/MediaEncodingConfiguration.idl:
* Source/WebCore/Modules/mediacapabilities/MediaEncodingType.idl:
* Source/WebCore/Modules/mediacapabilities/TransferFunction.idl:
* Source/WebCore/Modules/mediacapabilities/VideoConfiguration.idl:

Canonical link: <a href="https://commits.webkit.org/306607@main">https://commits.webkit.org/306607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d31b102066a5e525ca7a1d2e443e187c9a2ee3e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108973 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78807 "2 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11073 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8714 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2946 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152791 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117386 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29906 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13433 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69542 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13922 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2914 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13661 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77647 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->