### PR TITLE
Web Inspector: Search bar settings icon disappears when search field is active

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
@@ -54,6 +54,10 @@
     margin-inline-start: 6px;
 }
 
+.filter-bar > input[type="search"]:focus ~ * {
+    display: none;
+}
+
 :is(.filter-bar, .search-bar) > input[type="search"] {
     height: 22px;
     padding-top: 0;
@@ -103,10 +107,6 @@
 
 :is(.filter-bar, .search-bar) > input[type="search"] + :empty {
     margin-inline-start: 6px;
-}
-
-:is(.filter-bar, .search-bar) > input[type="search"]:focus ~ * {
-    display: none;
 }
 
 :is(.filter-bar, .search-bar) > input[type="search"] + .navigation-bar > .item.scope-bar:last-child {


### PR DESCRIPTION
#### fc8aa094c871910db21ed4070c9b24d536520455
<pre>
Web Inspector: Search bar settings icon disappears when search field is active
<a href="https://bugs.webkit.org/show_bug.cgi?id=305513">https://bugs.webkit.org/show_bug.cgi?id=305513</a>
<a href="https://rdar.apple.com/168213559">rdar://168213559</a>

Reviewed by BJ Burg and Devin Rousso.

When the search or filter bar input field has focus, the adjacent buttons are hidden
to make more space for the query. Maximizing this space was a concern when search
options were introduced: <a href="https://bugs.webkit.org/show_bug.cgi?id=192527#c7">https://bugs.webkit.org/show_bug.cgi?id=192527#c7</a>

However, the search input field is automatically focused when switching to the Search tab.
The default view for a user is that there are no options to configure the search.

Filter input fields require explicit user action to get focus, so options are initially visible.

We can afford the space to always show the search options regardless of the input focus state
and avoid user confusion. The navigation sidebar has a minimum width defined by
`WI.Sidebar.AbsoluteMinimumWidth` which ensures sufficient typing space for the query.

* Source/WebInspectorUI/UserInterface/Views/FilterBar.css:
(.filter-bar &gt; input[type=&quot;search&quot;]:focus ~ *):
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]:focus ~ *): Deleted.

Canonical link: <a href="https://commits.webkit.org/306719@main">https://commits.webkit.org/306719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e41343893a980d9174488b3665e256e81e2f12b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150755 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8cd4396-adf3-435f-bebe-46644e5d70e3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14685 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109260 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8447428-324b-422c-89b0-d98e6c081ab2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11795 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90158 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33c7028b-3169-4cfc-825d-e71b5be5c877) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/802 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153119 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4230 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14233 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117649 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13701 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124406 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14260 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13992 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14037 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->