### PR TITLE
perf issues with rowspan="0" on huge complex tables

### DIFF
--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-1-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x28
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 373x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 373x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
                 RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x22

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-2-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-2-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x222
         RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x28
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 373x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 373x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
                 RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x22

--- a/LayoutTests/platform/glib/tables/mozilla/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x348
       RenderTable {TABLE} at (0,0) size 156x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 154x50
           RenderTableRow {TR} at (0,2) size 154x22
-            RenderTableCell {TD} at (2,14) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,14) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,14) size 66x18
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 64x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x348
             RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (35,14) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,14) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
               RenderText {#text} at (2,14) size 66x18
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x348
       RenderTable {TABLE} at (0,0) size 156x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 154x50
           RenderTableRow {TR} at (0,2) size 154x22
-            RenderTableCell {TD} at (2,14) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,14) size 70x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,14) size 66x18
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 64x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x348
             RenderTableCell {TD} at (2,2) size 31x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 27x18
                 text run at (2,2) width 27: "auto"
-            RenderTableCell {TD} at (35,14) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,14) size 70x22 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
               RenderText {#text} at (2,14) size 66x18
                 text run at (2,2) width 66: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 31x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-1-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (0,0) size 784x40 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x30
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 375x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 375x24 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
                 RenderText {#text} at (2,3) size 27x20
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x24

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-2-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-2-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x240
         RenderTable {TABLE} at (0,0) size 784x40 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x30
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 375x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 375x24 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
                 RenderText {#text} at (2,3) size 27x20
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x24

--- a/LayoutTests/platform/ios/tables/mozilla/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x376
       RenderTable {TABLE} at (0,0) size 158x56 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 156x54
           RenderTableRow {TR} at (0,2) size 156x24
-            RenderTableCell {TD} at (2,15) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,15) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,15) size 67x20
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x376
             RenderTableCell {TD} at (2,2) size 32x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x20
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,15) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,15) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
               RenderText {#text} at (2,15) size 67x20
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x376
       RenderTable {TABLE} at (0,0) size 158x56 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 156x54
           RenderTableRow {TR} at (0,2) size 156x24
-            RenderTableCell {TD} at (2,15) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,15) size 71x24 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,15) size 67x20
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x24 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x376
             RenderTableCell {TD} at (2,2) size 32x24 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x20
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,15) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,15) size 71x24 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
               RenderText {#text} at (2,15) size 67x20
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x24 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x600
         RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x28
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
                 RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x22

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt
@@ -12,7 +12,7 @@ layer at (0,0) size 800x222
         RenderTable {TABLE} at (0,0) size 784x38 [border: (5px outset #000000)]
           RenderTableSection {TBODY} at (5,5) size 774x28
             RenderTableRow {TR} at (0,2) size 774x0
-              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+              RenderTableCell {TD} at (2,3) size 375x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
                 RenderText {#text} at (2,3) size 27x18
                   text run at (2,2) width 27: "One"
             RenderTableRow {TR} at (0,4) size 774x22

--- a/LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x348
       RenderTable {TABLE} at (0,0) size 158x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 156x50
           RenderTableRow {TR} at (0,2) size 156x22
-            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x348
             RenderTableCell {TD} at (2,2) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt
@@ -6,7 +6,7 @@ layer at (0,0) size 800x348
       RenderTable {TABLE} at (0,0) size 158x52 [border: (1px outset #000000)]
         RenderTableSection {TBODY} at (1,1) size 156x50
           RenderTableRow {TR} at (0,2) size 156x22
-            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=65534 cs=1]
+            RenderTableCell {TD} at (2,14) size 71x22 [border: (1px inset #000000)] [r=0 c=0 rs=2 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (74,2) size 66x22 [border: (1px inset #000000)] [r=0 c=1 rs=1 cs=1]
@@ -81,7 +81,7 @@ layer at (0,0) size 800x348
             RenderTableCell {TD} at (2,2) size 32x22 [border: (1px inset #000000)] [r=0 c=0 rs=1 cs=1]
               RenderText {#text} at (2,2) size 28x18
                 text run at (2,2) width 28: "auto"
-            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=65534 cs=1]
+            RenderTableCell {TD} at (35,14) size 71x22 [border: (1px inset #000000)] [r=0 c=1 rs=2 cs=1]
               RenderText {#text} at (2,14) size 67x18
                 text run at (2,2) width 67: "rowspan 0"
             RenderTableCell {TD} at (107,2) size 33x22 [border: (1px inset #000000)] [r=0 c=2 rs=1 cs=1]

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -62,14 +62,10 @@ unsigned HTMLTableCellElement::colSpan() const
 
 unsigned HTMLTableCellElement::rowSpan() const
 {
-    unsigned rowSpanValue = rowSpanForBindings();
-    // when rowspan=0, the HTML spec says it should apply to the full remaining rows.
-    // In https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
-    // > For this attribute, the value zero means that the cell is
-    // > to span all the remaining rows in the row group.
-    if (!rowSpanValue)
-        return maxRowspan;
-    return std::max(1u, rowSpanValue);
+    // When rowspan="0", return 0 to signal "span all remaining rows"
+    // The rendering layer (RenderTableCell::rowSpan) will calculate the actual count
+    // Per HTML spec: https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
+    return rowSpanForBindings();
 }
 
 unsigned HTMLTableCellElement::rowSpanForBindings() const

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include "HTMLTableCellElement.h"
 #include "RenderBlockFlow.h"
 #include "RenderTableRow.h"
 #include "RenderTableSection.h"
@@ -203,6 +204,7 @@ private:
 
     unsigned parseRowSpanFromDOM() const;
     unsigned parseColSpanFromDOM() const;
+    unsigned calculateRowSpanForRowspanZero() const;
 
     void nextSibling() const = delete;
     void previousSibling() const = delete;
@@ -245,7 +247,15 @@ inline unsigned RenderTableCell::rowSpan() const
 {
     if (!m_hasRowSpan)
         return 1;
-    return parseRowSpanFromDOM();
+
+    unsigned span = parseRowSpanFromDOM();
+
+    // Handle rowspan="0" which means "span all remaining rows in the row group"
+    // Per HTML spec: https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan
+    if (!span)
+        span = calculateRowSpanForRowspanZero();
+
+    return std::min(span, maxRowIndex);
 }
 
 inline void RenderTableCell::setCol(unsigned column)


### PR DESCRIPTION
#### f63c817dae2427eb2ee48ae805c8a478086aaec8
<pre>
perf issues with rowspan=&quot;0&quot; on huge complex tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=291405">https://bugs.webkit.org/show_bug.cgi?id=291405</a>
<a href="https://rdar.apple.com/146056348">rdar://146056348</a>

Reviewed by Alan Baradlay.

The HTML specification states that rowspan=&quot;0&quot; should span all remaining
rows in the current table row group (tbody, thead, or tfoot). In a
previous patch, we made WebKit returns maxRowspan (65,534) instead of
calculating the actual number of remaining rows. This caused severe
performance issues during table grid construction.

When RenderTableSection::addCell() processes a cell with rowspan=&quot;0&quot;, it
calls ensureRows(insertionRow + rowSpan) to allocate grid space. With
rowSpan returning 65,534, this created massive grid structures even for
simple tables with just 2-3 rows.

Example:
- A table with 3 rows and 1 cell with rowspan=&quot;0&quot;
- Expected: ensureRows(0 + 3) = 3 rows
- Actual (before fix): ensureRows(0 + 65534) = 65,534 rows
- Result: 65,534 iterations instead of 3 (~21,845x slower)

In more dramatic scenarios, it would crash Safari with tables
with ~1000+ cells with rowspan=&quot;0&quot;, it means millions of iterations.

This patch implements a two-layer approach:

1. DOM Layer (HTMLTableCellElement::rowSpan()):
   Return 0 for rowspan=&quot;0&quot; instead of maxRowspan (65,534)
   This kind of go back to what was done before.

2. Rendering Layer (RenderTableCell::rowSpan()):
   When rowSpan from DOM is 0, calculate actual remaining rows using
   the DOM structure via calculateRowSpanForRowspanZero()

During grid construction (recalcCells()), the DOM structure is complete
but the render tree is being built incrementally. We must count rows
from the DOM, not the render tree.

This fix makes WebKit spec-compliant and matches Chrome/Firefox behavior.

* LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-1-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug30332-2-expected.txt:
* LayoutTests/platform/glib/tables/mozilla/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/glib/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug30332-2-expected.txt:
* LayoutTests/platform/ios/tables/mozilla/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/ios/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug30332-2-expected.txt:
* LayoutTests/platform/mac/tables/mozilla/bugs/bug9879-1-expected.txt:
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug9879-1-expected.txt:

* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::rowSpan const): Return 0 for rowspan=&quot;0&quot;
instead of maxRowspan (65,534).

* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::calculateRowSpanForRowspanZero const):
(WebCore::RenderTableCell::calculateRowSpanForRowspanZero const): Added.
Navigate DOM structure to calculate actual remaining rows in the table
section. Uses sectionElement-&gt;numRows() which is stable during grid
construction, unlike render tree traversal.

* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::rowSpan const):
Add calculateRowSpanForRowspanZero() helper function declaration.
Modify inline rowSpan() to call helper when DOM returns 0.

Canonical link: <a href="https://commits.webkit.org/306891@main">https://commits.webkit.org/306891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9905121332874db3e7dc677459431f549634586b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95780 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0af306c9-e52b-4a47-908e-1f6a10f4d0eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15141 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109665 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90ffd6fc-f398-452a-9ca6-92fc8da68858) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90574 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccace979-5456-47b8-98fd-a25c950b9788) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11646 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9315 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1260 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153574 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14687 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117685 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118020 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30114 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14035 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70378 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14729 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3845 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14466 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14674 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14527 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->