### PR TITLE
Reduce use of protected functions in Source/WebCore/dom

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -519,7 +519,7 @@ void FetchResponse::consumeBodyReceivedByChunk(ConsumeDataByChunkCallback&& call
     }
 
     ASSERT(isLoading());
-    protectedLoader()->consumeDataByChunk(WTF::move(callback));
+    protect(loader())->consumeDataByChunk(WTF::move(callback));
 }
 
 void FetchResponse::setBodyData(ResponseData&& data, uint64_t bodySizeWithPadding)
@@ -555,7 +555,7 @@ void FetchResponse::consumeBodyAsStream()
     }
 
     ASSERT(m_loader);
-    auto data = protectedLoader()->startStreaming();
+    auto data = protect(loader())->startStreaming();
     if (data) {
         Ref readableStreamSource = *m_readableStreamSource;
         if (!readableStreamSource->enqueue(data->tryCreateArrayBuffer())) {

--- a/Source/WebCore/Modules/fetch/FetchResponse.h
+++ b/Source/WebCore/Modules/fetch/FetchResponse.h
@@ -188,7 +188,7 @@ private:
         bool m_shouldStartStreaming { false };
     };
 
-    RefPtr<Loader> protectedLoader() { return m_loader.get(); }
+    Loader* loader() const { return m_loader.get(); }
 
     mutable std::optional<ResourceResponse> m_filteredResponse;
     ResourceResponse m_internalResponse;

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -97,7 +97,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
             }
             auto lock = WakeLockSentinel::create(document, lockType);
             promise->resolve<IDLInterface<WakeLockSentinel>>(lock.get());
-            document->protectedWakeLockManager()->addWakeLock(WTF::move(lock), document->pageID());
+            protect(document->wakeLockManager())->addWakeLock(WTF::move(lock), document->pageID());
         });
     });
 }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2753,11 +2753,6 @@ WakeLockManager& Document::wakeLockManager()
     return *m_wakeLockManager;
 }
 
-Ref<WakeLockManager> Document::protectedWakeLockManager()
-{
-    return wakeLockManager();
-}
-
 FormController& Document::formController()
 {
     if (!m_formController)
@@ -4266,8 +4261,8 @@ ExceptionOr<void> Document::setBodyOrFrameset(RefPtr<HTMLElement>&& newBody)
         return Exception { ExceptionCode::HierarchyRequestError };
 
     if (currentBody)
-        return protectedDocumentElement()->replaceChild(*newBody, *currentBody);
-    return protectedDocumentElement()->appendChild(*newBody);
+        return protect(documentElement())->replaceChild(*newBody, *currentBody);
+    return protect(documentElement())->appendChild(*newBody);
 }
 
 Location* Document::location() const
@@ -6556,7 +6551,7 @@ void Document::invalidateEventListenerRegions()
     if (changed)
         scheduleFullStyleRebuild();
     else
-        protectedDocumentElement()->invalidateStyleInternal();
+        protect(documentElement())->invalidateStyleInternal();
 }
 
 void Document::invalidateRenderingDependentRegions()
@@ -9749,11 +9744,6 @@ DocumentLoader* Document::loader() const
     return loader;
 }
 
-RefPtr<DocumentLoader> Document::protectedLoader() const
-{
-    return loader();
-}
-
 bool Document::allowsContentJavaScript() const
 {
     // FIXME: Get all SPI clients off of this potentially dangerous Setting.
@@ -10079,7 +10069,7 @@ Ref<DocumentFragment> Document::documentFragmentForInnerOuterHTML()
 
 Ref<FontFaceSet> Document::fonts()
 {
-    return protectedFontSelector()->fontFaceSet();
+    return protect(fontSelector())->fontFaceSet();
 }
 
 EditingBehavior Document::editingBehavior() const
@@ -12181,13 +12171,6 @@ String Document::mediaKeysStorageDirectory()
 CheckedPtr<RenderView> Document::checkedRenderView() const
 {
     return m_renderView.get();
-}
-
-Ref<CSSFontSelector> Document::protectedFontSelector() const
-{
-    if (!m_fontSelector)
-        return const_cast<Document&>(*this).ensureFontSelector();
-    return *m_fontSelector;
 }
 
 PermissionsPolicy Document::permissionsPolicy() const

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -545,7 +545,6 @@ public:
     
     Element* documentElement() const { return m_documentElement.get(); }
     AsyncNodeDeletionQueue& asyncNodeDeletionQueue() { return m_asyncNodeDeletionQueue; };
-    inline RefPtr<Element> protectedDocumentElement() const; // Defined in DocumentInlines.h.
     static constexpr ptrdiff_t documentElementMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentElement); }
 
     WEBCORE_EXPORT Element* activeElement();
@@ -655,7 +654,6 @@ public:
     WEBCORE_EXPORT Ref<NodeList> getElementsByName(const AtomString& elementName);
 
     WakeLockManager& wakeLockManager();
-    Ref<WakeLockManager> protectedWakeLockManager();
 
     // Other methods (not part of DOM)
     bool isSynthesized() const { return m_isSynthesized; }
@@ -697,9 +695,7 @@ public:
 
     CSSFontSelector* fontSelectorIfExists() { return m_fontSelector.get(); }
     const CSSFontSelector* fontSelectorIfExists() const { return m_fontSelector.get(); }
-    inline CSSFontSelector& fontSelector();
-    inline const CSSFontSelector& fontSelector() const;
-    Ref<CSSFontSelector> protectedFontSelector() const;
+    inline CSSFontSelector& fontSelector() const; // Defined in DocumentInlines.h.
 
     WEBCORE_EXPORT bool haveStylesheetsLoaded() const;
     bool isIgnoringPendingStylesheets() const { return m_ignorePendingStylesheets; }
@@ -839,7 +835,6 @@ public:
     bool visuallyOrdered() const { return m_visuallyOrdered; }
 
     WEBCORE_EXPORT DocumentLoader* loader() const;
-    WEBCORE_EXPORT RefPtr<DocumentLoader> protectedLoader() const;
 
     WEBCORE_EXPORT ExceptionOr<RefPtr<WindowProxy>> openForBindings(LocalDOMWindow& activeWindow, LocalDOMWindow& firstDOMWindow, const String& url, const AtomString& name, const String& features);
     WEBCORE_EXPORT ExceptionOr<Document&> openForBindings(Document* entryDocument, const String&, const String&);

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -90,14 +90,7 @@ inline ScriptModuleLoader& Document::moduleLoader()
     return *m_moduleLoader;
 }
 
-inline CSSFontSelector& Document::fontSelector()
-{
-    if (!m_fontSelector)
-        return ensureFontSelector();
-    return *m_fontSelector;
-}
-
-inline const CSSFontSelector& Document::fontSelector() const
+inline CSSFontSelector& Document::fontSelector() const
 {
     if (!m_fontSelector)
         return const_cast<Document&>(*this).ensureFontSelector();
@@ -135,11 +128,6 @@ inline bool Document::wasLastFocusByClick() const { return m_latestFocusTrigger 
 inline RefPtr<DocumentParser> Document::protectedParser() const
 {
     return m_parser;
-}
-
-inline RefPtr<Element> Document::protectedDocumentElement() const
-{
-    return m_documentElement;
 }
 
 inline UndoManager& Document::undoManager() const

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3510,11 +3510,6 @@ ShadowRoot* Element::userAgentShadowRoot() const
     return shadowRoot();
 }
 
-RefPtr<ShadowRoot> Element::protectedUserAgentShadowRoot() const
-{
-    return userAgentShadowRoot();
-}
-
 ShadowRoot& Element::ensureUserAgentShadowRoot()
 {
     if (auto* shadow = userAgentShadowRoot())
@@ -5018,11 +5013,6 @@ DOMTokenList& Element::classList()
     if (!data.classList())
         data.setClassList(makeUniqueWithoutRefCountedCheck<DOMTokenList>(*this, HTMLNames::classAttr));
     return *data.classList();
-}
-
-Ref<DOMTokenList> Element::protectedClassList()
-{
-    return classList();
 }
 
 SpaceSplitString Element::partNames() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -468,7 +468,6 @@ public:
     ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, String referenceTarget, CustomElementRegistryKind);
 
     WEBCORE_EXPORT ShadowRoot* userAgentShadowRoot() const;
-    RefPtr<ShadowRoot> protectedUserAgentShadowRoot() const;
     WEBCORE_EXPORT ShadowRoot& ensureUserAgentShadowRoot();
     Ref<ShadowRoot> ensureProtectedUserAgentShadowRoot();
     WEBCORE_EXPORT ShadowRoot& createUserAgentShadowRoot();
@@ -654,7 +653,6 @@ public:
     WEBCORE_EXPORT ExceptionOr<Element*> closest(const String& selectors);
 
     WEBCORE_EXPORT DOMTokenList& classList();
-    WEBCORE_EXPORT Ref<DOMTokenList> protectedClassList();
 
     SpaceSplitString partNames() const;
     DOMTokenList& part();

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -176,7 +176,7 @@ bool isInsideOverlay(const SimpleRange& range)
 bool isInsideOverlay(const Node& node)
 {
     RefPtr host = imageOverlayHost(node);
-    return host && host->protectedUserAgentShadowRoot()->contains(node);
+    return host && protect(host->userAgentShadowRoot())->contains(node);
 }
 
 bool isOverlayText(const Node* node)
@@ -190,7 +190,7 @@ bool isOverlayText(const Node& node)
     if (!host)
         return false;
 
-    if (RefPtr overlay = host->protectedUserAgentShadowRoot()->getElementById(imageOverlayElementIdentifier()))
+    if (RefPtr overlay = protect(host->userAgentShadowRoot())->getElementById(imageOverlayElementIdentifier()))
         return node.isDescendantOf(*overlay);
 
     return false;

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -103,7 +103,7 @@ bool isInsideImageControls(const Node& node)
     if (!host)
         return false;
 
-    return host->protectedUserAgentShadowRoot()->contains(node);
+    return protect(host->userAgentShadowRoot())->contains(node);
 }
 
 void createImageControls(HTMLElement& element)

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -582,7 +582,7 @@ void BaseDateAndTimeInputType::didChangeValueFromControl()
         return;
     }
 
-    if (input->protectedUserAgentShadowRoot()->containsFocusedElement())
+    if (protect(input->userAgentShadowRoot())->containsFocusedElement())
         input->dispatchFormControlInputEvent();
     else
         input->dispatchFormControlChangeEvent();

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -71,7 +71,7 @@ RenderProgress* HTMLProgressElement::renderProgress() const
 {
     if (auto* renderProgress = dynamicDowncast<RenderProgress>(renderer()))
         return renderProgress;
-    return downcast<RenderProgress>(descendantsOfType<Element>(*protectedUserAgentShadowRoot()).first()->renderer());
+    return downcast<RenderProgress>(descendantsOfType<Element>(*protect(userAgentShadowRoot())).first()->renderer());
 }
 
 RefPtr<ProgressValueElement> HTMLProgressElement::protectedValueElement()

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -529,14 +529,14 @@ void HTMLTextAreaElement::updatePlaceholderText()
     auto& placeholderText = attributeWithoutSynchronization(placeholderAttr);
     if (placeholderText.isEmpty()) {
         if (RefPtr placeholder = m_placeholder) {
-            protectedUserAgentShadowRoot()->removeChild(*placeholder);
+            protect(userAgentShadowRoot())->removeChild(*placeholder);
             m_placeholder = nullptr;
         }
         return;
     }
     if (!m_placeholder) {
         m_placeholder = TextControlPlaceholderElement::create(protect(document()));
-        protectedUserAgentShadowRoot()->insertBefore(*protectedPlaceholderElement(), protect(innerTextElement()->nextSibling()));
+        protect(userAgentShadowRoot())->insertBefore(*protectedPlaceholderElement(), protect(innerTextElement()->nextSibling()));
     }
     protectedPlaceholderElement()->setInnerText(String { placeholderText });
 }

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -719,7 +719,7 @@ void HTMLTextFormControlElement::setInnerTextValue(String&& value)
 
         {
             // Events dispatched on the inner text element cannot execute arbitrary author scripts.
-            ScriptDisallowedScope::EventAllowedScope allowedScope(*protectedUserAgentShadowRoot());
+            ScriptDisallowedScope::EventAllowedScope allowedScope(*protect(userAgentShadowRoot()));
 
             bool endsWithNewLine = value.endsWith('\n') || value.endsWith('\r');
             innerText->setInnerText(WTF::move(value));

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -159,7 +159,7 @@ void ImageDocument::updateDuringParsing()
     if (!frame())
         return;
 
-    if (RefPtr buffer = protectedLoader()->mainResourceData()) {
+    if (RefPtr buffer = protect(loader())->mainResourceData()) {
         if (CachedResourceHandle cachedImage = Ref { *m_imageElement }->cachedImage())
             cachedImage->updateBuffer(*buffer);
     }

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -149,7 +149,7 @@ void RangeInputType::handleMouseDownEvent(MouseEvent& event)
         return;
 
     ASSERT(element->shadowRoot());
-    if (targetNode != element.ptr() && !targetNode->isDescendantOf(element->protectedUserAgentShadowRoot().get()))
+    if (targetNode != element.ptr() && !targetNode->isDescendantOf(protect(element->userAgentShadowRoot()).get()))
         return;
     Ref thumb = typedSliderThumbElement();
     if (targetNode == thumb.ptr())

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -648,9 +648,9 @@ void TextFieldInputType::updatePlaceholderText()
         Ref placeholder = TextControlPlaceholderElement::create(protect(element->document()));
         m_placeholder = placeholder.copyRef();
         if (RefPtr container = m_container)
-            element->protectedUserAgentShadowRoot()->insertBefore(placeholder, container);
+            protect(element->userAgentShadowRoot())->insertBefore(placeholder, container);
         else
-            element->protectedUserAgentShadowRoot()->insertBefore(placeholder, innerTextElement());
+            protect(element->userAgentShadowRoot())->insertBefore(placeholder, innerTextElement());
     }
     RefPtr { m_placeholder }->setInnerText(WTF::move(placeholderText));
 }

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -271,7 +271,7 @@ void VTTRegion::displayLastTextTrackCueBox()
 
     // If it's a scrolling region, add the scrolling class.
     if (scroll() == ScrollSetting::Up)
-        m_cueContainer->protectedClassList()->add(textTrackCueContainerScrollingClass());
+        protect(m_cueContainer->classList())->add(textTrackCueContainerScrollingClass());
 
     float regionBottom = m_regionDisplayTree->boundingClientRect().maxY();
 
@@ -301,7 +301,7 @@ void VTTRegion::willRemoveTextTrackCueBox(VTTCueBox* box)
 
     double boxHeight = box->boundingClientRect().height();
 
-    m_cueContainer->protectedClassList()->remove(textTrackCueContainerScrollingClass());
+    protect(m_cueContainer->classList())->remove(textTrackCueContainerScrollingClass());
 
     m_currentTop += boxHeight;
     m_cueContainer->setInlineStyleProperty(CSSPropertyTop, m_currentTop, CSSUnitType::CSS_PX);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1837,7 +1837,7 @@ void LocalDOMWindow::scrollTo(const ScrollToOptions& options, ScrollClamping cla
 
     // FIXME: Should we use document()->scrollingElement()?
     // See https://bugs.webkit.org/show_bug.cgi?id=205059
-    auto animated = useSmoothScrolling(scrollToOptions.behavior, document()->protectedDocumentElement().get()) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
+    auto animated = useSmoothScrolling(scrollToOptions.behavior, protect(document()->documentElement()).get()) ? ScrollIsAnimated::Yes : ScrollIsAnimated::No;
     auto scrollPositionChangeOptions = ScrollPositionChangeOptions::createProgrammaticWithOptions(clamping, animated, snapPointSelectionMethod, originalScrollDelta);
     view->setContentsScrollPosition(layoutPos, scrollPositionChangeOptions);
 }

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -202,7 +202,7 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
 
     Vector<Ref<Node>> serializedNodes;
     SerializerMarkupAccumulator accumulator(*this, *document, &serializedNodes);
-    String text = accumulator.serializeNodes(*document->protectedDocumentElement(), SerializedNodes::SubtreeIncludingNode);
+    String text = accumulator.serializeNodes(*protect(document->documentElement()), SerializedNodes::SubtreeIncludingNode);
     m_resources.append({ url, document->suggestedMIMEType(), SharedBuffer::create(textEncoding.encode(text, PAL::UnencodableHandling::Entities)) });
     m_resourceURLs.add(url);
 

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -69,7 +69,7 @@ void ImageOverlayController::updateDataDetectorHighlights(const HTMLElement& ove
     }
 
     Vector<Ref<HTMLElement>> dataDetectorResultElements;
-    for (Ref child : descendantsOfType<HTMLElement>(*overlayHost.protectedUserAgentShadowRoot())) {
+    for (Ref child : descendantsOfType<HTMLElement>(*protect(overlayHost.userAgentShadowRoot()))) {
         if (ImageOverlay::isDataDetectorResult(child) && child->renderer())
             dataDetectorResultElements.append(child);
     }

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -433,7 +433,7 @@ GlyphData FontCascade::glyphDataForCharacter(char32_t c, bool mirror, FontVarian
 
     auto emojiPolicy = resolvedEmojiPolicy.value_or(resolveEmojiPolicy(m_fontDescription.variantEmoji(), c));
 
-    return protectedFonts()->glyphDataForCharacter(c, m_fontDescription, protectedFontSelector().get(), variant, emojiPolicy);
+    return protectedFonts()->glyphDataForCharacter(c, m_fontDescription, protect(fontSelector()).get(), variant, emojiPolicy);
 }
 
 

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -288,7 +288,6 @@ public:
     static CodePath s_codePath;
 
     FontSelector* fontSelector() const;
-    RefPtr<FontSelector> protectedFontSelector() const;
 
     static bool isInvisibleReplacementObjectCharacter(char32_t character)
     {
@@ -419,7 +418,7 @@ private:
 inline Ref<const Font> FontCascade::primaryFont() const
 {
     ASSERT(m_fonts);
-    Ref font = protectedFonts()->primaryFont(m_fontDescription, protectedFontSelector().get());
+    Ref font = protectedFonts()->primaryFont(m_fontDescription, protect(fontSelector()).get());
     m_fontDescription.resolveFontSizeAdjustFromFontIfNeeded(font);
     return font;
 }
@@ -427,29 +426,24 @@ inline Ref<const Font> FontCascade::primaryFont() const
 inline const FontRanges& FontCascade::fallbackRangesAt(unsigned index) const
 {
     ASSERT(m_fonts);
-    return protectedFonts()->realizeFallbackRangesAt(m_fontDescription, protectedFontSelector().get(), index);
+    return protectedFonts()->realizeFallbackRangesAt(m_fontDescription, protect(fontSelector()).get(), index);
 }
 
 inline bool FontCascade::isFixedPitch() const
 {
     ASSERT(m_fonts);
-    return protectedFonts()->isFixedPitch(m_fontDescription, protectedFontSelector().get());
+    return protectedFonts()->isFixedPitch(m_fontDescription, protect(fontSelector()).get());
 }
 
 inline bool FontCascade::canTakeFixedPitchFastContentMeasuring() const
 {
     ASSERT(m_fonts);
-    return protectedFonts()->canTakeFixedPitchFastContentMeasuring(m_fontDescription, protectedFontSelector().get());
+    return protectedFonts()->canTakeFixedPitchFastContentMeasuring(m_fontDescription, protect(fontSelector()).get());
 }
 
 inline FontSelector* FontCascade::fontSelector() const
 {
     return m_fontSelector.get();
-}
-
-inline RefPtr<FontSelector> FontCascade::protectedFontSelector() const
-{
-    return m_fontSelector;
 }
 
 inline float FontCascade::tabWidth(const Font& font, const TabSize& tabSize, float position, Font::SyntheticBoldInclusion syntheticBoldInclusion) const

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -26,6 +26,7 @@
 #include "RenderSVGInlineText.h"
 
 #include "CSSFontSelector.h"
+#include "DocumentInlines.h"
 #include "FloatConversion.h"
 #include "FloatQuad.h"
 #include "InlineIteratorSVGTextBox.h"
@@ -275,7 +276,7 @@ bool RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
         fontDescription.setOrientation(FontOrientation::Horizontal);
 
     scaledFont = FontCascade(WTF::move(fontDescription));
-    scaledFont.update(renderer.document().protectedFontSelector().ptr());
+    scaledFont.update(protect(renderer.document().fontSelector()).ptr());
     return true;
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -38,6 +38,7 @@
 #include "CSSViewTransitionRule.h"
 #include "CustomFunctionRegistry.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "MediaQueryEvaluator.h"
 #include "MutableCSSSelector.h"
 #include "StyleCustomPropertyRegistry.h"
@@ -516,17 +517,17 @@ void RuleSetBuilder::addMutatingRulesToResolver()
 
         auto& rule = collectedRule.rule;
         if (RefPtr styleRuleFontFace = dynamicDowncast<StyleRuleFontFace>(rule.get())) {
-            m_resolver->document().protectedFontSelector()->addFontFaceRule(*styleRuleFontFace, false);
+            protect(m_resolver->document().fontSelector())->addFontFaceRule(*styleRuleFontFace, false);
             m_resolver->invalidateMatchedDeclarationsCache();
             continue;
         }
         if (RefPtr styleRuleFontPaletteValues = dynamicDowncast<StyleRuleFontPaletteValues>(rule.get())) {
-            m_resolver->document().protectedFontSelector()->addFontPaletteValuesRule(*styleRuleFontPaletteValues);
+            protect(m_resolver->document().fontSelector())->addFontPaletteValuesRule(*styleRuleFontPaletteValues);
             m_resolver->invalidateMatchedDeclarationsCache();
             continue;
         }
         if (RefPtr styleRuleFontFeatureValues = dynamicDowncast<StyleRuleFontFeatureValues>(rule.get())) {
-            m_resolver->document().protectedFontSelector()->addFontFeatureValuesRule(*styleRuleFontFeatureValues);
+            protect(m_resolver->document().fontSelector())->addFontFeatureValuesRule(*styleRuleFontFeatureValues);
             m_resolver->invalidateMatchedDeclarationsCache();
             continue;
         }

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -31,6 +31,7 @@
 
 #include "CSSFontSelector.h"
 #include "Document.h"
+#include "DocumentInlines.h"
 #include "FontCascade.h"
 #include "HTMLIFrameElement.h"
 #include "LocalFrame.h"
@@ -106,7 +107,7 @@ RenderStyle resolveForDocument(const Document& document)
     auto fontCascade = FontCascade { WTF::move(fontDescription), documentStyle.fontCascade() };
 
     // We don't just call setFontDescription() because we need to provide the fontSelector to the FontCascade.
-    RefPtr fontSelector = document.protectedFontSelector();
+    RefPtr fontSelector = document.fontSelector();
     fontCascade.update(WTF::move(fontSelector));
     documentStyle.setFontCascade(WTF::move(fontCascade));
 

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -208,7 +208,7 @@ void Resolver::initialize()
         document().fontSelector().incrementIsComputingRootStyleFont();
         m_rootDefaultStyle->fontCascade().update(&document().fontSelector());
         m_rootDefaultStyle->fontCascade().primaryFont();
-        document().protectedFontSelector()->decrementIsComputingRootStyleFont();
+        protect(document().fontSelector())->decrementIsComputingRootStyleFont();
     }
 
     if (m_rootDefaultStyle && view)

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -134,13 +134,13 @@ void Scope::createDocumentResolver()
 
     m_resolver->ruleSets().setDynamicViewTransitionsStyle(m_dynamicViewTransitionsStyle.get());
 
-    m_document->protectedFontSelector()->buildStarted();
+    protect(m_document->fontSelector())->buildStarted();
 
     m_resolver->ruleSets().initializeUserStyle();
     m_resolver->addCurrentSVGFontFaceRules();
     m_resolver->appendAuthorStyleSheets(m_activeStyleSheets);
 
-    m_document->protectedFontSelector()->buildCompleted();
+    protect(m_document->fontSelector())->buildCompleted();
 }
 
 void Scope::createOrFindSharedShadowTreeResolver()

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -548,7 +548,7 @@ static void cloneDataAndChildren(SVGElement& replacementClone, SVGElement& origi
 
 void SVGUseElement::expandUseElementsInShadowTree() const
 {
-    auto descendants = descendantsOfType<SVGUseElement>(*protectedUserAgentShadowRoot());
+    auto descendants = descendantsOfType<SVGUseElement>(*protect(userAgentShadowRoot()));
     for (auto it = descendants.begin(); it; ) {
         Ref originalClone = *it;
         it.dropAssertions();
@@ -582,7 +582,7 @@ void SVGUseElement::expandUseElementsInShadowTree() const
 
 void SVGUseElement::expandSymbolElementsInShadowTree() const
 {
-    auto descendants = descendantsOfType<SVGSymbolElement>(*protectedUserAgentShadowRoot());
+    auto descendants = descendantsOfType<SVGSymbolElement>(*protect(userAgentShadowRoot()));
     for (auto it = descendants.begin(); it; ) {
         Ref originalClone = *it;
         it.dropAssertions();
@@ -609,7 +609,7 @@ void SVGUseElement::expandSymbolElementsInShadowTree() const
 void SVGUseElement::transferEventListenersToShadowTree() const
 {
     // FIXME: Don't directly add event listeners on each descendant. Copy event listeners on the use element instead.
-    for (Ref descendant : descendantsOfType<SVGElement>(*protectedUserAgentShadowRoot())) {
+    for (Ref descendant : descendantsOfType<SVGElement>(*protect(userAgentShadowRoot()))) {
         if (EventTargetData* data = descendant->correspondingElement()->eventTargetData())
             data->eventListenerMap.copyEventListenersNotCreatedFromMarkupToTarget(descendant.ptr());
     }

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -721,7 +721,7 @@ bool XMLHttpRequest::internalAbort()
     // This would create internalAbort reentrant call.
     // m_loadingActivity is set to std::nullopt before being cancelled to exit early in any reentrant internalAbort() call.
     auto loadingActivity = std::exchange(m_loadingActivity, std::nullopt);
-    loadingActivity->protectedLoader()->cancel();
+    protect(loadingActivity->loader)->cancel();
 
     // If window.onload callback calls open() and send() on the same xhr, m_loadingActivity is now set to a new value.
     // The function calling internalAbort() should abort to let the open() and send() calls continue properly.
@@ -1134,7 +1134,7 @@ void XMLHttpRequest::timeoutTimerFired()
 {
     if (!m_loadingActivity)
         return;
-    m_loadingActivity->protectedLoader()->computeIsDone();
+    protect(m_loadingActivity->loader)->computeIsDone();
 }
 
 void XMLHttpRequest::notifyIsDone(bool isDone)
@@ -1229,11 +1229,6 @@ bool XMLHttpRequest::virtualHasPendingActivity() const
 void XMLHttpRequest::dispatchThrottledProgressEventIfNeeded()
 {
     m_progressEventThrottle->dispatchThrottledProgressEventIfNeeded();
-}
-
-Ref<ThreadableLoader> XMLHttpRequest::LoadingActivity::protectedLoader() const
-{
-    return loader;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -233,7 +233,6 @@ private:
     struct LoadingActivity {
         Ref<XMLHttpRequest> protectedThis; // Keep object alive while loading even if there is no longer a JS wrapper.
         Ref<ThreadableLoader> loader;
-        Ref<ThreadableLoader> protectedLoader() const;
     };
     std::optional<LoadingActivity> m_loadingActivity;
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -137,7 +137,6 @@ private:
     RefPtr<IPC::Connection> serviceWorkerConnection();
     template<typename Message> bool sendToClient(Message&&);
 
-    RefPtr<NetworkResourceLoader> protectedLoader() const;
     void sendNavigationPreloadUpdate();
 
     RefPtr<ServiceWorkerNavigationPreloader> protectedPreloader();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -687,7 +687,7 @@ void PDFPluginBase::addArchiveResource()
 
     RetainPtr data = originalData();
     auto resource = ArchiveResource::create(SharedBuffer::create(data.get()), view->mainResourceURL(), "application/pdf"_s, String(), String(), synthesizedResponse);
-    protect(view->frame())->protectedDocument()->protectedLoader()->addArchiveResource(resource.releaseNonNull());
+    protect(protect(protect(view->frame())->document())->loader())->addArchiveResource(resource.releaseNonNull());
 }
 
 void PDFPluginBase::tryRunScriptsInPDFDocument()

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -808,7 +808,7 @@ String WebFrame::innerText() const
     if (!localFrame->document()->documentElement())
         return String();
 
-    return localFrame->protectedDocument()->protectedDocumentElement()->innerText();
+    return protect(protect(localFrame->document())->documentElement())->innerText();
 }
 
 RefPtr<WebFrame> WebFrame::parentFrame() const


### PR DESCRIPTION
#### 5b795d6eed76f130a043ab12fc3d9b6242f488e9
<pre>
Reduce use of protected functions in Source/WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=306694">https://bugs.webkit.org/show_bug.cgi?id=306694</a>

Reviewed by Anne van Kesteren.

Adopt `protect()` at call sites instead.

* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::consumeBodyReceivedByChunk):
(WebCore::FetchResponse::consumeBodyAsStream):
* Source/WebCore/Modules/fetch/FetchResponse.h:
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setBodyOrFrameset):
(WebCore::Document::invalidateEventListenerRegions):
(WebCore::Document::fonts):
(WebCore::Document::protectedWakeLockManager): Deleted.
(WebCore::Document::protectedLoader const): Deleted.
(WebCore::Document::protectedFontSelector const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::asyncNodeDeletionQueue):
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::fontSelector const):
(WebCore::Document::fontSelector): Deleted.
(WebCore::Document::protectedDocumentElement const): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::protectedUserAgentShadowRoot const): Deleted.
(WebCore::Element::protectedClassList): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::isInsideOverlay):
(WebCore::ImageOverlay::isOverlayText):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::isInsideImageControls):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::renderProgress const):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::updatePlaceholderText):
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::setInnerTextValue):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::updateDuringParsing):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::handleMouseDownEvent):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::updatePlaceholderText):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::displayLastTextTrackCueBox):
(WebCore::VTTRegion::willRemoveTextTrackCueBox):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::scrollTo const):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeFrame):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::glyphDataForCharacter const):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::primaryFont const):
(WebCore::FontCascade::fallbackRangesAt const):
(WebCore::FontCascade::isFixedPitch const):
(WebCore::FontCascade::canTakeFixedPitchFastContentMeasuring const):
(WebCore::FontCascade::protectedFontSelector const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGInlineText.cpp:
(WebCore::RenderSVGInlineText::computeNewScaledFontForStyle):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addMutatingRulesToResolver):
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::initialize):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createDocumentResolver):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::expandUseElementsInShadowTree const):
(WebCore::SVGUseElement::expandSymbolElementsInShadowTree const):
(WebCore::SVGUseElement::transferEventListenersToShadowTree const):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::internalAbort):
(WebCore::XMLHttpRequest::timeoutTimerFired):
(WebCore::XMLHttpRequest::LoadingActivity::protectedLoader const): Deleted.
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::didFinish):
(WebKit::ServiceWorkerFetchTask::didFail):
(WebKit::ServiceWorkerFetchTask::didNotHandle):
(WebKit::ServiceWorkerFetchTask::usePreload):
(WebKit::ServiceWorkerFetchTask::convertToDownload):
(WebKit::ServiceWorkerFetchTask::sendData):
(WebKit::ServiceWorkerFetchTask::protectedLoader const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::addArchiveResource):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::innerText const):

Canonical link: <a href="https://commits.webkit.org/306616@main">https://commits.webkit.org/306616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ba8e567aa8812fba0d977d5ff2044f24bdb364e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94946 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd4653ef-c51c-44ef-9bc2-36e8e22b6215) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108984 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78816 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f046373-fd2c-48b0-9dcc-44497179e3ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144770 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11536 "Found 1 new test failure: webrtc/video-addTransceiver.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89880 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d3e2663-b45d-43a6-8a71-ec69779aad2a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8726 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/481 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152803 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13896 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117074 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13911 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12125 "Found 1 new test failure: imported/w3c/web-platform-tests/html/webappapis/user-prompts/print-during-beforeunload.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29913 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13445 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123644 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69564 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2925 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13673 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77659 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->