### PR TITLE
Add support for transferable readable streams

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
@@ -137,5 +137,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
@@ -122,5 +122,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
@@ -122,5 +122,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
@@ -122,5 +122,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
@@ -137,5 +137,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
@@ -137,5 +137,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
@@ -122,5 +122,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/readable-stream-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/readable-stream-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL sending one chunk through a transferred stream should work promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL sending ten chunks through a transferred stream should work promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL sending ten chunks one at a time should work promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL sending ten chunks on demand should work promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL transferring a stream should relieve backpressure promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL transferring a stream should add one chunk to the queue size promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL the extra queue from transferring is counted in chunks promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL cancel should be propagated to the original promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL cancel should abort a pending read() promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL stream cancel should not wait for underlying source cancel promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL serialization should not happen until the value is read promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL transferring a non-serializable chunk should error both sides promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL errors should be passed through promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL race between cancel() and error() should leave sides in different states promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL race between cancel() and close() should be benign promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL race between cancel() and enqueue() should be benign promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS sending one chunk through a transferred stream should work
+PASS sending ten chunks through a transferred stream should work
+PASS sending ten chunks one at a time should work
+PASS sending ten chunks on demand should work
+PASS transferring a stream should relieve backpressure
+PASS transferring a stream should add one chunk to the queue size
+PASS the extra queue from transferring is counted in chunks
+FAIL cancel should be propagated to the original assert_array_equals: cancel() should have been called lengths differ, expected array ["pull", "cancel", "message"] length 3, got ["pull", "pull", "cancel", "message"] length 4
+FAIL cancel should abort a pending read() assert_array_equals: events should match lengths differ, expected array ["pull", "cancel", "done"] length 3, got ["pull", "pull", "cancel", "done"] length 4
+PASS stream cancel should not wait for underlying source cancel
+PASS serialization should not happen until the value is read
+PASS transferring a non-serializable chunk should error both sides
+PASS errors should be passed through
+PASS race between cancel() and error() should leave sides in different states
+PASS race between cancel() and close() should be benign
+PASS race between cancel() and enqueue() should be benign
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/reason-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/reason-expected.txt
@@ -1,29 +1,29 @@
 
-FAIL reason with a simple value of 'hi' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of '	\r
-' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of '7' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of '3' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of 'undefined' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of 'null' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of 'true' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of 'false' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of 'NaN' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL reason with a simple value of 'Infinity' should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS reason with a simple value of 'hi' should be preserved
+PASS reason with a simple value of '	\r
+' should be preserved
+PASS reason with a simple value of '7' should be preserved
+PASS reason with a simple value of '3' should be preserved
+PASS reason with a simple value of 'undefined' should be preserved
+PASS reason with a simple value of 'null' should be preserved
+PASS reason with a simple value of 'true' should be preserved
+PASS reason with a simple value of 'false' should be preserved
+PASS reason with a simple value of 'NaN' should be preserved
+PASS reason with a simple value of 'Infinity' should be preserved
 PASS reason with a type of 'symbol' should be rejected and error the stream
 PASS reason with a type of 'function' should be rejected and error the stream
-FAIL objects that can be completely expressed in JSON should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL objects that cannot be expressed in JSON should also be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL the type and message of a TypeError should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL other attributes of a TypeError should not be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL a TypeError message should be converted to a string promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL a TypeError message should not be preserved if it is a getter promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL a TypeError message should not be preserved if it is inherited promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL DOMException errors should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError should be preserved promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS objects that can be completely expressed in JSON should be preserved
+PASS objects that cannot be expressed in JSON should also be preserved
+PASS the type and message of a TypeError should be preserved
+PASS other attributes of a TypeError should not be preserved
+PASS a TypeError message should be converted to a string
+PASS a TypeError message should not be preserved if it is a getter
+PASS a TypeError message should not be preserved if it is inherited
+PASS DOMException errors should be preserved
+PASS EvalError should be preserved
+PASS RangeError should be preserved
+PASS ReferenceError should be preserved
+PASS SyntaxError should be preserved
+PASS TypeError should be preserved
+PASS URIError should be preserved
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/service-worker.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/service-worker.https-expected.txt
@@ -1,5 +1,5 @@
 
 PASS service-worker
-FAIL serviceWorker.controller.postMessage should be able to transfer a ReadableStream The object can not be cloned.
-FAIL postMessage in a service worker should be able to transfer ReadableStream promise_test: Unhandled rejection with value: "The object can not be cloned."
+PASS serviceWorker.controller.postMessage should be able to transfer a ReadableStream
+PASS postMessage in a service worker should be able to transfer ReadableStream
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/shared-worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/shared-worker-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL worker.postMessage should be able to transfer a ReadableStream The object can not be cloned.
-FAIL postMessage in a worker should be able to transfer a ReadableStream promise_test: Unhandled rejection with value: "The object can not be cloned."
+PASS worker.postMessage should be able to transfer a ReadableStream
+PASS postMessage in a worker should be able to transfer a ReadableStream
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transfer-with-messageport.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transfer-with-messageport.window-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Transferring a MessagePort with a ReadableStream should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Transferring a MessagePort with a ReadableStream should set `.ports`
 FAIL Transferring a MessagePort with a WritableStream should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
 FAIL Transferring a MessagePort with a TransformStream should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Transferring a MessagePort with a ReadableStream should set `.ports`, advanced promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Transferring a MessagePort with a ReadableStream should set `.ports`, advanced
 FAIL Transferring a MessagePort with a WritableStream should set `.ports`, advanced promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
 FAIL Transferring a MessagePort with a TransformStream should set `.ports`, advanced promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
 FAIL Transferring a MessagePort with multiple streams should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/window-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL window.postMessage should be able to transfer a ReadableStream The object can not be cloned.
-FAIL port.postMessage should be able to transfer a ReadableStream The object can not be cloned.
-FAIL the same ReadableStream posted multiple times should arrive together The object can not be cloned.
-FAIL transfer to and from an iframe should work promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS window.postMessage should be able to transfer a ReadableStream
+PASS port.postMessage should be able to transfer a ReadableStream
+PASS the same ReadableStream posted multiple times should arrive together
+PASS transfer to and from an iframe should work
 

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/worker-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL worker.postMessage should be able to transfer a ReadableStream The object can not be cloned.
-FAIL postMessage in a worker should be able to transfer a ReadableStream promise_test: Unhandled rejection with value: "error in worker"
-FAIL terminating a worker should not error the stream promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS worker.postMessage should be able to transfer a ReadableStream
+PASS postMessage in a worker should be able to transfer a ReadableStream
+PASS terminating a worker should not error the stream
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
@@ -137,5 +137,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
@@ -137,5 +137,5 @@ PASS A detached ArrayBuffer cannot be transferred
 PASS A detached platform object cannot be transferred
 PASS Transferring a non-transferable platform object fails
 PASS An object whose interface is deleted from the global object must still be received
-NOTRUN A subclass instance will be received as its closest transferable superclass ReadableStream isn't transferable
+PASS A subclass instance will be received as its closest transferable superclass
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6412,6 +6412,20 @@ ReadableStreamIterableEnabled:
     WebKit:
       default: true
 
+ReadableStreamTransferEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "ReadableStream transfer"
+  humanReadableDescription: "Enable ReadableStream transfer"
+  defaultValue:
+    WebCore:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+
 RemoteMediaSessionManagerEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -46,6 +46,7 @@ class DOMPromise;
 class DeferredPromise;
 class InternalReadableStream;
 class JSDOMGlobalObject;
+class MessagePort;
 class ReadableStreamBYOBReader;
 class ReadableStreamDefaultReader;
 class ReadableStreamReadRequest;
@@ -56,6 +57,10 @@ struct StreamPipeOptions;
 struct UnderlyingSource;
 
 using ReadableStreamReader = Variant<RefPtr<ReadableStreamDefaultReader>, RefPtr<ReadableStreamBYOBReader>>;
+
+struct DetachedReadableStream {
+    Ref<MessagePort> readableStreamPort;
+};
 
 class ReadableStream : public RefCounted<ReadableStream>, public ContextDestructionObserver {
 public:
@@ -80,6 +85,9 @@ public:
 
     virtual ~ReadableStream();
 
+    ExceptionOr<DetachedReadableStream> runTransferSteps(JSDOMGlobalObject&);
+    static ExceptionOr<Ref<ReadableStream>> runTransferReceivingSteps(JSDOMGlobalObject&, DetachedReadableStream&&);
+
     // ContextDestructionObserver.
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
@@ -93,6 +101,7 @@ public:
 
     void lock();
     bool isLocked() const;
+    bool canTransfer() const;
     WEBCORE_EXPORT bool isDisturbed() const;
 
     Ref<DOMPromise> cancel(JSDOMGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -40,6 +40,7 @@
 #include "JSAudioWorkletProcessor.h"
 #include "JSAudioWorkletProcessorConstructor.h"
 #include "JSDOMConvert.h"
+#include "SerializedScriptValue.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/JSLock.h>
 #include <wtf/CrossThreadCopier.h>

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -36,6 +36,7 @@
 
 namespace JSC {
 class CallFrame;
+class JSGlobalObject;
 class JSObject;
 class JSValue;
 }

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -91,7 +91,7 @@ ExceptionOr<JSC::JSValue> WindowOrWorkerGlobalScope::structuredClone(JSDOMGlobal
     if (RefPtr scriptExecutionContext = relevantGlobalObject.scriptExecutionContext())
         entangledPorts = MessagePort::entanglePorts(*scriptExecutionContext, disentangledPorts.releaseReturnValue());
 
-    return messageData.returnValue()->deserialize(lexicalGlobalObject, &relevantGlobalObject, WTF::move(entangledPorts));
+    return messageData.returnValue()->deserialize(lexicalGlobalObject, &relevantGlobalObject, entangledPorts);
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8051,6 +8051,9 @@ headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessageP
 #if ENABLE(WEB_CODECS)
     Vector<Ref<WebCore::WebCodecsEncodedVideoChunkStorage>> serializedVideoChunks;
     Vector<Ref<WebCore::WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
+#endif
+    uint64_t exposedMessagePortCount;
+#if ENABLE(WEB_CODECS)
     [NotSerialized] Vector<WebCore::WebCodecsVideoFrameData> serializedVideoFrames;
     [NotSerialized] Vector<WebCore::WebCodecsAudioInternalData> serializedAudioData;
 #endif


### PR DESCRIPTION
#### 38a02eb7dd7533ac68da49b7356ff869322eec10
<pre>
Add support for transferable readable streams
<a href="https://rdar.apple.com/169179559">rdar://169179559</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306526">https://bugs.webkit.org/show_bug.cgi?id=306526</a>

Reviewed by Chris Dumez.

We add a runtime flag to control whether readable streams can be transfered.
We implement <a href="https://streams.spec.whatwg.org/#rs-transfer">https://streams.spec.whatwg.org/#rs-transfer</a> based on the newly added infrastructure.

For each readable stream, a port is added to the list of transferred ports.
To make sure these ports are not exposed through MessageEvent.ports, we store in SerializedScriptValue the number of ports to expose.
And we resize the list of ports after deserialization.

Canonical link: <a href="https://commits.webkit.org/306763@main">https://commits.webkit.org/306763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1224987bf5fa75813e940dc3c84990aa02d36002

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142166 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95342 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c071ff71-f277-4a76-aa5a-7d229ac7a9c9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109299 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78985 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4cb99d1a-8722-4966-9661-2de6c8ced8b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127251 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90198 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5e32c0e-af9b-4568-a2f1-29370814c019) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11353 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9018 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/832 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134150 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153149 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2970 "Found unexpected failure with change (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117354 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14263 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12426 "Found 1 new test failure: webrtc/audio-addTransceiver.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117676 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13728 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124447 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69941 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14290 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3488 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173455 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14022 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78006 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44893 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14067 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->