### PR TITLE
[AutoFill Debugging] Markdown output format sometimes fails to include URLs

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -1,3 +1,5 @@
+-- texttree
+
 root
 	section
 		link,url='example.com/search','Multiple query parameters'
@@ -7,11 +9,15 @@ root
 		link,url='javascript:','JavaScript link'
 		link,url='data:','HTML data URL'
 		link,url='mailto:test@example.com','Email with params'
+		link,url='mailto:test@example.com'
 		link,url='tel:+1-555-123-4567','Phone number'
 		link,url='blob:','Blob URL'
 		link,url='example.com/docs/guide.html','Path, query, and fragment'
 		link,url='example.com/docs/guide2.html','Query parameter'
 		link,url='example.com/docs/guide2.html','Query parameter (duplicate)'
+		link,url='example.com','Plain link'
+		link,url='example.com/2','Plain link (2)'
+		link,url='example.com/3','Plain link (3)'
 	section
 		image,src='image',alt='SVG data URL'
 		image,src='image2',alt='PNG data URL'
@@ -21,3 +27,32 @@ root
 		image,src='image.gif',alt='Image with high entropy name'
 		image,src='image2.gif',alt='Image with high entropy name 2'
 		image,src='image2.gif',alt='Image with high entropy name (duplicate)'
+
+-- markdown
+
+[Multiple query parameters](example.com/search)
+[Multiple query parameter 2](example.com/search2)
+[Path components 1](example.com/path/to/file.html)
+[Path components 2](example.com/oiiai_cat)
+[JavaScript link](javascript:)
+[HTML data URL](data:)
+[Email with params](mailto:test@example.com)
+[](mailto:test@example.com)
+[Phone number](tel:+1-555-123-4567)
+[Blob URL](blob:)
+[Path, query, and fragment](example.com/docs/guide.html)
+[Query parameter](example.com/docs/guide2.html)
+[Query parameter \(duplicate\)](example.com/docs/guide2.html)
+[Plain link](example.com)
+[Plain link \(2\)](example.com/2)
+[Plain link \(3\)](example.com/3)
+![SVG data URL](image)
+![PNG data URL](image2)
+![Long image path](vacation-2024-summer-beach.jpg)
+![Image with path](thumbnail.png)
+![Image with query params](thumbnail2.png)
+![Image with high entropy name](image.gif)
+![Image with high entropy name 2](image2.gif)
+![Image with high entropy name \(duplicate\)](image2.gif)
+
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
@@ -9,6 +9,10 @@ body {
     white-space: pre-wrap;
 }
 
+.text-representation {
+    white-space: pre-wrap;
+}
+
 .test-section {
     margin: 20px 0;
     padding: 10px;
@@ -18,6 +22,10 @@ body {
 img {
     width: 50px;
     height: 50px;
+}
+
+a, img {
+    display: block;
 }
 </style>
 <script src="../../resources/ui-helper.js"></script>
@@ -32,11 +40,15 @@ img {
         <a href="javascript:alert('Hello World')">JavaScript link</a>
         <a href="data:text/html;charset=utf-8,%3Ch1%3EHello%3C%2Fh1%3E">HTML data URL</a>
         <a href="mailto:test@example.com">Email with params</a>
+        <a href="mailto:test@example.com">mailto:test@example.com</a>
         <a href="tel:+1-555-123-4567">Phone number</a>
         <a href="blob:https://example.com/550e8400-e29b-41d4-a716-446655440000">Blob URL</a>
         <a href="https://example.com/docs/guide.html?version=latest#installation-steps">Path, query, and fragment</a>
         <a href="https://example.com/docs/guide.html?version=2025">Query parameter</a>
         <a href="https://example.com/docs/guide.html?version=2025">Query parameter (duplicate)</a>
+        <a href="https://example.com/d2fb0de6-daf3-42d7-b219-1a243d872156?cid=b3029797">Plain link</a>
+        <a href="https://example.com/7e61b3f7-8d81-4225-8d68-f646f977ce33?cid=63e3d9fb0bf5">Plain link (2)</a>
+        <a href="https://example.com/b3029797-1fb8-4edf-97bd-63e3d9fb0bf5?cid=4edf97bd">Plain link (3)</a>
     </section>
     <section class="test-section" title="Images">
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Ccircle cx='50' cy='50' r='40' fill='red'/%3E%3C/svg%3E" alt="SVG data URL">
@@ -58,10 +70,26 @@ addEventListener("load", async () => {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 
-    document.body.textContent = await UIHelper.requestDebugText({
-        includeURLs: true,
-        shortenURLs: true,
-    });
+    const results = [];
+    for (let outputFormat of ["texttree", "markdown"]) {
+        const heading = document.createElement("h1");
+        heading.textContent = `-- ${outputFormat}`;
+
+        const container = document.createElement("pre");
+        container.classList.add("text-representation");
+        let textContent = await UIHelper.requestDebugText({
+            includeURLs: true,
+            shortenURLs: true,
+            outputFormat,
+        });
+
+        container.textContent = textContent;
+        results.push(heading);
+        results.push(container);
+        results.push(document.createElement("br"));
+    }
+
+    document.body.replaceChildren(...results);
 
     testRunner.notifyDone();
 });

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -916,6 +916,8 @@ static void addPartsForText(const TextExtraction::TextItemData& textItem, Vector
                     auto escapedText = escapeStringForMarkdown(trimmedContent);
                     if (isStrikethrough)
                         escapedText = makeString("~~"_s, WTF::move(escapedText), "~~"_s);
+                    else if (valueOrDefault(urlString).containsIgnoringASCIICase(escapedText))
+                        escapedText = { };
                     textParts.append(urlString ? makeString('[', WTF::move(escapedText), "]("_s, WTF::move(*urlString), ')') : escapedText);
                 } else
                     textParts.append(makeString('\'', escapeString(trimmedContent), '\''));
@@ -1331,6 +1333,9 @@ static void addTextRepresentationRecursive(const TextExtraction::Item& item, std
     });
 
     bool omitChildTextNode = [&] {
+        if (aggregator.useMarkdownOutput())
+            return false;
+
         if (item.children.size() != 1)
             return false;
 

--- a/Source/WebKit/Shared/TextExtractionURLCache.cpp
+++ b/Source/WebKit/Shared/TextExtractionURLCache.cpp
@@ -50,8 +50,11 @@ String TextExtractionURLCache::add(const String& shortenedString, const URL& ori
 
         if (type == ExtractedURLType::Link) {
             auto slashIndex = string.reverseFind('/');
-            if ((slashIndex == notFound) || (fullStopIndex != notFound && slashIndex > fullStopIndex))
+            if ((slashIndex == notFound) || (fullStopIndex != notFound && slashIndex > fullStopIndex)) {
+                if (slashIndex == notFound && fullStopIndex != notFound)
+                    return makeString(string, '/', suffix);
                 return makeString(string, suffix);
+            }
         }
 
         if (fullStopIndex == notFound)


### PR DESCRIPTION
#### a9689a78cb4c05b6902ceaa39f6797bba727f136
<pre>
[AutoFill Debugging] Markdown output format sometimes fails to include URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=306738">https://bugs.webkit.org/show_bug.cgi?id=306738</a>
<a href="https://rdar.apple.com/169298031">rdar://169298031</a>

Reviewed by Abrar Rahman Protyasha.

Fix a couple of bugs involving URL shortening and extraction:

1.  We currently have logic to filter out redundant URLs from text extractions; however, this
    currently doesn&apos;t work when the output format is markdown, which only extracts visible text
    content. Fix this by pushing this logic for avoiding redundancy into `addPartsForText` in the
    markdown case, by replacing `[example.com](example.com)` with `[](example.com)`.

2.  Drive-by fix: in the case where shortened URLs don&apos;t contain *any* path components, shorten the
    URL by adding a new path component instead of just appending the numeric suffix. This means that
    instead of `example.com/&lt;UUID&gt;` becoming `example.com2`, it will become `example.com/2`.

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html:

Rebaseline a layout test to exercise both changes above.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::addTextRepresentationRecursive):
* Source/WebKit/Shared/TextExtractionURLCache.cpp:
(WebKit::TextExtractionURLCache::add):

Canonical link: <a href="https://commits.webkit.org/306629@main">https://commits.webkit.org/306629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a38f36df27ca2c89aec288867eda62dfdecaeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94945 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd83314a-dd2d-44f5-84dc-609ab03b4f71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108982 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78815 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa537464-da33-4f44-b6de-547d6c719583) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89878 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/daafde1f-a7f6-44a2-bcdf-a491c38abd61) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8724 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/480 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152802 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117072 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13910 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12123 "Found 1 new test failure: imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/document-write/047.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117394 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29924 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13444 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123642 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69562 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13933 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2923 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13672 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13875 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->