### PR TITLE
Reduce use of protected functions in Source/WebCore/loader

### DIFF
--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -242,14 +242,14 @@ template<typename T, typename WeakPtrImpl, typename PtrTraits = RawPtrTraits<T>>
     requires HasRefPtrMemberFunctions<T>::value
 ALWAYS_INLINE CLANG_POINTER_CONVERSION Ref<T, PtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
 {
-    return Ref<T, PtrTraits>(*weakRef.ptr());
+    return Ref<T, PtrTraits>(weakRef.get());
 }
 
 template<typename T, typename WeakPtrImpl, typename CheckedPtrTraits = RawPtrTraits<T>>
     requires (HasCheckedPtrMemberFunctions<T>::value && !HasRefPtrMemberFunctions<T>::value)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION CheckedRef<T, CheckedPtrTraits> protect(const WeakRef<T, WeakPtrImpl>& weakRef)
 {
-    return CheckedRef<T, CheckedPtrTraits>(*weakRef.ptr());
+    return CheckedRef<T, CheckedPtrTraits>(weakRef.get());
 }
 
 } // namespace WTF

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -612,7 +612,7 @@ DragImageRef DataTransfer::createDragImage(const Document* document, IntPoint& l
     if (m_dragImage) {
         HostWindow* hostWindow = document && document->view() ? document->view()->hostWindow() : nullptr;
         auto deviceScaleFactor = document ? document->deviceScaleFactor() : 1.f;
-        return createDragImageFromImage(m_dragImage->protectedImage().get(), ImageOrientation::Orientation::None, hostWindow, deviceScaleFactor);
+        return createDragImageFromImage(protect(m_dragImage->image()).get(), ImageOrientation::Orientation::None, hostWindow, deviceScaleFactor);
     }
 
     if (m_dragImageElement) {

--- a/Source/WebCore/dom/DataTransferMac.mm
+++ b/Source/WebCore/dom/DataTransferMac.mm
@@ -55,7 +55,7 @@ DragImageRef DataTransfer::createDragImage(const Document*, IntPoint& location) 
             location.setY(imageRect.height() - (elementRect.y() - imageRect.y() + m_dragLocation.y()));
         }
     } else if (m_dragImage) {
-        result = m_dragImage->protectedImage()->adapter().snapshotNSImage();
+        result = protect(m_dragImage->image())->adapter().snapshotNSImage();
         
         location = m_dragLocation;
         location.setY([result size].height - location.y());

--- a/Source/WebCore/dom/DecodedDataDocumentParser.cpp
+++ b/Source/WebCore/dom/DecodedDataDocumentParser.cpp
@@ -43,7 +43,7 @@ void DecodedDataDocumentParser::appendBytes(DocumentWriter& writer, std::span<co
     if (data.empty())
         return;
 
-    String decoded = writer.protectedDecoder()->decode(data);
+    String decoded = protect(writer.decoder())->decode(data);
     if (decoded.isEmpty())
         return;
 
@@ -53,7 +53,7 @@ void DecodedDataDocumentParser::appendBytes(DocumentWriter& writer, std::span<co
 
 void DecodedDataDocumentParser::flush(DocumentWriter& writer)
 {
-    String remainingData = writer.protectedDecoder()->flush();
+    String remainingData = protect(writer.decoder())->flush();
     if (remainingData.isEmpty())
         return;
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -517,7 +517,7 @@ void HTMLImageElement::didAttachRenderers()
     CheckedRef renderImageResource = renderImage->imageResource();
     if (renderImageResource->cachedImage())
         return;
-    renderImageResource->setCachedImage(m_imageLoader->protectedImage());
+    renderImageResource->setCachedImage(protect(m_imageLoader->image()));
 
     // If we have no image at all because we have no src attribute, set
     // image height and width for the alt text instead.

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -71,7 +71,7 @@ void HTMLImageLoader::dispatchLoadEvent()
     bool errorOccurred = image()->errorOccurred();
     if (!errorOccurred && image()->response().httpStatusCode() >= 400)
         errorOccurred = is<HTMLObjectElement>(element()); // An <object> considers a 404 to be an error and should fire onerror.
-    protectedElement()->dispatchEvent(Event::create(errorOccurred ? eventNames().errorEvent : eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    protect(element())->dispatchEvent(Event::create(errorOccurred ? eventNames().errorEvent : eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -659,7 +659,7 @@ void HTMLPlugInElement::didAttachRenderers()
         if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer())) {
             CheckedRef renderImageResource = renderImage->imageResource();
             if (!renderImageResource->cachedImage())
-                renderImageResource->setCachedImage(m_imageLoader->protectedImage());
+                renderImageResource->setCachedImage(protect(m_imageLoader->image()));
         }
     }
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -134,7 +134,7 @@ void HTMLVideoElement::didAttachRenderers()
             lazyInitialize(m_imageLoader, makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this));
         m_imageLoader->updateFromElement();
         if (CheckedPtr renderer = this->renderer())
-            renderer->checkedImageResource()->setCachedImage(m_imageLoader->protectedImage());
+            renderer->checkedImageResource()->setCachedImage(protect(m_imageLoader->image()));
     }
 }
 

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -146,7 +146,7 @@ void ImageInputType::attach()
         return;
 
     CheckedRef imageResource = renderer->imageResource();
-    imageResource->setCachedImage(imageLoader->protectedImage());
+    imageResource->setCachedImage(protect(imageLoader->image()));
 
     // If we have no image at all because we have no src attribute, set
     // image height and width for the alt text instead.

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -124,7 +124,7 @@ void MediaDocumentParser::createDocumentStructure()
     if (!frame)
         return;
 
-    frame->loader().protectedActiveDocumentLoader()->setMainResourceDataBufferingPolicy(DataBufferingPolicy::DoNotBufferData);
+    protect(frame->loader().activeDocumentLoader())->setMainResourceDataBufferingPolicy(DataBufferingPolicy::DoNotBufferData);
     frame->loader().setOutgoingReferrer(document->completeURL(m_outgoingReferrer));
 }
 

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -361,15 +361,10 @@ void ContentFilter::didDecide(State state)
     client->cancelMainResourceLoadForContentFilter(m_blockedError);
 }
 
-Ref<ContentFilterClient> ContentFilter::protectedClient() const
-{
-    return m_client.get();
-}
-
 void ContentFilter::deliverResourceData(const SharedBuffer& buffer)
 {
     ASSERT(m_state == State::Allowed);
-    protectedClient()->dataReceivedThroughContentFilter(buffer);
+    protect(m_client)->dataReceivedThroughContentFilter(buffer);
 }
 
 URL ContentFilter::url()
@@ -425,7 +420,7 @@ void ContentFilter::handleProvisionalLoadFailure(const ResourceError& error)
     ResourceResponse response { URL(), "text/html"_s, static_cast<long long>(replacementData->size()), "UTF-8"_s };
     SubstituteData substituteData { WTF::move(replacementData), URL { error.failingURL() }, WTF::move(response), SubstituteData::SessionHistoryVisibility::Hidden };
     SetForScope loadingBlockedPage { m_isLoadingBlockedPage, true };
-    protectedClient()->handleProvisionalLoadFailureFromContentFilter(blockedPageURL(), WTF::move(substituteData));
+    protect(m_client)->handleProvisionalLoadFailureFromContentFilter(blockedPageURL(), WTF::move(substituteData));
 }
 
 void ContentFilter::deliverStoredResourceData()

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -126,8 +126,6 @@ private:
     void deliverResourceData(const SharedBuffer&);
     void deliverStoredResourceData();
 
-    Ref<ContentFilterClient> protectedClient() const;
-    
     URL url();
 
     Container m_contentFilters;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -212,7 +212,6 @@ public:
     WEBCORE_EXPORT virtual void detachFromFrame(LoadWillContinueInAnotherProcess);
 
     WEBCORE_EXPORT FrameLoader* frameLoader() const;
-    WEBCORE_EXPORT RefPtr<FrameLoader> protectedFrameLoader() const;
     WEBCORE_EXPORT SubresourceLoader* mainResourceLoader() const;
     WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> mainResourceData() const;
     
@@ -225,7 +224,6 @@ public:
     ResourceRequest& request();
 
     CachedResourceLoader& cachedResourceLoader() { return m_cachedResourceLoader; }
-    Ref<CachedResourceLoader> protectedCachedResourceLoader() const;
 
     const SubstituteData& substituteData() const { return m_substituteData; }
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -109,14 +109,11 @@ class CachedRawResource;
 
         Ref<SecurityOrigin> topOrigin() const;
         SecurityOrigin& securityOrigin() const;
-        Ref<SecurityOrigin> protectedSecurityOrigin() const;
         const ContentSecurityPolicy& contentSecurityPolicy() const;
         CheckedRef<const ContentSecurityPolicy> checkedContentSecurityPolicy() const;
         const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const;
 
         Document& document() { return *m_document; }
-        Ref<Document> protectedDocument();
-        Ref<const Document> protectedDocument() const;
 
         const ThreadableLoaderOptions& options() const { return m_options; }
         const String& referrer() const { return m_referrer; }
@@ -130,8 +127,6 @@ class CachedRawResource;
 
         bool shouldSetHTTPHeadersToKeep() const;
         bool checkURLSchemeAsCORSEnabled(const URL&);
-
-        CachedResourceHandle<CachedRawResource> protectedResource() const;
 
         CachedResourceHandle<CachedRawResource> m_resource;
         WeakPtr<ThreadableLoaderClient> m_client;

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -296,11 +296,6 @@ TextResourceDecoder& DocumentWriter::decoder()
     return *m_decoder;
 }
 
-Ref<TextResourceDecoder> DocumentWriter::protectedDecoder()
-{
-    return decoder();
-}
-
 void DocumentWriter::reportDataReceived()
 {
     ASSERT(m_decoder);
@@ -313,11 +308,6 @@ void DocumentWriter::reportDataReceived()
     document->resolveStyle(Document::ResolveStyleType::Rebuild);
 }
 
-RefPtr<DocumentParser> DocumentWriter::protectedParser() const
-{
-    return m_parser;
-}
-
 void DocumentWriter::addData(const SharedBuffer& data)
 {
     // FIXME: Change these to ASSERT once https://bugs.webkit.org/show_bug.cgi?id=80427 has been resolved.
@@ -327,7 +317,7 @@ void DocumentWriter::addData(const SharedBuffer& data)
         return;
     }
     ASSERT(m_parser);
-    protectedParser()->appendBytes(*this, data.span());
+    protect(m_parser)->appendBytes(*this, data.span());
 }
 
 void DocumentWriter::insertDataSynchronously(const String& markup)
@@ -335,7 +325,7 @@ void DocumentWriter::insertDataSynchronously(const String& markup)
     ASSERT(m_state != State::NotStarted);
     ASSERT(m_state != State::Finished);
     ASSERT(m_parser);
-    protectedParser()->insert(markup);
+    protect(m_parser)->insert(markup);
 }
 
 void DocumentWriter::end()
@@ -355,10 +345,10 @@ void DocumentWriter::end()
     if (!m_parser)
         return;
     // FIXME: m_parser->finish() should imply m_parser->flush().
-    protectedParser()->flush(*this);
+    protect(m_parser)->flush(*this);
     if (!m_parser)
         return;
-    protectedParser()->finish();
+    protect(m_parser)->finish();
     m_parser = nullptr;
 }
 
@@ -376,7 +366,7 @@ void DocumentWriter::setFrame(LocalFrame& frame)
 void DocumentWriter::setDocumentWasLoadedAsPartOfNavigation()
 {
     ASSERT(m_parser && !m_parser->isStopped());
-    protectedParser()->setDocumentWasLoadedAsPartOfNavigation();
+    protect(m_parser)->setDocumentWasLoadedAsPartOfNavigation();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/DocumentWriter.h
+++ b/Source/WebCore/loader/DocumentWriter.h
@@ -62,8 +62,6 @@ public:
     const String& mimeType() const { return m_mimeType; }
     void setMIMEType(const String& type) { m_mimeType = type; }
 
-    Ref<TextResourceDecoder> protectedDecoder();
-
     // Exposed for DocumentParser::appendBytes.
     TextResourceDecoder& decoder();
     void reportDataReceived();
@@ -73,7 +71,6 @@ public:
 private:
     Ref<Document> createDocument(const URL&, std::optional<ScriptExecutionContextIdentifier>);
     void clear();
-    RefPtr<DocumentParser> protectedParser() const;
 
     WeakPtr<LocalFrame> m_frame;
 

--- a/Source/WebCore/loader/FormSubmission.h
+++ b/Source/WebCore/loader/FormSubmission.h
@@ -87,8 +87,7 @@ public:
     const URL& action() const { return m_action; }
     const AtomString& target() const { return m_target; }
     const String& contentType() const { return m_contentType; }
-    FormState& state() const { return *m_formState; }
-    RefPtr<FormState> protectedState() const { return m_formState; }
+    FormState* state() const { return m_formState.get(); }
     FormData& data() const { return *m_formData; }
     const String boundary() const { return m_boundary; }
     LockHistory lockHistory() const { return m_lockHistory; }

--- a/Source/WebCore/loader/FrameLoadRequest.cpp
+++ b/Source/WebCore/loader/FrameLoadRequest.cpp
@@ -63,24 +63,14 @@ FrameLoadRequest& FrameLoadRequest::operator=(const FrameLoadRequest&) = default
 FrameLoadRequest::FrameLoadRequest(FrameLoadRequest&&) = default;
 FrameLoadRequest& FrameLoadRequest::operator=(FrameLoadRequest&&) = default;
 
-Document& FrameLoadRequest::requester()
+Document& FrameLoadRequest::requester() const
 {
     return m_requester.get();
-}
-
-Ref<Document> FrameLoadRequest::protectedRequester() const
-{
-    return m_requester;
 }
 
 const SecurityOrigin& FrameLoadRequest::requesterSecurityOrigin() const
 {
     return m_requesterSecurityOrigin.get();
-}
-
-Ref<SecurityOrigin> FrameLoadRequest::protectedRequesterSecurityOrigin() const
-{
-    return m_requesterSecurityOrigin;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -119,10 +119,8 @@ public:
 
     bool isEmpty() const { return m_resourceRequest.isEmpty(); }
 
-    WEBCORE_EXPORT Document& requester();
-    Ref<Document> protectedRequester() const;
+    WEBCORE_EXPORT Document& requester() const;
     const SecurityOrigin& requesterSecurityOrigin() const;
-    Ref<SecurityOrigin> protectedRequesterSecurityOrigin() const;
 
     ResourceRequest& resourceRequest() { return m_resourceRequest; }
     const ResourceRequest& resourceRequest() const { return m_resourceRequest; }

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -122,7 +122,6 @@ public:
     void initForSynthesizedDocument(const URL&);
 
     WEBCORE_EXPORT LocalFrame& frame() const;
-    WEBCORE_EXPORT Ref<LocalFrame> protectedFrame() const;
 
     PolicyChecker& policyChecker() const { return m_policyChecker; }
 
@@ -182,12 +181,9 @@ public:
     String outgoingOrigin() const;
 
     WEBCORE_EXPORT DocumentLoader* activeDocumentLoader() const;
-    RefPtr<DocumentLoader> protectedActiveDocumentLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
-    WEBCORE_EXPORT RefPtr<DocumentLoader> protectedDocumentLoader() const;
     DocumentLoader* policyDocumentLoader() const { return m_policyDocumentLoader.get(); }
     DocumentLoader* provisionalDocumentLoader() const { return m_provisionalDocumentLoader.get(); }
-    RefPtr<DocumentLoader> protectedProvisionalDocumentLoader() const;
     FrameState state() const { return m_state; }
 
     enum class CanIncludeCurrentDocumentLoader : bool { No, Yes };
@@ -239,8 +235,6 @@ public:
 
     const LocalFrameLoaderClient& client() const { return m_client.get(); }
     LocalFrameLoaderClient& client() { return m_client.get(); }
-    WEBCORE_EXPORT Ref<const LocalFrameLoaderClient> protectedClient() const;
-    WEBCORE_EXPORT Ref<LocalFrameLoaderClient> protectedClient();
 
     WEBCORE_EXPORT FrameIdentifier frameID() const;
 
@@ -311,7 +305,6 @@ public:
     PageDismissalType pageDismissalEventBeingDispatched() const { return m_pageDismissalEventBeingDispatched; }
 
     WEBCORE_EXPORT NetworkingContext* networkingContext() const;
-    WEBCORE_EXPORT RefPtr<NetworkingContext> protectedNetworkingContext() const;
 
     void loadProgressingStatusChanged();
 

--- a/Source/WebCore/loader/FrameNetworkingContext.h
+++ b/Source/WebCore/loader/FrameNetworkingContext.h
@@ -49,7 +49,6 @@ protected:
     }
 
     LocalFrame* frame() const { return m_frame; }
-    RefPtr<LocalFrame> protectedFrame() const { return m_frame; }
 
 private:
     bool isValid() const override { return !!m_frame; }

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -80,18 +80,15 @@ public:
     void updateForFrameLoadCompleted();
 
     HistoryItem* currentItem() const { return m_currentItem.get(); }
-    WEBCORE_EXPORT RefPtr<HistoryItem> protectedCurrentItem() const;
     WEBCORE_EXPORT void setCurrentItem(Ref<HistoryItem>&&);
     void setCurrentItemTitle(const StringWithDirection&);
     bool currentItemShouldBeReplaced() const;
     WEBCORE_EXPORT void replaceCurrentItem(RefPtr<HistoryItem>&&);
 
     HistoryItem* previousItem() const { return m_previousItem.get(); }
-    RefPtr<HistoryItem> protectedPreviousItem() const;
     void clearPreviousItem();
 
     HistoryItem* provisionalItem() const { return m_provisionalItem.get(); }
-    RefPtr<HistoryItem> protectedProvisionalItem() const;
     void setProvisionalItem(RefPtr<HistoryItem>&&);
 
     void pushState(RefPtr<SerializedScriptValue>&&, const String& url);
@@ -130,7 +127,6 @@ private:
 
     struct FrameToNavigate;
     static void recursiveGatherFramesToNavigate(LocalFrame&, Vector<FrameToNavigate>&, HistoryItem& targetItem, HistoryItem* fromItem);
-    Ref<LocalFrame> protectedFrame() const;
 
     const WeakRef<LocalFrame> m_frame;
 

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -70,14 +70,12 @@ public:
 
     Element& element() { return m_element; }
     const Element& element() const { return m_element; }
-    Ref<Element> protectedElement() const { return m_element; }
 
     bool shouldIgnoreCandidateWhenLoadingFromArchive(const ImageCandidate&) const;
 
     bool imageComplete() const { return m_imageComplete; }
 
     CachedImage* image() const { return m_image.get(); }
-    CachedResourceHandle<CachedImage> protectedImage() const;
     void clearImage(); // Cancels pending load events, and doesn't dispatch new ones.
     
     size_t pendingDecodePromisesCountForTesting() const { return m_decodingPromises.size(); }
@@ -99,7 +97,6 @@ public:
     bool isDeferred() const { return m_lazyImageLoadState == LazyImageLoadState::Deferred || m_lazyImageLoadState == LazyImageLoadState::LoadImmediately; }
 
     Document& document() { return m_element->document(); }
-    Ref<Document> protectedDocument() { return m_element->document(); }
 
 protected:
     explicit ImageLoader(Element&);

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -194,11 +194,6 @@ Document* MediaResourceLoader::document()
     return m_document.get();
 }
 
-RefPtr<Document> MediaResourceLoader::protectedDocument()
-{
-    return document();
-}
-
 const String& MediaResourceLoader::crossOriginMode() const
 {
     assertIsMainThread();
@@ -287,12 +282,7 @@ MediaResource::MediaResource(MediaResourceLoader& loader, CachedResourceHandle<C
     assertIsMainThread();
 
     ASSERT(resource);
-    protectedResource()->addClient(*this);
-}
-
-CachedResourceHandle<CachedRawResource> MediaResource::protectedResource() const
-{
-    return m_resource;
+    protect(m_resource)->addClient(*this);
 }
 
 MediaResource::~MediaResource()
@@ -300,7 +290,7 @@ MediaResource::~MediaResource()
     assertIsMainThread();
 
     if (m_resource)
-        protectedResource()->removeClient(*this);
+        protect(m_resource)->removeClient(*this);
     m_loader->removeResource(*this);
 }
 
@@ -335,7 +325,7 @@ void MediaResource::responseReceived(const CachedResource& resource, const Resou
         return;
     }
 
-    if (!m_loader->verifyMediaResponse(resource.url(), response, resource.protectedOrigin().get())) {
+    if (!m_loader->verifyMediaResponse(resource.url(), response, protect(resource.origin()).get())) {
         static NeverDestroyed<const String> consoleMessage("Media response origin validation failed."_s);
         protect(m_loader->document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage.get());
         if (RefPtr client = this->client())

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -71,7 +71,6 @@ public:
     void removeResource(MediaResource&);
 
     Document* document();
-    RefPtr<Document> protectedDocument();
     const String& crossOriginMode() const;
 
     WEBCORE_EXPORT static void recordResponsesForTesting();
@@ -125,7 +124,6 @@ public:
     void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 
 private:
-    CachedResourceHandle<CachedRawResource> protectedResource() const;
 
     MediaResource(MediaResourceLoader&, CachedResourceHandle<CachedRawResource>&&);
     void ensureShutdown();

--- a/Source/WebCore/loader/NavigationAction.cpp
+++ b/Source/WebCore/loader/NavigationAction.cpp
@@ -142,12 +142,12 @@ NavigationAction::NavigationAction(Document& requester, const ResourceRequest& o
 
 NavigationAction::NavigationAction(FrameLoadRequest& request, NavigationType type, Event* event)
     : FrameLoadRequestBase(request)
-    , m_requester { NavigationRequester::from(request.protectedRequester().get()) }
+    , m_requester { NavigationRequester::from(protect(request.requester()).get()) }
     , m_originalRequest { request.resourceRequest() }
     , m_keyStateEventData { keyStateDataForFirstEventWithKeyState(event) }
     , m_mouseEventData { mouseEventDataForFirstMouseEvent(event) }
     , m_type { type }
-    , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(request.protectedRequester().get(), request.resourceRequest().url()) }
+    , m_treatAsSameOriginNavigation { shouldTreatAsSameOriginNavigation(protect(request.requester()).get(), request.resourceRequest().url()) }
 {
 }
 

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -84,7 +84,6 @@ private:
 
     void timerFired();
     void schedule(std::unique_ptr<ScheduledNavigation>);
-    Ref<Frame> protectedFrame() const;
 
     static LockBackForwardList mustLockBackForwardList(Frame& targetFrame);
 

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.cpp
@@ -96,7 +96,7 @@ void NetscapePlugInStreamLoader::init(ResourceRequest&& request, CompletionHandl
         if (!success)
             return completionHandler(false);
         ASSERT(!reachedTerminalState());
-        protectedDocumentLoader()->addPlugInStreamLoader(*this);
+        protect(documentLoader())->addPlugInStreamLoader(*this);
         m_isInitialized = true;
         completionHandler(true);
     });

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -227,7 +227,7 @@ void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTP
     // Document in the Frame, but the activeDocumentLoader will be associated
     // with the provisional DocumentLoader if there is a provisional
     // DocumentLoader.
-    bool shouldUseCredentialStorage = frame.loader().client().shouldUseCredentialStorage(frame.loader().protectedActiveDocumentLoader().get(), identifier);
+    bool shouldUseCredentialStorage = frame.loader().client().shouldUseCredentialStorage(protect(frame.loader().activeDocumentLoader()), identifier);
     ResourceLoaderOptions options;
     options.credentials = shouldUseCredentialStorage ? FetchOptions::Credentials::Include : FetchOptions::Credentials::Omit;
     options.redirect = shouldFollowRedirects == ShouldFollowRedirects::Yes ? FetchOptions::Redirect::Follow : FetchOptions::Redirect::Error;
@@ -247,16 +247,16 @@ void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTP
 
     // FIXME: Deprecate the ping load code path.
     if (platformStrategies()->loaderStrategy()->usePingLoad()) {
-        InspectorInstrumentation::willSendRequestOfType(&frame, identifier, frame.loader().protectedActiveDocumentLoader().get(), request, InspectorInstrumentation::LoadType::Ping);
+        InspectorInstrumentation::willSendRequestOfType(&frame, identifier, protect(frame.loader().activeDocumentLoader()), request, InspectorInstrumentation::LoadType::Ping);
 
         platformStrategies()->loaderStrategy()->startPingLoad(frame, request, WTF::move(originalRequestHeaders), options, policyCheck, [protectedFrame = Ref { frame }, identifier] (const ResourceError& error, const ResourceResponse& response) {
             if (!response.isNull())
-                InspectorInstrumentation::didReceiveResourceResponse(protectedFrame, identifier, protectedFrame->loader().protectedActiveDocumentLoader().get(), response, nullptr);
+                InspectorInstrumentation::didReceiveResourceResponse(protectedFrame, identifier, protect(protectedFrame->loader().activeDocumentLoader()), response, nullptr);
             if (!error.isNull()) {
-                InspectorInstrumentation::didFailLoading(protectedFrame.ptr(), protectedFrame->loader().protectedActiveDocumentLoader().get(), identifier, error);
+                InspectorInstrumentation::didFailLoading(protectedFrame.ptr(), protect(protectedFrame->loader().activeDocumentLoader()), identifier, error);
                 return;
             }
-            InspectorInstrumentation::didFinishLoading(protectedFrame.ptr(), protectedFrame->loader().protectedActiveDocumentLoader().get(), identifier, { }, nullptr);
+            InspectorInstrumentation::didFinishLoading(protectedFrame.ptr(), protect(protectedFrame->loader().activeDocumentLoader()), identifier, { }, nullptr);
         });
         return;
     }

--- a/Source/WebCore/loader/PolicyChecker.h
+++ b/Source/WebCore/loader/PolicyChecker.h
@@ -98,8 +98,6 @@ private:
     URLKeepingBlobAlive extendBlobURLLifetimeIfNecessary(const ResourceRequest&, const Document&, PolicyDecisionMode = PolicyDecisionMode::Asynchronous) const;
     std::optional<HitTestResult> hitTestResult(const NavigationAction&);
 
-    Ref<LocalFrame> protectedFrame() const;
-
     WeakRef<LocalFrame> m_frame;
 
     uint64_t m_javaScriptURLPolicyCheckIdentifier { 0 };

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -73,7 +73,6 @@ private:
     void progressEstimateChanged(LocalFrame&);
 
     void progressHeartbeatTimerFired();
-    Ref<Page> protectedPage() const;
 
     WeakRef<Page> m_page;
     const UniqueRef<ProgressTrackerClient> m_client;

--- a/Source/WebCore/loader/ResourceLoadNotifier.h
+++ b/Source/WebCore/loader/ResourceLoadNotifier.h
@@ -75,8 +75,6 @@ public:
     }
 
 private:
-    Ref<LocalFrame> protectedFrame() const;
-
     WeakRef<LocalFrame> m_frame;
     std::optional<ResourceLoaderIdentifier> m_initialRequestIdentifier;
 };

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -87,9 +87,7 @@ public:
 #endif
 
     WEBCORE_EXPORT FrameLoader* frameLoader() const;
-    WEBCORE_EXPORT RefPtr<FrameLoader> protectedFrameLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
-    WEBCORE_EXPORT RefPtr<DocumentLoader> protectedDocumentLoader() const;
     const ResourceRequest& originalRequest() const { return m_originalRequest; }
 
     WEBCORE_EXPORT void start();
@@ -113,7 +111,6 @@ public:
     const ResourceResponse& response() const { return m_response; }
 
     const FragmentedSharedBuffer* resourceData() const;
-    RefPtr<const FragmentedSharedBuffer> protectedResourceData() const;
     void clearResourceData();
     
     virtual bool isSubresourceLoader() const;
@@ -147,9 +144,8 @@ public:
     ContentEncodingSniffingPolicy contentEncodingSniffingPolicy() const { return m_options.contentEncodingSniffingPolicy; }
     WEBCORE_EXPORT bool isAllowedToAskUserForCredentials() const;
     WEBCORE_EXPORT bool shouldIncludeCertificateInfo() const;
-    
+
     virtual CachedResource* cachedResource() const { return nullptr; }
-    CachedResourceHandle<CachedResource> protectedCachedResource() const { return cachedResource(); }
 
     bool reachedTerminalState() const { return m_reachedTerminalState; }
 
@@ -168,7 +164,6 @@ public:
 #endif
 
     WEBCORE_EXPORT LocalFrame* frame() const;
-    RefPtr<LocalFrame> protectedFrame() const;
 
     const ResourceLoaderOptions& options() const { return m_options; }
 

--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -231,7 +231,7 @@ void ResourceMonitor::checkNetworkUsageExcessIfNecessary()
             return;
         }
 
-        frame->loader().protectedClient()->didExceedNetworkUsageThreshold();
+        protect(frame->loader().client())->didExceedNetworkUsageThreshold();
     }
 }
 

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -87,11 +87,6 @@ FrameLoader::SubframeLoader::SubframeLoader(LocalFrame& frame)
 {
 }
 
-Ref<LocalFrame> FrameLoader::SubframeLoader::protectedFrame() const
-{
-    return m_frame;
-}
-
 void FrameLoader::SubframeLoader::clear()
 {
     m_containsPlugins = false;
@@ -115,7 +110,7 @@ void FrameLoader::SubframeLoader::createFrameIfNecessary(HTMLFrameOwnerElement& 
         return;
     if (!canCreateSubFrame())
         return;
-    protectedFrame()->loader().client().createFrame(frameName, ownerElement);
+    protect(m_frame)->loader().client().createFrame(frameName, ownerElement);
     if (!ownerElement.contentFrame())
         return;
 
@@ -157,16 +152,16 @@ bool FrameLoader::SubframeLoader::pluginIsLoadable(const URL& url, const HTMLPlu
 
         Ref securityOrigin = document->securityOrigin();
         if (!securityOrigin->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
-            FrameLoader::reportLocalLoadFailed(protectedFrame().ptr(), url.string());
+            FrameLoader::reportLocalLoadFailed(protect(m_frame).ptr(), url.string());
             return false;
         }
 
         if (!portAllowed(url) || isIPAddressDisallowed(url)) {
-            FrameLoader::reportBlockedLoadFailed(protectedFrame(), url);
+            FrameLoader::reportBlockedLoadFailed(protect(m_frame), url);
             return false;
         }
 
-        if (MixedContentChecker::shouldBlockRequest(protectedFrame(), url))
+        if (MixedContentChecker::shouldBlockRequest(protect(m_frame), url))
             return false;
     }
 

--- a/Source/WebCore/loader/SubframeLoader.h
+++ b/Source/WebCore/loader/SubframeLoader.h
@@ -72,7 +72,6 @@ private:
     URL completeURL(const String&) const;
 
     bool shouldConvertInvalidURLsToBlank() const;
-    Ref<LocalFrame> protectedFrame() const;
 
     bool canCreateSubFrame() const;
 

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -53,13 +53,11 @@ public:
     void cancelIfNotFinishing();
     bool isSubresourceLoader() const final;
     CachedResource* cachedResource() const final { return m_resource.get(); };
-    CachedResourceHandle<CachedResource> protectedCachedResource() const { return cachedResource(); }
 
     WEBCORE_EXPORT const HTTPHeaderMap* originalHeaders() const;
 
     const SecurityOrigin* origin() const { return m_origin.get(); }
     SecurityOrigin* origin() { return m_origin.get(); }
-    RefPtr<SecurityOrigin> protectedOrigin() const;
 #if PLATFORM(IOS_FAMILY)
     void startLoading() final;
 

--- a/Source/WebCore/loader/SubstituteData.h
+++ b/Source/WebCore/loader/SubstituteData.h
@@ -51,7 +51,7 @@ public:
     SessionHistoryVisibility shouldRevealToSessionHistory() const { return m_shouldRevealToSessionHistory; }
 
     FragmentedSharedBuffer* content() const { return m_content.get(); }
-    RefPtr<FragmentedSharedBuffer> protectedContent() const { return m_content; }
+    RefPtr<FragmentedSharedBuffer> contentForSerialization() const { return m_content; }
     const String& mimeType() const { return m_response.mimeType(); }
     const String& textEncoding() const { return m_response.textEncodingName(); }
     const URL& failingURL() const { return m_failingURL; }

--- a/Source/WebCore/loader/SubstituteResource.h
+++ b/Source/WebCore/loader/SubstituteResource.h
@@ -38,7 +38,7 @@ public:
     const URL& url() const { return m_url; }
     const ResourceResponse& response() const { return m_response; }
     FragmentedSharedBuffer& data() const LIFETIME_BOUND { return *m_data.buffer(); }
-    Ref<FragmentedSharedBuffer> protectedData() const { return data(); }
+    Ref<FragmentedSharedBuffer> dataForSerialization() const { return m_data.copyBuffer(); }
     void append(const SharedBuffer& buffer) { m_data.append(buffer); }
     void clear() { m_data.empty(); }
 

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -116,7 +116,7 @@ void TextTrackLoader::deprecatedDidReceiveCachedResource(CachedResource& resourc
     if (!m_resource->resourceBuffer())
         return;
 
-    processNewCueData(*protectedResource());
+    processNewCueData(*protect(m_resource));
 }
 
 void TextTrackLoader::corsPolicyPreventedLoad()
@@ -243,11 +243,6 @@ Vector<String> TextTrackLoader::getNewStyleSheets()
     if (!m_cueParser)
         return { };
     return m_cueParser->takeStyleSheets();
-}
-
-CachedResourceHandle<CachedTextTrack> TextTrackLoader::protectedResource() const
-{
-    return m_resource.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/TextTrackLoader.h
+++ b/Source/WebCore/loader/TextTrackLoader.h
@@ -90,8 +90,6 @@ private:
     void cueLoadTimerFired();
     void corsPolicyPreventedLoad();
 
-    CachedResourceHandle<CachedTextTrack> protectedResource() const;
-
     enum State { Idle, Loading, Finished, Failed };
 
     WeakPtr<TextTrackLoaderClient> m_client;

--- a/Source/WebCore/loader/archive/ArchiveResource.cpp
+++ b/Source/WebCore/loader/archive/ArchiveResource.cpp
@@ -79,7 +79,7 @@ Expected<String, ArchiveError> ArchiveResource::saveToDisk(const String& directo
 
     auto filePath = FileSystem::pathByAppendingComponent(directory, m_relativeFilePath);
     FileSystem::makeAllDirectories(FileSystem::parentPath(filePath));
-    auto fileData = protectedData()->extractData();
+    auto fileData = protect(data())->extractData();
     auto bytesWritten = FileSystem::overwriteEntireFile(filePath, fileData.span());
 
     if (!bytesWritten)

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.h
@@ -67,8 +67,8 @@ public:
     WEBCORE_EXPORT static RefPtr<LegacyWebArchive> create(const SimpleRange&, ArchiveOptions&&);
 
     WEBCORE_EXPORT RetainPtr<CFDataRef> rawDataRepresentation();
+    Ref<ArchiveResource> mainResourceForSerialization() const { return *mainResource(); }
 
-    Ref<ArchiveResource> protectedMainResource() const { return *mainResource(); }
     std::optional<FrameIdentifier> frameIdentifier() const { return m_frameIdentifier; }
     Vector<FrameIdentifier> subframeIdentifiers() const { return m_subframeIdentifiers; }
     void appendSubframeArchive(Ref<Archive>&& subframeArchive) { addSubframeArchive(WTF::move(subframeArchive)); }

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
@@ -45,7 +45,7 @@ void CachedApplicationManifest::finishLoading(const FragmentedSharedBuffer* data
     if (data) {
         Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
-        m_text = protectedDecoder()->decodeAndFlush(contiguousData->span());
+        m_text = protect(m_decoder)->decodeAndFlush(contiguousData->span());
         m_data = WTF::move(contiguousData);
     } else {
         m_data = nullptr;
@@ -56,12 +56,12 @@ void CachedApplicationManifest::finishLoading(const FragmentedSharedBuffer* data
 
 void CachedApplicationManifest::setEncoding(const String& chs)
 {
-    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protect(m_decoder)->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 ASCIILiteral CachedApplicationManifest::encoding() const
 {
-    return protectedDecoder()->encoding().name();
+    return protect(m_decoder)->encoding().name();
 }
 
 std::optional<ApplicationManifest> CachedApplicationManifest::process(const URL& manifestURL, const URL& documentURL, Document* document)
@@ -71,11 +71,6 @@ std::optional<ApplicationManifest> CachedApplicationManifest::process(const URL&
     if (document)
         return ApplicationManifestParser::parse(*document, *m_text, manifestURL, documentURL);
     return ApplicationManifestParser::parse(*m_text, manifestURL, documentURL);
-}
-
-Ref<TextResourceDecoder> CachedApplicationManifest::protectedDecoder() const
-{
-    return m_decoder;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.h
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.h
@@ -44,7 +44,6 @@ public:
 private:
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.ptr(); }
-    Ref<TextResourceDecoder> protectedDecoder() const;
     void setEncoding(const String&) final;
     ASCIILiteral encoding() const final;
 

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.h
@@ -50,7 +50,6 @@ private:
     String responseMIMEType() const;
     bool canUseSheet(MIMETypeCheckHint, bool* hasValidMIMEType, bool* hasHTTPStatusOK) const;
     bool mayTryReplaceEncodedData() const final { return true; }
-    Ref<TextResourceDecoder> protectedDecoder() const;
 
     void didAddClient(CachedResourceClient&) final;
 

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -50,7 +50,7 @@ public:
     ~CachedFontLoadRequest()
     {
         if (m_fontLoadRequestClient)
-            protectedCachedFont()->removeClient(*this);
+            protect(m_font)->removeClient(*this);
     }
 
     // CachedResourceClient.
@@ -58,7 +58,6 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     CachedFont& cachedFont() const { return *m_font; }
-    CachedResourceHandle<CachedFont> protectedCachedFont() const { return m_font; }
 
 private:
     CachedFontLoadRequest(CachedFont& font, ScriptExecutionContext& context)
@@ -86,16 +85,16 @@ private:
 
     RefPtr<Font> createFont(const FontDescription& description, bool syntheticBold, bool syntheticItalic, const FontCreationContext& fontCreationContext) final
     {
-        return protectedCachedFont()->createFont(description, syntheticBold, syntheticItalic, fontCreationContext);
+        return protect(m_font)->createFont(description, syntheticBold, syntheticItalic, fontCreationContext);
     }
 
     void setClient(FontLoadRequestClient* client) final
     {
         WeakPtr oldClient = std::exchange(m_fontLoadRequestClient, client);
         if (!client && oldClient)
-            protectedCachedFont()->removeClient(*this);
+            protect(m_font)->removeClient(*this);
         else if (client && !oldClient)
-            protectedCachedFont()->addClient(*this);
+            protect(m_font)->addClient(*this);
     }
 
     bool isCachedFontLoadRequest() const final { return true; }

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -140,7 +140,7 @@ void CachedImage::didAddClient(CachedResourceClient& client)
 {
     if (m_data && !m_image && !errorOccurred()) {
         createImage();
-        protectedImage()->setData(m_data.copyRef(), true);
+        protect(m_image)->setData(m_data.copyRef(), true);
     }
 
     ASSERT(client.resourceClientType() == CachedImageClient::expectedType());
@@ -268,11 +268,6 @@ Image* CachedImage::image() const
         return m_image.get();
 
     return &Image::nullImage();
-}
-
-RefPtr<Image> CachedImage::protectedImage() const
-{
-    return image();
 }
 
 Image* CachedImage::imageForRenderer(const RenderObject* renderer)
@@ -500,7 +495,7 @@ inline void CachedImage::clearImage()
 
         if (imageObserver->cachedImages().isEmptyIgnoringNullReferences()) {
             ASSERT(imageObserver->hasOneRef());
-            protectedImage()->setImageObserver(nullptr);
+            protect(m_image)->setImageObserver(nullptr);
         }
     }
 
@@ -717,7 +712,7 @@ void CachedImage::imageFrameAvailable(const Image& image, ImageAnimatingState an
     }
 
     if (visibleState == VisibleInViewportState::No && animatingState == ImageAnimatingState::Yes)
-        protectedImage()->stopAnimation();
+        protect(m_image)->stopAnimation();
 
     if (decodingStatus != DecodingStatus::Partial)
         m_clientsWaitingForAsyncDecoding.clear();

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -63,7 +63,6 @@ public:
     virtual ~CachedImage();
 
     WEBCORE_EXPORT Image* image() const; // Returns the nullImage() if the image is not available yet.
-    WEBCORE_EXPORT RefPtr<Image> protectedImage() const;
     WEBCORE_EXPORT Image* imageForRenderer(const RenderObject*); // Returns the nullImage() if the image is not available yet.
     bool hasImage() const { return m_image.get(); }
     bool currentFrameKnownToBeOpaque(const RenderElement*);

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -168,7 +168,7 @@ void CachedRawResource::didAddClient(CachedResourceClient& c)
         return std::pair<ResourceRequest, ResourceResponse> { pair.m_request, pair.m_redirectResponse };
     });
 
-    iterateRedirects(CachedResourceHandle { this }, client, WTF::move(redirectsInReverseOrder), [this, protectedThis = CachedResourceHandle { this }, client = WeakPtr { client }] (ResourceRequest&&) mutable {
+    iterateRedirects(protect(this), client, WTF::move(redirectsInReverseOrder), [this, protectedThis = CachedResourceHandle { this }, client = WeakPtr { client }] (ResourceRequest&&) mutable {
         if (!client || !hasClient(*client))
             return;
         auto responseProcessedHandler = [this, protectedThis = WTF::move(protectedThis), client] {
@@ -223,7 +223,7 @@ void CachedRawResource::redirectReceived(ResourceRequest&& request, const Resour
         CachedResource::redirectReceived(WTF::move(request), response, WTF::move(completionHandler));
     else {
         m_redirectChain.append(RedirectPair(request, response));
-        iterateClients(CachedResourceClientWalker<CachedRawResourceClient>(*this), CachedResourceHandle { this }, WTF::move(request), makeUnique<ResourceResponse>(response), [this, protectedThis = CachedResourceHandle { this }, completionHandler = WTF::move(completionHandler), response] (ResourceRequest&& request) mutable {
+        iterateClients(CachedResourceClientWalker<CachedRawResourceClient>(*this), protect(this), WTF::move(request), makeUnique<ResourceResponse>(response), [this, protectedThis = CachedResourceHandle { this }, completionHandler = WTF::move(completionHandler), response] (ResourceRequest&& request) mutable {
             CachedResource::redirectReceived(WTF::move(request), response, WTF::move(completionHandler));
         });
     }

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -150,7 +150,6 @@ public:
     const String& cachePartition() const { return m_resourceRequest.cachePartition(); }
     PAL::SessionID sessionID() const { return m_sessionID; }
     const CookieJar* cookieJar() const { return m_cookieJar.get(); }
-    RefPtr<const CookieJar> protectedCookieJar() const;
     Type type() const { return m_type; }
     String mimeType() const { return response().mimeType(); }
     long long expectedContentLength() const { return response().expectedContentLength(); }
@@ -239,7 +238,6 @@ public:
     void clearLoader();
 
     FragmentedSharedBuffer* resourceBuffer() const { return m_data.get(); }
-    RefPtr<FragmentedSharedBuffer> protectedResourceBuffer() const;
 
     virtual void redirectReceived(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(ResourceRequest&&)>&&);
     virtual void responseReceived(ResourceResponse&&);
@@ -258,7 +256,6 @@ public:
 
     const SecurityOrigin* origin() const { return m_origin.get(); }
     SecurityOrigin* origin() { return m_origin.get(); }
-    RefPtr<SecurityOrigin> protectedOrigin() const;
     AtomString initiatorType() const { return m_initiatorType; }
 
     bool canDelete() const { return !hasClients() && !m_loader && !m_preloadCount && !m_handleCount && !m_resourceToRevalidate && !m_proxyResource; }
@@ -301,7 +298,6 @@ public:
 
     bool isCacheValidator() const { return !!m_resourceToRevalidate; }
     CachedResource* resourceToRevalidate() const { return m_resourceToRevalidate.get(); }
-    CachedResourceHandle<CachedResource> protectedResourceToRevalidate() const;
 
     // HTTP revalidation support methods for CachedResourceLoader.
     void setResourceToRevalidate(CachedResource*);

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -82,9 +82,45 @@ public:
     bool operator==(const CachedResourceHandleBase& o) const { return get() == o.get(); }
 };
 
-template <class R, class RR> bool operator==(const CachedResourceHandle<R>& h, const RR* res) 
-{ 
-    return h.get() == res; 
+template <class R, class RR> bool operator==(const CachedResourceHandle<R>& h, const RR* res)
+{
+    return h.get() == res;
 }
 
 } // namespace WebCore
+
+namespace WTF {
+
+template<typename T> requires std::derived_from<T, WebCore::CachedResource>
+WebCore::CachedResourceHandle<T> protect(T* resource)
+{
+    return WebCore::CachedResourceHandle<T> { resource };
+}
+
+template<typename T> requires std::derived_from<T, WebCore::CachedResource>
+WebCore::CachedResourceHandle<T> protect(T& resource)
+{
+    return WebCore::CachedResourceHandle<T> { resource };
+}
+
+template<typename T, typename WeakPtrImpl, typename PtrTraits>
+    requires std::derived_from<T, WebCore::CachedResource>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION WebCore::CachedResourceHandle<T> protect(const WeakPtr<T, WeakPtrImpl, PtrTraits>& resource)
+{
+    return WebCore::CachedResourceHandle<T> { resource.get() };
+}
+
+template<typename T, typename WeakPtrImpl>
+    requires std::derived_from<T, WebCore::CachedResource>
+ALWAYS_INLINE CLANG_POINTER_CONVERSION WebCore::CachedResourceHandle<T> protect(const WeakRef<T, WeakPtrImpl>& resource)
+{
+    return WebCore::CachedResourceHandle<T> { resource.get() };
+}
+
+template<typename T>
+WebCore::CachedResourceHandle<T> protect(const WebCore::CachedResourceHandle<T>& handle)
+{
+    return handle;
+}
+
+} // namespace WTF

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -145,9 +145,7 @@ public:
     CachePolicy cachePolicy(CachedResource::Type, const URL&) const;
     
     LocalFrame* frame() const; // Can be null
-    RefPtr<LocalFrame> protectedFrame() const;
     Document* document() const { return m_document.get(); } // Can be null
-    RefPtr<Document> protectedDocument() const { return document(); }
     void setDocument(Document* document) { m_document = document; }
     void clearDocumentLoader(); 
     void loadDone(LoadCompletionType, bool shouldPerformPostLoadActions = true);
@@ -214,8 +212,6 @@ private:
 
     bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL) const;
     bool canRequestInContentDispositionAttachmentSandbox(CachedResource::Type, const URL&) const;
-
-    RefPtr<DocumentLoader> protectedDocumentLoader() const;
 
     MemoryCompactRobinHoodHashSet<URL> m_validatedURLs;
     MemoryCompactRobinHoodHashSet<URL> m_cachedSVGImagesURLs;

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -106,7 +106,6 @@ public:
     RefPtr<SecurityOrigin> releaseOrigin() { return WTF::move(m_origin); }
     const SecurityOrigin* origin() const { return m_origin.get(); }
     SecurityOrigin* origin() { return m_origin.get(); }
-    RefPtr<SecurityOrigin> protectedOrigin() const { return m_origin; }
 
     bool hasFragmentIdentifier() const { return !m_fragmentIdentifier.isEmpty(); }
     String&& releaseFragmentIdentifier() { return WTF::move(m_fragmentIdentifier); }

--- a/Source/WebCore/loader/cache/CachedSVGDocument.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.cpp
@@ -45,17 +45,12 @@ CachedSVGDocument::~CachedSVGDocument() = default;
 
 void CachedSVGDocument::setEncoding(const String& chs)
 {
-    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protect(m_decoder)->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 ASCIILiteral CachedSVGDocument::encoding() const
 {
-    return protectedDecoder()->encoding().name();
-}
-
-RefPtr<TextResourceDecoder> CachedSVGDocument::protectedDecoder() const
-{
-    return m_decoder;
+    return protect(m_decoder)->encoding().name();
 }
 
 void CachedSVGDocument::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)
@@ -63,7 +58,7 @@ void CachedSVGDocument::finishLoading(const FragmentedSharedBuffer* data, const 
     if (data) {
         // We don't need to create a new frame because the new document belongs to the parent UseElement.
         Ref document = SVGDocument::create(nullptr, m_settings.copyRef(), response().url());
-        document->setMarkupUnsafe(protectedDecoder()->decodeAndFlush(data->makeContiguous()->span()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
+        document->setMarkupUnsafe(protect(m_decoder)->decodeAndFlush(data->makeContiguous()->span()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
         m_document = WTF::move(document);
     }
     CachedResource::finishLoading(data, metrics);

--- a/Source/WebCore/loader/cache/CachedSVGDocument.h
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.h
@@ -43,7 +43,6 @@ private:
     void setEncoding(const String&) override;
     ASCIILiteral encoding() const override;
     const TextResourceDecoder* textResourceDecoder() const override { return m_decoder.get(); }
-    RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) override;
 
     RefPtr<SVGDocument> m_document;

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -53,7 +53,7 @@ CachedSVGFont::CachedSVGFont(CachedResourceRequest&& request, PAL::SessionID ses
 }
 
 CachedSVGFont::CachedSVGFont(CachedResourceRequest&& request, CachedSVGFont& resource)
-    : CachedSVGFont(WTF::move(request), resource.sessionID(), resource.protectedCookieJar().get(), resource.m_settings.copyRef())
+    : CachedSVGFont(WTF::move(request), resource.sessionID(), protect(resource.cookieJar()).get(), resource.m_settings.copyRef())
 {
 }
 

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -47,19 +47,14 @@ CachedScript::CachedScript(CachedResourceRequest&& request, PAL::SessionID sessi
 
 CachedScript::~CachedScript() = default;
 
-RefPtr<TextResourceDecoder> CachedScript::protectedDecoder() const
-{
-    return m_decoder;
-}
-
 void CachedScript::setEncoding(const String& chs)
 {
-    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protect(m_decoder)->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 ASCIILiteral CachedScript::encoding() const
 {
-    return protectedDecoder()->encoding().name();
+    return protect(m_decoder)->encoding().name();
 }
 
 StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
@@ -100,7 +95,7 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
             forceUTF8Decoder->setAlwaysUseUTF8();
             result = forceUTF8Decoder->decodeAndFlush(contiguousData->span());
         } else
-            result = protectedDecoder()->decodeAndFlush(contiguousData->span());
+            result = protect(m_decoder)->decodeAndFlush(contiguousData->span());
 
 
         if (m_decodingState == NeverDecoded || shouldForceRedecoding)
@@ -146,7 +141,7 @@ JSC::CodeBlockHash CachedScript::codeBlockHashConcurrently(int startOffset, int 
             forceUTF8Decoder->setAlwaysUseUTF8();
             result = forceUTF8Decoder->decodeAndFlush(contiguousData->span());
         } else {
-            auto decoder = TextResourceDecoder::create(protectedDecoder()->contentType(), protectedDecoder()->encoding(), protectedDecoder()->usesEncodingDetector());
+            auto decoder = TextResourceDecoder::create(protect(m_decoder)->contentType(), protect(m_decoder)->encoding(), protect(m_decoder)->usesEncodingDetector());
             result = decoder->decodeAndFlush(contiguousData->span());
         }
 

--- a/Source/WebCore/loader/cache/CachedScript.h
+++ b/Source/WebCore/loader/cache/CachedScript.h
@@ -52,7 +52,6 @@ private:
     void setEncoding(const String&) final;
     ASCIILiteral encoding() const final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
-    RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
 
     void destroyDecodedData() final;

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -44,11 +44,6 @@ CachedXSLStyleSheet::CachedXSLStyleSheet(CachedResourceRequest&& request, PAL::S
 
 CachedXSLStyleSheet::~CachedXSLStyleSheet() = default;
 
-RefPtr<TextResourceDecoder> CachedXSLStyleSheet::protectedDecoder() const
-{
-    return m_decoder;
-}
-
 void CachedXSLStyleSheet::didAddClient(CachedResourceClient& client)
 {
     ASSERT(client.resourceClientType() == CachedStyleSheetClient::expectedType());
@@ -58,12 +53,12 @@ void CachedXSLStyleSheet::didAddClient(CachedResourceClient& client)
 
 void CachedXSLStyleSheet::setEncoding(const String& chs)
 {
-    protectedDecoder()->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
+    protect(m_decoder)->setEncoding(chs, TextResourceDecoder::EncodingFromHTTPHeader);
 }
 
 ASCIILiteral CachedXSLStyleSheet::encoding() const
 {
-    return protectedDecoder()->encoding().name();
+    return protect(m_decoder)->encoding().name();
 }
 
 void CachedXSLStyleSheet::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)
@@ -71,7 +66,7 @@ void CachedXSLStyleSheet::finishLoading(const FragmentedSharedBuffer* data, cons
     if (data) {
         Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
-        m_sheet = protectedDecoder()->decodeAndFlush(contiguousData->span());
+        m_sheet = protect(m_decoder)->decodeAndFlush(contiguousData->span());
         m_data = WTF::move(contiguousData);
     } else {
         m_data = nullptr;

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.h
@@ -47,7 +47,6 @@ private:
     void setEncoding(const String&) final;
     ASCIILiteral encoding() const final;
     const TextResourceDecoder* textResourceDecoder() const final { return m_decoder.get(); }
-    RefPtr<TextResourceDecoder> protectedDecoder() const;
     void finishLoading(const FragmentedSharedBuffer*, const NetworkLoadMetrics&) final;
 
     String m_sheet;

--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.h
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.h
@@ -73,8 +73,6 @@ private:
     void provideMainResourceForPreviewConverter(PreviewConverter&, CompletionHandler<void(Ref<FragmentedSharedBuffer>&&)>&&) final;
     void providePasswordForPreviewConverter(PreviewConverter&, Function<void(const String&)>&&) final;
 
-    RefPtr<PreviewConverter> protectedConverter() const;
-
     RefPtr<PreviewConverter> m_converter;
     const Ref<LegacyPreviewLoaderClient> m_client;
     SharedBufferBuilder m_originalData;

--- a/Source/WebCore/loader/mac/ResourceLoaderMac.mm
+++ b/Source/WebCore/loader/mac/ResourceLoaderMac.mm
@@ -40,7 +40,7 @@ void ResourceLoader::willCacheResponseAsync(ResourceHandle*, NSCachedURLResponse
 {
     if (m_options.sendLoadCallbacks == SendCallbackPolicy::DoNotSendCallbacks)
         return completionHandler(nullptr);
-    protectedFrameLoader()->protectedClient()->willCacheResponse(protectedDocumentLoader().get(), *identifier(), response, WTF::move(completionHandler));
+    protect(protect(frameLoader())->client())->willCacheResponse(protect(documentLoader()).get(), *identifier(), response, WTF::move(completionHandler));
 }
 
 }

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -154,7 +154,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
             if (navigationType == NavigationNavigationType::Traverse) {
                 m_currentEntryIndex = getEntryIndexOfHistoryItem(m_entries, *currentItem);
                 if (m_currentEntryIndex) {
-                    setActivation(frame()->loader().history().protectedPreviousItem().get(), navigationType);
+                    setActivation(protect(frame()->loader().history().previousItem()).get(), navigationType);
                     return;
                 }
                 // We are doing a cross document traversal, we can't rely on previous window, so clear
@@ -180,7 +180,7 @@ void Navigation::initializeForNewWindow(std::optional<NavigationNavigationType> 
     m_entries.append(NavigationHistoryEntry::create(*this, *currentItem));
     m_currentEntryIndex = m_entries.size() - 1;
 
-    setActivation(frame()->loader().history().protectedPreviousItem().get(), navigationType);
+    setActivation(protect(frame()->loader().history().previousItem()).get(), navigationType);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -175,12 +175,12 @@ void SVGImageElement::didAttachRenderers()
     SVGGraphicsElement::didAttachRenderers();
 
     if (CheckedPtr image = dynamicDowncast<RenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
-        image->imageResource().setCachedImage(m_imageLoader->protectedImage());
+        image->imageResource().setCachedImage(protect(m_imageLoader->image()));
         return;
     }
 
     if (CheckedPtr image = dynamicDowncast<LegacyRenderSVGImage>(renderer()); image && !image->imageResource().cachedImage()) {
-        image->imageResource().setCachedImage(m_imageLoader->protectedImage());
+        image->imageResource().setCachedImage(protect(m_imageLoader->image()));
         return;
     }
 }

--- a/Source/WebCore/svg/SVGImageLoader.cpp
+++ b/Source/WebCore/svg/SVGImageLoader.cpp
@@ -41,9 +41,9 @@ SVGImageLoader::~SVGImageLoader() = default;
 void SVGImageLoader::dispatchLoadEvent()
 {
     if (image()->errorOccurred())
-        protectedElement()->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
     else
-        downcast<SVGImageElement>(ImageLoader::protectedElement())->sendLoadEventIfPossible();
+        downcast<SVGImageElement>(protect(ImageLoader::element()))->sendLoadEventIfPossible();
 }
 
 }

--- a/Source/WebKit/Shared/APIWebArchiveResource.mm
+++ b/Source/WebKit/Shared/APIWebArchiveResource.mm
@@ -62,7 +62,7 @@ WebArchiveResource::~WebArchiveResource() = default;
 
 Ref<API::Data> WebArchiveResource::data()
 {
-    RetainPtr cfData = m_archiveResource->protectedData()->makeContiguous()->createCFData();
+    RetainPtr cfData = protect(m_archiveResource->data())->makeContiguous()->createCFData();
     auto cfDataSpan = span(cfData.get());
     return API::Data::createWithoutCopying(cfDataSpan, [cfData = WTF::move(cfData)] { });
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3529,7 +3529,7 @@ enum class WebCore::WasPrivateRelayed : bool;
 
 #if PLATFORM(COCOA)
 [RefCounted, CreateUsing=createWithData] class WebCore::ArchiveResource {
-    Ref<WebCore::FragmentedSharedBuffer> protectedData();
+    Ref<WebCore::FragmentedSharedBuffer> dataForSerialization();
     URL url();
     String mimeType();
     String textEncoding();
@@ -3539,7 +3539,7 @@ enum class WebCore::WasPrivateRelayed : bool;
 };
 
 [RefCounted, CreateUsing=create] class WebCore::LegacyWebArchive {
-    Ref<WebCore::ArchiveResource> protectedMainResource();
+    Ref<WebCore::ArchiveResource> mainResourceForSerialization();
     Vector<Ref<WebCore::ArchiveResource>> subresources();
     Vector<WebCore::FrameIdentifier> subframeIdentifiers();
     std::optional<WebCore::FrameIdentifier> frameIdentifier();
@@ -5158,7 +5158,7 @@ struct WebCore::PolicyContainer {
 [Nested] enum class WebCore::SubstituteData::SessionHistoryVisibility : bool
 
 class WebCore::SubstituteData {
-    RefPtr<WebCore::FragmentedSharedBuffer> protectedContent();
+    RefPtr<WebCore::FragmentedSharedBuffer> contentForSerialization();
     URL failingURL();
     WebCore::ResourceResponse response();
     WebCore::SubstituteData::SessionHistoryVisibility shouldRevealToSessionHistory();

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -238,7 +238,7 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
 #if ENABLE(WEB_ARCHIVE) || ENABLE(MHTML)
     // If the DocumentLoader schedules this as an archive resource load,
     // then we should remember the ResourceLoader in our records but not schedule it in the NetworkProcess.
-    if (resourceLoader.protectedDocumentLoader()->scheduleArchiveLoad(resourceLoader, resourceLoader.request())) {
+    if (protect(resourceLoader.documentLoader())->scheduleArchiveLoad(resourceLoader, resourceLoader.request())) {
         LOG(NetworkScheduling, "(WebProcess) WebLoaderStrategy::scheduleLoad, url '%s' will be handled as an archive resource.", resourceLoader.url().string().utf8().data());
         WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: URL will be handled as an archive resource");
         m_webResourceLoaders.set(identifier, WebResourceLoader::create(resourceLoader, trackingParameters));

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -401,7 +401,7 @@ void WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDeni
     LOG(Network, "(WebProcess) WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied for '%s'", coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_STOPLOADINGAFTERSECURITYPOLICYDENIED);
 
-    coreLoader->protectedDocumentLoader()->stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(*coreLoader->identifier(), response);
+    protect(coreLoader->documentLoader())->stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied(*coreLoader->identifier(), response);
 }
 
 #if ENABLE(SHAREABLE_RESOURCE)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -239,7 +239,7 @@ void WebLocalFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderI
     webPage->send(Messages::WebPageProxy::DidInitiateLoadForResource(identifier, m_frame->frameID(), request));
 #endif
 
-    webPage->addResourceRequest(identifier, request, loader, frameLoader ? frameLoader->protectedFrame().ptr() : nullptr);
+    webPage->addResourceRequest(identifier, request, loader, frameLoader ? protect(frameLoader->frame()).ptr() : nullptr);
 }
 
 void WebLocalFrameLoaderClient::dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier identifier, ResourceRequest& request, const ResourceResponse& redirectResponse)
@@ -330,7 +330,7 @@ void WebLocalFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader* loader,
     webPage->send(Messages::WebPageProxy::DidFinishLoadForResource(identifier, m_frame->frameID(), { }));
 #endif
 
-    webPage->removeResourceRequest(identifier, loader && loader->frameLoader() ? loader->protectedFrameLoader()->protectedFrame().ptr() : nullptr);
+    webPage->removeResourceRequest(identifier, loader && loader->frameLoader() ? protect(protect(loader->frameLoader())->frame()).ptr() : nullptr);
 }
 
 void WebLocalFrameLoaderClient::dispatchDidFailLoading(DocumentLoader* loader, ResourceLoaderIdentifier identifier, const ResourceError& error)
@@ -345,7 +345,7 @@ void WebLocalFrameLoaderClient::dispatchDidFailLoading(DocumentLoader* loader, R
     webPage->send(Messages::WebPageProxy::DidFinishLoadForResource(identifier, m_frame->frameID(), error));
 #endif
 
-    webPage->removeResourceRequest(identifier, loader && loader->frameLoader() ? loader->protectedFrameLoader()->protectedFrame().ptr() : nullptr);
+    webPage->removeResourceRequest(identifier, loader && loader->frameLoader() ? protect(protect(loader->frameLoader())->frame()).ptr() : nullptr);
 }
 
 bool WebLocalFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int /*length*/)
@@ -1446,7 +1446,7 @@ void WebLocalFrameLoaderClient::restoreViewState()
     }
 #else
     // Inform the UI process of the scale factor.
-    double scaleFactor = m_localFrame->loader().history().protectedCurrentItem()->pageScaleFactor();
+    double scaleFactor = protect(m_localFrame->loader().history().currentItem())->pageScaleFactor();
 
     // A scale factor of 0 means the history item has the default scale factor, thus we do not need to update it.
     RefPtr page = m_frame->page();

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -136,7 +136,7 @@ void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Eleme
 
     String extension;
     if (image) {
-        extension = image->protectedImage()->filenameExtension();
+        extension = protect(image->image())->filenameExtension();
         if (extension.isEmpty())
             return;
     }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3383,7 +3383,7 @@ void WebPage::pageStoppedScrolling()
 {
     // Maintain the current history item's scroll position up-to-date.
     if (RefPtr frame = m_mainFrame->coreLocalFrame())
-        frame->loader().history().saveScrollPositionAndViewStateToItem(frame->loader().history().protectedCurrentItem().get());
+        frame->loader().history().saveScrollPositionAndViewStateToItem(protect(frame->loader().history().currentItem()).get());
 }
 
 void WebPage::setHasActiveAnimatedScrolls(bool hasActiveAnimatedScrolls)
@@ -7788,7 +7788,7 @@ void WebPage::didSameDocumentNavigationForFrame(WebFrame& frame)
 {
     RefPtr<API::Object> userData;
 
-    auto navigationID = frame.coreLocalFrame()->loader().protectedDocumentLoader()->navigationID();
+    auto navigationID = protect(frame.coreLocalFrame()->loader().documentLoader())->navigationID();
 
     if (frame.isMainFrame())
         m_pendingNavigationID = std::nullopt;


### PR DESCRIPTION
#### 16eb95acb54170aaf52eb0af134a1b12a33cf090
<pre>
Reduce use of protected functions in Source/WebCore/loader
<a href="https://bugs.webkit.org/show_bug.cgi?id=306737">https://bugs.webkit.org/show_bug.cgi?id=306737</a>

Reviewed by Anne van Kesteren.

Adopt `protect()` at call sites instead.

* Source/WTF/wtf/WeakRef.h:
(WTF::protect):
* Source/WebCore/dom/DataTransferMac.mm:
(WebCore::DataTransfer::createDragImage const):
* Source/WebCore/dom/DecodedDataDocumentParser.cpp:
(WebCore::DecodedDataDocumentParser::appendBytes):
(WebCore::DecodedDataDocumentParser::flush):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::didAttachRenderers):
* Source/WebCore/html/HTMLImageLoader.cpp:
(WebCore::HTMLImageLoader::dispatchLoadEvent):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::didAttachRenderers):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::didAttachRenderers):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::attach):
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::MediaDocumentParser::createDocumentStructure):
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::deliverResourceData):
(WebCore::ContentFilter::handleProvisionalLoadFailure):
(WebCore::ContentFilter::protectedClient const): Deleted.
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::mainResourceData const):
(WebCore::DocumentLoader::setRequest):
(WebCore::DocumentLoader::setMainDocumentError):
(WebCore::DocumentLoader::mainReceivedError):
(WebCore::DocumentLoader::commitIfReady):
(WebCore::DocumentLoader::notifyFinished):
(WebCore::DocumentLoader::finishedLoading):
(WebCore::DocumentLoader::handleSubstituteDataLoadNow):
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::doCrossOriginOpenerHandlingOfResponse):
(WebCore::DocumentLoader::tryLoadingSubstituteData):
(WebCore::DocumentLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::continueAfterContentPolicy):
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::dataReceived):
(WebCore::DocumentLoader::setupForMultipartReplace):
(WebCore::DocumentLoader::isLoadingInAPISense const):
(WebCore::DocumentLoader::maybeCreateArchive):
(WebCore::DocumentLoader::setTitle):
(WebCore::DocumentLoader::isMultipartReplacingLoad const):
(WebCore::DocumentLoader::maybeLoadEmpty):
(WebCore::DocumentLoader::loadMainResource):
(WebCore::DocumentLoader::cancelPolicyCheckIfNeeded):
(WebCore::DocumentLoader::cancelMainResourceLoad):
(WebCore::DocumentLoader::maybeFinishLoadingMultipartContent):
(WebCore::DocumentLoader::addConsoleMessage):
(WebCore::DocumentLoader::enqueueSecurityPolicyViolationEvent):
(WebCore::DocumentLoader::handleProvisionalLoadFailureFromContentFilter):
(WebCore::DocumentLoader::handleContentFilterDidBlock):
(WebCore::DocumentLoader::protectedFrameLoader const): Deleted.
(WebCore::DocumentLoader::protectedCachedResourceLoader const): Deleted.
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::cachedResourceLoader):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::makeSimpleCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::computeIsDone):
(WebCore::DocumentThreadableLoader::redirectReceived):
(WebCore::DocumentThreadableLoader::didReceiveResponse):
(WebCore::DocumentThreadableLoader::didFail):
(WebCore::DocumentThreadableLoader::preflightSuccess):
(WebCore::DocumentThreadableLoader::preflightFailure):
(WebCore::DocumentThreadableLoader::loadRequest):
(WebCore::DocumentThreadableLoader::isAllowedRedirect):
(WebCore::DocumentThreadableLoader::securityOrigin const):
(WebCore::DocumentThreadableLoader::topOrigin const):
(WebCore::DocumentThreadableLoader::protectedResource const): Deleted.
(WebCore::DocumentThreadableLoader::protectedDocument): Deleted.
(WebCore::DocumentThreadableLoader::protectedDocument const): Deleted.
(WebCore::DocumentThreadableLoader::protectedSecurityOrigin const): Deleted.
* Source/WebCore/loader/DocumentThreadableLoader.h:
(WebCore::DocumentThreadableLoader::document):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::addData):
(WebCore::DocumentWriter::insertDataSynchronously):
(WebCore::DocumentWriter::end):
(WebCore::DocumentWriter::setDocumentWasLoadedAsPartOfNavigation):
(WebCore::DocumentWriter::protectedDecoder): Deleted.
(WebCore::DocumentWriter::protectedParser const): Deleted.
* Source/WebCore/loader/DocumentWriter.h:
* Source/WebCore/loader/FormSubmission.h:
(WebCore::FormSubmission::state const):
(WebCore::FormSubmission::protectedState const): Deleted.
* Source/WebCore/loader/FrameLoadRequest.cpp:
(WebCore::FrameLoadRequest::requester const):
(WebCore::FrameLoadRequest::requester): Deleted.
(WebCore::FrameLoadRequest::protectedRequester const): Deleted.
(WebCore::FrameLoadRequest::protectedRequesterSecurityOrigin const): Deleted.
* Source/WebCore/loader/FrameLoadRequest.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::init):
(WebCore::FrameLoader::setDefersLoading):
(WebCore::FrameLoader::checkContentPolicy):
(WebCore::FrameLoader::submitForm):
(WebCore::FrameLoader::didExplicitOpen):
(WebCore::FrameLoader::outgoingOrigin const):
(WebCore::FrameLoader::updateURLAndHistory):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::prepareForLoadStart):
(WebCore::FrameLoader::setupForMultipartReplace):
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::isNavigationAllowed const):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::clearProvisionalLoadForPolicyCheck):
(WebCore::FrameLoader::hasOpenedFrames const):
(WebCore::FrameLoader::willLoadMediaElementURL):
(WebCore::FrameLoader::reloadWithOverrideEncoding):
(WebCore::FrameLoader::reload):
(WebCore::FrameLoader::stopForBackForwardCache):
(WebCore::FrameLoader::setPolicyDocumentLoader):
(WebCore::FrameLoader::setState):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::transitionToCommitted):
(WebCore::FrameLoader::willRestoreFromCachedPage):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::detachChildren):
(WebCore::FrameLoader::closeAndRemoveChild):
(WebCore::FrameLoader::userAgent const):
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::scheduleRefreshIfNeeded):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::continueFragmentScrollAfterNavigationPolicy):
(WebCore::FrameLoader::scrollToFragmentWithParentBoundary):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::executeJavaScriptURL):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::findFrameForNavigation):
(WebCore::FrameLoader::loadSameDocumentItem):
(WebCore::FrameLoader::retryAfterFailedCacheOnlyMainResourceLoad):
(WebCore::FrameLoader::dispatchDidClearWindowObjectsInAllWorlds):
(WebCore::FrameLoader::dispatchDidCommitLoad):
(WebCore::FrameLoader::protectedFrame const): Deleted.
(WebCore::FrameLoader::protectedActiveDocumentLoader const): Deleted.
(WebCore::FrameLoader::protectedClient const): Deleted.
(WebCore::FrameLoader::protectedClient): Deleted.
(WebCore::FrameLoader::protectedNetworkingContext const): Deleted.
(WebCore::FrameLoader::protectedDocumentLoader const): Deleted.
(WebCore::FrameLoader::protectedProvisionalDocumentLoader const): Deleted.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/FrameNetworkingContext.h:
(WebCore::FrameNetworkingContext::frame const):
(WebCore::FrameNetworkingContext::protectedFrame const): Deleted.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::saveScrollPositionAndViewStateToItem):
(WebCore::HistoryController::restoreScrollPositionAndViewState):
(WebCore::HistoryController::saveDocumentAndScrollState):
(WebCore::HistoryController::goToItemShared):
(WebCore::HistoryController::updateForBackForwardNavigation):
(WebCore::HistoryController::updateForStandardLoad):
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateForClientRedirect):
(WebCore::HistoryController::recursiveUpdateForCommit):
(WebCore::HistoryController::updateForSameDocumentNavigation):
(WebCore::HistoryController::createItem):
(WebCore::HistoryController::createItemTree):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
(WebCore::HistoryController::protectedFrame const): Deleted.
(WebCore::HistoryController::protectedCurrentItem const): Deleted.
(WebCore::HistoryController::protectedPreviousItem const): Deleted.
(WebCore::HistoryController::protectedProvisionalItem const): Deleted.
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::canReuseFromListOfAvailableImages):
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::updateFromElementIgnoringPreviousErrorToSameValue):
(WebCore::ImageLoader::notifyFinished):
(WebCore::ImageLoader::updateRenderer):
(WebCore::ImageLoader::decode):
(WebCore::ImageLoader::dispatchPendingErrorEvent):
(WebCore::ImageLoader::resetLazyImageLoading):
(WebCore::ImageLoader::shouldIgnoreCandidateWhenLoadingFromArchive const):
(WebCore::ImageLoader::protectedImage const): Deleted.
* Source/WebCore/loader/ImageLoader.h:
(WebCore::ImageLoader::element const):
(WebCore::ImageLoader::image const):
(WebCore::ImageLoader::document):
(WebCore::ImageLoader::protectedElement const): Deleted.
(WebCore::ImageLoader::protectedDocument): Deleted.
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResource::MediaResource):
(WebCore::MediaResource::~MediaResource):
(WebCore::MediaResource::responseReceived):
(WebCore::MediaResourceLoader::protectedDocument): Deleted.
(WebCore::MediaResource::protectedResource const): Deleted.
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/loader/NavigationAction.cpp:
(WebCore::NavigationAction::NavigationAction):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::shouldScheduleNavigation const):
(WebCore::NavigationScheduler::scheduleFormSubmission):
(WebCore::NavigationScheduler::cancel):
(WebCore::NavigationScheduler::protectedFrame const): Deleted.
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/loader/NetscapePlugInStreamLoader.cpp:
(WebCore::NetscapePlugInStreamLoader::init):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
(WebCore::PolicyChecker::hitTestResult):
(WebCore::PolicyChecker::checkNewWindowPolicy):
(WebCore::PolicyChecker::stopCheck):
(WebCore::PolicyChecker::handleUnimplementablePolicy):
(WebCore::PolicyChecker::protectedFrame const): Deleted.
* Source/WebCore/loader/PolicyChecker.h:
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::progressStarted):
(WebCore::ProgressTracker::progressEstimateChanged):
(WebCore::ProgressTracker::finalProgressComplete):
(WebCore::ProgressTracker::incrementProgress):
(WebCore::ProgressTracker::protectedPage const): Deleted.
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::didReceiveAuthenticationChallenge):
(WebCore::ResourceLoadNotifier::willSendRequest):
(WebCore::ResourceLoadNotifier::didReceiveResponse):
(WebCore::ResourceLoadNotifier::didReceiveData):
(WebCore::ResourceLoadNotifier::didFinishLoad):
(WebCore::ResourceLoadNotifier::didFailToLoad):
(WebCore::ResourceLoadNotifier::assignIdentifierToInitialRequest):
(WebCore::ResourceLoadNotifier::protectedFrame const): Deleted.
* Source/WebCore/loader/ResourceLoadNotifier.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::start):
(WebCore::ResourceLoader::willSendRequestInternal):
(WebCore::ResourceLoader::shouldUseCredentialStorage):
(WebCore::ResourceLoader::canAuthenticateAgainstProtectionSpace):
(WebCore::ResourceLoader::protectedDocumentLoader const): Deleted.
(WebCore::ResourceLoader::protectedResourceData const): Deleted.
(WebCore::ResourceLoader::protectedFrameLoader const): Deleted.
(WebCore::ResourceLoader::protectedFrame const): Deleted.
* Source/WebCore/loader/ResourceLoader.h:
(WebCore::ResourceLoader::documentLoader const):
(WebCore::ResourceLoader::cachedResource const):
(WebCore::ResourceLoader::protectedCachedResource const): Deleted.
* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::createFrameIfNecessary):
(WebCore::FrameLoader::SubframeLoader::pluginIsLoadable const):
(WebCore::FrameLoader::SubframeLoader::protectedFrame const): Deleted.
* Source/WebCore/loader/SubframeLoader.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::didSendData):
(WebCore::SubresourceLoader::didReceivePreviewResponse):
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::checkResponseCrossOriginAccessControl):
(WebCore::SubresourceLoader::checkRedirectionCrossOriginAccessControl):
(WebCore::SubresourceLoader::didFinishLoading):
(WebCore::SubresourceLoader::notifyDone):
(WebCore::SubresourceLoader::releaseResources):
(WebCore::SubresourceLoader::reportResourceTiming):
(WebCore::SubresourceLoader::protectedOrigin const): Deleted.
* Source/WebCore/loader/SubresourceLoader.h:
* Source/WebCore/loader/SubstituteData.h:
(WebCore::SubstituteData::contentForSerialization const):
(WebCore::SubstituteData::protectedContent const): Deleted.
* Source/WebCore/loader/SubstituteResource.h:
(WebCore::SubstituteResource::dataForSerialization const):
(WebCore::SubstituteResource::protectedData const): Deleted.
* Source/WebCore/loader/TextTrackLoader.cpp:
(WebCore::TextTrackLoader::deprecatedDidReceiveCachedResource):
(WebCore::TextTrackLoader::protectedResource const): Deleted.
* Source/WebCore/loader/TextTrackLoader.h:
* Source/WebCore/loader/archive/ArchiveResource.cpp:
(WebCore::ArchiveResource::saveToDisk):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.h:
* Source/WebCore/loader/cache/CachedApplicationManifest.cpp:
(WebCore::CachedApplicationManifest::finishLoading):
(WebCore::CachedApplicationManifest::setEncoding):
(WebCore::CachedApplicationManifest::encoding const):
(WebCore::CachedApplicationManifest::protectedDecoder const): Deleted.
* Source/WebCore/loader/cache/CachedApplicationManifest.h:
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::setEncoding):
(WebCore::CachedCSSStyleSheet::encoding const):
(WebCore::CachedCSSStyleSheet::sheetText const):
(WebCore::CachedCSSStyleSheet::finishLoading):
(WebCore::CachedCSSStyleSheet::checkNotify):
(WebCore::CachedCSSStyleSheet::protectedDecoder const): Deleted.
* Source/WebCore/loader/cache/CachedCSSStyleSheet.h:
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::didAddClient):
(WebCore::CachedImage::clearImage):
(WebCore::CachedImage::imageFrameAvailable):
(WebCore::CachedImage::protectedImage const): Deleted.
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::didAddClient):
(WebCore::CachedRawResource::redirectReceived):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::load):
(WebCore::CachedResource::loadFrom):
(WebCore::CachedResource::setResponse):
(WebCore::CachedResource::switchClientsToRevalidatedResource):
(WebCore::CachedResource::varyHeaderValuesMatch):
(WebCore::CachedResource::cryptographicDigest const):
(WebCore::CachedResource::protectedOrigin const): Deleted.
(WebCore::CachedResource::protectedResourceToRevalidate const): Deleted.
(WebCore::CachedResource::protectedCookieJar const): Deleted.
(WebCore::CachedResource::protectedResourceBuffer const): Deleted.
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::cookieJar const):
(WebCore::CachedResource::resourceBuffer const):
(WebCore::CachedResource::origin):
(WebCore::CachedResource::resourceToRevalidate const):
* Source/WebCore/loader/cache/CachedResourceHandle.h:
(WebCore::operator==):
(WTF::protect):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::canRequest):
(WebCore::CachedResourceLoader::canRequestAfterRedirection const):
(WebCore::CachedResourceLoader::shouldContinueAfterNotifyingLoadedFromMemoryCache):
(WebCore::CachedResourceLoader::shouldUpdateCachedResourceWithCurrentRequest):
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::revalidateResource):
(WebCore::CachedResourceLoader::loadResource):
(WebCore::CachedResourceLoader::preload):
(WebCore::CachedResourceLoader::protectedFrame const): Deleted.
(WebCore::CachedResourceLoader::protectedDocumentLoader const): Deleted.
* Source/WebCore/loader/cache/CachedResourceLoader.h:
(WebCore::CachedResourceLoader::document const):
(WebCore::CachedResourceLoader::protectedDocument const): Deleted.
* Source/WebCore/loader/cache/CachedResourceRequest.h:
(WebCore::CachedResourceRequest::origin):
(WebCore::CachedResourceRequest::protectedOrigin const): Deleted.
* Source/WebCore/loader/cache/CachedSVGDocument.cpp:
(WebCore::CachedSVGDocument::setEncoding):
(WebCore::CachedSVGDocument::encoding const):
(WebCore::CachedSVGDocument::finishLoading):
(WebCore::CachedSVGDocument::protectedDecoder const): Deleted.
* Source/WebCore/loader/cache/CachedSVGDocument.h:
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
(WebCore::CachedSVGFont::CachedSVGFont):
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::setEncoding):
(WebCore::CachedScript::encoding const):
(WebCore::CachedScript::script):
(WebCore::CachedScript::codeBlockHashConcurrently):
(WebCore::CachedScript::protectedDecoder const): Deleted.
* Source/WebCore/loader/cache/CachedScript.h:
* Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp:
(WebCore::CachedXSLStyleSheet::setEncoding):
(WebCore::CachedXSLStyleSheet::encoding const):
(WebCore::CachedXSLStyleSheet::finishLoading):
(WebCore::CachedXSLStyleSheet::protectedDecoder const): Deleted.
* Source/WebCore/loader/cache/CachedXSLStyleSheet.h:
* Source/WebCore/loader/ios/LegacyPreviewLoader.h:
* Source/WebCore/loader/ios/LegacyPreviewLoader.mm:
(WebCore::LegacyPreviewLoader::didReceiveData):
(WebCore::LegacyPreviewLoader::didFinishLoading):
(WebCore::LegacyPreviewLoader::didFail):
(WebCore::LegacyPreviewLoader::previewConverterDidStartConverting):
(WebCore::LegacyPreviewLoader::protectedConverter const): Deleted.
* Source/WebCore/loader/mac/ResourceLoaderMac.mm:
(WebCore::ResourceLoader::willCacheResponseAsync):
* Source/WebCore/loader/sedMWeKJC: Removed.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::didAttachRenderers):
* Source/WebCore/svg/SVGImageLoader.cpp:
(WebCore::SVGImageLoader::dispatchLoadEvent):
* Source/WebKit/Shared/APIWebArchiveResource.mm:
(API::WebArchiveResource::data):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoad):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::assignIdentifierToInitialRequest):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFinishLoading):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailLoading):
(WebKit::WebLocalFrameLoaderClient::restoreViewState):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::WebDragClient::declareAndWriteDragImage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::pageStoppedScrolling):
(WebKit::WebPage::didSameDocumentNavigationForFrame):

Canonical link: <a href="https://commits.webkit.org/306620@main">https://commits.webkit.org/306620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9bab89d6d7801be683bea533ae51968e97ed47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94965 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143707 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108999 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78831 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6ba7733-b664-4f6b-ade2-55c0224ede6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89895 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79b06f76-4474-4e19-afde-91ed054b3900) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11100 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8743 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/500 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133824 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152822 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2644 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13915 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117087 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117409 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29916 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13460 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69593 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13953 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2985 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173129 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77678 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44833 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->