### PR TITLE
[macOS] Scrolling in direction opposite to current stretch causes page to snap back

### DIFF
--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -76,11 +76,12 @@ private:
     // ScrollingEffectsControllerClient.
     bool allowsHorizontalStretching(const PlatformWheelEvent&) const final;
     bool allowsVerticalStretching(const PlatformWheelEvent&) const final;
+    bool isScrollDeltaOpposingStretch(ScrollEventAxis, float) const final;
     IntSize stretchAmount() const final;
     bool isPinnedOnSide(BoxSide) const final;
     RectEdges<bool> edgePinnedState() const final;
 
-    bool shouldRubberBandOnSide(BoxSide) const final;
+    bool shouldRubberBandOnSide(BoxSide, FloatSize) const final;
     void didStopRubberBandAnimation() final;
     void rubberBandingStateChanged(bool) final;
     bool scrollPositionIsNotRubberbandingEdge(const FloatPoint&) const;

--- a/Source/WebCore/platform/ScrollAnimator.h
+++ b/Source/WebCore/platform/ScrollAnimator.h
@@ -127,6 +127,9 @@ public:
 
 protected:
     bool handleSteppedScrolling(const PlatformWheelEvent&);
+#if HAVE(RUBBER_BANDING)
+    IntSize stretchAmount() const final;
+#endif
 
 private:
     void notifyPositionChanged(const FloatSize& delta);
@@ -157,7 +160,6 @@ private:
     void adjustScrollPositionToBoundsIfNecessary() final;
 
 #if HAVE(RUBBER_BANDING)
-    IntSize stretchAmount() const final;
     RectEdges<bool> edgePinnedState() const final;
     bool isPinnedOnSide(BoxSide) const final;
 #endif

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -96,12 +96,13 @@ public:
     virtual bool allowsHorizontalStretching(const PlatformWheelEvent&) const = 0;
     virtual bool allowsVerticalStretching(const PlatformWheelEvent&) const = 0;
     virtual IntSize stretchAmount() const = 0;
+    virtual bool isScrollDeltaOpposingStretch(ScrollEventAxis, float) const = 0;
 
     // "Pinned" means scrolled at or beyond the edge.
     virtual bool isPinnedOnSide(BoxSide) const = 0;
     virtual RectEdges<bool> edgePinnedState() const = 0;
 
-    virtual bool shouldRubberBandOnSide(BoxSide) const = 0;
+    virtual bool shouldRubberBandOnSide(BoxSide, FloatSize) const = 0;
 
     virtual void willStartRubberBandAnimation() { }
     virtual void didStopRubberBandAnimation() { }
@@ -186,6 +187,7 @@ public:
 
 #if PLATFORM(MAC)
     static FloatSize wheelDeltaBiasingTowardsVertical(const FloatSize&);
+    static bool isScrollDeltaOpposingStretch(IntSize stretch, ScrollEventAxis, float delta);
 
     // Returns true if handled.
     bool processWheelEventForScrollSnap(const PlatformWheelEvent&);
@@ -223,7 +225,7 @@ private:
     void willStartRubberBandAnimation();
     void didStopRubberBandAnimation();
 
-    bool shouldRubberBandOnSide(BoxSide) const;
+    bool shouldRubberBandOnSide(BoxSide, FloatSize) const;
     bool isRubberBandInProgressInternal() const;
     void updateRubberBandingState();
     void updateRubberBandingEdges(IntSize clientStretch);

--- a/Source/WebCore/platform/mac/ScrollAnimatorMac.h
+++ b/Source/WebCore/platform/mac/ScrollAnimatorMac.h
@@ -56,7 +56,8 @@ private:
     // ScrollingEffectsControllerClient.
     bool allowsHorizontalStretching(const PlatformWheelEvent&) const final;
     bool allowsVerticalStretching(const PlatformWheelEvent&) const final;
-    bool shouldRubberBandOnSide(BoxSide) const final;
+    bool shouldRubberBandOnSide(BoxSide, FloatSize) const final;
+    bool isScrollDeltaOpposingStretch(ScrollEventAxis, float) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimatorMac.mm
@@ -160,7 +160,12 @@ bool ScrollAnimatorMac::allowsHorizontalStretching(const PlatformWheelEvent& whe
     return false;
 }
 
-bool ScrollAnimatorMac::shouldRubberBandOnSide(BoxSide) const
+bool ScrollAnimatorMac::isScrollDeltaOpposingStretch(ScrollEventAxis axis, float delta) const
+{
+    return ScrollingEffectsController::isScrollDeltaOpposingStretch(stretchAmount(), axis, delta);
+}
+
+bool ScrollAnimatorMac::shouldRubberBandOnSide(BoxSide, FloatSize) const
 {
     return false;
 }


### PR DESCRIPTION
#### ffd2f37638743584a2eac91a88015e45848d2c9c
<pre>
[macOS] Scrolling in direction opposite to current stretch causes page to snap back
<a href="https://bugs.webkit.org/show_bug.cgi?id=306747">https://bugs.webkit.org/show_bug.cgi?id=306747</a>
<a href="https://rdar.apple.com/169220724">rdar://169220724</a>

Reviewed by Simon Fraser.

When scroll stretching occurs, if the user switches scroll directions so that
the scroll now opposes the stretch direction rather than causing the stretch
to increase, instead of just scrolling with no resistance, the page immediately
snaps out of the stretch. If that same scroll continues, and the user then reverses
scroll direction once again to cause the page to stretch, the stretch will snap back
into the maximum stretch that occurred before changing direction.

The first bug occurs due to the following:
In `ScrollingEffectsController::applyScrollDeltaWithStretching`, an immediate scroll
is performed with an amount equal to the damped delta minus the current stretch amount.
This damped delta is also clamped by calling
`ScrollingEffectsController::clampDeltaForAllowedAxes`, which checks with the scroll
client to see if vertical or horizontal stretching are allowed. Inside this check
in `ScrollingTreeScrollingNodeDelegateMac::allowsVerticalStretching` (and the horizontal
equivalent), we take `ScrollableArea::targetSideForScrollDelta` and pass the side to
`shouldRubberBandOnSide`. When the scroll opposes the stretch direction,
`targetSideForScrollDelta` is set equal to the side opposite of the stretch, so when
`shouldRubberBandOnSide` sees the side is not contained in the pinned edges, it
immediately returns false. This causes `ScrollingEffectsController` to clamp the delta
to zero, so when we perform the immediate scroll (damped delta - current stretch), we
get an immediate scroll equal to opposite of the current stretch, and the page snaps
as a result.

As the scroll continues and the stretch ends, switching directions mid scroll back to
the edge that was previously stretched triggers the second bug (snapping back into the
largest stretch that occurred before changing direction) due to m_stretchScrollForce
retaining the previous maximum force, from which the damped delta is calculated.

Both bugs require us to determine when a scroll delta opposes the current stretch direction.
To determine this, we add a new method `isScrollDeltaOpposingStretch` to
`ScrollingEffectsController` which simply takes a `ScrollEventAxis` and the delta on that
axis. To resolve the first bug, we make
`ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide` now consult this
method when making a decision. To fix the second bug, we check
`isScrollDeltaOpposingStretch` in `ScrollingEffectsController::applyScrollDeltaWithStretching`
for both axes. When true, that axis&apos; component in `m_stretchScrollForce` is set to zero.

Additionally, `ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide` does not dampen
scroll deltas when scrolling in a direction opposite of the stretch since there should be no
resistance.

* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalStretching const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::allowsVerticalStretching const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::isScrollDeltaOpposingStretch const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::shouldRubberBandOnSide const):
* Source/WebCore/platform/ScrollAnimator.h:
* Source/WebCore/platform/ScrollingEffectsController.h:
* Source/WebCore/platform/mac/ScrollAnimatorMac.h:
* Source/WebCore/platform/mac/ScrollAnimatorMac.mm:
(WebCore::ScrollAnimatorMac::isScrollDeltaOpposingStretch const):
(WebCore::ScrollAnimatorMac::shouldRubberBandOnSide const):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::handleWheelEvent):
(WebCore::ScrollingEffectsController::applyScrollDeltaWithStretching):
(WebCore::ScrollingEffectsController::isScrollDeltaOpposingStretch):
(WebCore::ScrollingEffectsController::shouldRubberBandOnSide const):

Canonical link: <a href="https://commits.webkit.org/306796@main">https://commits.webkit.org/306796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b00beaa83d052222af37da5d12cbfe8d6e3ba132

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14667 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150904 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95447 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a26dd55-4fda-4905-874e-f4d0b76c9c95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109388 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95447 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90287 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9687a3d3-9c54-42f2-badf-9b1221142877) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9095 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/937 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153254 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14346 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117440 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117763 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30047 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13807 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124558 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70046 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14395 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3574 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78111 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14332 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->