### PR TITLE
[AutoFill Debugging] Allow clients to enable text extraction for debugging purposes

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -366,9 +366,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self._protectedPageConfiguration->setProcessPool(processPool ? processPool->_processPool.get() : nullptr);
 }
 
+- (Ref<WebKit::WebPreferences>)_webPreferences
+{
+    return self._protectedPageConfiguration->preferences();
+}
+
 - (WKPreferences *)preferences
 {
-    return wrapper(protect(self._protectedPageConfiguration->preferences()).get());
+    return wrapper(self._webPreferences.get());
 }
 
 - (void)setPreferences:(WKPreferences *)preferences
@@ -725,12 +730,12 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (BOOL)_respectsImageOrientation
 {
-    return Ref { *self.preferences->_preferences }->shouldRespectImageOrientation();
+    return self._webPreferences->shouldRespectImageOrientation();
 }
 
 - (void)_setRespectsImageOrientation:(BOOL)respectsImageOrientation
 {
-    Ref { *self.preferences->_preferences }->setShouldRespectImageOrientation(respectsImageOrientation);
+    self._webPreferences->setShouldRespectImageOrientation(respectsImageOrientation);
 }
 
 - (BOOL)_printsBackgrounds
@@ -1569,6 +1574,23 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     return NO;
 #endif
 }
+
+- (void)_setSystemTextExtractionEnabled:(BOOL)enabled
+{
+#if ENABLE(SYSTEM_TEXT_EXTRACTION)
+    self._webPreferences->setSystemTextExtractionEnabled(enabled);
+#endif
+}
+
+- (BOOL)_systemTextExtractionEnabled
+{
+#if ENABLE(SYSTEM_TEXT_EXTRACTION)
+    return self._webPreferences->systemTextExtractionEnabled();
+#else
+    return NO;
+#endif
+}
+
 
 - (void)_setBackgroundTextExtractionEnabled:(BOOL)enabled
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -181,6 +181,7 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 @property (nonatomic, setter=_setCSSTransformStyleSeparatedEnabled:) BOOL _cssTransformStyleSeparatedEnabled WK_API_AVAILABLE(visionos(2.4));
 #endif
 
+@property (nonatomic, setter=_setSystemTextExtractionEnabled:) BOOL _systemTextExtractionEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, setter=_setBackgroundTextExtractionEnabled:) BOOL _backgroundTextExtractionEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end


### PR DESCRIPTION
#### 9a8fdd7d0715039fd0e0910f134cfb3103299286
<pre>
[AutoFill Debugging] Allow clients to enable text extraction for debugging purposes
<a href="https://bugs.webkit.org/show_bug.cgi?id=306735">https://bugs.webkit.org/show_bug.cgi?id=306735</a>
<a href="https://rdar.apple.com/169400412">rdar://169400412</a>

Reviewed by Richard Robinson.

Make the internal feature flag for `SystemTextExtractionEnabled` (easily) configurable by clients,
for debugging purposes.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _webPreferences]):
(-[WKWebViewConfiguration preferences]):
(-[WKWebViewConfiguration _respectsImageOrientation]):
(-[WKWebViewConfiguration _setRespectsImageOrientation:]):
(-[WKWebViewConfiguration _setSystemTextExtractionEnabled:]):
(-[WKWebViewConfiguration _systemTextExtractionEnabled]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:

Canonical link: <a href="https://commits.webkit.org/306612@main">https://commits.webkit.org/306612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7a909529d1b219b109fd4c5dcdb2a89f77d0abf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150407 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94941 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7773ff0a-079f-4244-b2a9-dc9e3eaf708c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108978 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78812 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ef07b90-1e25-42b4-9e4c-6b8591d98fd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89874 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eed7630b-d9a8-4e78-984e-9457193c7e1d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11080 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8721 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/476 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120389 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152798 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13891 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117069 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13906 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12120 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/range-restore-oninput-onchange-event.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29911 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13440 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123638 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69552 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13929 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2919 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13871 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->