### PR TITLE
[WPE] Web Inspector: implement platformSave

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -245,6 +245,7 @@ UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 
 UIProcess/Inspector/glib/RemoteInspectorClient.cpp
 UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
 
 UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
 UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -256,6 +256,7 @@ UIProcess/gstreamer/WebPageProxyGStreamer.cpp
 
 UIProcess/Inspector/glib/RemoteInspectorClient.cpp
 UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
 
 UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -260,6 +260,9 @@ private:
     void platformStartWindowDrag();
     void platformRevealFileExternally(const String&);
     void platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool forceSaveAs);
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    void platformSaveDataToFile(GRefPtr<GFile>&&, const String& content, bool base64Encoded);
+#endif
     void platformLoad(const String& path, CompletionHandler<void(const String&)>&&);
     void platformPickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&&);
 

--- a/Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,50 +24,44 @@
  */
 
 #include "config.h"
-#include "WebInspectorUI.h"
-
-#if ENABLE(WPE_PLATFORM)
+#include "WebInspectorUIProxy.h"
 
 #include <gio/gio.h>
-#include <wtf/glib/GResources.h>
+#include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/Base64.h>
 
 namespace WebKit {
 
-void WebInspectorUI::didEstablishConnection()
+static void fileReplaceContentsCallback(GObject* sourceObject, GAsyncResult* result, gpointer)
 {
-    WTF::registerInspectorResourceIfNeeded();
+    GFile* file = G_FILE(sourceObject);
+    g_file_replace_contents_finish(file, result, nullptr, nullptr);
 }
 
-bool WebInspectorUI::canSave(InspectorFrontendClient::SaveMode saveMode)
+void WebInspectorUIProxy::platformSaveDataToFile(GRefPtr<GFile>&& file, const String& content, bool base64Encoded)
 {
-    switch (saveMode) {
-    case InspectorFrontendClient::SaveMode::SingleFile:
-        return true;
+    GUniqueOutPtr<GError> error;
 
-    case InspectorFrontendClient::SaveMode::FileVariants:
-        return false;
-    }
+    Vector<uint8_t> dataVector;
+    CString dataString;
+    if (base64Encoded) {
+        auto decodedData = base64Decode(content);
+        if (!decodedData)
+            return;
+        decodedData->shrinkToFit();
+        dataVector = WTF::move(*decodedData);
+    } else
+        dataString = content.utf8();
 
-    ASSERT_NOT_REACHED();
-    return false;
-}
+    const char* data = !dataString.isNull() ? dataString.data() : reinterpret_cast<const char*>(dataVector.span().data());
+    size_t dataLength = !dataString.isNull() ? dataString.length() : dataVector.size();
 
-bool WebInspectorUI::canLoad()
-{
-    return false;
-}
+    g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
+        G_FILE_CREATE_NONE, nullptr, fileReplaceContentsCallback, protect(inspectorPage()).get());
 
-bool WebInspectorUI::canPickColorFromScreen()
-{
-    return false;
-}
-
-String WebInspectorUI::localizedStringsURL() const
-{
-    return "resource:///org/webkit/inspector/Localizations/en.lproj/localizedStrings.js"_s;
+    if (error)
+        g_warning("Failed to save inspector data: %s", error->message);
 }
 
 } // namespace WebKit
-
-#endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -529,12 +529,6 @@ void WebInspectorUIProxy::platformStartWindowDrag()
     notImplemented();
 }
 
-static void fileReplaceContentsCallback(GObject* sourceObject, GAsyncResult* result, gpointer userData)
-{
-    GFile* file = G_FILE(sourceObject);
-    g_file_replace_contents_finish(file, result, nullptr, nullptr);
-}
-
 void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
 {
     ASSERT(saveDatas.size() == 1);
@@ -562,23 +556,8 @@ void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::
     if (gtk_native_dialog_run(GTK_NATIVE_DIALOG(dialog.get())) != GTK_RESPONSE_ACCEPT)
         return;
 
-    Vector<uint8_t> dataVector;
-    CString dataString;
-    if (saveDatas[0].base64Encoded) {
-        auto decodedData = base64Decode(saveDatas[0].content, { Base64DecodeOption::ValidatePadding });
-        if (!decodedData)
-            return;
-        decodedData->shrinkToFit();
-        dataVector = WTF::move(*decodedData);
-    } else
-        dataString = saveDatas[0].content.utf8();
-
-    const char* data = !dataString.isNull() ? dataString.data() : reinterpret_cast<const char*>(dataVector.span().data());
-    size_t dataLength = !dataString.isNull() ? dataString.length() : dataVector.size();
     GRefPtr<GFile> file = adoptGRef(gtk_file_chooser_get_file(chooser));
-    GUniquePtr<char> path(g_file_get_path(file.get()));
-    g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
-        G_FILE_CREATE_REPLACE_DESTINATION, nullptr, fileReplaceContentsCallback, protect(inspectorPage()).get());
+    platformSaveDataToFile(WTF::move(file), saveDatas[0].content, saveDatas[0].base64Encoded);
 }
 
 void WebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
@@ -230,9 +230,25 @@ void WebInspectorUIProxy::platformShowCertificate(const WebCore::CertificateInfo
     notImplemented();
 }
 
-void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool /* forceSaveAs */)
+void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&& saveDatas, bool forceSaveAs)
 {
-    notImplemented();
+    ASSERT(saveDatas.size() == 1);
+    UNUSED_PARAM(forceSaveAs);
+
+    // Some inspector views (Audits for instance) use a custom URI scheme, such
+    // as web-inspector. So we can't rely on the URL being a valid file:/// URL
+    // unfortunately.
+    URL url { saveDatas[0].url };
+    auto* filename = url.path().substring(1).utf8().data();
+
+    const gchar* downloadsDir = g_get_user_special_dir(G_USER_DIRECTORY_DOWNLOAD);
+    if (!downloadsDir) {
+        // If we don't have XDG user dirs info, set just to HOME.
+        downloadsDir = g_get_home_dir();
+    }
+
+    GRefPtr<GFile> file = adoptGRef(g_file_new_build_filename(downloadsDir, filename, nullptr));
+    platformSaveDataToFile(WTF::move(file), saveDatas[0].content, saveDatas[0].base64Encoded);
 }
 
 void WebInspectorUIProxy::platformLoad(const String&, CompletionHandler<void(const String&)>&& completionHandler)


### PR DESCRIPTION
#### 657ee259022b8d9de156d21aaf0ef08ca3e0ae30
<pre>
[WPE] Web Inspector: implement platformSave
<a href="https://bugs.webkit.org/show_bug.cgi?id=306768">https://bugs.webkit.org/show_bug.cgi?id=306768</a>

Reviewed by NOBODY (OOPS!).

Extracted a common GIO-based implementation for WebKitGTK and WPE WebKit
into WebInspectorUIProxyGLib.

For WebKitGTK, the logic keeps using file chooser dialog to get an
appropriate destination filename.

For WPE, this uses G_USER_DIRECTORY_DOWNLOAD and falls back to the
user&apos;s home directory if undefined, saving the file there with the first
8 elements of the contents hash to avoid accidental overwrites.

* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp: Added.
(WebKit::fileReplaceContentsCallback):
(WebKit::platformSaveDataToFile):
* Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.h:
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformSave):
(WebKit::fileReplaceContentsCallback): Deleted.
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::computeContentHash):
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/WebProcess/Inspector/wpe/WebInspectorUIWPE.cpp:
(WebKit::WebInspectorUI::canSave):
</pre>