### PR TITLE
Use C++20 std::ranges::count in WebCore

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp
@@ -179,7 +179,7 @@ static constexpr SingleByteDecodeTable ibm866 {
 template<const SingleByteDecodeTable& decodeTable> SingleByteEncodeTable tableForEncoding()
 {
     // Allocate this at runtime because building it at compile time would make the binary much larger and this is often not used.
-    static constexpr auto size = std::size(decodeTable) - std::count(std::begin(decodeTable), std::end(decodeTable), replacementCharacter);
+    static constexpr auto size = std::size(decodeTable) - std::ranges::count(decodeTable, replacementCharacter);
     static const NeverDestroyed<std::unique_ptr<std::array<SingleByteEncodeTableEntry, size>>> entries = [] {
         auto mutableEntries = std::make_unique<std::array<SingleByteEncodeTableEntry, size>>(); // NOLINT.
         size_t j = 0;

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCBCGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCBCGCrypt.cpp
@@ -155,7 +155,7 @@ static std::optional<Vector<uint8_t>> gcryptDecrypt(const Vector<uint8_t>& key, 
 
         // Bail if the last `paddingValue` bytes don't have the value of `paddingValue`.
         auto padding = output.subspan(size - paddingValue, paddingValue);
-        if (std::count(padding.begin(), padding.end(), paddingValue) != paddingValue)
+        if (std::ranges::count(padding, paddingValue) != paddingValue)
             return std::nullopt;
 
         // Shrink the output Vector object to drop the PKCS#7 padding.


### PR DESCRIPTION
#### 7427e518eb5a28decb963b4560b385a5e43aa35a
<pre>
Use C++20 std::ranges::count in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=306732">https://bugs.webkit.org/show_bug.cgi?id=306732</a>
<a href="https://rdar.apple.com/169397797">rdar://169397797</a>

Reviewed by Sam Weinig.

* Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp:
(PAL::tableForEncoding):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESCBCGCrypt.cpp:
(WebCore::gcryptDecrypt):

Canonical link: <a href="https://commits.webkit.org/306608@main">https://commits.webkit.org/306608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6fb74e96bd1f21fdcd13cdea3c17fdfa3e804fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78808 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126928 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11075 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8716 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152792 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13885 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117065 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12115 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117387 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29908 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13435 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69543 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13923 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2915 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77648 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->