### PR TITLE
[Model element] Support `loop` attribute in GPU process model element

### DIFF
--- a/Source/WebCore/Modules/model-element/WebModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/WebModelPlayer.h
@@ -133,6 +133,7 @@ private:
     float m_yaw { 0.f };
     float m_pitch { 0.f };
     float m_playbackRate { 1.0f };
+    bool m_isLooping { false };
 };
 
 }

--- a/Source/WebGPU/WebGPU/ModelTypes.h
+++ b/Source/WebGPU/WebGPU/ModelTypes.h
@@ -690,6 +690,7 @@ NS_SWIFT_SENDABLE
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
+- (double)currentTime;
 - (double)duration;
 - (void)loadModelFrom:(NSURL *)url;
 - (void)update:(double)deltaTime;

--- a/Source/WebGPU/WebGPU/USDModel.swift
+++ b/Source/WebGPU/WebGPU/USDModel.swift
@@ -1738,6 +1738,10 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
         return 0.0
     }
 
+    func currentTime() -> Double {
+        time - startTime
+    }
+
     func loadModel(from data: Data) {
     }
 
@@ -1805,6 +1809,14 @@ extension WebBridgeModelLoader {
             return 0.0
         }
         return loader.duration()
+    }
+
+    @objc
+    func currentTime() -> Double {
+        guard let loader else {
+            return 0.0
+        }
+        return loader.currentTime()
     }
 
     fileprivate func updateMesh(webRequest: WebBridgeUpdateMesh) {
@@ -1998,6 +2010,11 @@ extension WebBridgeModelLoader {
 
     @objc
     func duration() -> Double {
+        0.0
+    }
+
+    @objc
+    func currentTime() -> Double {
         0.0
     }
 }


### PR DESCRIPTION
#### 4a147761f109eb547258ad4614319a6face1138a
<pre>
[Model element] Support `loop` attribute in GPU process model element
<a href="https://bugs.webkit.org/show_bug.cgi?id=299479">https://bugs.webkit.org/show_bug.cgi?id=299479</a>
<a href="https://rdar.apple.com/161268576">rdar://161268576</a>

Reviewed by Etienne Segonzac.

If looping is disabled, stop the animation when it completes.

* Source/WebCore/Modules/model-element/WebModelPlayer.h:
* Source/WebCore/Modules/model-element/WebModelPlayer.mm:
(WebCore::WebModelPlayer::isLoopingAnimation):
(WebCore::WebModelPlayer::setIsLoopingAnimation):
(WebCore::WebModelPlayer::update):
* Source/WebGPU/WebGPU/ModelTypes.h:
* Source/WebGPU/WebGPU/USDModel.swift:
(USDModelLoader.currentTime):
(WebBridgeModelLoader.currentTime):

Canonical link: <a href="https://commits.webkit.org/306797@main">https://commits.webkit.org/306797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74b4609eaa56039a888061ad5cf236c982a1989b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14777 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151027 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53f7cef0-31a8-4fb8-a283-7039a564d964) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144248 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14931 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109485 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1af13e7-dcb7-417e-812f-69a9b3695143) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12003 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90387 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f027254-2f87-41f8-beb0-ba83ee0e3713) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11519 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1047 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/3910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153364 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14456 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117524 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117849 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13900 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70168 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14505 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14237 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14442 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->