### PR TITLE
Reduce use of protected functions in Source/WebCore/svg

### DIFF
--- a/Source/WebCore/svg/SVGAnimateElementBase.cpp
+++ b/Source/WebCore/svg/SVGAnimateElementBase.cpp
@@ -48,7 +48,7 @@ SVGAttributeAnimator* SVGAnimateElementBase::animator() const
     ASSERT(!hasInvalidCSSAttributeType());
 
     if (!m_animator)
-        m_animator = protectedTargetElement()->createAnimator(attributeName(), animationMode(), calcMode(), isAccumulated(), isAdditive());
+        m_animator = protect(targetElement())->createAnimator(attributeName(), animationMode(), calcMode(), isAccumulated(), isAdditive());
 
     return m_animator;
 }
@@ -58,7 +58,7 @@ bool SVGAnimateElementBase::hasValidAttributeType() const
     if (!targetElement() || hasInvalidCSSAttributeType())
         return false;
 
-    return protectedTargetElement()->isAnimatedAttribute(attributeName());
+    return protect(targetElement())->isAnimatedAttribute(attributeName());
 }
 
 bool SVGAnimateElementBase::hasInvalidCSSAttributeType() const
@@ -67,7 +67,7 @@ bool SVGAnimateElementBase::hasInvalidCSSAttributeType() const
         return false;
 
     if (!m_hasInvalidCSSAttributeType)
-        m_hasInvalidCSSAttributeType = hasValidAttributeName() && attributeType() == AttributeType::CSS && !isTargetAttributeCSSProperty(protectedTargetElement().get(), attributeName());
+        m_hasInvalidCSSAttributeType = hasValidAttributeName() && attributeType() == AttributeType::CSS && !isTargetAttributeCSSProperty(protect(targetElement()).get(), attributeName());
 
     return m_hasInvalidCSSAttributeType.value();
 }

--- a/Source/WebCore/svg/SVGDocumentExtensions.cpp
+++ b/Source/WebCore/svg/SVGDocumentExtensions.cpp
@@ -85,7 +85,7 @@ void SVGDocumentExtensions::startAnimations()
     // In the future we should refactor the use-element to avoid this. See https://webkit.org/b/53704
     auto timeContainers = copyToVectorOf<Ref<SVGSVGElement>>(m_timeContainers);
     for (auto& element : timeContainers)
-        element->protectedTimeContainer()->begin();
+        protect(element->timeContainer())->begin();
 }
 
 void SVGDocumentExtensions::pauseAnimations()

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -72,11 +72,6 @@ Ref<SVGFontFaceElement> SVGFontFaceElement::create(const QualifiedName& tagName,
     return adoptRef(*new SVGFontFaceElement(tagName, document));
 }
 
-Ref<StyleRuleFontFace> SVGFontFaceElement::protectedFontFaceRule() const
-{
-    return m_fontFaceRule;
-}
-
 void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     auto propertyId = cssPropertyIdForSVGAttributeName(name, document().settings());
@@ -248,7 +243,7 @@ int SVGFontFaceElement::descent() const
 
 String SVGFontFaceElement::fontFamily() const
 {
-    return protectedFontFaceRule()->properties().getPropertyValue(CSSPropertyFontFamily);
+    return protect(fontFaceRule())->properties().getPropertyValue(CSSPropertyFontFamily);
 }
 
 SVGFontElement* SVGFontFaceElement::associatedFontElement() const
@@ -256,11 +251,6 @@ SVGFontElement* SVGFontFaceElement::associatedFontElement() const
     ASSERT(parentNode() == m_fontElement);
     ASSERT(!parentNode() || is<SVGFontElement>(*parentNode()));
     return m_fontElement.get();
-}
-
-RefPtr<SVGFontElement> SVGFontFaceElement::protectedFontElement() const
-{
-    return associatedFontElement();
 }
 
 void SVGFontFaceElement::rebuildFontFace()
@@ -286,7 +276,7 @@ void SVGFontFaceElement::rebuildFontFace()
         return;
 
     // Parse in-memory CSS rules
-    protectedFontFaceRule()->mutableProperties().addParsedProperty(CSSProperty(CSSPropertySrc, list.releaseNonNull()));
+    protect(fontFaceRule())->mutableProperties().addParsedProperty(CSSProperty(CSSPropertySrc, list.releaseNonNull()));
 
     if (describesParentFont) {
         // Traverse parsed CSS values and associate CSSFontFaceSrcLocalValue elements with ourselves.

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -48,11 +48,9 @@ public:
     String fontFamily() const;
 
     SVGFontElement* associatedFontElement() const;
-    RefPtr<SVGFontElement> protectedFontElement() const;
     void rebuildFontFace();
-    
-    StyleRuleFontFace& fontFaceRule() { return m_fontFaceRule.get(); }
-    Ref<StyleRuleFontFace> protectedFontFaceRule() const;
+
+    StyleRuleFontFace& fontFaceRule() const { return m_fontFaceRule.get(); }
 
 private:
     SVGFontFaceElement(const QualifiedName&, Document&);

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -84,18 +84,13 @@ AffineTransform SVGGraphicsElement::getScreenCTM(StyleUpdateStrategy styleUpdate
     return SVGLocatable::computeCTM(this, CTMScope::ScreenScope, styleUpdateStrategy);
 }
 
-Ref<const SVGTransformList> SVGGraphicsElement::protectedTransform() const
-{
-    return m_transform->currentValue();
-}
-
 AffineTransform SVGGraphicsElement::animatedLocalTransform() const
 {
     // LBSE handles transforms via RenderLayer, no need to handle CSS transforms here.
     if (document().settings().layerBasedSVGEngineEnabled()) {
         if (m_supplementalTransform)
             return *m_supplementalTransform * transform().concatenate();
-        return protectedTransform()->concatenate();
+        return protect(transform())->concatenate();
     }
 
     AffineTransform matrix;

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -72,7 +72,6 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGraphicsElement, SVGElement, SVGTests>;
 
     const SVGTransformList& transform() const { return m_transform->currentValue(); }
-    Ref<const SVGTransformList> protectedTransform() const;
     SVGAnimatedTransformList& transformAnimated() { return m_transform; }
 
 protected:

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -193,14 +193,9 @@ void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) 
         attributes.setPatternContentElement(this);
 }
 
-Ref<const SVGTransformList> SVGPatternElement::protectedPatternTransform() const
-{
-    return m_patternTransform->currentValue();
-}
-
 AffineTransform SVGPatternElement::localCoordinateSpaceTransform(CTMScope) const
 {
-    return protectedPatternTransform()->concatenate();
+    return protect(patternTransform())->concatenate();
 }
 
 }

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -50,7 +50,6 @@ public:
     SVGUnitTypes::SVGUnitType patternUnits() const { return m_patternUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGUnitTypes::SVGUnitType patternContentUnits() const { return m_patternContentUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     const SVGTransformList& patternTransform() const { return m_patternTransform->currentValue(); }
-    Ref<const SVGTransformList> protectedPatternTransform() const;
 
     SVGAnimatedLength& xAnimated() { return m_x; }
     SVGAnimatedLength& yAnimated() { return m_y; }

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -537,23 +537,23 @@ bool SVGSVGElement::resumePausedAnimationsIfNeeded(const IntRect& visibleRect)
 
 bool SVGSVGElement::animationsPaused() const
 {
-    return protectedTimeContainer()->isPaused();
+    return protect(timeContainer())->isPaused();
 }
 
 bool SVGSVGElement::hasActiveAnimation() const
 {
-    return protectedTimeContainer()->isActive();
+    return protect(timeContainer())->isActive();
 }
 
 float SVGSVGElement::getCurrentTime() const
 {
-    return narrowPrecisionToFloat(protectedTimeContainer()->elapsed().value());
+    return narrowPrecisionToFloat(protect(timeContainer())->elapsed().value());
 }
 
 void SVGSVGElement::setCurrentTime(float seconds)
 {
     ASSERT(std::isfinite(seconds));
-    protectedTimeContainer()->setElapsed(std::max(seconds, 0.0f));
+    protect(timeContainer())->setElapsed(std::max(seconds, 0.0f));
 }
 
 bool SVGSVGElement::selfHasRelativeLengths() const
@@ -678,7 +678,7 @@ AffineTransform SVGSVGElement::viewBoxToViewTransform(float viewWidth, float vie
 
     RefPtr viewSpec = m_viewSpec;
     AffineTransform transform = SVGFitToViewBox::viewBoxToViewTransform(currentViewBoxRect(), viewSpec->preserveAspectRatio(), viewWidth, viewHeight);
-    transform *= viewSpec->protectedTransform()->concatenate();
+    transform *= protect(viewSpec->transform())->concatenate();
     return transform;
 }
 
@@ -765,11 +765,6 @@ bool SVGSVGElement::scrollToFragment(StringView fragmentIdentifier)
     // FIXME: We need to decide which <svg> to focus on, and zoom to it.
     // FIXME: We need to actually "highlight" the viewTarget(s).
     return false;
-}
-
-Ref<SMILTimeContainer> SVGSVGElement::protectedTimeContainer() const
-{
-    return m_timeContainer;
 }
 
 void SVGSVGElement::resetScrollAnchor()

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -95,7 +95,7 @@ public:
     using SVGGraphicsElement::deref;
 
     SMILTimeContainer& timeContainer() { return m_timeContainer.get(); }
-    Ref<SMILTimeContainer> protectedTimeContainer() const;
+    const SMILTimeContainer& timeContainer() const { return m_timeContainer.get(); }
 
     void setCurrentTranslate(const FloatPoint&); // Used to pan.
     void updateCurrentTranslate();

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -88,24 +88,14 @@ bool SVGTests::isValid() const
     return true;
 }
 
-Ref<SVGStringList> SVGTests::protectedRequiredExtensions()
-{
-    return requiredExtensions();
-}
-
-Ref<SVGStringList> SVGTests::protectedSystemLanguage()
-{
-    return systemLanguage();
-}
-
 void SVGTests::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
 {
     switch (attributeName.nodeName()) {
     case AttributeNames::requiredExtensionsAttr:
-        protectedRequiredExtensions()->reset(value);
+        protect(requiredExtensions())->reset(value);
         break;
     case AttributeNames::systemLanguageAttr:
-        protectedSystemLanguage()->reset(value);
+        protect(systemLanguage())->reset(value);
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGTests.h
+++ b/Source/WebCore/svg/SVGTests.h
@@ -64,9 +64,7 @@ public:
 
     // These methods are called from DOM through the super classes.
     SVGStringList& requiredExtensions() { return conditionalProcessingAttributes().requiredExtensions(); }
-    Ref<SVGStringList> protectedRequiredExtensions();
     SVGStringList& systemLanguage() { return conditionalProcessingAttributes().systemLanguage(); }
-    Ref<SVGStringList> protectedSystemLanguage();
 
 protected:
     bool isValid() const;

--- a/Source/WebCore/svg/SVGTransform.h
+++ b/Source/WebCore/svg/SVGTransform.h
@@ -64,7 +64,7 @@ public:
 
     ~SVGTransform()
     {
-        m_value.protectedMatrix()->detach();
+        protect(m_value.matrix())->detach();
     }
 
     Ref<SVGTransform> clone() const
@@ -75,7 +75,6 @@ public:
     unsigned short type() { return m_value.type(); }
     float angle() { return m_value.angle(); }
     SVGMatrix& matrix() { return m_value.matrix(); }
-    Ref<SVGMatrix> protectedMatrix() { return matrix(); }
 
     ExceptionOr<void> setMatrix(DOMMatrix2DInit&& matrixInit)
     {
@@ -154,14 +153,14 @@ public:
     {
         Base::attach(owner, access);
         // Reattach the SVGMatrix to the SVGTransformValue with the new SVGPropertyAccess.
-        m_value.protectedMatrix()->reattach(this, access);
+        protect(m_value.matrix())->reattach(this, access);
     }
 
     void detach() override
     {
         Base::detach();
         // Reattach the SVGMatrix to the SVGTransformValue with the SVGPropertyAccess::ReadWrite.
-        m_value.protectedMatrix()->reattach(this, access());
+        protect(m_value.matrix())->reattach(this, access());
     }
 
 private:
@@ -175,7 +174,7 @@ private:
     SVGTransform(SVGTransformValue&& value)
         : Base(WTF::move(value))
     {
-        m_value.protectedMatrix()->attach(this, SVGPropertyAccess::ReadWrite);
+        protect(m_value.matrix())->attach(this, SVGPropertyAccess::ReadWrite);
     }
 
     SVGPropertyOwner* owner() const override { return m_owner; }

--- a/Source/WebCore/svg/SVGTransformValue.h
+++ b/Source/WebCore/svg/SVGTransformValue.h
@@ -109,7 +109,6 @@ public:
 
     SVGTransformType type() const { return m_type; }
     SVGMatrix& matrix() const { return m_matrix; }
-    Ref<SVGMatrix> protectedMatrix() const { return m_matrix; }
     float angle() const { return m_angle; }
     FloatPoint rotationCenter() const { return m_rotationCenter; }
 
@@ -120,7 +119,7 @@ public:
         m_type = SVG_TRANSFORM_MATRIX;
         m_angle = 0;
         m_rotationCenter = { };
-        protectedMatrix()->setValue(matrix);
+        protect(this->matrix())->setValue(matrix);
     }
 
     void matrixDidChange()

--- a/Source/WebCore/svg/SVGViewSpec.cpp
+++ b/Source/WebCore/svg/SVGViewSpec.cpp
@@ -55,15 +55,10 @@ RefPtr<SVGElement> SVGViewSpec::viewTarget() const
     return dynamicDowncast<SVGElement>(contextElement->treeScope().getElementById(m_viewTargetString));
 }
 
-Ref<SVGTransformList> SVGViewSpec::protectedTransform()
-{
-    return m_transform;
-}
-
 void SVGViewSpec::reset()
 {
     m_viewTargetString = emptyString();
-    protectedTransform()->clearItems();
+    protect(transform())->clearItems();
     SVGFitToViewBox::reset();
     SVGZoomAndPan::reset();
 }
@@ -136,7 +131,7 @@ bool SVGViewSpec::parseViewSpec(StringView string)
                     return false;
                 if (!skipExactly(buffer, '('))
                     return false;
-                protectedTransform()->parse(buffer);
+                protect(transform())->parse(buffer);
                 if (!skipExactly(buffer, ')'))
                     return false;
             } else

--- a/Source/WebCore/svg/SVGViewSpec.h
+++ b/Source/WebCore/svg/SVGViewSpec.h
@@ -48,7 +48,6 @@ public:
 
     String transformString() const { return m_transform->valueAsString(); }
     Ref<SVGTransformList>& transform() { return m_transform; }
-    Ref<SVGTransformList> protectedTransform();
 
     const WeakPtr<SVGElement, WeakPtrImplWithEventTargetData>& contextElementConcurrently() const { return m_contextElement; }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -153,7 +153,7 @@ SVGSMILElement::~SVGSMILElement()
     smilEventSender().cancelEvent(*this);
     disconnectConditions();
     if (RefPtr timeContainer = m_timeContainer; timeContainer && m_targetElement && hasValidAttributeName())
-        timeContainer->unschedule(this, protectedTargetElement().get(), m_attributeName);
+        timeContainer->unschedule(this, protect(targetElement()).get(), m_attributeName);
 }
 
 void SVGSMILElement::clearResourceReferences()
@@ -244,7 +244,7 @@ static inline void clearTimesWithDynamicOrigins(Vector<SMILTimeWithOrigin>& time
 
 void SVGSMILElement::reset()
 {
-    stopAnimation(protectedTargetElement().get());
+    stopAnimation(protect(targetElement()).get());
 
     m_activeState = Inactive;
     m_isWaitingForFirstInterval = true;
@@ -255,11 +255,6 @@ void SVGSMILElement::reset()
     m_lastRepeat = 0;
     m_nextProgressTime = 0;
     resolveFirstInterval();
-}
-
-RefPtr<SMILTimeContainer> SVGSMILElement::protectedTimeContainer() const
-{
-    return m_timeContainer;
 }
 
 Node::InsertedIntoAncestorResult SVGSMILElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
@@ -278,7 +273,7 @@ Node::InsertedIntoAncestorResult SVGSMILElement::insertedIntoAncestor(InsertionT
         return InsertedIntoAncestorResult::Done;
 
     m_timeContainer = owner->timeContainer();
-    protectedTimeContainer()->setDocumentOrderIndexesDirty();
+    protect(timeContainer())->setDocumentOrderIndexesDirty();
 
     // "If no attribute is present, the default begin value (an offset-value of 0) must be evaluated."
     if (!hasAttributeWithoutSynchronization(SVGNames::beginAttr))
@@ -627,10 +622,10 @@ void SVGSMILElement::setAttributeName(const QualifiedName& attributeName)
 {
     if (RefPtr timeContainer = m_timeContainer; timeContainer && m_targetElement && m_attributeName != attributeName) {
         if (hasValidAttributeName())
-            timeContainer->unschedule(this, protectedTargetElement().get(), m_attributeName);
+            timeContainer->unschedule(this, protect(targetElement()).get(), m_attributeName);
         m_attributeName = attributeName;
         if (hasValidAttributeName())
-            timeContainer->schedule(this, protectedTargetElement().get(), m_attributeName);
+            timeContainer->schedule(this, protect(targetElement()).get(), m_attributeName);
     } else
         m_attributeName = attributeName;
 
@@ -1164,7 +1159,7 @@ bool SVGSMILElement::progress(SMILTime elapsed, SVGSMILElement& firstAnimation, 
         smilEventSender().dispatchEventSoon(*this, eventNames().endEventEvent);
         endedActiveInterval();
         if (m_activeState != Frozen)
-            stopAnimation(protectedTargetElement().get());
+            stopAnimation(protect(targetElement()).get());
     } else if (oldActiveState != Active && m_activeState == Active)
         smilEventSender().dispatchEventSoon(*this, eventNames().beginEventEvent);
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -57,11 +57,9 @@ public:
     virtual bool hasValidAttributeName() const;
     virtual void animationAttributeChanged() = 0;
 
-    SMILTimeContainer* timeContainer() { return m_timeContainer.get(); }
-    RefPtr<SMILTimeContainer> protectedTimeContainer() const;
+    SMILTimeContainer* timeContainer() { return m_timeContainer; }
 
     SVGElement* targetElement() const { return m_targetElement; }
-    RefPtr<SVGElement> protectedTargetElement() const { return m_targetElement; }
     const QualifiedName& attributeName() const { return m_attributeName; }
 
     void beginByLinkActivation();

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -204,7 +204,7 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
     adjustedSrcSize.scale(roundedContainerSize.width() / containerSize.width(), roundedContainerSize.height() / containerSize.height());
     scaledSrc.setSize(adjustedSrcSize);
 
-    protectedFrameView()->scrollToFragment(initialFragmentURL);
+    protect(frameView())->scrollToFragment(initialFragmentURL);
 
     ImageDrawResult result = draw(context, dstRect, scaledSrc, options);
 
@@ -371,11 +371,6 @@ LocalFrameView* SVGImage::frameView() const
         return nullptr;
 
     return localMainFrame->view();
-}
-
-RefPtr<LocalFrameView> SVGImage::protectedFrameView() const
-{
-    return frameView();
 }
 
 bool SVGImage::hasRelativeWidth() const

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -50,7 +50,6 @@ public:
 
     RenderBox* embeddedContentBox() const;
     LocalFrameView* frameView() const;
-    RefPtr<LocalFrameView> protectedFrameView() const;
 
     bool isSVGImage() const final { return true; }
 


### PR DESCRIPTION
#### af5bd62df479da65ccdfdd91dd95787644f261ba
<pre>
Reduce use of protected functions in Source/WebCore/svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=306745">https://bugs.webkit.org/show_bug.cgi?id=306745</a>

Reviewed by Anne van Kesteren.

Use `protect()` at call sites instead.

* Source/WebCore/svg/SVGAnimateElementBase.cpp:
(WebCore::SVGAnimateElementBase::animator const):
(WebCore::SVGAnimateElementBase::hasValidAttributeType const):
(WebCore::SVGAnimateElementBase::hasInvalidCSSAttributeType const):
* Source/WebCore/svg/SVGDocumentExtensions.cpp:
(WebCore::SVGDocumentExtensions::startAnimations):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::fontFamily const):
(WebCore::SVGFontFaceElement::rebuildFontFace):
(WebCore::SVGFontFaceElement::protectedFontFaceRule const): Deleted.
(WebCore::SVGFontFaceElement::protectedFontElement const): Deleted.
* Source/WebCore/svg/SVGFontFaceElement.h:
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::animatedLocalTransform const):
(WebCore::SVGGraphicsElement::protectedTransform const): Deleted.
* Source/WebCore/svg/SVGGraphicsElement.h:
(WebCore::SVGGraphicsElement::transform const):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::localCoordinateSpaceTransform const):
(WebCore::SVGPatternElement::protectedPatternTransform const): Deleted.
* Source/WebCore/svg/SVGPatternElement.h:
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::animationsPaused const):
(WebCore::SVGSVGElement::hasActiveAnimation const):
(WebCore::SVGSVGElement::getCurrentTime const):
(WebCore::SVGSVGElement::setCurrentTime):
(WebCore::SVGSVGElement::viewBoxToViewTransform const):
(WebCore::SVGSVGElement::protectedTimeContainer const): Deleted.
* Source/WebCore/svg/SVGSVGElement.h:
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::parseAttribute):
(WebCore::SVGTests::protectedRequiredExtensions): Deleted.
(WebCore::SVGTests::protectedSystemLanguage): Deleted.
* Source/WebCore/svg/SVGTests.h:
(WebCore::SVGTests::requiredExtensions):
(WebCore::SVGTests::systemLanguage):
* Source/WebCore/svg/SVGTransform.h:
(WebCore::SVGTransform::~SVGTransform):
(WebCore::SVGTransform::matrix):
(WebCore::SVGTransform::SVGTransform):
(WebCore::SVGTransform::protectedMatrix): Deleted.
* Source/WebCore/svg/SVGTransformValue.h:
(WebCore::SVGTransformValue::matrix const):
(WebCore::SVGTransformValue::setMatrix):
(WebCore::SVGTransformValue::protectedMatrix const): Deleted.
* Source/WebCore/svg/SVGViewSpec.cpp:
(WebCore::SVGViewSpec::reset):
(WebCore::SVGViewSpec::parseViewSpec):
(WebCore::SVGViewSpec::protectedTransform): Deleted.
* Source/WebCore/svg/SVGViewSpec.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::~SVGSMILElement):
(WebCore::SVGSMILElement::reset):
(WebCore::SVGSMILElement::insertedIntoAncestor):
(WebCore::SVGSMILElement::setAttributeName):
(WebCore::SVGSMILElement::progress):
(WebCore::SVGSMILElement::protectedTimeContainer const): Deleted.
* Source/WebCore/svg/animation/SVGSMILElement.h:
(WebCore::SVGSMILElement::timeContainer):
(WebCore::SVGSMILElement::targetElement const):
(WebCore::SVGSMILElement::protectedTargetElement const): Deleted.
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::drawForContainer):
(WebCore::SVGImage::protectedFrameView const): Deleted.
* Source/WebCore/svg/graphics/SVGImage.h:

Canonical link: <a href="https://commits.webkit.org/306619@main">https://commits.webkit.org/306619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf707da99193564ad9af78f9f54cbc366dd4f9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141858 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/3965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150455 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/94983 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/600d6930-26b5-42e7-8c87-c5c848c6554f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109016 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/94983 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bb00334-f3d0-4d96-98d7-eb65f5a270c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11560 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/126983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89912 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed5a7666-e809-4ff8-b7ac-5b81763d9890) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11111 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/518 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152840 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3559 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117102 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117424 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29915 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13471 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69616 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13971 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3024 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13710 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77696 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13757 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->