### PR TITLE
Reduce use of protected functions in Source/WebCore/workers

### DIFF
--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -706,7 +706,7 @@ void ScriptExecutionContext::registerServiceWorker(ServiceWorker& serviceWorker)
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 
     ensureOnMainThread([identifier = serviceWorker.identifier()] {
-        ServiceWorkerProvider::singleton().protectedServiceWorkerConnection()->registerServiceWorkerInServer(identifier);
+        protect(ServiceWorkerProvider::singleton().serviceWorkerConnection())->registerServiceWorkerInServer(identifier);
     });
 }
 
@@ -715,7 +715,7 @@ void ScriptExecutionContext::unregisterServiceWorker(ServiceWorker& serviceWorke
     m_serviceWorkers.remove(serviceWorker.identifier());
 
     ensureOnMainThread([identifier = serviceWorker.identifier()] {
-        ServiceWorkerProvider::singleton().protectedServiceWorkerConnection()->unregisterServiceWorkerInServer(identifier);
+        protect(ServiceWorkerProvider::singleton().serviceWorkerConnection())->unregisterServiceWorkerInServer(identifier);
     });
 }
 

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -241,7 +241,7 @@ ExceptionOr<std::optional<OffscreenRenderingContext>> OffscreenCanvas::getContex
             RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
             Ref scriptExecutionContext = *this->scriptExecutionContext();
             if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext)) {
-                if (RefPtr gpu = globalScope->protectedNavigator()->gpu())
+                if (RefPtr gpu = protect(globalScope->navigator())->gpu())
                     m_context = GPUCanvasContext::create(*this, *gpu, nullptr);
             } else if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext)) {
                 if (RefPtr window = document->window()) {

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -609,7 +609,7 @@ void DocumentLoader::matchRegistration(const URL& url, SWClientConnection::Regis
 
     RefPtr frame = m_frame.get();
     auto origin = (!frame->isMainFrame() && frame->document()) ? protect(frame->document())->topOrigin().data() : SecurityOriginData::fromURL(url);
-    if (!ServiceWorkerProvider::singleton().protectedServiceWorkerConnection()->mayHaveServiceWorkerRegisteredForOrigin(origin)) {
+    if (!protect(ServiceWorkerProvider::singleton().serviceWorkerConnection())->mayHaveServiceWorkerRegisteredForOrigin(origin)) {
         callback(std::nullopt);
         return;
     }

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -303,7 +303,7 @@ void WorkerThreadableLoader::MainThreadBridge::didFinishTiming(const ResourceTim
 
         // No need to notify clients, just add the performance timing entry.
         if (auto* globalScope = dynamicDowncast<WorkerGlobalScope>(context))
-            globalScope->protectedPerformance()->addResourceTiming(WTF::move(resourceTiming));
+            protect(globalScope->performance())->addResourceTiming(WTF::move(resourceTiming));
     }, m_taskMode);
 }
 

--- a/Source/WebCore/workers/ScriptBuffer.h
+++ b/Source/WebCore/workers/ScriptBuffer.h
@@ -46,7 +46,7 @@ public:
     String toString() const;
     const SharedBufferBuilder& bufferBuilder() const { return m_buffer; }
     const FragmentedSharedBuffer* buffer() const { return m_buffer.buffer(); }
-    RefPtr<const FragmentedSharedBuffer> protectedBuffer() const { return m_buffer.buffer(); }
+    RefPtr<const FragmentedSharedBuffer> bufferForSerialization() const { return m_buffer.buffer(); }
     size_t size() const { return m_buffer.size(); }
 
     ScriptBuffer isolatedCopy() const { return ScriptBuffer(m_buffer ? RefPtr<FragmentedSharedBuffer>(m_buffer.copyBuffer()) : nullptr); }

--- a/Source/WebCore/workers/WorkerAnimationController.cpp
+++ b/Source/WebCore/workers/WorkerAnimationController.cpp
@@ -116,14 +116,14 @@ void WorkerAnimationController::scheduleAnimation()
         return;
 
     Seconds animationInterval = RequestAnimationFrameCallback::fullSpeedAnimationInterval;
-    Seconds scheduleDelay = std::max(animationInterval - Seconds::fromMilliseconds(m_workerGlobalScope->protectedPerformance()->now() - m_lastAnimationFrameTimestamp), 0_s);
+    Seconds scheduleDelay = std::max(animationInterval - Seconds::fromMilliseconds(protect(m_workerGlobalScope->performance())->now() - m_lastAnimationFrameTimestamp), 0_s);
 
     m_animationTimer.startOneShot(scheduleDelay);
 }
 
 void WorkerAnimationController::animationTimerFired()
 {
-    m_lastAnimationFrameTimestamp = m_workerGlobalScope->protectedPerformance()->now();
+    m_lastAnimationFrameTimestamp = protect(m_workerGlobalScope->performance())->now();
     serviceRequestAnimationFrameCallbacks(m_lastAnimationFrameTimestamp);
 }
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -227,11 +227,6 @@ SocketProvider* WorkerGlobalScope::socketProvider()
     return m_socketProvider.get();
 }
 
-RefPtr<SocketProvider> WorkerGlobalScope::protectedSocketProvider()
-{
-    return socketProvider();
-}
-
 RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerGlobalScope::createRTCDataChannelRemoteHandlerConnection()
 {
     RefPtr<RTCDataChannelRemoteHandlerConnection> connection;
@@ -332,11 +327,6 @@ WorkerNavigator& WorkerGlobalScope::navigator()
     if (!m_navigator)
         lazyInitialize(m_navigator, WorkerNavigator::create(*this, m_userAgent, m_isOnline));
     return *m_navigator;
-}
-
-Ref<WorkerNavigator> WorkerGlobalScope::protectedNavigator()
-{
-    return navigator();
 }
 
 void WorkerGlobalScope::setIsOnline(bool isOnline)
@@ -556,11 +546,6 @@ Crypto& WorkerGlobalScope::crypto()
 }
 
 Performance& WorkerGlobalScope::performance() const
-{
-    return *m_performance;
-}
-
-Ref<Performance> WorkerGlobalScope::protectedPerformance() const
 {
     return *m_performance;
 }

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -124,7 +124,6 @@ public:
 
     virtual ExceptionOr<void> importScripts(const FixedVector<Variant<RefPtr<TrustedScriptURL>, String>>& urls);
     WorkerNavigator& navigator();
-    Ref<WorkerNavigator> protectedNavigator();
 
     void setIsOnline(bool);
     bool isOnline() const { return m_isOnline; }
@@ -146,7 +145,6 @@ public:
 
     Crypto& crypto();
     Performance& performance() const;
-    Ref<Performance> protectedPerformance() const;
     ReportingScope& reportingScope() const { return m_reportingScope.get(); }
 
     void prepareForDestruction() override;
@@ -205,7 +203,6 @@ private:
     EventTarget* errorEventTarget() final;
     String resourceRequestIdentifier() const final { return m_inspectorIdentifier; }
     SocketProvider* socketProvider() final;
-    RefPtr<SocketProvider> protectedSocketProvider();
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
 
     bool shouldBypassMainWorldContentSecurityPolicy() const final { return m_shouldBypassMainWorldContentSecurityPolicy; }

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -458,7 +458,7 @@ void WorkerOrWorkletScriptController::linkAndEvaluateModule(WorkerScriptFetcher&
     }
 
     if (returnedException) {
-        if (protectedGlobalScope()->canIncludeErrorDetails(sourceCode.cachedScript(), sourceCode.url().string())) {
+        if (protect(globalScope())->canIncludeErrorDetails(sourceCode.cachedScript(), sourceCode.url().string())) {
             // FIXME: It's not great that this can run arbitrary code to string-ify the value of the exception.
             // Do we need to do anything to handle that properly, if it, say, raises another exception?
             if (returnedExceptionMessage)
@@ -472,11 +472,6 @@ void WorkerOrWorkletScriptController::linkAndEvaluateModule(WorkerScriptFetcher&
         JSLockHolder lock(vm);
         reportException(m_globalScopeWrapper.get(), returnedException);
     }
-}
-
-RefPtr<WorkerOrWorkletGlobalScope> WorkerOrWorkletScriptController::protectedGlobalScope() const
-{
-    return m_globalScope.get();
 }
 
 void WorkerOrWorkletScriptController::loadAndEvaluateModule(const URL& moduleURL, FetchOptions::Credentials credentials, CompletionHandler<void(std::optional<Exception>&&)>&& completionHandler)
@@ -625,7 +620,7 @@ void WorkerOrWorkletScriptController::initScriptWithSubclass()
     ASSERT(m_globalScopeWrapper->globalObject() == m_globalScopeWrapper);
     ASSERT(asObject(m_globalScopeWrapper->getPrototypeDirect())->globalObject() == m_globalScopeWrapper);
 
-    m_consoleClient = makeUnique<WorkerConsoleClient>(*protectedGlobalScope());
+    m_consoleClient = makeUnique<WorkerConsoleClient>(*protect(globalScope()));
     m_globalScopeWrapper->setConsoleClient(*m_consoleClient);
 }
 

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -112,7 +112,6 @@ public:
 
 protected:
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
-    RefPtr<WorkerOrWorkletGlobalScope> protectedGlobalScope() const;
 
     void initScriptIfNeeded()
     {

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -94,7 +94,7 @@ void WorkerOrWorkletThread::startRunningDebuggerTasks()
 
     MessageQueueWaitResult result;
     do {
-        result = downcast<WorkerDedicatedRunLoop>(m_runLoop.get()).runInDebuggerMode(*protectedGlobalScope());
+        result = downcast<WorkerDedicatedRunLoop>(m_runLoop.get()).runInDebuggerMode(*protect(globalScope()));
     } while (result != MessageQueueTerminated && m_pausedForDebugger);
 }
 
@@ -107,7 +107,7 @@ void WorkerOrWorkletThread::runEventLoop()
 {
     // Does not return until terminated.
     if (auto* runLoop = dynamicDowncast<WorkerDedicatedRunLoop>(m_runLoop.get()))
-        runLoop->run(protectedGlobalScope().get());
+        runLoop->run(protect(globalScope()).get());
 }
 
 void WorkerOrWorkletThread::workerOrWorkletThread()
@@ -119,7 +119,7 @@ void WorkerOrWorkletThread::workerOrWorkletThread()
         if (!m_globalScope)
             return;
 
-        downcast<WorkerMainRunLoop>(m_runLoop.get()).setGlobalScope(*protectedGlobalScope());
+        downcast<WorkerMainRunLoop>(m_runLoop.get()).setGlobalScope(*protect(globalScope()));
 
         String exceptionMessage;
         evaluateScriptIfNecessary(exceptionMessage);
@@ -363,11 +363,6 @@ void WorkerOrWorkletThread::removeChildThread(WorkerOrWorkletThread& childThread
 CheckedPtr<WorkerLoaderProxy> WorkerOrWorkletThread::checkedWorkerLoaderProxy() const
 {
     return workerLoaderProxy();
-}
-
-RefPtr<WorkerOrWorkletGlobalScope> WorkerOrWorkletThread::protectedGlobalScope() const
-{
-    return m_globalScope.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -63,7 +63,6 @@ public:
     virtual CheckedPtr<WorkerLoaderProxy> checkedWorkerLoaderProxy() const;
 
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
-    RefPtr<WorkerOrWorkletGlobalScope> protectedGlobalScope() const;
     WorkerRunLoop& runLoop() { return m_runLoop; }
 
     void start(Function<void(const String&)>&& evaluateCallback = { });

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -105,11 +105,6 @@ SWClientConnection& ServiceWorker::swConnection()
     return ServiceWorkerProvider::singleton().serviceWorkerConnection();
 }
 
-Ref<SWClientConnection> ServiceWorker::protectedSWConnection()
-{
-    return swConnection();
-}
-
 ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
     if (m_isStopped)
@@ -134,7 +129,7 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
     }();
 
     MessageWithMessagePorts message { messageData.releaseReturnValue(), portsOrException.releaseReturnValue() };
-    protectedSWConnection()->postMessageToServiceWorker(identifier(), WTF::move(message), sourceIdentifier);
+    protect(swConnection())->postMessageToServiceWorker(identifier(), WTF::move(message), sourceIdentifier);
     return { };
 }
 

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -89,7 +89,6 @@ private:
     void stop() final;
 
     SWClientConnection& swConnection();
-    Ref<SWClientConnection> protectedSWConnection();
 
     ServiceWorkerData m_data;
     bool m_isStopped { false };

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -68,7 +68,7 @@ Ref<ServiceWorkerGlobalScope> ServiceWorkerGlobalScope::create(ServiceWorkerCont
 ServiceWorkerGlobalScope::ServiceWorkerGlobalScope(ServiceWorkerContextData&& contextData, ServiceWorkerData&& workerData, const WorkerParameters& params, Ref<SecurityOrigin>&& origin, ServiceWorkerThread& thread, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy* connectionProxy, SocketProvider* socketProvider, std::unique_ptr<NotificationClient>&& notificationClient, std::unique_ptr<WorkerClient>&& workerClient)
     : WorkerGlobalScope(WorkerThreadType::ServiceWorker, params, WTF::move(origin), thread, WTF::move(topOrigin), connectionProxy, socketProvider, WTF::move(workerClient))
     , m_contextData(WTF::move(contextData))
-    , m_registration(ServiceWorkerRegistration::getOrCreate(*this, protectedNavigator()->serviceWorker(), WTF::move(m_contextData.registration)))
+    , m_registration(ServiceWorkerRegistration::getOrCreate(*this, protect(navigator())->serviceWorker(), WTF::move(m_contextData.registration)))
     , m_serviceWorker(ServiceWorker::getOrCreate(*this, WTF::move(workerData)))
     , m_clients(ServiceWorkerClients::create())
     , m_notificationClient(WTF::move(notificationClient))

--- a/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
@@ -54,9 +54,4 @@ void ServiceWorkerProvider::setSharedProvider(ServiceWorkerProvider& newProvider
     sharedProvider = &newProvider;
 }
 
-Ref<SWClientConnection> ServiceWorkerProvider::protectedServiceWorkerConnection()
-{
-    return serviceWorkerConnection();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerProvider.h
+++ b/Source/WebCore/workers/service/ServiceWorkerProvider.h
@@ -41,7 +41,6 @@ public:
     static void setSharedProvider(ServiceWorkerProvider&);
 
     virtual SWClientConnection& serviceWorkerConnection() = 0;
-    Ref<SWClientConnection> protectedServiceWorkerConnection();
     virtual SWClientConnection* existingServiceWorkerConnection() = 0;
     virtual void terminateWorkerForTesting(ServiceWorkerIdentifier, CompletionHandler<void()>&&) = 0;
 

--- a/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
@@ -52,7 +52,7 @@ void ServiceWorkerWindowClient::focus(ScriptExecutionContext& context, Ref<Defer
 
     auto promiseIdentifier = serviceWorkerContext.clients().addPendingPromise(WTF::move(promise));
     callOnMainThread([clientIdentifier = identifier(), promiseIdentifier, serviceWorkerIdentifier = serviceWorkerContext.thread()->identifier()]() mutable {
-        SWContextManager::singleton().protectedConnection()->focus(clientIdentifier, [promiseIdentifier, serviceWorkerIdentifier](auto result) mutable {
+        protect(SWContextManager::singleton().connection())->focus(clientIdentifier, [promiseIdentifier, serviceWorkerIdentifier](auto result) mutable {
             SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, result = crossThreadCopy(WTF::move(result))](auto& serviceWorkerContext) mutable {
                 auto promise = serviceWorkerContext.clients().takePendingPromise(promiseIdentifier);
                 if (!promise)
@@ -88,7 +88,7 @@ void ServiceWorkerWindowClient::navigate(ScriptExecutionContext& context, const 
     auto& serviceWorkerContext = downcast<ServiceWorkerGlobalScope>(context);
     auto promiseIdentifier = serviceWorkerContext.clients().addPendingPromise(WTF::move(promise));
     callOnMainThread([clientIdentifier = identifier(), promiseIdentifier, serviceWorkerIdentifier = serviceWorkerContext.thread()->identifier(), url = WTF::move(url).isolatedCopy()]() mutable {
-        SWContextManager::singleton().protectedConnection()->navigate(clientIdentifier, serviceWorkerIdentifier, url, [promiseIdentifier, serviceWorkerIdentifier](auto result) mutable {
+        protect(SWContextManager::singleton().connection())->navigate(clientIdentifier, serviceWorkerIdentifier, url, [promiseIdentifier, serviceWorkerIdentifier](auto result) mutable {
             SWContextManager::singleton().postTaskToServiceWorker(serviceWorkerIdentifier, [promiseIdentifier, result = crossThreadCopy(WTF::move(result))](auto& serviceWorkerContext) mutable {
                 auto promise = serviceWorkerContext.clients().takePendingPromise(promiseIdentifier);
                 if (!promise)

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -88,10 +88,10 @@ void SWContextManager::registerServiceWorkerThreadForInstall(Ref<ServiceWorkerTh
 void SWContextManager::startedServiceWorker(std::optional<ServiceWorkerJobDataIdentifier> jobDataIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, const String& exceptionMessage, bool doesHandleFetch)
 {
     if (!exceptionMessage.isEmpty()) {
-        protectedConnection()->serviceWorkerFailedToStart(jobDataIdentifier, serviceWorkerIdentifier, exceptionMessage);
+        protect(connection())->serviceWorkerFailedToStart(jobDataIdentifier, serviceWorkerIdentifier, exceptionMessage);
         return;
     }
-    protectedConnection()->serviceWorkerStarted(jobDataIdentifier, serviceWorkerIdentifier, doesHandleFetch);
+    protect(connection())->serviceWorkerStarted(jobDataIdentifier, serviceWorkerIdentifier, doesHandleFetch);
 }
 
 ServiceWorkerThreadProxy* SWContextManager::serviceWorkerThreadProxy(ServiceWorkerIdentifier identifier) const

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -105,7 +105,6 @@ public:
 
     WEBCORE_EXPORT void setConnection(Ref<Connection>&&);
     WEBCORE_EXPORT Connection* connection() const;
-    RefPtr<Connection> protectedConnection() const { return m_connection; }
 
     WEBCORE_EXPORT void registerServiceWorkerThreadForInstall(Ref<ServiceWorkerThreadProxy>&&, Function<void()>&& debuggerTasksStartedCallback = { });
     WEBCORE_EXPORT ServiceWorkerThreadProxy* serviceWorkerThreadProxy(ServiceWorkerIdentifier) const;

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -91,7 +91,7 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
     size_t size = script.size();
 
     auto iterateOverBufferAndWriteData = [&](NOESCAPE const Function<bool(std::span<const uint8_t>)>& writeData) {
-        script.protectedBuffer()->forEachSegment([&](std::span<const uint8_t> span) {
+        protect(script.buffer())->forEachSegment([&](std::span<const uint8_t> span) {
             writeData(span);
         });
     };

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -277,7 +277,7 @@ void SWServer::removeRegistration(ServiceWorkerRegistrationIdentifier registrati
     if (RefPtr store = m_registrationStore)
         store->removeRegistration(registration->key());
 
-    protectedBackgroundFetchEngine()->remove(*registration);
+    protect(backgroundFetchEngine())->remove(*registration);
 }
 
 Vector<ServiceWorkerRegistrationData> SWServer::getRegistrations(const SecurityOriginData& topOrigin, const URL& clientURL)
@@ -1939,7 +1939,7 @@ void SWServer::Connection::startBackgroundFetch(ServiceWorkerRegistrationIdentif
             return;
         }
 
-        server->protectedBackgroundFetchEngine()->startBackgroundFetch(*registration, backgroundFetchIdentifier, WTF::move(requests), WTF::move(options), WTF::move(callback));
+        protect(server->backgroundFetchEngine())->startBackgroundFetch(*registration, backgroundFetchIdentifier, WTF::move(requests), WTF::move(options), WTF::move(callback));
     });
 }
 
@@ -1948,11 +1948,6 @@ BackgroundFetchEngine& SWServer::backgroundFetchEngine()
     if (!m_backgroundFetchEngine)
         m_backgroundFetchEngine = BackgroundFetchEngine::create(*this);
     return *m_backgroundFetchEngine;
-}
-
-Ref<BackgroundFetchEngine> SWServer::protectedBackgroundFetchEngine()
-{
-    return backgroundFetchEngine();
 }
 
 bool SWServer::addHandlerIfHasControlledClients(CompletionHandler<void()>&& completionHandler)
@@ -1980,7 +1975,7 @@ void SWServer::Connection::backgroundFetchInformation(ServiceWorkerRegistrationI
         return;
     }
 
-    server->protectedBackgroundFetchEngine()->backgroundFetchInformation(*registration, backgroundFetchIdentifier, WTF::move(callback));
+    protect(server->backgroundFetchEngine())->backgroundFetchInformation(*registration, backgroundFetchIdentifier, WTF::move(callback));
 }
 
 void SWServer::Connection::backgroundFetchIdentifiers(ServiceWorkerRegistrationIdentifier registrationIdentifier, BackgroundFetchEngine::BackgroundFetchIdentifiersCallback&& callback)
@@ -1997,7 +1992,7 @@ void SWServer::Connection::backgroundFetchIdentifiers(ServiceWorkerRegistrationI
         return;
     }
 
-    server->protectedBackgroundFetchEngine()->backgroundFetchIdentifiers(*registration, WTF::move(callback));
+    protect(server->backgroundFetchEngine())->backgroundFetchIdentifiers(*registration, WTF::move(callback));
 }
 
 void SWServer::Connection::abortBackgroundFetch(ServiceWorkerRegistrationIdentifier registrationIdentifier, const String& backgroundFetchIdentifier, BackgroundFetchEngine::AbortBackgroundFetchCallback&& callback)
@@ -2014,7 +2009,7 @@ void SWServer::Connection::abortBackgroundFetch(ServiceWorkerRegistrationIdentif
         return;
     }
 
-    server->protectedBackgroundFetchEngine()->abortBackgroundFetch(*registration, backgroundFetchIdentifier, WTF::move(callback));
+    protect(server->backgroundFetchEngine())->abortBackgroundFetch(*registration, backgroundFetchIdentifier, WTF::move(callback));
 }
 
 void SWServer::Connection::matchBackgroundFetch(ServiceWorkerRegistrationIdentifier registrationIdentifier, const String& backgroundFetchIdentifier, RetrieveRecordsOptions&& options, BackgroundFetchEngine::MatchBackgroundFetchCallback&& callback)
@@ -2031,13 +2026,13 @@ void SWServer::Connection::matchBackgroundFetch(ServiceWorkerRegistrationIdentif
         return;
     }
 
-    server->protectedBackgroundFetchEngine()->matchBackgroundFetch(*registration, backgroundFetchIdentifier, WTF::move(options), WTF::move(callback));
+    protect(server->backgroundFetchEngine())->matchBackgroundFetch(*registration, backgroundFetchIdentifier, WTF::move(options), WTF::move(callback));
 }
 
 void SWServer::Connection::retrieveRecordResponse(BackgroundFetchRecordIdentifier recordIdentifier, BackgroundFetchEngine::RetrieveRecordResponseCallback&& callback)
 {
     if (RefPtr server = m_server.get())
-        server->protectedBackgroundFetchEngine()->retrieveRecordResponse(recordIdentifier, WTF::move(callback));
+        protect(server->backgroundFetchEngine())->retrieveRecordResponse(recordIdentifier, WTF::move(callback));
     else
         callback(makeUnexpected(ExceptionData { ExceptionCode::InvalidStateError, "No server found"_s }));
 }
@@ -2045,7 +2040,7 @@ void SWServer::Connection::retrieveRecordResponse(BackgroundFetchRecordIdentifie
 void SWServer::Connection::retrieveRecordResponseBody(BackgroundFetchRecordIdentifier recordIdentifier, BackgroundFetchEngine::RetrieveRecordResponseBodyCallback&& callback)
 {
     if (RefPtr server = m_server.get())
-        server->protectedBackgroundFetchEngine()->retrieveRecordResponseBody(recordIdentifier, WTF::move(callback));
+        protect(server->backgroundFetchEngine())->retrieveRecordResponseBody(recordIdentifier, WTF::move(callback));
     else
         callback(makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, { }, "No server found"_s }));
 }

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -298,7 +298,6 @@ public:
     RefPtr<BackgroundFetchRecordLoader> createBackgroundFetchRecordLoader(BackgroundFetchRecordLoaderClient& client, const BackgroundFetchRequest& request, size_t responseDataSize, const WebCore::ClientOrigin& origin) { return CheckedRef { *m_delegate }->createBackgroundFetchRecordLoader(client, request, responseDataSize, origin); }
     Ref<BackgroundFetchStore> createBackgroundFetchStore() { return CheckedRef { *m_delegate }->createBackgroundFetchStore(); }
     WEBCORE_EXPORT BackgroundFetchEngine& backgroundFetchEngine();
-    WEBCORE_EXPORT Ref<BackgroundFetchEngine> protectedBackgroundFetchEngine();
 
     WEBCORE_EXPORT Vector<ServiceWorkerClientPendingMessage> releaseServiceWorkerClientPendingMessage(ScriptExecutionContextIdentifier);
 

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -168,7 +168,7 @@ void SWServerJobQueue::scriptContextFailedToStart(const ServiceWorkerJobDataIden
     }
 
     ASSERT(registration->preInstallationWorker());
-    registration->protectedPreInstallationWorker()->terminate();
+    protect(registration->preInstallationWorker())->terminate();
     registration->setPreInstallationWorker(nullptr);
 
     // Invoke Reject Job Promise with job and TypeError.
@@ -239,7 +239,7 @@ void SWServerJobQueue::didResolveRegistrationPromise()
 
     // Queue a task to fire the InstallEvent.
     ASSERT(registration->installingWorker());
-    server->fireInstallEvent(*registration->protectedInstallingWorker());
+    server->fireInstallEvent(*protect(registration->installingWorker()));
 }
 
 // https://w3c.github.io/ServiceWorker/#install

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -301,11 +301,11 @@ void SWServerRegistration::activate()
         updateWorkerState(*worker, ServiceWorkerState::Redundant);
     }
     // Run the Update Registration State algorithm passing registration, "active" and registration's waiting worker as the arguments.
-    updateRegistrationState(ServiceWorkerRegistrationState::Active, protectedWaitingWorker().get());
+    updateRegistrationState(ServiceWorkerRegistrationState::Active, protect(waitingWorker()).get());
     // Run the Update Registration State algorithm passing registration, "waiting" and null as the arguments.
     updateRegistrationState(ServiceWorkerRegistrationState::Waiting, nullptr);
     // Run the Update Worker State algorithm passing registration's active worker and activating as the arguments.
-    updateWorkerState(*protectedActiveWorker(), ServiceWorkerState::Activating);
+    updateWorkerState(*protect(activeWorker()), ServiceWorkerState::Activating);
     // FIXME: For each service worker client whose creation URL matches registration's scope url...
 
     // The registration now has an active worker so we need to check if there are any ready promises that were waiting for this.

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -80,13 +80,9 @@ public:
 
     void setPreInstallationWorker(SWServerWorker*);
     SWServerWorker* preInstallationWorker() const { return m_preInstallationWorker.get(); }
-    RefPtr<SWServerWorker> protectedPreInstallationWorker() const { return m_preInstallationWorker; }
     SWServerWorker* installingWorker() const { return m_installingWorker.get(); }
-    RefPtr<SWServerWorker> protectedInstallingWorker() const { return m_installingWorker; }
     SWServerWorker* waitingWorker() const { return m_waitingWorker.get(); }
-    RefPtr<SWServerWorker> protectedWaitingWorker() const { return m_waitingWorker; }
     SWServerWorker* activeWorker() const { return m_activeWorker.get(); }
-    RefPtr<SWServerWorker> protectedActiveWorker() const { return m_activeWorker; }
 
     MonotonicTime creationTime() const { return m_creationTime; }
 

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -52,11 +52,6 @@ SWServer* SWServerToContextConnection::server() const
     return m_server.get();
 }
 
-RefPtr<SWServer> SWServerToContextConnection::protectedServer() const
-{
-    return m_server.get();
-}
-
 void SWServerToContextConnection::scriptContextFailedToStart(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, const String& message)
 {
     if (RefPtr worker = SWServerWorker::existingWorkerForIdentifier(serviceWorkerIdentifier))
@@ -142,7 +137,7 @@ bool SWServerToContextConnection::terminateWhenPossible()
     m_shouldTerminateWhenPossible = true;
 
     bool hasServiceWorkerWithPendingEvents = false;
-    protectedServer()->forEachServiceWorker([&](auto& worker) {
+    protect(server())->forEachServiceWorker([&](auto& worker) {
         if (worker.isRunning() && worker.topRegistrableDomain() == m_site.domain() && worker.hasPendingEvents()) {
             hasServiceWorkerWithPendingEvents = true;
             return false;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -60,7 +60,6 @@ public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();
 
     WEBCORE_EXPORT SWServer* server() const;
-    WEBCORE_EXPORT RefPtr<SWServer> protectedServer() const;
 
     // This flag gets set when the service worker process is no longer clean (because it has loaded several eTLD+1s).
     bool shouldTerminateWhenPossible() const { return m_shouldTerminateWhenPossible; }

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -84,7 +84,7 @@ public:
     bool isNotRunning() const { return m_state == State::NotRunning; }
     void setState(State);
 
-    SWServer* server() { return m_server.get(); }
+    SWServer* server() const { return m_server.get(); }
     const ServiceWorkerRegistrationKey& registrationKey() const { return m_registrationKey; }
     RegistrableDomain firstPartyForCookies() const { return m_registrationKey.firstPartyForCookies(); }
     const URL& scriptURL() const { return m_data.scriptURL; }
@@ -177,8 +177,6 @@ private:
     void callTerminationCallbacks();
     void terminateIfPossible();
     bool shouldBeTerminated() const;
-
-    RefPtr<SWServer> protectedServer() const;
 
     WeakPtr<SWServer> m_server;
     ServiceWorkerRegistrationKey m_registrationKey;

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.h
@@ -73,7 +73,6 @@ public:
 
     WEBCORE_EXPORT void setConnection(RefPtr<Connection>&&);
     WEBCORE_EXPORT Connection* connection() const;
-    RefPtr<Connection> protectedConnection() const { return m_connection; }
 
     WEBCORE_EXPORT void registerSharedWorkerThread(Ref<SharedWorkerThreadProxy>&&);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6184,7 +6184,7 @@ struct WebCore::ServiceWorkerImportedScript {
 };
 
 class WebCore::ScriptBuffer {
-    RefPtr<const WebCore::FragmentedSharedBuffer> protectedBuffer();
+    RefPtr<const WebCore::FragmentedSharedBuffer> bufferForSerialization();
 };
 
 header: <wtf/RobinHoodHashTable.h>

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2225,11 +2225,11 @@ void WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWo
     switch (workerType) {
     case RemoteWorkerType::ServiceWorker:
         SWContextManager::singleton().setConnection(WebSWContextManagerConnection::create(WTF::move(ipcConnection), WTF::move(site), serviceWorkerPageIdentifier, pageGroupID, webPageProxyID, pageID, store, WTF::move(initializationData)));
-        SWContextManager::singleton().protectedConnection()->establishConnection(WTF::move(completionHandler));
+        protect(SWContextManager::singleton().connection())->establishConnection(WTF::move(completionHandler));
         break;
     case RemoteWorkerType::SharedWorker:
         SharedWorkerContextManager::singleton().setConnection(WebSharedWorkerContextManagerConnection::create(WTF::move(ipcConnection), WTF::move(site), pageGroupID, webPageProxyID, pageID, store, WTF::move(initializationData)));
-        SharedWorkerContextManager::singleton().protectedConnection()->establishConnection(WTF::move(completionHandler));
+        protect(SharedWorkerContextManager::singleton().connection())->establishConnection(WTF::move(completionHandler));
         break;
     }
 }


### PR DESCRIPTION
#### 4d541ee463c91efb430ac662e09a7d4b5ff95be0
<pre>
Reduce use of protected functions in Source/WebCore/workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=306743">https://bugs.webkit.org/show_bug.cgi?id=306743</a>

Reviewed by Anne van Kesteren.

Adopt `protect()` at call sites instead.

* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::registerServiceWorker):
(WebCore::ScriptExecutionContext::unregisterServiceWorker):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::getContext):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::matchRegistration):
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::MainThreadBridge::didFinishTiming):
* Source/WebCore/workers/ScriptBuffer.h:
(WebCore::ScriptBuffer::bufferForSerialization const):
(WebCore::ScriptBuffer::protectedBuffer const): Deleted.
* Source/WebCore/workers/WorkerAnimationController.cpp:
(WebCore::WorkerAnimationController::scheduleAnimation):
(WebCore::WorkerAnimationController::animationTimerFired):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::protectedSocketProvider): Deleted.
(WebCore::WorkerGlobalScope::protectedNavigator): Deleted.
(WebCore::WorkerGlobalScope::protectedPerformance const): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::linkAndEvaluateModule):
(WebCore::WorkerOrWorkletScriptController::initScriptWithSubclass):
(WebCore::WorkerOrWorkletScriptController::protectedGlobalScope const): Deleted.
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:
* Source/WebCore/workers/WorkerOrWorkletThread.cpp:
(WebCore::WorkerOrWorkletThread::startRunningDebuggerTasks):
(WebCore::WorkerOrWorkletThread::runEventLoop):
(WebCore::WorkerOrWorkletThread::workerOrWorkletThread):
(WebCore::WorkerOrWorkletThread::protectedGlobalScope const): Deleted.
* Source/WebCore/workers/WorkerOrWorkletThread.h:
(WebCore::WorkerOrWorkletThread::globalScope const):
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::postMessage):
(WebCore::ServiceWorker::protectedSWConnection): Deleted.
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::ServiceWorkerGlobalScope):
* Source/WebCore/workers/service/ServiceWorkerProvider.cpp:
(WebCore::ServiceWorkerProvider::protectedServiceWorkerConnection): Deleted.
* Source/WebCore/workers/service/ServiceWorkerProvider.h:
* Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp:
(WebCore::ServiceWorkerWindowClient::focus):
(WebCore::ServiceWorkerWindowClient::navigate):
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::startedServiceWorker):
* Source/WebCore/workers/service/context/SWContextManager.h:
(WebCore::SWContextManager::protectedConnection const): Deleted.
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::removeRegistration):
(WebCore::SWServer::Connection::startBackgroundFetch):
(WebCore::SWServer::Connection::backgroundFetchInformation):
(WebCore::SWServer::Connection::backgroundFetchIdentifiers):
(WebCore::SWServer::Connection::abortBackgroundFetch):
(WebCore::SWServer::Connection::matchBackgroundFetch):
(WebCore::SWServer::Connection::retrieveRecordResponse):
(WebCore::SWServer::Connection::retrieveRecordResponseBody):
(WebCore::SWServer::protectedBackgroundFetchEngine): Deleted.
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::scriptContextFailedToStart):
(WebCore::SWServerJobQueue::didResolveRegistrationPromise):
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::activate):
* Source/WebCore/workers/service/server/SWServerRegistration.h:
(WebCore::SWServerRegistration::preInstallationWorker const):
(WebCore::SWServerRegistration::installingWorker const):
(WebCore::SWServerRegistration::waitingWorker const):
(WebCore::SWServerRegistration::activeWorker const):
(WebCore::SWServerRegistration::protectedPreInstallationWorker const): Deleted.
(WebCore::SWServerRegistration::protectedInstallingWorker const): Deleted.
(WebCore::SWServerRegistration::protectedWaitingWorker const): Deleted.
(WebCore::SWServerRegistration::protectedActiveWorker const): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::terminateWhenPossible):
(WebCore::SWServerToContextConnection::protectedServer const): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::m_routes):
(WebCore::SWServerWorker::startTermination):
(WebCore::SWServerWorker::findClientByIdentifier const):
(WebCore::SWServerWorker::findClientByVisibleIdentifier):
(WebCore::SWServerWorker::matchAll):
(WebCore::SWServerWorker::userAgent const):
(WebCore::SWServerWorker::setState):
(WebCore::SWServerWorker::workerThreadMode const):
(WebCore::SWServerWorker::shouldBeTerminated const):
(WebCore::SWServerWorker::terminationIfPossibleTimerFired):
(WebCore::SWServerWorker::isClientActiveServiceWorker const):
(WebCore::SWServerWorker::protectedServer const): Deleted.
* Source/WebCore/workers/service/server/SWServerWorker.h:
(WebCore::SWServerWorker::server const):
(WebCore::SWServerWorker::server): Deleted.
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.h:
(WebCore::SharedWorkerContextManager::protectedConnection const): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::establishRemoteWorkerContextConnectionToNetworkProcess):

Canonical link: <a href="https://commits.webkit.org/306617@main">https://commits.webkit.org/306617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9607145e97e3fd084ff90f886504d25b5354d8ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150426 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94958 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2752e152-9a4e-4a4a-a86c-de2b26ee85b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/108992 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78823 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe0bd25c-1eb6-43ce-91df-5973d06047d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/126951 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89888 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7fe9868-a8db-4a43-acb5-209fc6a620a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11094 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8737 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/493 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/2970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152815 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13908 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117081 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13923 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12136 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-self-allowed-target-blank.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117403 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29914 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13454 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69579 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13946 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/2938 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13732 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->