### PR TITLE
[JSC][WASM][Debugger] Add Swift WASM do-catch exception handling test case

### DIFF
--- a/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/Package.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "do-catch-throw",
+    targets: [
+        .executableTarget(
+            name: "do-catch-throw",
+            path: "Sources/test",
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "--export=test_do_throw_catch"]),
+                .unsafeFlags(["-Xlinker", "--export=test_do_throw_catch_nested"]),
+                .unsafeFlags(["-Xlinker", "--export=test_do_throw_func_catch"]),
+                .unsafeFlags(["-Xlinker", "--export=test_do_throw_func_catch_nested"])
+            ]
+        )
+    ]
+)

--- a/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/Sources/test/test.swift
+++ b/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/Sources/test/test.swift
@@ -1,0 +1,90 @@
+enum TestError: Error {
+    case testException
+    case anotherException
+}
+
+func throwingFunction() throws -> Int32 {
+    throw TestError.testException
+}
+
+// Test 1: do-catch with conditional direct throw (no function call)
+@_cdecl("test_do_throw_catch")
+public func testDoThrowCatch(_ num: Int32) -> Int32 {
+    do {
+        if num % 2 == 0 {
+            throw TestError.testException
+        }
+        return 23
+    } catch {
+        return 42
+    }
+}
+
+// Test 2: Nested do-catch with direct throw
+@_cdecl("test_do_throw_catch_nested")
+public func testDoThrowCatchNested(_ num: Int32) -> Int32 {
+    var result: Int32 = 0
+    do {
+        // Outer try block
+        do {
+            // Inner try block
+            if num % 2 == 0 {
+                throw TestError.testException
+            }
+            result = 23
+        } catch TestError.testException {
+            // Inner catch - rethrow as different exception
+            throw TestError.anotherException
+        }
+        return result
+    } catch TestError.anotherException {
+        // Outer catch
+        return 42
+    } catch {
+        return 99
+    }
+}
+
+// Test 3: do-catch with throwing function call
+@_cdecl("test_do_throw_func_catch")
+public func testDoThrowFuncCatch() -> Int32 {
+    do {
+        let result = try throwingFunction()
+        return result
+    } catch {
+        return 42
+    }
+}
+
+// Test 4: Nested do-catch with throwing function call
+@_cdecl("test_do_throw_func_catch_nested")
+public func testDoThrowFuncCatchNested() -> Int32 {
+    var result: Int32 = 0
+    do {
+        // Outer try block
+        do {
+            // Inner try block - call throwing function
+            result += try throwingFunction()
+            result = 3
+        } catch TestError.testException {
+            // Inner catch - rethrow as different exception
+            throw TestError.anotherException
+        }
+        return result
+    } catch TestError.anotherException {
+        // Outer catch
+        return 42
+    } catch {
+        return 99
+    }
+}
+
+@main
+struct TryCatchTest {
+    static func main() {
+        _ = testDoThrowCatch
+        _ = testDoThrowCatchNested
+        _ = testDoThrowFuncCatch
+        _ = testDoThrowFuncCatchNested
+    }
+}

--- a/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/build.sh
+++ b/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script is used to compile Swift WASM.
+# Note that the corresponding tests needs to be updated due to updated WASM binary.
+set -e
+
+cd "$(dirname "$0")"
+
+# Build Swift WASM with Swiftly https://www.swift.org/documentation/articles/wasm-getting-started.html
+echo "Building Swift WebAssembly do-catch-throw test..."
+/Users/yijiahuang/.swiftly/bin/swift build --swift-sdk swift-6.2.3-RELEASE_wasm
+
+# Move compiled WASM beside main.js
+echo "Moving do-catch-throw.wasm..."
+mv .build/wasm32-unknown-wasip1/debug/do-catch-throw.wasm ./do-catch-throw.wasm
+
+# Clean up build artifacts
+echo "Cleaning up..."
+rm -rf .build
+
+echo "Done! do-catch-throw.wasm is ready for testing."

--- a/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/main.js
+++ b/JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw/main.js
@@ -1,0 +1,62 @@
+var wasm_code = read('do-catch-throw.wasm', 'binary');
+var wasm_module = new WebAssembly.Module(wasm_code);
+var imports = {
+    wasi_snapshot_preview1: {
+        proc_exit: function (code) {
+            print("Program exited with code:", code);
+        },
+        args_get: function () { return 0; },
+        args_sizes_get: function () { return 0; },
+        environ_get: function () { return 0; },
+        environ_sizes_get: function () { return 0; },
+        fd_write: function () { return 0; },
+        fd_read: function () { return 0; },
+        fd_close: function () { return 0; },
+        fd_seek: function () { return 0; },
+        fd_fdstat_get: function () { return 0; },
+        fd_prestat_get: function () { return 8; },
+        fd_prestat_dir_name: function () { return 8; },
+        path_open: function () { return 8; },
+        random_get: function () { return 0; },
+        clock_time_get: function () { return 0; }
+    }
+};
+
+var instance = new WebAssembly.Instance(wasm_module, imports);
+
+print("Available exports:", Object.keys(instance.exports));
+
+let testDoThrowCatch = instance.exports.test_do_throw_catch;
+let testDoThrowCatchNested = instance.exports.test_do_throw_catch_nested;
+let testDoThrowFuncCatch = instance.exports.test_do_throw_func_catch;
+let testDoThrowFuncCatchNested = instance.exports.test_do_throw_func_catch_nested;
+
+// Test 1: Direct throw in do block
+print("\n=== Test 1: do-throw-catch (direct throw) ===");
+print("test_do_throw_catch(2):", testDoThrowCatch(2));   // Even: throws, returns 42
+print("test_do_throw_catch(3):", testDoThrowCatch(3));   // Odd: no throw, returns 23
+
+// Test 2: Nested do-catch with direct throw
+print("\n=== Test 2: do-throw-catch-nested (direct throw, nested) ===");
+print("test_do_throw_catch_nested(2):", testDoThrowCatchNested(2));   // Even: inner throw → outer catch, returns 42
+print("test_do_throw_catch_nested(3):", testDoThrowCatchNested(3));   // Odd: no throw, returns 23
+
+// Test 3: Throw via function call
+print("\n=== Test 3: do-throw-func-catch (function call) ===");
+print("test_do_throw_func_catch():", testDoThrowFuncCatch());  // Expected: 42
+
+// Test 4: Nested do-catch with function call
+print("\n=== Test 4: do-throw-func-catch-nested (function call, nested) ===");
+print("test_do_throw_func_catch_nested():", testDoThrowFuncCatchNested());  // Expected: 42
+
+print("\n=== Running continuous loop ===");
+let iteration = 0;
+for (; ;) {
+    testDoThrowCatch(2);
+    testDoThrowCatchNested(2);
+    testDoThrowFuncCatch();
+    testDoThrowFuncCatchNested();
+    iteration += 1;
+    if (iteration % 1e5 == 0)
+        print("iteration=", iteration);
+}

--- a/JSTests/wasm/debugger/tests/tests.py
+++ b/JSTests/wasm/debugger/tests/tests.py
@@ -1513,3 +1513,40 @@ class MultiVMSameModuleDifferentFunctionsTestCase(BaseTestCase):
     def stepTest(self):
         # FIXME: Add tests when thread select is full supported
         return
+
+
+class DoCatchThrowTestCase(BaseTestCase):
+
+    def __init__(self, build_config: str = None, port: int = None):
+        super().__init__(build_config, port)
+
+    def execute(self):
+        self.setup_debugging_session_or_raise("resources/swift-wasm/do-catch-throw/main.js")
+
+        try:
+            for _ in range(1):
+                self.stepTest()
+
+        except Exception as e:
+            raise Exception(f"Test failed: {e}")
+
+    def stepTest(self):
+        self.send_lldb_command_or_raise("b testDoThrowCatch")
+        self.send_lldb_command_or_raise("c", patterns=["-> 14"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 15"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 18"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 19"])
+        self.send_lldb_command_or_raise("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+        self.send_lldb_command_or_raise("b testDoThrowCatchNested")
+        self.send_lldb_command_or_raise("c", patterns=["-> 26"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 31"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 32"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 37"])
+        self.send_lldb_command_or_raise("n", patterns=["-> 42"])
+        self.send_lldb_command_or_raise("br del -f", patterns=["All breakpoints removed. (1 breakpoint)"])
+
+        # FIXME: Swift WASM Compiler Bug Incorrect DWARF Line Numbers rdar://169306069
+        # self.send_lldb_command_or_raise("b testDoThrowCatch")
+        # self.send_lldb_command_or_raise("b testDoThrowFuncCatchNested")
+        return


### PR DESCRIPTION
#### a9e86615c78fea731f69b5fbbab13a3337e2aea0
<pre>
[JSC][WASM][Debugger] Add Swift WASM do-catch exception handling test case
<a href="https://bugs.webkit.org/show_bug.cgi?id=306782">https://bugs.webkit.org/show_bug.cgi?id=306782</a>
<a href="https://rdar.apple.com/169455288">rdar://169455288</a>

Reviewed by Mark Lam.

Add test coverage for Swift exception handling in WebAssembly with
do-catch-throw patterns. Includes tests for:
- Direct throw with conditional logic (testDoThrowCatch)
- Nested do-catch with exception rethrowing (testDoThrowCatchNested)

Tests for function call throws are disabled due to Swift WASM compiler
bug that generates incorrect DWARF line numbers in catch block prologues.

* JSTests/wasm/debugger/tests/tests.py:
(DoCatchThrowTestCase): Added test case for Swift exception handling.

* JSTests/wasm/debugger/resources/swift-wasm/do-catch-throw: Added.
(Package.swift): Swift package configuration.
(build.sh): Build script to compile Swift to WASM.
(main.js): JavaScript test harness.
(do-catch-throw.wasm): Compiled WebAssembly binary.
(Sources/test/test.swift): Swift source with exception handling tests.

Canonical link: <a href="https://commits.webkit.org/306655@main">https://commits.webkit.org/306655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8851e03c76bf14c50f12a6fa385db1141e41ff19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141924 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95099 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45c37261-8961-476e-af11-9bdcf3784a08) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109082 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78870 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e878c35d-00ff-460c-9ba0-e87e9ad7c680) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127056 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89979 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1781603e-88d8-422d-934c-ec2192f80d95) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11169 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8814 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/584 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/133908 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120491 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152906 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2728 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/13999 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117162 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117482 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13526 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69693 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21906 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14037 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3182 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173213 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13776 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44847 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->