### PR TITLE
Promote WKWebpagePreferences _alternateRequest and _overrideReferrerForAllRequests to public API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift
@@ -59,6 +59,9 @@ extension WKWebpagePreferences {
         if let isLockdownModeEnabled = wrapped.backingIsLockdownModeEnabled, self.isLockdownModeEnabled != isLockdownModeEnabled {
             self.isLockdownModeEnabled = isLockdownModeEnabled
         }
+
+        self.alternateRequest = wrapped.alternateRequest
+        self.overrideReferrer = wrapped.overrideReferrer
     }
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h
@@ -128,4 +128,12 @@ WK_CLASS_AVAILABLE(macos(10.15), ios(13.0))
  */
 @property (nonatomic) WKSecurityRestrictionMode securityRestrictionMode WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+/* @abstract Used to make changes to the network request that will be used for this navigation's main resource load.
+*/
+@property (nonatomic, copy, nullable) NSURLRequest *alternateRequest WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+/* @abstract Used to apply a custom `referer` header to all resource loads in the frame for this navigation.
+*/
+@property (nonatomic, copy, nullable) NSString *overrideReferrer WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -499,14 +499,24 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     }
 }
 
-- (void)_setOverrideReferrerForAllRequests:(NSString *)referrer
+- (void)setOverrideReferrer:(NSString *)referrer
 {
     _websitePolicies->setOverrideReferrerForAllRequests(referrer);
 }
 
+- (void)_setOverrideReferrerForAllRequests:(NSString *)referrer
+{
+    [self setOverrideReferrer:referrer];
+}
+
+- (NSString *)overrideReferrer
+{
+    return nsStringNilIfNull(_websitePolicies->overrideReferrerForAllRequests()).autorelease();
+}
+
 - (NSString *)_overrideReferrerForAllRequests
 {
-    return _websitePolicies->overrideReferrerForAllRequests().createNSString().autorelease();
+    return [self overrideReferrer];
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
@@ -819,16 +829,25 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     _websitePolicies->setPushAndNotificationsEnabledPolicy(enabled ? WebKit::WebsitePushAndNotificationsEnabledPolicy::Yes : WebKit::WebsitePushAndNotificationsEnabledPolicy::No);
 }
 
-- (void)_setAlternateRequest:(NSURLRequest *)request
+- (void)setAlternateRequest:(NSURLRequest *)request
 {
     protectedWebsitePolicies(self)->setAlternateRequest(request);
 }
 
-- (NSURLRequest *)_alternateRequest
+- (NSURLRequest *)alternateRequest
 {
     return protectedWebsitePolicies(self)->alternateRequest().protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).autorelease();
 }
 
+- (NSURLRequest *)_alternateRequest
+{
+    return [self alternateRequest];
+}
+
+- (void)_setAlternateRequest:(NSURLRequest *)request
+{
+    [self setAlternateRequest:request];
+}
 
 - (void)_setAllowsJSHandleCreationInPageWorld:(BOOL)allows
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -131,12 +131,12 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 
 @property (nonatomic, setter=_setPushAndNotificationAPIEnabled:) BOOL _pushAndNotificationAPIEnabled;
 
-@property (nonatomic, setter=_setAlternateRequest:) NSURLRequest *_alternateRequest WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=setAlternateRequest:) NSURLRequest *_alternateRequest WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic, setter=_setAllowsJSHandleCreationInPageWorld:) BOOL _allowsJSHandleCreationInPageWorld WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @property (nonatomic, setter=_setEnhancedSecurityEnabled:) BOOL _enhancedSecurityEnabled WK_API_DEPRECATED_WITH_REPLACEMENT("securityRestrictionMode", macos(WK_MAC_TBA, WK_MAC_TBA), ios(WK_IOS_TBA, WK_IOS_TBA), visionos(WK_XROS_TBA, WK_XROS_TBA));
 
-@property (nonatomic, setter=_setOverrideReferrerForAllRequests:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, setter=setOverrideReferrer:) NSString *_overrideReferrerForAllRequests WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift
@@ -128,6 +128,18 @@ extension WebPage {
             get { backingSecurityRestrictionMode ?? .none }
             set { backingSecurityRestrictionMode = newValue }
         }
+
+        /// Used to make changes to the network request that will be used for this navigation's main resource load.
+        @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+        @available(watchOS, unavailable)
+        @available(tvOS, unavailable)
+        public var alternateRequest: URLRequest? = nil
+
+        /// Used to apply a custom `referer` header to all resource loads in the frame of this navigation.
+        @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+        @available(watchOS, unavailable)
+        @available(tvOS, unavailable)
+        public var overrideReferrer: Swift.String? = nil
     }
 }
 
@@ -185,6 +197,9 @@ extension WebPage.NavigationPreferences {
         self.allowsContentJavaScript = wrapped.allowsContentJavaScript
         self.isLockdownModeEnabled = wrapped.isLockdownModeEnabled
         self.securityRestrictionMode = .init(wrapped.securityRestrictionMode)
+
+        self.alternateRequest = wrapped.alternateRequest
+        self.overrideReferrer = wrapped.overrideReferrer
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -1873,6 +1873,48 @@ TEST(WebpagePreferences, ToggleAdvancedPrivacyProtections)
     EXPECT_TRUE([preferences _networkConnectionIntegrityEnabled]);
 }
 
+TEST(WebpagePreferences, AlternateRequestSPIToAPI)
+{
+    RetainPtr request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]];
+
+    auto preferences = adoptNS([WKWebpagePreferences new]);
+    EXPECT_NULL([preferences alternateRequest]);
+    EXPECT_NULL([preferences _alternateRequest]);
+
+    preferences.get()._alternateRequest = request.get();
+    EXPECT_EQ(preferences.get().alternateRequest, preferences.get()._alternateRequest);
+    EXPECT_EQ(preferences.get().alternateRequest, request.get());
+
+    [preferences setAlternateRequest:nil];
+    EXPECT_NULL([preferences alternateRequest]);
+    EXPECT_NULL([preferences _alternateRequest]);
+
+    [preferences setAlternateRequest:request.get()];
+    EXPECT_EQ(preferences.get().alternateRequest, preferences.get()._alternateRequest);
+    EXPECT_EQ(preferences.get().alternateRequest, request.get());
+}
+
+TEST(WebpagePreferences, OverrideReferrerSPIToAPI)
+{
+    NSString *referrer = @"hello";
+
+    auto preferences = adoptNS([WKWebpagePreferences new]);
+    EXPECT_NULL([preferences overrideReferrer]);
+    EXPECT_NULL([preferences _overrideReferrerForAllRequests]);
+
+    preferences.get()._overrideReferrerForAllRequests = referrer;
+    EXPECT_EQ(preferences.get().overrideReferrer, preferences.get()._overrideReferrerForAllRequests);
+    EXPECT_TRUE([preferences.get().overrideReferrer isEqual:referrer]);
+
+    [preferences setOverrideReferrer:nil];
+    EXPECT_NULL([preferences overrideReferrer]);
+    EXPECT_NULL([preferences _overrideReferrerForAllRequests]);
+
+    [preferences setOverrideReferrer:referrer];
+    EXPECT_EQ(preferences.get().overrideReferrer, preferences.get()._overrideReferrerForAllRequests);
+    EXPECT_TRUE([preferences.get().overrideReferrer isEqual:referrer]);
+}
+
 TEST(WebpagePreferences, HttpPageContentBlockers)
 {
     [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];


### PR DESCRIPTION
#### 5239365d5875d0c3b88ce07657ca47bf3aa36a6a
<pre>
Promote WKWebpagePreferences _alternateRequest and _overrideReferrerForAllRequests to public API
<a href="https://rdar.apple.com/169460317">rdar://169460317</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306786">https://bugs.webkit.org/show_bug.cgi?id=306786</a>

Reviewed by Richard Robinson.

These SPIs have proven stable and have clear utility for all WebKit clients.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences+Extras.swift:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences setOverrideReferrer:]):
(-[WKWebpagePreferences _setOverrideReferrerForAllRequests:]):
(-[WKWebpagePreferences overrideReferrer]):
(-[WKWebpagePreferences _overrideReferrerForAllRequests]):
(-[WKWebpagePreferences setAlternateRequest:]):
(-[WKWebpagePreferences alternateRequest]):
(-[WKWebpagePreferences _alternateRequest]):
(-[WKWebpagePreferences _setAlternateRequest:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationPreferences.swift:
(alternateRequest):
(overrideReferrer):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:
((WebpagePreferences, AlternateRequestSPIToAPI)):
((WebpagePreferences, OverrideReferrerSPIToAPI)):

Canonical link: <a href="https://commits.webkit.org/306660@main">https://commits.webkit.org/306660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f203ef5146ea001c191d6944a71755543ecf93e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150562 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/229cf6ec-6d92-4570-89e2-ef2c162175f8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00c3bb5e-6bfe-4cb0-953c-9063c47c4dec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11647 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90008 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c203a99e-1711-4721-be3a-0e11cdf7f2af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11194 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8841 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/616 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3295 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152938 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14031 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3910 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117190 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117508 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29947 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13553 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69725 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14069 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3216 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77794 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->