### PR TITLE
[AutoFill Debugging] Include scroll position in text extraction output for scrollable containers

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-scrolling-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-scrolling-expected.txt
@@ -1,0 +1,4 @@
+root,scrollPosition=(0,0),contentSize=[…]
+    scrollable,scrollPosition=(5000,0),contentSize=[…]
+        link,url='https://webkit.org/'
+    scrollable,scrollPosition=(10,0),contentSize=[…],'2. Hello world'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-scrolling.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-scrolling.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+::-webkit-scrollbar {
+    display: none;
+}
+
+.text-representation {
+    white-space: pre-wrap;
+}
+
+.scroller {
+    width: 150px;
+    height: 150px;
+    overflow: scroll;
+    white-space: nowrap;
+    border: 1px solid tomato;
+    display: inline-block;
+}
+
+.vspace {
+    width: 1px;
+    height: 5000px;
+}
+
+.hspace {
+    width: 5000px;
+    height: 10px;
+    background: #eee;
+    display: inline-block;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<main>
+    <div class="scroller top">
+        <span>1. Hello world</span>
+        <span class="hspace"></span>
+        <span><a href="https://webkit.org">WebKit</a></span>
+    </div>
+    <div class="scroller middle">
+        <span>2. Hello world</span>
+        <span class="hspace"></span>
+        <span><a href="https://webkit.org">WebKit</a></span>
+    </div>
+    <div class="vspace"></div>
+    <div class="scroller bottom">
+        <span>3. Hello world</span>
+        <span class="hspace"></span>
+        <span><a href="https://webkit.org">WebKit</a></span>
+    </div>
+</main>
+
+<script>
+document.querySelector(".top").scrollBy(5000, 0);
+document.querySelector(".middle").scrollBy(10, 0);
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    window.internals?.setUsesOverlayScrollbars(true);
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    await UIHelper.ensurePresentationUpdate();
+
+    const extractionResult = await UIHelper.requestDebugText({
+        includeURLs: true,
+        includeRects: false,
+        clipToBounds: true,
+        normalize: true,
+    });
+
+    document.body.classList.add("text-representation");
+    document.body.textContent = extractionResult;
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2586,7 +2586,8 @@ window.UIHelper = class UIHelper {
                     debugText = debugText
                         .replace(/uid=((\d+_)+)?(\d+)/g, "uid=…")
                         .replace(/"uid":\"((\d+_)+)?(\d+)\"/g, "\"uid\":\"…\"")
-                        .replace(/\[\d+,\d+;\d+x\d+\]/g, "[…]")
+                        .replace(/contentSize=\[\d+×\d+\]/g, "contentSize=[…]")
+                        .replace(/\[\d+,\d+;\d+×\d+\]/g, "[…]")
                         .replace(/\t/g, "    ");
                 }
                 resolve(debugText);

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -29,6 +29,7 @@
 #include <WebCore/CharacterRange.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/FloatSize.h>
+#include <WebCore/IntPoint.h>
 #include <WebCore/NodeIdentifier.h>
 #include <WebCore/WebKitJSHandle.h>
 #include <wtf/Forward.h>
@@ -124,6 +125,9 @@ struct TextItemData {
 
 struct ScrollableItemData {
     FloatSize contentSize;
+    IntPoint scrollPosition;
+    bool isRoot { false };
+    bool hasOverflowItems { false };
 };
 
 struct ImageItemData {
@@ -179,7 +183,6 @@ struct SelectData {
 };
 
 enum class ContainerType : uint8_t {
-    Root,
     ViewportConstrained,
     List,
     ListItem,

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6889,6 +6889,9 @@ header: <WebCore/TextExtractionTypes.h>
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::ScrollableItemData {
     WebCore::FloatSize contentSize;
+    WebCore::IntPoint scrollPosition;
+    bool isRoot;
+    bool hasOverflowItems;
 };
 
 header: <WebCore/TextExtractionTypes.h>
@@ -6953,7 +6956,6 @@ header: <WebCore/TextExtractionTypes.h>
 
 header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] enum class WebCore::TextExtraction::ContainerType : uint8_t {
-    Root,
     ViewportConstrained,
     List,
     ListItem,


### PR DESCRIPTION
#### f5dc68f8b169e8057d1c3a4c594c84d4b03f8f7f
<pre>
[AutoFill Debugging] Include scroll position in text extraction output for scrollable containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=306795">https://bugs.webkit.org/show_bug.cgi?id=306795</a>
<a href="https://rdar.apple.com/169219513">rdar://169219513</a>

Reviewed by Patrick Angle and Abrar Rahman Protyasha.

Add more information about scrollable containers, for both JSON and text tree text extraction output
formats. See below for more details.

Test: fast/text-extraction/debug-text-extraction-scrolling.html

* LayoutTests/fast/text-extraction/debug-text-extraction-scrolling-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-scrolling.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.prototype.async requestDebugText):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:

Remove `ContainerType::Root`, and instead represent the root node using a `ScrollableItemData`
with `isRoot := true`.

(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::shouldIncludeNodeIdentifier):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Add some more information to `ScrollableItemData`: the current `scrollPosition`, a flag indicating
whether the scrollable container represents the root node, and lastly, whether or not there are any
text extraction items underneath the scrollable container, that were excluded from the extraction
output due to being outside of the target collection rect.

* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::containerTypeString):
(WebKit::jsonTypeStringForItem):
(WebKit::populateJSONForItem):
(WebKit::partsForItem):
(WebKit::addPartsForItem):
(WebKit::addTextRepresentationRecursive):

Add `scrollPosition` and `contentSize` only if there are items underneath the scroll container that
can potentially be accessed by scrolling the container.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKTextExtractionUtilities.mm:
(WebKit::containerType):
(WebKit::createItemWithChildren):
(WebKit::createItem):

Canonical link: <a href="https://commits.webkit.org/306665@main">https://commits.webkit.org/306665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91451c4b782c51da8c59e5b78102e14b4e7222f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95125 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27241429-a4ee-47f4-a425-d7fc634888f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143816 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109104 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5816fcc7-7015-4fcc-ae5c-98a6ab975d23) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11190 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8837 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/609 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152931 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14024 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117184 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14039 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117504 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13550 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69718 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14062 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3210 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77787 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13848 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->