### PR TITLE
[CoordinatedGraphics] Move playstation accelerated surface implementation to its own file

### DIFF
--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -92,7 +92,7 @@ list(APPEND WebKit_SOURCES
 
     WebProcess/InjectedBundle/playstation/InjectedBundlePlayStation.cpp
 
-    WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+    WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.cpp
     WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
 
     WebProcess/WebPage/playstation/WebPagePlayStation.cpp

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -731,10 +731,6 @@ AcceleratedSurface::SwapChain::SwapChain(uint64_t surfaceID, RenderingPurpose re
     case PlatformDisplay::Type::Default:
         break;
 #endif // PLATFORM(GTK) || OS(ANDROID)
-#if PLATFORM(PLAYSTATION)
-    case PlatformDisplay::Type::Surfaceless:
-        break;
-#endif // PLATFORM(PLAYSTATION)
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.cpp
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AcceleratedSurfacePlayStation.h"
+
+#if USE(COORDINATED_GRAPHICS)
+#include "WebPage.h"
+#include "WebProcess.h"
+#include <WebCore/GLContext.h>
+#include <WebCore/GLFence.h>
+#include <WebCore/GraphicsContext.h>
+#include <WebCore/Page.h>
+#include <WebCore/PlatformDisplay.h>
+#include <WebCore/Region.h>
+#include <WebCore/Settings.h>
+#include <WebCore/ShareableBitmap.h>
+#include <array>
+#include <fcntl.h>
+#include <unistd.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#else
+#include <GLES2/gl2.h>
+#endif
+
+#if USE(WPE_RENDERER)
+#include <WebCore/PlatformDisplayLibWPE.h>
+#include <wpe/wpe-egl.h>
+#include <wtf/UniStdExtras.h>
+#endif
+
+namespace WebKit {
+using namespace WebCore;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurface);
+
+static inline bool isColorOpaque(AcceleratedSurface::ColorComponents color)
+{
+    return color[3] == WebCore::AlphaTraits<float>::opaque;
+}
+
+static uint64_t generateID()
+{
+    static uint64_t identifier = 0;
+    return ++identifier;
+}
+
+Ref<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Function<void()>&& frameCompleteHandler)
+{
+    return adoptRef(*new AcceleratedSurface(webPage, WTF::move(frameCompleteHandler)));
+}
+
+static bool useExplicitSync()
+{
+    auto& display = PlatformDisplay::sharedDisplay();
+    auto& extensions = display.eglExtensions();
+    return extensions.ANDROID_native_fence_sync && (display.eglCheckVersion(1, 5) || extensions.KHR_fence_sync);
+}
+
+AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& frameCompleteHandler)
+    : m_webPage(webPage)
+    , m_frameCompleteHandler(WTF::move(frameCompleteHandler))
+    , m_id(generateID())
+    , m_isVisible(webPage.activityState().contains(ActivityState::IsVisible))
+    , m_useExplicitSync(useExplicitSync())
+{
+    auto color = webPage.backgroundColor();
+    m_backgroundColor = color ? color->toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::SRGB) : white;
+
+#if USE(WPE_RENDERER)
+    if (m_swapChain.type() == SwapChain::Type::WPEBackend)
+        m_swapChain.initialize(webPage);
+#endif
+}
+
+AcceleratedSurface::~AcceleratedSurface() = default;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(AcceleratedSurface::RenderTarget);
+
+static uint64_t generateTargetID()
+{
+    static uint64_t identifier = 0;
+    return ++identifier;
+}
+
+AcceleratedSurface::RenderTarget::RenderTarget()
+    : m_id(generateTargetID())
+{
+}
+
+AcceleratedSurface::RenderTarget::~RenderTarget() = default;
+
+#if USE(WPE_RENDERER)
+std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTargetWPEBackend::create(const IntSize& initialSize, UnixFileDescriptor&& hostFD, const AcceleratedSurface& surface)
+{
+    return makeUnique<RenderTargetWPEBackend>(initialSize, WTF::move(hostFD), surface);
+}
+
+AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend(const IntSize& initialSize, UnixFileDescriptor&& hostFD, const AcceleratedSurface& surface)
+    : RenderTarget()
+    , m_backend(wpe_renderer_backend_egl_target_create(hostFD.release()))
+{
+    static struct wpe_renderer_backend_egl_target_client s_client = {
+        // frame_complete
+        [](void* data) {
+            auto& surface = *reinterpret_cast<AcceleratedSurface*>(data);
+            surface.frameDone();
+        },
+        // padding
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr
+    };
+    wpe_renderer_backend_egl_target_set_client(m_backend, &s_client, const_cast<AcceleratedSurface*>(&surface));
+    wpe_renderer_backend_egl_target_initialize(m_backend, downcast<PlatformDisplayLibWPE>(PlatformDisplay::sharedDisplay()).backend(),
+        std::max(1, initialSize.width()), std::max(1, initialSize.height()));
+}
+
+AcceleratedSurface::RenderTargetWPEBackend::~RenderTargetWPEBackend()
+{
+#if WPE_CHECK_VERSION(1, 9, 1)
+    // libwpe 1.9.1 introduced an additional ::deinitialize function, which
+    // may be called some time before destruction. As there is no better place
+    // to invoke it at the moment, do it right before destroying the object.
+    wpe_renderer_backend_egl_target_deinitialize(m_backend);
+#endif
+
+    wpe_renderer_backend_egl_target_destroy(m_backend);
+}
+
+uint64_t AcceleratedSurface::RenderTargetWPEBackend::window() const
+{
+    // EGLNativeWindowType changes depending on the EGL implementation: reinterpret_cast works
+    // for pointers (only if they are 64-bit wide and not for other cases), and static_cast for
+    // numeric types (and when needed they get extended to 64-bit) but not for pointers. Using
+    // a plain C cast expression in this one instance works in all cases.
+    static_assert(sizeof(EGLNativeWindowType) <= sizeof(uint64_t), "EGLNativeWindowType must not be longer than 64 bits.");
+    return (uint64_t)wpe_renderer_backend_egl_target_get_native_window(m_backend);
+}
+
+void AcceleratedSurface::RenderTargetWPEBackend::resize(const IntSize& size)
+{
+    wpe_renderer_backend_egl_target_resize(m_backend, std::max(1, size.width()), std::max(1, size.height()));
+}
+
+void AcceleratedSurface::RenderTargetWPEBackend::willRenderFrame()
+{
+    wpe_renderer_backend_egl_target_frame_will_render(m_backend);
+}
+
+void AcceleratedSurface::RenderTargetWPEBackend::didRenderFrame(Vector<IntRect, 1>&&)
+{
+    wpe_renderer_backend_egl_target_frame_rendered(m_backend);
+}
+#endif
+
+AcceleratedSurface::SwapChain::SwapChain()
+{
+    auto& display = PlatformDisplay::sharedDisplay();
+    switch (display.type()) {
+#if USE(WPE_RENDERER)
+    case PlatformDisplay::Type::WPE:
+        m_type = Type::WPEBackend;
+        break;
+#endif
+#if PLATFORM(PLAYSTATION)
+    case PlatformDisplay::Type::Surfaceless:
+        break;
+#endif // PLATFORM(PLAYSTATION)
+    }
+}
+
+bool AcceleratedSurface::SwapChain::resize(const IntSize& size)
+{
+    if (m_size == size)
+        return false;
+
+    m_size = size;
+#if USE(WPE_RENDERER)
+    if (m_type == Type::WPEBackend) {
+        static_cast<RenderTargetWPEBackend*>(m_lockedTargets[0].get())->resize(m_size);
+        return true;
+    }
+#endif
+    reset();
+    return true;
+}
+
+std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::SwapChain::createTarget() const
+{
+    switch (m_type) {
+#if USE(WPE_RENDERER)
+    case Type::WPEBackend:
+        ASSERT_NOT_REACHED();
+        break;
+#endif
+    case Type::Invalid:
+        break;
+    }
+    return nullptr;
+}
+
+AcceleratedSurface::RenderTarget* AcceleratedSurface::SwapChain::nextTarget()
+{
+#if USE(WPE_RENDERER)
+    if (m_type == Type::WPEBackend)
+        return m_lockedTargets[0].get();
+#endif
+
+    if (m_freeTargets.isEmpty()) {
+        ASSERT(m_lockedTargets.size() < s_maximumBuffers);
+
+        if (m_lockedTargets.isEmpty()) [[unlikely]] {
+            // Initial setup.
+            for (unsigned i = 0; i < s_initialBuffers; ++i)
+                m_freeTargets.append(createTarget());
+        } else {
+            // Additional buffers creted on demand.
+            m_lockedTargets.insert(0, createTarget());
+            return m_lockedTargets[0].get();
+        }
+    }
+
+    auto target = m_freeTargets.takeLast();
+    m_lockedTargets.insert(0, WTF::move(target));
+    return m_lockedTargets[0].get();
+}
+
+void AcceleratedSurface::SwapChain::releaseTarget(uint64_t targetID, UnixFileDescriptor&& releaseFence)
+{
+#if USE(WPE_RENDERER)
+    ASSERT(m_type != Type::WPEBackend);
+#endif
+
+    auto index = m_lockedTargets.reverseFindIf([targetID](const auto& item) {
+        return item->id() == targetID;
+    });
+    if (index != notFound) {
+        m_lockedTargets[index]->setReleaseFenceFD(WTF::move(releaseFence));
+        m_freeTargets.insert(0, WTF::move(m_lockedTargets[index]));
+        m_lockedTargets.removeAt(index);
+    }
+}
+
+void AcceleratedSurface::SwapChain::reset()
+{
+    m_lockedTargets.clear();
+    m_freeTargets.clear();
+}
+
+void AcceleratedSurface::SwapChain::releaseUnusedBuffers()
+{
+#if USE(WPE_RENDERER)
+    ASSERT(m_type != Type::WPEBackend);
+#endif
+
+    m_freeTargets.clear();
+}
+
+#if USE(WPE_RENDERER)
+void AcceleratedSurface::SwapChain::initialize(WebPage& webPage)
+{
+    ASSERT(m_type == Type::WPEBackend);
+    m_hostFD = webPage.hostFileDescriptor();
+    m_initialSize = webPage.size();
+    m_initialSize.scale(webPage.deviceScaleFactor());
+}
+
+uint64_t AcceleratedSurface::SwapChain::initializeTarget(const AcceleratedSurface& surface)
+{
+    ASSERT(m_type == Type::WPEBackend);
+    auto target = RenderTargetWPEBackend::create(m_initialSize, WTF::move(m_hostFD), surface);
+    auto window = static_cast<RenderTargetWPEBackend*>(target.get())->window();
+    m_lockedTargets.append(WTF::move(target));
+    return window;
+}
+#endif
+
+void AcceleratedSurface::visibilityDidChange(bool isVisible)
+{
+    if (m_isVisible == isVisible)
+        return;
+
+    m_isVisible = isVisible;
+    if (!m_releaseUnusedBuffersTimer)
+        return;
+
+    if (m_isVisible)
+        m_releaseUnusedBuffersTimer->stop();
+    else {
+        static const Seconds releaseUnusedBuffersDelay = 10_s;
+        m_releaseUnusedBuffersTimer->startOneShot(releaseUnusedBuffersDelay);
+    }
+}
+
+void AcceleratedSurface::backgroundColorDidChange()
+{
+    ASSERT(RunLoop::isMain());
+    const auto& color = m_webPage->backgroundColor();
+
+    bool wasOpaque = isColorOpaque(m_backgroundColor);
+    m_backgroundColor = color ? color->toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::SRGB) : white;
+    bool isOpaque = isColorOpaque(m_backgroundColor);
+
+    if (isOpaque == wasOpaque)
+        return;
+}
+
+void AcceleratedSurface::releaseUnusedBuffersTimerFired()
+{
+    m_swapChain.releaseUnusedBuffers();
+}
+
+void AcceleratedSurface::didCreateCompositingRunLoop(RunLoop& runLoop)
+{
+#if USE(WPE_RENDERER)
+    if (m_swapChain.type() == SwapChain::Type::WPEBackend)
+        return;
+#endif
+
+    m_releaseUnusedBuffersTimer = makeUnique<RunLoop::Timer>(runLoop, "AcceleratedSurface::ReleaseUnusedBuffersTimer"_s, this, &AcceleratedSurface::releaseUnusedBuffersTimerFired);
+#if USE(GLIB_EVENT_LOOP)
+    m_releaseUnusedBuffersTimer->setPriority(RunLoopSourcePriority::ReleaseUnusedResourcesTimer);
+#endif
+}
+
+void AcceleratedSurface::willDestroyCompositingRunLoop()
+{
+    m_frameCompleteHandler = nullptr;
+
+#if USE(WPE_RENDERER)
+    if (m_swapChain.type() == SwapChain::Type::WPEBackend)
+        return;
+#endif
+
+    m_releaseUnusedBuffersTimer = nullptr;
+}
+
+void AcceleratedSurface::willDestroyGLContext()
+{
+    m_swapChain.reset();
+}
+
+uint64_t AcceleratedSurface::surfaceID() const
+{
+    return m_id;
+}
+
+uint64_t AcceleratedSurface::window() const
+{
+#if USE(WPE_RENDERER)
+    if (m_swapChain.type() == SwapChain::Type::WPEBackend)
+        return const_cast<SwapChain*>(&m_swapChain)->initializeTarget(*this);
+#endif
+    return 0;
+}
+
+void AcceleratedSurface::willRenderFrame(const IntSize& size)
+{
+    bool sizeDidChange = m_swapChain.resize(size);
+
+    m_target = m_swapChain.nextTarget();
+    if (m_target)
+        m_target->willRenderFrame();
+
+    if (sizeDidChange)
+        glViewport(0, 0, size.width(), size.height());
+}
+
+void AcceleratedSurface::clear(const OptionSet<WebCore::CompositionReason>& reasons)
+{
+    ASSERT(!RunLoop::isMain());
+    auto backgroundColor = m_backgroundColor.load();
+    if (!isColorOpaque(backgroundColor)) {
+        glClearColor(0, 0, 0, 0);
+        glClear(GL_COLOR_BUFFER_BIT);
+    } else if (reasons.contains(CompositionReason::AsyncScrolling)) {
+        auto [r, g, b, a] = backgroundColor;
+        glClearColor(r, g, b, a);
+        glClear(GL_COLOR_BUFFER_BIT);
+    }
+}
+
+void AcceleratedSurface::didRenderFrame()
+{
+    if (!m_target)
+        return;
+
+    m_target->sync(m_useExplicitSync);
+
+    Vector<IntRect, 1> damageRects;
+    m_target->didRenderFrame(WTF::move(damageRects));
+}
+
+void AcceleratedSurface::frameDone()
+{
+    if (m_frameCompleteHandler)
+        m_frameCompleteHandler();
+    m_target = nullptr;
+}
+
+} // namespace WebKit
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.h
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+
+#include <WebCore/ColorComponents.h>
+#include <WebCore/ColorModels.h>
+#include <WebCore/CoordinatedCompositionReason.h>
+#include <WebCore/Damage.h>
+#include <WebCore/IntSize.h>
+#include <wtf/RunLoop.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/WeakRef.h>
+#include <wtf/unix/UnixFileDescriptor.h>
+
+#if USE(WPE_RENDERER)
+struct wpe_renderer_backend_egl_target;
+#endif
+
+namespace WTF {
+class RunLoop;
+}
+
+namespace WebCore {
+class GLFence;
+class GraphicsContext;
+class ShareableBitmap;
+class ShareableBitmapHandle;
+}
+
+namespace WebKit {
+class AcceleratedSurface;
+}
+
+namespace WebKit {
+class WebPage;
+
+class AcceleratedSurface final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AcceleratedSurface, WTF::DestructionThread::MainRunLoop> {
+    WTF_MAKE_TZONE_ALLOCATED(AcceleratedSurface);
+public:
+    static Ref<AcceleratedSurface> create(WebPage&, Function<void()>&& frameCompleteHandler);
+    ~AcceleratedSurface();
+
+    using ColorComponents = WebCore::ColorComponents<float, 4>;
+
+    uint64_t window() const;
+    uint64_t surfaceID() const;
+    bool shouldPaintMirrored() const { return true; }
+
+    void willDestroyGLContext();
+    void willRenderFrame(const WebCore::IntSize&);
+    void didRenderFrame();
+    void clear(const OptionSet<WebCore::CompositionReason>&);
+
+    void didCreateCompositingRunLoop(WTF::RunLoop&);
+    void willDestroyCompositingRunLoop();
+
+    void visibilityDidChange(bool);
+    void backgroundColorDidChange();
+
+private:
+    AcceleratedSurface(WebPage&, Function<void()>&& frameCompleteHandler);
+
+    void frameDone();
+    void releaseUnusedBuffersTimerFired();
+
+    class RenderTarget {
+        WTF_MAKE_TZONE_ALLOCATED(RenderTarget);
+    public:
+        virtual ~RenderTarget();
+
+        uint64_t id() const { return m_id; }
+
+        virtual void willRenderFrame() { }
+        virtual void didRenderFrame(Vector<WebCore::IntRect, 1>&&) { }
+
+        virtual void sync(bool) { }
+        virtual void setReleaseFenceFD(UnixFileDescriptor&&) { }
+
+    protected:
+        RenderTarget();
+
+        uint64_t m_id { 0 };
+    };
+
+#if USE(WPE_RENDERER)
+    class RenderTargetWPEBackend final : public RenderTarget {
+    public:
+        static std::unique_ptr<RenderTarget> create(const WebCore::IntSize&, UnixFileDescriptor&&, const AcceleratedSurface&);
+        RenderTargetWPEBackend(const WebCore::IntSize&, UnixFileDescriptor&&, const AcceleratedSurface&);
+        ~RenderTargetWPEBackend();
+
+        uint64_t window() const;
+        void resize(const WebCore::IntSize&);
+
+    private:
+        void willRenderFrame() override;
+        void didRenderFrame(Vector<WebCore::IntRect, 1>&&) override;
+
+        struct wpe_renderer_backend_egl_target* m_backend { nullptr };
+    };
+#endif
+
+    class SwapChain {
+        WTF_MAKE_NONCOPYABLE(SwapChain);
+    public:
+        SwapChain();
+
+        enum class Type {
+            Invalid,
+#if USE(WPE_RENDERER)
+            WPEBackend
+#endif
+        };
+
+        Type type() const { return m_type; }
+        bool resize(const WebCore::IntSize&);
+        const WebCore::IntSize& size() const { return m_size; }
+        RenderTarget* nextTarget();
+        void releaseTarget(uint64_t, UnixFileDescriptor&& releaseFence);
+        void reset();
+        void releaseUnusedBuffers();
+
+#if USE(WPE_RENDERER)
+        void initialize(WebPage&);
+        uint64_t initializeTarget(const AcceleratedSurface&);
+#endif
+
+    private:
+        // FIXME: Allow configuring the initial buffer count, e.g. for triple buffering.
+        static constexpr unsigned s_initialBuffers = 2;
+        static constexpr unsigned s_maximumBuffers = 4;
+
+        std::unique_ptr<RenderTarget> createTarget() const;
+
+        Type m_type { Type::Invalid };
+        WebCore::IntSize m_size;
+        Vector<std::unique_ptr<RenderTarget>, s_maximumBuffers> m_freeTargets;
+        Vector<std::unique_ptr<RenderTarget>, s_maximumBuffers> m_lockedTargets;
+#if USE(WPE_RENDERER)
+        UnixFileDescriptor m_hostFD;
+        WebCore::IntSize m_initialSize;
+#endif
+    };
+
+    static constexpr ColorComponents white { 1.f, 1.f, 1.f, WebCore::AlphaTraits<float>::opaque };
+
+    WeakRef<WebPage> m_webPage;
+    Function<void()> m_frameCompleteHandler;
+    uint64_t m_id { 0 };
+    WebCore::IntSize m_size;
+    SwapChain m_swapChain;
+    RenderTarget* m_target { nullptr };
+    bool m_isVisible { false };
+    bool m_useExplicitSync { false };
+    std::atomic<ColorComponents> m_backgroundColor { white };
+    std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
+};
+
+} // namespace WebKit
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
@@ -27,7 +27,7 @@
 #include "ThreadedCompositorPlayStation.h"
 
 #if USE(COORDINATED_GRAPHICS)
-#include "AcceleratedSurface.h"
+#include "AcceleratedSurfacePlayStation.h"
 #include "CompositingRunLoop.h"
 #include "CoordinatedSceneState.h"
 #include "LayerTreeHostPlayStation.h"


### PR DESCRIPTION
#### e490585bb6bab91ef4d8709b36e2e0e93d4632d8
<pre>
[CoordinatedGraphics] Move playstation accelerated surface implementation to its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=306756">https://bugs.webkit.org/show_bug.cgi?id=306756</a>

Reviewed by Adrian Perez de Castro.

* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::SwapChain::SwapChain):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.cpp: Added.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurfacePlayStation.h: Added.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp:

Canonical link: <a href="https://commits.webkit.org/306698@main">https://commits.webkit.org/306698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a1227baa6818edab54a803f4de53f43c0e15201

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150656 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11726 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90083 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11266 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8924 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/712 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120596 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153029 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4078 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117259 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12322 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117578 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13624 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69821 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21922 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14170 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3352 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77886 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->