### PR TITLE
[JSC] Optimize `[...map.keys()]` and `[...map.values()]`

### DIFF
--- a/JSTests/microbenchmarks/spread-map-keys.js
+++ b/JSTests/microbenchmarks/spread-map-keys.js
@@ -1,0 +1,16 @@
+// Benchmark for spread on Map.keys()
+
+function benchmarkSpreadMapKeys() {
+    const map = new Map();
+    for (let i = 0; i < 100; i++)
+        map.set(i, i * 2);
+
+    let sum = 0;
+    for (let i = 0; i < 10000; i++) {
+        const arr = [...map.keys()];
+        sum += arr.length;
+    }
+    return sum;
+}
+
+benchmarkSpreadMapKeys();

--- a/JSTests/microbenchmarks/spread-map-values.js
+++ b/JSTests/microbenchmarks/spread-map-values.js
@@ -1,0 +1,16 @@
+// Benchmark for spread on Map.values()
+
+function benchmarkSpreadMapValues() {
+    const map = new Map();
+    for (let i = 0; i < 100; i++)
+        map.set(i, i * 2);
+
+    let sum = 0;
+    for (let i = 0; i < 10000; i++) {
+        const arr = [...map.values()];
+        sum += arr.length;
+    }
+    return sum;
+}
+
+benchmarkSpreadMapValues();

--- a/JSTests/stress/spread-map-iterator-dfg-ftl.js
+++ b/JSTests/stress/spread-map-iterator-dfg-ftl.js
@@ -1,0 +1,79 @@
+//@ runDefault("--forceEagerCompilation=true", "--useConcurrentJIT=false")
+
+// DFG/FTL optimization tests for spread on Map iterator objects
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; i++)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Test that spread optimization works in DFG/FTL
+function testSpreadKeys(map) {
+    return [...map.keys()];
+}
+
+function testSpreadValues(map) {
+    return [...map.values()];
+}
+
+const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+
+// Warm up to trigger DFG/FTL compilation
+for (let i = 0; i < 10000; i++) {
+    testSpreadKeys(map);
+    testSpreadValues(map);
+}
+
+// Verify correctness after optimization
+shouldBeArray(testSpreadKeys(map), [1, 2, 3]);
+shouldBeArray(testSpreadValues(map), ['a', 'b', 'c']);
+
+// Test with different maps to ensure polymorphic behavior
+const map2 = new Map([['x', 10], ['y', 20]]);
+shouldBeArray(testSpreadKeys(map2), ['x', 'y']);
+shouldBeArray(testSpreadValues(map2), [10, 20]);
+
+// Test empty map
+const emptyMap = new Map();
+shouldBeArray(testSpreadKeys(emptyMap), []);
+shouldBeArray(testSpreadValues(emptyMap), []);
+
+// Test that iterator consumption is correct in optimized code
+function testPartialIteratorKeys(map) {
+    const iter = map.keys();
+    iter.next();
+    return [...iter];
+}
+
+function testPartialIteratorValues(map) {
+    const iter = map.values();
+    iter.next();
+    return [...iter];
+}
+
+for (let i = 0; i < 10000; i++) {
+    testPartialIteratorKeys(map);
+    testPartialIteratorValues(map);
+}
+
+shouldBeArray(testPartialIteratorKeys(map), [2, 3]);
+shouldBeArray(testPartialIteratorValues(map), ['b', 'c']);
+
+// Test inline caching with consistent structure
+function testConsistentStructure() {
+    const m = new Map();
+    for (let i = 0; i < 5; i++)
+        m.set(i, i * 10);
+    return [...m.keys()].reduce((a, b) => a + b, 0);
+}
+
+for (let i = 0; i < 10000; i++)
+    testConsistentStructure();
+
+shouldBe(testConsistentStructure(), 0 + 1 + 2 + 3 + 4);

--- a/JSTests/stress/spread-map-iterator-having-a-bad-time.js
+++ b/JSTests/stress/spread-map-iterator-having-a-bad-time.js
@@ -1,0 +1,148 @@
+//@ runDefault("--forceEagerCompilation=true", "--useConcurrentJIT=false")
+
+// Having-a-bad-time tests for spread on Map iterator objects
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; i++)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Test that spread works correctly even in having-a-bad-time mode
+{
+    function spreadKeys(map) {
+        return [...map.keys()];
+    }
+
+    function spreadValues(map) {
+        return [...map.values()];
+    }
+
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+
+    // Warm up
+    for (let i = 0; i < 10000; i++) {
+        spreadKeys(map);
+        spreadValues(map);
+    }
+
+    shouldBeArray(spreadKeys(map), [1, 2, 3]);
+    shouldBeArray(spreadValues(map), ['a', 'b', 'c']);
+
+    // Trigger having-a-bad-time by modifying Array prototype
+    Array.prototype[10] = 'bad';
+
+    // Spread should still work correctly
+    const keys = spreadKeys(map);
+    const values = spreadValues(map);
+
+    shouldBeArray(keys, [1, 2, 3]);
+    shouldBeArray(values, ['a', 'b', 'c']);
+
+    // Verify the array doesn't have prototype pollution
+    shouldBe(keys.hasOwnProperty(10), false);
+    shouldBe(values.hasOwnProperty(10), false);
+
+    // Clean up
+    delete Array.prototype[10];
+}
+
+// Test with Object.prototype modification
+{
+    function spreadKeys(map) {
+        return [...map.keys()];
+    }
+
+    const map = new Map([['x', 1], ['y', 2]]);
+
+    // Warm up
+    for (let i = 0; i < 5000; i++)
+        spreadKeys(map);
+
+    // Modify Object.prototype
+    Object.prototype.badProperty = 'evil';
+
+    const result = spreadKeys(map);
+    shouldBeArray(result, ['x', 'y']);
+
+    // Clean up
+    delete Object.prototype.badProperty;
+}
+
+// Test with Array constructor replacement (should not affect Map spread)
+{
+    function spreadValues(map) {
+        return [...map.values()];
+    }
+
+    const map = new Map([[1, 100], [2, 200]]);
+
+    // Warm up
+    for (let i = 0; i < 5000; i++)
+        spreadValues(map);
+
+    // Note: We can't actually replace Array constructor globally,
+    // but we can verify the spread creates proper arrays
+    const result = spreadValues(map);
+    shouldBe(Array.isArray(result), true);
+    shouldBe(result.constructor, Array);
+    shouldBeArray(result, [100, 200]);
+}
+
+// Test with indexed property on Array.prototype (having-a-bad-time trigger)
+{
+    function testSpread(map) {
+        const keys = [...map.keys()];
+        const values = [...map.values()];
+        return { keys, values };
+    }
+
+    const map = new Map([[0, 'zero'], [1, 'one'], [2, 'two']]);
+
+    // Warm up
+    for (let i = 0; i < 5000; i++)
+        testSpread(map);
+
+    // Add indexed property to Array.prototype
+    Array.prototype[1] = 'prototype-value';
+
+    const result = testSpread(map);
+
+    // The spread result should have its own property at index 1
+    shouldBe(result.keys.hasOwnProperty(1), true);
+    shouldBe(result.keys[1], 1);
+    shouldBe(result.values.hasOwnProperty(1), true);
+    shouldBe(result.values[1], 'one');
+
+    // Clean up
+    delete Array.prototype[1];
+}
+
+// Test combination of modifications
+{
+    function spreadTest(map) {
+        return [...map.keys(), ...map.values()];
+    }
+
+    const map = new Map([['a', 1], ['b', 2]]);
+
+    // Warm up
+    for (let i = 0; i < 5000; i++)
+        spreadTest(map);
+
+    // Multiple modifications
+    Array.prototype[5] = 'bad5';
+    Object.prototype.weird = 'weird';
+
+    const result = spreadTest(map);
+    shouldBeArray(result, ['a', 'b', 1, 2]);
+
+    // Clean up
+    delete Array.prototype[5];
+    delete Object.prototype.weird;
+}

--- a/JSTests/stress/spread-map-iterator-osr-exit.js
+++ b/JSTests/stress/spread-map-iterator-osr-exit.js
@@ -1,0 +1,123 @@
+//@ runDefault("--forceEagerCompilation=true", "--useConcurrentJIT=false")
+
+// OSR exit tests for spread on Map iterator objects
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; i++)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Test OSR exit when iterator protocol is modified
+{
+    function spreadKeys(map) {
+        return [...map.keys()];
+    }
+
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+
+    // Warm up
+    for (let i = 0; i < 10000; i++)
+        spreadKeys(map);
+
+    shouldBeArray(spreadKeys(map), [1, 2, 3]);
+
+    // Modify iterator protocol - should cause OSR exit
+    const MapIteratorPrototype = Object.getPrototypeOf(new Map().keys());
+    const originalNext = MapIteratorPrototype.next;
+
+    let callCount = 0;
+    MapIteratorPrototype.next = function() {
+        callCount++;
+        return originalNext.call(this);
+    };
+
+    // This should use the slow path
+    const result = spreadKeys(map);
+    shouldBeArray(result, [1, 2, 3]);
+    shouldBe(callCount > 0, true);
+
+    // Restore
+    MapIteratorPrototype.next = originalNext;
+}
+
+// Test OSR exit when Symbol.iterator is modified on iterator
+{
+    function spreadValues(map) {
+        return [...map.values()];
+    }
+
+    const map = new Map([[1, 'x'], [2, 'y']]);
+
+    // Warm up
+    for (let i = 0; i < 10000; i++)
+        spreadValues(map);
+
+    shouldBeArray(spreadValues(map), ['x', 'y']);
+
+    // Modify Symbol.iterator on MapIterator prototype
+    const MapIteratorPrototype = Object.getPrototypeOf(new Map().values());
+    const originalIterator = MapIteratorPrototype[Symbol.iterator];
+
+    MapIteratorPrototype[Symbol.iterator] = function() {
+        return {
+            next: () => ({ done: true })
+        };
+    };
+
+    // This should use the slow path with modified behavior
+    const result = spreadValues(map);
+    shouldBeArray(result, []);
+
+    // Restore
+    MapIteratorPrototype[Symbol.iterator] = originalIterator;
+}
+
+// Test OSR exit with different map types
+{
+    function testMixed(iterable) {
+        return [...iterable];
+    }
+
+    const map = new Map([[1, 'a'], [2, 'b']]);
+    const set = new Set([1, 2, 3]);
+    const array = [4, 5, 6];
+
+    // Warm up with map iterator
+    for (let i = 0; i < 5000; i++)
+        testMixed(map.keys());
+
+    shouldBeArray(testMixed(map.keys()), [1, 2]);
+
+    // Should still work with different iterables (causes speculation failure)
+    shouldBeArray(testMixed(set), [1, 2, 3]);
+    shouldBeArray(testMixed(array), [4, 5, 6]);
+    shouldBeArray(testMixed(map.values()), ['a', 'b']);
+}
+
+// Test OSR exit when map is modified during iteration
+{
+    function spreadKeysWithModification(map, modifyFn) {
+        const iter = map.keys();
+        modifyFn(map);
+        return [...iter];
+    }
+
+    // Warm up without modification
+    for (let i = 0; i < 5000; i++) {
+        const m = new Map([[1, 'a'], [2, 'b']]);
+        spreadKeysWithModification(m, () => {});
+    }
+
+    // Now test with modification
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    const result = spreadKeysWithModification(map, (m) => m.delete(2));
+    // After deletion, spread should return remaining keys
+    // Note: behavior depends on implementation - we just verify it doesn't crash
+    shouldBe(result.length <= 3, true);
+}

--- a/JSTests/stress/spread-map-iterator.js
+++ b/JSTests/stress/spread-map-iterator.js
@@ -1,0 +1,148 @@
+// Basic functionality tests for spread on Map iterator objects
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; i++)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Test basic spread on map.keys()
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    const keys = [...map.keys()];
+    shouldBeArray(keys, [1, 2, 3]);
+}
+
+// Test basic spread on map.values()
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    const values = [...map.values()];
+    shouldBeArray(values, ['a', 'b', 'c']);
+}
+
+// Test empty map
+{
+    const map = new Map();
+    const keys = [...map.keys()];
+    const values = [...map.values()];
+    shouldBeArray(keys, []);
+    shouldBeArray(values, []);
+}
+
+// Test single element
+{
+    const map = new Map([[42, 'answer']]);
+    shouldBeArray([...map.keys()], [42]);
+    shouldBeArray([...map.values()], ['answer']);
+}
+
+// Test various key/value types
+{
+    const obj = {};
+    const sym = Symbol('test');
+    const map = new Map([
+        ['string', 1],
+        [42, 2],
+        [obj, 3],
+        [sym, 4],
+        [null, 5],
+        [undefined, 6]
+    ]);
+
+    const keys = [...map.keys()];
+    shouldBe(keys.length, 6);
+    shouldBe(keys[0], 'string');
+    shouldBe(keys[1], 42);
+    shouldBe(keys[2], obj);
+    shouldBe(keys[3], sym);
+    shouldBe(keys[4], null);
+    shouldBe(keys[5], undefined);
+
+    const values = [...map.values()];
+    shouldBeArray(values, [1, 2, 3, 4, 5, 6]);
+}
+
+// Test that spread consumes iterator
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    const iter = map.keys();
+    iter.next(); // consume first element
+    const remaining = [...iter];
+    shouldBeArray(remaining, [2, 3]);
+}
+
+// Test that spread consumes iterator (values)
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    const iter = map.values();
+    iter.next(); // consume first element
+    const remaining = [...iter];
+    shouldBeArray(remaining, ['b', 'c']);
+}
+
+// Test closed iterator
+{
+    const map = new Map([[1, 'a'], [2, 'b']]);
+    const iter = map.keys();
+    iter.next();
+    iter.next();
+    iter.next(); // close iterator
+    const result = [...iter];
+    shouldBeArray(result, []);
+}
+
+// Test large map
+{
+    const map = new Map();
+    for (let i = 0; i < 1000; i++)
+        map.set(i, i * 2);
+
+    const keys = [...map.keys()];
+    const values = [...map.values()];
+
+    shouldBe(keys.length, 1000);
+    shouldBe(values.length, 1000);
+    shouldBe(keys[500], 500);
+    shouldBe(values[500], 1000);
+}
+
+// Test that original map is not modified
+{
+    const map = new Map([[1, 'a'], [2, 'b']]);
+    const keys = [...map.keys()];
+    keys.push(3);
+    shouldBe(map.size, 2);
+    shouldBe(keys.length, 3);
+}
+
+// Test insertion order is preserved
+{
+    const map = new Map();
+    map.set('z', 1);
+    map.set('a', 2);
+    map.set('m', 3);
+
+    shouldBeArray([...map.keys()], ['z', 'a', 'm']);
+    shouldBeArray([...map.values()], [1, 2, 3]);
+}
+
+// Test re-insertion maintains order
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    map.set(1, 'x'); // re-insert, should not change order
+    shouldBeArray([...map.keys()], [1, 2, 3]);
+    shouldBeArray([...map.values()], ['x', 'b', 'c']);
+}
+
+// Test delete and spread
+{
+    const map = new Map([[1, 'a'], [2, 'b'], [3, 'c']]);
+    map.delete(2);
+    shouldBeArray([...map.keys()], [1, 3]);
+    shouldBeArray([...map.values()], ['a', 'c']);
+}

--- a/Source/JavaScriptCore/bytecode/SpeculatedType.h
+++ b/Source/JavaScriptCore/bytecode/SpeculatedType.h
@@ -251,6 +251,11 @@ inline bool isSetObjectSpeculation(SpeculatedType value)
     return value == SpecSetObject;
 }
 
+inline bool isMapIteratorSpeculation(SpeculatedType value)
+{
+    return value == SpecMapIteratorObject;
+}
+
 inline bool isGlobalProxySpeculation(SpeculatedType value)
 {
     return value == SpecGlobalProxy;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3682,8 +3682,8 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             break;
         default:
             if (!m_graph.canDoFastSpread(node, forNode(node->child1()))) {
-                // SetObjectUse has no side effects since we iterate directly over internal storage.
-                if (node->child1().useKind() == SetObjectUse)
+                // SetObjectUse and MapIteratorObjectUse have no side effects since we iterate directly over internal storage.
+                if (node->child1().useKind() == SetObjectUse || node->child1().useKind() == MapIteratorObjectUse)
                     didFoldClobberWorld();
                 else
                     clobberWorld();

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1977,6 +1977,10 @@ private:
                 && m_graph.isWatchingSetIteratorProtocolWatchpoint(node->child1().node())
                 && m_graph.isWatchingHavingABadTimeWatchpoint(node->child1().node()))
                 fixEdge<SetObjectUse>(node->child1());
+            else if (node->child1()->shouldSpeculateMapIteratorObject()
+                && m_graph.isWatchingMapIteratorProtocolWatchpoint(node->child1().node())
+                && m_graph.isWatchingHavingABadTimeWatchpoint(node->child1().node()))
+                fixEdge<MapIteratorObjectUse>(node->child1());
             else
                 fixEdge<CellUse>(node->child1());
             break;

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -909,6 +909,13 @@ public:
         return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::SetIteratorProtocolWatchpointSet);
     }
 
+    bool isWatchingMapIteratorProtocolWatchpoint(Node* node)
+    {
+        JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);
+        InlineWatchpointSet& set = globalObject->mapIteratorProtocolWatchpointSet();
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::MapIteratorProtocolWatchpointSet);
+    }
+
     bool isWatchingNumberToStringWatchpoint(Node* node)
     {
         JSGlobalObject* globalObject = globalObjectFor(node->origin.semantic);

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -49,6 +49,7 @@ JITData::JITData(unsigned stubInfoSize, unsigned poolSize, const JITCode& jitCod
         case LinkerIR::Type::ArrayBufferDetachWatchpointSet:
         case LinkerIR::Type::ArrayIteratorProtocolWatchpointSet:
         case LinkerIR::Type::SetIteratorProtocolWatchpointSet:
+        case LinkerIR::Type::MapIteratorProtocolWatchpointSet:
         case LinkerIR::Type::NumberToStringWatchpointSet:
         case LinkerIR::Type::StructureCacheClearedWatchpointSet:
         case LinkerIR::Type::StringToStringWatchpointSet:
@@ -151,6 +152,11 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
         case LinkerIR::Type::SetIteratorProtocolWatchpointSet: {
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
             success &= attemptToWatch(codeBlock, m_globalObject->setIteratorProtocolWatchpointSet(), watchpoint);
+            break;
+        }
+        case LinkerIR::Type::MapIteratorProtocolWatchpointSet: {
+            auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
+            success &= attemptToWatch(codeBlock, m_globalObject->mapIteratorProtocolWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::NumberToStringWatchpointSet: {

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -96,6 +96,7 @@ public:
         ArrayBufferDetachWatchpointSet,
         ArrayIteratorProtocolWatchpointSet,
         SetIteratorProtocolWatchpointSet,
+        MapIteratorProtocolWatchpointSet,
         NumberToStringWatchpointSet,
         StructureCacheClearedWatchpointSet,
         StringToStringWatchpointSet,

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3253,6 +3253,11 @@ public:
         return isSetObjectSpeculation(prediction());
     }
 
+    bool shouldSpeculateMapIteratorObject()
+    {
+        return isMapIteratorSpeculation(prediction());
+    }
+
     bool shouldSpeculateGlobalProxy()
     {
         return isGlobalProxySpeculation(prediction());

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -66,6 +66,7 @@
 #include "JSLexicalEnvironment.h"
 #include "JSMap.h"
 #include "JSMapIterator.h"
+#include "JSMapIteratorInlines.h"
 #include "JSPromiseConstructor.h"
 #include "JSPromiseReaction.h"
 #include "JSPropertyNameEnumerator.h"
@@ -4685,6 +4686,23 @@ JSC_DEFINE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject* globalObj
     JSSet* set = jsCast<JSSet*>(cell);
 
     OPERATION_RETURN(scope, JSCellButterfly::createFromSet(globalObject, set));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationSpreadMapIterator, JSCell*, (JSGlobalObject* globalObject, JSCell* cell))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT(jsDynamicCast<JSMapIterator*>(cell));
+    JSMapIterator* iterator = jsCast<JSMapIterator*>(cell);
+    // Entries is not supported in the fast path - it requires creating [key, value] pairs.
+    // The slow path in CommonSlowPathsInlines.h filters out Entries, but DFG/FTL may still
+    // reach here if the code was compiled before we observed Entries usage.
+    ASSERT(iterator->kind() == IterationKind::Keys || iterator->kind() == IterationKind::Values);
+
+    OPERATION_RETURN(scope, JSCellButterfly::createFromMapIterator(globalObject, iterator));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject* globalObject, JSCell* cell))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -401,6 +401,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueCo
 
 JSC_DECLARE_JIT_OPERATION(operationSpreadFastArray, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSpreadSet, JSCell*, (JSGlobalObject*, JSCell*));
+JSC_DECLARE_JIT_OPERATION(operationSpreadMapIterator, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSpreadGeneric, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationNewArrayWithSpreadSlow, JSCell*, (JSGlobalObject*, void*, uint32_t));
 JSC_DECLARE_JIT_OPERATION(operationCreateImmutableButterfly, JSCell*, (JSGlobalObject*, unsigned length));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10188,6 +10188,8 @@ IGNORE_CLANG_WARNINGS_END
             speculateArray(m_node->child1());
         else if (m_node->child1().useKind() == SetObjectUse)
             speculateSetObject(m_node->child1());
+        else if (m_node->child1().useKind() == MapIteratorObjectUse)
+            speculateMapIteratorObject(m_node->child1());
 
         if (m_graph.canDoFastSpread(m_node, m_state.forNode(m_node->child1()))) {
             LBasicBlock copyOnWriteContiguousCheck = m_out.newBlock();
@@ -10352,6 +10354,9 @@ IGNORE_CLANG_WARNINGS_END
             m_out.appendTo(continuation, lastNext);
             result = m_out.phi(pointerType(), fastResult, slowResult);
             mutatorFence();
+        } else if (m_node->child1().useKind() == MapIteratorObjectUse) {
+            // MapIterator spread does not use inline fast path; call the C++ operation directly.
+            result = vmCall(pointerType(), operationSpreadMapIterator, weakPointer(globalObject), argument);
         } else
             result = vmCall(pointerType(), operationSpreadGeneric, weakPointer(globalObject), argument);
 

--- a/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h
@@ -29,6 +29,7 @@
 #include "ClonedArguments.h"
 #include "CommonSlowPaths.h"
 #include "DirectArguments.h"
+#include "JSMapIteratorInlines.h"
 #include "JSSetInlines.h"
 #include "ScopedArguments.h"
 
@@ -199,6 +200,16 @@ ALWAYS_INLINE JSCellButterfly* trySpreadFast(JSGlobalObject* globalObject, JSCel
         auto* set = jsCast<JSSet*>(iterable);
         if (set->isIteratorProtocolFastAndNonObservable()) [[likely]]
             return JSCellButterfly::createFromSet(globalObject, set);
+        return nullptr;
+    }
+    case JSMapIteratorType: {
+        auto* iterator = jsCast<JSMapIterator*>(iterable);
+        // IterationKind::Entries requires more complex processing (returns [key, value] pairs).
+        // This optimization only handles Keys and Values.
+        if (iterator->kind() == IterationKind::Entries)
+            return nullptr;
+        if (iterator->isIteratorProtocolFastAndNonObservable()) [[likely]]
+            return JSCellButterfly::createFromMapIterator(globalObject, iterator);
         return nullptr;
     }
     default:

--- a/Source/JavaScriptCore/runtime/JSCellButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSCellButterfly.h
@@ -40,6 +40,7 @@ namespace JSC {
 
 class ClonedArguments;
 class DirectArguments;
+class JSMapIterator;
 class JSSet;
 class ScopedArguments;
 
@@ -149,6 +150,7 @@ public:
     static JSCellButterfly* createFromDirectArguments(JSGlobalObject*, DirectArguments*);
     static JSCellButterfly* createFromScopedArguments(JSGlobalObject*, ScopedArguments*);
     static JSCellButterfly* createFromSet(JSGlobalObject*, JSSet*);
+    static JSCellButterfly* createFromMapIterator(JSGlobalObject*, JSMapIterator*);
     static JSCellButterfly* createFromString(JSGlobalObject*, JSString*);
     static JSCellButterfly* tryCreateFromArgList(VM&, ArgList);
 

--- a/Source/JavaScriptCore/runtime/JSMapIterator.h
+++ b/Source/JavaScriptCore/runtime/JSMapIterator.h
@@ -182,6 +182,8 @@ public:
     }
     JSMap::Helper::Entry entry() const { return JSMap::Helper::toNumber(internalField(Field::Entry).get()); }
 
+    inline bool isIteratorProtocolFastAndNonObservable();
+
     void setIteratedObject(VM& vm, JSMap* map) { internalField(Field::IteratedObject).set(vm, this, map); }
     void setStorage(VM& vm, JSCell* storage) { internalField(Field::Storage).set(vm, this, storage); }
     void setEntry(VM& vm, JSMap::Helper::Entry entry) { internalField(Field::Entry).set(vm, this, JSMap::Helper::toJSValue(entry)); }

--- a/Source/JavaScriptCore/runtime/JSMapIteratorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSMapIteratorInlines.h
@@ -25,13 +25,36 @@
 
 #pragma once
 
+#include "JSGlobalObjectInlines.h"
 #include "JSMapIterator.h"
+#include "MapIteratorPrototype.h"
 
 namespace JSC {
 
 inline Structure* JSMapIterator::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
 {
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSMapIteratorType, StructureFlags), info());
+}
+
+ALWAYS_INLINE bool JSMapIterator::isIteratorProtocolFastAndNonObservable()
+{
+    JSGlobalObject* globalObject = this->globalObject();
+    if (!globalObject->isMapPrototypeIteratorProtocolFastAndNonObservable())
+        return false;
+
+    VM& vm = globalObject->vm();
+    Structure* structure = this->structure();
+    // This is the fast case. Many map iterators will be an original map iterator.
+    if (structure == globalObject->mapIteratorStructure())
+        return true;
+
+    if (getPrototypeDirect() != globalObject->mapIteratorPrototype())
+        return false;
+
+    if (getDirectOffset(vm, vm.propertyNames->next) != invalidOffset)
+        return false;
+
+    return true;
 }
 
 } // namespace JSC


### PR DESCRIPTION
#### a82152a948706387199daa4d8c53c74dcca27318
<pre>
[JSC] Optimize `[...map.keys()]` and `[...map.values()]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=306740">https://bugs.webkit.org/show_bug.cgi?id=306740</a>

Reviewed by Yusuke Suzuki.

This patch changes to optimize `[...map.keys()]` and `[...map.values()]`.

                           TipOfTree                  Patched

spread-map-keys          6.1927+-0.1612     ^      1.6373+-0.1146        ^ definitely 3.7822x faster
spread-map-values        6.3760+-0.1259     ^      1.6840+-0.0844        ^ definitely 3.7862x faster

* JSTests/microbenchmarks/spread-map-keys.js: Added.
(benchmarkSpreadMapKeys):
* JSTests/microbenchmarks/spread-map-values.js: Added.
(benchmarkSpreadMapValues):
* JSTests/stress/spread-map-iterator-dfg-ftl.js: Added.
(shouldBe):
(shouldBeArray):
(testSpreadKeys):
(testSpreadValues):
(testPartialIteratorKeys):
(testPartialIteratorValues):
(testConsistentStructure):
* JSTests/stress/spread-map-iterator-having-a-bad-time.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBe.spreadKeys):
(shouldBe.spreadValues):
(spreadKeys):
(spreadValues):
(shouldBeArray.testSpread):
(spreadTest):
* JSTests/stress/spread-map-iterator-osr-exit.js: Added.
(shouldBe):
(shouldBeArray):
(shouldBe.spreadKeys):
(shouldBe.MapIteratorPrototype.next):
(spreadValues):
(MapIteratorPrototype.Symbol.iterator):
(testMixed):
(spreadKeysWithModification):
(set shouldBeArray):
* JSTests/stress/spread-map-iterator.js: Added.
(shouldBe):
(shouldBeArray):
* Source/JavaScriptCore/bytecode/SpeculatedType.h:
(JSC::isMapIteratorSpeculation):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::JITData):
(JSC::DFG::JITData::tryInitialize):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::shouldSpeculateMapIteratorObject):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileSpread):
* Source/JavaScriptCore/runtime/CommonSlowPathsInlines.h:
(JSC::CommonSlowPaths::trySpreadFast):
* Source/JavaScriptCore/runtime/JSCellButterfly.cpp:
(JSC::JSCellButterfly::createFromMapIterator):
* Source/JavaScriptCore/runtime/JSCellButterfly.h:
* Source/JavaScriptCore/runtime/JSMapIterator.h:
* Source/JavaScriptCore/runtime/JSMapIteratorInlines.h:
(JSC::JSMapIterator::isIteratorProtocolFastAndNonObservable):

Canonical link: <a href="https://commits.webkit.org/306710@main">https://commits.webkit.org/306710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d48f21deb3ee0cf73e66e043487918eb9a1521d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95244 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109208 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78935 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90105 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11274 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8937 "Found 1 new API test failure: TestWebKitAPI.WebKit2.GetUserMediaAfterMuting (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/734 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134052 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153051 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2872 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14143 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117278 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117598 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13644 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69843 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14192 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3376 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173357 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77908 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44872 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->