### PR TITLE
[Style] Add utility to perform em-to-px conversions

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3528,6 +3528,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     style/values/primitives/StylePrimitiveNumericOrKeyword.h
     style/values/primitives/StylePrimitiveNumericTypes+Calculation.h
     style/values/primitives/StylePrimitiveNumericTypes+Evaluation.h
+    style/values/primitives/StylePrimitiveNumericTypes+Rounding.h
     style/values/primitives/StylePrimitiveNumericTypes.h
     style/values/primitives/StyleRatio.h
     style/values/primitives/StyleURL.h

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -43,6 +43,7 @@
 #include "RenderView.h"
 #include "StyleCalculationValue.h"
 #include "StyleLengthResolution.h"
+#include "StylePrimitiveNumericTypes+Rounding.h"
 #include <wtf/Hasher.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
@@ -500,12 +501,12 @@ bool CSSPrimitiveValue::conversionToCanonicalUnitRequiresConversionData() const
 
 template<> int CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<int>(resolveAsLengthDouble(conversionData));
+    return Style::roundForImpreciseConversion<int>(resolveAsLengthDouble(conversionData));
 }
 
 template<> unsigned CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<unsigned>(resolveAsLengthDouble(conversionData));
+    return Style::roundForImpreciseConversion<unsigned>(resolveAsLengthDouble(conversionData));
 }
 
 template<> float CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
@@ -520,12 +521,12 @@ template<> double CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversion
 
 template<> short CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<short>(resolveAsLengthDouble(conversionData));
+    return Style::roundForImpreciseConversion<short>(resolveAsLengthDouble(conversionData));
 }
 
 template<> unsigned short CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const
 {
-    return roundForImpreciseConversion<unsigned short>(resolveAsLengthDouble(conversionData));
+    return Style::roundForImpreciseConversion<unsigned short>(resolveAsLengthDouble(conversionData));
 }
 
 template<> LayoutUnit CSSPrimitiveValue::resolveAsLength(const CSSToLengthConversionData& conversionData) const

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -46,25 +46,6 @@ template<typename> class ExceptionOr;
 constexpr float maxValueForCssLength = static_cast<float>(intMaxForLayoutUnit - 2);
 constexpr float minValueForCssLength = static_cast<float>(intMinForLayoutUnit + 2);
 
-// Dimension calculations are imprecise, often resulting in values of e.g.
-// 44.99998. We need to round if we're really close to the next integer value.
-template<typename T> inline T roundForImpreciseConversion(double value)
-{
-    value += (value < 0) ? -0.01 : +0.01;
-    return ((value > std::numeric_limits<T>::max()) || (value < std::numeric_limits<T>::min())) ? 0 : static_cast<T>(value);
-}
-
-template<> inline float roundForImpreciseConversion(double value)
-{
-    double ceiledValue = ceil(value);
-    double proximityToNextInt = ceiledValue - value;
-    if (proximityToNextInt <= 0.01 && value > 0)
-        return static_cast<float>(ceiledValue);
-    if (proximityToNextInt >= 0.99 && value < 0)
-        return static_cast<float>(floor(value));
-    return static_cast<float>(value);
-}
-
 class CSSPrimitiveValue final : public CSSValue {
 public:
     static constexpr bool isLength(CSSUnitType);

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -49,6 +49,7 @@
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
+#include "StyleLengthResolution.h"
 #include "StyleResolver.h"
 #include "TextEvent.h"
 #include "TextEventInputType.h"
@@ -144,13 +145,7 @@ std::optional<Style::UnadjustedStyle> TextControlInnerElement::resolveCustomStyl
         newStyle->setTextOverflow(TextOverflow::Clip);
         newStyle->setOverflowX(Overflow::Hidden);
         newStyle->setOverflowY(Overflow::Hidden);
-
-        // Set "flex-basis: 1em". Note that CSSPrimitiveValue::resolveAsLength<int>() only needs the element's
-        // style to calculate em lengths. Since the element might not be in a document, just pass nullptr
-        // for the root element style, the parent element style, and the render view.
-        auto emSize = CSSPrimitiveValue::create(1, CSSUnitType::CSS_EM);
-        int pixels = emSize->resolveAsLength<int>(CSSToLengthConversionData { *newStyle, nullptr, nullptr, nullptr });
-        newStyle->setFlexBasis(Style::FlexBasis::Fixed { static_cast<float>(pixels) });
+        newStyle->setFlexBasis(Style::FlexBasis::Fixed { static_cast<float>(Style::emToPx<int>(1, *newStyle)) });
     }
 
     return Style::UnadjustedStyle { WTF::move(newStyle) };

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -31,6 +31,8 @@
 #include <WebCore/RenderStyleProperties+GettersInlines.h>
 #undef RENDER_STYLE_PROPERTIES_GETTERS_INLINES_INCLUDE_TRAP
 
+#include <WebCore/StylePrimitiveNumericTypes+Rounding.h>
+
 namespace WebCore {
 
 // MARK: - Comparisons
@@ -431,7 +433,7 @@ inline int adjustForAbsoluteZoom(int value, const RenderStyle& style)
             value++;
     }
 
-    return roundForImpreciseConversion<int>(value / zoomFactor);
+    return Style::roundForImpreciseConversion<int>(value / zoomFactor);
 }
 
 inline LayoutSize adjustLayoutSizeForAbsoluteZoom(LayoutSize size, const RenderStyle& style)

--- a/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
+++ b/Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp
@@ -53,10 +53,10 @@ DropShadow DropShadow::passthroughForInterpolation()
 
 IntOutsets DropShadow::calculateOutsets(ZoomFactor zoom) const
 {
-    // FIXME: roundForImpreciseConversion<int> only being used to match FilterOperation behavior.
-    auto x = roundForImpreciseConversion<int>(evaluate<float>(this->location.x(), zoom));
-    auto y = roundForImpreciseConversion<int>(evaluate<float>(this->location.y(), zoom));
-    auto stdDeviation = roundForImpreciseConversion<int>(evaluate<float>(this->stdDeviation, zoom));
+    // FIXME: Style::roundForImpreciseConversion<int> only being used to match FilterOperation behavior.
+    auto x = Style::roundForImpreciseConversion<int>(evaluate<float>(this->location.x(), zoom));
+    auto y = Style::roundForImpreciseConversion<int>(evaluate<float>(this->location.y(), zoom));
+    auto stdDeviation = Style::roundForImpreciseConversion<int>(evaluate<float>(this->stdDeviation, zoom));
 
     return FEDropShadow::calculateOutsets(FloatSize(x, y), FloatSize(stdDeviation, stdDeviation));
 }
@@ -89,10 +89,10 @@ auto Evaluation<DropShadow, Ref<FilterEffect>>::operator()(const DropShadow& val
 {
     auto zoom = style.usedZoomForLength();
 
-    // FIXME: roundForImpreciseConversion<int> only being used to match FilterOperation behavior.
-    auto x = roundForImpreciseConversion<int>(evaluate<float>(value.location.x(), zoom));
-    auto y = roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom));
-    auto stdDeviation = roundForImpreciseConversion<int>(evaluate<float>(value.stdDeviation, zoom));
+    // FIXME: Style::roundForImpreciseConversion<int> only being used to match FilterOperation behavior.
+    auto x = Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.x(), zoom));
+    auto y = Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom));
+    auto stdDeviation = Style::roundForImpreciseConversion<int>(evaluate<float>(value.stdDeviation, zoom));
 
     return FEDropShadow::create(stdDeviation, stdDeviation, x, y, value.color.resolveColor(style.color()), 1);
 }
@@ -106,10 +106,10 @@ auto ToPlatform<DropShadow>::operator()(const DropShadow& value, const RenderSty
     return DropShadowFilterOperation::create(
         value.color.resolveColor(style.color()),
         IntPoint {
-            roundForImpreciseConversion<int>(evaluate<float>(value.location.x(), zoom)),
-            roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom)),
+            Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.x(), zoom)),
+            Style::roundForImpreciseConversion<int>(evaluate<float>(value.location.y(), zoom)),
         },
-        roundForImpreciseConversion<int>(evaluate<float>(value.stdDeviation, zoom))
+        Style::roundForImpreciseConversion<int>(evaluate<float>(value.stdDeviation, zoom))
     );
 }
 

--- a/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2025-2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,8 +26,8 @@
 #include "config.h"
 #include "StyleWebKitTextStrokeWidth.h"
 
-#include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleLengthResolution.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 
 namespace WebCore {
@@ -41,19 +41,18 @@ auto CSSValueConversion<WebkitTextStrokeWidth>::operator()(BuilderState& state, 
     if (!primitiveValue)
         return 0_css_px;
 
-    auto handleKeyword = [&](double result) -> WebkitTextStrokeWidth {
-        Ref emsValue = CSSPrimitiveValue::create(result, CSSUnitType::CSS_EM);
-        return toStyleFromCSSValue<WebkitTextStrokeWidth::Length>(state, emsValue);
+    auto convertFromEms = [&](auto ems) -> WebkitTextStrokeWidth::Length {
+        return emToPx<float>(ems, state.renderStyle());
     };
 
     if (primitiveValue->isValueID()) {
         switch (primitiveValue->valueID()) {
         case CSSValueThin:
-            return handleKeyword(1.0 / 48.0);
+            return convertFromEms(1.0 / 48.0);
         case CSSValueMedium:
-            return handleKeyword(3.0 / 48.0);
+            return convertFromEms(3.0 / 48.0);
         case CSSValueThick:
-            return handleKeyword(5.0 / 48.0);
+            return convertFromEms(5.0 / 48.0);
         default:
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return 0_css_px;

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -477,5 +477,15 @@ bool equalForLengthResolution(const RenderStyle& styleA, const RenderStyle& styl
     return true;
 }
 
+double emToPxDouble(double value, const CSSToLengthConversionData& conversionData)
+{
+    return computeNonCalcLengthDouble(value, CSS::LengthUnit::Em, conversionData);
+}
+
+double emToPxDouble(double value, const RenderStyle& style)
+{
+    return computeNonCalcLengthDouble(value, CSS::LengthUnit::Em, CSSToLengthConversionData(style, nullptr, nullptr, nullptr));
+}
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -33,6 +33,7 @@
 #include "StyleBuilderState.h"
 #include "StyleCalculationValue.h"
 #include "StylePrimitiveNumericTypes.h"
+#include "StylePrimitiveNumericTypes+Rounding.h"
 
 namespace WebCore {
 namespace Style {

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Rounding.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Rounding.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <concepts>
+#include <limits>
+
+namespace WebCore {
+namespace Style {
+
+// Dimension calculations are imprecise, often resulting in values of e.g.
+// 44.99998. We need to round if we're really close to the next integer value.
+template<typename T> inline T roundForImpreciseConversion(double value)
+{
+    if constexpr (std::floating_point<T>) {
+        double ceiledValue = std::ceil(value);
+        double proximityToNextInt = ceiledValue - value;
+        if (proximityToNextInt <= 0.01 && value > 0)
+            return static_cast<T>(ceiledValue);
+        if (proximityToNextInt >= 0.99 && value < 0)
+            return static_cast<T>(floor(value));
+        return static_cast<T>(value);
+    } else if constexpr (std::integral<T>) {
+        value += (value < 0) ? -0.01 : +0.01;
+        return ((value > std::numeric_limits<T>::max()) || (value < std::numeric_limits<T>::min())) ? 0 : static_cast<T>(value);
+    }
+}
+
+} // namespace Style
+} // namespace WebCore


### PR DESCRIPTION
#### 58d688191f045a2b017fa1ce74fa9963b5b01021
<pre>
[Style] Add utility to perform em-to-px conversions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306792">https://bugs.webkit.org/show_bug.cgi?id=306792</a>

Reviewed by Antti Koivisto.

Adds utility functions, `emToPx`, to perform em-to-px conversions,
replacing the existing method which used CSSPrimitiveValue to do it.

Also moves numeric rounding function to its own file so it can be
used without including CSSPrimitiveValue.h.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
* Source/WebCore/style/values/filter-effects/StyleDropShadowFunction.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitTextStrokeWidth.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.cpp:
* Source/WebCore/style/values/primitives/StyleLengthResolution.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Rounding.h: Added.

Canonical link: <a href="https://commits.webkit.org/306800@main">https://commits.webkit.org/306800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c802425acc06809fd074c330d4eb891d2518fb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142377 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151023 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109487 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90389 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9176 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153360 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117525 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117850 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30049 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13902 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14501 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3691 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78217 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14438 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14278 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->