### PR TITLE
[Bindings] Make the ImplementationRequired extended attribute a parse time transformation like ImplementationDefaultValue

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -1928,8 +1928,7 @@ sub GetDictionaryMemberDefaultValueFunctor
 {
     my ($interface, $member) = @_;
 
-    my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
-    if (!$effectivelyRequired && defined $member->default && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) {
+    if (!$member->isRequired && defined $member->default && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) {
         my $IDLType = GetIDLType($interface, $member->type);
         my $defaultValue = GenerateDefaultValue($interface, $member, $member->type, $member->default);
         return "[&] -> ConversionResult<${IDLType}> { return ${defaultValue}; }";
@@ -2914,8 +2913,7 @@ sub GenerateDictionaryImplementationMemberConversion
     }
 
     my $defaultValueFunctor = GetDictionaryMemberDefaultValueFunctor($typeScope, $member);
-    my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
-    my $optional = !$effectivelyRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
+    my $optional = !$member->isRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
 
     my $conversion;
     if ($member->extendedAttributes->{PermissiveInvalidValue} && $codeGenerator->IsEnumType($type)) {
@@ -3224,8 +3222,7 @@ sub GenerateConvertDictionaryToJS
                 $indent = "    ";
             }
 
-            my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
-            if (!$effectivelyRequired && not defined $member->default) {
+            if (!$member->isRequired && not defined $member->default) {
                 my $IDLType = GetIDLType($typeScope, $member->type);
                 my $conversionExpression = NativeToJSValueUsingReferences($member, $typeScope, "${IDLType}::extractValueFromNullable(${valueExpression})", "globalObject");
 
@@ -3316,8 +3313,7 @@ sub GenerateConvertDictionaryToJSForLegacyNativeDictionaryRequiredInterfaceNulla
                 $indent = "    ";
             }
 
-            my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
-            if (!$effectivelyRequired && not defined $member->default) {
+            if (!$member->isRequired && not defined $member->default) {
                 my $IDLType = GetIDLType($typeScope, $member->type);
                 my $conversionExpression = NativeToJSValueUsingReferences($member, $typeScope, "${IDLType}::extractValueFromNullable(${valueExpression})", "globalObject");
 
@@ -8139,8 +8135,7 @@ sub GetIDLTypeForDictionaryMember
     my ($interface, $member) = @_;
 
     my $defaultValueFunctor = GetDictionaryMemberDefaultValueFunctor($interface, $member);
-    my $effectivelyRequired = $member->isRequired || $member->extendedAttributes->{ImplementationRequired};
-    my $optional = !$effectivelyRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
+    my $optional = !$member->isRequired && ((defined($member->default) && !WillConvertUndefinedToDefaultParameterValue($member->type, $member->default)) || !defined($member->default));
 
     my $IDLType = GetIDLType($interface, $member->type);
     $IDLType = "IDLOptional<" . $IDLType . ">" if $optional && !$defaultValueFunctor;

--- a/Source/WebCore/bindings/scripts/IDLParser.pm
+++ b/Source/WebCore/bindings/scripts/IDLParser.pm
@@ -1436,7 +1436,12 @@ sub parseDictionaryMember
 
             $self->assertExtendedAttributesValidForContext($extendedAttributeList, "dictionary-member");
 
-            # Substitute a value specified by the `ImplementationDefaultValue` extended attribute if necessary.
+            # Override `isRequired` if the `ImplementationRequired` extended attribute is set.
+            if (defined($extendedAttributeList->{ImplementationRequired})) {
+                $member->isRequired(1);
+            }
+
+            # Override `default` if the `ImplementationDefaultValue` extended attribute is set.
             if (!defined($member->default) && defined($extendedAttributeList->{ImplementationDefaultValue})) {
                 $member->default($extendedAttributeList->{ImplementationDefaultValue});
             }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -852,6 +852,16 @@ static_assert(IsIncreasing<
     , offsetof(TestObj::Dictionary, requiredBufferSourceValue)
     , offsetof(TestObj::Dictionary, annotatedTypeInUnionMember)
     , offsetof(TestObj::Dictionary, annotatedTypeInSequenceMember)
+    , offsetof(TestObj::Dictionary, integerWithImplementationDefaultValue)
+    , offsetof(TestObj::Dictionary, sequenceWithImplementationDefaultValue)
+    , offsetof(TestObj::Dictionary, dictionaryWithImplementationDefaultValue)
+    , offsetof(TestObj::Dictionary, nullableIntegerWithImplementationDefaultValue)
+    , offsetof(TestObj::Dictionary, nullableNodeWithImplementationDefaultValue)
+    , offsetof(TestObj::Dictionary, integerWithImplementationRequired)
+    , offsetof(TestObj::Dictionary, sequenceWithImplementationRequired)
+    , offsetof(TestObj::Dictionary, dictionaryWithImplementationRequired)
+    , offsetof(TestObj::Dictionary, nullableIntegerWithImplementationRequired)
+    , offsetof(TestObj::Dictionary, nullableNodeWithImplementationRequired)
 >);
 
 IGNORE_WARNINGS_END
@@ -966,6 +976,30 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
     auto dictionaryMemberWithDefaultConversionResult = convert<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, dictionaryMemberWithDefaultValue);
     if (dictionaryMemberWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
+    JSValue dictionaryWithImplementationDefaultValueValue;
+    if (isNullOrUndefined)
+        dictionaryWithImplementationDefaultValueValue = jsUndefined();
+    else {
+        dictionaryWithImplementationDefaultValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "dictionaryWithImplementationDefaultValue"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto dictionaryWithImplementationDefaultValueConversionResult = convert<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, dictionaryWithImplementationDefaultValueValue);
+    if (dictionaryWithImplementationDefaultValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue dictionaryWithImplementationRequiredValue;
+    if (isNullOrUndefined)
+        dictionaryWithImplementationRequiredValue = jsUndefined();
+    else {
+        dictionaryWithImplementationRequiredValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "dictionaryWithImplementationRequired"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    if (dictionaryWithImplementationRequiredValue.isUndefined()) {
+        throwRequiredMemberTypeError(lexicalGlobalObject, throwScope, "dictionaryWithImplementationRequired"_s, "TestDictionary"_s, "ParentDictionary"_s);
+        return ConversionResultException { };
+    }
+    auto dictionaryWithImplementationRequiredConversionResult = convert<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, dictionaryWithImplementationRequiredValue);
+    if (dictionaryWithImplementationRequiredConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
     JSValue enumerationValueWithDefaultValue;
     if (isNullOrUndefined)
         enumerationValueWithDefaultValue = jsUndefined();
@@ -1036,6 +1070,30 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
     auto integerWithDefaultConversionResult = convert<IDLLong>(lexicalGlobalObject, integerWithDefaultValue);
     if (integerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
+    JSValue integerWithImplementationDefaultValueValue;
+    if (isNullOrUndefined)
+        integerWithImplementationDefaultValueValue = jsUndefined();
+    else {
+        integerWithImplementationDefaultValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "integerWithImplementationDefaultValue"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto integerWithImplementationDefaultValueConversionResult = convert<IDLLong>(lexicalGlobalObject, integerWithImplementationDefaultValueValue);
+    if (integerWithImplementationDefaultValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue integerWithImplementationRequiredValue;
+    if (isNullOrUndefined)
+        integerWithImplementationRequiredValue = jsUndefined();
+    else {
+        integerWithImplementationRequiredValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "integerWithImplementationRequired"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    if (integerWithImplementationRequiredValue.isUndefined()) {
+        throwRequiredMemberTypeError(lexicalGlobalObject, throwScope, "integerWithImplementationRequired"_s, "TestDictionary"_s, "long"_s);
+        return ConversionResultException { };
+    }
+    auto integerWithImplementationRequiredConversionResult = convert<IDLLong>(lexicalGlobalObject, integerWithImplementationRequiredValue);
+    if (integerWithImplementationRequiredConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
     JSValue largeIntegerValue;
     if (isNullOrUndefined)
         largeIntegerValue = jsUndefined();
@@ -1076,6 +1134,30 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
     auto nullableIntegerWithDefaultConversionResult = convertOptionalWithDefault<IDLNullable<IDLLong>>(lexicalGlobalObject, nullableIntegerWithDefaultValue, [&] -> ConversionResult<IDLNullable<IDLLong>> { return typename Converter<IDLNullable<IDLLong>>::ReturnType { std::nullopt }; });
     if (nullableIntegerWithDefaultConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
+    JSValue nullableIntegerWithImplementationDefaultValueValue;
+    if (isNullOrUndefined)
+        nullableIntegerWithImplementationDefaultValueValue = jsUndefined();
+    else {
+        nullableIntegerWithImplementationDefaultValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableIntegerWithImplementationDefaultValue"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto nullableIntegerWithImplementationDefaultValueConversionResult = convertOptionalWithDefault<IDLNullable<IDLLong>>(lexicalGlobalObject, nullableIntegerWithImplementationDefaultValueValue, [&] -> ConversionResult<IDLNullable<IDLLong>> { return typename Converter<IDLNullable<IDLLong>>::ReturnType { std::nullopt }; });
+    if (nullableIntegerWithImplementationDefaultValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue nullableIntegerWithImplementationRequiredValue;
+    if (isNullOrUndefined)
+        nullableIntegerWithImplementationRequiredValue = jsUndefined();
+    else {
+        nullableIntegerWithImplementationRequiredValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableIntegerWithImplementationRequired"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    if (nullableIntegerWithImplementationRequiredValue.isUndefined()) {
+        throwRequiredMemberTypeError(lexicalGlobalObject, throwScope, "nullableIntegerWithImplementationRequired"_s, "TestDictionary"_s, "long"_s);
+        return ConversionResultException { };
+    }
+    auto nullableIntegerWithImplementationRequiredConversionResult = convert<IDLNullable<IDLLong>>(lexicalGlobalObject, nullableIntegerWithImplementationRequiredValue);
+    if (nullableIntegerWithImplementationRequiredConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
     JSValue nullableNodeValue;
     if (isNullOrUndefined)
         nullableNodeValue = jsUndefined();
@@ -1085,6 +1167,30 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
     }
     auto nullableNodeConversionResult = convert<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, nullableNodeValue);
     if (nullableNodeConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue nullableNodeWithImplementationDefaultValueValue;
+    if (isNullOrUndefined)
+        nullableNodeWithImplementationDefaultValueValue = jsUndefined();
+    else {
+        nullableNodeWithImplementationDefaultValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableNodeWithImplementationDefaultValue"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto nullableNodeWithImplementationDefaultValueConversionResult = convert<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, nullableNodeWithImplementationDefaultValueValue);
+    if (nullableNodeWithImplementationDefaultValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue nullableNodeWithImplementationRequiredValue;
+    if (isNullOrUndefined)
+        nullableNodeWithImplementationRequiredValue = jsUndefined();
+    else {
+        nullableNodeWithImplementationRequiredValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "nullableNodeWithImplementationRequired"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    if (nullableNodeWithImplementationRequiredValue.isUndefined()) {
+        throwRequiredMemberTypeError(lexicalGlobalObject, throwScope, "nullableNodeWithImplementationRequired"_s, "TestDictionary"_s, "Node"_s);
+        return ConversionResultException { };
+    }
+    auto nullableNodeWithImplementationRequiredConversionResult = convert<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, nullableNodeWithImplementationRequiredValue);
+    if (nullableNodeWithImplementationRequiredConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue nullableStringWithDefaultValue;
     if (isNullOrUndefined)
@@ -1169,6 +1275,30 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
     }
     auto sequenceOfStringsConversionResult = convert<IDLOptional<IDLSequence<IDLDOMString>>>(lexicalGlobalObject, sequenceOfStringsValue);
     if (sequenceOfStringsConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue sequenceWithImplementationDefaultValueValue;
+    if (isNullOrUndefined)
+        sequenceWithImplementationDefaultValueValue = jsUndefined();
+    else {
+        sequenceWithImplementationDefaultValueValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "sequenceWithImplementationDefaultValue"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    auto sequenceWithImplementationDefaultValueConversionResult = convertOptionalWithDefault<IDLSequence<IDLDOMString>>(lexicalGlobalObject, sequenceWithImplementationDefaultValueValue, [&] -> ConversionResult<IDLSequence<IDLDOMString>> { return Converter<IDLSequence<IDLDOMString>>::ReturnType { }; });
+    if (sequenceWithImplementationDefaultValueConversionResult.hasException(throwScope)) [[unlikely]]
+        return ConversionResultException { };
+    JSValue sequenceWithImplementationRequiredValue;
+    if (isNullOrUndefined)
+        sequenceWithImplementationRequiredValue = jsUndefined();
+    else {
+        sequenceWithImplementationRequiredValue = object->get(&lexicalGlobalObject, Identifier::fromString(vm, "sequenceWithImplementationRequired"_s));
+        RETURN_IF_EXCEPTION(throwScope, ConversionResultException { });
+    }
+    if (sequenceWithImplementationRequiredValue.isUndefined()) {
+        throwRequiredMemberTypeError(lexicalGlobalObject, throwScope, "sequenceWithImplementationRequired"_s, "TestDictionary"_s, "sequence"_s);
+        return ConversionResultException { };
+    }
+    auto sequenceWithImplementationRequiredConversionResult = convert<IDLSequence<IDLDOMString>>(lexicalGlobalObject, sequenceWithImplementationRequiredValue);
+    if (sequenceWithImplementationRequiredConversionResult.hasException(throwScope)) [[unlikely]]
         return ConversionResultException { };
     JSValue smallIntegerClampedValue;
     if (isNullOrUndefined)
@@ -1388,6 +1518,16 @@ template<> ConversionResult<IDLDictionary<TestObj::Dictionary>> convertDictionar
         requiredBufferSourceValueConversionResult.releaseReturnValue(),
         annotatedTypeInUnionMemberConversionResult.releaseReturnValue(),
         annotatedTypeInSequenceMemberConversionResult.releaseReturnValue(),
+        integerWithImplementationDefaultValueConversionResult.releaseReturnValue(),
+        sequenceWithImplementationDefaultValueConversionResult.releaseReturnValue(),
+        dictionaryWithImplementationDefaultValueConversionResult.releaseReturnValue(),
+        nullableIntegerWithImplementationDefaultValueConversionResult.releaseReturnValue(),
+        nullableNodeWithImplementationDefaultValueConversionResult.releaseReturnValue(),
+        integerWithImplementationRequiredConversionResult.releaseReturnValue(),
+        sequenceWithImplementationRequiredConversionResult.releaseReturnValue(),
+        dictionaryWithImplementationRequiredConversionResult.releaseReturnValue(),
+        nullableIntegerWithImplementationRequiredConversionResult.releaseReturnValue(),
+        nullableNodeWithImplementationRequiredConversionResult.releaseReturnValue(),
     };
 }
 
@@ -1438,6 +1578,12 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
     auto dictionaryMemberWithDefaultValue = toJS<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, globalObject, throwScope, dictionary.dictionaryMemberWithDefault);
     RETURN_IF_EXCEPTION(throwScope, { });
     result->putDirect(vm, JSC::Identifier::fromString(vm, "dictionaryMemberWithDefault"_s), dictionaryMemberWithDefaultValue);
+    auto dictionaryWithImplementationDefaultValueValue = toJS<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, globalObject, throwScope, dictionary.dictionaryWithImplementationDefaultValue);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "dictionaryWithImplementationDefaultValue"_s), dictionaryWithImplementationDefaultValueValue);
+    auto dictionaryWithImplementationRequiredValue = toJS<IDLDictionary<TestObj::ParentDictionary>>(lexicalGlobalObject, globalObject, throwScope, dictionary.dictionaryWithImplementationRequired);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "dictionaryWithImplementationRequired"_s), dictionaryWithImplementationRequiredValue);
     auto enumerationValueWithDefaultValue = toJS<IDLEnumeration<TestObj::EnumType>>(lexicalGlobalObject, throwScope, dictionary.enumerationValueWithDefault);
     RETURN_IF_EXCEPTION(throwScope, { });
     result->putDirect(vm, JSC::Identifier::fromString(vm, "enumerationValueWithDefault"_s), enumerationValueWithDefaultValue);
@@ -1463,6 +1609,12 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
     auto integerWithDefaultValue = toJS<IDLLong>(lexicalGlobalObject, throwScope, dictionary.integerWithDefault);
     RETURN_IF_EXCEPTION(throwScope, { });
     result->putDirect(vm, JSC::Identifier::fromString(vm, "integerWithDefault"_s), integerWithDefaultValue);
+    auto integerWithImplementationDefaultValueValue = toJS<IDLLong>(lexicalGlobalObject, throwScope, dictionary.integerWithImplementationDefaultValue);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "integerWithImplementationDefaultValue"_s), integerWithImplementationDefaultValueValue);
+    auto integerWithImplementationRequiredValue = toJS<IDLLong>(lexicalGlobalObject, throwScope, dictionary.integerWithImplementationRequired);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "integerWithImplementationRequired"_s), integerWithImplementationRequiredValue);
     if (!IDLLongLong::isNullValue(dictionary.largeInteger)) {
         auto largeIntegerValue = toJS<IDLLongLong>(lexicalGlobalObject, throwScope, IDLLongLong::extractValueFromNullable(dictionary.largeInteger));
         RETURN_IF_EXCEPTION(throwScope, { });
@@ -1477,9 +1629,21 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
     auto nullableIntegerWithDefaultValue = toJS<IDLNullable<IDLLong>>(lexicalGlobalObject, throwScope, dictionary.nullableIntegerWithDefault);
     RETURN_IF_EXCEPTION(throwScope, { });
     result->putDirect(vm, JSC::Identifier::fromString(vm, "nullableIntegerWithDefault"_s), nullableIntegerWithDefaultValue);
+    auto nullableIntegerWithImplementationDefaultValueValue = toJS<IDLNullable<IDLLong>>(lexicalGlobalObject, throwScope, dictionary.nullableIntegerWithImplementationDefaultValue);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "nullableIntegerWithImplementationDefaultValue"_s), nullableIntegerWithImplementationDefaultValueValue);
+    auto nullableIntegerWithImplementationRequiredValue = toJS<IDLNullable<IDLLong>>(lexicalGlobalObject, throwScope, dictionary.nullableIntegerWithImplementationRequired);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "nullableIntegerWithImplementationRequired"_s), nullableIntegerWithImplementationRequiredValue);
     auto nullableNodeValue = toJS<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, globalObject, throwScope, dictionary.nullableNode);
     RETURN_IF_EXCEPTION(throwScope, { });
     result->putDirect(vm, JSC::Identifier::fromString(vm, "nullableNode"_s), nullableNodeValue);
+    auto nullableNodeWithImplementationDefaultValueValue = toJS<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, globalObject, throwScope, dictionary.nullableNodeWithImplementationDefaultValue);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "nullableNodeWithImplementationDefaultValue"_s), nullableNodeWithImplementationDefaultValueValue);
+    auto nullableNodeWithImplementationRequiredValue = toJS<IDLNullable<IDLInterface<Node>>>(lexicalGlobalObject, globalObject, throwScope, dictionary.nullableNodeWithImplementationRequired);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "nullableNodeWithImplementationRequired"_s), nullableNodeWithImplementationRequiredValue);
     auto nullableStringWithDefaultValue = toJS<IDLNullable<IDLDOMString>>(lexicalGlobalObject, throwScope, dictionary.nullableStringWithDefault);
     RETURN_IF_EXCEPTION(throwScope, { });
     result->putDirect(vm, JSC::Identifier::fromString(vm, "nullableStringWithDefault"_s), nullableStringWithDefaultValue);
@@ -1510,6 +1674,12 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
         RETURN_IF_EXCEPTION(throwScope, { });
         result->putDirect(vm, JSC::Identifier::fromString(vm, "sequenceOfStrings"_s), sequenceOfStringsValue);
     }
+    auto sequenceWithImplementationDefaultValueValue = toJS<IDLSequence<IDLDOMString>>(lexicalGlobalObject, globalObject, throwScope, dictionary.sequenceWithImplementationDefaultValue);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "sequenceWithImplementationDefaultValue"_s), sequenceWithImplementationDefaultValueValue);
+    auto sequenceWithImplementationRequiredValue = toJS<IDLSequence<IDLDOMString>>(lexicalGlobalObject, globalObject, throwScope, dictionary.sequenceWithImplementationRequired);
+    RETURN_IF_EXCEPTION(throwScope, { });
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "sequenceWithImplementationRequired"_s), sequenceWithImplementationRequiredValue);
     if (!IDLClampAdaptor<IDLByte>::isNullValue(dictionary.smallIntegerClamped)) {
         auto smallIntegerClampedValue = toJS<IDLClampAdaptor<IDLByte>>(lexicalGlobalObject, throwScope, IDLClampAdaptor<IDLByte>::extractValueFromNullable(dictionary.smallIntegerClamped));
         RETURN_IF_EXCEPTION(throwScope, { });

--- a/Source/WebCore/bindings/scripts/test/TestObj.idl
+++ b/Source/WebCore/bindings/scripts/test/TestObj.idl
@@ -573,6 +573,16 @@ typedef any AnyTypedef;
     required BufferSource requiredBufferSourceValue;
     (DOMString or [Clamp] long) annotatedTypeInUnionMember;
     sequence<[Clamp] long> annotatedTypeInSequenceMember;
+    [ImplementationDefaultValue=0] long integerWithImplementationDefaultValue;
+    [ImplementationDefaultValue=[]] sequence<DOMString> sequenceWithImplementationDefaultValue;
+    [ImplementationDefaultValue={}] ParentDictionary dictionaryWithImplementationDefaultValue;
+    [ImplementationDefaultValue=null] long? nullableIntegerWithImplementationDefaultValue;
+    [ImplementationDefaultValue=null] Node? nullableNodeWithImplementationDefaultValue;
+    [ImplementationRequired] long integerWithImplementationRequired;
+    [ImplementationRequired] sequence<DOMString> sequenceWithImplementationRequired;
+    [ImplementationRequired] ParentDictionary dictionaryWithImplementationRequired;
+    [ImplementationRequired] long? nullableIntegerWithImplementationRequired;
+    [ImplementationRequired] Node? nullableNodeWithImplementationRequired;
 };
 
 dictionary TestDictionaryThatShouldNotTolerateNull {


### PR DESCRIPTION
#### 6569ba93f116ac23e87f372ae88fb1f0cbcfd81a
<pre>
[Bindings] Make the ImplementationRequired extended attribute a parse time transformation like ImplementationDefaultValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=306775">https://bugs.webkit.org/show_bug.cgi?id=306775</a>

Reviewed by Anne van Kesteren.

Makes the `ImplementationRequired` IDL extended attribute a parse time transformation
(just like `ImplementationDefaultValue`) to avoid needing to check for it in every spot
where `isRequired` is checked.

Also adds some tests for for both `ImplementationRequired` and `ImplementationDefaultValue`.

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
* Source/WebCore/bindings/scripts/IDLParser.pm:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
* Source/WebCore/bindings/scripts/test/TestObj.idl:

Canonical link: <a href="https://commits.webkit.org/306649@main">https://commits.webkit.org/306649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f4ae7ce2f199ac8c4bab2ed923a82790f52cadd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109076 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78865 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11159 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8805 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120480 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152898 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117156 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117477 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29937 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13519 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124039 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69682 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14029 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3177 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77754 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->