### PR TITLE
[WPE] Touch event preventDefault() should prevent synthetic click events

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -240,25 +240,28 @@ void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent&, bool)
 #if ENABLE(TOUCH_EVENTS)
 void PageClientImpl::doneWithTouchEvent(const WebTouchEvent& touchEvent, bool wasEventHandled)
 {
-    if (wasEventHandled) {
-#if ENABLE(WPE_PLATFORM)
-        // If the touch event was handled, we must interrupt any gesture detection sequence ongoing so that gestures
-        // are not detected by engine itself.
-        if (!m_view.wpeView())
-            return;
-        if (auto* gestureController = wpe_view_get_gesture_controller(m_view.wpeView()))
-            wpe_gesture_controller_cancel(gestureController);
-#endif
-        return;
-    }
-
 #if ENABLE(WPE_PLATFORM)
     if (m_view.wpeView()) {
-        if (touchEvent.isNativeWebTouchEvent())
-            static_cast<WKWPE::ViewPlatform&>(m_view).handleGesture(static_cast<const NativeWebTouchEvent&>(touchEvent).nativeEvent());
+        if (wasEventHandled) {
+            // If the touch event was handled, we must interrupt any gesture detection sequence ongoing so that gestures
+            // are not detected by engine itself.
+            if (auto* gestureController = wpe_view_get_gesture_controller(m_view.wpeView()))
+                wpe_gesture_controller_cancel(gestureController);
+        } else {
+            // First, let the gesture controller process the event and potentially recognize a TAP gesture.
+            if (touchEvent.isNativeWebTouchEvent())
+                static_cast<WKWPE::ViewPlatform&>(m_view).handleGesture(static_cast<const NativeWebTouchEvent&>(touchEvent).nativeEvent());
+        }
+
+        // Complete any pending TAP gesture. If the touch event was handled by the page
+        // (e.g., preventDefault was called), synthetic mouse events will not be generated.
+        static_cast<WKWPE::ViewPlatform&>(m_view).completePendingGesture(wasEventHandled);
         return;
     }
 #endif
+
+    if (wasEventHandled)
+        return;
 
 #if USE(LIBWPE)
     const struct wpe_input_touch_event_raw* touchPoint = touchEvent.isNativeWebTouchEvent() ? static_cast<const NativeWebTouchEvent&>(touchEvent).nativeFallbackTouchPoint() : nullptr;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -441,32 +441,12 @@ void ViewPlatform::handleGesture(WPEEvent* event)
     case WPE_GESTURE_TAP:
         if (wpe_event_get_event_type(event) == WPE_EVENT_TOUCH_MOVE)
             return;
+        // Store the pending TAP gesture; synthetic mouse events will be generated
+        // later in completePendingGesture() only if the touch was not handled by the page.
         if (double x, y; wpe_gesture_controller_get_gesture_position(gestureController, &x, &y)) {
-            // Mouse motion towards the point of the click.
-            {
-                GRefPtr<WPEEvent> simulatedEvent = adoptGRef(wpe_event_pointer_move_new(
-                    WPE_EVENT_POINTER_MOVE, m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, static_cast<WPEModifiers>(0), x, y, 0, 0
-                ));
-                page().handleMouseEvent(WebKit::NativeWebMouseEvent(simulatedEvent.get()));
-            }
-
-            // Mouse down on the point of the click.
-            {
-                GRefPtr<WPEEvent> simulatedEvent = adoptGRef(wpe_event_pointer_button_new(
-                    WPE_EVENT_POINTER_DOWN, m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, WPE_MODIFIER_POINTER_BUTTON1, 1, x, y, 1
-                ));
-                page().handleMouseEvent(WebKit::NativeWebMouseEvent(simulatedEvent.get()));
-            }
-
-            wpe_view_focus_in(m_wpeView.get());
-
-            // Mouse up on the same location.
-            {
-                GRefPtr<WPEEvent> simulatedEvent = adoptGRef(wpe_event_pointer_button_new(
-                    WPE_EVENT_POINTER_UP, m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, static_cast<WPEModifiers>(0), 1, x, y, 0
-                ));
-                page().handleMouseEvent(WebKit::NativeWebMouseEvent(simulatedEvent.get()));
-            }
+            m_hasPendingTapGesture = true;
+            m_pendingTapX = x;
+            m_pendingTapY = y;
         }
         break;
     case WPE_GESTURE_DRAG:
@@ -479,6 +459,48 @@ void ViewPlatform::handleGesture(WPEEvent* event)
                 : (wpe_event_get_event_type(event) == WPE_EVENT_TOUCH_UP) ? WebWheelEvent::Phase::Ended : WebWheelEvent::Phase::Changed;
             page().handleNativeWheelEvent(WebKit::NativeWebWheelEvent(simulatedScrollEvent.get(), phase));
         }
+    }
+}
+
+void ViewPlatform::completePendingGesture(bool wasEventHandled)
+{
+    if (!m_hasPendingTapGesture)
+        return;
+
+    m_hasPendingTapGesture = false;
+
+    // If the touch event was handled by the page (e.g., preventDefault was called),
+    // don't generate synthetic mouse events.
+    if (wasEventHandled)
+        return;
+
+    double x = m_pendingTapX;
+    double y = m_pendingTapY;
+
+    // Mouse motion towards the point of the click.
+    {
+        GRefPtr<WPEEvent> simulatedEvent = adoptGRef(wpe_event_pointer_move_new(
+            WPE_EVENT_POINTER_MOVE, m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, static_cast<WPEModifiers>(0), x, y, 0, 0
+        ));
+        page().handleMouseEvent(WebKit::NativeWebMouseEvent(simulatedEvent.get()));
+    }
+
+    // Mouse down on the point of the click.
+    {
+        GRefPtr<WPEEvent> simulatedEvent = adoptGRef(wpe_event_pointer_button_new(
+            WPE_EVENT_POINTER_DOWN, m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, WPE_MODIFIER_POINTER_BUTTON1, 1, x, y, 1
+        ));
+        page().handleMouseEvent(WebKit::NativeWebMouseEvent(simulatedEvent.get()));
+    }
+
+    wpe_view_focus_in(m_wpeView.get());
+
+    // Mouse up on the same location.
+    {
+        GRefPtr<WPEEvent> simulatedEvent = adoptGRef(wpe_event_pointer_button_new(
+            WPE_EVENT_POINTER_UP, m_wpeView.get(), WPE_INPUT_SOURCE_TOUCHSCREEN, 0, static_cast<WPEModifiers>(0), 1, x, y, 0
+        ));
+        page().handleMouseEvent(WebKit::NativeWebMouseEvent(simulatedEvent.get()));
     }
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -69,6 +69,7 @@ public:
     WebKit::RendererBufferDescription renderBufferDescription() const;
 
     void handleGesture(WPEEvent*);
+    void completePendingGesture(bool wasEventHandled);
 
 private:
     ViewPlatform(WPEDisplay*, const API::PageConfiguration&);
@@ -96,6 +97,9 @@ private:
     gboolean handleEvent(WPEEvent*);
 
     GRefPtr<WPEView> m_wpeView;
+    bool m_hasPendingTapGesture { false };
+    double m_pendingTapX { 0 };
+    double m_pendingTapY { 0 };
     RefPtr<WebKit::AcceleratedBackingStore> m_backingStore;
     uint32_t m_displayID { 0 };
     unsigned long m_bufferRenderedID { 0 };


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=306724

Reviewed by NOBODY (OOPS!).

When a touch event handler calls preventDefault(), synthetic mouse events should not be generated. This patch defers TAP gesture completion until after doneWithTouchEvent() is called.

* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp: (WebKit::PageClientImpl::doneWithTouchEvent):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp: (WKWPE::ViewPlatform::handleGesture):
(WKWPE::ViewPlatform::completePendingGesture):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h:

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06ceae9f348bf0609a2604dfb87d6984265d88b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94956 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108989 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78820 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8735 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/491 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120406 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13906 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117079 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117401 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13453 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123653 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69577 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13944 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2934 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77669 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->