### PR TITLE
REGRESSION(266411@main): [GLib] `mousemove` events are not throttle to one per rendering update

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3527,3 +3527,10 @@ void WKPageClearBackForwardCache(WKPageRef page)
     RefPtr protectedPage = toProtectedImpl(page);
     protect(protectedPage->backForwardCache())->removeEntriesForPage(*protectedPage);
 }
+
+void WKPageDoAfterProcessingAllPendingMouseEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingMouseEventsFunction completionHandler)
+{
+    toProtectedImpl(page)->doAfterProcessingAllPendingMouseEvents([context, completionHandler] {
+        completionHandler(context);
+    });
+}

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -237,6 +237,9 @@ WK_EXPORT void WKPageDisplayAndTrackRepaintsForTesting(WKPageRef page, void* con
 typedef void (*WKPageFindStringForTestingFunction)(bool found, void* functionContext);
 WK_EXPORT void WKPageFindStringForTesting(WKPageRef page, void* context, WKStringRef string, WKFindOptions options, unsigned maxMatchCount, WKPageFindStringForTestingFunction completionHandler);
 
+typedef void (*WKPageDoAfterProcessingAllPendingMouseEventsFunction)(void* functionContext);
+WK_EXPORT void WKPageDoAfterProcessingAllPendingMouseEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingMouseEventsFunction function);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3690,7 +3690,7 @@ void WebPage::mouseEvent(FrameIdentifier frameID, const WebMouseEvent& mouseEven
 
     flushDeferredDidReceiveMouseEvent();
 
-    if (shouldDeferDidReceiveEvent && drawingArea->scheduleRenderingUpdate()) {
+    if (shouldDeferDidReceiveEvent) {
         // For mousemove events where the user is only hovering (not clicking and dragging),
         // we defer sending the DidReceiveEvent() IPC message until the end of the rendering
         // update to throttle the rate of these events to the rendering update frequency.
@@ -3698,6 +3698,7 @@ void WebPage::mouseEvent(FrameIdentifier frameID, const WebMouseEvent& mouseEven
         // coalesces mousemove events until the DidReceiveEvent() message is received after
         // the rendering update.
         m_deferredDidReceiveMouseEvent = { { mouseEvent.type(), handled } };
+        protect(corePage())->scheduleRenderingUpdate({ });
         return;
     }
 

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -49,7 +49,6 @@ namespace WTR {
 
 void TestController::notifyDone()
 {
-    RunLoop::mainSingleton().stop();
 }
 
 void TestController::platformInitialize(const Options&)
@@ -68,7 +67,6 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
         TimeoutTimer(WTF::Seconds timeout, bool& timedOut)
             : m_timer(RunLoop::mainSingleton(), "TestController::TimeoutTimer"_s, [&timedOut] {
                 timedOut = true;
-                RunLoop::mainSingleton().stop();
             })
         {
             m_timer.setPriority(G_PRIORITY_DEFAULT_IDLE);
@@ -79,8 +77,9 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
         RunLoop::Timer m_timer;
     } timeoutTimer(timeout, timedOut);
 
+    auto* mainContext = g_main_context_default();
     while (!done && !timedOut)
-        RunLoop::mainSingleton().run();
+        g_main_context_iteration(mainContext, TRUE);
 }
 
 static char* getEnvironmentVariableAsUTF8String(const char* variableName)

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -30,6 +30,7 @@
 #include "PlatformWebView.h"
 #include "TestController.h"
 #include <WebCore/NotImplemented.h>
+#include <WebKit/WKPagePrivate.h>
 
 namespace WTR {
 
@@ -367,8 +368,30 @@ void EventSenderProxy::cancelTouchPoint(int)
 }
 #endif // ENABLE(TOUCH_EVENTS)
 
+struct DoAfterProcessingAllPendingMouseEventsCallbackContext {
+    bool done { false };
+    bool timedOut { false };
+};
+
+static void doAfterProcessingAllPendingMouseEventsCallback(void* userData)
+{
+    auto* context = static_cast<DoAfterProcessingAllPendingMouseEventsCallbackContext*>(userData);
+    if (context->timedOut) {
+        delete context;
+        return;
+    }
+    context->done = true;
+}
+
 void EventSenderProxy::waitForPendingMouseEvents()
 {
+    auto* context = new DoAfterProcessingAllPendingMouseEventsCallbackContext;
+    WKPageDoAfterProcessingAllPendingMouseEvents(m_testController->mainWebView()->page(), context, doAfterProcessingAllPendingMouseEventsCallback);
+    m_testController->runUntil(context->done, 100_ms);
+    if (context->done)
+        delete context;
+    else
+        context->timedOut = true;
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -43,7 +43,6 @@ namespace WTR {
 
 void TestController::notifyDone()
 {
-    RunLoop::mainSingleton().stop();
 }
 
 void TestController::setHidden(bool)
@@ -68,9 +67,8 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
     class TimeoutTimer {
     public:
         TimeoutTimer(WTF::Seconds timeout, bool& timedOut)
-            : m_timer(RunLoop::mainSingleton(), "TestController::TimeoutTimer::Timer"_s, [&timedOut] {
+            : m_timer(RunLoop::mainSingleton(), "TestController::TimeoutTimer"_s, [&timedOut] {
                 timedOut = true;
-                RunLoop::mainSingleton().stop();
             })
         {
             m_timer.setPriority(G_PRIORITY_DEFAULT_IDLE);
@@ -81,8 +79,9 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
         RunLoop::Timer m_timer;
     } timeoutTimer(timeout, timedOut);
 
+    auto* mainContext = g_main_context_default();
     while (!done && !timedOut)
-        RunLoop::mainSingleton().run();
+        g_main_context_iteration(mainContext, TRUE);
 }
 
 void TestController::platformDidCommitLoadForFrame(WKPageRef, WKFrameRef)


### PR DESCRIPTION
#### 548162624138f2bbd8079ae8474feb8e504937f8
<pre>
REGRESSION(266411@main): [GLib] `mousemove` events are not throttle to one per rendering update
<a href="https://bugs.webkit.org/show_bug.cgi?id=306766">https://bugs.webkit.org/show_bug.cgi?id=306766</a>

Reviewed by Wenson Hsieh and Darin Adler.

Starting from 266411@main, it is required for a `DrawingArea` subclass
to override `scheduleRenderingUpdate()` and return `true` in order to
enable throttling of `mousemove` events to one per rendering update.
This method is currently only implemented by `RemoteLayerTreeDrawingArea`
which is used by Apple ports. The main purpose of it is to schedule next
rendering update to process deferred `mousemove` events. But it is
possible to schedule next rendering update by calling
`RenderingUpdateScheduler::scheduleRenderingUpdate()` which is driven by
the display refresh monitor.

This patch also implements `EventSenderProxy::waitForPendingMouseEvents()`
on GTK, WPE, and Windows by calling a new private
`WKPageDoAfterProcessingAllPendingMouseEvents()` function, which is
required to pass layout tests that use asynchronous mouse events.

Because `EventSenderProxy::waitForPendingMouseEvents()` internally calls
`m_testController-&gt;runUntil()`, `TestController::platformRunUntil()` now
explicitly iterates the main context instead of running and stopping the
main run loop to avoid completely stopping the TestController after
processing pending mouse events, which would cause tests to time out.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageDoAfterProcessingAllPendingMouseEvents):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::mouseEvent):
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::doAfterProcessingAllPendingMouseEventsCallback):
(WTR::EventSenderProxy::waitForPendingMouseEvents):
* Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp:
(WTR::TestController::notifyDone):
(WTR::TestController::platformRunUntil):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp:
(WTR::doAfterProcessingAllPendingMouseEventsCallback):
(WTR::EventSenderProxy::waitForPendingMouseEvents):
* Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp:
(WTR::doAfterProcessingAllPendingMouseEventsCallback):
(WTR::EventSenderProxy::waitForPendingMouseEvents):
* Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp:
(WTR::TestController::notifyDone):
(WTR::TestController::platformRunUntil):

Canonical link: <a href="https://commits.webkit.org/307370@main">https://commits.webkit.org/307370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bde4b2500c52dbc98136386c00b4a24d1c948a2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152806 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17297 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110831 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10438 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/252 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122183 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155118 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118847 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119205 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30574 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15091 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127357 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72088 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16289 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5795 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80068 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->