### PR TITLE
[GFC] Add support for inline axis fit-content sizing

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -464,7 +464,7 @@ std::pair<UsedInlineSizes, UsedBlockSizes> GridLayout::layoutGridItems(const Pla
         auto& gridAreaInlineSize = gridAreaSizes.inlineSizes[gridItemIndex];
         auto& gridAreaBlockSize = gridAreaSizes.blockSizes[gridItemIndex];
 
-        auto usedInlineSizeForGridItem = GridLayoutUtils::usedInlineSizeForGridItem(gridItem, gridItemBoxGeometry.horizontalBorderAndPadding(), gridAreaInlineSize);
+        auto usedInlineSizeForGridItem = GridLayoutUtils::usedInlineSizeForGridItem(gridItem, gridItemBoxGeometry.horizontalBorderAndPadding(), gridAreaInlineSize, integrationUtils);
         usedInlineSizes.append(usedInlineSizeForGridItem);
 
         auto usedBlockSizeForGridItem = GridLayoutUtils::usedBlockSizeForGridItem(gridItem, gridItemBoxGeometry.verticalBorderAndPadding(), gridAreaBlockSize);

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -111,7 +111,84 @@ static bool hasScrollableBlockOverflow(const PlacedGridItem&)
     return false;
 }
 
-LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit columnsSize)
+static bool selfAlignmentCausesFitContentSizing(const ItemPosition& position)
+{
+    switch (position) {
+    case ItemPosition::Normal:
+    case ItemPosition::Stretch:
+        return false;
+    case ItemPosition::Start:
+    case ItemPosition::Legacy:
+    case ItemPosition::Baseline:
+    case ItemPosition::LastBaseline:
+    case ItemPosition::Center:
+    case ItemPosition::End:
+    case ItemPosition::SelfStart:
+    case ItemPosition::SelfEnd:
+    case ItemPosition::FlexStart:
+    case ItemPosition::FlexEnd:
+    case ItemPosition::Left:
+    case ItemPosition::Right:
+    case ItemPosition::AnchorCenter:
+        return true;
+    // Auto should have been resolved when we constructed the corresponding PlacedGridItem.
+    case ItemPosition::Auto:
+        ASSERT_NOT_REACHED();
+        return false;
+    default:
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+}
+
+// https://www.w3.org/TR/css-align-3/#propdef-align-self
+// When the box’s computed width/height (as appropriate to the axis) is auto and neither of
+// its margins (in the appropriate axis) are auto, sets the box’s used size to the length
+// necessary to make its outer size as close to filling the alignment container as possible
+// while still respecting the constraints imposed by min-height/min-width/max-height/max-width.
+//
+// Also: https://www.w3.org/TR/css-sizing-4/#stretch-fit-sizing
+// Stretch-fit sizing tries to set the box’s used size to the length necessary to make its outer
+// size as close to filling the containing block as possible while still respecting the constraints
+// imposed by min-height/min-width/max-height/max-width.
+//
+// Formally, its behavior is the same as specifying an automatic size together with a self-alignment
+// property value of stretch (in the relevant axis), except that the resulting box, which can end up
+// not exactly fitting its alignment container, can be subsequently aligned by its actual
+// self-alignment property value.
+static LayoutUnit stretchFitSize(const Style::MinimumSize& computedMinimumSize, const Style::MaximumSize& computedMaximumSize, LayoutUnit availableSpace,
+    const Style::MarginEdge& marginStart, const Style::MarginEdge& marginEnd, LayoutUnit borderAndPadding, const Style::ZoomFactor& usedZoom)
+{
+    ASSERT(marginStart.isFixed() && marginEnd.isFixed());
+    ASSERT(computedMinimumSize.isFixed() && (computedMaximumSize.isFixed() || computedMaximumSize.isNone()));
+
+    auto minimumSize = LayoutUnit { computedMinimumSize.tryFixed()->resolveZoom(usedZoom) };
+    auto maximumSize = [&computedMaximumSize, &usedZoom] {
+        if (computedMaximumSize.isNone())
+            return LayoutUnit::max();
+        return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
+    };
+
+    auto stretchedSize = availableSpace - LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) } - LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) } - borderAndPadding;
+    return std::max(minimumSize, std::min(maximumSize(), stretchedSize));
+}
+
+// https://www.w3.org/TR/css-sizing-4/#valdef-width-fit-content
+// Essentially fit-content(stretch) i.e. min(max-content, max(min-content, stretch)).
+static LayoutUnit inlineFitContentSize(const PlacedGridItem& gridItem, LayoutUnit columnsSize, LayoutUnit borderAndPadding, const IntegrationUtils& integrationUtils)
+{
+    auto& layoutBox = gridItem.layoutBox();
+    auto minContentSize = integrationUtils.minContentWidth(layoutBox);
+    auto maxContentSize = integrationUtils.maxContentWidth(layoutBox);
+
+    auto& inlineAxisSizes = gridItem.inlineAxisSizes();
+    ASSERT(inlineAxisSizes.marginStart.isFixed() && inlineAxisSizes.marginEnd.isFixed());
+    auto& usedZoom = gridItem.usedZoom();
+    return std::min(maxContentSize, std::max(minContentSize, stretchFitSize(inlineAxisSizes.minimumSize, inlineAxisSizes.maximumSize, columnsSize,
+        inlineAxisSizes.marginStart, inlineAxisSizes.marginEnd, borderAndPadding, usedZoom)));
+}
+
+LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils& integrationUtils)
 {
     auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();
     ASSERT(inlineAxisSizes.minimumSize.isFixed() && (inlineAxisSizes.maximumSize.isFixed() || inlineAxisSizes.maximumSize.isNone()));
@@ -125,29 +202,23 @@ LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, Layou
         // normal:
         // If the grid item has no preferred aspect ratio, and no natural size in the relevant
         // axis (if it is a replaced element), the grid item is sized as for align-self: stretch.
-        //
-        // https://www.w3.org/TR/css-align-3/#propdef-align-self
-        //
-        // When the box’s computed width/height (as appropriate to the axis) is auto and neither of
-        // its margins (in the appropriate axis) are auto, sets the box’s used size to the length
-        // necessary to make its outer size as close to filling the alignment container as possible
-        // while still respecting the constraints imposed by min-height/min-width/max-height/max-width.
         auto& marginStart = inlineAxisSizes.marginStart;
         auto& marginEnd = inlineAxisSizes.marginEnd;
         if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.hasPreferredAspectRatio() && !placedGridItem.isReplacedElement()
             && !marginStart.isAuto() && !marginEnd.isAuto()) {
             auto& usedZoom = placedGridItem.usedZoom();
 
-            auto minimumSize = LayoutUnit { inlineAxisSizes.minimumSize.tryFixed()->resolveZoom(usedZoom) };
-            auto maximumSize = [&inlineAxisSizes, &usedZoom] {
-                auto& computedMaximumSize = inlineAxisSizes.maximumSize;
-                if (computedMaximumSize.isNone())
-                    return LayoutUnit::max();
-                return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
-            };
-
-            auto stretchedWidth = columnsSize - LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) } - LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) } - borderAndPadding;
-            return std::max(minimumSize, std::min(maximumSize(), stretchedWidth));
+            return stretchFitSize(inlineAxisSizes.minimumSize, inlineAxisSizes.maximumSize, columnsSize, marginStart, marginEnd, borderAndPadding, usedZoom);
+        } else if (selfAlignmentCausesFitContentSizing(alignmentPosition)) {
+            // all other values
+            // Size the item as fit-content.
+            //
+            // NOTE: The table in 6.2 shows that replaced elements are just the natural size.
+            if (placedGridItem.isReplacedElement()) {
+                ASSERT_NOT_IMPLEMENTED_YET();
+                return { };
+            }
+            return inlineFitContentSize(placedGridItem, columnsSize, borderAndPadding, integrationUtils);
         }
 
         ASSERT_NOT_IMPLEMENTED_YET();

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -38,7 +38,7 @@ namespace GridLayoutUtils {
 
 LayoutUnit computeGapValue(const Style::GapGutter&);
 
-LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit columnsSize);
+LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit columnsSize, const IntegrationUtils&);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);
 
 LayoutUnit usedInlineMinimumSize(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit columnsSize);


### PR DESCRIPTION
#### 5c7a6378e8fa49ec03addf89e53dcfabe82f1f34
<pre>
[GFC] Add support for inline axis fit-content sizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=306800">https://bugs.webkit.org/show_bug.cgi?id=306800</a>
<a href="https://rdar.apple.com/169474575">rdar://169474575</a>

Reviewed by NOBODY (OOPS!).

The way that a grid item is supposed to be sized in a specific axis is
dependent upon its self-alignment as well as whether it is a replaced
element. If a non-replaced grid item has a self-alignment value that is
*not* either normal or stretch, then it is supposed to be sized as
&quot;fit-content&quot; for that axis.
<a href="https://drafts.csswg.org/css-grid-1/#grid-item-sizing">https://drafts.csswg.org/css-grid-1/#grid-item-sizing</a>

This patch implements this logic for the inline axis only for
simplicity&apos;s sake since the block axis will be basically the same thing
with a different set of constraints.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::selfAlignmentCausesFitContentSizing):
New helper function that helps us determine if the grid item&apos;s self
alignment is supposed to trigger fit-content sizing. This should be
fairly straightforward since any other value besides &quot;normal,&quot; or
&quot;stretch,&quot; should cause this.

(WebCore::Layout::GridLayoutUtils::stretchFitSize):
Since fit-content also uses the &quot;stretch-fit&quot; size:
<a href="https://www.w3.org/TR/css-sizing-4/#valdef-width-fit-content">https://www.w3.org/TR/css-sizing-4/#valdef-width-fit-content</a> -&gt;
<a href="https://www.w3.org/TR/css-sizing-4/#valdef-width-stretch">https://www.w3.org/TR/css-sizing-4/#valdef-width-stretch</a> -&gt;
<a href="https://www.w3.org/TR/css-sizing-4/#stretch-fit-sizing">https://www.w3.org/TR/css-sizing-4/#stretch-fit-sizing</a>

we factor out that logic into its own helper function and use it as part
of the newly added function which computes the fit-content size of the
grid item in the inline axis.

(WebCore::Layout::GridLayoutUtils::inlineFitContentSize):
New helper that computes the fit-content size in the inline axis
according to the definition in the spec:
Essentially fit-content(stretch) i.e. min(max-content, max(min-content, stretch)).

(WebCore::Layout::GridLayoutUtils::usedInlineSizeForGridItem):
Extends the logic to incorporate fit-content sizing for non-replaced
boxes.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7a6378e8fa49ec03addf89e53dcfabe82f1f34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150874 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95418 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edf481ff-5be6-46c1-9ba9-10185d0f95fa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14791 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109361 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79019 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0e47824-e3b2-4b8b-a658-916a78fa6297) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90261 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9bbc74a-a607-431f-95fd-2afb20accc69) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9074 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/908 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120755 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153225 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14317 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117414 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117737 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13785 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70017 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14366 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3551 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78082 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14303 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14143 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->