### PR TITLE
Web Inspector: Adding color contrast information within Color Picker

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -443,6 +443,8 @@ localizedStrings["Connection Close Frame"] = "Connection Close Frame";
 localizedStrings["Connection Closed"] = "Connection Closed";
 localizedStrings["Connection ID"] = "Connection ID";
 localizedStrings["Connection:"] = "Connection:";
+/* Label for contrast ratio section in Color Picker */
+localizedStrings["Contrast @ Color Picker"] = "Contrast";
 localizedStrings["Console"] = "Console";
 localizedStrings["Console Evaluation"] = "Console Evaluation";
 localizedStrings["Console Evaluation %d"] = "Console Evaluation %d";
@@ -1943,6 +1945,14 @@ localizedStrings["Warning: "] = "Warning: ";
 localizedStrings["Warnings"] = "Warnings";
 localizedStrings["Watch Expressions"] = "Watch Expressions";
 localizedStrings["Waterfall"] = "Waterfall";
+/* Tooltip for AA contrast line in color picker */
+localizedStrings["WCAG AA minimum contrast (4.5:1) @ Tooltip for AA contrast line in color picker"] = "WCAG AA minimum contrast (4.5:1)";
+/* Tooltip for AA contrast line in color picker for large text */
+localizedStrings["WCAG AA minimum contrast for large text (3:1) @ Tooltip for AA contrast line in color picker"] = "WCAG AA minimum contrast for large text (3:1)";
+/* Tooltip for AAA contrast line in color picker */
+localizedStrings["WCAG AAA enhanced contrast (7:1) @ Tooltip for AAA contrast line in color picker"] = "WCAG AAA enhanced contrast (7:1)";
+/* Tooltip for AAA contrast line in color picker for large text */
+localizedStrings["WCAG AAA enhanced contrast for large text (4.5:1) @ Tooltip for AAA contrast line in color picker"] = "WCAG AAA enhanced contrast for large text (4.5:1)";
 localizedStrings["Web Animation"] = "Web Animation";
 /* Section title for the JavaScript backtrace of the creation of a web animation */
 localizedStrings["Web Animation Backtrace Title"] = "Backtrace";
@@ -2140,3 +2150,5 @@ localizedStrings["unsupported version"] = "unsupported version";
 localizedStrings["value"] = "value";
 /* Placeholder text in an editable field for the value of a HTTP header */
 localizedStrings["value @ Local Override Popover New Headers Data Grid Item"] = "value";
+/* Separator between foreground and background colors in contrast info */
+localizedStrings["vs @ Color Picker Contrast"] = "vs";

--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
@@ -113,6 +113,12 @@
     padding: 8px 0 0;
 }
 
+.color-picker > .contrast-info + .variable-color-swatches {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-color);
+}
+
 .color-picker > .variable-color-swatches > ul{
     list-style: none;
     display: flex;
@@ -137,4 +143,72 @@
 .color-picker > .variable-color-swatches > h2 {
     margin: 0;
     font-size: 1.15em;
+}
+
+.color-picker > .contrast-info {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 0 0;
+    margin-top: 8px;
+    border-top: 1px solid var(--border-color);
+    font-size: 11px;
+}
+
+.color-picker > .contrast-info > .contrast-label {
+    color: var(--text-color-secondary);
+}
+
+.color-picker > .contrast-info > .contrast-ratio {
+    font-variant-numeric: tabular-nums;
+}
+
+.color-picker > .contrast-info > .compliance-badge {
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+}
+
+.color-picker > .contrast-info > .compliance-badge.contrast-aaa {
+    background-color: hsl(120, 50%, 35%);
+    color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+    .color-picker > .contrast-info > .compliance-badge.contrast-aaa {
+        background-color: hsl(120, 50%, 45%);
+    }
+}
+
+.color-picker > .contrast-info > .compliance-badge.contrast-aa {
+    background-color: hsl(90, 50%, 40%);
+    color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+    .color-picker > .contrast-info > .compliance-badge.contrast-aa {
+        background-color: hsl(90, 50%, 50%);
+    }
+}
+
+.color-picker > .contrast-info > .compliance-badge.contrast-fail {
+    background-color: hsl(0, 60%, 50%);
+    color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+    .color-picker > .contrast-info > .compliance-badge.contrast-fail {
+        background-color: hsl(0, 60%, 60%);
+    }
+}
+
+.color-picker > .contrast-info > .contrast-separator {
+    color: var(--text-color-tertiary);
+    margin: 0 2px;
+}
+
+.color-picker > .contrast-info > .inline-swatch {
+    --inline-swatch-margin-right-override: 0;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ColorSquare.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorSquare.css
@@ -99,3 +99,56 @@
         stroke-opacity: var(--stroke-opacity) / 2;
     }
 }
+
+.color-square > .contrast-lines-svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.color-square > .contrast-lines-svg > .contrast-line {
+    fill: none;
+    stroke-width: 1px;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.color-square > .contrast-lines-svg > .contrast-line.contrast-aa-threshold {
+    stroke: white;
+    stroke-opacity: 0.8;
+}
+
+.color-square > .contrast-lines-svg > .contrast-line.contrast-aaa-threshold {
+    stroke: white;
+    stroke-opacity: 0.6;
+}
+
+.color-square > .contrast-label {
+    position: absolute;
+    padding: 1px 3px;
+    font-size: 9px;
+    font-weight: bold;
+    border-radius: 2px;
+    pointer-events: none;
+    z-index: 2;
+    color: white;
+    text-shadow: 0 0 2px black;
+}
+
+.color-square > .contrast-label.contrast-aa-label {
+    opacity: 0.9;
+}
+
+.color-square > .contrast-label.contrast-aaa-label {
+    opacity: 0.7;
+}
+
+@media (prefers-color-scheme: dark) {
+    .color-square > .contrast-label {
+        text-shadow: 0 0 2px white;
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
+++ b/Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js
@@ -346,7 +346,11 @@ WI.InlineSwatch = class InlineSwatch extends WI.Object
             break;
 
         case WI.InlineSwatch.Type.Color:
-            this._valueEditor = new WI.ColorPicker({preventChangingColorFormats: this._preventChangingColorFormats, colorVariables: this._delegate?.inlineSwatchGetColorVariables?.(this)});
+            this._valueEditor = new WI.ColorPicker({
+                preventChangingColorFormats: this._preventChangingColorFormats,
+                colorVariables: this._delegate?.inlineSwatchGetColorVariables?.(this),
+                contrastInfo: this._delegate?.inlineSwatchGetContrastInfo?.(this),
+            });
             this._valueEditor.addEventListener(WI.ColorPicker.Event.ColorChanged, this._valueEditorValueDidChange, this);
             break;
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
@@ -490,6 +490,35 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
         return this._property.ownerStyle.nodeStyles.computedStyle.variablesForType(WI.CSSStyleDeclaration.VariablesGroupType.Colors);
     }
 
+    inlineSwatchGetContrastInfo(inlineSwatch)
+    {
+        let propertyName = this._property.name.toLowerCase();
+        let isTextColorProperty = propertyName === "color" || propertyName === "-webkit-text-fill-color" || propertyName === "-webkit-text-stroke-color";
+
+        if (!isTextColorProperty)
+            return null;
+
+        let computedStyle = this._property.ownerStyle.nodeStyles?.computedStyle;
+        if (!computedStyle)
+            return null;
+
+        let backgroundColor = WI.Color.fromString(computedStyle.propertyForName("background-color")?.value ?? "");
+        if (!backgroundColor)
+            return null;
+
+        if (backgroundColor.alpha < 1)
+            backgroundColor = backgroundColor.blendOverBackground(WI.Color.fromString("white"));
+
+        let fontSizeInPt = parseFloat(computedStyle.propertyForName("font-size")?.value) * 0.75;
+        let isLargeText = fontSizeInPt >= 18;
+        if (!isLargeText && fontSizeInPt >= 14) {
+            let fontWeight = parseInt(computedStyle.propertyForName("font-weight")?.value);
+            isLargeText = fontWeight >= 700;
+        }
+
+        return {backgroundColor, isLargeText};
+    }
+
     // Private
 
     _toggle()


### PR DESCRIPTION
#### 70fe1a50bf5af47e75e73943e95489c7d94c69c5
<pre>
Web Inspector: Adding color contrast information within Color Picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=260101">https://bugs.webkit.org/show_bug.cgi?id=260101</a>
<a href="https://rdar.apple.com/113887185">rdar://113887185</a>

Reviewed by Devin Rousso (OOPS\!).

Add contrast ratio threshold lines to the color picker overlay when editing text color
properties. Two lines indicate AA and AAA WCAG compliance thresholds, helping developers
pick accessible colors without leaving the picker.

All contrast calculations happen in the frontend using the WCAG 2.0 relative luminance
formula (<a href="https://www.w3.org/TR/WCAG20/#relativeluminancedef)">https://www.w3.org/TR/WCAG20/#relativeluminancedef)</a> and contrast ratio formula
(<a href="https://www.w3.org/TR/WCAG20/#contrast-ratiodef).">https://www.w3.org/TR/WCAG20/#contrast-ratiodef).</a> This avoids backend round-trips and
provides instant feedback as users drag within the color square. The implementation uses
binary search to find brightness values that achieve target luminance at each saturation
level, rendering results as SVG polylines.

Semi-transparent foreground colors are blended over the background before calculating
contrast, ensuring accurate ratios for colors with alpha &lt; 1.

WCAG defines relaxed thresholds for &quot;large text&quot; (≥18pt or ≥14pt bold). Normal text requires
4.5:1 for AA and 7:1 for AAA. Large text only requires 3:1 for AA and 4.5:1 for AAA. The
implementation reads computed font-size and font-weight to detect large text and adjusts
the threshold lines accordingly.

A contrast info section below the picker displays the current ratio and
compliance badge (AAA/AA/Fail) alongside the background color swatch.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/Color.js:
(WI.Color.prototype.contrastComplianceForRatio):
(WI.Color.prototype.relativeLuminance):
(WI.Color.prototype.contrastRatio):
(WI.Color.prototype.contrastCompliance):
(WI.Color.prototype.blendOverBackground):
(WI.Color):
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.css:
(.color-picker &gt; .contrast-info + .variable-color-swatches):
(.color-picker &gt; .variable-color-swatches &gt; h2):
(.color-picker &gt; .contrast-info):
(.color-picker &gt; .contrast-info &gt; .contrast-label):
(.color-picker &gt; .contrast-info &gt; .contrast-ratio):
(.color-picker &gt; .contrast-info &gt; .compliance-badge):
(.color-picker &gt; .contrast-info &gt; .compliance-badge.contrast-aaa):
(@media (prefers-color-scheme: dark) .color-picker &gt; .contrast-info &gt; .compliance-badge.contrast-aaa):
(.color-picker &gt; .contrast-info &gt; .compliance-badge.contrast-aa):
(@media (prefers-color-scheme: dark) .color-picker &gt; .contrast-info &gt; .compliance-badge.contrast-aa):
(.color-picker &gt; .contrast-info &gt; .compliance-badge.contrast-fail):
(@media (prefers-color-scheme: dark) .color-picker &gt; .contrast-info &gt; .compliance-badge.contrast-fail):
(.color-picker &gt; .contrast-info &gt; .contrast-separator):
(.color-picker &gt; .contrast-info &gt; .inline-swatch):
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.js:
(WI.ColorPicker.prototype.async colorInputsWrapperElement):
(WI.ColorPicker.prototype.set opacity):
(WI.ColorPicker.prototype.set color):
(WI.ColorPicker.prototype._updateColor):
(WI.ColorPicker.prototype._createContrastInfoSection):
(WI.ColorPicker.prototype._updateContrastInfo):
(WI.ColorPicker):
* Source/WebInspectorUI/UserInterface/Views/ColorSquare.css:
(.color-square &gt; .contrast-lines-svg):
(.color-square &gt; .contrast-lines-svg &gt; .contrast-line):
(.color-square &gt; .contrast-lines-svg &gt; .contrast-line.contrast-aa-threshold):
(.color-square &gt; .contrast-lines-svg &gt; .contrast-line.contrast-aaa-threshold):
(.color-square &gt; .contrast-label):
(.color-square &gt; .contrast-label.contrast-aa-label):
(.color-square &gt; .contrast-label.contrast-aaa-label):
(@media (prefers-color-scheme: dark) .color-square &gt; .contrast-label):
* Source/WebInspectorUI/UserInterface/Views/ColorSquare.js:
(WI.ColorSquare):
(WI.ColorSquare.prototype.get contrastBackgroundColor):
(WI.ColorSquare.prototype.set contrastBackgroundColor):
(WI.ColorSquare.prototype.get opacity):
(WI.ColorSquare.prototype.set opacity):
(WI.ColorSquare.prototype.get isLargeText):
(WI.ColorSquare.prototype.set isLargeText):
(WI.ColorSquare.prototype._updateBaseColor):
(WI.ColorSquare.prototype._drawSRGBOutline):
(WI.ColorSquare.prototype._drawContrastLines):
(WI.ColorSquare.prototype._calculateContrastLinePoints):
(WI.ColorSquare.prototype._findBrightnessForLuminance):
(WI.ColorSquare.prototype._updatePolylinePoints):
(WI.ColorSquare.prototype._updateContrastLabel):
* Source/WebInspectorUI/UserInterface/Views/InlineSwatch.js:
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype.inlineSwatchGetContrastInfo):

Canonical link: <a href="https://commits.webkit.org/308318@main">https://commits.webkit.org/308318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fbf3c41e18259886e18acb083c8db745decffe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155846 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f27667b2-c5fa-4002-a699-2c0da325ee9a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113410 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1c1c46e-cfff-4709-a191-9a7f496bbc8a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132193 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94171 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8fddd38-b306-475b-8237-1b4df7a4414b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3288 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158177 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121437 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16475 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31148 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19655 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131884 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17176 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83016 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18992 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19050 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->