### PR TITLE
Support immersive request cancellation

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-basic.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-basic.html
@@ -141,7 +141,7 @@ promise_test(async t => {
     
     model.remove();
     
-    assert_equals(document.immersiveElement, null, 'No immersive element after removal');
+    await t.step_wait(() => document.immersiveElement === null, 'Waiting for immersive element to be cleared after removal');
 }, 'Removing immersive model from DOM exits immersive mode');
 
 promise_test(async t => {

--- a/LayoutTests/model-element/immersive/model-element-immersive-no-client-approval.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-no-client-approval.html
@@ -15,7 +15,7 @@ promise_test(async t => {
 
     await test_driver.bless("immersive");
 
-    await promise_rejects_js(t, TypeError, 
+    await promise_rejects_dom(t, "AbortError", 
         model.requestImmersive(),
         'Should reject without client\'s approval'
     );

--- a/LayoutTests/model-element/immersive/model-element-immersive-state-consistency-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-state-consistency-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Second request during first request completes correctly
+PASS Immersive request during immersive exit should first wait for exit and then proceeds
+PASS Rapid request/exit cycles maintain consistent state
+PASS Multiple concurrent requests - exactly one succeeds
+PASS State remains clean after request aborted by element removal
+PASS Element removed while waiting for exit to complete
+

--- a/LayoutTests/model-element/immersive/model-element-immersive-state-consistency.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-state-consistency.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ModelElementImmersiveEnabled=true shouldAcceptImmersiveEnvironmentRequests=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> immersive state consistency</title>
+<script src="../../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/model-element-test-utils.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/cube.usdz");
+
+    await test_driver.bless("immersive");
+    const promise1 = model1.requestImmersive();
+
+    await test_driver.bless("immersive");
+    const promise2 = model2.requestImmersive();
+
+    await promise_rejects_dom(t, "AbortError", promise1,
+        'First request should be superseded by second');
+
+    await promise2;
+
+    assert_equals(document.immersiveElement, model2,
+        'document.immersiveElement should match successful request');
+
+}, 'Second request during first request completes correctly');
+
+promise_test(async t => {
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/cube.usdz");
+
+    await test_driver.bless("immersive");
+    await model1.requestImmersive();
+    const exitPromise = document.exitImmersive();
+
+    await test_driver.bless("immersive");
+    const requestPromise = model2.requestImmersive();
+
+    await t.step_wait(() => document.immersiveElement === null, 'Waiting for immersive exit');
+    await t.step_wait(() => document.immersiveElement === model2, 'Waiting for new model to be immersive');
+}, 'Immersive request during immersive exit should first wait for exit and then proceeds');
+
+promise_test(async t => {
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model3, source3] = createModelAndSource(t, "../resources/cube.usdz");
+
+    await test_driver.bless("immersive");
+    await model1.requestImmersive();
+    assert_equals(document.immersiveElement, model1);
+
+    await document.exitImmersive();
+    assert_equals(document.immersiveElement, null);
+
+    await test_driver.bless("immersive");
+    await model2.requestImmersive();
+    assert_equals(document.immersiveElement, model2);
+
+    await document.exitImmersive();
+    assert_equals(document.immersiveElement, null);
+
+    await test_driver.bless("immersive");
+    await model3.requestImmersive();
+    assert_equals(document.immersiveElement, model3);
+
+}, 'Rapid request/exit cycles maintain consistent state');
+
+promise_test(async t => {
+    const promises = [];
+    const models = [];
+
+    // Create 5 models and start 5 concurrent requests
+    for (let i = 0; i < 5; i++) {
+        const [model, source] = createModelAndSource(t, "../resources/teapot.usdz");
+        models.push(model);
+        await test_driver.bless("immersive", () => {
+            promises.push(model.requestImmersive());
+        });
+    }
+
+    const results = await Promise.allSettled(promises);
+
+    const succeeded = results.filter(r => r.status === 'fulfilled');
+    const failed = results.filter(r => r.status === 'rejected');
+
+    assert_equals(succeeded.length, 1, 'Exactly one request should succeed');
+    assert_equals(failed.length, 4, 'Four requests should be rejected');
+
+    for (const result of failed) {
+        assert_equals(result.reason.name, 'AbortError', 'Failed requests should reject with AbortError');
+        assert_true(result.reason.message.includes('superseded'), 'Failed requests should indicate they were superseded');
+    }
+
+    assert_equals(document.immersiveElement, models[4], 'Last request should be the one fulfilled');
+
+}, 'Multiple concurrent requests - exactly one succeeds');
+
+promise_test(async t => {
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/cube.usdz");
+
+    await test_driver.bless("immersive");
+    const promise1 = model1.requestImmersive();
+    model1.remove();
+    await promise_rejects_dom(t, "AbortError", promise1);
+
+    assert_equals(document.immersiveElement, null, 'No immersive element after aborted request');
+
+    await test_driver.bless("immersive");
+    await model2.requestImmersive();
+
+    assert_equals(document.immersiveElement, model2, 'State should be clean for new request');
+
+}, 'State remains clean after request aborted by element removal');
+
+promise_test(async t => {
+    const [model1, source1] = createModelAndSource(t, "../resources/cube.usdz");
+    const [model2, source2] = createModelAndSource(t, "../resources/cube.usdz");
+
+    await test_driver.bless("immersive");
+    await model1.requestImmersive();
+    const exitPromise = document.exitImmersive();
+
+    await test_driver.bless("immersive");
+    const requestPromise = model2.requestImmersive();
+    model2.remove();
+
+    await exitPromise;
+    await promise_rejects_dom(t, "AbortError", requestPromise);
+    assert_equals(document.immersiveElement, null, 'State should be clean after removal during exit');
+
+}, 'Element removed while waiting for exit to complete');
+
+</script>
+</body>

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -35,6 +35,7 @@
 #include <WebCore/DocumentEnums.h>
 #include <WebCore/DocumentEventTiming.h>
 #include <WebCore/Element.h>
+#include <WebCore/ExceptionOr.h>
 #include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FontSelectorClient.h>
 #include <WebCore/FrameDestructionObserver.h>
@@ -321,8 +322,6 @@ struct SystemPreviewInfo;
 class RTCPeerConnection;
 #endif
 
-template<typename> class ExceptionOr;
-
 enum class CollectionType : uint8_t;
 enum CSSPropertyID : uint16_t;
 enum class DidUpdateAnyContentRelevancy : bool;
@@ -514,6 +513,24 @@ public:
     using ContainerNode::ref;
     using ContainerNode::deref;
     using TreeScope::rootNode;
+
+#if ENABLE(FULLSCREEN_API) || ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    class CompletionHandlerScope final {
+    public:
+        CompletionHandlerScope(CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
+            : m_completionHandler(WTF::move(completionHandler)) { }
+        CompletionHandlerScope(CompletionHandlerScope&&) = default;
+        CompletionHandlerScope& operator=(CompletionHandlerScope&&) = default;
+        ~CompletionHandlerScope()
+        {
+            if (m_completionHandler)
+                m_completionHandler({ });
+        }
+        CompletionHandler<void(ExceptionOr<void>)> release() { return WTF::move(m_completionHandler); }
+    private:
+        CompletionHandler<void(ExceptionOr<void>)> m_completionHandler;
+    };
+#endif
 
     bool canContainRangeEndPoint() const final { return true; }
 

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -69,22 +69,6 @@
 
 namespace WebCore {
 
-class DocumentFullscreen::CompletionHandlerScope final {
-public:
-    CompletionHandlerScope(CompletionHandler<void(ExceptionOr<void>)>&& completionHandler)
-        : m_completionHandler(WTF::move(completionHandler)) { }
-    CompletionHandlerScope(CompletionHandlerScope&&) = default;
-    CompletionHandlerScope& operator=(CompletionHandlerScope&&) = default;
-    ~CompletionHandlerScope()
-    {
-        if (m_completionHandler)
-            m_completionHandler({ });
-    }
-    CompletionHandler<void(ExceptionOr<void>)> release() { return WTF::move(m_completionHandler); }
-private:
-    CompletionHandler<void(ExceptionOr<void>)> m_completionHandler;
-};
-
 // MARK: - Constructor.
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentFullscreen);

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -112,6 +112,8 @@ protected:
     void clearPendingEvents() { m_pendingEvents.clear(); }
 
 private:
+    using CompletionHandlerScope = Document::CompletionHandlerScope;
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const { return protectedDocument()->logger(); }
     uint64_t logIdentifier() const { return m_logIdentifier; }
@@ -147,8 +149,6 @@ private:
 #if !RELEASE_LOG_DISABLED
     const uint64_t m_logIdentifier;
 #endif
-
-    class CompletionHandlerScope;
 };
 
 }


### PR DESCRIPTION
#### b2c322a1aa1808d972bc2b50dd2e79281b853701
<pre>
Support immersive request cancellation
<a href="https://rdar.apple.com/168579428">rdar://168579428</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306774">https://bugs.webkit.org/show_bug.cgi?id=306774</a>

Reviewed by Etienne Segonzac.

Refactor DocumentImmersive to properly handle lifecycle edge cases including
request superseding, cancellation, and element removal during async operations.

This patch introduces proper lifecycle management:
  - Track active request stage (Permission, ModelPlayer, Presentation)
  - Track pending immersive element to detect superseding
  - Cancel active requests before starting new ones
  - Queue requests during exit and resume after exit completes
  - Add CompletionHandlerScope to ensure completion handlers are always called
  similarly to fullscreen&apos;s logic

Test: model-element/immersive/model-element-immersive-state-consistency.html

* LayoutTests/model-element/immersive/model-element-immersive-basic.html:
* LayoutTests/model-element/immersive/model-element-immersive-no-client-approval.html:
* LayoutTests/model-element/immersive/model-element-immersive-state-consistency-expected.txt: Added.
* LayoutTests/model-element/immersive/model-element-immersive-state-consistency.html: Added.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFullscreen.cpp:
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::requestImmersive):
Refactored to use new lifecycle methods.
(WebCore::DocumentImmersive::exitImmersive):
Added proper cancellation and exit queueing.
(WebCore::DocumentImmersive::handleImmersiveError):
New centralized error handling.
(WebCore::DocumentImmersive::checkRequestStillValid):
Validate request hasn&apos;t been superseded/cancelled.
(WebCore::DocumentImmersive::cancelActiveRequest):
Cancel active request with stage-specific cleanup.
(WebCore::DocumentImmersive::beginImmersiveRequest):
Start immersive request flow.
(WebCore::DocumentImmersive::createModelPlayerForImmersive):
Create model player with queueing support.
(WebCore::DocumentImmersive::presentImmersiveElement):
Present immersive element.
(WebCore::DocumentImmersive::clear):
Clear all state including pending handlers.
* Source/WebCore/dom/DocumentImmersive.h:

Canonical link: <a href="https://commits.webkit.org/306871@main">https://commits.webkit.org/306871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d3fa82df83a43ee46a9b644772aa5b3b016b5ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151287 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109691 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90600 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11666 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9338 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153601 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4747 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117712 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118047 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14060 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70405 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14756 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14493 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78458 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->