### PR TITLE
Update setupCrossRealmTransformReadable implementation following ReadableStream.from improvements

### DIFF
--- a/LayoutTests/streams/transfer-internal-expected.txt
+++ b/LayoutTests/streams/transfer-internal-expected.txt
@@ -1,5 +1,7 @@
 
 PASS Validate readable default behavior
+PASS Validate readable multiple values
+PASS Cancel should reject if reason is not serializable
 PASS Validate readable invalid type
 PASS Validate readable invalid object messages
 PASS Validate writable default behavior

--- a/LayoutTests/streams/transfer-internal.html
+++ b/LayoutTests/streams/transfer-internal.html
@@ -5,9 +5,6 @@
 function createReadableStreamAndPort()
 {
     const channel = new MessageChannel();
-    channel.port1.start();
-    channel.port2.start();
-
     const stream = internals.readableStreamFromMessagePort(channel.port2);
     return { stream, port: channel.port1 };
 }
@@ -51,6 +48,43 @@ promise_test(async t => {
     port.postMessage({ type:"close" });
     await reader.closed;
 }, 'Validate readable default behavior');
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const { stream, port } = createReadableStreamAndPort();
+    const reader = stream.getReader();
+
+    const channel = new MessageChannel();
+    channel.port1.postMessage(port, [port]);
+    const newPort = await new Promise(resolve => channel.port2.onmessage = e => resolve(e.data));
+
+    newPort.postMessage({ type:"chunk", value:"test1" });
+    newPort.postMessage({ type:"chunk", value:"test2" });
+    newPort.postMessage({ type:"chunk", value:"test3" });
+    newPort.postMessage({ type:"close" });
+
+    let chunk = await reader.read();
+    assert_equals(chunk.value, "test1");
+
+    chunk = await reader.read();
+    assert_equals(chunk.value, "test2");
+
+    chunk = await reader.read();
+    assert_equals(chunk.value, "test3");
+
+    await reader.closed;
+}, 'Validate readable multiple values');
+
+promise_test(async t => {
+    if (!window.internals)
+        return;
+
+    const { stream, port } = createReadableStreamAndPort();
+    const reader = stream.getReader();
+    await promise_rejects_js(t, TypeError, stream.cancel(stream));
+}, 'Cancel should reject if reason is not serializable');
 
 promise_test(async t => {
     if (!window.internals)

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -66,6 +66,7 @@ void MessagePort::setMessageHandler(MessageHandler&& messageHandler)
 {
     ASSERT(!m_messageHandler);
     m_messageHandler = WTF::move(messageHandler);
+    start();
 }
 
 bool MessagePort::isMessagePortAliveForTesting(const MessagePortIdentifier& identifier)
@@ -287,7 +288,7 @@ void MessagePort::dispatchMessages()
             if (pendingActivity->object().m_messageHandler) {
                 ASSERT(message.transferredPorts.isEmpty());
                 pendingActivity->object().m_messageHandler(*JSC::jsCast<JSDOMGlobalObject*>(globalObject), message.message.releaseNonNull().get());
-                return;
+                continue;
             }
 
             auto ports = MessagePort::entanglePorts(*context, WTF::move(message.transferredPorts));


### PR DESCRIPTION
#### 83342a89ef1cddb45c3a3f07213d84db3e611e93
<pre>
Update setupCrossRealmTransformReadable implementation following ReadableStream.from improvements
<a href="https://rdar.apple.com/169438536">rdar://169438536</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306763">https://bugs.webkit.org/show_bug.cgi?id=306763</a>

Reviewed by Chris Dumez.

Following on ReadableStream.from implementation, we can now reject the cancel promise and create ReadableStream with a high water mark of 0.
We update setupCrossRealmTransformReadable and CrossRealmReadableStreamSource accordingly.

In addition to that, we fix the case of enqueuing several values at once, which is possible as messages can come in batches.
This requires a fix in MessagePort::dispatchMessages and when pullFinished is called (synchronously in doPull).
We also start a MessagePort when setMessageHandler is called, which is similar to what is done when a JS message event listener is set.
We add a test to cover this.

Canonical link: <a href="https://commits.webkit.org/306704@main">https://commits.webkit.org/306704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64d8971d4cc65db83e2f1a59e9a079685577c26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150683 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea4b3086-f134-4348-a4f2-7152d57acff7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109204 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eeda6e0f-ba40-44f3-a7c3-583b80527458) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11742 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90101 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e866e2b8-e92b-4b33-bc59-bd03778db5cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11278 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8936 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/735 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153052 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14144 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117276 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117596 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13648 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69844 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14193 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3381 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13925 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->