### PR TITLE
[Model element] Enable Swift code for specific framework versions or later

### DIFF
--- a/Source/WebCore/Modules/Model/ModelInlineConverters.h
+++ b/Source/WebCore/Modules/Model/ModelInlineConverters.h
@@ -455,21 +455,12 @@ static WebModel::ImageAssetSwizzle convert(MTLTextureSwizzleChannels swizzle)
 
 static WebModel::ImageAsset convert(WebBridgeImageAsset *imageAsset)
 {
-    RetainPtr imageSource = adoptCF(CGImageSourceCreateWithData((CFDataRef)imageAsset.data, nullptr));
-    auto platformImage = adoptCF(CGImageSourceCreateImageAtIndex(imageSource.get(), 0, nullptr));
-    RetainPtr pixelDataCfData = adoptCF(CGDataProviderCopyData(CGImageGetDataProvider(platformImage.get())));
-    auto byteSpan = span(pixelDataCfData.get());
-
-    auto width = CGImageGetWidth(platformImage.get());
-    auto height = CGImageGetHeight(platformImage.get());
-    auto bytesPerPixel = (int)(byteSpan.size() / (width * height));
-
     return WebModel::ImageAsset {
-        .data = Vector<uint8_t> { byteSpan },
-        .width = static_cast<long>(width),
-        .height = static_cast<long>(height),
+        .data = makeVector(imageAsset.data),
+        .width = imageAsset.width,
+        .height = imageAsset.height,
         .depth = 1,
-        .bytesPerPixel = bytesPerPixel,
+        .bytesPerPixel = imageAsset.bytesPerPixel,
         .textureType = imageAsset.textureType,
         .pixelFormat = imageAsset.pixelFormat,
         .mipmapLevelCount = imageAsset.mipmapLevelCount,

--- a/Source/WebGPU/WebGPU/Mesh.mm
+++ b/Source/WebGPU/WebGPU/Mesh.mm
@@ -289,7 +289,7 @@ void Mesh::updateTexture(WebBridgeUpdateTexture* descriptor)
 void Mesh::updateMaterial(const WebModel::UpdateMaterialDescriptor& originalDescriptor)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    WebBridgeUpdateMaterial *descriptor = [[WebBridgeUpdateMaterial alloc] initWithMaterialGraph:WebModel::convert(originalDescriptor.materialGraph) identifier:originalDescriptor.identifier.createNSString().get()];
+    WebBridgeUpdateMaterial *descriptor = [[WebBridgeUpdateMaterial alloc] initWithMaterialGraph:WebModel::convert(originalDescriptor.materialGraph) identifier:originalDescriptor.identifier.createNSString().get() geometryModifierFunctionReference:nil surfaceShaderFunctionReference:nil shaderGraphModule:nil];
     if (!descriptor)
         return;
 

--- a/Source/WebGPU/WebGPU/ModelIBLTextures.swift
+++ b/Source/WebGPU/WebGPU/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9999)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
 
 import Metal
 @_spi(RealityCoreRendererAPI) import RealityKit

--- a/Source/WebGPU/WebGPU/ModelParameters.swift
+++ b/Source/WebGPU/WebGPU/ModelParameters.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9999)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
 
 @_spi(RealityCoreRendererAPI) import RealityKit
 

--- a/Source/WebGPU/WebGPU/ModelRenderer.swift
+++ b/Source/WebGPU/WebGPU/ModelRenderer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9999)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
 
 import QuartzCore
 @_spi(RealityCoreRendererAPI) @_spi(Private) import RealityKit

--- a/Source/WebGPU/WebGPU/ModelUtils.swift
+++ b/Source/WebGPU/WebGPU/ModelUtils.swift
@@ -21,14 +21,14 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9999)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
 
 import DirectResource
 import Metal
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(SGInternal) import RealityKit
 internal import WebGPU_Private.ModelTypes
-@_spi(UsdLoaderAPI) import _USDStageKit_SwiftUI
+@_spi(UsdLoaderAPI) import _RealityKit_SwiftUI
 
 nonisolated func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
     switch semantic {

--- a/Source/WebGPU/WebGPU/USDModel.swift
+++ b/Source/WebGPU/WebGPU/USDModel.swift
@@ -26,33 +26,654 @@ internal import OSLog
 internal import WebGPU_Private.ModelTypes
 internal import simd
 
-#if canImport(RealityCoreRenderer, _version: 9999)
-@_spi(RealityCoreRendererAPI) @_spi(ShaderGraph) import RealityKit
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+@_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(RealityCoreTextureProcessingAPI) import RealityCoreTextureProcessing
-@_spi(UsdLoaderAPI) import _USDStageKit_SwiftUI
+@_spi(UsdLoaderAPI) import _USDKit_RealityKit
 @_spi(SwiftAPI) import DirectResource
-import USDStageKit
-import _USDStageKit_SwiftUI
+import _USDKit_RealityKit
 import RealityKit
+@_spi(SGPrivate) import ShaderGraph
+import RealityCoreDeformation
 
-extension _USDStageKit_SwiftUI._Proto_MeshDataUpdate_v1 {
-    @_silgen_name("$s20_USDStageKit_SwiftUI24_Proto_MeshDataUpdate_v1V18instanceTransformsSaySo13simd_float4x4aGvg")
+extension _USDKit_RealityKit._Proto_MeshDataUpdate_v1 {
+    @_silgen_name("$s18_USDKit_RealityKit24_Proto_MeshDataUpdate_v1V18instanceTransformsSaySo13simd_float4x4aGvg")
     internal func instanceTransformsCompat() -> [simd_float4x4]
 }
 
-extension _USDStageKit_SwiftUI._Proto_DeformationData_v1.SkinningData {
-    @_silgen_name("$s20_USDStageKit_SwiftUI25_Proto_DeformationData_v1V08SkinningG0V21geometryBindTransformSo13simd_float4x4avg")
+extension _USDKit_RealityKit._Proto_DeformationData_v1.SkinningData {
+    @_silgen_name("$s18_USDKit_RealityKit25_Proto_DeformationData_v1V08SkinningF0V21geometryBindTransformSo13simd_float4x4avg")
     internal func geometryBindTransformCompat() -> simd_float4x4
 }
 
-extension _USDStageKit_SwiftUI._Proto_DeformationData_v1.SkinningData {
-    @_silgen_name("$s20_USDStageKit_SwiftUI25_Proto_DeformationData_v1V08SkinningG0V15jointTransformsSaySo13simd_float4x4aGvg")
+extension _USDKit_RealityKit._Proto_DeformationData_v1.SkinningData {
+    @_silgen_name("$s18_USDKit_RealityKit25_Proto_DeformationData_v1V08SkinningF0V15jointTransformsSaySo13simd_float4x4aGvg")
     internal func jointTransformsCompat() -> [simd_float4x4]
 }
 
-extension _USDStageKit_SwiftUI._Proto_DeformationData_v1.SkinningData {
-    @_silgen_name("$s20_USDStageKit_SwiftUI25_Proto_DeformationData_v1V08SkinningG0V16inverseBindPosesSaySo13simd_float4x4aGvg")
+extension _USDKit_RealityKit._Proto_DeformationData_v1.SkinningData {
+    @_silgen_name("$s18_USDKit_RealityKit25_Proto_DeformationData_v1V08SkinningF0V16inverseBindPosesSaySo13simd_float4x4aGvg")
     internal func inverseBindPosesCompat() -> [simd_float4x4]
+}
+
+extension RealityCoreRenderer._Proto_LowLevelRenderContext_v1 {
+    @_silgen_name(
+        "$s19RealityCoreRenderer16MaterialCompilerC24makeShaderGraphFunctionsyAA015_Proto_LowLevelD11Resource_v1C0gH6OutputV10Foundation4DataVSg_ScA_pSgYitYaKF"
+    )
+    internal func makeShaderGraphFunctions(
+        module shaderGraphModule: ShaderGraph.Module,
+        geometryModifier geometryModifierFunctionReference: ShaderGraph.FunctionReference?,
+        surfaceShader surfaceShaderFunctionReference: ShaderGraph.FunctionReference,
+        _ isolation: isolated (any Actor)?
+    ) async throws -> sending _Proto_LowLevelMaterialResource_v1.ShaderGraphOutput
+}
+
+private func toSGType(_ module: WebBridgeModule?) -> ShaderGraph.Module? {
+    guard let module else { return nil }
+
+    // Convert the WebBridgeModule to ShaderGraph.Module
+    // LIMITATION: ShaderGraph.Module's public initializer only accepts name and imports
+    // The typeDefinitions, functions, and graphs cannot be set via the public API
+    //
+    // This means converting a complete WebBridgeModule to ShaderGraph.Module will
+    // lose the typeDefinitions, functions, and graphs data.
+    //
+    // For a complete conversion, you may need to:
+    // 1. Use the materialSourceArchive approach (see commented code in updateMaterial)
+    // 2. Find an alternative ShaderGraph API that accepts all module components
+    // 3. Use a different serialization/deserialization approach
+
+    // Convert imports
+    let imports = module.imports.compactMap { toSGModuleReference($0) }
+
+    // Log warning if we're losing data
+    if !module.typeDefinitions.isEmpty || !module.functions.isEmpty || !module.graphs.isEmpty {
+        logError(
+            "WARNING: Converting WebBridgeModule to ShaderGraph.Module - losing \(module.typeDefinitions.count) type definitions, \(module.functions.count) functions, and \(module.graphs.count) graphs due to API limitations"
+        )
+    }
+
+    // Create the ShaderGraph.Module with available data only
+    return ShaderGraph.Module(module.name, imports: imports)
+}
+
+// Helper conversion functions for nested types
+private func toSGModuleReference(_ ref: WebBridgeModuleReference) -> ShaderGraph.ModuleReference? {
+    // Convert WebBridgeModuleReference to ShaderGraph.ModuleReference
+    guard let module = toSGType(ref.module) else { return nil }
+    return ShaderGraph.ModuleReference(module)
+}
+
+private func toSGTypeDefinition(_ typeDef: WebBridgeTypeDefinition) -> ShaderGraph.TypeDefinition? {
+    // TypeDefinition cannot be constructed - must be obtained from Module
+    // This conversion is not possible without a Module context
+    nil
+}
+
+private func toSGTypeReference(_ typeRef: WebBridgeTypeReference) -> ShaderGraph.TypeReference? {
+    // TypeReference cannot be constructed - must be obtained from TypeDefinition
+    // This conversion is not possible
+    nil
+}
+
+private func toSGStructMember(_ member: WebBridgeStructMember) -> ShaderGraph.TypeDefinition.StructMember? {
+    guard let type = toSGTypeReference(member.type) else { return nil }
+    return ShaderGraph.TypeDefinition.StructMember(member.name, type: type)
+}
+
+private func toSGEnumCase(_ enumCase: WebBridgeEnumCase) -> ShaderGraph.TypeDefinition.EnumCase? {
+    ShaderGraph.TypeDefinition.EnumCase(enumCase.name, value: enumCase.value)
+}
+
+private func toSGFunction(_ function: WebBridgeFunction) -> ShaderGraph.Function? {
+    // Function cannot be constructed - must be obtained from Module or created via addGraph
+    // This conversion is not possible
+    nil
+}
+
+private func toSGFunctionArgument(_ arg: WebBridgeFunctionArgument) -> ShaderGraph.Function.Argument? {
+    guard let type = toSGTypeReference(arg.type) else { return nil }
+    return ShaderGraph.Function.Argument(name: arg.name, type: type)
+}
+
+private func toSGModuleGraph(_ graph: WebBridgeModuleGraph) -> ShaderGraph.ModuleGraph? {
+    // ModuleGraph cannot be constructed - must be created via Module.addGraph()
+    // This conversion is not possible
+    nil
+}
+
+private func toSGNode(_ node: WebBridgeNode) -> ShaderGraph.ModuleGraph.Node? {
+    // Node cannot be constructed - created via ModuleGraph.insert()
+    // This conversion is not possible
+    nil
+}
+
+private func toSGNodeID(_ nodeID: WebBridgeNodeID) -> ShaderGraph.ModuleGraph.Node.ID? {
+    // Node.ID cannot be constructed - returned from ModuleGraph.insert()
+    // This conversion is not possible
+    nil
+}
+
+private func toSGNodeInstruction(_ instruction: WebBridgeNodeInstruction) -> ShaderGraph.ModuleGraph.Node.Instruction? {
+    // Convert WebBridgeNodeInstruction to ShaderGraph.ModuleGraph.Node.Instruction
+    // The instruction type determines which properties are used
+    switch instruction.type {
+    case .functionCall:
+        guard let functionCall = instruction.functionCall else { return nil }
+        return toSGNodeInstructionFromFunctionCall(functionCall)
+
+    case .functionConstant:
+        guard let constantName = instruction.constantName,
+            let literal = instruction.literal
+        else { return nil }
+        return toSGNodeInstructionFromFunctionConstant(name: constantName, literal: literal)
+
+    case .literal:
+        guard let literal = instruction.literal else { return nil }
+        return toSGNodeInstructionFromLiteral(literal)
+
+    case .argument:
+        guard let argumentName = instruction.argumentName else { return nil }
+        return toSGNodeInstructionFromArgument(argumentName)
+
+    case .element:
+        guard let elementType = instruction.elementType,
+            let elementName = instruction.elementName
+        else { return nil }
+        return toSGNodeInstructionFromElement(type: elementType, name: elementName)
+
+    @unknown default:
+        logError("Unknown WebBridgeNodeInstructionType: \(instruction.type.rawValue)")
+        return nil
+    }
+}
+
+private func toSGNodeInstructionFromFunctionCall(_ functionCall: WebBridgeFunctionCall) -> ShaderGraph.ModuleGraph.Node.Instruction? {
+    // Based on the test: .functionCall(.name("dot")) or .functionCall(.reference(fnRef))
+    switch functionCall.type {
+    case .name:
+        guard let name = functionCall.name else { return nil }
+        return .functionCall(.name(name))
+
+    case .reference:
+        guard let reference = functionCall.reference,
+            let sgRef = toSGType(reference)
+        else { return nil }
+        return .functionCall(.reference(sgRef))
+
+    @unknown default:
+        logError("Unknown WebBridgeFunctionCallType: \(functionCall.type.rawValue)")
+        return nil
+    }
+}
+
+private func toSGNodeInstructionFromFunctionConstant(name: String, literal: WebBridgeLiteral) -> ShaderGraph.ModuleGraph.Node.Instruction? {
+    // Based on the test: .functionConstant("dayCycleConstant", .int32(0))
+    guard let sgLiteral = toSGLiteral(literal) else { return nil }
+    return .functionConstant(name, sgLiteral)
+}
+
+private func toSGNodeInstructionFromLiteral(_ literal: WebBridgeLiteral) -> ShaderGraph.ModuleGraph.Node.Instruction? {
+    // Based on the test: .literal(.float3(SIMD3<Float>(1,0,1)))
+    guard let sgLiteral = toSGLiteral(literal) else { return nil }
+    return .literal(sgLiteral)
+}
+
+private func toSGNodeInstructionFromArgument(_ argumentName: String) -> ShaderGraph.ModuleGraph.Node.Instruction? {
+    // Based on the test: .argument("params")
+    .argument(argumentName)
+}
+
+private func toSGNodeInstructionFromElement(type: WebBridgeTypeReference, name: String) -> ShaderGraph.ModuleGraph.Node.Instruction? {
+    // Based on the test: .element(uniformsType, "vector")
+    guard let sgType = toSGTypeReference(type) else { return nil }
+    return .element(sgType, name)
+}
+
+private func toSGLiteral(_ literal: WebBridgeLiteral) -> ShaderGraph.Literal? {
+    // Convert WebBridgeLiteral to ShaderGraph.Literal
+    // ShaderGraph.Literal is an enum - we need to construct the appropriate case
+    let data = literal.archive.data.map { $0.uint32Value }
+
+    // Helper function to reconstruct different types from UInt32 array
+    func toFloat(_ value: UInt32) -> Float {
+        Float(bitPattern: value)
+    }
+
+    func toInt32(_ value: UInt32) -> Int32 {
+        Int32(bitPattern: value)
+    }
+
+    #if arch(arm64)
+    func toHalf(_ value: UInt32) -> Swift.Float16 {
+        Swift.Float16(bitPattern: UInt16(value))
+    }
+    #endif
+
+    // Reconstruct the literal based on its type
+    switch literal.type {
+    case .bool:
+        guard let first = data.first else { return nil }
+        return .bool(first != 0)
+
+    case .int32:
+        guard let first = data.first else { return nil }
+        return .int32(toInt32(first))
+
+    case .uInt32:
+        guard let first = data.first else { return nil }
+        return .uint32(first)
+
+    case .float:
+        guard let first = data.first else { return nil }
+        return .float(toFloat(first))
+
+    case .float2:
+        guard data.count >= 2 else { return nil }
+        return .float2(SIMD2(toFloat(data[0]), toFloat(data[1])))
+
+    case .float3:
+        guard data.count >= 3 else { return nil }
+        return .float3(SIMD3(toFloat(data[0]), toFloat(data[1]), toFloat(data[2])))
+
+    case .float4:
+        guard data.count >= 4 else { return nil }
+        return .float4(SIMD4(toFloat(data[0]), toFloat(data[1]), toFloat(data[2]), toFloat(data[3])))
+
+    #if arch(arm64)
+    case .half:
+        guard let first = data.first else { return nil }
+        return .half(toHalf(first))
+
+    case .half2:
+        guard data.count >= 2 else { return nil }
+        return .half2(SIMD2(toHalf(data[0]), toHalf(data[1])))
+
+    case .half3:
+        guard data.count >= 3 else { return nil }
+        return .half3(SIMD3(toHalf(data[0]), toHalf(data[1]), toHalf(data[2])))
+
+    case .half4:
+        guard data.count >= 4 else { return nil }
+        return .half4(SIMD4(toHalf(data[0]), toHalf(data[1]), toHalf(data[2]), toHalf(data[3])))
+    #endif
+
+    case .int2:
+        guard data.count >= 2 else { return nil }
+        return .int2(SIMD2(toInt32(data[0]), toInt32(data[1])))
+
+    case .int3:
+        guard data.count >= 3 else { return nil }
+        return .int3(SIMD3(toInt32(data[0]), toInt32(data[1]), toInt32(data[2])))
+
+    case .int4:
+        guard data.count >= 4 else { return nil }
+        return .int4(SIMD4(toInt32(data[0]), toInt32(data[1]), toInt32(data[2]), toInt32(data[3])))
+
+    case .uInt2:
+        guard data.count >= 2 else { return nil }
+        return .uint2(SIMD2(data[0], data[1]))
+
+    case .uInt3:
+        guard data.count >= 3 else { return nil }
+        return .uint3(SIMD3(data[0], data[1], data[2]))
+
+    case .uInt4:
+        guard data.count >= 4 else { return nil }
+        return .uint4(SIMD4(data[0], data[1], data[2], data[3]))
+
+    case .float2x2:
+        guard data.count >= 4 else { return nil }
+        return .float2x2(
+            SIMD2(toFloat(data[0]), toFloat(data[1])),
+            SIMD2(toFloat(data[2]), toFloat(data[3]))
+        )
+
+    case .float3x3:
+        guard data.count >= 9 else { return nil }
+        return .float3x3(
+            SIMD3(toFloat(data[0]), toFloat(data[1]), toFloat(data[2])),
+            SIMD3(toFloat(data[3]), toFloat(data[4]), toFloat(data[5])),
+            SIMD3(toFloat(data[6]), toFloat(data[7]), toFloat(data[8]))
+        )
+
+    case .float4x4:
+        guard data.count >= 16 else { return nil }
+        return .float4x4(
+            SIMD4(toFloat(data[0]), toFloat(data[1]), toFloat(data[2]), toFloat(data[3])),
+            SIMD4(toFloat(data[4]), toFloat(data[5]), toFloat(data[6]), toFloat(data[7])),
+            SIMD4(toFloat(data[8]), toFloat(data[9]), toFloat(data[10]), toFloat(data[11])),
+            SIMD4(toFloat(data[12]), toFloat(data[13]), toFloat(data[14]), toFloat(data[15]))
+        )
+
+    #if arch(arm64)
+    case .half2x2:
+        guard data.count >= 4 else { return nil }
+        return .half2x2(
+            SIMD2(toHalf(data[0]), toHalf(data[1])),
+            SIMD2(toHalf(data[2]), toHalf(data[3]))
+        )
+
+    case .half3x3:
+        guard data.count >= 9 else { return nil }
+        return .half3x3(
+            SIMD3(toHalf(data[0]), toHalf(data[1]), toHalf(data[2])),
+            SIMD3(toHalf(data[3]), toHalf(data[4]), toHalf(data[5])),
+            SIMD3(toHalf(data[6]), toHalf(data[7]), toHalf(data[8]))
+        )
+
+    case .half4x4:
+        guard data.count >= 16 else { return nil }
+        return .half4x4(
+            SIMD4(toHalf(data[0]), toHalf(data[1]), toHalf(data[2]), toHalf(data[3])),
+            SIMD4(toHalf(data[4]), toHalf(data[5]), toHalf(data[6]), toHalf(data[7])),
+            SIMD4(toHalf(data[8]), toHalf(data[9]), toHalf(data[10]), toHalf(data[11])),
+            SIMD4(toHalf(data[12]), toHalf(data[13]), toHalf(data[14]), toHalf(data[15]))
+        )
+    #endif
+
+    @unknown default:
+        logError("Unknown WebBridgeLiteralType: \(literal.type.rawValue)")
+        return nil
+    }
+}
+
+private func toSGGraphEdge(_ edge: WebBridgeGraphEdge) -> (ShaderGraph.ModuleGraph.Node.ID, ShaderGraph.ModuleGraph.Node.ID, String)? {
+    // ShaderGraph edges are tuples created via graph.connect()
+    // We cannot create them directly without a ModuleGraph context
+    // This conversion is not possible
+    nil
+}
+
+private func toSGType(_ functionRef: WebBridgeFunctionReference?) -> ShaderGraph.FunctionReference? {
+    guard let functionRef else { return nil }
+    return nil
+}
+
+// Conversion functions from ShaderGraph types to WebBridge types
+private func fromSGType(_ module: ShaderGraph.Module?) -> WebBridgeModule? {
+    guard let module else { return nil }
+
+    // Convert all nested types from ShaderGraph to WebBridge format
+    let imports = fromSGModuleReferenceArray(module.imports)
+    let typeDefinitions = fromSGTypeDefinitionArray(module.typeDefinitions)
+    let functions = fromSGFunctionArray(module.functions)
+    let graphs = fromSGModuleGraphArray(module.graphs)
+
+    return WebBridgeModule(
+        name: module.name,
+        imports: imports,
+        typeDefinitions: typeDefinitions,
+        functions: functions,
+        graphs: graphs
+    )
+}
+
+// Helper conversion functions from ShaderGraph to WebBridge types
+private func fromSGModuleReferenceArray(_ refs: [ShaderGraph.ModuleReference]) -> [WebBridgeModuleReference] {
+    refs.compactMap { fromSGModuleReference($0) }
+}
+
+private func fromSGModuleReference(_ ref: ShaderGraph.ModuleReference) -> WebBridgeModuleReference? {
+    guard let module = fromSGType(ref.module) else { return nil }
+    return WebBridgeModuleReference(module: module)
+}
+
+private func fromSGTypeDefinitionArray(_ typeDefs: [ShaderGraph.TypeDefinition]) -> [WebBridgeTypeDefinition] {
+    typeDefs.compactMap { fromSGTypeDefinition($0) }
+}
+
+private func fromSGTypeDefinition(_ typeDef: ShaderGraph.TypeDefinition) -> WebBridgeTypeDefinition? {
+    // TypeDefinition doesn't expose structMembers, enumCases, or structureType through public API
+    // The proper way to serialize/deserialize is using ModuleCoder
+    // For now, return nil to indicate this conversion is not supported
+    logError("Cannot convert ShaderGraph.TypeDefinition - use ModuleCoder for serialization")
+    return nil
+}
+
+private func fromSGTypeReference(_ typeRef: ShaderGraph.TypeReference) -> WebBridgeTypeReference? {
+    // TypeReference doesn't expose moduleName or typeDefIndex through public API
+    // The proper way to serialize/deserialize is using ModuleCoder
+    logError("Cannot convert ShaderGraph.TypeReference - use ModuleCoder for serialization")
+    return nil
+}
+
+private func fromSGStructMember(_ member: ShaderGraph.TypeDefinition.StructMember) -> WebBridgeStructMember? {
+    guard let type = fromSGTypeReference(member.type) else { return nil }
+    return WebBridgeStructMember(name: member.name, type: type)
+}
+
+private func fromSGEnumCase(_ enumCase: ShaderGraph.TypeDefinition.EnumCase) -> WebBridgeEnumCase? {
+    WebBridgeEnumCase(name: enumCase.name, value: enumCase.value)
+}
+
+private func fromSGFunctionArray(_ functions: [ShaderGraph.Function]) -> [WebBridgeFunction] {
+    functions.compactMap { fromSGFunction($0) }
+}
+
+private func fromSGFunction(_ function: ShaderGraph.Function) -> WebBridgeFunction? {
+    // Function doesn't expose kind or kindName through public API
+    // The proper way to serialize/deserialize is using ModuleCoder
+    logError("Cannot convert ShaderGraph.Function - use ModuleCoder for serialization")
+    return nil
+}
+
+private func fromSGFunctionArgument(_ arg: ShaderGraph.Function.Argument) -> WebBridgeFunctionArgument? {
+    guard let type = fromSGTypeReference(arg.type) else { return nil }
+    return WebBridgeFunctionArgument(name: arg.name, type: type)
+}
+
+private func fromSGModuleGraphArray(_ graphs: [ShaderGraph.ModuleGraph]) -> [WebBridgeModuleGraph] {
+    graphs.compactMap { fromSGModuleGraph($0) }
+}
+
+private func fromSGModuleGraph(_ graph: ShaderGraph.ModuleGraph) -> WebBridgeModuleGraph? {
+    // ModuleGraph doesn't expose index property through public API
+    // The proper way to serialize/deserialize is using ModuleCoder
+    logError("Cannot convert ShaderGraph.ModuleGraph - use ModuleCoder for serialization")
+    return nil
+}
+
+private func fromSGNode(_ node: ShaderGraph.ModuleGraph.Node) -> WebBridgeNode? {
+    // Node doesn't expose identifier property through public API
+    // The proper way to serialize/deserialize is using ModuleCoder
+    logError("Cannot convert ShaderGraph.ModuleGraph.Node - use ModuleCoder for serialization")
+    return nil
+}
+
+private func fromSGNodeID(_ nodeID: ShaderGraph.ModuleGraph.Node.ID) -> WebBridgeNodeID? {
+    // Node.ID doesn't expose value property through public API
+    // The proper way to serialize/deserialize is using ModuleCoder
+    logError("Cannot convert ShaderGraph.ModuleGraph.Node.ID - use ModuleCoder for serialization")
+    return nil
+}
+
+private func fromSGNodeInstruction(_ instruction: ShaderGraph.ModuleGraph.Node.Instruction) -> WebBridgeNodeInstruction? {
+    // Convert ShaderGraph.ModuleGraph.Node.Instruction to WebBridgeNodeInstruction
+    // Based on the test example, Instruction is an enum with cases:
+    // .functionCall(FunctionCall), .literal(Literal), .argument(String), .element(TypeReference, String), .functionConstant(String, Literal)
+    switch instruction {
+    case .functionCall(let call):
+        // FunctionCall is itself an enum with .name(String) or .reference(FunctionReference)
+        switch call {
+        case .name(let name):
+            let functionCall = WebBridgeFunctionCall(name: name)
+            return WebBridgeNodeInstruction(functionCall: functionCall)
+        case .reference(let ref):
+            guard let webRef = fromSGType(ref) else { return nil }
+            let functionCall = WebBridgeFunctionCall(reference: webRef)
+            return WebBridgeNodeInstruction(functionCall: functionCall)
+        @unknown default:
+            fatalError("unexpecetd value contained in call")
+        }
+
+    case .functionConstant(let name, let literal):
+        guard let webLiteral = fromSGLiteral(literal) else { return nil }
+        return WebBridgeNodeInstruction(functionConstant: name, literal: webLiteral)
+
+    case .literal(let literal):
+        guard let webLiteral = fromSGLiteral(literal) else { return nil }
+        return WebBridgeNodeInstruction(literal: webLiteral)
+
+    case .argument(let argumentName):
+        return WebBridgeNodeInstruction(argument: argumentName)
+
+    case .element(let type, let name):
+        guard let webType = fromSGTypeReference(type) else { return nil }
+        return WebBridgeNodeInstruction(elementType: webType, elementName: name)
+    @unknown default:
+        fatalError("unexpecetd value contained in instruction")
+    }
+}
+
+private func fromSGLiteral(_ literal: ShaderGraph.Literal) -> WebBridgeLiteral? {
+    // Convert ShaderGraph.Literal to WebBridgeLiteral
+    // ShaderGraph.Literal is an enum with associated values
+    // We need to pattern match each case and convert to WebBridgeLiteral format
+    let (literalType, data): (WebBridgeLiteralType, [UInt32])
+
+    switch literal {
+    case .bool(let value):
+        literalType = .bool
+        data = [value ? 1 : 0]
+
+    case .int32(let value):
+        literalType = .int32
+        data = [UInt32(bitPattern: value)]
+
+    case .uint32(let value):
+        literalType = .uInt32
+        data = [value]
+
+    case .float(let value):
+        literalType = .float
+        data = [value.bitPattern]
+
+    case .float2(let value):
+        literalType = .float2
+        data = [value.x.bitPattern, value.y.bitPattern]
+
+    case .float3(let value):
+        literalType = .float3
+        data = [value.x.bitPattern, value.y.bitPattern, value.z.bitPattern]
+
+    case .float4(let value):
+        literalType = .float4
+        data = [value.x.bitPattern, value.y.bitPattern, value.z.bitPattern, value.w.bitPattern]
+
+    #if arch(arm64)
+    case .half(let value):
+        literalType = .half
+        data = [UInt32(value.bitPattern)]
+
+    case .half2(let value):
+        literalType = .half2
+        data = [UInt32(value.x.bitPattern), UInt32(value.y.bitPattern)]
+
+    case .half3(let value):
+        literalType = .half3
+        data = [UInt32(value.x.bitPattern), UInt32(value.y.bitPattern), UInt32(value.z.bitPattern)]
+
+    case .half4(let value):
+        literalType = .half4
+        data = [UInt32(value.x.bitPattern), UInt32(value.y.bitPattern), UInt32(value.z.bitPattern), UInt32(value.w.bitPattern)]
+    #endif
+
+    case .int2(let value):
+        literalType = .int2
+        data = [UInt32(bitPattern: value.x), UInt32(bitPattern: value.y)]
+
+    case .int3(let value):
+        literalType = .int3
+        data = [UInt32(bitPattern: value.x), UInt32(bitPattern: value.y), UInt32(bitPattern: value.z)]
+
+    case .int4(let value):
+        literalType = .int4
+        data = [UInt32(bitPattern: value.x), UInt32(bitPattern: value.y), UInt32(bitPattern: value.z), UInt32(bitPattern: value.w)]
+
+    case .uint2(let value):
+        literalType = .uInt2
+        data = [value.x, value.y]
+
+    case .uint3(let value):
+        literalType = .uInt3
+        data = [value.x, value.y, value.z]
+
+    case .uint4(let value):
+        literalType = .uInt4
+        data = [value.x, value.y, value.z, value.w]
+
+    case .float2x2(let col0, let col1):
+        literalType = .float2x2
+        data = [col0.x.bitPattern, col0.y.bitPattern, col1.x.bitPattern, col1.y.bitPattern]
+
+    case .float3x3(let col0, let col1, let col2):
+        literalType = .float3x3
+        data = [
+            col0.x.bitPattern, col0.y.bitPattern, col0.z.bitPattern,
+            col1.x.bitPattern, col1.y.bitPattern, col1.z.bitPattern,
+            col2.x.bitPattern, col2.y.bitPattern, col2.z.bitPattern,
+        ]
+
+    case .float4x4(let col0, let col1, let col2, let col3):
+        literalType = .float4x4
+        data = [
+            col0.x.bitPattern, col0.y.bitPattern, col0.z.bitPattern, col0.w.bitPattern,
+            col1.x.bitPattern, col1.y.bitPattern, col1.z.bitPattern, col1.w.bitPattern,
+            col2.x.bitPattern, col2.y.bitPattern, col2.z.bitPattern, col2.w.bitPattern,
+            col3.x.bitPattern, col3.y.bitPattern, col3.z.bitPattern, col3.w.bitPattern,
+        ]
+
+    #if arch(arm64)
+    case .half2x2(let col0, let col1):
+        literalType = .half2x2
+        data = [
+            UInt32(col0.x.bitPattern), UInt32(col0.y.bitPattern),
+            UInt32(col1.x.bitPattern), UInt32(col1.y.bitPattern),
+        ]
+
+    case .half3x3(let col0, let col1, let col2):
+        literalType = .half3x3
+        data = [
+            UInt32(col0.x.bitPattern), UInt32(col0.y.bitPattern), UInt32(col0.z.bitPattern),
+            UInt32(col1.x.bitPattern), UInt32(col1.y.bitPattern), UInt32(col1.z.bitPattern),
+            UInt32(col2.x.bitPattern), UInt32(col2.y.bitPattern), UInt32(col2.z.bitPattern),
+        ]
+
+    case .half4x4(let col0, let col1, let col2, let col3):
+        literalType = .half4x4
+        data = [
+            UInt32(col0.x.bitPattern), UInt32(col0.y.bitPattern), UInt32(col0.z.bitPattern), UInt32(col0.w.bitPattern),
+            UInt32(col1.x.bitPattern), UInt32(col1.y.bitPattern), UInt32(col1.z.bitPattern), UInt32(col1.w.bitPattern),
+            UInt32(col2.x.bitPattern), UInt32(col2.y.bitPattern), UInt32(col2.z.bitPattern), UInt32(col2.w.bitPattern),
+            UInt32(col3.x.bitPattern), UInt32(col3.y.bitPattern), UInt32(col3.z.bitPattern), UInt32(col3.w.bitPattern),
+        ]
+    #endif
+
+    @unknown default:
+        logError("Unknown ShaderGraph.Literal case")
+        return nil
+    }
+
+    // Convert UInt32 array to NSNumber array
+    let nsData = data.map { NSNumber(value: $0) }
+
+    return WebBridgeLiteral(type: literalType, data: nsData)
+}
+
+private func fromSGGraphEdge(_ edge: (ShaderGraph.ModuleGraph.Node.ID, ShaderGraph.ModuleGraph.Node.ID, String)) -> WebBridgeGraphEdge? {
+    guard let source = fromSGNodeID(edge.0) else { return nil }
+    guard let destination = fromSGNodeID(edge.1) else { return nil }
+    return WebBridgeGraphEdge(source: source, destination: destination, argument: edge.2)
+}
+
+private func fromSGType(_ functionRef: ShaderGraph.FunctionReference?) -> WebBridgeFunctionReference? {
+    guard let functionRef else { return nil }
+    #if canImport(RealityCoreRenderer, _version: 8)
+    return WebBridgeFunctionReference(moduleName: functionRef.module, functionIndex: 0)
+    #else
+    return WebBridgeFunctionReference(moduleName: "functionRef.module", functionIndex: 0)
+    #endif
 }
 
 extension MTLCaptureDescriptor {
@@ -188,10 +809,6 @@ private func makeMTLTextureFromImageAsset(
     unsafe imageAssetData.bytes.withUnsafeBytes { textureBytes in
         guard let textureBytesBaseAddress = textureBytes.baseAddress else {
             return
-        }
-        if imageAsset.bytesPerPixel == 0 {
-            logError("bytesPerPixel == 0")
-            fatalError()
         }
         for face in 0..<sliceCount {
             let offset = face * bytesPerImage
@@ -563,8 +1180,6 @@ extension WebBridgeReceiver {
 
     @nonobjc
     fileprivate var textureResources: [String: _Proto_LowLevelTextureResource_v1] = [:]
-    @nonobjc
-    fileprivate var textureData: [_Proto_ResourceId: (MTLTexture, String)] = [:]
 
     @nonobjc
     fileprivate var modelTransform: simd_float4x4
@@ -718,7 +1333,7 @@ extension WebBridgeReceiver {
             renderContext: renderContext,
             commandQueue: commandQueue,
             generateMips: true,
-            overridePixelFormat: true
+            overridePixelFormat: false
         ) {
             textureResources[textureHash] = textureResource
         }
@@ -730,8 +1345,14 @@ extension WebBridgeReceiver {
         do {
             let identifier = data.identifier
             logInfo("updateMaterial \(identifier)")
-            let materialSourceArchive = data.materialGraph
-            let shaderGraphFunctions = try await renderContext.makeShaderGraphFunctions(materialSourceArchive)
+
+            guard let materialSourceArchive = data.materialGraph else {
+                logError("No materialGraph data provided for material \(identifier)")
+                return
+            }
+
+            let shaderGraphFunctions = try await renderContext.makeShaderGraphFunctions(data.materialGraph)
+
             let geometryArguments = try makeParameters(
                 for: shaderGraphFunctions.geometryModifier,
                 renderContext: renderContext,
@@ -1003,7 +1624,7 @@ private func webUpdateMeshRequestFromUpdateMeshRequest(
 ) -> WebBridgeUpdateMesh {
     var descriptor: WebBridgeMeshDescriptor?
     if let requestDescriptor = request.descriptor {
-        descriptor = .init(requestDescriptor)
+        descriptor = .init(request: requestDescriptor)
     }
 
     return WebBridgeUpdateMesh(
@@ -1023,7 +1644,13 @@ private func webUpdateMeshRequestFromUpdateMeshRequest(
 nonisolated func webUpdateMaterialRequestFromUpdateMaterialRequest(
     _ request: _Proto_MaterialDataUpdate_v1
 ) -> WebBridgeUpdateMaterial {
-    WebBridgeUpdateMaterial(materialGraph: request.materialSourceArchive, identifier: request.identifier)
+    WebBridgeUpdateMaterial(
+        materialGraph: request.materialSourceArchive,
+        identifier: request.identifier,
+        geometryModifierFunctionReference: nil,
+        surfaceShaderFunctionReference: nil,
+        shaderGraphModule: nil,
+    )
 }
 
 final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
@@ -1045,7 +1672,7 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
 
     init(objcInstance: WebBridgeModelLoader) {
         objcLoader = objcInstance
-        usdLoader = .init()
+        usdLoader = _Proto_UsdStageSession_v1.noMetalSession(gpuFamily: MTLGPUFamily.apple5)
         dispatchSerialQueue = DispatchSerialQueue(label: "USDModelWebProcess", qos: .userInteractive)
         usdLoader.delegate = self
     }


### PR DESCRIPTION
#### 4a4a3a64946a77b55dcb090e2f8f69b79dc5dfb0
<pre>
[Model element] Enable Swift code for specific framework versions or later
<a href="https://bugs.webkit.org/show_bug.cgi?id=299471">https://bugs.webkit.org/show_bug.cgi?id=299471</a>
<a href="https://rdar.apple.com/161268032">rdar://161268032</a>

Reviewed by Etienne Segonzac.

Use RealityCoreRenderer-6 or later instead of placeholder 9999 version
which enables URL based &lt;model&gt;

Add some placeholder types for the migration to non-archive shader graph
loading.

* Source/WebCore/Modules/Model/ModelInlineConverters.h:
(WebCore::convert):
* Source/WebGPU/WebGPU/Mesh.mm:
(WebModel::Mesh::updateMaterial):
* Source/WebGPU/WebGPU/ModelBridge.swift:
* Source/WebGPU/WebGPU/ModelIBLTextures.swift:
* Source/WebGPU/WebGPU/ModelParameters.swift:
* Source/WebGPU/WebGPU/ModelRenderer.swift:
* Source/WebGPU/WebGPU/ModelTypes.h:
* Source/WebGPU/WebGPU/ModelUtils.swift:
* Source/WebGPU/WebGPU/USDModel.swift:
(toSGType(_:)):
(toSGModuleReference(_:)):
(toSGTypeDefinition(_:)):
(toSGTypeReference(_:)):
(toSGStructMember(_:)):
(toSGEnumCase(_:)):
(toSGFunction(_:)):
(toSGFunctionArgument(_:)):
(toSGModuleGraph(_:)):
(toSGNode(_:)):
(toSGNodeID(_:)):
(toSGNodeInstruction(_:)):
(toSGNodeInstructionFromFunctionCall(_:)):
(toSGNodeInstructionFromFunctionConstant(_:literal:)):
(toSGNodeInstructionFromLiteral(_:)):
(toSGNodeInstructionFromArgument(_:)):
(toSGNodeInstructionFromElement(_:name:)):
(toSGLiteral(_:)):
(toSGGraphEdge(_:ShaderGraph:String:)):
(fromSGType(_:)):
(fromSGModuleReferenceArray(_:)):
(fromSGModuleReference(_:)):
(fromSGTypeDefinitionArray(_:)):
(fromSGTypeDefinition(_:)):
(fromSGTypeReference(_:)):
(fromSGStructMember(_:)):
(fromSGEnumCase(_:)):
(fromSGFunctionArray(_:)):
(fromSGFunction(_:)):
(fromSGFunctionArgument(_:)):
(fromSGModuleGraphArray(_:)):
(fromSGModuleGraph(_:)):
(fromSGNode(_:)):
(fromSGNodeID(_:)):
(fromSGNodeInstruction(_:)):
(fromSGLiteral(_:)):
(fromSGGraphEdge(_:ShaderGraph:String:)):
(Material.textureResources):
(Material.updateTexture(_:)):
(Material.updateMaterial(_:)):
(_USDStageKit_SwiftUI.instanceTransformsCompat): Deleted.
(_USDStageKit_SwiftUI.geometryBindTransformCompat): Deleted.
(_USDStageKit_SwiftUI.jointTransformsCompat): Deleted.
(_USDStageKit_SwiftUI.inverseBindPosesCompat): Deleted.
(mapSemantic(_:)): Deleted.
(Material.textureData): Deleted.

Canonical link: <a href="https://commits.webkit.org/306723@main">https://commits.webkit.org/306723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41a9f77cc32acf72627d2193e57ebd233310c6e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150753 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38ba00f3-e40f-4ab6-adc2-7c765befc520) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144001 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109257 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b793fb5c-b7ac-4156-b18e-21ae8a9a3b07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90155 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ce8c5c5-0f05-4a16-9492-3e33f83f85da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11326 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/800 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153117 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117327 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117647 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13700 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124410 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69909 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14258 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3463 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77974 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14194 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->