### PR TITLE
Web Inspector: uniqueOrderedStyles could be optimized

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -99,10 +99,21 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
     static uniqueOrderedStyles(orderedStyles)
     {
         let uniqueOrderedStyles = [];
+        let seenRuleIds = new Set;
 
         for (let style of orderedStyles) {
             let rule = style.ownerRule;
             if (!rule) {
+                uniqueOrderedStyles.push(style);
+                continue;
+            }
+
+            let ruleId = rule.id;
+            if (ruleId) {
+                let ruleKey = `${ruleId.styleSheetId}:${ruleId.ordinal}`;
+                if (seenRuleIds.has(ruleKey))
+                    continue;
+                seenRuleIds.add(ruleKey);
                 uniqueOrderedStyles.push(style);
                 continue;
             }


### PR DESCRIPTION
#### 6285cc0dc923129575db36ce490f7b87295da6c1
<pre>
Web Inspector: uniqueOrderedStyles could be optimized
<a href="https://bugs.webkit.org/show_bug.cgi?id=306761">https://bugs.webkit.org/show_bug.cgi?id=306761</a>
<a href="https://rdar.apple.com/problem/169436468">rdar://problem/169436468</a>

Reviewed by BJ Burg and Devin Rousso.

The uniqueOrderedStyles method was using nested loops to filter duplicate CSS rules,
which resulted in O(n²) complexity. This caused noticeable lag when inspecting elements
with many matching rules - pretty common on modern sites using frameworks like Tailwind
or Bootstrap.

The fix uses a Set with rule ID keys for O(1) duplicate detection instead of searching
through the array each time. Since rules are equal when their IDs match (styleSheetId
and ordinal), we can use &quot;${styleSheetId}:${ordinal}&quot; as a unique key. Rules without
IDs (user-agent styles, which are rare) fall back to the original comparison.

* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.uniqueOrderedStyles):

Canonical link: <a href="https://commits.webkit.org/306687@main">https://commits.webkit.org/306687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0538b28f47d857c06e13ee2ab20f1df5adb259bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95060 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70097f9e-cb1b-4461-8c3f-064a72ed6f3f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/14982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109045 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78843 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6650541f-ca93-42f8-8483-b9fa0d0d3383) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89942 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07577ad8-87c4-482a-adbf-8f3033fdb82f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11141 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8779 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/545 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152867 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13960 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117128 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/13975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117449 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29966 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13497 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/123882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69647 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/13998 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3097 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->