### PR TITLE
Ensure Scene Understanding Component is applied on immersive models

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -1058,9 +1058,11 @@ void ModelProcessModelPlayerProxy::ensureImmersivePresentation(CompletionHandler
         if (!protectedThis)
             return completion(std::nullopt);
 
-        if (loaded)
+        RetainPtr entity = protectedThis->m_modelRKEntity;
+        if (loaded && entity) {
+            [entity ensureSceneUnderstanding];
             completion(protectedThis->layerHostingContextIdentifier().value());
-        else {
+        } else {
             protectedThis->setImmersivePresentation(false);
             completion(std::nullopt);
         }

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h
@@ -75,6 +75,9 @@ NS_SWIFT_UI_ACTOR
 - (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform;
 - (void)recenterEntityAtTransform:(WKEntityTransform)transform;
 - (void)applyDefaultIBL;
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+- (void)ensureSceneUnderstanding;
+#endif
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift
@@ -395,6 +395,20 @@ extension WKRKEntity {
         #endif
     }
 
+    #if ENABLE_MODEL_ELEMENT_IMMERSIVE
+    func ensureSceneUnderstanding() {
+        applySceneUnderstandingComponentRecursively(to: entity)
+    }
+
+    @nonobjc
+    private final func applySceneUnderstandingComponentRecursively(to entity: Entity) {
+        entity.components[SceneUnderstandingComponent.self] = .init(entityType: .meshChunk)
+        for child in entity.children {
+            applySceneUnderstandingComponentRecursively(to: child)
+        }
+    }
+    #endif
+
     private func animationPlaybackStateDidUpdate() {
         delegate?.entityAnimationPlaybackStateDidUpdate?(self)
     }


### PR DESCRIPTION
#### b5c58bbcd742d9364d06f36b1b2ac69316f93741
<pre>
Ensure Scene Understanding Component is applied on immersive models
<a href="https://bugs.webkit.org/show_bug.cgi?id=306788">https://bugs.webkit.org/show_bug.cgi?id=306788</a>
<a href="https://rdar.apple.com/168579548">rdar://168579548</a>

Reviewed by Etienne Segonzac.

Add the SceneUnderstandingComponent recursively on the model entity
when this one is displayed as immersive.

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::ensureImmersivePresentation):
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.h:
* Source/WebKit/WebKitSwift/RealityKit/WKRKEntity.swift:
(WKRKEntity.ensureSceneUnderstanding):
(WKRKEntity.applySceneUnderstandingComponentRecursively(to:)):

Canonical link: <a href="https://commits.webkit.org/306699@main">https://commits.webkit.org/306699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/365bc58f4ae4d17f8634195281bcfe9583fb75bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109093 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78880 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/89990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8829 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/599 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120500 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152921 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14014 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3887 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117173 "Found 1 new test failure: media/media-vp8-webm.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117493 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29975 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13538 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124072 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69708 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14052 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3201 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77777 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/13994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->