### PR TITLE
Address most adoptNS/adoptCF Safer CPP warnings on iOS in WebKit/

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -757,7 +757,6 @@ symbols = [
     "CGPDFDocumentIsTaggedPDF",
     "CGPDFPageLayoutGetAreaOfInterestAtPoint",
     "CGSVGDocumentCreateFromData",
-    "CGSVGDocumentRelease",
     "FBSActivateForEventOptionTypeBackgroundContentFetching",
     "FBSOpenApplicationOptionKeyActivateForEvent",
     "FBSOpenApplicationOptionKeyPayloadOptions",

--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -98,7 +98,8 @@ void GPUConnectionToWebProcess::setTCCIdentity()
         return;
     }
 
-    auto identity = adoptOSObject(tcc_identity_create(TCC_IDENTITY_CODE_BUNDLE_ID, bundleIdentifier.utf8().data()));
+    // FIXME: Adopting is needed here but static analysis is not able to tell.
+    SUPPRESS_RETAINPTR_CTOR_ADOPT auto identity = adoptOSObject(tcc_identity_create(TCC_IDENTITY_CODE_BUNDLE_ID, bundleIdentifier.utf8().data()));
     if (!identity) {
         RELEASE_LOG_ERROR(WebRTC, "tcc_identity_create returned null");
         return;

--- a/Source/WebKit/Platform/spi/Cocoa/CoreSVGSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/CoreSVGSPI.h
@@ -38,7 +38,6 @@ WTF_EXTERN_C_BEGIN
 typedef struct CGSVGDocument *CGSVGDocumentRef;
 
 CGSVGDocumentRef CGSVGDocumentCreateFromData(CFDataRef, CFDictionaryRef);
-void CGSVGDocumentRelease(CGSVGDocumentRef);
 
 WTF_EXTERN_C_END
 

--- a/Source/WebKit/Shared/LogStream.cpp
+++ b/Source/WebKit/Shared/LogStream.cpp
@@ -90,7 +90,8 @@ void LogStream::logOnBehalfOfWebContent(std::span<const uint8_t> logSubsystem, s
         auto category = byteCast<char>(logCategory.data());
         if (equalSpans("Testing\0"_span, logCategory))
             globalLogCountForTesting++;
-        osLog = adoptOSObject(os_log_create(subsystem, category));
+        // Adopting is needed here but static analysis is not able to tell.
+        SUPPRESS_RETAINPTR_CTOR_ADOPT osLog = adoptOSObject(os_log_create(subsystem, category));
     }
 
     auto osLogPointer = osLog.get() ? osLog.get() : OS_LOG_DEFAULT;

--- a/Source/WebKit/Shared/ios/AuxiliaryProcessIOS.mm
+++ b/Source/WebKit/Shared/ios/AuxiliaryProcessIOS.mm
@@ -78,11 +78,11 @@ void AuxiliaryProcess::populateMobileGestaltCache(std::optional<SandboxExtension
         MGGetBoolAnswer(kMGQSupportsForceTouch);
 
         auto answer = adoptCF(MGCopyAnswer(kMGQBluetoothCapability, nullptr));
-        answer = MGCopyAnswer(kMGQDeviceProximityCapability, nullptr);
-        answer = MGCopyAnswer(kMGQDeviceSupportsARKit, nullptr);
-        answer = MGCopyAnswer(kMGQTimeSyncCapability, nullptr);
-        answer = MGCopyAnswer(kMGQWAPICapability, nullptr);
-        answer = MGCopyAnswer(kMGQMainDisplayRotation, nullptr);
+        answer = adoptCF(MGCopyAnswer(kMGQDeviceProximityCapability, nullptr));
+        answer = adoptCF(MGCopyAnswer(kMGQDeviceSupportsARKit, nullptr));
+        answer = adoptCF(MGCopyAnswer(kMGQTimeSyncCapability, nullptr));
+        answer = adoptCF(MGCopyAnswer(kMGQWAPICapability, nullptr));
+        answer = adoptCF(MGCopyAnswer(kMGQMainDisplayRotation, nullptr));
 
         ok = extension->revoke();
         ASSERT_UNUSED(ok, ok);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreviewActionItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreviewActionItem.mm
@@ -42,7 +42,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    WKPreviewAction *action = [super copyWithZone:zone];
+    // We are in a copy function so we intentionally do not adopt.
+    SUPPRESS_RETAINPTR_CTOR_ADOPT WKPreviewAction *action = [super copyWithZone:zone];
     action->_identifier = self.identifier;
     return action;
 }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -569,7 +569,8 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
         [_customContentView removeFromSuperview];
         [_customContentFixedOverlayView removeFromSuperview];
 
-        _customContentView = adoptNS([[representationClass alloc] web_initWithFrame:self.bounds webView:self mimeType:mimeType.createNSString().get()]);
+        // This is correct, static analysis gets confused by the `web_` prefix to the init method.
+        SUPPRESS_RETAINPTR_CTOR_ADOPT _customContentView = adoptNS([[representationClass alloc] web_initWithFrame:self.bounds webView:self mimeType:mimeType.createNSString().get()]);
         _customContentFixedOverlayView = adoptNS([[UIView alloc] initWithFrame:self.bounds]);
         [_customContentFixedOverlayView layer].name = @"CustomContentFixedOverlay";
         [_customContentFixedOverlayView setUserInteractionEnabled:NO];

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -56,7 +56,6 @@
 
 SOFT_LINK_PRIVATE_FRAMEWORK(CoreSVG)
 SOFT_LINK(CoreSVG, CGSVGDocumentCreateFromData, CGSVGDocumentRef, (CFDataRef data, CFDictionaryRef options), (data, options))
-SOFT_LINK(CoreSVG, CGSVGDocumentRelease, void, (CGSVGDocumentRef document), (document))
 #endif
 
 namespace WebKit {
@@ -335,13 +334,12 @@ Expected<Ref<WebCore::Icon>, RefPtr<API::Error>> WebExtension::iconForPath(const
 #if !USE(APPKIT)
     auto imageType = resourceMIMETypeForPath(imagePath);
     if (equalLettersIgnoringASCIICase(imageType, "image/svg+xml"_s)) {
-        CGSVGDocumentRef document = CGSVGDocumentCreateFromData(bridge_cast(imageData), nullptr);
+        RetainPtr document = adoptCF(CGSVGDocumentCreateFromData(bridge_cast(imageData), nullptr));
         if (!document)
             return makeUnexpected(nullptr);
 
         // Since we need to rasterize, scale the image for the densest display, so it will have enough pixels to be sharp.
-        result = [UIImage _imageWithCGSVGDocument:document scale:displayScale orientation:UIImageOrientationUp];
-        CGSVGDocumentRelease(document);
+        result = [UIImage _imageWithCGSVGDocument:document.get() scale:displayScale orientation:UIImageOrientationUp];
     }
 #endif // !USE(APPKIT)
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -92,7 +92,7 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
         if (![WKMaterialHostingSupport isMaterialHostingAvailable])
             return makeWithView(adoptNS([[WKCompositingView alloc] init]));
 
-        return makeWithView([[WKMaterialHostingView alloc] init]);
+        return makeWithView(adoptNS([[WKMaterialHostingView alloc] init]));
     }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12842,7 +12842,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
     return valueOrDefault(_imageAnalysisContextMenuActionData).hasVisualSearchResults;
 }
 
-- (CGImageRef)copySubjectResultForImageContextMenu
+- (CGImageRef)subjectResultForImageContextMenu
 {
     return valueOrDefault(_imageAnalysisContextMenuActionData).copySubjectResult.getAutoreleased();
 }
@@ -13305,7 +13305,7 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
                 continue;
 
             if ([action.identifier isEqual:elementActionTypeToUIActionIdentifier(_WKElementActionTypeCopyCroppedImage)]) {
-                if (self.copySubjectResultForImageContextMenu)
+                if (self.subjectResultForImageContextMenu)
                     action.attributes &= ~UIMenuElementAttributesDisabled;
 
                 continue;
@@ -13359,15 +13359,15 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
 
 - (BOOL)actionSheetAssistantShouldIncludeCopySubjectAction:(WKActionSheetAssistant *)assistant
 {
-    return !!self.copySubjectResultForImageContextMenu;
+    return !!self.subjectResultForImageContextMenu;
 }
 
 - (void)actionSheetAssistant:(WKActionSheetAssistant *)assistant copySubject:(UIImage *)image sourceMIMEType:(NSString *)sourceMIMEType
 {
-    if (!self.copySubjectResultForImageContextMenu)
+    if (!self.subjectResultForImageContextMenu)
         return;
 
-    auto [data, type] = WebKit::imageDataForRemoveBackground(self.copySubjectResultForImageContextMenu, (__bridge CFStringRef)sourceMIMEType);
+    auto [data, type] = WebKit::imageDataForRemoveBackground(self.subjectResultForImageContextMenu, (__bridge CFStringRef)sourceMIMEType);
     if (!data)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -36,6 +36,7 @@
 #import <WebCore/SecurityOrigin.h>
 #import <pal/spi/cocoa/NSFileManagerSPI.h>
 #import <wtf/Deque.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/NotificationCenterCF.h>
@@ -117,10 +118,10 @@ struct PermissionRequest {
 
 + (instancetype)sharedPolicyDecider
 {
-    static WKWebGeolocationPolicyDecider *policyDecider = nil;
-    if (!policyDecider)
-        policyDecider = [[WKWebGeolocationPolicyDecider alloc] init];
-    return policyDecider;
+    static NeverDestroyed<RetainPtr<WKWebGeolocationPolicyDecider>> policyDecider;
+    if (!policyDecider.get())
+        policyDecider.get() = adoptNS([[WKWebGeolocationPolicyDecider alloc] init]);
+    return policyDecider.get().get();
 }
 
 - (id)init

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -1377,9 +1377,10 @@ static RetainPtr<NSString> displayStringForDocumentsAtURLs(NSArray<NSURL *> *url
         RetainPtr filePath = [temporaryDirectory stringByAppendingPathComponent:coordinatedOriginalURL.lastPathComponent];
         RetainPtr destinationFileURL = adoptNS([[NSURL alloc] initFileURLWithPath:filePath.get() isDirectory:NO]);
 
-        if (asCopy)
-            didMoveOrCopy = [fileManager copyItemAtURL:coordinatedOriginalURL toURL:destinationFileURL.get() error:&error];
-        else
+        if (asCopy) {
+            // This is a safer cpp false positive. Despite having `copy` in its name, this method returns a BOOL.
+            SUPPRESS_RETAINPTR_CTOR_ADOPT didMoveOrCopy = [fileManager copyItemAtURL:coordinatedOriginalURL toURL:destinationFileURL.get() error:&error];
+        } else
             didMoveOrCopy = [fileManager moveItemAtURL:coordinatedOriginalURL toURL:destinationFileURL.get() error:&error];
 
         if (!didMoveOrCopy || error) {


### PR DESCRIPTION
#### d981c83ca9c3c117afbcea6ac8d168a8b9ebdbdc
<pre>
Address most adoptNS/adoptCF Safer CPP warnings on iOS in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=306752">https://bugs.webkit.org/show_bug.cgi?id=306752</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/Configurations/AllowedSPI-legacy.toml:
* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::setTCCIdentity):
* Source/WebKit/Platform/spi/Cocoa/CoreSVGSPI.h:
* Source/WebKit/Shared/LogStream.cpp:
(WebKit::LogStream::logOnBehalfOfWebContent):
* Source/WebKit/Shared/ios/AuxiliaryProcessIOS.mm:
(WebKit::AuxiliaryProcess::populateMobileGestaltCache):
* Source/WebKit/UIProcess/API/Cocoa/WKPreviewActionItem.mm:
(-[WKPreviewAction copyWithZone:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm:
(+[_WKTouchEventGenerator sharedTouchEventGenerator]):
(-[_WKTouchEventGenerator _createIOHIDEventType:]):
(-[_WKTouchEventGenerator _updateTouchPoints:window:]):
(-[_WKTouchEventGenerator touchDownAtPoints:touchCount:window:]):
(-[_WKTouchEventGenerator liftUpAtPoints:touchCount:window:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setHasCustomContentView:loadedMIMEType:]):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::iconForPath):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView subjectResultForImageContextMenu]):
(-[WKContentView _insertDynamicImageAnalysisContextMenuItemsIfPossible]):
(-[WKContentView actionSheetAssistantShouldIncludeCopySubjectAction:]):
(-[WKContentView actionSheetAssistant:copySubject:sourceMIMEType:]):
(-[WKContentView copySubjectResultForImageContextMenu]): Deleted.
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(+[WKWebGeolocationPolicyDecider sharedPolicyDecider]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:

Canonical link: <a href="https://commits.webkit.org/306669@main">https://commits.webkit.org/306669@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbae64d196b4adef0d44d512929422ecf37caa89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150590 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b75aea05-95d1-48a0-830a-2036773e28dd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109131 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fc24d46-2fe2-4368-a016-d1c3b1e766b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11666 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90027 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6350c8a-a28b-4bc4-b20a-8f52506db43e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8864 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/648 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120535 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152965 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14057 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117527 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29954 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13570 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69751 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14106 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3242 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77822 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->