### PR TITLE
Drop remaining `protected*()` member function on Document

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -659,10 +659,10 @@ static bool isOriginClean(const auto& source, ScriptExecutionContext& context)
     }, [&](const RefPtr<ImageData>) -> ResultType {
         return true;
     }, [&](const RefPtr<HTMLImageElement> imageElement) -> ResultType {
-        return imageElement->originClean(*context.protectedSecurityOrigin().get());
+        return imageElement->originClean(*protect(context.securityOrigin()).get());
     }, [&](const RefPtr<HTMLVideoElement> videoElement) -> ResultType {
 #if PLATFORM(COCOA)
-        return !videoElement->taintsOrigin(*context.protectedSecurityOrigin().get());
+        return !videoElement->taintsOrigin(*protect(context.securityOrigin()).get());
 #else
         UNUSED_PARAM(videoElement);
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -495,7 +495,7 @@ ExceptionOr<Ref<ApplePaySession>> ApplePaySession::create(Document& document, un
     if (!document.page())
         return Exception { ExceptionCode::InvalidAccessError, "Frame is detached"_s };
 
-    auto convertedPaymentRequest = convertAndValidate(document, version, WTF::move(paymentRequest), document.protectedPage()->protectedPaymentCoordinator().get());
+    auto convertedPaymentRequest = convertAndValidate(document, version, WTF::move(paymentRequest), protect(document.page())->protectedPaymentCoordinator().get());
     if (convertedPaymentRequest.hasException())
         return convertedPaymentRequest.releaseException();
 

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -160,7 +160,7 @@ ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& 
         }
     }
 
-    auto cachedResource = document.protectedCachedResourceLoader()->requestBeaconResource({ WTF::move(request), options });
+    auto cachedResource = protect(document.cachedResourceLoader())->requestBeaconResource({ WTF::move(request), options });
     if (!cachedResource) {
         logError(cachedResource.error());
         return false;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -76,7 +76,7 @@ void MediaKeySystemRequest::start()
         return;
     }
 
-    auto* controller = MediaKeySystemController::from(document->protectedPage().get());
+    auto* controller = MediaKeySystemController::from(protect(document->page()).get());
     if (!controller) {
         deny();
         return;
@@ -115,7 +115,7 @@ void MediaKeySystemRequest::deny(const String& message)
 void MediaKeySystemRequest::stop()
 {
     Ref document = *this->document();
-    if (auto* controller = MediaKeySystemController::from(document->protectedPage().get()))
+    if (auto* controller = MediaKeySystemController::from(protect(document->page()).get()))
         controller->cancelMediaKeySystemRequest(*this);
 }
 

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -67,7 +67,7 @@ static ExceptionOr<String> computeReferrer(ScriptExecutionContext& context, cons
     if (referrerURL.protocolIsAbout() && referrerURL.path() == "client"_s)
         return "client"_str;
 
-    if (!(context.securityOrigin() && context.protectedSecurityOrigin()->canRequest(referrerURL, OriginAccessPatternsForWebProcess::singleton())))
+    if (!(context.securityOrigin() && protect(context.securityOrigin())->canRequest(referrerURL, OriginAccessPatternsForWebProcess::singleton())))
         return "client"_str;
 
     return String { referrerURL.string() };

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -191,7 +191,7 @@ void NavigatorGamepad::gamepadDisconnected(PlatformGamepad& platformGamepad)
 RefPtr<Page> NavigatorGamepad::protectedPage() const
 {
     RefPtr frame = m_navigator->frame();
-    return frame ? frame->protectedPage() : nullptr;
+    return frame ? protect(frame->page()) : nullptr;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightStorage.cpp
@@ -278,7 +278,7 @@ bool AppHighlightStorage::attemptToRestoreHighlightAndScroll(AppHighlightRangeDa
     if (!range)
         return false;
 
-    document->protectedAppHighlightRegistry()->addAnnotationHighlightWithRange(StaticRange::create(*range));
+    protect(document->appHighlightRegistry())->addAnnotationHighlightWithRange(StaticRange::create(*range));
 
     if (scroll == ScrollToHighlight::Yes) {
         auto textIndicator = TextIndicator::createWithRange(range.value(), { TextIndicatorOption::DoNotClipToVisibleRect }, WebCore::TextIndicatorPresentationTransition::Bounce);

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -126,7 +126,7 @@ void CredentialRequestCoordinator::prepareCredentialRequest(const Document& docu
         return promise.reject(ExceptionCode::AbortError, "Page was destroyed."_s);
 
     auto validatedRequestsOrException = m_client->validateAndParseDigitalCredentialRequests(
-        document.protectedTopOrigin(),
+        protect(document.topOrigin()),
         document,
         unvalidatedRequests);
 
@@ -152,8 +152,8 @@ void CredentialRequestCoordinator::prepareCredentialRequest(const Document& docu
     auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
     DigitalCredentialsRequestData requestData {
         WTF::move(validatedCredentialRequests),
-        document.protectedTopOrigin()->data(),
-        document.protectedSecurityOrigin()->data(),
+        protect(document.topOrigin())->data(),
+        protect(document.securityOrigin())->data(),
     };
 
     m_client->showDigitalCredentialsPicker(

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -75,7 +75,7 @@ void ArtworkImageLoader::requestImageResource()
 
     CachedResourceRequest request(ResourceRequest(document->completeURL(m_src)), options);
     request.setInitiatorType(AtomString { document->documentURI() });
-    m_cachedImage = document->protectedCachedResourceLoader()->requestImage(WTF::move(request)).value_or(nullptr);
+    m_cachedImage = protect(document->cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
 
     if (m_cachedImage)
         m_cachedImage->addClient(*this);

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -659,7 +659,7 @@ MediaTime MediaSession::mediaSessionDuration() const
 std::optional<MediaSessionGroupIdentifier> MediaSession::mediaSessionGroupIdentifier() const
 {
     RefPtr document = this->document();
-    return document && document->page() ? document->protectedPage()->mediaSessionGroupIdentifier() : std::nullopt;
+    return document && document->page() ? protect(document->page())->mediaSessionGroupIdentifier() : std::nullopt;
 }
 
 }

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -82,7 +82,7 @@ void MediaDevices::stop()
 {
     if (m_deviceChangeToken) {
         RefPtr document = this->document();
-        auto* controller = document ? UserMediaController::from(document->protectedPage().get()) : nullptr;
+        auto* controller = document ? UserMediaController::from(protect(document->page()).get()) : nullptr;
         if (controller)
             controller->removeDeviceChangeObserver(*m_deviceChangeToken);
     }
@@ -430,7 +430,7 @@ void MediaDevices::enumerateDevices(EnumerateDevicesPromise&& promise)
     if (!document)
         return;
 
-    auto* controller = UserMediaController::from(document->protectedPage().get());
+    auto* controller = UserMediaController::from(protect(document->page()).get());
     if (!controller) {
         promise.resolve({ });
         return;
@@ -484,7 +484,7 @@ ScriptExecutionContext* MediaDevices::scriptExecutionContext() const
 void MediaDevices::listenForDeviceChanges()
 {
     RefPtr document = this->document();
-    auto* controller = document ? UserMediaController::from(document->protectedPage().get()) : nullptr;
+    auto* controller = document ? UserMediaController::from(protect(document->page()).get()) : nullptr;
     if (!controller)
         return;
 

--- a/Source/WebCore/Modules/mediastream/RTCController.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCController.cpp
@@ -74,9 +74,9 @@ void RTCController::remove(RTCPeerConnection& connection)
 
 static inline bool matchDocumentOrigin(Document& document, SecurityOrigin& topOrigin, SecurityOrigin& clientOrigin)
 {
-    if (topOrigin.isSameOriginAs(document.protectedSecurityOrigin()))
+    if (topOrigin.isSameOriginAs(protect(document.securityOrigin())))
         return true;
-    return topOrigin.isSameOriginAs(document.protectedTopOrigin()) && clientOrigin.isSameOriginAs(document.protectedSecurityOrigin());
+    return topOrigin.isSameOriginAs(protect(document.topOrigin())) && clientOrigin.isSameOriginAs(protect(document.securityOrigin()));
 }
 
 bool RTCController::shouldDisableICECandidateFiltering(Document& document)

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -109,7 +109,7 @@ void UserMediaRequest::start()
     //    attribute name allowusermedia, return a promise rejected with a DOMException object whose name
     //    attribute has the value SecurityError.
     Ref document = downcast<Document>(*context);
-    auto* controller = UserMediaController::from(document->protectedPage().get());
+    auto* controller = UserMediaController::from(protect(document->page()).get());
     if (!controller) {
         deny(MediaAccessDenialReason::UserMediaDisabled);
         return;
@@ -287,7 +287,7 @@ void UserMediaRequest::deny(MediaAccessDenialReason reason, const String& messag
 void UserMediaRequest::stop()
 {
     Ref document = downcast<Document>(*scriptExecutionContext());
-    if (auto* controller = UserMediaController::from(document->protectedPage().get()))
+    if (auto* controller = UserMediaController::from(protect(document->page()).get()))
         controller->cancelUserMediaAccessRequest(*this);
 }
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -507,7 +507,7 @@ void HTMLModelElement::createModelPlayer()
 #endif
 
     if (!m_modelPlayerProvider)
-        m_modelPlayerProvider = document().protectedPage()->modelPlayerProvider();
+        m_modelPlayerProvider = protect(document().page())->modelPlayerProvider();
     if (RefPtr modelPlayerProvider = m_modelPlayerProvider.get()) {
         modelPlayer = modelPlayerProvider->createModelPlayer(*this);
         m_modelPlayer = modelPlayer.copyRef();
@@ -618,7 +618,7 @@ void HTMLModelElement::reloadModelPlayer()
     ASSERT(animationState && transformState);
 
     if (!m_modelPlayerProvider)
-        m_modelPlayerProvider = protect(document())->protectedPage()->modelPlayerProvider();
+        m_modelPlayerProvider = protect(protect(document())->page())->modelPlayerProvider();
     if (RefPtr modelPlayerProvider = m_modelPlayerProvider.get()) {
         modelPlayer = modelPlayerProvider->createModelPlayer(*this);
         m_modelPlayer = modelPlayer.copyRef();
@@ -1147,7 +1147,7 @@ URL HTMLModelElement::selectEnvironmentMapURL() const
 void HTMLModelElement::environmentMapRequestResource()
 {
     auto request = createResourceRequest(m_environmentMapURL, FetchOptions::Destination::Environmentmap);
-    auto resource = document().protectedCachedResourceLoader()->requestEnvironmentMapResource(WTF::move(request));
+    auto resource = protect(document().cachedResourceLoader())->requestEnvironmentMapResource(WTF::move(request));
     if (!resource.has_value()) {
         if (!m_environmentMapReadyPromise->isFulfilled())
             m_environmentMapReadyPromise->reject(Exception { ExceptionCode::NetworkError });
@@ -1633,7 +1633,7 @@ Node::InsertedIntoAncestorResult HTMLModelElement::insertedIntoAncestor(Insertio
 #if ENABLE(MODEL_PROCESS)
         document->incrementModelElementCount();
 #endif
-        m_modelPlayerProvider = document->protectedPage()->modelPlayerProvider();
+        m_modelPlayerProvider = protect(document->page())->modelPlayerProvider();
         LazyLoadModelObserver::observe(*this);
     }
 
@@ -1701,7 +1701,7 @@ void HTMLModelElement::sourceRequestResource()
         return triggerModelPlayerCreationCallbacksIfNeeded(Exception { ExceptionCode::AbortError, "The source URL is empty"_s });
 
     auto request = createResourceRequest(m_sourceURL, FetchOptions::Destination::Model);
-    auto resource = protect(document())->protectedCachedResourceLoader()->requestModelResource(WTF::move(request));
+    auto resource = protect(protect(document())->cachedResourceLoader())->requestModelResource(WTF::move(request));
     if (!resource.has_value()) {
         ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
         if (!m_readyPromise->isFulfilled())

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -467,7 +467,7 @@ NotificationData Notification::data() const
         m_tag,
         m_lang,
         m_direction,
-        context->protectedSecurityOrigin()->toString(),
+        protect(context->securityOrigin())->toString(),
         m_serviceWorkerRegistrationURL,
         identifier(),
         context->identifier(),

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -72,7 +72,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
 
     // FIXME: The permission check can likely be dropped once the specification gets updated to only
     // require transient activation (https://github.com/w3c/screen-wake-lock/pull/326).
-    bool hasTransientActivation = document->window() && document->protectedWindow()->hasTransientActivation();
+    bool hasTransientActivation = document->window() && protect(document->window())->hasTransientActivation();
     PermissionController::singleton().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, *document->page(), PermissionQuerySource::Window, [this, protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTF::move(promise), lockType](std::optional<PermissionState> permission) mutable {
         if (!permission || *permission == PermissionState::Prompt) {
             if (hasTransientActivation || m_wasPreviouslyAuthorizedDueToTransientActivation) {

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -542,7 +542,7 @@ void AudioContext::didReceiveRemoteControlCommand(PlatformMediaSession::RemoteCo
 std::optional<MediaSessionGroupIdentifier> AudioContext::mediaSessionGroupIdentifier() const
 {
     RefPtr document = this->document();
-    return document && document->page() ? document->protectedPage()->mediaSessionGroupIdentifier() : std::nullopt;
+    return document && document->page() ? protect(document->page())->mediaSessionGroupIdentifier() : std::nullopt;
 }
 
 static bool hasPlayBackAudioSession(Document* document)

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -295,7 +295,7 @@ bool BaseAudioContext::wouldTaintOrigin(const URL& url) const
         return false;
 
     if (RefPtr document = this->document())
-        return !document->protectedSecurityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton());
+        return !protect(document->securityOrigin())->canRequest(url, OriginAccessPatternsForWebProcess::singleton());
 
     return false;
 }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -102,9 +102,9 @@ static ScopeAndCrossOriginParent scopeAndCrossOriginParent(const Document& docum
     auto url = document.url();
     std::optional<SecurityOriginData> crossOriginParent;
     for (RefPtr parentDocument = document.parentDocument(); parentDocument; parentDocument = parentDocument->parentDocument()) {
-        if (!origin->isSameOriginDomain(parentDocument->protectedSecurityOrigin()) && !areRegistrableDomainsEqual(url, parentDocument->url()))
+        if (!origin->isSameOriginDomain(protect(parentDocument->securityOrigin())) && !areRegistrableDomainsEqual(url, parentDocument->url()))
             isSameSite = false;
-        if (!crossOriginParent && !origin->isSameOriginAs(parentDocument->protectedSecurityOrigin()))
+        if (!crossOriginParent && !origin->isSameOriginAs(protect(parentDocument->securityOrigin())))
             crossOriginParent = parentDocument->securityOrigin().data();
     }
 
@@ -409,7 +409,7 @@ void AuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable(con
     };
 
     // Async operation are dispatched and handled in the messenger.
-    m_client->isUserVerifyingPlatformAuthenticatorAvailable(document.protectedSecurityOrigin().get(), WTF::move(completionHandler));
+    m_client->isUserVerifyingPlatformAuthenticatorAvailable(protect(document.securityOrigin()).get(), WTF::move(completionHandler));
 }
 
 
@@ -424,7 +424,7 @@ void AuthenticatorCoordinator::isConditionalMediationAvailable(const Document& d
         promise.resolve(result);
     };
     // Async operations are dispatched and handled in the messenger.
-    m_client->isConditionalMediationAvailable(document.protectedSecurityOrigin().get(), WTF::move(completionHandler));
+    m_client->isConditionalMediationAvailable(protect(document.securityOrigin()).get(), WTF::move(completionHandler));
 }
 
 void AuthenticatorCoordinator::getClientCapabilities(const Document& document, DOMPromiseDeferred<PublicKeyCredentialClientCapabilities>&& promise) const
@@ -438,7 +438,7 @@ void AuthenticatorCoordinator::getClientCapabilities(const Document& document, D
         promise.resolve(result);
     };
 
-    m_client->getClientCapabilities(document.protectedSecurityOrigin().get(), WTF::move(completionHandler));
+    m_client->getClientCapabilities(protect(document.securityOrigin()).get(), WTF::move(completionHandler));
 }
 
 void AuthenticatorCoordinator::signalUnknownCredential(const Document& document, UnknownCredentialOptions&& options, DOMPromiseDeferred<void>&& promise)

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
@@ -181,7 +181,7 @@ bool DatabaseContext::allowDatabaseAccess() const
 {
     RefPtr context = scriptExecutionContext();
     if (RefPtr document = dynamicDowncast<Document>(*context)) {
-        if (!document->page() || (document->page()->usesEphemeralSession() && !LegacySchemeRegistry::allowsDatabaseAccessInPrivateBrowsing(document->protectedSecurityOrigin()->protocol())))
+        if (!document->page() || (document->page()->usesEphemeralSession() && !LegacySchemeRegistry::allowsDatabaseAccessInPrivateBrowsing(protect(document->securityOrigin())->protocol())))
             return false;
         return true;
     }

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -112,7 +112,7 @@ std::optional<ResourceRequest> ThreadableWebSocketChannel::webSocketConnectReque
     request.setDomainForCachePartition(document.domainForCachePartition());
     request.setAllowCookies(validatedURL->areCookiesAllowed);
     request.setFirstPartyForCookies(document.firstPartyForCookies());
-    request.setHTTPHeaderField(HTTPHeaderName::Origin, document.protectedSecurityOrigin()->toString());
+    request.setHTTPHeaderField(HTTPHeaderName::Origin, protect(document.securityOrigin())->toString());
 
     if (RefPtr documentLoader = document.loader())
         request.setIsAppInitiated(documentLoader->lastNavigationWasAppInitiated());
@@ -133,9 +133,9 @@ std::optional<ResourceRequest> ThreadableWebSocketChannel::webSocketConnectReque
         request.addHTTPHeaderField(HTTPHeaderName::SecFetchDest, "websocket"_s);
         request.addHTTPHeaderField(HTTPHeaderName::SecFetchMode, "websocket"_s);
 
-        if (document.protectedSecurityOrigin()->isSameOriginAs(requestOrigin.get()))
+        if (protect(document.securityOrigin())->isSameOriginAs(requestOrigin.get()))
             request.addHTTPHeaderField(HTTPHeaderName::SecFetchSite, "same-origin"_s);
-        else if (document.protectedSecurityOrigin()->isSameSiteAs(requestOrigin))
+        else if (protect(document.securityOrigin())->isSameSiteAs(requestOrigin))
             request.addHTTPHeaderField(HTTPHeaderName::SecFetchSite, "same-site"_s);
         else
             request.addHTTPHeaderField(HTTPHeaderName::SecFetchSite, "cross-site"_s);

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -209,7 +209,7 @@ bool WebXRSystem::immersiveSessionRequestIsAllowedForGlobalObject(LocalDOMWindow
         return false;
 
     // https://immersive-web.github.io/webxr/#active-and-focused
-    if (!document.hasFocus() || !document.protectedSecurityOrigin()->isSameOriginAs(globalObject.document()->securityOrigin()))
+    if (!document.hasFocus() || !protect(document.securityOrigin())->isSameOriginAs(globalObject.document()->securityOrigin()))
         return false;
 
     // 3. If user intent to begin an immersive session is not well understood,

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1309,7 +1309,7 @@ TextStream& operator<<(TextStream& stream, AXObjectCache& axObjectCache)
     RefPtr document = axObjectCache.document();
     if (!document)
         stream << "No document!";
-    else if (RefPtr root = axObjectCache.get(document->protectedView().get())) {
+    else if (RefPtr root = axObjectCache.get(protect(document->view()).get())) {
         constexpr OptionSet<AXStreamOptions> options = { AXStreamOptions::ObjectID, AXStreamOptions::Role, AXStreamOptions::ParentID, AXStreamOptions::IdentifierAttribute, AXStreamOptions::OuterHTML, AXStreamOptions::DisplayContents, AXStreamOptions::Address, AXStreamOptions::RendererOrNode };
         streamSubtree(stream, root.releaseNonNull(), options);
     } else

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -384,7 +384,7 @@ void AXObjectCache::postPlatformAnnouncementNotification(const String& message)
 
     // To simplify monitoring of notifications in tests, repost as a simple NSNotification instead of forcing test infrastucture to setup an IPC client and do all the translation between WebCore types and platform specific IPC types and back.
     if (gShouldRepostNotificationsForTests) [[unlikely]] {
-        if (RefPtr root = getOrCreate(m_document->protectedView().get()))
+        if (RefPtr root = getOrCreate(protect(m_document->view()).get()))
             [root->wrapper() accessibilityPostedNotification:NSAccessibilityAnnouncementRequestedNotification userInfo:userInfo];
     }
 }
@@ -405,7 +405,7 @@ void AXObjectCache::postPlatformARIANotifyNotification(AccessibilityObject& obje
     NSAccessibilityPostNotificationWithUserInfo(object.wrapper(), NSAccessibilityAnnouncementRequestedNotification, userInfo);
 
     if (gShouldRepostNotificationsForTests) [[unlikely]] {
-        if (RefPtr root = getOrCreate(m_document->protectedView().get()))
+        if (RefPtr root = getOrCreate(protect(m_document->view()).get()))
             [root->wrapper() accessibilityPostedNotification:NSAccessibilityAnnouncementRequestedNotification userInfo:userInfo];
     }
 }
@@ -417,7 +417,7 @@ void AXObjectCache::postPlatformLiveRegionNotification(AccessibilityObject& obje
     NSAccessibilityPostNotificationWithUserInfo(object.wrapper(), NSAccessibilityAnnouncementRequestedNotification, userInfo.get());
 
     if (gShouldRepostNotificationsForTests) [[unlikely]] {
-        if (RefPtr root = getOrCreate(m_document->protectedView().get()))
+        if (RefPtr root = getOrCreate(protect(m_document->view()).get()))
             [root->wrapper() accessibilityPostedNotification:NSAccessibilityAnnouncementRequestedNotification userInfo:userInfo.get()];
     }
 }

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -310,7 +310,7 @@ void AnimationTimelinesController::resumeAnimations()
 
 ReducedResolutionSeconds AnimationTimelinesController::liveCurrentTime() const
 {
-    return protectedDocument()->protectedWindow()->nowTimestamp();
+    return protect(protectedDocument()->window())->nowTimestamp();
 }
 
 std::optional<Seconds> AnimationTimelinesController::currentTime(UseCachedCurrentTime useCachedCurrentTime)

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -71,7 +71,7 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(D
     if (!m_initiatorType.isNull())
         request.setInitiatorType(m_initiatorType);
 
-    return document.protectedCachedResourceLoader()->requestScript(WTF::move(request)).value_or(nullptr);
+    return protect(document.cachedResourceLoader())->requestScript(WTF::move(request)).value_or(nullptr);
 }
 
 }

--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -82,7 +82,7 @@ static inline bool canAccessDocument(JSC::JSGlobalObject* lexicalGlobalObject, D
 
     auto& active = activeDOMWindow(*lexicalGlobalObject);
 
-    if (active.document()->protectedSecurityOrigin()->isSameOriginDomain(targetDocument->securityOrigin()))
+    if (protect(active.document()->securityOrigin())->isSameOriginDomain(targetDocument->securityOrigin()))
         return true;
 
     switch (reportingOption) {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -760,7 +760,7 @@ JSC::JSGlobalObject* JSDOMGlobalObject::deriveShadowRealmGlobalObject(JSC::JSGlo
 
         while (!document->isTopDocument()) {
             CheckedPtr candidateDocument = document->parentDocument();
-            if (!candidateDocument || !candidateDocument->protectedSecurityOrigin()->isSameOriginDomain(originalOrigin))
+            if (!candidateDocument || !protect(candidateDocument->securityOrigin())->isSameOriginDomain(originalOrigin))
                 break;
 
             document = candidateDocument;

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -100,7 +100,7 @@ void WindowProxy::replaceFrame(Frame& frame)
 {
     ASSERT(m_frame);
     m_frame = frame;
-    setDOMWindow(frame.protectedWindow().get());
+    setDOMWindow(protect(frame.window()).get());
 }
 
 void WindowProxy::destroyJSWindowProxy(DOMWrapperWorld& world)
@@ -119,7 +119,7 @@ JSWindowProxy& WindowProxy::createJSWindowProxy(DOMWrapperWorld& world)
 
     VM& vm = world.vm();
 
-    Strong<JSWindowProxy> jsWindowProxy(vm, &JSWindowProxy::create(vm, *m_frame->protectedWindow().get(), world));
+    Strong<JSWindowProxy> jsWindowProxy(vm, &JSWindowProxy::create(vm, *protect(m_frame->window()).get(), world));
     m_jsWindowProxies.add(world, jsWindowProxy);
     world.didCreateWindowProxy(this);
     return *jsWindowProxy.get();

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -343,7 +343,7 @@ bool CSSStyleSheet::canAccessRules() const
     if (!document)
         return false;
 
-    return document->protectedSecurityOrigin()->canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton());
+    return protect(document->securityOrigin())->canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton());
 }
 
 ExceptionOr<unsigned> CSSStyleSheet::insertRule(const String& ruleString, unsigned index)

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -156,12 +156,12 @@ void StyleRuleImport::requestStyleSheet()
 
         request.setOptions(WTF::move(options));
 
-        m_cachedSheet = document->protectedCachedResourceLoader()->requestUserCSSStyleSheet(*page, WTF::move(request));
+        m_cachedSheet = protect(document->cachedResourceLoader())->requestUserCSSStyleSheet(*page, WTF::move(request));
     } else {
         auto options = request.options();
         options.loadedFromOpaqueSource = m_parentStyleSheet->loadedFromOpaqueSource();
         request.setOptions(WTF::move(options));
-        m_cachedSheet = document->protectedCachedResourceLoader()->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
+        m_cachedSheet = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
     }
     if (m_cachedSheet) {
         // if the import rule is issued dynamically, the sheet may be

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -84,7 +84,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     this->charset = charset;
     mode = document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode;
     isHTMLDocument = document.isHTMLDocument();
-    hasDocumentSecurityOrigin = sheetBaseURL.isNull() || document.protectedSecurityOrigin()->canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton());
+    hasDocumentSecurityOrigin = sheetBaseURL.isNull() || protect(document.securityOrigin())->canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton());
     webkitMediaTextTrackDisplayQuirkEnabled = document.quirks().needsWebKitMediaTextTrackDisplayQuirk();
 }
 

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -197,7 +197,7 @@ private:
 static float deviceScaleFactor(const FeatureEvaluationContext& context)
 {
     Ref frame = *context.document->frame();
-    auto mediaType = frame->protectedView()->mediaType();
+    auto mediaType = protect(frame->view())->mediaType();
     
     if (mediaType == screenAtom())
         return frame->page() ? frame->page()->deviceScaleFactor() : 1;
@@ -426,7 +426,7 @@ static const LengthSchema& heightFeatureSchema()
         "height"_s,
         MediaQueryDynamicDependency::Viewport,
         [](auto& context) {
-            auto height = context.document->protectedView()->layoutHeight();
+            auto height = protect(context.document->view())->layoutHeight();
             if (CheckedPtr renderView = context.document->renderView())
                 height = adjustForAbsoluteZoom(height, *renderView);
             return height;
@@ -488,11 +488,11 @@ static const IntegerSchema& monochromeFeatureSchema()
                 if (frame->settings().forcedDisplayIsMonochromeAccessibilityValue() == ForcedAccessibilityValue::Off)
                     return false;
                 if (localFrame)
-                    return screenIsMonochrome(localFrame->protectedView().get());
+                    return screenIsMonochrome(protect(localFrame->view()).get());
                 return false;
             }();
 
-            return isMonochrome && localFrame ? screenDepthPerComponent(localFrame->protectedView().get()) : 0;
+            return isMonochrome && localFrame ? screenDepthPerComponent(protect(localFrame->view()).get()) : 0;
         }
     };
     return schema;
@@ -718,7 +718,7 @@ static const LengthSchema& widthFeatureSchema()
         "width"_s,
         MediaQueryDynamicDependency::Viewport,
         [](auto& context) {
-            auto width = context.document->protectedView()->layoutWidth();
+            auto width = protect(context.document->view())->layoutWidth();
             if (CheckedPtr renderView = context.document->renderView())
                 width = adjustForAbsoluteZoom(width, *renderView);
             return width;

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -66,7 +66,7 @@ static HashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& ch
 
 static PartitionedSecurityOrigin partitionedSecurityOriginFromContext(ScriptExecutionContext& context)
 {
-    return { context.topOrigin(), context.protectedSecurityOrigin().releaseNonNull() };
+    return { context.topOrigin(), protect(context.securityOrigin()).releaseNonNull() };
 }
 
 class BroadcastChannel::MainThreadBridge : public ThreadSafeRefCounted<MainThreadBridge, WTF::DestructionThread::Main>, public Identified<BroadcastChannelIdentifier> {
@@ -112,7 +112,7 @@ void BroadcastChannel::MainThreadBridge::ensureOnMainThread(Function<void(Page*)
     ASSERT(context->isContextThread());
 
     if (RefPtr document = dynamicDowncast<Document>(*context)) {
-        task(document->protectedPage().get());
+        task(protect(document->page()).get());
         return;
     }
 
@@ -121,7 +121,7 @@ void BroadcastChannel::MainThreadBridge::ensureOnMainThread(Function<void(Page*)
         return;
 
     workerLoaderProxy->postTaskToLoader([task = WTF::move(task)](auto& context) {
-        task(downcast<Document>(context).protectedPage().get());
+        task(protect(downcast<Document>(context).page()).get());
     });
 }
 

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -389,7 +389,7 @@ void CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue(Element
     ASSERT(element.reactionQueue());
     element.setIsInCustomElementReactionQueue();
     if (!CustomElementReactionStack::s_currentProcessingStack) {
-        protect(element.document())->protectedWindowEventLoop()->backupElementQueue().add(element);
+        protect(protect(element.document())->windowEventLoop())->backupElementQueue().add(element);
         return;
     }
 

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -147,7 +147,7 @@ Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
         auto titleElement = HTMLTitleElement::create(titleTag, document);
         titleElement->appendChild(document->createTextNode(WTF::move(title)));
         ASSERT(document->head());
-        document->protectedHead()->appendChild(titleElement);
+        protect(document->head())->appendChild(titleElement);
     }
     document->setContextDocument(thisDocument->contextDocument());
     document->setSecurityOriginPolicy(thisDocument->securityOriginPolicy());
@@ -201,7 +201,7 @@ Ref<Document> DOMImplementation::createDocument(const String& contentType, Local
 
     // The following is the relatively costly lookup that requires initializing the plug-in database.
     if (frame && frame->page()) {
-        if (frame->protectedPage()->protectedPluginData()->supportsWebVisibleMimeType(contentType, PluginData::OnlyApplicationPlugins))
+        if (protect(frame->page())->protectedPluginData()->supportsWebVisibleMimeType(contentType, PluginData::OnlyApplicationPlugins))
             return PluginDocument::create(*frame, url);
     }
 

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -238,7 +238,7 @@ String DataTransfer::readStringFromPasteboard(Document& document, const String& 
     }
 
     if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == "text/uri-list"_s) {
-        return readURLsFromPasteboardAsString(document.protectedPage().get(), *m_pasteboard, [] (auto&) {
+        return readURLsFromPasteboardAsString(protect(document.page()).get(), *m_pasteboard, [] (auto&) {
             return true;
         });
     }

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -58,7 +58,7 @@ DeviceOrientationOrMotionPermissionState DeviceOrientationAndMotionAccessControl
 
     // Check per-site setting.
     Ref topDocument = m_topDocument.get();
-    if (&document == topDocument.ptr() || document.protectedSecurityOrigin()->isSameOriginAs(topDocument->protectedSecurityOrigin())) {
+    if (&document == topDocument.ptr() || protect(document.securityOrigin())->isSameOriginAs(protect(topDocument->securityOrigin()))) {
         RefPtr frame = topDocument->frame();
         if (RefPtr documentLoader = frame ? frame->loader().documentLoader() : nullptr)
             return documentLoader->deviceOrientationAndMotionAccessState();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -727,9 +727,7 @@ public:
     void setStateForNewFormElements(const Vector<AtomString>&);
 
     inline LocalFrameView* view() const; // Defined in DocumentView.h.
-    inline RefPtr<LocalFrameView> protectedView() const; // Defined in DocumentView.h.
     inline Page* page() const; // Defined in DocumentPage.h.
-    inline RefPtr<Page> protectedPage() const; // Defined in DocumentPage.h.
     WEBCORE_EXPORT RefPtr<LocalFrame> localMainFrame() const;
     const Settings& settings() const { return m_settings.get(); }
     EditingBehavior editingBehavior() const;
@@ -792,7 +790,6 @@ public:
     WEBCORE_EXPORT void pageSizeAndMarginsInPixels(int pageIndex, IntSize& pageSize, int& marginTop, int& marginRight, int& marginBottom, int& marginLeft);
 
     inline CachedResourceLoader& cachedResourceLoader(); // Defined in DocumentResourceLoader.h
-    inline Ref<CachedResourceLoader> protectedCachedResourceLoader() const; // Defined in DocumentResourceLoader.h
 
     WEBCORE_EXPORT void didBecomeCurrentDocumentInFrame();
     void destroyRenderTree();
@@ -906,10 +903,8 @@ public:
     bool requiresTrustedTypes() const { return m_requiresTrustedTypes && !shouldBypassMainWorldContentSecurityPolicy(); }
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
-    RefPtr<IDBClient::IDBConnectionProxy> protectedIDBConnectionProxy();
     StorageConnection* storageConnection();
     SocketProvider* socketProvider() final;
-    RefPtr<SocketProvider> protectedSocketProvider();
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
 
 #if ENABLE(WEB_RTC)
@@ -926,7 +921,6 @@ public:
     
     virtual Ref<DocumentParser> createParser();
     DocumentParser* parser() const { return m_parser.get(); }
-    inline RefPtr<DocumentParser> protectedParser() const; // Defined in DocumentInlines.h.
     ScriptableDocumentParser* scriptableDocumentParser() const;
     HTMLDocumentParser* htmlDocumentParser() const;
 
@@ -985,7 +979,6 @@ public:
     WEBCORE_EXPORT bool setFocusedElement(Element*, BroadcastFocusedElement = BroadcastFocusedElement::Yes);
     WEBCORE_EXPORT bool setFocusedElement(Element*, const FocusOptions&, BroadcastFocusedElement = BroadcastFocusedElement::Yes);
     Element* focusedElement() const { return m_focusedElement.get(); }
-    inline RefPtr<Element> protectedFocusedElement() const; // Defined in DocumentInlines.h.
     inline bool wasLastFocusByClick() const;
     void setLatestFocusTrigger(FocusTrigger trigger) { m_latestFocusTrigger = trigger; }
     UserActionElementSet& userActionElements()  { return m_userActionElements; }
@@ -1063,16 +1056,13 @@ public:
     void takeDOMWindowFrom(Document&);
 
     LocalDOMWindow* window() const { return m_domWindow.get(); }
-    inline RefPtr<LocalDOMWindow> protectedWindow() const; // Defined in DocumentWindow.h.
 
     // In DOM Level 2, the Document's LocalDOMWindow is called the defaultView.
     WEBCORE_EXPORT WindowProxy* windowProxy() const;
-    RefPtr<WindowProxy> protectedWindowProxy() const;
 
     inline bool hasBrowsingContext() const; // Defined in DocumentInlines.h.
 
     Document& contextDocument() const;
-    Ref<Document> protectedContextDocument() const { return contextDocument(); }
     void setContextDocument(Ref<Document>&& document) { m_contextDocument = WTF::move(document); }
     
     OptionSet<ParserContentPolicy> parserContentPolicy() const { return m_parserContentPolicy; }
@@ -1256,13 +1246,11 @@ public:
     // This is the "body element" as defined by HTML5, the first body or frameset child of the
     // document element. See https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2.
     WEBCORE_EXPORT HTMLElement* bodyOrFrameset() const;
-    WEBCORE_EXPORT RefPtr<HTMLElement> protectedBodyOrFrameset() const;
     WEBCORE_EXPORT ExceptionOr<void> setBodyOrFrameset(RefPtr<HTMLElement>&&);
 
     Location* location() const;
 
     WEBCORE_EXPORT HTMLHeadElement* head();
-    RefPtr<HTMLHeadElement> protectedHead();
 
     inline const DocumentMarkerController* markersIfExists() const { return m_markers.get(); }
     inline DocumentMarkerController* markersIfExists() { return m_markers.get(); }
@@ -1279,7 +1267,6 @@ public:
     WEBCORE_EXPORT ExceptionOr<String> queryCommandValue(const String& command);
 
     UndoManager& undoManager() const;
-    inline Ref<UndoManager> protectedUndoManager() const; // Defined in DocumentInlines.h.
 
     // designMode support
     enum class DesignMode : bool { Off, On };
@@ -1288,17 +1275,14 @@ public:
     WEBCORE_EXPORT void setDesignMode(const String&);
 
     WEBCORE_EXPORT Document* parentDocument() const;
-    RefPtr<Document> protectedParentDocument() const { return parentDocument(); }
 
     WEBCORE_EXPORT Document* mainFrameDocument() const;
-    RefPtr<Document> protectedMainFrameDocument() const { return mainFrameDocument(); }
     bool isTopDocument() const { return mainFrameDocument() == this; }
 
     RefPtr<Document> sameOriginTopLevelTraversable() const;
 
     ScriptRunner* scriptRunnerIfExists() { return m_scriptRunner.get(); }
     inline ScriptRunner& scriptRunner();
-    Ref<ScriptRunner> protectedScriptRunner();
     inline ScriptModuleLoader& moduleLoader();
 
     Element* currentScript() const { return !m_currentScriptStack.isEmpty() ? m_currentScriptStack.last().get() : nullptr; }
@@ -1344,7 +1328,6 @@ public:
     WEBCORE_EXPORT EventLoopTaskGroup& eventLoop() final;
     inline CheckedRef<EventLoopTaskGroup> checkedEventLoop(); // Defined in DocumentEventLoop.h
     WindowEventLoop& windowEventLoop();
-    Ref<WindowEventLoop> protectedWindowEventLoop();
 
     ScriptedAnimationController* scriptedAnimationController() { return m_scriptedAnimationController.get(); }
     void suspendScriptedAnimationControllerCallbacks();
@@ -1403,7 +1386,6 @@ public:
 
     void setDecoder(RefPtr<TextResourceDecoder>&&);
     TextResourceDecoder* decoder() const { return m_decoder.get(); }
-    inline RefPtr<TextResourceDecoder> protectedDecoder() const; // Defined in DocumentInlines.h.
 
     WEBCORE_EXPORT String displayStringModifiedByEncoding(const String&) const;
 
@@ -1475,8 +1457,6 @@ public:
     const DocumentFullscreen* fullscreenIfExists() const { return m_fullscreen.get(); }
     WEBCORE_EXPORT DocumentFullscreen& fullscreen();
     WEBCORE_EXPORT const DocumentFullscreen& fullscreen() const;
-    WEBCORE_EXPORT Ref<DocumentFullscreen> protectedFullscreen();
-    WEBCORE_EXPORT Ref<const DocumentFullscreen> protectedFullscreen() const;
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
@@ -1484,8 +1464,6 @@ public:
     const DocumentImmersive* immersiveIfExists() const { return m_immersive.get(); }
     WEBCORE_EXPORT DocumentImmersive& immersive();
     WEBCORE_EXPORT const DocumentImmersive& immersive() const;
-    WEBCORE_EXPORT Ref<DocumentImmersive> protectedImmersive();
-    WEBCORE_EXPORT Ref<const DocumentImmersive> protectedImmersive() const;
 #endif
 
 #if ENABLE(POINTER_LOCK)
@@ -1669,10 +1647,8 @@ public:
     void addMessage(MessageSource, MessageLevel, const String& message, const String& sourceURL, unsigned lineNumber, unsigned columnNumber, RefPtr<Inspector::ScriptCallStack>&&, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0) final;
 
     SecurityOrigin& securityOrigin() const { return *SecurityContext::securityOrigin(); }
-    inline Ref<SecurityOrigin> protectedSecurityOrigin() const; // Defined in DocumentSecurityOrigin.h.
     WEBCORE_EXPORT SecurityOrigin& topOrigin() const final;
     URL topURL() const;
-    Ref<SecurityOrigin> protectedTopOrigin() const;
     inline ClientOrigin clientOrigin() const;
 
     inline bool isSameOriginAsTopDocument() const; // Defined in DocumentSecurityOrigin
@@ -1972,12 +1948,10 @@ public:
 
     HighlightRegistry* textExtractionHighlightRegistryIfExists() const { return m_textExtractionHighlightRegistry.get(); }
     HighlightRegistry& textExtractionHighlightRegistry();
-    Ref<HighlightRegistry> protectedTextExtractionHighlightRegistry();
-        
+
 #if ENABLE(APP_HIGHLIGHTS)
     HighlightRegistry* appHighlightRegistryIfExists() { return m_appHighlightRegistry.get(); }
     WEBCORE_EXPORT HighlightRegistry& appHighlightRegistry();
-    WEBCORE_EXPORT Ref<HighlightRegistry> protectedAppHighlightRegistry();
 
     WEBCORE_EXPORT AppHighlightStorage& appHighlightStorage();
     AppHighlightStorage* appHighlightStorageIfExists() const { return m_appHighlightStorage.get(); };
@@ -2008,8 +1982,6 @@ public:
 
     WEBCORE_EXPORT Editor& editor();
     WEBCORE_EXPORT const Editor& editor() const;
-    WEBCORE_EXPORT Ref<Editor> protectedEditor();
-    WEBCORE_EXPORT Ref<const Editor> protectedEditor() const;
     FrameSelection& selection() { return m_selection; }
     const FrameSelection& selection() const { return m_selection; }
 
@@ -2042,7 +2014,6 @@ public:
 
     ReportingScope* reportingScopeIfExists() const { return m_reportingScope.get(); }
     inline ReportingScope& reportingScope() const;
-    inline Ref<ReportingScope> protectedReportingScope() const; // Defined in DocumentInlines.h.
     WEBCORE_EXPORT String endpointURIForToken(const String&) const final;
 
     bool hasSleepDisabler() const { return !!m_sleepDisabler; }
@@ -2071,12 +2042,10 @@ public:
     unsigned unloadCounter() const { return m_unloadCounter; }
 
     WEBCORE_EXPORT FrameMemoryMonitor& frameMemoryMonitor();
-    Ref<FrameMemoryMonitor> protectedFrameMemoryMonitor();
 
 #if ENABLE(CONTENT_EXTENSIONS)
     ResourceMonitor* resourceMonitorIfExists();
     ResourceMonitor& resourceMonitor();
-    Ref<ResourceMonitor> protectedResourceMonitor();
     ResourceMonitor* parentResourceMonitorIfExists();
 
     bool shouldSkipResourceMonitorThrottling() const { return m_shouldSkipResourceMonitorThrottling; }
@@ -2140,7 +2109,6 @@ private:
     WEBCORE_EXPORT DocumentImmersive& ensureImmersive();
 #endif
     inline DocumentFontLoader& fontLoader();
-    Ref<DocumentFontLoader> protectedFontLoader();
     DocumentFontLoader& ensureFontLoader();
     CSSFontSelector& ensureFontSelector();
     UndoManager& ensureUndoManager();

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -72,7 +72,7 @@ CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiat
 
     CachedResourceRequest request(ResourceRequest(WTF::move(url)), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
-    return protectedDocument()->protectedCachedResourceLoader()->requestFont(WTF::move(request), isSVG).value_or(nullptr).get();
+    return protect(protectedDocument()->cachedResourceLoader())->requestFont(WTF::move(request), isSVG).value_or(nullptr).get();
 }
 
 void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
@@ -84,7 +84,7 @@ void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
     // Increment the request count now, in order to prevent didFinishLoad from being dispatched
     // after this font has been requested but before it began loading. Balanced by
     // decrementRequestCount() in fontLoadingTimerFired() and in stopLoadingAndClearFonts().
-    protectedDocument()->protectedCachedResourceLoader()->incrementRequestCount(font);
+    protect(protectedDocument()->cachedResourceLoader())->incrementRequestCount(font);
 
     if (!m_isFontLoadingSuspended && !m_fontLoadingTimer.isActive())
         m_fontLoadingTimer.startOneShot(0_s);
@@ -114,7 +114,7 @@ void DocumentFontLoader::fontLoadingTimerFired()
     // FIXME: Use SubresourceLoader instead.
     // Call FrameLoader::loadDone before FrameLoader::subresourceLoadDone to match the order in SubresourceLoader::notifyDone.
     Ref document = m_document.get();
-    document->protectedCachedResourceLoader()->loadDone(LoadCompletionType::Finish);
+    protect(document->cachedResourceLoader())->loadDone(LoadCompletionType::Finish);
     // Ensure that if the request count reaches zero, the frame loader will know about it.
     // New font loads may be triggered by layout after the document load is complete but before we have dispatched
     // didFinishLoading for the frame. Make sure the delegate is always dispatched by checking explicitly.

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -52,12 +52,12 @@ public:
     // Document+Fullscreen.idl methods.
     static void exitFullscreen(Document&, Ref<DeferredPromise>&&);
     static bool fullscreenEnabled(Document&);
-    static bool webkitFullscreenEnabled(Document& document) { return document.protectedFullscreen()->enabledByPermissionsPolicy(); }
-    static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(document.protectedFullscreen()->protectedFullscreenElement().get()); };
+    static bool webkitFullscreenEnabled(Document& document) { return protect(document.fullscreen())->enabledByPermissionsPolicy(); }
+    static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(protect(document.fullscreen())->protectedFullscreenElement().get()); };
     WEBCORE_EXPORT static void webkitExitFullscreen(Document&);
-    static bool webkitIsFullScreen(Document& document) { return document.protectedFullscreen()->isFullscreen(); };
-    static bool webkitFullScreenKeyboardInputAllowed(Document& document) { return document.protectedFullscreen()->isFullscreenKeyboardInputAllowed(); };
-    static void webkitCancelFullScreen(Document& document) { document.protectedFullscreen()->fullyExitFullscreen(); };
+    static bool webkitIsFullScreen(Document& document) { return protect(document.fullscreen())->isFullscreen(); };
+    static bool webkitFullScreenKeyboardInputAllowed(Document& document) { return protect(document.fullscreen())->isFullscreenKeyboardInputAllowed(); };
+    static void webkitCancelFullScreen(Document& document) { protect(document.fullscreen())->fullyExitFullscreen(); };
 
     // Helpers.
     Document& document() { return m_document; }

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -125,11 +125,6 @@ inline ClientOrigin Document::clientOrigin() const { return { topOrigin().data()
 
 inline bool Document::wasLastFocusByClick() const { return m_latestFocusTrigger == FocusTrigger::Click; }
 
-inline RefPtr<DocumentParser> Document::protectedParser() const
-{
-    return m_parser;
-}
-
 inline UndoManager& Document::undoManager() const
 {
     if (!m_undoManager)
@@ -137,31 +132,11 @@ inline UndoManager& Document::undoManager() const
     return *m_undoManager;
 }
 
-inline Ref<UndoManager> Document::protectedUndoManager() const
-{
-    return undoManager();
-}
-
 inline ReportingScope& Document::reportingScope() const
 {
     if (!m_reportingScope)
         return const_cast<Document&>(*this).ensureReportingScope();
     return *m_reportingScope;
-}
-
-inline Ref<ReportingScope> Document::protectedReportingScope() const
-{
-    return reportingScope();
-}
-
-inline RefPtr<TextResourceDecoder> Document::protectedDecoder() const
-{
-    return m_decoder;
-}
-
-inline RefPtr<Element> Document::protectedFocusedElement() const
-{
-    return m_focusedElement;
 }
 
 inline Ref<DocumentSyncData> Document::syncData()

--- a/Source/WebCore/dom/DocumentPage.h
+++ b/Source/WebCore/dom/DocumentPage.h
@@ -53,9 +53,4 @@ inline Page* Document::page() const
     return m_frame ? m_frame->page() : nullptr;
 }
 
-inline RefPtr<Page> Document::protectedPage() const
-{
-    return page();
-}
-
 }

--- a/Source/WebCore/dom/DocumentResourceLoader.h
+++ b/Source/WebCore/dom/DocumentResourceLoader.h
@@ -37,9 +37,4 @@ inline CachedResourceLoader& Document::cachedResourceLoader()
     return *m_cachedResourceLoader;
 }
 
-inline Ref<CachedResourceLoader> Document::protectedCachedResourceLoader() const
-{
-    return const_cast<Document&>(*this).cachedResourceLoader();
-}
-
 }

--- a/Source/WebCore/dom/DocumentSecurityOrigin.h
+++ b/Source/WebCore/dom/DocumentSecurityOrigin.h
@@ -32,12 +32,7 @@ namespace WebCore {
 
 inline bool Document::isSameOriginAsTopDocument() const
 {
-    return protectedSecurityOrigin()->isSameOriginAs(protectedTopOrigin());
-}
-
-inline Ref<SecurityOrigin> Document::protectedSecurityOrigin() const
-{
-    return SecurityContext::protectedSecurityOrigin().releaseNonNull();
+    return protect(securityOrigin())->isSameOriginAs(protect(topOrigin()));
 }
 
 }

--- a/Source/WebCore/dom/DocumentView.h
+++ b/Source/WebCore/dom/DocumentView.h
@@ -46,9 +46,4 @@ inline LocalFrameView* Document::view() const
     return m_frame ? m_frame->view() : nullptr;
 }
 
-inline RefPtr<LocalFrameView> Document::protectedView() const
-{
-    return view();
-}
-
 }

--- a/Source/WebCore/dom/DocumentWindow.h
+++ b/Source/WebCore/dom/DocumentWindow.h
@@ -30,9 +30,4 @@
 
 namespace WebCore {
 
-inline RefPtr<LocalDOMWindow> Document::protectedWindow() const
-{
-    return m_domWindow;
-}
-
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1729,7 +1729,7 @@ void Element::setScrollLeft(int newLeft)
     if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
             IntPoint position(static_cast<int>(newLeft * frame->pageZoomFactor() * frame->frameScaleFactor()), frame->view()->scrollY());
-            frame->protectedView()->setScrollPosition(position, options);
+            protect(frame->view())->setScrollPosition(position, options);
         }
         return;
     }
@@ -1755,7 +1755,7 @@ void Element::setScrollTop(int newTop)
     if (document->scrollingElement() == this) {
         if (RefPtr frame = documentFrameWithNonNullView()) {
             IntPoint position(frame->view()->scrollX(), static_cast<int>(newTop * frame->pageZoomFactor() * frame->frameScaleFactor()));
-            frame->protectedView()->setScrollPosition(position, options);
+            protect(frame->view())->setScrollPosition(position, options);
         }
         return;
     }
@@ -4268,7 +4268,7 @@ void Element::blur()
 {
     if (treeScope().focusedElementInScope() == this) {
         if (RefPtr frame = document().frame())
-            frame->protectedPage()->focusController().setFocusedElement(nullptr, frame.get());
+            protect(frame->page())->focusController().setFocusedElement(nullptr, frame.get());
         else
             protect(document())->setFocusedElement(nullptr);
     }

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -68,7 +68,7 @@ int IdleCallbackController::queueIdleCallback(Ref<IdleRequestCallback>&& callbac
     }
 
     if (RefPtr document = m_document.get())
-        document->protectedWindowEventLoop()->scheduleIdlePeriod();
+        protect(document->windowEventLoop())->scheduleIdlePeriod();
 
     return handle;
 }

--- a/Source/WebCore/dom/IdleDeadline.cpp
+++ b/Source/WebCore/dom/IdleDeadline.cpp
@@ -41,7 +41,7 @@ DOMHighResTimeStamp IdleDeadline::timeRemaining(Document& document) const
         return 0;
     Ref performance = window->performance();
     auto now = performance->now();
-    auto deadline = performance->relativeTimeFromTimeOriginInReducedResolution(document.protectedWindowEventLoop()->computeIdleDeadline() - performance->timeResolution());
+    auto deadline = performance->relativeTimeFromTimeOriginInReducedResolution(protect(document.windowEventLoop())->computeIdleDeadline() - performance->timeResolution());
     return deadline < now ? 0 : deadline - now;
 }
 

--- a/Source/WebCore/dom/LoadableSpeculationRules.cpp
+++ b/Source/WebCore/dom/LoadableSpeculationRules.cpp
@@ -81,7 +81,7 @@ CachedResourceHandle<CachedScript> LoadableSpeculationRules::requestSpeculationR
     request.upgradeInsecureRequestIfNeeded(document);
     request.setPriority(ResourceLoadPriority::Low);
 
-    return document.protectedCachedResourceLoader()->requestScript(WTF::move(request)).value_or(nullptr);
+    return protect(document.cachedResourceLoader())->requestScript(WTF::move(request)).value_or(nullptr);
 }
 
 bool LoadableSpeculationRules::load(Document& document, const URL& url)

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -147,14 +147,14 @@ void ProcessingInstruction::checkStyleSheet()
             if (m_isXSL) {
                 auto options = CachedResourceLoader::defaultCachedResourceOptions();
                 options.mode = FetchOptions::Mode::SameOrigin;
-                m_cachedSheet = document->protectedCachedResourceLoader()->requestXSLStyleSheet({ ResourceRequest(document->completeURL(href)), options }).value_or(nullptr);
+                m_cachedSheet = protect(document->cachedResourceLoader())->requestXSLStyleSheet({ ResourceRequest(document->completeURL(href)), options }).value_or(nullptr);
             } else
 #endif
             {
                 String charset = attributes->get<HashTranslatorASCIILiteral>("charset"_s);
                 CachedResourceRequest request(document->completeURL(href), CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, charset.isEmpty() ? String::fromLatin1(document->charset()) : WTF::move(charset));
 
-                m_cachedSheet = document->protectedCachedResourceLoader()->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
+                m_cachedSheet = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
             }
             if (CachedResourceHandle cachedSheet = m_cachedSheet)
                 cachedSheet->addClient(*this);

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -67,14 +67,14 @@ Ref<PseudoElement> PseudoElement::create(Element& host, PseudoElementType pseudo
 {
     Ref pseudoElement = adoptRef(*new PseudoElement(host, pseudoElementType));
 
-    InspectorInstrumentation::pseudoElementCreated(host.document().protectedPage().get(), pseudoElement.get());
+    InspectorInstrumentation::pseudoElementCreated(protect(host.document().page()).get(), pseudoElement.get());
 
     return pseudoElement;
 }
 
 void PseudoElement::clearHostElement()
 {
-    InspectorInstrumentation::pseudoElementDestroyed(document().protectedPage().get(), *this);
+    InspectorInstrumentation::pseudoElementDestroyed(protect(document().page()).get(), *this);
 
     Styleable::fromElement(*this).elementWasRemoved();
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -323,11 +323,11 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
     } else if ((isClassicExternalScript || scriptType == ScriptType::Module) && !hasAsyncAttribute() && !m_forceAsync) {
         m_willExecuteInOrder = true;
         ASSERT(m_loadableScript);
-        document->protectedScriptRunner()->queueScriptForExecution(*this, *protectedLoadableScript(), ScriptRunner::IN_ORDER_EXECUTION);
+        protect(document->scriptRunner())->queueScriptForExecution(*this, *protectedLoadableScript(), ScriptRunner::IN_ORDER_EXECUTION);
     } else if (hasSourceAttribute() || scriptType == ScriptType::Module) {
         ASSERT(m_loadableScript);
         ASSERT(hasAsyncAttribute() || m_forceAsync);
-        document->protectedScriptRunner()->queueScriptForExecution(*this, *protectedLoadableScript(), ScriptRunner::ASYNC_EXECUTION);
+        protect(document->scriptRunner())->queueScriptForExecution(*this, *protectedLoadableScript(), ScriptRunner::ASYNC_EXECUTION);
     } else if (!hasSourceAttribute() && m_parserInserted == ParserInserted::Yes && !document->haveStylesheetsLoaded()) {
         ASSERT(scriptType == ScriptType::Classic || scriptType == ScriptType::ImportMap || scriptType == ScriptType::SpeculationRules);
         m_willBeParserExecuted = true;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -468,7 +468,7 @@ bool ScriptExecutionContext::canIncludeErrorDetails(CachedScript* script, const 
         ASSERT(securityOrigin()->toString() == script->origin()->toString());
         return script->isCORSSameOrigin();
     }
-    return protectedSecurityOrigin()->canRequest(completeSourceURL, OriginAccessPatternsForWebProcess::singleton());
+    return protect(securityOrigin())->canRequest(completeSourceURL, OriginAccessPatternsForWebProcess::singleton());
 }
 
 void ScriptExecutionContext::reportException(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, JSC::Exception* exception, RefPtr<ScriptCallStack>&& callStack, CachedScript* cachedScript, bool fromModule)
@@ -679,7 +679,7 @@ String ScriptExecutionContext::domainForCachePartition() const
     if (m_storageBlockingPolicy != StorageBlockingPolicy::BlockThirdParty)
         return emptyString();
 
-    return protectedTopOrigin()->domainForCachePartition();
+    return protect(topOrigin())->domainForCachePartition();
 }
 
 bool ScriptExecutionContext::allowsMediaDevices() const
@@ -882,7 +882,7 @@ ScriptExecutionContext::HasResourceAccess ScriptExecutionContext::canAccessResou
     case ResourceType::SessionStorage:
         if (m_storageBlockingPolicy == StorageBlockingPolicy::BlockAll)
             return HasResourceAccess::No;
-        if ((m_storageBlockingPolicy == StorageBlockingPolicy::BlockThirdParty) && !protectedTopOrigin()->isSameOriginAs(*origin) && !origin->hasUniversalAccess())
+        if ((m_storageBlockingPolicy == StorageBlockingPolicy::BlockThirdParty) && !protect(topOrigin())->isSameOriginAs(*origin) && !origin->hasUniversalAccess())
             return HasResourceAccess::DefaultForThirdParty;
         return HasResourceAccess::Yes;
     }
@@ -1006,7 +1006,7 @@ bool ScriptExecutionContext::requiresScriptTrackingPrivacyProtection(ScriptTrack
     if (category == ScriptTrackingPrivacyCategory::NetworkRequests && !page->settings().scriptTrackingPrivacyNetworkRequestBlockingEnabled())
         return false;
 
-    if (page->shouldAllowScriptAccess(taintedURL, protectedTopOrigin(), category))
+    if (page->shouldAllowScriptAccess(taintedURL, protect(topOrigin()), category))
         return false;
 
     if (!page->settings().scriptTrackingPrivacyLoggingEnabled())

--- a/Source/WebCore/dom/SerializedNode.cpp
+++ b/Source/WebCore/dom/SerializedNode.cpp
@@ -109,7 +109,7 @@ Ref<Node> SerializedNode::deserialize(SerializedNode&& serializedNode, WebCore::
             document,
             RefPtr { document.securityOriginPolicy() }.get(),
             serializedDocument.contentType,
-            document.protectedDecoder().get()
+            protect(document.decoder()).get()
         );
     }, [&] (SerializedNode::Element&& element) -> Ref<Node> {
         constexpr bool createdByParser { false };

--- a/Source/WebCore/dom/SimulatedClick.cpp
+++ b/Source/WebCore/dom/SimulatedClick.cpp
@@ -121,12 +121,12 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SimulatedPointerEvent);
 
 static void simulateMouseEvent(const AtomString& eventType, Element& element, Event* underlyingEvent, SimulatedClickSource source)
 {
-    element.dispatchEvent(SimulatedMouseEvent::create(eventType, element.document().protectedWindowProxy().get(), underlyingEvent, element, source));
+    element.dispatchEvent(SimulatedMouseEvent::create(eventType, protect(element.document().windowProxy()).get(), underlyingEvent, element, source));
 }
 
 static void simulatePointerEvent(const AtomString& eventType, Element& element, Event* underlyingEvent, SimulatedClickSource source)
 {
-    Ref mouseEvent = SimulatedMouseEvent::create(eventType, element.document().protectedWindowProxy().get(), underlyingEvent, element, source);
+    Ref mouseEvent = SimulatedMouseEvent::create(eventType, protect(element.document().windowProxy()).get(), underlyingEvent, element, source);
     Ref pointerEvent = SimulatedPointerEvent::create(eventType, mouseEvent.get(), underlyingEvent, element, source);
 
     element.dispatchEvent(pointerEvent.get());

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2507,7 +2507,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
                 FocusOptions focusOptions;
                 if (options & SetSelectionOption::ForBindings)
                     focusOptions.trigger = FocusTrigger::Bindings;
-                document->protectedPage()->focusController().setFocusedElement(target.get(), document->protectedFrame().get(), focusOptions);
+                protect(document->page())->focusController().setFocusedElement(target.get(), document->protectedFrame().get(), focusOptions);
                 return;
             }
             target = target->parentOrShadowHostElement();
@@ -2516,7 +2516,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
     }
 
     if (caretBrowsing)
-        document->protectedPage()->focusController().setFocusedElement(nullptr, document->protectedFrame().get());
+        protect(document->page())->focusController().setFocusedElement(nullptr, document->protectedFrame().get());
 }
 
 void DragCaretController::paintDragCaret(LocalFrame* frame, GraphicsContext& p, const LayoutPoint& paintOffset) const

--- a/Source/WebCore/editing/SpellingCorrectionCommand.cpp
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.cpp
@@ -66,7 +66,7 @@ private:
     void doUnapply() override
     {
         if (!m_hasBeenUndone) {
-            document().protectedEditor()->unappliedSpellCorrection(startingSelection(), m_corrected, m_correction);
+            protect(document().editor())->unappliedSpellCorrection(startingSelection(), m_corrected, m_correction);
             m_hasBeenUndone = true;
         }
         

--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -242,7 +242,7 @@ bool selectionAllowsSmartLists(const String& text, const VisibleSelection& selec
     if (!document)
         return false;
 
-    if (!document->protectedEditor()->isSmartListsEnabled())
+    if (!protect(document->editor())->isSmartListsEnabled())
         return false;
 
     if (text != " "_s) {

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -79,7 +79,7 @@ void BlobURLRegistry::registerURL(const ScriptExecutionContext& context, const U
         Locker locker { m_urlsPerContextLock };
         m_urlsPerContext.add(context.identifier(), HashSet<URL>()).iterator->value.add(publicURL.isolatedCopy());
     }
-    ThreadableBlobRegistry::registerBlobURL(context.protectedSecurityOrigin().get(), context.policyContainer(), publicURL, downcast<Blob>(blob).url(), context.topOrigin().data());
+    ThreadableBlobRegistry::registerBlobURL(protect(context.securityOrigin()).get(), context.policyContainer(), publicURL, downcast<Blob>(blob).url(), context.topOrigin().data());
 }
 
 void BlobURLRegistry::unregisterURL(const URL& url, const SecurityOriginData& topOrigin)

--- a/Source/WebCore/fileapi/BlobURL.cpp
+++ b/Source/WebCore/fileapi/BlobURL.cpp
@@ -58,7 +58,7 @@ static const Document* blobOwner(const SecurityOrigin& blobOrigin)
         return nullptr;
 
     for (auto& document : Document::allDocuments()) {
-        if (document->protectedSecurityOrigin()->isSameOriginAs(blobOrigin))
+        if (protect(document->securityOrigin())->isSameOriginAs(blobOrigin))
             return document.ptr();
     }
     return nullptr;

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -286,7 +286,7 @@ static bool canCachePage(Page& page)
     if (RefPtr provisionalDocumentLoader = localMainFrame->loader().provisionalDocumentLoader()) {
         if (provisionalDocumentLoader->responseClearSiteDataValues().contains(ClearSiteDataValue::Cache)) {
             if (RefPtr topDocument = localMainFrame->document()) {
-                if (topDocument->protectedSecurityOrigin()->isSameOriginAs(SecurityOrigin::create(provisionalDocumentLoader->response().url()))) {
+                if (protect(topDocument->securityOrigin())->isSameOriginAs(SecurityOrigin::create(provisionalDocumentLoader->response().url()))) {
                     PCLOG("   -`Clear-Site-Data: cache` HTTP header is present"_s);
                     isCacheable = false;
                 }
@@ -325,7 +325,7 @@ void BackForwardCache::dump() const
     for (auto& item : m_cachedPageMap) {
         if (auto* cachedPage = std::get_if<UniqueRef<CachedPage>>(&item.value)) {
             RefPtr document = (*cachedPage)->document();
-            WTFLogAlways("  Page %p, document %p %s", (*cachedPage)->protectedPage().ptr(), document.get(), document ? document->url().string().utf8().data() : "");
+            WTFLogAlways("  Page %p, document %p %s", protect((*cachedPage)->page()).ptr(), document.get(), document ? document->url().string().utf8().data() : "");
         }
     }
 }
@@ -378,7 +378,7 @@ void BackForwardCache::markPagesForDeviceOrPageScaleChanged(Page& page)
             ASSERT(!m_items.contains(item.key));
             continue;
         }
-        if (&page.mainFrame() == &(*cachedPage)->cachedMainFrame()->protectedView()->frame())
+        if (&page.mainFrame() == &protect((*cachedPage)->cachedMainFrame()->view())->frame())
             (*cachedPage)->markForDeviceOrPageScaleChanged();
     }
 }
@@ -391,7 +391,7 @@ void BackForwardCache::markPagesForContentsSizeChanged(Page& page)
             ASSERT(!m_items.contains(item.key));
             continue;
         }
-        if (&page.mainFrame() == &(*cachedPage)->cachedMainFrame()->protectedView()->frame())
+        if (&page.mainFrame() == &protect((*cachedPage)->cachedMainFrame()->view())->frame())
             (*cachedPage)->markForContentsSizeChanged();
     }
 }

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -133,7 +133,7 @@ void CachedFrameBase::restore()
         // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
         for (auto& childFrame : m_childFrames) {
             ASSERT(childFrame->view()->frame().page());
-            frame->tree().appendChild(childFrame->protectedView()->protectedFrame());
+            frame->tree().appendChild(protect(childFrame->view())->protectedFrame());
             childFrame->open();
             if (localFrame)
                 RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_document == localFrame->document());
@@ -155,7 +155,7 @@ void CachedFrameBase::restore()
 #endif
 
     if (localFrame)
-        localFrame->protectedView()->didRestoreFromBackForwardCache();
+        protect(localFrame->view())->didRestoreFromBackForwardCache();
 }
 
 CachedFrame::CachedFrame(Frame& frame)
@@ -184,7 +184,7 @@ CachedFrame::CachedFrame(Frame& frame)
     m_cachedFrameScriptData = localFrame ? makeUnique<ScriptCachedFrameData>(*localFrame) : nullptr;
 
     if (document)
-        document->protectedWindow()->suspendForBackForwardCache();
+        protect(document->window())->suspendForBackForwardCache();
 
     // Clear FrameView to reset flags such as 'firstVisuallyNonEmptyLayoutCallbackPending' so that the
     // 'DidFirstVisuallyNonEmptyLayout' callback gets called against when restoring from the BackForwardCache.
@@ -280,7 +280,7 @@ void CachedFrame::destroy()
     ASSERT(m_view);
     ASSERT(!document->frame());
 
-    document->protectedWindow()->willDestroyCachedFrame();
+    protect(document->window())->willDestroyCachedFrame();
 
     RefPtr view = m_view;
     Ref frame = view->frame();

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -668,7 +668,7 @@ bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserPar
     }
 
     if (CheckedPtr renderer = element->renderer())
-        parameters.anchorRectInRootView = document->protectedView()->contentsToRootView(renderer->absoluteBoundingBoxRect());
+        parameters.anchorRectInRootView = protect(document->view())->contentsToRootView(renderer->absoluteBoundingBoxRect());
     else
         parameters.anchorRectInRootView = IntRect();
     parameters.currentValue = element->value();

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -355,12 +355,12 @@ IntRect ColorInputType::elementRectRelativeToRootView() const
     CheckedPtr renderer = element->renderer();
     if (!renderer)
         return IntRect();
-    return protect(element->document())->protectedView()->contentsToRootView(renderer->absoluteBoundingBoxRect());
+    return protect(protect(element->document())->view())->contentsToRootView(renderer->absoluteBoundingBoxRect());
 }
 
 std::optional<FrameIdentifier> ColorInputType::rootFrameID() const
 {
-    return protect(element()->document())->protectedView()->rootFrameID();
+    return protect(protect(element()->document())->view())->rootFrameID();
 }
 
 bool ColorInputType::supportsAlpha() const

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -104,7 +104,7 @@ String DOMURL::createObjectURL(ScriptExecutionContext& scriptExecutionContext, B
 
 String DOMURL::createPublicURL(ScriptExecutionContext& scriptExecutionContext, URLRegistrable& registrable)
 {
-    URL publicURL = BlobURL::createPublicURL(scriptExecutionContext.protectedSecurityOrigin().get());
+    URL publicURL = BlobURL::createPublicURL(protect(scriptExecutionContext.securityOrigin()).get());
     if (publicURL.isEmpty())
         return String();
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -565,7 +565,7 @@ void HTMLAnchorElement::handleClick(Event& event)
     AtomString downloadAttribute;
     if (document->settings().downloadAttributeEnabled()) {
         // Ignore the download attribute completely if the href URL is cross origin.
-        bool isSameOrigin = completedURL.protocolIsData() || document->protectedSecurityOrigin()->canRequest(completedURL, OriginAccessPatternsForWebProcess::singleton());
+        bool isSameOrigin = completedURL.protocolIsData() || protect(document->securityOrigin())->canRequest(completedURL, OriginAccessPatternsForWebProcess::singleton());
         if (isSameOrigin)
             downloadAttribute = AtomString { ResourceResponse::sanitizeSuggestedFilename(attributeWithoutSynchronization(downloadAttr)) };
         else if (hasAttributeWithoutSynchronization(downloadAttr))

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1263,7 +1263,7 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
 
     Ref document = this->document();
     if (RefPtr element = popoverData()->previouslyFocusedElement()) {
-        if (focusPreviousElement == FocusPreviousElement::Yes && isShadowIncludingInclusiveAncestorOf(document->protectedFocusedElement().get())) {
+        if (focusPreviousElement == FocusPreviousElement::Yes && isShadowIncludingInclusiveAncestorOf(protect(document->focusedElement()).get())) {
             FocusOptions options;
             options.preventScroll = true;
             element->focus(options);

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -186,7 +186,7 @@ String HTMLIFrameElement::srcdoc() const
 
 ExceptionOr<void> HTMLIFrameElement::setSrcdoc(Variant<RefPtr<TrustedHTML>, String>&& value, SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
 {
-    auto stringValueHolder = trustedTypeCompliantString(protect(document())->protectedContextDocument(), WTF::move(value), "HTMLIFrameElement srcdoc"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(protect(document())->contextDocument()), WTF::move(value), "HTMLIFrameElement srcdoc"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1425,7 +1425,7 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     // https://github.com/whatwg/html/issues/6909#issuecomment-917138991
     if (!m_inputType->allowsShowPickerAcrossFrames()) {
         RefPtr localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
-        if (!localTopFrame || !protect(frame->document())->protectedSecurityOrigin()->isSameOriginAs(protect(localTopFrame->document())->protectedSecurityOrigin()))
+        if (!localTopFrame || !protect(protect(frame->document())->securityOrigin())->isSameOriginAs(protect(protect(localTopFrame->document())->securityOrigin())))
             return Exception { ExceptionCode::SecurityError, "Input showPicker() called from cross-origin iframe."_s };
     }
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -398,7 +398,7 @@ void HTMLLinkElement::process()
         request.setInitiator(*this);
 
         ASSERT_WITH_SECURITY_IMPLICATION(!m_cachedSheet);
-        m_cachedSheet = document->protectedCachedResourceLoader()->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
+        m_cachedSheet = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
 
         if (CachedResourceHandle cachedSheet = m_cachedSheet)
             cachedSheet->addClient(*this);

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -182,7 +182,7 @@ void HTMLMetaElement::process(const AtomString& oldValue)
     // tree (changing a meta tag while it's not in the tree shouldn't have any effect
     // on the document)
     if (!httpEquivValue.isNull())
-        document->processMetaHttpEquiv(httpEquivValue, contentValue, isDescendantOf(document->protectedHead().get()));
+        document->processMetaHttpEquiv(httpEquivValue, contentValue, isDescendantOf(protect(document->head()).get()));
     
     if (nameValue.isNull())
         return;

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -546,7 +546,7 @@ bool HTMLPlugInElement::canLoadURL(const URL& completeURL) const
         if (is<RemoteFrame>(contentFrame()))
             return false;
         RefPtr contentDocument = this->contentDocument();
-        if (contentDocument && !protect(document())->protectedSecurityOrigin()->isSameOriginDomain(contentDocument->protectedSecurityOrigin().get()))
+        if (contentDocument && !protect(protect(document())->securityOrigin())->isSameOriginDomain(protect(contentDocument->securityOrigin()).get()))
             return false;
     }
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1814,7 +1814,7 @@ ExceptionOr<void> HTMLSelectElement::showPicker()
 
     // In cross-origin iframes it should throw a "SecurityError" DOMException. In same-origin iframes it should work fine.
     RefPtr localTopFrame = dynamicDowncast<LocalFrame>(frame->tree().top());
-    if (!localTopFrame || !protect(frame->document())->protectedSecurityOrigin()->isSameOriginAs(protect(localTopFrame->document())->protectedSecurityOrigin()))
+    if (!localTopFrame || !protect(protect(frame->document())->securityOrigin())->isSameOriginAs(protect(protect(localTopFrame->document())->securityOrigin())))
         return Exception { ExceptionCode::SecurityError, "Select showPicker() called from cross-origin iframe."_s };
 
     RefPtr window = frame->window();

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -264,7 +264,7 @@ void HTMLTextAreaElement::subtreeHasChanged()
     setChangedSinceLastFormControlChangeEvent(true);
 
     if (RefPtr frame = document().frame())
-        frame->protectedEditor()->textDidChangeInTextArea(*this);
+        protect(frame->editor())->textDidChangeInTextArea(*this);
     // When typing in a textarea, childrenChanged is not called, so we need to force the directionality check.
     if (selfOrPrecedingNodesAffectDirAuto())
         updateEffectiveTextDirection();

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -849,9 +849,9 @@ void HTMLVideoElement::setVideoFullscreenStandby(bool value)
         return;
 
     if (videoFullscreenStandby())
-        document().protectedPage()->chrome().client().enterVideoFullscreenForVideoElement(*this, VideoFullscreenModeNone, true);
+        protect(document().page())->chrome().client().enterVideoFullscreenForVideoElement(*this, VideoFullscreenModeNone, true);
     else {
-        document().protectedPage()->chrome().client().exitVideoFullscreenForVideoElement(*this, [this, protectedThis = Ref { *this }](auto success) mutable {
+        protect(document().page())->chrome().client().exitVideoFullscreenForVideoElement(*this, [this, protectedThis = Ref { *this }](auto success) mutable {
             setVideoFullscreenStandbyInternal(!success);
         });
     }

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -676,7 +676,7 @@ bool MediaElementSession::canShowControlsManager(PlaybackControlsPurpose purpose
     if (purpose == MediaElementSession::PlaybackControlsPurpose::NowPlaying
         && hasBehaviorRestriction(RequirePageVisibilityForVideoToBeNowPlaying)
         && element->isVideo()
-        && !protect(element->document())->protectedPage()->isVisibleAndActive()) {
+        && !protect(protect(element->document())->page())->isVisibleAndActive()) {
         INFO_LOG(LOGIDENTIFIER, "returning FALSE: NowPlaying restricted for video in a page that is not visible");
         return false;
     }

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -159,7 +159,7 @@ void PluginDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>
     // recurse too many times and delay its post-layout tasks (such as creating
     // the widget). Here we kick off the pending post-layout tasks so that we
     // can synchronously redirect data to the plugin.
-    frame->protectedView()->flushAnyPendingPostLayoutTasks();
+    protect(frame->view())->flushAnyPendingPostLayoutTasks();
 
     if (CheckedPtr renderer = Ref { *m_embedElement }->renderWidget()) {
         if (RefPtr widget = renderer->widget()) {

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -214,7 +214,7 @@ auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallB
         event.setDefaultHandled();
     }
     RefPtr frame = element->document().frame();
-    if (frame && frame->protectedEditor()->doTextFieldCommandFromEvent(element.get(), &event))
+    if (frame && protect(frame->editor())->doTextFieldCommandFromEvent(element.get(), &event))
         event.setDefaultHandled();
     return ShouldCallBaseEventHandler::Yes;
 }
@@ -279,7 +279,7 @@ void TextFieldInputType::handleFocusEvent(Node* oldFocusedNode, FocusDirection)
     ASSERT_UNUSED(oldFocusedNode, oldFocusedNode != element());
     Ref element = *this->element();
     if (RefPtr frame = element->document().frame())
-        frame->protectedEditor()->textFieldDidBeginEditing(element.get());
+        protect(frame->editor())->textFieldDidBeginEditing(element.get());
 }
 
 void TextFieldInputType::handleBlurEvent()
@@ -707,7 +707,7 @@ void TextFieldInputType::didSetValueByUserEdit()
     if (!element->focused())
         return;
     if (RefPtr frame = element->document().frame())
-        frame->protectedEditor()->textDidChangeInTextField(element.get());
+        protect(frame->editor())->textDidChangeInTextField(element.get());
     if (element->hasDataList())
         displaySuggestions(DataListSuggestionActivationType::TextChanged);
 }
@@ -934,7 +934,7 @@ IntRect TextFieldInputType::elementRectInRootViewCoordinates() const
     if (!element()->renderer())
         return IntRect();
     Ref element = *this->element();
-    return protect(element->document())->protectedView()->contentsToRootView(element->checkedRenderer()->absoluteBoundingBoxRect());
+    return protect(protect(element->document())->view())->contentsToRootView(element->checkedRenderer()->absoluteBoundingBoxRect());
 }
 
 Vector<DataListSuggestion> TextFieldInputType::suggestions()

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -110,7 +110,7 @@ void HTMLResourcePreloader::preload(std::unique_ptr<PreloadRequest> preload)
     if (!MQ::MediaQueryEvaluator { screenAtom(), *document, document->renderStyle() }.evaluate(queries))
         return;
 
-    std::ignore = document->protectedCachedResourceLoader()->preload(preload->resourceType(), preload->resourceRequest(*document));
+    std::ignore = protect(document->cachedResourceLoader())->preload(preload->resourceType(), preload->resourceRequest(*document));
 }
 
 }

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -89,7 +89,7 @@ TrackBase::~TrackBase() = default;
 
 void TrackBase::didMoveToNewDocument(Document& newDocument)
 {
-    observeContext(newDocument.protectedContextDocument().ptr());
+    observeContext(protect(newDocument.contextDocument()).ptr());
 }
 
 #if ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -61,10 +61,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameInspectorController);
 
 FrameInspectorController::FrameInspectorController(LocalFrame& frame)
     : m_frame(frame)
-    , m_instrumentingAgents(InstrumentingAgents::create(*this, frame.protectedPage()->protectedInspectorController()->instrumentingAgents()))
-    , m_injectedScriptManager(frame.protectedPage()->protectedInspectorController()->injectedScriptManager())
+    , m_instrumentingAgents(InstrumentingAgents::create(*this, protect(frame.page())->protectedInspectorController()->instrumentingAgents()))
+    , m_injectedScriptManager(protect(frame.page())->protectedInspectorController()->injectedScriptManager())
     , m_frontendRouter(FrontendRouter::create())
-    , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef(), &frame.protectedPage()->protectedInspectorController()->backendDispatcher()))
+    , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef(), &protect(frame.page())->protectedInspectorController()->backendDispatcher()))
     , m_executionStopwatch(Stopwatch::create())
 {
 }

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1368,7 +1368,7 @@ InstrumentingAgents* InspectorInstrumentation::instrumentingAgents(ScriptExecuti
 {
     // Using RefPtr makes us hit the m_inRemovedLastRefFunction assert.
     if (WeakPtr document = dynamicDowncast<Document>(context))
-        return instrumentingAgents(document->protectedPage().get());
+        return instrumentingAgents(protect(document->page()).get());
     if (RefPtr workerOrWorkletGlobal = dynamicDowncast<WorkerOrWorkletGlobalScope>(context))
         return &instrumentingAgents(*workerOrWorkletGlobal);
     return nullptr;

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -613,7 +613,7 @@ void InspectorIndexedDBAgent::requestDatabase(const String& securityOrigin, cons
         return;
 
     Ref databaseLoader = DatabaseLoader::create(document, WTF::move(callback));
-    databaseLoader->start(idbFactory, document->protectedSecurityOrigin().ptr(), databaseName);
+    databaseLoader->start(idbFactory, protect(document->securityOrigin()).ptr(), databaseName);
 }
 
 void InspectorIndexedDBAgent::requestData(const String& securityOrigin, const String& databaseName, const String& objectStoreName, const String& indexName, int skipCount, int pageSize, RefPtr<JSON::Object>&& keyRange, Ref<RequestDataCallback>&& callback)
@@ -635,7 +635,7 @@ void InspectorIndexedDBAgent::requestData(const String& securityOrigin, const St
 
     auto injectedScript = m_injectedScriptManager->injectedScriptFor(&mainWorldGlobalObject(*frame));
     auto dataLoader = DataLoader::create(document, WTF::move(callback), injectedScript, objectStoreName, indexName, WTF::move(idbKeyRange), skipCount, pageSize);
-    dataLoader->start(idbFactory, document->protectedSecurityOrigin().ptr(), databaseName);
+    dataLoader->start(idbFactory, protect(document->securityOrigin()).ptr(), databaseName);
 }
 
 namespace {
@@ -730,7 +730,7 @@ void InspectorIndexedDBAgent::clearObjectStore(const String& securityOrigin, con
         return;
 
     Ref<ClearObjectStore> clearObjectStore = ClearObjectStore::create(document, objectStoreName, WTF::move(callback));
-    clearObjectStore->start(idbFactory, document->protectedSecurityOrigin().ptr(), databaseName);
+    clearObjectStore->start(idbFactory, protect(document->securityOrigin()).ptr(), databaseName);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -91,7 +91,7 @@ bool ApplicationManifestLoader::startLoading()
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
     CachedResourceRequest request(WTF::move(resourceRequest), options);
 
-    auto cachedResource = frame->document()->protectedCachedResourceLoader()->requestApplicationManifest(WTF::move(request));
+    auto cachedResource = protect(frame->document()->cachedResourceLoader())->requestApplicationManifest(WTF::move(request));
     m_resource = cachedResource.value_or(nullptr);
     if (CachedResourceHandle resource = m_resource)
         resource->addClient(*this);

--- a/Source/WebCore/loader/CrossOriginAccessControl.cpp
+++ b/Source/WebCore/loader/CrossOriginAccessControl.cpp
@@ -178,14 +178,14 @@ CachedResourceRequest createPotentialAccessControlRequest(ResourceRequest&& requ
         options.storedCredentialsPolicy = StoredCredentialsPolicy::Use;
         break;
     case FetchOptions::Credentials::SameOrigin:
-        options.storedCredentialsPolicy = document.protectedSecurityOrigin()->canRequest(request.url(), OriginAccessPatternsForWebProcess::singleton()) ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse;
+        options.storedCredentialsPolicy = protect(document.securityOrigin())->canRequest(request.url(), OriginAccessPatternsForWebProcess::singleton()) ? StoredCredentialsPolicy::Use : StoredCredentialsPolicy::DoNotUse;
         break;
     case FetchOptions::Credentials::Omit:
         options.storedCredentialsPolicy = StoredCredentialsPolicy::DoNotUse;
     }
 
     CachedResourceRequest cachedRequest { WTF::move(request), WTF::move(options) };
-    updateRequestForAccessControl(cachedRequest.resourceRequest(), document.protectedSecurityOrigin().get(), options.storedCredentialsPolicy);
+    updateRequestForAccessControl(cachedRequest.resourceRequest(), protect(document.securityOrigin()).get(), options.storedCredentialsPolicy);
     return cachedRequest;
 }
 

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -144,7 +144,7 @@ void CrossOriginPreflightChecker::startPreflight()
     preflightRequest.setInitiatorType(AtomString { loader->options().initiatorType });
 
     ASSERT(!m_resource);
-    m_resource = loader->document().protectedCachedResourceLoader()->requestRawResource(WTF::move(preflightRequest)).value_or(nullptr);
+    m_resource = protect(loader->document().cachedResourceLoader())->requestRawResource(WTF::move(preflightRequest)).value_or(nullptr);
     if (CachedResourceHandle resource = m_resource)
         resource->addClient(*this);
 }

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -142,7 +142,7 @@ void DocumentPrefetcher::prefetch(const URL& url, const Vector<String>& tags, st
     if (lowPriority)
         prefetchRequest.setPriority(ResourceLoadPriority::Low);
 
-    auto resourceErrorOr = document->protectedCachedResourceLoader()->requestRawResource(WTF::move(prefetchRequest));
+    auto resourceErrorOr = protect(document->cachedResourceLoader())->requestRawResource(WTF::move(prefetchRequest));
 
     if (!resourceErrorOr)
         return;

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -601,7 +601,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
             resource->removeClient(*this);
 
-        auto cachedResource = protect(*m_document)->protectedCachedResourceLoader()->requestRawResource(WTF::move(newRequest));
+        auto cachedResource = protect(protect(*m_document)->cachedResourceLoader())->requestRawResource(WTF::move(newRequest));
         m_resource = cachedResource.value_or(nullptr);
         if (CachedResourceHandle resource = m_resource)
             resource->addClient(*this);

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -66,7 +66,7 @@ static inline bool canReferToParentFrameEncoding(const LocalFrame* frame, const 
     RefPtr document = frame->document();
     if (is<XMLDocument>(document))
         return false;
-    return parentFrame && protect(parentFrame->document())->protectedSecurityOrigin()->isSameOriginDomain(document->protectedSecurityOrigin());
+    return parentFrame && protect(protect(parentFrame->document())->securityOrigin())->isSameOriginDomain(protect(document->securityOrigin()));
 }
     
 // This is only called by ScriptController::executeIfJavaScriptURL
@@ -235,7 +235,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
             RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
             if (parentFrame && parentFrame->document()) {
                 document->inheritPolicyContainerFrom(parentFrame->document()->policyContainer());
-                document->checkedContentSecurityPolicy()->updateSourceSelf(protect(parentFrame->document())->protectedSecurityOrigin());
+                document->checkedContentSecurityPolicy()->updateSourceSelf(protect(protect(parentFrame->document())->securityOrigin()));
             }
         } else if (triggeringAction && triggeringAction->requester() && !isLoadingBrowserControlledHTML()) {
             document->inheritPolicyContainerFrom(triggeringAction->requester()->policyContainer);
@@ -260,7 +260,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     m_parser = document->parser();
 
     if (frame->view() && frameLoader->client().hasHTMLView())
-        frame->protectedView()->setContentsSize(IntSize());
+        protect(frame->view())->setContentsSize(IntSize());
 
     m_state = State::Started;
     return true;
@@ -283,7 +283,7 @@ TextResourceDecoder& DocumentWriter::decoder()
         // FIXME: This might be too cautious for non-7bit-encodings and
         // we may consider relaxing this later after testing.
         if (canReferToParentFrameEncoding(frame.ptr(), parentFrame.get()))
-            decoder->setHintEncoding(parentFrame->document()->protectedDecoder().get());
+            decoder->setHintEncoding(protect(parentFrame->document()->decoder()).get());
         if (m_encoding.isEmpty()) {
             if (canReferToParentFrameEncoding(frame.ptr(), parentFrame.get()))
                 decoder->setEncoding(parentFrame->document()->textEncoding(), TextResourceDecoder::EncodingFromParentFrame);

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -129,11 +129,11 @@ static inline bool pageIsBeingDismissed(Document& document)
 // https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data:list-of-available-images
 static bool canReuseFromListOfAvailableImages(const CachedResourceRequest& request, Document& document)
 {
-    CachedResourceHandle resource = MemoryCache::singleton().resourceForRequest(request.resourceRequest(), document.protectedPage()->sessionID());
+    CachedResourceHandle resource = MemoryCache::singleton().resourceForRequest(request.resourceRequest(), protect(document.page())->sessionID());
     if (!resource || resource->stillNeedsLoad() || resource->isPreloaded())
         return false;
 
-    if (resource->options().mode == FetchOptions::Mode::Cors && !document.protectedSecurityOrigin()->isSameOriginAs(*protect(resource->origin())))
+    if (resource->options().mode == FetchOptions::Mode::Cors && !protect(document.securityOrigin())->isSameOriginAs(*protect(resource->origin())))
         return false;
 
     if (resource->options().mode != request.options().mode || resource->options().credentials != request.options().credentials)
@@ -288,7 +288,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
                 }
             }
             auto imageLoading = (m_lazyImageLoadState == LazyImageLoadState::Deferred) ? ImageLoading::DeferredUntilVisible : ImageLoading::Immediate;
-            newImage = document->protectedCachedResourceLoader()->requestImage(WTF::move(request), imageLoading).value_or(nullptr);
+            newImage = protect(document->cachedResourceLoader())->requestImage(WTF::move(request), imageLoading).value_or(nullptr);
             LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " updateFromElement " << element.get() << " - state changed from " << oldState << " to " << m_lazyImageLoadState << ", loading is " << imageLoading << " new image " << newImage.get());
         }
 
@@ -304,7 +304,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
                 auto request = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), document, crossOriginAttribute);
                 request.setInitiator(*imageElement);
 
-                document->protectedCachedResourceLoader()->requestImage(WTF::move(request));
+                protect(document->cachedResourceLoader())->requestImage(WTF::move(request));
             }
         }
 #endif

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -318,7 +318,7 @@ void LinkLoader::preconnectIfNeeded(const LinkLoadParameters& params, Document& 
 
     ASSERT(document.settings().linkPreconnectEnabled());
     StoredCredentialsPolicy storageCredentialsPolicy = StoredCredentialsPolicy::Use;
-    if (equalLettersIgnoringASCIICase(params.crossOrigin, "anonymous"_s) && !document.protectedSecurityOrigin()->isSameOriginDomain(SecurityOrigin::create(params.href)))
+    if (equalLettersIgnoringASCIICase(params.crossOrigin, "anonymous"_s) && !protect(document.securityOrigin())->isSameOriginDomain(SecurityOrigin::create(params.href)))
         storageCredentialsPolicy = StoredCredentialsPolicy::DoNotUse;
     ASSERT(document.frame()->loader().networkingContext());
     platformStrategies()->loaderStrategy()->preconnectTo(document.protectedFrame()->loader(), WTF::move(request), storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href = params.href](ResourceError error) {
@@ -401,7 +401,7 @@ RefPtr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const LinkLoadPara
     linkRequest.setIgnoreForRequestCount(true);
     linkRequest.setIsLinkPreload();
 
-    auto cachedLinkResource = document.protectedCachedResourceLoader()->preload(type.value(), WTF::move(linkRequest)).value_or(nullptr);
+    auto cachedLinkResource = protect(document.cachedResourceLoader())->preload(type.value(), WTF::move(linkRequest)).value_or(nullptr);
 
     if (cachedLinkResource && cachedLinkResource->type() != *type)
         return nullptr;
@@ -440,7 +440,7 @@ void LinkLoader::prefetchIfNeeded(const LinkLoadParameters& params, Document& do
     options.cachingPolicy = CachingPolicy::DisallowCaching;
     options.referrerPolicy = params.referrerPolicy;
     options.nonce = params.nonce;
-    m_cachedLinkResource = document.protectedCachedResourceLoader()->requestLinkResource(type, CachedResourceRequest(ResourceRequest { document.completeURL(params.href.string()) }, options, priority)).value_or(nullptr);
+    m_cachedLinkResource = protect(document.cachedResourceLoader())->requestLinkResource(type, CachedResourceRequest(ResourceRequest { document.completeURL(params.href.string()) }, options, priority)).value_or(nullptr);
     if (CachedResourceHandle cachedLinkResource = m_cachedLinkResource)
         cachedLinkResource->addClient(*this);
 }

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -159,7 +159,7 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
     if (RefPtr element = m_element.get())
         cachedRequest.setInitiator(*element);
 
-    auto resource = document->protectedCachedResourceLoader()->requestMedia(WTF::move(cachedRequest)).value_or(nullptr);
+    auto resource = protect(document->cachedResourceLoader())->requestMedia(WTF::move(cachedRequest)).value_or(nullptr);
     if (!resource)
         return nullptr;
 

--- a/Source/WebCore/loader/NavigationAction.cpp
+++ b/Source/WebCore/loader/NavigationAction.cpp
@@ -69,7 +69,7 @@ NavigationAction& NavigationAction::operator=(NavigationAction&&) = default;
 
 static bool shouldTreatAsSameOriginNavigation(const Document& document, const URL& url)
 {
-    return url.protocolIsAbout() || url.protocolIsData() || (url.protocolIsBlob() && document.protectedSecurityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton()));
+    return url.protocolIsAbout() || url.protocolIsData() || (url.protocolIsBlob() && protect(document.securityOrigin())->canRequest(url, OriginAccessPatternsForWebProcess::singleton()));
 }
 
 static bool shouldTreatAsSameOriginNavigation(const NavigationRequester& requester, const URL& url)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -463,7 +463,7 @@ public:
         Ref requestingDocument = m_submission->state()->sourceDocument();
         if (requestingDocument->canNavigate(&frame) != CanNavigateState::Able)
             return;
-        FrameLoadRequest frameLoadRequest { requestingDocument.copyRef(), requestingDocument->protectedSecurityOrigin(), { }, { }, initiatedByMainFrame() };
+        FrameLoadRequest frameLoadRequest { requestingDocument.copyRef(), protect(requestingDocument->securityOrigin()), { }, { }, initiatedByMainFrame() };
         frameLoadRequest.setLockHistory(lockHistory());
         frameLoadRequest.setLockBackForwardList(lockBackForwardList());
         frameLoadRequest.setReferrerPolicy(m_submission->referrerPolicy());
@@ -547,7 +547,7 @@ public:
         ResourceRequest resourceRequest { URL { originDocument->url() }, emptyString(), ResourceRequestCachePolicy::ReloadIgnoringCacheData };
         if (RefPtr documentLoader = originDocument->loader())
             resourceRequest.setIsAppInitiated(documentLoader->lastNavigationWasAppInitiated());
-        FrameLoadRequest frameLoadRequest { originDocument.copyRef(), originDocument->protectedSecurityOrigin(), WTF::move(resourceRequest), { }, initiatedByMainFrame() };
+        FrameLoadRequest frameLoadRequest { originDocument.copyRef(), protect(originDocument->securityOrigin()), WTF::move(resourceRequest), { }, initiatedByMainFrame() };
         frameLoadRequest.setLockHistory(lockHistory());
         frameLoadRequest.setLockBackForwardList(lockBackForwardList());
         frameLoadRequest.setSubstituteData(WTF::move(replacementData));
@@ -609,7 +609,7 @@ void NavigationScheduler::scheduleRedirect(Document& initiatingDocument, double 
     // We want a new back/forward list item if the refresh timeout is > 1 second.
     if (!m_redirect || delay <= m_redirect->delay()) {
         auto lockBackForwardList = delay <= 1 ? LockBackForwardList::Yes : LockBackForwardList::No;
-        schedule(makeUnique<ScheduledRedirect>(initiatingDocument, delay, downcast<LocalFrame>(m_frame.get()).document()->protectedSecurityOrigin().ptr(), url, LockHistory::Yes, lockBackForwardList, isMetaRefresh));
+        schedule(makeUnique<ScheduledRedirect>(initiatingDocument, delay, protect(downcast<LocalFrame>(m_frame.get()).document()->securityOrigin()).ptr(), url, LockHistory::Yes, lockBackForwardList, isMetaRefresh));
     }
 }
 
@@ -733,7 +733,7 @@ void NavigationScheduler::scheduleRefresh(Document& initiatingDocument)
     if (url.isEmpty())
         return;
 
-    schedule(makeUnique<ScheduledRefresh>(initiatingDocument, frame->document()->protectedSecurityOrigin().ptr(), url, frame->loader().outgoingReferrer()));
+    schedule(makeUnique<ScheduledRefresh>(initiatingDocument, protect(protect(frame->document())->securityOrigin()).ptr(), url, frame->loader().outgoingReferrer()));
 }
 
 void NavigationScheduler::scheduleHistoryNavigation(int steps)

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -91,7 +91,7 @@ void PingLoader::loadImage(LocalFrame& frame, URL&& url)
     ASSERT(frame.document());
     Ref document = *frame.document();
 
-    if (!document->protectedSecurityOrigin()->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
+    if (!protect(document->securityOrigin())->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
         FrameLoader::reportLocalLoadFailed(&frame, url.string());
         return;
     }
@@ -156,7 +156,7 @@ void PingLoader::sendPing(LocalFrame& frame, URL&& sendPingURL, const URL& desti
     frame.loader().updateRequestAndAddExtraFields(request, IsMainResource::No);
 
     // https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing
-    if (document->protectedSecurityOrigin()->isSameOriginAs(SecurityOrigin::create(pingURL).get())
+    if (protect(document->securityOrigin())->isSameOriginAs(SecurityOrigin::create(pingURL).get())
         || !document->url().protocolIs("https"_s))
         request.setHTTPHeaderField(HTTPHeaderName::PingFrom, document->url().string());
     request.setHTTPHeaderField(HTTPHeaderName::PingTo, destinationURL.string());
@@ -202,7 +202,7 @@ void PingLoader::sendViolationReport(LocalFrame& frame, URL&& violationReportURL
     }
 
     bool removeCookies = true;
-    if (document->protectedSecurityOrigin()->isSameSchemeHostPort(SecurityOrigin::create(reportURL).get()))
+    if (protect(document->securityOrigin())->isSameSchemeHostPort(SecurityOrigin::create(reportURL).get()))
         removeCookies = false;
     if (removeCookies)
         request.setAllowCookies(false);
@@ -262,7 +262,7 @@ void PingLoader::startPingLoad(LocalFrame& frame, ResourceRequest& request, HTTP
     }
 
     CachedResourceRequest cachedResourceRequest { ResourceRequest { request }, options };
-    std::ignore = protect(frame.document())->protectedCachedResourceLoader()->requestPingResource(WTF::move(cachedResourceRequest));
+    std::ignore = protect(protect(frame.document())->cachedResourceLoader())->requestPingResource(WTF::move(cachedResourceRequest));
 }
 
 // // https://html.spec.whatwg.org/multipage/origin.html#sanitize-url-report

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -154,7 +154,7 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
         return completionHandler(false);
     m_defersLoading = m_options.defersLoadingPolicy == DefersLoadingPolicy::AllowDefersLoading && frame->page()->defersLoading();
 
-    if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !frame->document()->protectedSecurityOrigin()->canDisplay(clientRequest.url(), OriginAccessPatternsForWebProcess::singleton())) {
+    if (m_options.securityCheck == SecurityCheckPolicy::DoSecurityCheck && !protect(protect(frame->document())->securityOrigin())->canDisplay(clientRequest.url(), OriginAccessPatternsForWebProcess::singleton())) {
         RESOURCELOADER_RELEASE_LOG("init: Cancelling load because it violates security policy.");
         FrameLoader::reportLocalLoadFailed(frame.get(), clientRequest.url().string());
         releaseResources();
@@ -527,7 +527,7 @@ static void logResourceResponseSource(LocalFrame* frame, ResourceResponse::Sourc
         return;
     }
 
-    frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessage(DiagnosticLoggingKeys::resourceResponseSourceKey(), sourceKey, ShouldSample::Yes);
+    protect(frame->page())->diagnosticLoggingClient().logDiagnosticMessage(DiagnosticLoggingKeys::resourceResponseSourceKey(), sourceKey, ShouldSample::Yes);
 }
 
 bool ResourceLoader::shouldAllowResourceToAskForCredentials() const
@@ -841,7 +841,7 @@ bool ResourceLoader::isAllowedToAskUserForCredentials() const
     if (!shouldAllowResourceToAskForCredentials())
         return false;
     RefPtr frame = m_frame.get();
-    return m_options.credentials == FetchOptions::Credentials::Include || (m_options.credentials == FetchOptions::Credentials::SameOrigin && frame && frame->document()->protectedSecurityOrigin()->canRequest(originalRequest().url(), OriginAccessPatternsForWebProcess::singleton()));
+    return m_options.credentials == FetchOptions::Credentials::Include || (m_options.credentials == FetchOptions::Credentials::SameOrigin && frame && protect(protect(frame->document())->securityOrigin())->canRequest(originalRequest().url(), OriginAccessPatternsForWebProcess::singleton()));
 }
 
 bool ResourceLoader::shouldIncludeCertificateInfo() const

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -65,7 +65,7 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
     if (resource.type() == CachedResource::Type::MainResource && document.frame() && document.frame()->loader().shouldReportResourceTimingToParentFrame()) {
         initiatorDocument = document.parentDocument();
         if (initiatorDocument)
-            resourceTiming.updateExposure(initiatorDocument->protectedSecurityOrigin());
+            resourceTiming.updateExposure(protect(initiatorDocument->securityOrigin()));
     }
     if (!initiatorDocument)
         return;

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -95,7 +95,7 @@ void FrameLoader::SubframeLoader::clear()
 bool FrameLoader::SubframeLoader::canCreateSubFrame() const
 {
     Ref frame = m_frame;
-    if (!frame->page() || frame->protectedPage()->subframeCount() >= Page::maxNumberOfFrames)
+    if (!frame->page() || protect(frame->page())->subframeCount() >= Page::maxNumberOfFrames)
         return false;
 
     if (frame->tree().depth() >= Page::maxFrameDepth)
@@ -251,7 +251,7 @@ bool FrameLoader::SubframeLoader::requestObject(HTMLPlugInElement& ownerElement,
     bool useFallback;
     if (shouldUsePlugin(completedURL, mimeType, hasFallbackContent, useFallback)) {
         bool success = requestPlugin(ownerElement, completedURL, mimeType, paramNames, paramValues, useFallback);
-        logPluginRequest(document->protectedPage().get(), mimeType, completedURL);
+        logPluginRequest(protect(document->page()).get(), mimeType, completedURL);
         return success;
     }
 
@@ -284,7 +284,7 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
                 page->willChangeLocationInCompletelyLoadedSubframe();
         }
 
-        frame->protectedNavigationScheduler()->scheduleLocationChange(initiatingDocument, initiatingDocument->protectedSecurityOrigin(), upgradedRequestURL, m_frame->loader().outgoingReferrer(), lockHistory, lockBackForwardList, NavigationHistoryBehavior::Auto, WTF::move(stopDelayingLoadEvent));
+        frame->protectedNavigationScheduler()->scheduleLocationChange(initiatingDocument, protect(initiatingDocument->securityOrigin()), upgradedRequestURL, m_frame->loader().outgoingReferrer(), lockHistory, lockBackForwardList, NavigationHistoryBehavior::Auto, WTF::move(stopDelayingLoadEvent));
     } else
         frame = loadSubframe(ownerElement, upgradedRequestURL, frameName, m_frame->loader().outgoingReferrerURL());
 
@@ -300,7 +300,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     Ref frame = m_frame;
     Ref document = ownerElement.document();
 
-    if (!document->protectedSecurityOrigin()->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
+    if (!protect(document->securityOrigin())->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
         FrameLoader::reportLocalLoadFailed(frame.ptr(), url.string());
         return nullptr;
     }
@@ -313,7 +313,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
     if (!SubframeLoadingDisabler::canLoadFrame(ownerElement))
         return nullptr;
 
-    if (!frame->page() || frame->protectedPage()->subframeCount() >= Page::maxNumberOfFrames)
+    if (!frame->page() || protect(frame->page())->subframeCount() >= Page::maxNumberOfFrames)
         return nullptr;
 
     if (frame->tree().depth() >= Page::maxFrameDepth)

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -289,7 +289,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
             newRequest.makeUnconditional();
             MemoryCache::singleton().revalidationFailed(*resource);
             if (frame && frame->page())
-                frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
+                protect(frame->page())->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
         }
 
         RefPtr documentLoader = this->documentLoader();
@@ -438,7 +438,7 @@ void SubresourceLoader::didReceiveResponse(ResourceResponse&& response, Completi
             resource->setResponse(ResourceResponse { revalidationResponse });
             MemoryCache::singleton().revalidationSucceeded(*resource, resource->response());
             if (frame && frame->page())
-                frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultPass, ShouldSample::Yes);
+                protect(frame->page())->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultPass, ShouldSample::Yes);
             if (!reachedTerminalState())
                 ResourceLoader::didReceiveResponse(WTF::move(revalidationResponse), [completionHandlerCaller = WTF::move(completionHandlerCaller)] { });
             return;
@@ -446,7 +446,7 @@ void SubresourceLoader::didReceiveResponse(ResourceResponse&& response, Completi
         // Did not get 304 response, continue as a regular resource load.
         MemoryCache::singleton().revalidationFailed(*resource);
         if (frame && frame->page())
-            frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
+            protect(frame->page())->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
     }
 
     auto accessControlCheckResult = checkResponseCrossOriginAccessControl(response);
@@ -644,7 +644,7 @@ static void logResourceLoaded(LocalFrame* frame, CachedResource::Type type)
         break;
     }
     
-    frame->protectedPage()->diagnosticLoggingClient().logDiagnosticMessage(DiagnosticLoggingKeys::resourceLoadedKey(), resourceType, ShouldSample::Yes);
+    protect(frame->page())->diagnosticLoggingClient().logDiagnosticMessage(DiagnosticLoggingKeys::resourceLoadedKey(), resourceType, ShouldSample::Yes);
 }
 
 Expected<void, String> SubresourceLoader::checkResponseCrossOriginAccessControl(const ResourceResponse& response)

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -173,7 +173,7 @@ bool TextTrackLoader::load(const URL& url, HTMLTrackElement& element)
         resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*mediaElement));
 
     auto cueRequest = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), *document, element.mediaElementCrossOriginAttribute());
-    m_resource = document->protectedCachedResourceLoader()->requestTextTrack(WTF::move(cueRequest)).value_or(nullptr);
+    m_resource = protect(document->cachedResourceLoader())->requestTextTrack(WTF::move(cueRequest)).value_or(nullptr);
     if (CachedResourceHandle resource = m_resource) {
         resource->addClient(*this);
         return true;

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -92,7 +92,7 @@ void IconLoader::startLoading()
 
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().icon);
 
-    auto cachedResource = protect(frame->document())->protectedCachedResourceLoader()->requestIcon(WTF::move(request));
+    auto cachedResource = protect(protect(frame->document())->cachedResourceLoader())->requestIcon(WTF::move(request));
     m_resource = cachedResource.value_or(nullptr);
     if (CachedResourceHandle resource = m_resource)
         resource->addClient(*this);

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -398,7 +398,7 @@ bool Chrome::print(LocalFrame& frame)
     // FIXME: This should have PageGroupLoadDeferrer, like runModal() or runJavaScriptAlert(), because it's no different from those.
 
     if (frame.document()->isSandboxed(SandboxFlag::Modals)) {
-        frame.document()->protectedWindow()->printErrorMessage("Use of window.print is not allowed in a sandboxed frame when the allow-modals flag is not set."_s);
+        protect(frame.document()->window())->printErrorMessage("Use of window.print is not allowed in a sandboxed frame when the allow-modals flag is not set."_s);
         return false;
     }
 

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -274,7 +274,7 @@ static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event,
     if (!oldPage)
         return;
 
-    FrameLoadRequest frameLoadRequest { protect(frame.document()).releaseNonNull(), frame.document()->protectedSecurityOrigin(), ResourceRequest(URL { urlToLoad }, frame.loader().outgoingReferrer()), { }, InitiatedByMainFrame::Unknown };
+    FrameLoadRequest frameLoadRequest { protect(frame.document()).releaseNonNull(), protect(protect(frame.document())->securityOrigin()), ResourceRequest(URL { urlToLoad }, frame.loader().outgoingReferrer()), { }, InitiatedByMainFrame::Unknown };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
 
@@ -291,7 +291,7 @@ static void openNewWindow(const URL& urlToLoad, LocalFrame& frame, Event* event,
 static void insertUnicodeCharacter(char16_t character, LocalFrame& frame)
 {
     String text(span(character));
-    if (!frame.protectedEditor()->shouldInsertText(text, frame.selection().selection().toNormalizedRange(), EditorInsertAction::Typed))
+    if (!protect(frame.editor())->shouldInsertText(text, frame.selection().selection().toNormalizedRange(), EditorInsertAction::Typed))
         return;
 
     ASSERT(frame.document());
@@ -331,7 +331,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         m_client->downloadURL(m_context.hitTestResult().absoluteLinkURL());
         break;
     case ContextMenuItemTagCopyLinkToClipboard:
-        frame->protectedEditor()->copyURL(m_context.hitTestResult().absoluteLinkURL(), m_context.hitTestResult().textContent());
+        protect(frame->editor())->copyURL(m_context.hitTestResult().absoluteLinkURL(), m_context.hitTestResult().textContent());
         break;
     case ContextMenuItemTagOpenImageInNewWindow:
         openNewWindow(m_context.hitTestResult().absoluteImageURL(), *frame, nullptr, ShouldOpenExternalURLsPolicy::ShouldNotAllow);
@@ -343,11 +343,11 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
     case ContextMenuItemTagCopyImageToClipboard:
         // FIXME: The Pasteboard class is not written yet
         // For now, call into the client. This is temporary!
-        frame->protectedEditor()->copyImage(m_context.hitTestResult());
+        protect(frame->editor())->copyImage(m_context.hitTestResult());
         break;
 #if PLATFORM(GTK)
     case ContextMenuItemTagCopyImageURLToClipboard:
-        frame->protectedEditor()->copyURL(m_context.hitTestResult().absoluteImageURL(), m_context.hitTestResult().textContent());
+        protect(frame->editor())->copyURL(m_context.hitTestResult().absoluteImageURL(), m_context.hitTestResult().textContent());
         break;
 #endif
     case ContextMenuItemTagOpenMediaInNewWindow:
@@ -358,7 +358,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         m_client->downloadURL(m_context.hitTestResult().absoluteMediaURL());
         break;
     case ContextMenuItemTagCopyMediaLinkToClipboard:
-        frame->protectedEditor()->copyURL(m_context.hitTestResult().absoluteMediaURL(), m_context.hitTestResult().textContent());
+        protect(frame->editor())->copyURL(m_context.hitTestResult().absoluteMediaURL(), m_context.hitTestResult().textContent());
         break;
     case ContextMenuItemTagToggleMediaControls:
         m_context.hitTestResult().toggleMediaControlsDisplay();
@@ -414,7 +414,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         break;
 #endif // ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     case ContextMenuItemTagCopy:
-        frame->protectedEditor()->copy();
+        protect(frame->editor())->copy();
         break;
     case ContextMenuItemTagCopyLinkWithHighlight:
         if (RefPtr page = frame->page()) {
@@ -450,7 +450,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         frame->editor().command("PasteAsPlainText"_s).execute();
         break;
     case ContextMenuItemTagDelete:
-        frame->protectedEditor()->performDelete();
+        protect(frame->editor())->performDelete();
         break;
     case ContextMenuItemTagUnicodeInsertLRMMark:
         insertUnicodeCharacter(leftToRightMark, *frame);
@@ -491,7 +491,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
 #endif
     case ContextMenuItemTagSpellingGuess: {
         VisibleSelection selection = frame->selection().selection();
-        if (frame->protectedEditor()->shouldInsertText(title, selection.toNormalizedRange(), EditorInsertAction::Pasted)) {
+        if (protect(frame->editor())->shouldInsertText(title, selection.toNormalizedRange(), EditorInsertAction::Pasted)) {
             OptionSet<ReplaceSelectionCommand::CommandOption> replaceOptions { ReplaceSelectionCommand::MatchStyle, ReplaceSelectionCommand::PreventNesting };
 
             if (frame->editor().behavior().shouldAllowSpellingSuggestionsWithoutSelection()) {
@@ -513,10 +513,10 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         break;
     }
     case ContextMenuItemTagIgnoreSpelling:
-        frame->protectedEditor()->ignoreSpelling();
+        protect(frame->editor())->ignoreSpelling();
         break;
     case ContextMenuItemTagLearnSpelling:
-        frame->protectedEditor()->learnSpelling();
+        protect(frame->editor())->learnSpelling();
         break;
     case ContextMenuItemTagSearchWeb:
         m_client->searchWithGoogle(frame.get());
@@ -543,7 +543,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         frame->editor().command("ToggleItalic"_s).execute();
         break;
     case ContextMenuItemTagUnderline:
-        frame->protectedEditor()->toggleUnderline();
+        protect(frame->editor())->toggleUnderline();
         break;
     case ContextMenuItemTagOutline:
         // We actually never enable this because CSS does not have a way to specify an outline font,
@@ -560,13 +560,13 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         m_client->stopSpeaking();
         break;
     case ContextMenuItemTagDefaultDirection:
-        frame->protectedEditor()->setBaseWritingDirection(WritingDirection::Natural);
+        protect(frame->editor())->setBaseWritingDirection(WritingDirection::Natural);
         break;
     case ContextMenuItemTagLeftToRight:
-        frame->protectedEditor()->setBaseWritingDirection(WritingDirection::LeftToRight);
+        protect(frame->editor())->setBaseWritingDirection(WritingDirection::LeftToRight);
         break;
     case ContextMenuItemTagRightToLeft:
-        frame->protectedEditor()->setBaseWritingDirection(WritingDirection::RightToLeft);
+        protect(frame->editor())->setBaseWritingDirection(WritingDirection::RightToLeft);
         break;
     case ContextMenuItemTagTextDirectionDefault:
         frame->editor().command("MakeTextWritingDirectionNatural"_s).execute();
@@ -578,57 +578,57 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         frame->editor().command("MakeTextWritingDirectionRightToLeft"_s).execute();
         break;
     case ContextMenuItemTagShowSpellingPanel:
-        frame->protectedEditor()->showSpellingGuessPanel();
+        protect(frame->editor())->showSpellingGuessPanel();
         break;
     case ContextMenuItemTagCheckSpelling:
-        frame->protectedEditor()->advanceToNextMisspelling();
+        protect(frame->editor())->advanceToNextMisspelling();
         break;
     case ContextMenuItemTagCheckSpellingWhileTyping:
-        frame->protectedEditor()->toggleContinuousSpellChecking();
+        protect(frame->editor())->toggleContinuousSpellChecking();
         break;
     case ContextMenuItemTagCheckGrammarWithSpelling:
-        frame->protectedEditor()->toggleGrammarChecking();
+        protect(frame->editor())->toggleGrammarChecking();
         break;
 #if USE(APPKIT)
     case ContextMenuItemTagMakeUpperCase:
-        frame->protectedEditor()->uppercaseWord();
+        protect(frame->editor())->uppercaseWord();
         break;
     case ContextMenuItemTagMakeLowerCase:
-        frame->protectedEditor()->lowercaseWord();
+        protect(frame->editor())->lowercaseWord();
         break;
     case ContextMenuItemTagCapitalize:
-        frame->protectedEditor()->capitalizeWord();
+        protect(frame->editor())->capitalizeWord();
         break;
 #endif
 #if PLATFORM(COCOA)
     case ContextMenuItemTagChangeBack:
-        frame->protectedEditor()->changeBackToReplacedString(m_context.hitTestResult().replacedString());
+        protect(frame->editor())->changeBackToReplacedString(m_context.hitTestResult().replacedString());
         break;
 #endif
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)
     case ContextMenuItemTagShowSubstitutions:
-        frame->protectedEditor()->showSubstitutionsPanel();
+        protect(frame->editor())->showSubstitutionsPanel();
         break;
     case ContextMenuItemTagSmartCopyPaste:
-        frame->protectedEditor()->toggleSmartInsertDelete();
+        protect(frame->editor())->toggleSmartInsertDelete();
         break;
     case ContextMenuItemTagSmartQuotes:
-        frame->protectedEditor()->toggleAutomaticQuoteSubstitution();
+        protect(frame->editor())->toggleAutomaticQuoteSubstitution();
         break;
     case ContextMenuItemTagSmartDashes:
-        frame->protectedEditor()->toggleAutomaticDashSubstitution();
+        protect(frame->editor())->toggleAutomaticDashSubstitution();
         break;
     case ContextMenuItemTagSmartLinks:
-        frame->protectedEditor()->toggleAutomaticLinkDetection();
+        protect(frame->editor())->toggleAutomaticLinkDetection();
         break;
     case ContextMenuItemTagSmartLists:
-        frame->protectedEditor()->toggleSmartLists();
+        protect(frame->editor())->toggleSmartLists();
         break;
     case ContextMenuItemTagTextReplacement:
-        frame->protectedEditor()->toggleAutomaticTextReplacement();
+        protect(frame->editor())->toggleAutomaticTextReplacement();
         break;
     case ContextMenuItemTagCorrectSpellingAutomatically:
-        frame->protectedEditor()->toggleAutomaticSpellingCorrection();
+        protect(frame->editor())->toggleAutomaticSpellingCorrection();
         break;
 #endif
     case ContextMenuItemTagInspectElement:
@@ -636,7 +636,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
             page->inspectorController().inspect(m_context.hitTestResult().innerNonSharedNode());
         break;
     case ContextMenuItemTagDictationAlternative:
-        frame->protectedEditor()->applyDictationAlternative(title);
+        protect(frame->editor())->applyDictationAlternative(title);
         break;
 #if PLATFORM(MAC)
     case ContextMenuItemTagShowFonts:

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -1033,7 +1033,7 @@ bool DOMWindow::isInsecureScriptAccess(const LocalDOMWindow& activeWindow, const
 
         // This check only makes sense with LocalDOMWindows as RemoteDOMWindows necessarily have different origins
         RefPtr localDocument = documentIfLocal();
-        if (localDocument && protect(activeWindow.document())->protectedSecurityOrigin()->isSameOriginDomain(localDocument->protectedSecurityOrigin()))
+        if (localDocument && protect(protect(activeWindow.document())->securityOrigin())->isSameOriginDomain(protect(localDocument->securityOrigin())))
             return false;
     }
 

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -137,7 +137,7 @@ bool MouseWheelRegionOverlay::updateRegion()
 
         Ref document = *localFrame->document();
         auto frameRegion = document->absoluteRegionForWheelEventTargets();
-        frameRegion.first.translate(toIntSize(localFrame->protectedView()->contentsToRootView(IntPoint())));
+        frameRegion.first.translate(toIntSize(protect(localFrame->view())->contentsToRootView(IntPoint())));
         region->unite(frameRegion.first);
     }
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -138,7 +138,7 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
 
 Frame::~Frame()
 {
-    protectedWindowProxy()->detachFromFrame();
+    protect(windowProxy())->detachFromFrame();
     protectedNavigationScheduler()->cancel();
 
 #if ASSERT_ENABLED
@@ -177,10 +177,10 @@ void Frame::takeWindowProxyAndOpenerFrom(Frame& frame)
 {
     ASSERT(is<LocalDOMWindow>(window()) != is<LocalDOMWindow>(frame.window()) || page() != frame.page());
     ASSERT(m_windowProxy->frame() == this);
-    protectedWindowProxy()->detachFromFrame();
+    protect(windowProxy())->detachFromFrame();
     m_windowProxy = frame.windowProxy();
     frame.resetWindowProxy();
-    protectedWindowProxy()->replaceFrame(*this);
+    protect(windowProxy())->replaceFrame(*this);
 
     ASSERT(!m_opener);
     m_opener = frame.m_opener;

--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -451,7 +451,7 @@ void FrameConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Re
             Ref frame = m_frame.get();
             if (RefPtr localMainFrame = frame->localMainFrame()) {
                 // If no target is provided, capture an image of the viewport.
-                auto viewportRect = localMainFrame->protectedView()->unobscuredContentRect();
+                auto viewportRect = protect(localMainFrame->view())->unobscuredContentRect();
                 if (RefPtr snapshot = WebCore::snapshotFrameRect(*localMainFrame, viewportRect, { { }, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }))
                     dataURL = snapshot->toDataURL("image/png"_s, /* quality */ std::nullopt, PreserveResolution::Yes);
             }

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -306,7 +306,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
         return result.releaseException();
 
     if (document->settings().navigationAPIEnabled()) {
-        Ref navigation = document->protectedWindow()->navigation();
+        Ref navigation = protect(document->window())->navigation();
         if (!navigation->dispatchPushReplaceReloadNavigateEvent(fullURL, historyBehavior == NavigationHistoryBehavior::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true, nullptr, data.get()))
             return { };
     }

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -640,7 +640,7 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
 
         bool isSameOriginObservation = [&] () {
             if (RefPtr hostFrameSecurityOrigin = hostFrame.frameDocumentSecurityOrigin())
-                return target->document().protectedSecurityOrigin()->isSameOriginDomain(*hostFrameSecurityOrigin);
+                return protect(target->document().securityOrigin())->isSameOriginDomain(*hostFrameSecurityOrigin);
 
             return false;
         }();

--- a/Source/WebCore/page/LocalDOMWindowProperty.cpp
+++ b/Source/WebCore/page/LocalDOMWindowProperty.cpp
@@ -39,7 +39,7 @@ LocalDOMWindowProperty::LocalDOMWindowProperty(LocalDOMWindow* window)
 
 LocalFrame* LocalDOMWindowProperty::frame() const
 {
-    return m_window ? protectedWindow()->localFrame() : nullptr;
+    return m_window ? protect(window())->localFrame() : nullptr;
 }
 
 RefPtr<LocalFrame> LocalDOMWindowProperty::protectedFrame() const

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -334,7 +334,7 @@ void LocalFrame::setDocument(RefPtr<Document>&& newDocument)
     if (RefPtr previousDocument = m_doc) {
 #if ENABLE(ATTACHMENT_ELEMENT)
         for (Ref attachment : previousDocument->attachmentElementsByIdentifier().values())
-            protectedEditor()->didRemoveAttachmentElement(attachment);
+            protect(editor())->didRemoveAttachmentElement(attachment);
 #endif
 
         if (previousDocument->backForwardCacheState() != Document::InBackForwardCache)
@@ -696,7 +696,7 @@ void LocalFrame::setPrinting(bool printing, FloatSize pageSize, FloatSize origin
     // See https://bugs.webkit.org/show_bug.cgi?id=43704
     ResourceCacheValidationSuppressor validationSuppressor(document->cachedResourceLoader());
 
-    protectedView()->adjustMediaTypeForPrinting(printing);
+    protect(view())->adjustMediaTypeForPrinting(printing);
 
     // FIXME: Consider invoking Page::updateRendering or an equivalent.
     document->styleScope().didChangeStyleSheetEnvironment();
@@ -878,7 +878,7 @@ void LocalFrame::clearTimers(LocalFrameView *view, Document *document)
 
 void LocalFrame::clearTimers()
 {
-    clearTimers(protectedView().get(), protect(document()).get());
+    clearTimers(protect(view()).get(), protect(document()).get());
 }
 
 CheckedRef<ScriptController> LocalFrame::checkedScript()
@@ -946,7 +946,7 @@ VisiblePosition LocalFrame::visiblePositionForPoint(const IntPoint& framePoint) 
 
 HitTestResult LocalFrame::hitTestResultAtPoint(IntPoint point, OptionSet<HitTestRequest::Type> hitType)
 {
-    IntPoint pointInContents = protectedView()->windowToContents(point);
+    IntPoint pointInContents = protect(view())->windowToContents(point);
 
     if (hitType.isEmpty())
         return HitTestResult { pointInContents };
@@ -978,12 +978,12 @@ std::optional<SimpleRange> LocalFrame::rangeForPoint(const IntPoint& framePoint)
         return std::nullopt;
 
     if (auto previousCharacterRange = makeSimpleRange(position.previous(), position)) {
-        if (protectedEditor()->firstRectForRange(*previousCharacterRange).contains(framePoint))
+        if (protect(editor())->firstRectForRange(*previousCharacterRange).contains(framePoint))
             return *previousCharacterRange;
     }
 
     if (auto nextCharacterRange = makeSimpleRange(position, position.next())) {
-        if (protectedEditor()->firstRectForRange(*nextCharacterRange).contains(framePoint))
+        if (protect(editor())->firstRectForRange(*nextCharacterRange).contains(framePoint))
             return *nextCharacterRange;
     }
 
@@ -997,7 +997,7 @@ void LocalFrame::createView(const IntSize& viewportSize, const std::optional<Col
     bool isRootFrame = this->isRootFrame();
 
     if (isRootFrame && view())
-        protectedView()->setParentVisible(false);
+        protect(view())->setParentVisible(false);
 
     setView(nullptr);
 
@@ -1021,7 +1021,7 @@ void LocalFrame::createView(const IntSize& viewportSize, const std::optional<Col
     if (CheckedPtr ownerRenderer = this->ownerRenderer())
         ownerRenderer->setWidget(frameView);
 
-    protectedView()->setCanHaveScrollbars(scrollingMode() != ScrollbarMode::AlwaysOff);
+    protect(view())->setCanHaveScrollbars(scrollingMode() != ScrollbarMode::AlwaysOff);
 }
 
 LocalDOMWindow* LocalFrame::window() const
@@ -1072,7 +1072,7 @@ String LocalFrame::trackedRepaintRectsAsText() const
 {
     if (!m_view)
         return String();
-    return protectedView()->trackedRepaintRectsAsText();
+    return protect(view())->trackedRepaintRectsAsText();
 }
 
 void LocalFrame::setPageZoomFactor(float factor)
@@ -1098,7 +1098,7 @@ void LocalFrame::setPageAndTextZoomFactors(float pageZoomFactor, float textZoomF
     if (!document)
         return;
 
-    protectedEditor()->dismissCorrectionPanelAsIgnored();
+    protect(editor())->dismissCorrectionPanelAsIgnored();
 
     // Respect SVGs zoomAndPan="disabled" property in standalone SVG documents.
     // FIXME: How to handle compound documents + zoomAndPan="disabled"? Needs SVG WG clarification.
@@ -1209,7 +1209,7 @@ FloatSize LocalFrame::screenSize() const
     if (m_overrideScreenSize)
         return m_overrideScreenSize->size;
 
-    auto defaultSize = screenRect(protectedView().get()).size();
+    auto defaultSize = screenRect(protect(view()).get()).size();
     RefPtr document = this->document();
     if (!document)
         return defaultSize;
@@ -1321,7 +1321,7 @@ void LocalFrame::documentURLOrOriginDidChange()
     RefPtr page = this->page();
     RefPtr document = this->document();
     if (page && document)
-        page->setMainFrameURLAndOrigin(document->url(), document->protectedSecurityOrigin());
+        page->setMainFrameURLAndOrigin(document->url(), protect(document->securityOrigin()));
 }
 
 void LocalFrame::dispatchLoadEventToParent()

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -907,7 +907,7 @@ void LocalFrameView::updateSnapOffsets()
     LayoutRect viewport = LayoutRect(IntPoint(), baseLayoutViewportSize());
     viewport.move(-rootRenderer->marginLeft(), -rootRenderer->marginTop());
 
-    updateSnapOffsetsForScrollableArea(*this, *rootRenderer, *styleToUse, viewport, rootRenderer->style().writingMode(), m_frame->document()->protectedFocusedElement().get());
+    updateSnapOffsetsForScrollableArea(*this, *rootRenderer, *styleToUse, viewport, rootRenderer->style().writingMode(), protect(m_frame->document()->focusedElement()).get());
 }
 
 bool LocalFrameView::isScrollSnapInProgress() const
@@ -4428,7 +4428,7 @@ bool LocalFrameView::safeToPropagateScrollToParent() const
     if (!parentDocument)
         return false;
 
-    return document->protectedSecurityOrigin()->isSameOriginDomain(parentDocument->protectedSecurityOrigin());
+    return protect(document->securityOrigin())->isSameOriginDomain(protect(parentDocument->securityOrigin()));
 }
 
 void LocalFrameView::scheduleScrollToAnchorAndTextFragment()
@@ -4576,9 +4576,9 @@ void LocalFrameView::scrollToPendingTextFragmentRange()
                 return;
         }
         if (m_haveCreatedTextIndicator)
-            document->protectedPage()->chrome().client().updateTextIndicator(WTF::move(textIndicator));
+            protect(document->page())->chrome().client().updateTextIndicator(WTF::move(textIndicator));
         else {
-            document->protectedPage()->chrome().client().setTextIndicator(WTF::move(textIndicator));
+            protect(document->page())->chrome().client().setTextIndicator(WTF::move(textIndicator));
             m_haveCreatedTextIndicator = true;
         }
     }

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -284,7 +284,7 @@ void Location::reload(LocalDOMWindow& activeWindow)
     // FIXME: It's not clear this cross-origin security check is valuable.
     // We allow one page to change the location of another. Why block attempts to reload?
     // Other location operations simply block use of JavaScript URLs cross origin.
-    if (!activeDocument->protectedSecurityOrigin()->isSameOriginDomain(targetDocument->protectedSecurityOrigin())) {
+    if (!protect(activeDocument->securityOrigin())->isSameOriginDomain(protect(targetDocument->securityOrigin()))) {
         Ref targetWindow = *targetDocument->window();
         targetWindow->printErrorMessage(targetWindow->crossDomainAccessErrorMessage(activeWindow, IncludeTargetOrigin::Yes));
         return;

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -146,7 +146,7 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         document->styleScope().releaseMemory();
         if (RefPtr fontSelector = document->fontSelectorIfExists())
             fontSelector->emptyCaches();
-        document->protectedCachedResourceLoader()->garbageCollectDocumentResources();
+        protect(document->cachedResourceLoader())->garbageCollectDocumentResources();
 
         if (RefPtr pluginDocument = dynamicDowncast<PluginDocument>(document))
             pluginDocument->releaseMemory();

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -127,7 +127,7 @@ uint64_t NavigationHistoryEntry::index() const
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     if (!document || !document->isFullyActive())
         return -1;
-    return document->protectedWindow()->protectedNavigation()->entries().findIf([this] (auto& entry) {
+    return protect(protect(document->window())->navigation())->entries().findIf([this] (auto& entry) {
         return entry.ptr() == this;
     });
 }

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -288,7 +288,7 @@ void Navigator::initializePluginAndMimeTypeArrays()
 
     // macOS uses a PDF Plugin (which may be disabled). Other ports handle PDF's through native
     // platform views outside the engine, or use pdf.js.
-    PluginInfo pdfPluginInfo = frame->protectedPage()->pluginData().builtInPDFPlugin().value_or(PluginData::dummyPDFPluginInfo());
+    PluginInfo pdfPluginInfo = protect(frame->page())->pluginData().builtInPDFPlugin().value_or(PluginData::dummyPDFPluginInfo());
 
     Vector<Ref<DOMPlugin>> domPlugins;
     Vector<Ref<DOMMimeType>> domMimeTypes;

--- a/Source/WebCore/page/NavigatorLoginStatus.cpp
+++ b/Source/WebCore/page/NavigatorLoginStatus.cpp
@@ -70,7 +70,7 @@ bool NavigatorLoginStatus::hasSameOrigin() const
     Ref origin = document->securityOrigin();
     bool isSameSite = true;
     for (RefPtr parentDocument = document->parentDocument(); parentDocument; parentDocument = parentDocument->parentDocument()) {
-        if (!origin->isSameOriginAs(parentDocument->protectedSecurityOrigin())) {
+        if (!origin->isSameOriginAs(protect(parentDocument->securityOrigin()))) {
             isSameSite = false;
             break;
         }
@@ -91,7 +91,7 @@ void NavigatorLoginStatus::setStatus(IsLoggedIn isLoggedIn, Ref<DeferredPromise>
         promise->reject();
         return;
     }
-    page->chrome().client().setLoginStatus(RegistrableDomain::uncheckedCreateFromHost(document->protectedSecurityOrigin()->host()), isLoggedIn, [promise = WTF::move(promise)] {
+    page->chrome().client().setLoginStatus(RegistrableDomain::uncheckedCreateFromHost(protect(document->securityOrigin())->host()), isLoggedIn, [promise = WTF::move(promise)] {
         promise->resolve();
     });
 }
@@ -109,7 +109,7 @@ void NavigatorLoginStatus::isLoggedIn(Ref<DeferredPromise>&& promise)
         promise->reject();
         return;
     }
-    page->chrome().client().isLoggedIn(RegistrableDomain::uncheckedCreateFromHost(document->protectedSecurityOrigin()->host()), [promise = WTF::move(promise)] (bool isLoggedIn) {
+    page->chrome().client().isLoggedIn(RegistrableDomain::uncheckedCreateFromHost(protect(document->securityOrigin())->host()), [promise = WTF::move(promise)] (bool isLoggedIn) {
         promise->resolve<IDLBoolean>(isLoggedIn);
     });
 }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -219,7 +219,7 @@ bool Quirks::needsAutoplayPlayPauseEvents() const
     if (allowedAutoplayQuirks(document).contains(AutoplayQuirk::SynthesizedPauseEvents))
         return true;
 
-    return allowedAutoplayQuirks(document->protectedMainFrameDocument().get()).contains(AutoplayQuirk::SynthesizedPauseEvents);
+    return allowedAutoplayQuirks(protect(document->mainFrameDocument()).get()).contains(AutoplayQuirk::SynthesizedPauseEvents);
 }
 
 // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030

--- a/Source/WebCore/page/Screen.cpp
+++ b/Source/WebCore/page/Screen.cpp
@@ -110,7 +110,7 @@ unsigned Screen::colorDepth() const
         return 24;
     if (frame->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::singleton().logScreenAPIAccessed(*protect(frame->document()), ScreenAPIsAccessed::ColorDepth);
-    return static_cast<unsigned>(screenDepth(frame->protectedView().get()));
+    return static_cast<unsigned>(screenDepth(protect(frame->view()).get()));
 }
 
 int Screen::availLeft() const
@@ -125,7 +125,7 @@ int Screen::availLeft() const
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
 
-    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).x());
+    return static_cast<int>(screenAvailableRect(protect(frame->view()).get()).x());
 }
 
 int Screen::availTop() const
@@ -140,7 +140,7 @@ int Screen::availTop() const
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return 0;
 
-    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).y());
+    return static_cast<int>(screenAvailableRect(protect(frame->view()).get()).y());
 }
 
 int Screen::availHeight() const
@@ -155,7 +155,7 @@ int Screen::availHeight() const
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().height());
 
-    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).height());
+    return static_cast<int>(screenAvailableRect(protect(frame->view()).get()).height());
 }
 
 int Screen::availWidth() const
@@ -170,7 +170,7 @@ int Screen::availWidth() const
     if (shouldApplyScreenFingerprintingProtections(*frame))
         return static_cast<int>(frame->screenSize().width());
 
-    return static_cast<int>(screenAvailableRect(frame->protectedView().get()).width());
+    return static_cast<int>(screenAvailableRect(protect(frame->view()).get()).width());
 }
 
 ScreenOrientation& Screen::orientation()

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -389,8 +389,8 @@ void SettingsBase::imageLoadingSettingsTimerFired()
         RefPtr document = localFrame->document();
         if (!document)
             continue;
-        document->protectedCachedResourceLoader()->setImagesEnabled(m_page->settings().areImagesEnabled());
-        document->protectedCachedResourceLoader()->setAutoLoadImages(m_page->settings().loadsImagesAutomatically());
+        protect(document->cachedResourceLoader())->setImagesEnabled(m_page->settings().areImagesEnabled());
+        protect(document->cachedResourceLoader())->setAutoLoadImages(m_page->settings().loadsImagesAutomatically());
     }
 }
 

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -242,9 +242,9 @@ static bool takeSnapshots(TextIndicatorData& data, LocalFrame& frame, IntRect sn
             snapshotOptions.flags.add(SnapshotFlags::PaintWith3xBaseScale);
 
         float snapshotScaleFactor;
-        auto visibleContentRect = frame.protectedView()->visibleContentRect();
+        auto visibleContentRect = protect(frame.view())->visibleContentRect();
         data.contentImageWithoutSelection = takeSnapshot(frame, visibleContentRect, WTF::move(snapshotOptions), snapshotScaleFactor, { });
-        data.contentImageWithoutSelectionRectInRootViewCoordinates = frame.protectedView()->contentsToRootView(visibleContentRect);
+        data.contentImageWithoutSelectionRectInRootViewCoordinates = protect(frame.view())->contentsToRootView(visibleContentRect);
     }
     
     return true;
@@ -389,7 +389,7 @@ static bool initializeIndicator(TextIndicatorData& data, LocalFrame& frame, cons
         textRectInDocumentCoordinatesIncludingMargin.inflateY(margin.height());
         textBoundingRectInDocumentCoordinates.unite(textRectInDocumentCoordinatesIncludingMargin);
 
-        FloatRect textRectInRootViewCoordinates = frame.protectedView()->contentsToRootView(enclosingIntRect(textRectInDocumentCoordinatesIncludingMargin));
+        FloatRect textRectInRootViewCoordinates = protect(frame.view())->contentsToRootView(enclosingIntRect(textRectInDocumentCoordinatesIncludingMargin));
         textRectsInRootViewCoordinates.append(textRectInRootViewCoordinates);
         textBoundingRectInRootViewCoordinates.unite(textRectInRootViewCoordinates);
     }
@@ -403,7 +403,7 @@ static bool initializeIndicator(TextIndicatorData& data, LocalFrame& frame, cons
 
     // Store the selection rect in window coordinates, to be used subsequently
     // to determine if the indicator and selection still precisely overlap.
-    data.selectionRectInRootViewCoordinates = frame.protectedView()->contentsToRootView(enclosingIntRect(frame.checkedSelection()->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
+    data.selectionRectInRootViewCoordinates = protect(frame.view())->contentsToRootView(enclosingIntRect(frame.checkedSelection()->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
     data.textBoundingRectInRootViewCoordinates = textBoundingRectInRootViewCoordinates;
     data.textRectsInBoundingRectCoordinates = WTF::move(textRectsInBoundingRectCoordinates);
 

--- a/Source/WebCore/page/UndoManager.cpp
+++ b/Source/WebCore/page/UndoManager.cpp
@@ -57,7 +57,7 @@ ExceptionOr<void> UndoManager::addItem(Ref<UndoItem>&& item)
         return Exception { ExceptionCode::SecurityError, "A browsing context is required to add an UndoItem"_s };
 
     item->setUndoManager(this);
-    frame->protectedEditor()->registerCustomUndoStep(CustomUndoStep::create(item));
+    protect(frame->editor())->registerCustomUndoStep(CustomUndoStep::create(item));
     m_items.add(WTF::move(item));
     return { };
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -119,7 +119,7 @@ ContentSecurityPolicy::ContentSecurityPolicy(URL&& protectedURL, ScriptExecution
     , m_protectedURL { WTF::move(protectedURL) }
 {
     ASSERT(scriptExecutionContext.securityOrigin());
-    updateSourceSelf(*scriptExecutionContext.protectedSecurityOrigin());
+    updateSourceSelf(*protect(scriptExecutionContext.securityOrigin()));
     // FIXME: handle the non-document case.
     if (auto* document = dynamicDowncast<Document>(scriptExecutionContext)) {
         if (auto* page = document->page())
@@ -1166,7 +1166,7 @@ void ContentSecurityPolicy::upgradeInsecureRequestIfNeeded(URL& url, InsecureReq
     ShouldUpgradeLocalhostAndIPAddress shouldUpgradeLocalhostAndIPAddress = (upgradeRequest || shouldUpgradeLocalhostAndIPAddressInMixedContext) ? ShouldUpgradeLocalhostAndIPAddress::Yes : ShouldUpgradeLocalhostAndIPAddress::No;
     std::optional<uint16_t> upgradePort;
     if (RefPtr document = dynamicDowncast<Document>(scriptExecutionContext.get()); document && document->page()) {
-        auto portsForUpgradingInsecureScheme = document->protectedPage()->portsForUpgradingInsecureSchemeForTesting();
+        auto portsForUpgradingInsecureScheme = protect(document->page())->portsForUpgradingInsecureSchemeForTesting();
         if (portsForUpgradingInsecureScheme) {
             if (url.port() == portsForUpgradingInsecureScheme->first)
                 upgradePort = portsForUpgradingInsecureScheme->second;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -117,7 +117,7 @@ static inline bool checkFrameAncestors(ContentSecurityPolicySourceListDirective*
         RefPtr localFrame = dynamicDowncast<LocalFrame>(*current);
         if (!localFrame)
             continue;
-        URL origin = urlFromOrigin(protect(localFrame->document())->protectedSecurityOrigin());
+        URL origin = urlFromOrigin(protect(protect(localFrame->document())->securityOrigin()));
         if (!origin.isValid() || !directive->allows(origin, didReceiveRedirectResponse, ContentSecurityPolicySourceListDirective::ShouldAllowEmptyURLIfSourceListIsNotNone::No))
             return false;
     }

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -488,7 +488,7 @@ static inline NodeQualifier ancestorRespondingToClickEventsNodeQualifier(Securit
             *nodeBounds = IntRect();
 
         auto node = hitTestResult.innerNode();
-        if (!node || (securityOrigin && !securityOrigin->isSameOriginAs(protect(node->document())->protectedSecurityOrigin())))
+        if (!node || (securityOrigin && !securityOrigin->isSameOriginAs(protect(protect(node->document())->securityOrigin()))))
             return nullptr;
 
         for (; node && node != terminationNode; node = node->parentInComposedTree()) {

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -677,7 +677,7 @@ static inline bool shouldIncludeNodeIdentifier(NodeIdentifierInclusion inclusion
 
 static bool areSameOrigin(Document& document, Document& other)
 {
-    return document.protectedSecurityOrigin()->isSameOriginAs(other.protectedSecurityOrigin());
+    return protect(document.securityOrigin())->isSameOriginAs(protect(other.securityOrigin()));
 }
 
 static inline void extractRecursive(Node& node, Item& parentItem, TraversalContext& context)
@@ -1654,7 +1654,7 @@ static void focusAndInsertText(NodeIdentifier identifier, String&& text, bool re
 
         UserTypingGestureIndicator indicator { *frame };
 
-        document->protectedEditor()->pasteAsPlainText(text, false);
+        protect(document->editor())->pasteAsPlainText(text, false);
         completion(true, "Inserted text by simulating paste with plain text"_s);
     });
 }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -267,7 +267,7 @@ bool HitTestResult::allowsFollowingLink() const
     if (!document)
         return false;
 
-    return document->protectedSecurityOrigin()->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton());
+    return protect(document->securityOrigin())->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton());
 }
 
 bool HitTestResult::allowsFollowingImageURL() const
@@ -284,7 +284,7 @@ bool HitTestResult::allowsFollowingImageURL() const
     if (!document)
         return false;
 
-    return document->protectedSecurityOrigin()->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton());
+    return protect(document->securityOrigin())->canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton());
 }
 
 String HitTestResult::selectedText() const

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3758,7 +3758,7 @@ PositionWithAffinity RenderBlockFlow::positionForPointWithInlineChildren(const L
         }
     }
 
-    bool moveCaretToBoundary = protectedFrame()->protectedEditor()->behavior().shouldMoveCaretToHorizontalBoundaryWhenPastTopOrBottom();
+    bool moveCaretToBoundary = protect(protectedFrame()->editor())->behavior().shouldMoveCaretToHorizontalBoundaryWhenPastTopOrBottom();
 
     if (!moveCaretToBoundary && !closestBox && lastLineBoxWithChildren) {
         // y coordinate is below last root line box, pretend we hit it

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1735,7 +1735,7 @@ void RenderElement::notifyFinished(CachedResource& resource, const NetworkLoadMe
     if (auto* cachedImage = dynamicDowncast<CachedImage>(resource))
         imageContentChanged(*cachedImage);
 
-    document().protectedCachedResourceLoader()->notifyFinished(resource);
+    protect(document().cachedResourceLoader())->notifyFinished(resource);
 }
 
 bool RenderElement::allowsAnimation() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -190,7 +190,7 @@ bool RenderLayerScrollableArea::isUserScrollInProgress() const
     if (!scrollsOverflow())
         return false;
 
-    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
+    if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator()) {
         if (scrollingCoordinator->isUserScrollInProgress(scrollingNodeID()))
             return true;
     }
@@ -207,7 +207,7 @@ bool RenderLayerScrollableArea::isRubberBandInProgress() const
     if (!scrollsOverflow())
         return false;
 
-    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
+    if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator()) {
         if (scrollingCoordinator->isRubberBandInProgress(scrollingNodeID()))
             return true;
     }
@@ -271,7 +271,7 @@ bool RenderLayerScrollableArea::requestScrollToPosition(const ScrollPosition& po
 #if ENABLE(ASYNC_SCROLLING)
     LOG_WITH_STREAM(Scrolling, stream << "RenderLayerScrollableArea::requestScrollToPosition " << position << " options  " << options);
 
-    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator())
         return scrollingCoordinator->requestScrollToPosition(*this, position, options);
 #else
     UNUSED_PARAM(position);
@@ -282,7 +282,7 @@ bool RenderLayerScrollableArea::requestScrollToPosition(const ScrollPosition& po
 
 bool RenderLayerScrollableArea::requestStartKeyboardScrollAnimation(const KeyboardScroll& scrollData)
 {
-    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator())
         return scrollingCoordinator->requestStartKeyboardScrollAnimation(*this, scrollData);
 
     return false;
@@ -290,7 +290,7 @@ bool RenderLayerScrollableArea::requestStartKeyboardScrollAnimation(const Keyboa
 
 bool RenderLayerScrollableArea::requestStopKeyboardScrollAnimation(bool immediate)
 {
-    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator())
         return scrollingCoordinator->requestStopKeyboardScrollAnimation(*this, immediate);
 
     return false;
@@ -301,7 +301,7 @@ void RenderLayerScrollableArea::stopAsyncAnimatedScroll()
 #if ENABLE(ASYNC_SCROLLING)
     LOG_WITH_STREAM(Scrolling, stream << m_layer << " stopAsyncAnimatedScroll");
 
-    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator())
         return scrollingCoordinator->stopAnimatedScroll(*this);
 #endif
 }
@@ -440,7 +440,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
         view.frameView().didChangeScrollOffset();
 
     view.frameView().viewportContentsChanged();
-    frame->protectedEditor()->renderLayerDidScroll(m_layer);
+    protect(frame->editor())->renderLayerDidScroll(m_layer);
 }
 
 void RenderLayerScrollableArea::scrollDidEnd()
@@ -550,7 +550,7 @@ bool RenderLayerScrollableArea::handleWheelEventForScrolling(const PlatformWheel
 
 #if ENABLE(ASYNC_SCROLLING)
     if (usesAsyncScrolling() && scrollingNodeID()) {
-        if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
+        if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator()) {
             auto result = scrollingCoordinator->handleWheelEventForScrolling(wheelEvent, *scrollingNodeID(), gestureState);
             if (!result.needsMainThreadProcessing())
                 return result.wasHandled;
@@ -865,7 +865,7 @@ bool RenderLayerScrollableArea::canShowNonOverlayScrollbars() const
 
 void RenderLayerScrollableArea::createScrollbarsController()
 {
-    m_layer.page().chrome().client().ensureScrollbarsController(m_layer.protectedPage(), *this);
+    m_layer.page().chrome().client().ensureScrollbarsController(protect(m_layer.page()), *this);
 }
 
 static inline RenderElement* rendererForScrollbar(RenderLayerModelObject& renderer)
@@ -1679,7 +1679,7 @@ void RenderLayerScrollableArea::updateSnapOffsets()
         clearSnapOffsets();
         return;
     }
-    updateSnapOffsetsForScrollableArea(*this, *box, box->style(), box->paddingBoxRect(), box->style().writingMode(), m_layer.renderer().document().protectedFocusedElement().get());
+    updateSnapOffsetsForScrollableArea(*this, *box, box->style(), box->paddingBoxRect(), box->style().writingMode(), protect(m_layer.renderer().document().focusedElement()).get());
 }
 
 bool RenderLayerScrollableArea::isScrollSnapInProgress() const
@@ -1687,7 +1687,7 @@ bool RenderLayerScrollableArea::isScrollSnapInProgress() const
     if (!scrollsOverflow())
         return false;
 
-    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
+    if (RefPtr scrollingCoordinator = protect(m_layer.page())->scrollingCoordinator()) {
         if (scrollingCoordinator->isScrollSnapInProgress(scrollingNodeID()))
             return true;
     }
@@ -2052,7 +2052,7 @@ String RenderLayerScrollableArea::debugDescription() const
 
 void RenderLayerScrollableArea::didStartScrollAnimation()
 {
-    m_layer.protectedPage()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
+    protect(m_layer.page())->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
 }
 
 void RenderLayerScrollableArea::animatedScrollDidEnd()

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -258,7 +258,7 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
 
     if (paintInfo.requireSecurityOriginAccessForWidgets) {
         if (RefPtr contentDocument = frameOwnerElement().contentDocument()) {
-            if (!document().protectedSecurityOrigin()->isSameOriginDomain(contentDocument->securityOrigin()))
+            if (!protect(document().securityOrigin())->isSameOriginDomain(contentDocument->securityOrigin()))
                 return;
         }
     }

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -310,7 +310,7 @@ void RenderThemeCocoa::paintFileUploadIconDecorations(const RenderElement&, cons
 
 Seconds RenderThemeCocoa::animationRepeatIntervalForProgressBar(const RenderProgress& renderer) const
 {
-    return renderer.protectedPage()->preferredRenderingUpdateInterval();
+    return protect(renderer.page())->preferredRenderingUpdateInterval();
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -137,7 +137,7 @@ RefPtr<Image> StyleFilterImage::image(const RenderElement* renderElement, const 
     if (!image || image->isNull())
         return &Image::nullImage();
 
-    auto preferredFilterRenderingModes = renderer->protectedPage()->preferredFilterRenderingModes(destinationContext);
+    auto preferredFilterRenderingModes = protect(renderer->page())->preferredFilterRenderingModes(destinationContext);
     auto sourceImageRect = FloatRect { { }, size };
 
     auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, {

--- a/Source/WebCore/storage/Storage.cpp
+++ b/Source/WebCore/storage/Storage.cpp
@@ -150,7 +150,7 @@ Ref<StorageArea> Storage::protectedArea() const
 
 bool Storage::requiresScriptTrackingPrivacyProtection() const
 {
-    RefPtr document = window() ? protectedWindow()->document() : nullptr;
+    RefPtr document = window() ? protect(window())->document() : nullptr;
     return document && document->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::LocalStorage);
 }
 

--- a/Source/WebCore/storage/StorageNamespaceProvider.cpp
+++ b/Source/WebCore/storage/StorageNamespaceProvider.cpp
@@ -54,11 +54,11 @@ Ref<StorageArea> StorageNamespaceProvider::localStorageArea(Document& document)
 
     RefPtr<StorageNamespace> storageNamespace;
     if (document.canAccessResource(ScriptExecutionContext::ResourceType::LocalStorage) == ScriptExecutionContext::HasResourceAccess::DefaultForThirdParty)
-        storageNamespace = transientLocalStorageNamespace(document.protectedTopOrigin().get(), document.protectedPage()->sessionID());
+        storageNamespace = transientLocalStorageNamespace(protect(document.topOrigin()).get(), protect(document.page())->sessionID());
     else
-        storageNamespace = localStorageNamespace(document.protectedPage()->sessionID());
+        storageNamespace = localStorageNamespace(protect(document.page())->sessionID());
 
-    return storageNamespace->storageArea(document.protectedSecurityOrigin().get());
+    return storageNamespace->storageArea(protect(document.securityOrigin()).get());
 }
 
 Ref<StorageArea> StorageNamespaceProvider::sessionStorageArea(Document& document)
@@ -67,7 +67,7 @@ Ref<StorageArea> StorageNamespaceProvider::sessionStorageArea(Document& document
     // so the Document had better still actually have a Page.
     ASSERT(document.page());
 
-    return sessionStorageNamespace(document.protectedTopOrigin().get(), *document.protectedPage())->storageArea(document.protectedSecurityOrigin().get());
+    return sessionStorageNamespace(protect(document.topOrigin()).get(), *protect(document.page()))->storageArea(protect(document.securityOrigin()).get());
 }
 
 StorageNamespace& StorageNamespaceProvider::localStorageNamespace(PAL::SessionID sessionID)

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -90,7 +90,7 @@ void SVGFEImageElement::requestImageResource()
 
     CachedResourceRequest request(ResourceRequest(document().completeURL(href())), options);
     request.setInitiator(*this);
-    m_cachedImage = document().protectedCachedResourceLoader()->requestImage(WTF::move(request)).value_or(nullptr);
+    m_cachedImage = protect(document().cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
 
     if (CachedResourceHandle cachedImage = m_cachedImage)
         cachedImage->addClient(*this);

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -685,7 +685,7 @@ void SVGUseElement::updateExternalDocument()
         options.sniffContent = ContentSniffingPolicy::DoNotSniffContent;
         CachedResourceRequest request { ResourceRequest { WTF::move(externalDocumentURL) }, options };
         request.setInitiator(*this);
-        m_externalDocument = document->protectedCachedResourceLoader()->requestSVGDocument(WTF::move(request)).value_or(nullptr);
+        m_externalDocument = protect(document->cachedResourceLoader())->requestSVGDocument(WTF::move(request)).value_or(nullptr);
         if (CachedResourceHandle externalDocument = m_externalDocument)
             externalDocument->addClient(*this);
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3385,7 +3385,7 @@ ExceptionOr<void> Internals::setInspectorIsUnderTest(bool isUnderTest)
     if (!document || !document->page())
         return Exception { ExceptionCode::InvalidAccessError };
 
-    document->protectedPage()->inspectorController().setIsUnderTest(isUnderTest);
+    protect(document->page())->inspectorController().setIsUnderTest(isUnderTest);
     return { };
 }
 
@@ -4123,7 +4123,7 @@ ExceptionOr<void> Internals::setFullscreenAutoHideDuration(double duration)
     RefPtr document = contextDocument();
     if (!document || !document->page())
         return Exception { ExceptionCode::InvalidStateError };
-    document->protectedPage()->setFullscreenAutoHideDuration(Seconds(duration));
+    protect(document->page())->setFullscreenAutoHideDuration(Seconds(duration));
     return { };
 }
 
@@ -5542,7 +5542,7 @@ RefPtr<HTMLMediaElement> Internals::bestMediaElementForRemoteControls(Internals:
     if (!document || !document->page())
         return nullptr;
 
-    return document->protectedPage()->bestMediaElementForRemoteControls(purpose, document.get());
+    return protect(document->page())->bestMediaElementForRemoteControls(purpose, document.get());
 }
 
 Internals::MediaSessionState Internals::mediaSessionState(HTMLMediaElement& element)
@@ -8226,7 +8226,7 @@ void Internals::setTopDocumentURLForQuirks(const String& urlString)
     if (!document || !document->page())
         return;
 
-    document->protectedPage()->settings().setNeedsSiteSpecificQuirks(true);
+    protect(document->page())->settings().setNeedsSiteSpecificQuirks(true);
     document->quirks().setTopDocumentURLForTesting(URL { urlString });
 }
 
@@ -8397,7 +8397,7 @@ ExceptionOr<void> Internals::copyImageAtLocation(int x, int y)
         return Exception { ExceptionCode::InvalidAccessError };
 
     auto hitTestResult = localFrame->eventHandler().hitTestResultAtPoint(IntPoint(x, y), hitType);
-    localFrame->protectedEditor()->copyImage(hitTestResult);
+    protect(localFrame->editor())->copyImage(hitTestResult);
 #endif
     UNUSED_PARAM(x);
     UNUSED_PARAM(y);

--- a/Source/WebCore/testing/Internals.mm
+++ b/Source/WebCore/testing/Internals.mm
@@ -199,7 +199,7 @@ void Internals::setUsesOverlayScrollbars(bool enabled)
     if (!localFrame)
         return;
 
-    localFrame->protectedView()->scrollbarStyleDidChange();
+    protect(localFrame->view())->scrollbarStyleDidChange();
 }
 
 #endif

--- a/Source/WebCore/workers/AbstractWorker.cpp
+++ b/Source/WebCore/workers/AbstractWorker.cpp
@@ -72,7 +72,7 @@ ExceptionOr<URL> AbstractWorker::resolveURL(const String& url)
 std::optional<Exception> AbstractWorker::validateURL(ScriptExecutionContext& context, const URL& scriptURL)
 {
     // Per the specification, any same-origin URL (including blob: URLs) can be used. data: URLs can also be used, but they create a worker with an opaque origin.
-    if (!context.protectedSecurityOrigin()->canRequest(scriptURL, OriginAccessPatternsForWebProcess::singleton()) && !scriptURL.protocolIsData())
+    if (!protect(context.securityOrigin())->canRequest(scriptURL, OriginAccessPatternsForWebProcess::singleton()) && !scriptURL.protocolIsData())
         return Exception { ExceptionCode::SecurityError };
 
     ASSERT(context.contentSecurityPolicy());

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -164,7 +164,7 @@ void WorkerMessagingProxy::startWorkerGlobalScope(const URL& scriptURL, PAL::Ses
         scriptExecutionContext->advancedPrivacyProtections(),
         scriptExecutionContext->noiseInjectionHashSalt()
     };
-    auto thread = DedicatedWorkerThread::create(params, sourceCode, *this, *this, *this, *this, startMode, scriptExecutionContext->protectedTopOrigin(), proxy.get(), socketProvider.get(), runtimeFlags);
+    auto thread = DedicatedWorkerThread::create(params, sourceCode, *this, *this, *this, *this, startMode, protect(scriptExecutionContext->topOrigin()), proxy.get(), socketProvider.get(), runtimeFlags);
 
     if (parentWorkerGlobalScope) {
         parentWorkerGlobalScope->thread()->addChildThread(thread);

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -92,7 +92,7 @@ ExceptionOr<void> ServiceWorkerClient::postMessage(JSC::JSGlobalObject& globalOb
     MessageWithMessagePorts message = { messageData.releaseReturnValue(), portsOrException.releaseReturnValue() };
     Ref context = downcast<ServiceWorkerGlobalScope>(*scriptExecutionContext());
     auto sourceIdentifier = context->thread()->identifier();
-    callOnMainThread([message = WTF::move(message), destinationIdentifier = identifier(), sourceIdentifier, sourceOrigin = context->protectedSecurityOrigin()->data().isolatedCopy()] {
+    callOnMainThread([message = WTF::move(message), destinationIdentifier = identifier(), sourceIdentifier, sourceOrigin = protect(context->securityOrigin())->data().isolatedCopy()] {
         if (RefPtr connection = SWContextManager::singleton().connection())
             connection->postMessageToServiceWorkerClient(destinationIdentifier, message, sourceIdentifier, sourceOrigin);
     });

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -79,7 +79,7 @@ ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(Ref<Page>&& page, ServiceWork
 #if ENABLE(REMOTE_INSPECTOR)
     , m_remoteDebuggable(ServiceWorkerDebuggable::create(*this, contextData))
 #endif
-    , m_serviceWorkerThread(ServiceWorkerThread::create(WTF::move(contextData), WTF::move(workerData), WTF::move(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, *this, protectedIDBConnectionProxy(m_document).get(), m_document->protectedSocketProvider().get(), WTF::move(notificationClient), m_page->sessionID(), m_document->noiseInjectionHashSalt(), m_document->advancedPrivacyProtections()))
+    , m_serviceWorkerThread(ServiceWorkerThread::create(WTF::move(contextData), WTF::move(workerData), WTF::move(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, *this, protectedIDBConnectionProxy(m_document).get(), protect(m_document->socketProvider()).get(), WTF::move(notificationClient), m_page->sessionID(), m_document->noiseInjectionHashSalt(), m_document->advancedPrivacyProtections()))
     , m_cacheStorageProvider(cacheStorageProvider)
     , m_inspectorProxy(*this)
 {

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -79,7 +79,7 @@ static inline SharedWorkerObjectConnection* mainThreadConnection()
 
 ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<RefPtr<TrustedScriptURL>, String>&& scriptURLString, std::optional<Variant<String, WorkerOptions>>&& maybeOptions)
 {
-    auto compliantScriptURLString = trustedTypeCompliantString(document.protectedContextDocument(), WTF::move(scriptURLString), "SharedWorker constructor"_s);
+    auto compliantScriptURLString = trustedTypeCompliantString(protect(document.contextDocument()), WTF::move(scriptURLString), "SharedWorker constructor"_s);
     if (compliantScriptURLString.hasException())
         return compliantScriptURLString.releaseException();
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -104,7 +104,7 @@ SharedWorkerThreadProxy::SharedWorkerThreadProxy(Ref<Page>&& page, SharedWorkerI
     : m_page(WTF::move(page))
     , m_document(*m_page->localTopDocument())
     , m_contextIdentifier(*initializationData.clientIdentifier)
-    , m_workerThread(SharedWorkerThread::create(sharedWorkerIdentifier, generateWorkerParameters(workerFetchResult, WTF::move(workerOptions), WTF::move(initializationData), m_document), WTF::move(workerFetchResult.script), *this, *this, *this, *this, WorkerThreadStartMode::Normal, clientOrigin.topOrigin.securityOrigin(), m_document->protectedIDBConnectionProxy().get(), m_document->protectedSocketProvider().get(), JSC::RuntimeFlags::createAllEnabled()))
+    , m_workerThread(SharedWorkerThread::create(sharedWorkerIdentifier, generateWorkerParameters(workerFetchResult, WTF::move(workerOptions), WTF::move(initializationData), m_document), WTF::move(workerFetchResult.script), *this, *this, *this, *this, WorkerThreadStartMode::Normal, clientOrigin.topOrigin.securityOrigin(), protect(m_document->idbConnectionProxy()).get(), protect(m_document->socketProvider()).get(), JSC::RuntimeFlags::createAllEnabled()))
     , m_cacheStorageProvider(cacheStorageProvider)
     , m_clientOrigin(clientOrigin)
 {

--- a/Source/WebCore/xml/DOMParser.cpp
+++ b/Source/WebCore/xml/DOMParser.cpp
@@ -46,7 +46,7 @@ Ref<DOMParser> DOMParser::create(Document& contextDocument)
 
 ExceptionOr<Ref<Document>> DOMParser::parseFromString(Variant<RefPtr<TrustedHTML>, String>&& string, const AtomString& contentType)
 {
-    auto stringValueHolder = trustedTypeCompliantString(protectedContextDocument()->protectedContextDocument(), WTF::move(string), "DOMParser parseFromString"_s);
+    auto stringValueHolder = trustedTypeCompliantString(protect(protectedContextDocument()->contextDocument()), WTF::move(string), "DOMParser parseFromString"_s);
 
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -487,7 +487,7 @@ static bool shouldAllowExternalLoad(const URL& url)
     RefPtr currentCachedResourceLoader = XMLDocumentParserScope::currentCachedResourceLoader().get();
     if (!currentCachedResourceLoader || !currentCachedResourceLoader->document())
         return false;
-    if (!protect(currentCachedResourceLoader->document())->protectedSecurityOrigin()->canRequest(url, OriginAccessPatternsForWebProcess::singleton())) {
+    if (!protect(protect(currentCachedResourceLoader->document())->securityOrigin())->canRequest(url, OriginAccessPatternsForWebProcess::singleton())) {
         currentCachedResourceLoader->printAccessDeniedMessage(url);
         return false;
     }
@@ -506,7 +506,7 @@ static void* openFunc(const char* uri)
 
     RefPtr document = cachedResourceLoader->document();
     // Same logic as Document::completeURL(). Keep them in sync.
-    auto* encoding = (document && document->decoder()) ? document->protectedDecoder()->encodingForURLParsing() : nullptr;
+    auto* encoding = (document && document->decoder()) ? protect(document->decoder())->encodingForURLParsing() : nullptr;
     URL url(document ? document->fallbackBaseURL() : URL(), String::fromLatin1(uri), encoding);
 
     if (!shouldAllowExternalLoad(url))
@@ -1399,7 +1399,7 @@ void XMLDocumentParser::doEnd()
         XMLTreeViewer xmlTreeViewer(*document);
         xmlTreeViewer.transformDocumentToTreeView();
     } else if (m_sawXSLTransform) {
-        xmlDocPtr doc = xmlDocPtrForString(document->protectedCachedResourceLoader(), m_originalSourceForTransform.toString(), document->url().string());
+        xmlDocPtr doc = xmlDocPtrForString(protect(document->cachedResourceLoader()), m_originalSourceForTransform.toString(), document->url().string());
         document->setTransformSource(makeUnique<TransformSource>(doc));
 
         document->setParsing(false); // Make the document think it's done, so it will apply XSL stylesheets.

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -413,7 +413,7 @@ void WebFullScreenManager::willEnterFullScreen(Element& element, CompletionHandl
 
     m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::Yes);
 
-    auto result = protect(element.document())->protectedFullscreen()->willEnterFullscreen(element, mode);
+    auto result = protect(protect(element.document())->fullscreen())->willEnterFullscreen(element, mode);
     if (result.hasException())
         close();
     willEnterFullscreenCallback(result);
@@ -504,7 +504,7 @@ void WebFullScreenManager::willExitFullScreen(CompletionHandler<void()>&& comple
 #endif
 
     m_finalFrame = screenRectOfContents(*element);
-    if (!protect(element->document())->protectedFullscreen()->willExitFullscreen()) {
+    if (!protect(protect(element->document())->fullscreen())->willExitFullscreen()) {
         close();
         return completionHandler();
     }
@@ -525,7 +525,7 @@ static Vector<Ref<Element>> collectFullscreenElementsFromElement(Element* rawEle
 
     RefPtr document = rawElement->document();
 
-    if (rawElement != document->protectedFullscreen()->fullscreenElement())
+    if (rawElement != protect(document->fullscreen())->fullscreenElement())
         return { };
 
     RefPtr element = rawElement;
@@ -539,7 +539,7 @@ static Vector<Ref<Element>> collectFullscreenElementsFromElement(Element* rawEle
         if (!document)
             break;
 
-        element = document->protectedFullscreen()->fullscreenElement();
+        element = protect(document->fullscreen())->fullscreenElement();
         if (!element)
             break;
     }
@@ -591,7 +591,7 @@ void WebFullScreenManager::setAnimatingFullScreen(bool animating)
 {
     if (!m_element)
         return;
-    protect(m_element->document())->protectedFullscreen()->setAnimatingFullscreen(animating);
+    protect(protect(m_element->document())->fullscreen())->setAnimatingFullscreen(animating);
 }
 
 void WebFullScreenManager::requestRestoreFullScreen(CompletionHandler<void(bool)>&& completionHandler)
@@ -608,7 +608,7 @@ void WebFullScreenManager::requestRestoreFullScreen(CompletionHandler<void(bool)
 
     ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
     WebCore::UserGestureIndicator gestureIndicator(WebCore::IsProcessingUserGesture::Yes, &element->document());
-    protect(element->document())->protectedFullscreen()->requestFullscreen(*element, WebCore::DocumentFullscreen::ExemptIFrameAllowFullscreenRequirement, [completionHandler = WTF::move(completionHandler)] (auto result) mutable {
+    protect(protect(element->document())->fullscreen())->requestFullscreen(*element, WebCore::DocumentFullscreen::ExemptIFrameAllowFullscreenRequirement, [completionHandler = WTF::move(completionHandler)] (auto result) mutable {
         completionHandler(!result.hasException());
     });
 }
@@ -623,14 +623,14 @@ void WebFullScreenManager::requestExitFullScreen()
 
     RefPtr localMainFrame = m_page->localMainFrame();
     RefPtr topDocument = localMainFrame ? localMainFrame->document() : nullptr;
-    if (!topDocument || !topDocument->protectedFullscreen()->fullscreenElement()) {
+    if (!topDocument || !protect(topDocument->fullscreen())->fullscreenElement()) {
         ALWAYS_LOG(LOGIDENTIFIER, "top document not in fullscreen, closing");
         close();
         return;
     }
 
     ALWAYS_LOG(LOGIDENTIFIER);
-    protect(m_element->document())->protectedFullscreen()->fullyExitFullscreen();
+    protect(protect(m_element->document())->fullscreen())->fullyExitFullscreen();
 }
 
 void WebFullScreenManager::close()
@@ -662,7 +662,7 @@ void WebFullScreenManager::handleEvent(WebCore::ScriptExecutionContext& context,
         return;
 
     Ref document = m_element->document();
-    if (&context != document.ptr() || !document->protectedFullscreen()->isFullscreen())
+    if (&context != document.ptr() || !protect(document->fullscreen())->isFullscreen())
         return;
 
     if (targetElement == m_element) {
@@ -690,7 +690,7 @@ void WebFullScreenManager::handleEvent(WebCore::ScriptExecutionContext& context,
 #if ENABLE(IMAGE_ANALYSIS)
 void WebFullScreenManager::mainVideoElementTextRecognitionTimerFired()
 {
-    if (!m_element || !protect(m_element->document())->protectedFullscreen()->isFullscreen())
+    if (!m_element || !protect(protect(m_element->document())->fullscreen())->isFullscreen())
         return;
 
     updateMainVideoElement();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -279,7 +279,7 @@ WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
     if (!coreFrame)
         return 0;
 
-    return WebKit::toCopiedAPI(coreFrame->protectedDocument()->protectedSecurityOrigin().ptr());
+    return WebKit::toCopiedAPI(protect(protect(coreFrame->document())->securityOrigin()).ptr());
 }
 
 void WKBundleFrameFocus(WKBundleFrameRef frameRef)
@@ -301,7 +301,7 @@ void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef mes
         return;
 
     if (RefPtr document = coreFrame->document())
-        document->protectedReportingScope()->generateTestReport(WebKit::toWTFString(message), WebKit::toWTFString(group));
+        protect(document->reportingScope())->generateTestReport(WebKit::toWTFString(message), WebKit::toWTFString(group));
 }
 
 void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
@@ -74,7 +74,7 @@ static Ref<WebCore::Document> protectedImpl(WKDOMDocument *document)
 
 - (WKDOMElement *)body
 {
-    return WebKit::toWKDOMElement(protectedImpl(self)->protectedBodyOrFrameset().get());
+    return WebKit::toWKDOMElement(protect(protectedImpl(self)->bodyOrFrameset()).get());
 }
 
 - (WKDOMNode *)createDocumentFragmentWithMarkupString:(NSString *)markupString baseURL:(NSURL *)baseURL

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -361,7 +361,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
 {
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = frame.document())
-        document->protectedFullscreen()->fullyExitFullscreen();
+        protect(document->fullscreen())->fullyExitFullscreen();
 #endif
 
     auto& webProcess = WebProcess::singleton();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -568,12 +568,12 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 
 #if ENABLE(FULLSCREEN_API)
     RefPtr document = m_localFrame->document();
-    if (document && document->protectedFullscreen()->fullscreenElement()) {
+    if (document && protect(document->fullscreen())->fullscreenElement()) {
         Ref fullScreenManager = webPage->fullScreenManager();
         RefPtr element = fullScreenManager->element();
         fullScreenManager->exitFullScreenForElement(element.get(), [element] {
             if (element)
-                protect(element->document())->protectedFullscreen()->didExitFullscreen([](auto) { });
+                protect(protect(element->document())->fullscreen())->didExitFullscreen([](auto) { });
         });
     }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -862,7 +862,7 @@ unsigned WebFrame::pendingUnloadCount() const
     if (!localFrame)
         return 0;
 
-    return localFrame->protectedDocument()->protectedWindow()->pendingUnloadEventListeners();
+    return protect(protect(localFrame->document())->window())->pendingUnloadEventListeners();
 }
 
 bool WebFrame::allowsFollowingLink(const URL& url) const

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5380,7 +5380,7 @@ void WebPage::notifyReportObservers(FrameIdentifier frameID, Ref<WebCore::Report
     if (!coreFrame)
         return;
     if (RefPtr document = coreFrame->document())
-        document->protectedReportingScope()->notifyReportObservers(WTF::move(report));
+        protect(document->reportingScope())->notifyReportObservers(WTF::move(report));
 }
 
 void WebPage::sendReportToEndpoints(FrameIdentifier frameID, URL&& baseURL, const Vector<String>& endpointURIs, const Vector<String>& endpointTokens, IPC::FormDataReference&& reportData, WebCore::ViolationReportType reportType)
@@ -5683,7 +5683,7 @@ void WebPage::closeCurrentTypingCommand()
         return;
 
     if (RefPtr document = frame->document())
-        document->protectedEditor()->closeTyping();
+        protect(document->editor())->closeTyping();
 }
 
 void WebPage::setActivePopupMenu(WebPopupMenu* menu)
@@ -9339,7 +9339,7 @@ void WebPage::createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighli
     if (!selectionRange)
         return;
 
-    document->protectedAppHighlightRegistry()->addAnnotationHighlightWithRange(StaticRange::create(selectionRange.value()));
+    protect(document->appHighlightRegistry())->addAnnotationHighlightWithRange(StaticRange::create(selectionRange.value()));
     document->appHighlightStorage().storeAppHighlight(StaticRange::create(selectionRange.value()), [completionHandler = WTF::move(completionHandler), protectedThis = Ref { *this }, this] (WebCore::AppHighlight&& highlight) mutable {
         highlight.isNewGroup = m_internals->highlightIsNewGroup;
         highlight.requestOriginatedInApp = m_internals->highlightRequestOriginatedInApp;
@@ -9373,7 +9373,7 @@ void WebPage::setAppHighlightsVisibility(WebCore::HighlightVisibility appHighlig
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->protectedAppHighlightRegistry()->setHighlightVisibility(appHighlightVisibility);
+            protect(document->appHighlightRegistry())->setHighlightVisibility(appHighlightVisibility);
     }
 }
 
@@ -9533,7 +9533,7 @@ bool WebPage::handlesPageScaleGesture()
 void WebPage::generateTestReport(String&& message, String&& group)
 {
     if (RefPtr localTopDocument = this->localTopDocument())
-        localTopDocument->protectedReportingScope()->generateTestReport(WTF::move(message), WTF::move(group));
+        protect(localTopDocument->reportingScope())->generateTestReport(WTF::move(message), WTF::move(group));
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -80,7 +80,7 @@ static FloatRect inlineVideoFrame(HTMLVideoElement& element)
     if (renderer->hasLayer() && renderer->checkedEnclosingLayer()->isComposited()) {
         FloatQuad contentsBox = static_cast<FloatRect>(renderer->enclosingLayer()->backing()->contentsBox());
         contentsBox = renderer->localToAbsoluteQuad(contentsBox);
-        return document->protectedView()->contentsToRootView(contentsBox.boundingBox());
+        return protect(document->view())->contentsToRootView(contentsBox.boundingBox());
     }
 
     return renderer->videoBoxInRootView();
@@ -288,7 +288,7 @@ bool VideoPresentationManager::canEnterVideoFullscreen(HTMLVideoElement& videoEl
     ASSERT(mode != HTMLMediaElementEnums::VideoFullscreenModeNone);
 
 #if ENABLE(FULLSCREEN_API)
-    if (protect(videoElement.document())->protectedFullscreen()->isAnimatingFullscreen())
+    if (protect(protect(videoElement.document())->fullscreen())->isAnimatingFullscreen())
         return false;
 #endif
 


### PR DESCRIPTION
#### 3335f461801245c9ee68daaa79839bae66213e64
<pre>
Drop remaining `protected*()` member function on Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=306748">https://bugs.webkit.org/show_bug.cgi?id=306748</a>

Reviewed by Ryosuke Niwa.

Call `protect()` at call sites instead.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::isOriginClean):
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::ApplePaySession::create):
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::sendBeacon):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::start):
(WebCore::MediaKeySystemRequest::stop):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::computeReferrer):
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::protectedPage const):
* Source/WebCore/Modules/highlight/AppHighlightStorage.cpp:
(WebCore::AppHighlightStorage::attemptToRestoreHighlightAndScroll):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequest):
* Source/WebCore/Modules/mediasession/MediaMetadata.cpp:
(WebCore::ArtworkImageLoader::requestImageResource):
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::mediaSessionGroupIdentifier const):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::stop):
(WebCore::MediaDevices::enumerateDevices):
(WebCore::MediaDevices::listenForDeviceChanges):
* Source/WebCore/Modules/mediastream/RTCController.cpp:
(WebCore::matchDocumentOrigin):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::start):
(WebCore::UserMediaRequest::stop):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::reloadModelPlayer):
(WebCore::HTMLModelElement::environmentMapRequestResource):
(WebCore::HTMLModelElement::insertedIntoAncestor):
(WebCore::HTMLModelElement::sourceRequestResource):
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::data const):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::mediaSessionGroupIdentifier const):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::wouldTaintOrigin const):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinatorInternal::scopeAndCrossOriginParent):
(WebCore::AuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable const):
(WebCore::AuthenticatorCoordinator::isConditionalMediationAvailable const):
(WebCore::AuthenticatorCoordinator::getClientCapabilities const):
* Source/WebCore/Modules/webdatabase/DatabaseContext.cpp:
(WebCore::DatabaseContext::allowDatabaseAccess const):
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::webSocketConnectRequest):
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::immersiveSessionRequestIsAllowedForGlobalObject const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformAnnouncementNotification):
(WebCore::AXObjectCache::postPlatformARIANotifyNotification):
(WebCore::AXObjectCache::postPlatformLiveRegionNotification):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::liveCurrentTime const):
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestScriptWithCache const):
* Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp:
(WebCore::canAccessDocument):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::deriveShadowRealmGlobalObject):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::jsWindowProxy):
(WebCore::ScriptController::setEvalEnabled):
(WebCore::ScriptController::setWebAssemblyEnabled):
(WebCore::ScriptController::setTrustedTypesEnforcement):
(WebCore::ScriptController::canAccessFromCurrentOrigin):
(WebCore::ScriptController::updateDocument):
(WebCore::ScriptController::collectIsolatedContexts):
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::replaceFrame):
(WebCore::WindowProxy::createJSWindowProxy):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::canAccessRules const):
* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::requestStyleSheet):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::deviceScaleFactor):
(WebCore::MQ::Features::heightFeatureSchema):
(WebCore::MQ::Features::monochromeFeatureSchema):
(WebCore::MQ::Features::widthFeatureSchema):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::partitionedSecurityOriginFromContext):
(WebCore::BroadcastChannel::MainThreadBridge::ensureOnMainThread):
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::enqueueElementOnAppropriateElementQueue):
* Source/WebCore/dom/DOMImplementation.cpp:
(WebCore::DOMImplementation::createHTMLDocument):
(WebCore::DOMImplementation::createDocument):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::readStringFromPasteboard const):
* Source/WebCore/dom/DecodedDataDocumentParser.cpp:
(WebCore::DecodedDataDocumentParser::appendBytes):
(WebCore::DecodedDataDocumentParser::flush):
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp:
(WebCore::DeviceOrientationAndMotionAccessController::accessState const):
* Source/WebCore/dom/Document.cpp:
(WebCore::printNavigationErrorMessage):
(WebCore::Document::~Document):
(WebCore::Document::updateLayout):
(WebCore::Document::willDetachPage):
(WebCore::Document::willBeRemovedFromFrame):
(WebCore::Document::removeAllEventListeners):
(WebCore::Document::openForBindings):
(WebCore::Document::open):
(WebCore::Document::fontLoadRequest):
(WebCore::Document::beginLoadingFontSoon):
(WebCore::Document::implicitClose):
(WebCore::Document::setParsing):
(WebCore::Document::supportsPaintTiming const):
(WebCore::Document::enqueuePaintTimingEntryIfNeeded):
(WebCore::Document::enqueueEventTimingEntriesIfNeeded):
(WebCore::Document::willLoadScriptElement):
(WebCore::Document::willLoadFrameElement):
(WebCore::Document::isNavigationBlockedByThirdPartyIFrameRedirectBlocking):
(WebCore::Document::cloneNodeInternal const):
(WebCore::Document::runScrollSteps):
(WebCore::Document::setFocusedElement):
(WebCore::Document::takeDOMWindowFrom):
(WebCore::Document::setWindowAttributeEventListener):
(WebCore::Document::dispatchWindowLoadEvent):
(WebCore::Document::cookie):
(WebCore::Document::sameOriginTopLevelTraversable const):
(WebCore::Document::initSecurityContext):
(WebCore::Document::initContentSecurityPolicy):
(WebCore::Document::fullscreen const):
(WebCore::Document::immersive const):
(WebCore::Document::didRemoveEventTargetNode):
(WebCore::Document::noiseInjectionHashSalt const):
(WebCore::Document::protectedTopOrigin const): Deleted.
(WebCore::Document::protectedFontLoader): Deleted.
(WebCore::Document::protectedEditor): Deleted.
(WebCore::Document::protectedEditor const): Deleted.
(WebCore::Document::protectedTextExtractionHighlightRegistry): Deleted.
(WebCore::Document::protectedAppHighlightRegistry): Deleted.
(WebCore::Document::protectedBodyOrFrameset const): Deleted.
(WebCore::Document::protectedHead): Deleted.
(WebCore::Document::protectedIDBConnectionProxy): Deleted.
(WebCore::Document::protectedSocketProvider): Deleted.
(WebCore::Document::protectedWindowProxy const): Deleted.
(WebCore::Document::protectedScriptRunner): Deleted.
(WebCore::Document::protectedWindowEventLoop): Deleted.
(WebCore::Document::protectedFullscreen): Deleted.
(WebCore::Document::protectedFullscreen const): Deleted.
(WebCore::Document::protectedImmersive): Deleted.
(WebCore::Document::protectedImmersive const): Deleted.
(WebCore::Document::protectedFrameMemoryMonitor): Deleted.
(WebCore::Document::protectedResourceMonitor): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::parser const):
(WebCore::Document::focusedElement const):
(WebCore::Document::window const):
(WebCore::Document::decoder const):
(WebCore::Document::securityOrigin const):
(WebCore::Document::protectedContextDocument const): Deleted.
(WebCore::Document::protectedParentDocument const): Deleted.
(WebCore::Document::protectedMainFrameDocument const): Deleted.
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::cachedFont):
(WebCore::DocumentFontLoader::beginLoadingFontSoon):
(WebCore::DocumentFontLoader::fontLoadingTimerFired):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::fullscreenEnabled):
(WebCore::DocumentFullscreen::requestFullscreen):
(WebCore::DocumentFullscreen::willEnterFullscreen):
(WebCore::DocumentFullscreen::elementEnterFullscreen):
(WebCore::documentsToUnfullscreen):
(WebCore::DocumentFullscreen::exitFullscreen):
(WebCore::DocumentFullscreen::webkitExitFullscreen):
(WebCore::DocumentFullscreen::finishExitFullscreen):
(WebCore::DocumentFullscreen::fullyExitFullscreen):
(WebCore::DocumentFullscreen::queueFullscreenChangeEventForDocument):
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::protectedParser const): Deleted.
(WebCore::Document::protectedUndoManager const): Deleted.
(WebCore::Document::protectedReportingScope const): Deleted.
(WebCore::Document::protectedDecoder const): Deleted.
(WebCore::Document::protectedFocusedElement const): Deleted.
* Source/WebCore/dom/DocumentPage.h:
(WebCore::Document::protectedPage const): Deleted.
* Source/WebCore/dom/DocumentResourceLoader.h:
(WebCore::Document::protectedCachedResourceLoader const): Deleted.
* Source/WebCore/dom/DocumentSecurityOrigin.h:
(WebCore::Document::isSameOriginAsTopDocument const):
(WebCore::Document::protectedSecurityOrigin const): Deleted.
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::hasSameOriginAsAllAncestors):
(WebCore::DocumentStorageAccess::hasStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::hasStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessQuickCheck):
(WebCore::DocumentStorageAccess::requestStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessForDocumentQuirk):
* Source/WebCore/dom/DocumentView.h:
(WebCore::Document::protectedView const): Deleted.
* Source/WebCore/dom/DocumentWindow.h:
(WebCore::Document::protectedWindow const): Deleted.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setScrollLeft):
(WebCore::Element::setScrollTop):
(WebCore::Element::blur):
* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::queueIdleCallback):
* Source/WebCore/dom/IdleDeadline.cpp:
(WebCore::IdleDeadline::timeRemaining const):
* Source/WebCore/dom/LoadableSpeculationRules.cpp:
(WebCore::LoadableSpeculationRules::requestSpeculationRules):
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::checkStyleSheet):
* Source/WebCore/dom/PseudoElement.cpp:
(WebCore::PseudoElement::create):
(WebCore::PseudoElement::clearHostElement):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::canIncludeErrorDetails):
(WebCore::ScriptExecutionContext::domainForCachePartition const):
(WebCore::ScriptExecutionContext::canAccessResource const):
(WebCore::ScriptExecutionContext::requiresScriptTrackingPrivacyProtection):
* Source/WebCore/dom/SerializedNode.cpp:
(WebCore::SerializedNode::deserialize):
* Source/WebCore/dom/SimulatedClick.cpp:
(WebCore::simulateMouseEvent):
(WebCore::simulatePointerEvent):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setFocusedElementIfNeeded):
* Source/WebCore/editing/SpellingCorrectionCommand.cpp:
* Source/WebCore/editing/TextListParser.cpp:
(WebCore::selectionAllowsSmartLists):
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::BlobURLRegistry::registerURL):
* Source/WebCore/fileapi/BlobURL.cpp:
(WebCore::blobOwner):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCachePage):
(WebCore::BackForwardCache::dump const):
(WebCore::BackForwardCache::markPagesForDeviceOrPageScaleChanged):
(WebCore::BackForwardCache::markPagesForContentsSizeChanged):
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::goBackOrForward):
(WebCore::BackForwardController::goBack):
(WebCore::BackForwardController::goForward):
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::restore):
(WebCore::CachedFrame::CachedFrame):
(WebCore::CachedFrame::destroy):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::setupDateTimeChooserParameters):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::elementRectRelativeToRootView const):
(WebCore::ColorInputType::rootFrameID const):
* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::createPublicURL):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::hidePopoverInternal):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::setSrcdoc):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::showPicker):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::process):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::isSafeToLoadURL const):
(WebCore::HTMLMediaElement::mediaLoadingFailed):
(WebCore::HTMLMediaElement::setReadyState):
(WebCore::HTMLMediaElement::mediaPlayerDidReportGPUMemoryFootprint):
(WebCore::HTMLMediaElement::dispatchEvent):
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::exitFullscreen):
(WebCore::HTMLMediaElement::prepareForVideoFullscreenStandby):
(WebCore::HTMLMediaElement::shouldDisableHDR const):
(WebCore::HTMLMediaElement::logTextTrackDiagnostics):
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::HTMLMetaElement::process):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::canLoadURL const):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::showPicker):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::subtreeHasChanged):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::setVideoFullscreenStandby):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::canShowControlsManager const):
* Source/WebCore/html/PluginDocument.cpp:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::handleKeydownEvent):
(WebCore::TextFieldInputType::handleFocusEvent):
(WebCore::TextFieldInputType::didSetValueByUserEdit):
(WebCore::TextFieldInputType::elementRectInRootViewCoordinates const):
* Source/WebCore/html/closewatcher/CloseWatcher.cpp:
(WebCore::CloseWatcher::create):
(WebCore::CloseWatcher::establish):
(WebCore::CloseWatcher::requestToClose):
(WebCore::CloseWatcher::destroy):
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::HTMLResourcePreloader::preload):
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::didMoveToNewDocument):
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::instrumentingAgents):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::InspectorIndexedDBAgent::requestDatabase):
(WebCore::InspectorIndexedDBAgent::requestData):
(WebCore::InspectorIndexedDBAgent::clearObjectStore):
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::startLoading):
* Source/WebCore/loader/CrossOriginAccessControl.cpp:
(WebCore::createPotentialAccessControlRequest):
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::startPreflight):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::shouldUseActiveServiceWorkerFromParent):
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::checkLoadComplete):
(WebCore::DocumentLoader::startLoadingMainResource):
(WebCore::DocumentLoader::navigationCanTriggerCrossDocumentViewTransition):
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::prefetch):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::makeSimpleCrossOriginAccessRequest):
(WebCore::DocumentThreadableLoader::redirectReceived):
(WebCore::DocumentThreadableLoader::preflightSuccess):
(WebCore::DocumentThreadableLoader::loadRequest):
(WebCore::DocumentThreadableLoader::isAllowedRedirect):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::canReferToParentFrameEncoding):
(WebCore::DocumentWriter::begin):
(WebCore::DocumentWriter::decoder):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::submitForm):
(WebCore::FrameLoader::closeURL):
(WebCore::shouldClearWindowName):
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::outgoingOrigin const):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::stopForUserCancel):
(WebCore::FrameLoader::setState):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::open):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::dispatchUnloadEvents):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::shouldTreatURLAsSameAsCurrent const):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::dispatchDidClearWindowObjectInWorld):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::invalidateCurrentItemCachedPage):
(WebCore::HistoryController::goToItemForNavigationAPI):
(WebCore::HistoryController::pushState):
(WebCore::HistoryController::replaceState):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::canReuseFromListOfAvailableImages):
(WebCore::ImageLoader::updateFromElement):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preconnectIfNeeded):
(WebCore::LinkLoader::preloadIfNeeded):
(WebCore::LinkLoader::prefetchIfNeeded):
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::requestResource):
* Source/WebCore/loader/NavigationAction.cpp:
(WebCore::shouldTreatAsSameOriginNavigation):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleRedirect):
(WebCore::NavigationScheduler::scheduleRefresh):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::loadImage):
(WebCore::PingLoader::sendPing):
(WebCore::PingLoader::sendViolationReport):
(WebCore::PingLoader::startPingLoad):
* Source/WebCore/loader/ProgressTracker.cpp:
(WebCore::ProgressTracker::progressStarted):
(WebCore::ProgressTracker::progressEstimateChanged):
(WebCore::ProgressTracker::finalProgressComplete):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::init):
(WebCore::logResourceResponseSource):
(WebCore::ResourceLoader::isAllowedToAskUserForCredentials const):
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::addResourceTiming):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::canCreateSubFrame const):
(WebCore::FrameLoader::SubframeLoader::requestObject):
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::logResourceLoaded):
(WebCore::SubresourceLoader::notifyDone):
(WebCore::SubresourceLoader::reportResourceTiming):
* Source/WebCore/loader/TextTrackLoader.cpp:
(WebCore::TextTrackLoader::load):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::canRequest):
(WebCore::CachedResourceLoader::canRequestAfterRedirection const):
(WebCore::CachedResourceLoader::canRequestInContentDispositionAttachmentSandbox const):
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::printAccessDeniedMessage const):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::startLoading):
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::scroll):
(WebCore::Chrome::runJavaScriptConfirm):
(WebCore::Chrome::runJavaScriptPrompt):
(WebCore::Chrome::mouseDidMoveOverElement):
(WebCore::Chrome::print):
(WebCore::Chrome::windowScreenDidChange):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::openNewWindow):
(WebCore::insertUnicodeCharacter):
(WebCore::ContextMenuController::contextMenuItemSelected):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::isInsecureScriptAccess):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::MouseWheelRegionOverlay::updateRegion):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::dragEnteredOrUpdated):
(WebCore::DragController::tryDocumentDrag):
(WebCore::DragController::dispatchTextInputEventFor):
(WebCore::DragController::concludeEditDrag):
(WebCore::DragController::canProcessDrag):
(WebCore::DragController::prepareForDragStart const):
(WebCore::DragController::startDrag):
(WebCore::DragController::placeDragCaret):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::mouseMoved):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::canDropCurrentlyDraggedImageAsFile const):
(WebCore::EventHandler::dispatchMouseEvent):
(WebCore::EventHandler::handleWheelEventInternal):
(WebCore::EventHandler::sendContextMenuEventForKey):
(WebCore::EventHandler::internalKeyEvent):
(WebCore::EventHandler::beginKeyboardScrollGesture):
(WebCore::EventHandler::handleTouchEvent):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
(WebCore::FocusController::setFocused):
(WebCore::FocusController::setActive):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::~Frame):
(WebCore::Frame::takeWindowProxyAndOpenerFrom):
* Source/WebCore/page/FrameConsoleClient.cpp:
(WebCore::FrameConsoleClient::screenshot):
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/ImageOverlayController.cpp:
(WebCore::ImageOverlayController::selectionQuadsDidChange):
(WebCore::ImageOverlayController::installPageOverlayIfNeeded):
(WebCore::ImageOverlayController::uninstallPageOverlay):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::updateObservations):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::isSameSecurityOriginAsMainFrame const):
(WebCore::LocalDOMWindow::deviceOrientationController const):
(WebCore::LocalDOMWindow::deviceMotionController const):
(WebCore::LocalDOMWindow::incrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::decrementScrollEventListenersCount):
(WebCore::LocalDOMWindow::queueEventTimingCandidateForDispatch):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::createWindow):
(WebCore::LocalDOMWindow::open):
(WebCore::LocalDOMWindow::showModalDialog):
* Source/WebCore/page/LocalDOMWindowProperty.cpp:
(WebCore::LocalDOMWindowProperty::frame const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::setDocument):
(WebCore::LocalFrame::setPrinting):
(WebCore::LocalFrame::clearTimers):
(WebCore::LocalFrame::hitTestResultAtPoint):
(WebCore::LocalFrame::rangeForPoint):
(WebCore::LocalFrame::createView):
(WebCore::LocalFrame::trackedRepaintRectsAsText const):
(WebCore::LocalFrame::setPageAndTextZoomFactors):
(WebCore::LocalFrame::screenSize const):
(WebCore::LocalFrame::documentURLOrOriginDidChange):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateSnapOffsets):
(WebCore::LocalFrameView::safeToPropagateScrollToParent const):
(WebCore::LocalFrameView::scrollToPendingTextFragmentRange):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::runPostLayoutTasks):
(WebCore::LocalFrameViewLayoutContext::flushUpdateLayerPositions):
(WebCore::LocalFrameViewLayoutContext::updateCompositingLayersAfterStyleChange):
(WebCore::LocalFrameViewLayoutContext::updateStyleForLayout):
(WebCore::LocalFrameViewLayoutContext::renderView const):
* Source/WebCore/page/Location.cpp:
(WebCore::Location::reload):
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseCriticalMemory):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeForNewWindow):
(WebCore::Navigation::setActivation):
(WebCore::Navigation::createForPageswapEvent):
(WebCore::Navigation::performTraversal):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::index const):
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::initializePluginAndMimeTypeArrays):
* Source/WebCore/page/NavigatorLoginStatus.cpp:
(WebCore::NavigatorLoginStatus::hasSameOrigin const):
(WebCore::NavigatorLoginStatus::setStatus):
(WebCore::NavigatorLoginStatus::isLoggedIn):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::findString):
(WebCore::Page::findTextMatches):
(WebCore::Page::rangeOfString):
(WebCore::Page::findMatchesForText):
(WebCore::replaceRanges):
(WebCore::Page::replaceSelectionWithText):
(WebCore::Page::updateRendering):
(WebCore::Page::prioritizeVisibleResources):
(WebCore::Page::setDebugger):
(WebCore::Page::setUseColorAppearance):
(WebCore::Page::outermostFullscreenDocument const):
(WebCore::Page::didFinishLoadingImageForElement):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::installedPageOverlaysChanged):
(WebCore::PageOverlayController::attachViewOverlayLayers):
(WebCore::PageOverlayController::detachViewOverlayLayers):
(WebCore::PageOverlayController::installPageOverlay):
(WebCore::PageOverlayController::updateForceSynchronousScrollLayerPositionUpdates):
(WebCore::PageOverlayController::didChangeViewExposedRect):
(WebCore::PageOverlayController::notifyFlushRequired):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsAutoplayPlayPauseEvents const):
* Source/WebCore/page/Screen.cpp:
(WebCore::Screen::colorDepth const):
(WebCore::Screen::availLeft const):
(WebCore::Screen::availTop const):
(WebCore::Screen::availHeight const):
(WebCore::Screen::availWidth const):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::imageLoadingSettingsTimerFired):
(WebCore::SettingsBase::fontFallbackPrefersPictographsChanged):
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::takeSnapshots):
(WebCore::initializeIndicator):
* Source/WebCore/page/UndoManager.cpp:
(WebCore::UndoManager::addItem):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::upgradeInsecureRequestIfNeeded const):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkFrameAncestors):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::ancestorRespondingToClickEventsNodeQualifier):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::handleDataDetectorAction):
(WebCore::ImageOverlayController::scheduleRenderingUpdate):
(WebCore::ImageOverlayController::deviceScaleFactor const):
(WebCore::ImageOverlayController::createGraphicsLayer):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::scheduleRenderingUpdate):
(WebCore::ServicesOverlayController::deviceScaleFactor const):
(WebCore::ServicesOverlayController::createGraphicsLayer):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::areSameOrigin):
(WebCore::TextExtraction::focusAndInsertText):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::allowsFollowingLink const):
(WebCore::HitTestResult::allowsFollowingImageURL const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::positionForPointWithInlineChildren):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::notifyFinished):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::scheduleRenderingUpdate):
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::layerBecameNonComposited):
(WebCore::RenderLayerCompositor::updateCompositingForLayerTreeAsTextDump):
(WebCore::RenderLayerCompositor::updateLayerForOverhangAreasBackgroundColor):
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingRole):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::isUserScrollInProgress const):
(WebCore::RenderLayerScrollableArea::isRubberBandInProgress const):
(WebCore::RenderLayerScrollableArea::requestScrollToPosition):
(WebCore::RenderLayerScrollableArea::requestStartKeyboardScrollAnimation):
(WebCore::RenderLayerScrollableArea::requestStopKeyboardScrollAnimation):
(WebCore::RenderLayerScrollableArea::stopAsyncAnimatedScroll):
(WebCore::RenderLayerScrollableArea::scrollTo):
(WebCore::RenderLayerScrollableArea::handleWheelEventForScrolling):
(WebCore::RenderLayerScrollableArea::createScrollbarsController):
(WebCore::RenderLayerScrollableArea::updateSnapOffsets):
(WebCore::RenderLayerScrollableArea::isScrollSnapInProgress const):
(WebCore::RenderLayerScrollableArea::didStartScrollAnimation):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paintContents):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::animationRepeatIntervalForProgressBar const):
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
(WebCore::StyleFilterImage::image const):
* Source/WebCore/storage/Storage.cpp:
(WebCore::Storage::requiresScriptTrackingPrivacyProtection const):
* Source/WebCore/storage/StorageNamespaceProvider.cpp:
(WebCore::StorageNamespaceProvider::localStorageArea):
(WebCore::StorageNamespaceProvider::sessionStorageArea):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::requestImageResource):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::updateExternalDocument):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setInspectorIsUnderTest):
(WebCore::Internals::setFullscreenAutoHideDuration):
(WebCore::Internals::bestMediaElementForRemoteControls):
(WebCore::Internals::setTopDocumentURLForQuirks):
(WebCore::Internals::copyImageAtLocation):
* Source/WebCore/testing/Internals.mm:
(WebCore::Internals::setUsesOverlayScrollbars):
* Source/WebCore/workers/AbstractWorker.cpp:
(WebCore::AbstractWorker::validateURL):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::startWorkerGlobalScope):
* Source/WebCore/workers/service/ServiceWorkerClient.cpp:
(WebCore::ServiceWorkerClient::postMessage):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::SharedWorkerThreadProxy):
* Source/WebCore/xml/DOMParser.cpp:
(WebCore::DOMParser::parseFromString):
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::docLoaderFunc):
(WebCore::xmlDocPtrFromNode):
(WebCore::XSLTProcessor::transformToString):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::shouldAllowExternalLoad):
(WebCore::openFunc):
(WebCore::XMLDocumentParser::doEnd):

Canonical link: <a href="https://commits.webkit.org/306661@main">https://commits.webkit.org/306661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f42506f185cfcae86354ef772499316e74343024

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141970 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150579 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd0b3f62-b76f-4c53-a4e5-6db300fc716e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109125 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f5848e7-c7b6-49dd-b0c8-4ae0cad830a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90021 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b238b15c-8998-455e-b7ba-4125cb98df8f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8858 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/635 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152955 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14045 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3935 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117205 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117522 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29950 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13579 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69739 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14094 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3239 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77809 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14030 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->