### PR TITLE
[WGSL] webgpu:shader,validation,parse,blankspace,* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt
@@ -1,29 +1,7 @@
 
-FAIL :null_characters:contains_null=true;placement="comment" assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    // Here is a \0 character
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/blankspace.spec.js:25:24
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :null_characters:contains_null=true;placement="comment"
 PASS :null_characters:contains_null=true;placement="delimiter"
-FAIL :null_characters:contains_null=true;placement="eol" assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
-
-
-    ---- shader ----
-    const name : i32 = 0;\0
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/blankspace.spec.js:25:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
- Reached unreachable code
+PASS :null_characters:contains_null=true;placement="eol"
 PASS :null_characters:contains_null=false;placement="comment"
 PASS :null_characters:contains_null=false;placement="delimiter"
 PASS :null_characters:contains_null=false;placement="eol"
@@ -33,66 +11,11 @@ PASS :blankspace:blankspace=["%5Cn","line_feed"]
 PASS :blankspace:blankspace=["%5Cu000b","vertical_tab"]
 PASS :blankspace:blankspace=["%5Cf","form_feed"]
 PASS :blankspace:blankspace=["%5Cr","carriage_return"]
-FAIL :blankspace:blankspace=["%C2%85","next_line"] assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:6: error: Expected a Identifier, but got a Invalid
-
-    ---- shader ----
-    constident : i32 = 0;
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:5: Expected a Identifier, but got a Invalid
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :blankspace:blankspace=["%E2%80%8E","left_to_right_mark"] assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:6: error: Expected a Identifier, but got a Invalid
-
-    ---- shader ----
-    const‎ident : i32 = 0;
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:5: Expected a Identifier, but got a Invalid
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :blankspace:blankspace=["%E2%80%8F","right_to_left_mark"] assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:6: error: Expected a Identifier, but got a Invalid
-
-    ---- shader ----
-    const‏ident : i32 = 0;
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:5: Expected a Identifier, but got a Invalid
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :blankspace:blankspace=["%E2%80%A8","line_separator"] assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:6: error: Expected a Identifier, but got a Invalid
-
-    ---- shader ----
-    const ident : i32 = 0;
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:5: Expected a Identifier, but got a Invalid
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
-FAIL :blankspace:blankspace=["%E2%80%A9","paragraph_separator"] assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    1:6: error: Expected a Identifier, but got a Invalid
-
-    ---- shader ----
-    const ident : i32 = 0;
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    1:5: Expected a Identifier, but got a Invalid
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
- Reached unreachable code
+PASS :blankspace:blankspace=["%C2%85","next_line"]
+PASS :blankspace:blankspace=["%E2%80%8E","left_to_right_mark"]
+PASS :blankspace:blankspace=["%E2%80%8F","right_to_left_mark"]
+PASS :blankspace:blankspace=["%E2%80%A8","line_separator"]
+PASS :blankspace:blankspace=["%E2%80%A9","paragraph_separator"]
 PASS :bom:include_bom=true
 PASS :bom:include_bom=false
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -288,8 +288,6 @@ RefPtr<ShaderModule> DeviceImpl::createShaderModule(const ShaderModuleDescriptor
 {
     auto label = descriptor.label.utf8();
 
-    auto source = descriptor.code.utf8();
-
     auto entryPoints = descriptor.hints.map([](const auto& hint) {
         return hint.key.utf8();
     });
@@ -307,7 +305,7 @@ RefPtr<ShaderModule> DeviceImpl::createShaderModule(const ShaderModuleDescriptor
     }
 
     WGPUShaderModuleDescriptor backingDescriptor {
-        .wgslDescriptor = source.data(),
+        .wgslDescriptor = descriptor.code,
         .label = label.data(),
         .hintCount = hintsEntries.size(),
         .hints = hintsEntries.size() ? &hintsEntries[0] : nullptr,

--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -61,7 +61,7 @@ private:
     T peek(unsigned = 0);
     void newLine();
     bool skipBlockComments();
-    void skipLineComment();
+    bool skipLineComment();
     bool skipWhitespaceAndComments();
 
     StringParsingBuffer<T> m_code;

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -44,13 +44,13 @@
 namespace WebGPU {
 
 struct ShaderModuleParameters {
-    const char* wgslCode;
+    String wgslCode;
     const WGPUShaderModuleCompilationHint* hints;
 };
 
 static std::optional<ShaderModuleParameters> findShaderModuleParameters(const WGPUShaderModuleDescriptor& descriptor)
 {
-    const char* wgslCode = descriptor.wgslDescriptor;
+    const auto& wgslCode = descriptor.wgslDescriptor;
     const WGPUShaderModuleCompilationHint* hints = descriptor.hints;
 
     if (!wgslCode)
@@ -178,7 +178,7 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
         return ShaderModule::createInvalid(*this);
 
     auto supportedFeatures = buildFeatureSet(m_capabilities.features);
-    auto checkResult = WGSL::staticCheck(fromAPI(shaderModuleParameters->wgslCode), std::nullopt, WGSL::Configuration {
+    auto checkResult = WGSL::staticCheck(shaderModuleParameters->wgslCode, std::nullopt, WGSL::Configuration {
         .maxBuffersPlusVertexBuffersForVertexStage = maxBuffersPlusVertexBuffersForVertexStage(),
         .maxBuffersForFragmentStage = maxBuffersForFragmentStage(),
         .maxBuffersForComputeStage = maxBuffersForComputeStage(),

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -1258,7 +1258,7 @@ typedef struct WGPURequiredLimits {
 } WGPURequiredLimits WGPU_STRUCTURE_ATTRIBUTE;
 
 typedef struct WGPUShaderModuleDescriptor {
-    char const * wgslDescriptor;
+    WTF::String wgslDescriptor;
     WGPU_NULLABLE char const * label;
     size_t hintCount;
     WGPUShaderModuleCompilationHint const * hints;


### PR DESCRIPTION
#### 33c2323b2b434378215955183503b4249d5a29f2
<pre>
[WGSL] webgpu:shader,validation,parse,blankspace,* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=306784">https://bugs.webkit.org/show_bug.cgi?id=306784</a>
<a href="https://rdar.apple.com/169458432">rdar://169458432</a>

Reviewed by Mike Wyrzykowski.

Fix parsing of null characters and unicode space characters.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/blankspace-expected.txt:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createShaderModule):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::skipBlockComments):
(WGSL::Lexer&lt;T&gt;::skipLineComment):
(WGSL::Lexer&lt;T&gt;::skipWhitespaceAndComments):
* Source/WebGPU/WGSL/Lexer.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::findShaderModuleParameters):
(WebGPU::Device::createShaderModule):
* Source/WebGPU/WebGPU/WebGPU.h:

Canonical link: <a href="https://commits.webkit.org/306765@main">https://commits.webkit.org/306765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff1263642f762e24a6c29d02abe4e58142c13e97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150937 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109416 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21b19afa-7ec7-4039-b936-c1bbad9caeb7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90316 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c8b2e71-4a75-4388-8af0-9362b9717ea0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11456 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/966 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153283 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14375 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4430 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117789 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13837 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124606 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14424 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3616 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14156 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78140 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14361 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->