### PR TITLE
Add C++17 [[nodiscard]] to WTF::Vector accessor functions

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -716,13 +716,13 @@ public:
     Vector(Vector&&);
     Vector& operator=(Vector&&);
 
-    size_t size() const { return m_size; }
-    size_t sizeInBytes() const { return static_cast<size_t>(m_size) * sizeof(T); }
+    [[nodiscard]] size_t size() const { return m_size; }
+    [[nodiscard]] size_t sizeInBytes() const { return static_cast<size_t>(m_size) * sizeof(T); }
     static constexpr ptrdiff_t sizeMemoryOffset() { return OBJECT_OFFSETOF(Vector, m_size); }
-    size_t capacity() const { return Base::capacity(); }
-    bool isEmpty() const { return !size(); }
-    std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }
-    std::span<T> mutableSpan() LIFETIME_BOUND { return { data(), size() }; }
+    [[nodiscard]] size_t capacity() const { return Base::capacity(); }
+    [[nodiscard]] bool isEmpty() const { return !size(); }
+    [[nodiscard]] std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }
+    [[nodiscard]] std::span<T> mutableSpan() LIFETIME_BOUND { return { data(), size() }; }
 
     Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
     {
@@ -734,38 +734,38 @@ public:
         return span().subspan(offset, length);
     }
 
-    T& at(size_t i) LIFETIME_BOUND
+    [[nodiscard]] T& at(size_t i) LIFETIME_BOUND
     {
         if (i >= size()) [[unlikely]]
             OverflowHandler::overflowed();
         return Base::buffer()[i];
     }
-    const T& at(size_t i) const LIFETIME_BOUND
+    [[nodiscard]] const T& at(size_t i) const LIFETIME_BOUND
     {
         if (i >= size()) [[unlikely]]
             OverflowHandler::overflowed();
         return Base::buffer()[i];
     }
 
-    T& operator[](size_t i) LIFETIME_BOUND { return at(i); }
-    const T& operator[](size_t i) const LIFETIME_BOUND { return at(i); }
+    [[nodiscard]] T& operator[](size_t i) LIFETIME_BOUND { return at(i); }
+    [[nodiscard]] const T& operator[](size_t i) const LIFETIME_BOUND { return at(i); }
 
     static constexpr ptrdiff_t dataMemoryOffset() { return Base::bufferMemoryOffset(); }
 
-    iterator begin() LIFETIME_BOUND { return data(); }
-    iterator end() LIFETIME_BOUND { return begin() + m_size; }
-    const_iterator begin() const LIFETIME_BOUND { return data(); }
-    const_iterator end() const LIFETIME_BOUND { return begin() + m_size; }
+    [[nodiscard]] iterator begin() LIFETIME_BOUND { return data(); }
+    [[nodiscard]] iterator end() LIFETIME_BOUND { return begin() + m_size; }
+    [[nodiscard]] const_iterator begin() const LIFETIME_BOUND { return data(); }
+    [[nodiscard]] const_iterator end() const LIFETIME_BOUND { return begin() + m_size; }
 
-    reverse_iterator rbegin() LIFETIME_BOUND { return reverse_iterator(end()); }
-    reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
-    const_reverse_iterator rbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
+    [[nodiscard]] reverse_iterator rbegin() LIFETIME_BOUND { return reverse_iterator(end()); }
+    [[nodiscard]] reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
+    [[nodiscard]] const_reverse_iterator rbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
+    [[nodiscard]] const_reverse_iterator rend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
 
-    T& first() LIFETIME_BOUND { return at(0); }
-    const T& first() const LIFETIME_BOUND { return at(0); }
-    T& last() LIFETIME_BOUND { return at(size() - 1); }
-    const T& last() const LIFETIME_BOUND { return at(size() - 1); }
+    [[nodiscard]] T& first() LIFETIME_BOUND { return at(0); }
+    [[nodiscard]] const T& first() const LIFETIME_BOUND { return at(0); }
+    [[nodiscard]] T& last() LIFETIME_BOUND { return at(size() - 1); }
+    [[nodiscard]] const T& last() const LIFETIME_BOUND { return at(size() - 1); }
     
     T takeLast()
     {
@@ -930,8 +930,8 @@ private:
         new (NotNull, begin() + position) T(std::forward<U>(value));
     }
 
-    T* data() LIFETIME_BOUND { return Base::buffer(); }
-    const T* data() const LIFETIME_BOUND { return Base::buffer(); }
+    [[nodiscard]] T* data() LIFETIME_BOUND { return Base::buffer(); }
+    [[nodiscard]] const T* data() const LIFETIME_BOUND { return Base::buffer(); }
 
     void asanSetInitialBufferSizeTo(size_t);
     void asanSetBufferSizeToFullCapacity(size_t);


### PR DESCRIPTION
#### 4b535ee9b46f7a36862c7511dd164180bc98d8d3
<pre>
Add C++17 [[nodiscard]] to WTF::Vector accessor functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306733">https://bugs.webkit.org/show_bug.cgi?id=306733</a>
<a href="https://rdar.apple.com/169398241">rdar://169398241</a>

Reviewed by Sam Weinig.

libc++ marks std::vector&apos;s accessor functions as [[nodiscard]].
Apply the same to WTF::Vector to warn against discarding return values.

LLVM/libc++ docs: <a href="https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant">https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant</a>

* Source/WTF/wtf/Vector.h:
(WTF::Vector::size const):
(WTF::Vector::sizeInBytes const):
(WTF::Vector::capacity const):
(WTF::Vector::isEmpty const):

Canonical link: <a href="https://commits.webkit.org/306614@main">https://commits.webkit.org/306614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b2293d0c592a4faaf8adb70688c857a934c65a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94942 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78813 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89876 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11081 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8722 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/477 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133801 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152799 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2621 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13892 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117070 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13907 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12121 "Too many flaky failures: imported/w3c/web-platform-tests/cookies/attributes/secure-non-secure.html, imported/w3c/web-platform-tests/dom/nodes/remove-and-adopt-thcrash.html, imported/w3c/web-platform-tests/file-system-access/opaque-origin.https.window.html, imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/cross-origin-top-navigation-without-user-activation.window.html, imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/window_length.html, imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/range-restore-oninput-onchange-event.https.html, imported/w3c/web-platform-tests/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html, imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/047.html, imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/document.open-02.html, imported/w3c/web-platform-tests/speculation-rules/prefetch/clear-prefetch-cache-after-clear-site-data-cache.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117392 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29912 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13442 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69555 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13930 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2921 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173106 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77655 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44824 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->