### PR TITLE
[macOS] Create sandbox extension for temp and cache folders instead of using sandbox parameters

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -281,6 +281,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/InsertTextOptions.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/MachSendRightAnnotated.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RemoteObjectInvocation.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/SafeSendRight.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -685,6 +685,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCCFCharacterSet.serialization.in \
 	Shared/Cocoa/DataDetectionResult.serialization.in \
 	Shared/Cocoa/InsertTextOptions.serialization.in \
+	Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in \
 	Shared/Cocoa/RemoteObjectInvocation.serialization.in \
 	Shared/Cocoa/RevealItem.serialization.in \
 	Shared/Cocoa/SharedCARingBuffer.serialization.in \

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -297,9 +297,6 @@ private:
     WebCore::Timer m_idleExitTimer;
     std::unique_ptr<WebCore::NowPlayingManager> m_nowPlayingManager;
     String m_applicationVisibleName;
-#if PLATFORM(MAC)
-    String m_uiProcessName;
-#endif
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     mutable RefPtr<RemoteAudioSessionProxyManager> m_audioSessionManager;
 #endif

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -35,6 +35,10 @@
 #include <WebCore/DRMDevice.h>
 #endif
 
+#if PLATFORM(MAC)
+#include "ProcessStartupSandboxExtensions.h"
+#endif
+
 namespace IPC {
 class Decoder;
 class Encoder;
@@ -78,6 +82,9 @@ struct GPUProcessCreationParameters {
 #if ENABLE(AV1)
     std::optional<bool> hasAV1HardwareDecoder;
 #endif
+#endif
+#if PLATFORM(MAC)
+    ProcessStartupSandboxExtensions processStartupSandboxExtensions;
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in
@@ -62,6 +62,9 @@
     std::optional<bool> hasAV1HardwareDecoder;
 #endif
 #endif
+#if PLATFORM(MAC)
+    WebKit::ProcessStartupSandboxExtensions processStartupSandboxExtensions;
+#endif
 };
 
 #endif

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -109,6 +109,8 @@ void GPUProcess::ensureAVCaptureServerConnection()
 void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& parameters)
 {
 #if PLATFORM(MAC)
+    parameters.processStartupSandboxExtensions.consumeSandboxExtensions();
+
     auto launchServicesExtension = SandboxExtension::create(WTF::move(parameters.launchServicesExtensionHandle));
     if (launchServicesExtension) {
         bool ok = launchServicesExtension->consume();

--- a/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
+++ b/Source/WebKit/GPUProcess/mac/GPUProcessMac.mm
@@ -60,7 +60,7 @@ void GPUProcess::initializeProcess(const AuxiliaryProcessInitializationParameter
 void GPUProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
 #if PLATFORM(MAC)
-    m_uiProcessName = parameters.uiProcessName;
+    setUIProcessName(parameters.uiProcessName);
 #endif
 }
 
@@ -69,7 +69,7 @@ void GPUProcess::updateProcessName()
 {
 #if !PLATFORM(MACCATALYST)
 ALLOW_NONLITERAL_FORMAT_BEGIN
-    RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("%@ Graphics and Media", "visible name of the GPU process. The argument is the application name.").createNSString().get(), m_uiProcessName.createNSString().get()]);
+    RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("%@ Graphics and Media", "visible name of the GPU process. The argument is the application name.").createNSString().get(), uiProcessName().createNSString().get()]);
 ALLOW_NONLITERAL_FORMAT_END
     RetainPtr asn = _LSGetCurrentApplicationASN();
     auto result = _LSSetApplicationInformationItem(kLSDefaultSessionID, asn.get(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);

--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -743,22 +743,12 @@
 
 (allow-reading-global-preferences)
 
-;; On-disk WebKit2 framework location, to account for debug installations outside of /System/Library/Frameworks,
-;; and to allow issuing extensions.
-(allow-read-directory-and-issue-read-extensions (param "WEBKIT2_FRAMEWORK_DIR"))
-
 (read-only-and-issue-extensions (extension "com.apple.app-sandbox.read"))
 (read-write-and-issue-extensions (extension "com.apple.app-sandbox.read-write"))
 
 ;; Allow the OpenGL Profiler to attach.
 (with-filter (system-attribute apple-internal)
     (allow mach-register (global-name-regex #"^_oglprof_attach_<[0-9]+>$")))
-
-(if (positive? (string-length (param "DARWIN_USER_CACHE_DIR")))
-    (allow-read-write-directory-and-issue-read-write-extensions (param "DARWIN_USER_CACHE_DIR")))
-
-(if (positive? (string-length (param "DARWIN_USER_TEMP_DIR")))
-    (allow-read-write-directory-and-issue-read-write-extensions (param "DARWIN_USER_TEMP_DIR")))
 
 ;; IOKit user clients
 (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -682,10 +682,6 @@ private:
     };
     HashMap<TaskIdentifier, DeleteWebsiteDataTask> m_deleteWebsiteDataTasks;
 
-#if PLATFORM(MAC)
-    String m_uiProcessName;
-#endif
-
 #if ENABLE(DNS_SERVER_FOR_TESTING_IN_NETWORKING_PROCESS)
     OSObjectPtr<nw_resolver_config_t> m_resolverConfig;
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -608,6 +608,10 @@ private:
     void performDeleteWebsiteDataTask(TaskIdentifier, TaskTrigger = TaskTrigger::Connection);
     void deleteWebsiteDataImpl(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime, CompletionHandler<void()>&&);
 
+#if PLATFORM(MAC)
+    void updateProcessName();
+#endif
+
     // Connections to WebProcesses.
     HashMap<WebCore::ProcessIdentifier, Ref<NetworkConnectionToWebProcess>> m_webProcessConnections;
     HashMap<WebCore::ProcessIdentifier, Vector<CompletionHandler<void()>>> m_webProcessConnectionCloseHandlers;
@@ -677,6 +681,10 @@ private:
         CompletionHandler<void()> completionHandler;
     };
     HashMap<TaskIdentifier, DeleteWebsiteDataTask> m_deleteWebsiteDataTasks;
+
+#if PLATFORM(MAC)
+    String m_uiProcessName;
+#endif
 
 #if ENABLE(DNS_SERVER_FOR_TESTING_IN_NETWORKING_PROCESS)
     OSObjectPtr<nw_resolver_config_t> m_resolverConfig;

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -41,6 +41,10 @@
 #include <wtf/MemoryPressureHandler.h>
 #endif
 
+#if PLATFORM(MAC)
+#include "ProcessStartupSandboxExtensions.h"
+#endif
+
 namespace WebKit {
 
 struct WebsiteDataStoreParameters;
@@ -86,6 +90,9 @@ struct NetworkProcessCreationParameters {
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;
 
     Markable<double> defaultRequestTimeoutInterval;
+#if PLATFORM(MAC)
+    ProcessStartupSandboxExtensions processStartupSandboxExtensions;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -64,6 +64,9 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
     Vector<WebCore::OrganizationStorageAccessPromptQuirk> storageAccessPromptQuirksData;
 
     Markable<double> defaultRequestTimeoutInterval;
+#if PLATFORM(MAC)
+    WebKit::ProcessStartupSandboxExtensions processStartupSandboxExtensions;
+#endif
 }
 
 enum class WebKit::LoadedWebArchive : bool

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -89,6 +89,10 @@ static void initializeNetworkSettings()
 
 void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessCreationParameters& parameters)
 {
+#if PLATFORM(MAC)
+    parameters.processStartupSandboxExtensions.consumeSandboxExtensions();
+#endif
+
     m_isParentProcessFullWebBrowserOrRunningTest = parameters.isParentProcessFullWebBrowserOrRunningTest;
 
     _CFNetworkSetATSContext(parameters.networkATSContext.get());

--- a/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
@@ -58,7 +58,7 @@ void NetworkProcess::initializeProcess(const AuxiliaryProcessInitializationParam
 void NetworkProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
 #if PLATFORM(MAC)
-    m_uiProcessName = parameters.uiProcessName;
+    setUIProcessName(parameters.uiProcessName);
 #else
     UNUSED_PARAM(parameters);
 #endif
@@ -67,7 +67,7 @@ void NetworkProcess::initializeProcessName(const AuxiliaryProcessInitializationP
 void NetworkProcess::updateProcessName()
 {
 #if !PLATFORM(MACCATALYST)
-    SUPPRESS_UNRETAINED_ARG RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), m_uiProcessName.createNSString().get()]);
+    SUPPRESS_UNRETAINED_ARG RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), uiProcessName().createNSString().get()]);
     _LSSetApplicationInformationItem(kLSDefaultSessionID, RetainPtr { _LSGetCurrentApplicationASN() }.get(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
 #endif
 }

--- a/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm
@@ -57,8 +57,17 @@ void NetworkProcess::initializeProcess(const AuxiliaryProcessInitializationParam
 
 void NetworkProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
+#if PLATFORM(MAC)
+    m_uiProcessName = parameters.uiProcessName;
+#else
+    UNUSED_PARAM(parameters);
+#endif
+}
+
+void NetworkProcess::updateProcessName()
+{
 #if !PLATFORM(MACCATALYST)
-    SUPPRESS_UNRETAINED_ARG RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), parameters.uiProcessName.createNSString().get()]);
+    SUPPRESS_UNRETAINED_ARG RetainPtr applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Networking", "visible name of the network process. The argument is the application name."), m_uiProcessName.createNSString().get()]);
     _LSSetApplicationInformationItem(kLSDefaultSessionID, RetainPtr { _LSGetCurrentApplicationASN() }.get(), _kLSDisplayNameKey, (CFStringRef)applicationName.get(), nullptr);
 #endif
 }

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -195,10 +195,6 @@
     (subpath "/System/Library/PrivateFrameworks")
     (subpath "/usr/lib"))
 
-(if (positive? (string-length (param "DARWIN_USER_TEMP_DIR")))
-    (allow file-map-executable
-        (subpath (param "DARWIN_USER_TEMP_DIR"))))
-
 (allow file-read-metadata
     (literal "/etc")
     (literal "/tmp")
@@ -380,23 +376,11 @@
     (subpath "/Library/Frameworks")
     (subpath "/Library/Managed Preferences"))
 
-;; On-disk WebKit2 framework location, to account for debug installations
-;; outside of /System/Library/Frameworks
-(allow file-read* file-test-existence
-    (subpath (param "WEBKIT2_FRAMEWORK_DIR")))
-
 (allow file-read-data
-    (literal "/usr/local/lib/log") ; <rdar://problem/36629495>
-)
+    (literal "/usr/local/lib/log")) ; <rdar://problem/36629495>
 
 (read-only-and-issue-extensions (extension "com.apple.app-sandbox.read"))
 (read-write-and-issue-extensions (extension "com.apple.app-sandbox.read-write"))
-
-(if (positive? (string-length (param "DARWIN_USER_CACHE_DIR")))
-    (allow file-read* file-write* (subpath (param "DARWIN_USER_CACHE_DIR"))))
-
-(if (positive? (string-length (param "DARWIN_USER_TEMP_DIR")))
-    (allow file-read* file-write* (subpath (param "DARWIN_USER_TEMP_DIR"))))
 
 ;; IOKit user clients
 (allow IOKIT_OPEN_USER_CLIENT

--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -178,6 +178,11 @@ protected:
     static const WTF::String& increaseContrastPreferenceKey();
 #endif
 
+#if PLATFORM(MAC)
+    const String& uiProcessName() const { return m_uiProcessName; }
+    void setUIProcessName(const String& uiProcessName) { m_uiProcessName = uiProcessName; }
+#endif
+
 private:
 #if ENABLE(CFPREFS_DIRECT_MODE)
     void handleAXPreferenceChange(const String& domain, const String& key, id value);
@@ -206,6 +211,10 @@ private:
     IPC::MessageReceiverMap m_messageReceiverMap;
 
     UserActivity m_processSuppressionDisabled;
+
+#if PLATFORM(MAC)
+    String m_uiProcessName;
+#endif
 };
 
 struct AuxiliaryProcessInitializationParameters {

--- a/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.h
+++ b/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,28 +25,25 @@
 
 #pragma once
 
-DECLARE_SYSTEM_HEADER
+#include "SandboxExtension.h"
 
-#if USE(APPLE_INTERNAL_SDK)
-#include <dirhelper_priv.h>
-#else
+#include <wtf/text/ASCIILiteral.h>
 
-WTF_EXTERN_C_BEGIN
-char *_get_user_dir_suffix();
-bool _set_user_dir_suffix(const char *user_dir_suffix);
+namespace WebKit {
 
-typedef enum {
-    DIRHELPER_USER_LOCAL_TEMP = 1,
-    DIRHELPER_USER_LOCAL_CACHE = 2,
-} dirhelper_which_t;
+struct ProcessStartupSandboxExtensions {
 
-char *__user_local_dirname(uid_t, dirhelper_which_t, char *path, size_t pathlen);
-WTF_EXTERN_C_END
+    void createSandboxExtensions(ASCIILiteral processName);
+    void consumeSandboxExtensions() const;
 
-#endif
+    SandboxExtension::Handle webKitBundleDirectoryExtension;
+    SandboxExtension::Handle cacheDirectoryExtension;
+    SandboxExtension::Handle tempDirectoryExtension;
 
-WTF_EXTERN_C_BEGIN
+private:
+    String webKitBundlePath() const;
+    void createCacheDirectorySandboxExtension(ASCIILiteral processName);
+    void createTempDirectorySandboxExtension(ASCIILiteral processName);
+};
 
-void _CSCheckFixDisable();
-
-WTF_EXTERN_C_END
+}

--- a/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.h
+++ b/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.h
@@ -39,11 +39,12 @@ struct ProcessStartupSandboxExtensions {
     SandboxExtension::Handle webKitBundleDirectoryExtension;
     SandboxExtension::Handle cacheDirectoryExtension;
     SandboxExtension::Handle tempDirectoryExtension;
+    String userDirectorySuffix;
 
 private:
     String webKitBundlePath() const;
-    void createCacheDirectorySandboxExtension(ASCIILiteral processName);
-    void createTempDirectorySandboxExtension(ASCIILiteral processName);
+    void createCacheDirectorySandboxExtension(String userDirectorySuffix);
+    void createTempDirectorySandboxExtension(String userDirectorySuffix);
 };
 
 }

--- a/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.mm
+++ b/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.mm
@@ -27,7 +27,12 @@
 #import "ProcessStartupSandboxExtensions.h"
 
 #import <pal/spi/cocoa/CoreServicesSPI.h>
+#import <sysexits.h>
 #import <wtf/FileSystem.h>
+#import <wtf/WTFProcess.h>
+#import <wtf/text/MakeString.h>
+#import <wtf/text/StringBuilder.h>
+#import <wtf/text/cf/StringConcatenateCF.h>
 
 namespace WebKit {
 
@@ -36,28 +41,29 @@ void ProcessStartupSandboxExtensions::createSandboxExtensions(ASCIILiteral proce
     String bundlePath = webKitBundlePath();
     if (auto handle = SandboxExtension::createHandle(bundlePath, SandboxExtension::Type::ReadOnly))
         webKitBundleDirectoryExtension = WTF::move(*handle);
-    createCacheDirectorySandboxExtension(processName);
-    createTempDirectorySandboxExtension(processName);
+    userDirectorySuffix = makeString([[NSBundle mainBundle] bundleIdentifier], '+', processName);
+    createCacheDirectorySandboxExtension(userDirectorySuffix);
+    createTempDirectorySandboxExtension(userDirectorySuffix);
 }
 
-void ProcessStartupSandboxExtensions::createCacheDirectorySandboxExtension(ASCIILiteral processName)
+void ProcessStartupSandboxExtensions::createCacheDirectorySandboxExtension(String userDirectorySuffix)
 {
     char cacheDirectory[PATH_MAX] = { 0 };
     if (__user_local_dirname(getuid(), DIRHELPER_USER_LOCAL_CACHE, cacheDirectory, PATH_MAX)) {
         auto cacheDirectorySpan = unsafeSpan(cacheDirectory);
-        String cacheDirectoryForProcess = FileSystem::pathByAppendingComponent(cacheDirectorySpan, processName);
-        if (auto handle = SandboxExtension::createHandle(cacheDirectoryForProcess, SandboxExtension::Type::ReadOnly))
+        String cacheDirectoryForProcess = FileSystem::pathByAppendingComponent(cacheDirectorySpan, userDirectorySuffix);
+        if (auto handle = SandboxExtension::createHandleForReadWriteDirectory(cacheDirectoryForProcess))
             cacheDirectoryExtension = WTF::move(*handle);
     }
 }
 
-void ProcessStartupSandboxExtensions::createTempDirectorySandboxExtension(ASCIILiteral processName)
+void ProcessStartupSandboxExtensions::createTempDirectorySandboxExtension(String userDirectorySuffix)
 {
     char tempDirectory[PATH_MAX] = { 0 };
     if (__user_local_dirname(getuid(), DIRHELPER_USER_LOCAL_TEMP, tempDirectory, PATH_MAX)) {
         auto tempDirectorySpan = unsafeSpan(tempDirectory);
-        String tempDirectoryForProcess = FileSystem::pathByAppendingComponent(tempDirectorySpan, processName);
-        if (auto handle = SandboxExtension::createHandle(tempDirectoryForProcess, SandboxExtension::Type::ReadOnly))
+        String tempDirectoryForProcess = FileSystem::pathByAppendingComponent(tempDirectorySpan, userDirectorySuffix);
+        if (auto handle = SandboxExtension::createHandleForReadWriteDirectory(tempDirectoryForProcess))
             tempDirectoryExtension = WTF::move(*handle);
     }
 }
@@ -67,6 +73,15 @@ void ProcessStartupSandboxExtensions::consumeSandboxExtensions() const
     SandboxExtension::consumePermanently(webKitBundleDirectoryExtension);
     SandboxExtension::consumePermanently(cacheDirectoryExtension);
     SandboxExtension::consumePermanently(tempDirectoryExtension);
+
+    // Use private temporary and cache directories.
+    setenv("DIRHELPER_USER_DIR_SUFFIX", FileSystem::fileSystemRepresentation(userDirectorySuffix).data(), 1);
+    char temporaryDirectory[PATH_MAX];
+    if (!confstr(_CS_DARWIN_USER_TEMP_DIR, temporaryDirectory, sizeof(temporaryDirectory))) {
+        WTFLogAlways("%s: couldn't retrieve private temporary directory path: %d\n", getprogname(), errno);
+        exitProcess(EX_NOPERM);
+    }
+    setenv("TMPDIR", temporaryDirectory, 1);
 }
 
 String ProcessStartupSandboxExtensions::webKitBundlePath() const

--- a/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.mm
+++ b/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.mm
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "ProcessStartupSandboxExtensions.h"
+
+#import <pal/spi/cocoa/CoreServicesSPI.h>
+#import <wtf/FileSystem.h>
+
+namespace WebKit {
+
+void ProcessStartupSandboxExtensions::createSandboxExtensions(ASCIILiteral processName)
+{
+    String bundlePath = webKitBundlePath();
+    if (auto handle = SandboxExtension::createHandle(bundlePath, SandboxExtension::Type::ReadOnly))
+        webKitBundleDirectoryExtension = WTF::move(*handle);
+    createCacheDirectorySandboxExtension(processName);
+    createTempDirectorySandboxExtension(processName);
+}
+
+void ProcessStartupSandboxExtensions::createCacheDirectorySandboxExtension(ASCIILiteral processName)
+{
+    char cacheDirectory[PATH_MAX] = { 0 };
+    if (__user_local_dirname(getuid(), DIRHELPER_USER_LOCAL_CACHE, cacheDirectory, PATH_MAX)) {
+        auto cacheDirectorySpan = unsafeSpan(cacheDirectory);
+        String cacheDirectoryForProcess = FileSystem::pathByAppendingComponent(cacheDirectorySpan, processName);
+        if (auto handle = SandboxExtension::createHandle(cacheDirectoryForProcess, SandboxExtension::Type::ReadOnly))
+            cacheDirectoryExtension = WTF::move(*handle);
+    }
+}
+
+void ProcessStartupSandboxExtensions::createTempDirectorySandboxExtension(ASCIILiteral processName)
+{
+    char tempDirectory[PATH_MAX] = { 0 };
+    if (__user_local_dirname(getuid(), DIRHELPER_USER_LOCAL_TEMP, tempDirectory, PATH_MAX)) {
+        auto tempDirectorySpan = unsafeSpan(tempDirectory);
+        String tempDirectoryForProcess = FileSystem::pathByAppendingComponent(tempDirectorySpan, processName);
+        if (auto handle = SandboxExtension::createHandle(tempDirectoryForProcess, SandboxExtension::Type::ReadOnly))
+            tempDirectoryExtension = WTF::move(*handle);
+    }
+}
+
+void ProcessStartupSandboxExtensions::consumeSandboxExtensions() const
+{
+    SandboxExtension::consumePermanently(webKitBundleDirectoryExtension);
+    SandboxExtension::consumePermanently(cacheDirectoryExtension);
+    SandboxExtension::consumePermanently(tempDirectoryExtension);
+}
+
+String ProcessStartupSandboxExtensions::webKitBundlePath() const
+{
+    RetainPtr<NSBundle> bundle = [NSBundle bundleForClass:NSClassFromString(@"WKWebView")];
+    String bundlePath = bundle.get().bundlePath;
+    if (!bundlePath.startsWith("/System/Library/Frameworks"_s))
+        bundlePath = bundle.get().bundlePath.stringByDeletingLastPathComponent;
+    return bundlePath;
+}
+
+}

--- a/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in
@@ -24,4 +24,5 @@
     WebKit::SandboxExtensionHandle webKitBundleDirectoryExtension;
     WebKit::SandboxExtensionHandle cacheDirectoryExtension;
     WebKit::SandboxExtensionHandle tempDirectoryExtension;
+    String userDirectorySuffix;
 };

--- a/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,14 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-[RValue] struct WebKit::AuxiliaryProcessCreationParameters {
-    String wtfLoggingChannels;
-    String webCoreLoggingChannels;
-    String webKitLoggingChannels;
-    std::unique_ptr<HashSet<String>> classNamesExemptFromSecureCodingCrash;
-
-#if ENABLE(CORE_IPC_SIGNPOSTS)
-    bool shouldEnableIPCSignposts;
-    bool shouldEnableStreamingIPCSignposts;
-#endif
+[RValue] struct WebKit::ProcessStartupSandboxExtensions {
+    WebKit::SandboxExtensionHandle webKitBundleDirectoryExtension;
+    WebKit::SandboxExtensionHandle cacheDirectoryExtension;
+    WebKit::SandboxExtensionHandle tempDirectoryExtension;
 };

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -70,6 +70,10 @@
 #include <WebCore/DRMDevice.h>
 #endif
 
+#if PLATFORM(MAC)
+#include "ProcessStartupSandboxExtensions.h"
+#endif
+
 namespace API {
 class Data;
 }
@@ -295,6 +299,10 @@ struct WebProcessCreationParameters {
 
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
     bool shouldEnableWebAssemblyDebugger { false };
+#endif
+
+#if PLATFORM(MAC)
+    ProcessStartupSandboxExtensions processStartupSandboxExtensions;
 #endif
 };
 

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -239,4 +239,8 @@
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
     bool shouldEnableWebAssemblyDebugger;
 #endif
+
+#if PLATFORM(MAC)
+    WebKit::ProcessStartupSandboxExtensions processStartupSandboxExtensions;
+#endif
 };

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -674,14 +674,6 @@ static void populateSandboxInitializationParameters(SandboxInitializationParamet
     }
     setenv("TMPDIR", temporaryDirectory, 1);
 
-    String bundlePath = webKit2BundleSingleton().bundlePath;
-    if (!bundlePath.startsWith("/System/Library/Frameworks"_s))
-        bundlePath = webKit2BundleSingleton().bundlePath.stringByDeletingLastPathComponent;
-
-    sandboxParameters.addPathParameter("WEBKIT2_FRAMEWORK_DIR"_s, bundlePath.utf8().data());
-    sandboxParameters.addConfDirectoryParameter("DARWIN_USER_TEMP_DIR"_s, _CS_DARWIN_USER_TEMP_DIR);
-    sandboxParameters.addConfDirectoryParameter("DARWIN_USER_CACHE_DIR"_s, _CS_DARWIN_USER_CACHE_DIR);
-
     auto homeDirectory = getHomeDirectory();
     
     sandboxParameters.addPathParameter("HOME_DIR"_s, homeDirectory.utf8().data());

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -568,7 +568,8 @@ AuxiliaryProcessCreationParameters AuxiliaryProcessProxy::auxiliaryProcessParame
     parameters.shouldEnableIPCSignposts = IPC::Connection::signpostsEnabled();
     parameters.shouldEnableStreamingIPCSignposts = IPC::StreamClientConnection::signpostsEnabled();
 #endif
-
+#if PLATFORM(MAC)
+#endif
     return parameters;
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -60,6 +60,9 @@ void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationP
 #endif
     parameters.enableMetalDebugDeviceForTesting = m_isMetalDebugDeviceEnabledForTesting;
     parameters.enableMetalShaderValidationForTesting = m_isMetalShaderValidationEnabledForTesting;
+#if PLATFORM(MAC)
+    parameters.processStartupSandboxExtensions.createSandboxExtensions("com.apple.WebKit.GPU"_s);
+#endif
 }
 
 #if HAVE(POWERLOG_TASK_MODE_QUERY)

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -563,6 +563,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
     parameters.isDebugLoggingEnabled = os_log_debug_enabled(OS_LOG_DEFAULT);
 #endif
+
+#if PLATFORM(MAC)
+    parameters.processStartupSandboxExtensions.createSandboxExtensions("com.apple.WebKit.WebContent"_s);
+#endif
 }
 
 void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationParameters& parameters)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -243,6 +243,9 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->beginResponsivenessChecks();
     });
+#if PLATFORM(MAC)
+    parameters.processStartupSandboxExtensions.createSandboxExtensions("com.apple.WebKit.Networking"_s);
+#endif
 }
 
 static bool anyProcessPoolAlwaysRunsAtBackgroundPriority()

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -238,14 +238,15 @@ void NetworkProcessProxy::sendCreationParametersToNewProcess()
 
     parameters.defaultRequestTimeoutInterval = API::URLRequest::defaultTimeoutInterval();
 
+#if PLATFORM(MAC)
+    parameters.processStartupSandboxExtensions.createSandboxExtensions("com.apple.WebKit.Networking"_s);
+#endif
+
     WebProcessPool::platformInitializeNetworkProcess(parameters);
     sendWithAsyncReply(Messages::NetworkProcess::InitializeNetworkProcess(WTF::move(parameters)), [weakThis = WeakPtr { *this }, initializationActivityAndGrant = initializationActivityAndGrant()] {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->beginResponsivenessChecks();
     });
-#if PLATFORM(MAC)
-    parameters.processStartupSandboxExtensions.createSandboxExtensions("com.apple.WebKit.Networking"_s);
-#endif
 }
 
 static bool anyProcessPoolAlwaysRunsAtBackgroundPriority()

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2368,6 +2368,7 @@
 		E326F4DC2CA6C44F00182187 /* LogStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E326F4DA2CA6C44F00182187 /* LogStream.cpp */; };
 		E326F4DD2CA6C44F00182187 /* LogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = E326F4D92CA6C44F00182187 /* LogStream.h */; };
 		E33E8FFD2C7FD2980002BEB3 /* UseDownloadPlaceholder.h in Headers */ = {isa = PBXBuildFile; fileRef = E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */; };
+		E343ABBA2F30E75900324372 /* ProcessStartupSandboxExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = E343ABB82F30DE4000324372 /* ProcessStartupSandboxExtensions.h */; };
 		E34DAD392B753FA700FABEE2 /* ExtensionProcess.mm in Sources */ = {isa = PBXBuildFile; fileRef = E34DAD372B753FA700FABEE2 /* ExtensionProcess.mm */; };
 		E34DAD3A2B753FA700FABEE2 /* ExtensionProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = E34DAD382B753FA700FABEE2 /* ExtensionProcess.h */; };
 		E3607DEA2C7FE92200956766 /* WKDownloadDelegatePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = E3607DE92C7FE92200956766 /* WKDownloadDelegatePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2403,6 +2404,7 @@
 		E3E84BDA2AE0AAE50091B3C2 /* XPCEndpoint.h in Copy Testing Headers */ = {isa = PBXBuildFile; fileRef = C14D306724B794E700480387 /* XPCEndpoint.h */; };
 		E3E84BDB2AE0AAE50091B3C2 /* XPCEndpointClient.h in Copy Testing Headers */ = {isa = PBXBuildFile; fileRef = C14D306824B794E700480387 /* XPCEndpointClient.h */; };
 		E3E84BEE2AE1AA5A0091B3C2 /* ExtensionKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = E3E84BED2AE1AA5A0091B3C2 /* ExtensionKitSPI.h */; };
+		E3F0F3CD2F30E98D003D51DD /* ProcessStartupSandboxExtensions.mm in Sources */ = {isa = PBXBuildFile; fileRef = E3F0F3CC2F30E98D003D51DD /* ProcessStartupSandboxExtensions.mm */; };
 		E413F59D1AC1ADC400345360 /* NetworkCacheEntry.h in Headers */ = {isa = PBXBuildFile; fileRef = E413F59B1AC1ADB600345360 /* NetworkCacheEntry.h */; };
 		E42E06101AA7523B00B11699 /* NetworkCacheIOChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = E42E060B1AA7440D00B11699 /* NetworkCacheIOChannel.h */; };
 		E42E06121AA75ABD00B11699 /* NetworkCacheData.h in Headers */ = {isa = PBXBuildFile; fileRef = E42E06111AA75ABD00B11699 /* NetworkCacheData.h */; };
@@ -2582,7 +2584,7 @@
 		F4DBC0C1276AA6CA0001D169 /* _WKModalContainerInfoInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DBC0C0276AA6CA0001D169 /* _WKModalContainerInfoInternal.h */; };
 		F4DF71E82B069AC6009A4522 /* WKExtendedTextInputTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF71D72B0689A5009A4522 /* WKExtendedTextInputTraits.h */; };
 		F4DF72122B0C3A8C009A4522 /* WKBaseScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4DF72102B0C324F009A4522 /* WKBaseScrollView.h */; };
-		F4E038F82F230571003A8F3A /* WKWebView+SystemTextExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E038F72F230567003A8F3A /* WKWebView+SystemTextExtraction.swift */; };
+		F4E038F82F230571003A8F3A /* $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WKWebView+SystemTextExtraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E038F72F230567003A8F3A /* $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WKWebView+SystemTextExtraction.swift */; };
 		F4E07ACA2D8479D400322226 /* WKIdentityDocumentPresentmentController.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E07AC52D84701600322226 /* WKIdentityDocumentPresentmentController.h */; };
 		F4E08FDD2D84B27E00322226 /* WKIdentityDocumentPresentmentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E08FDA2D84AE0500322226 /* WKIdentityDocumentPresentmentRequest.h */; };
 		F4E08FE52D84B98500322226 /* WKIdentityDocumentPresentmentMobileDocumentRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E08FDE2D84B55600322226 /* WKIdentityDocumentPresentmentMobileDocumentRequest.h */; };
@@ -8464,6 +8466,8 @@
 		E326F4DA2CA6C44F00182187 /* LogStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogStream.cpp; sourceTree = "<group>"; };
 		E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UseDownloadPlaceholder.h; sourceTree = "<group>"; };
 		E3439B632345463A0011DE0B /* NetworkProcessConnectionInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkProcessConnectionInfo.h; path = Network/NetworkProcessConnectionInfo.h; sourceTree = "<group>"; };
+		E343ABB82F30DE4000324372 /* ProcessStartupSandboxExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProcessStartupSandboxExtensions.h; sourceTree = "<group>"; };
+		E343ABB92F30E28B00324372 /* ProcessStartupSandboxExtensions.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = ProcessStartupSandboxExtensions.serialization.in; sourceTree = "<group>"; };
 		E34B110C27C46BC6006D2F2E /* libWebCoreTestShim.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestShim.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		E34B110F27C46D09006D2F2E /* libWebCoreTestSupport.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestSupport.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		E34DAD372B753FA700FABEE2 /* ExtensionProcess.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ExtensionProcess.mm; sourceTree = "<group>"; };
@@ -8530,6 +8534,7 @@
 		E3E84BED2AE1AA5A0091B3C2 /* ExtensionKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtensionKitSPI.h; sourceTree = "<group>"; };
 		E3EFB02C2550617C003C2F96 /* WebSystemSoundDelegate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSystemSoundDelegate.cpp; sourceTree = "<group>"; };
 		E3EFB02D2550617C003C2F96 /* WebSystemSoundDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSystemSoundDelegate.h; sourceTree = "<group>"; };
+		E3F0F3CC2F30E98D003D51DD /* ProcessStartupSandboxExtensions.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ProcessStartupSandboxExtensions.mm; sourceTree = "<group>"; };
 		E404907121DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollingTreeFrameScrollingNodeRemoteMac.cpp; sourceTree = "<group>"; };
 		E404907321DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeFrameScrollingNodeRemoteMac.h; sourceTree = "<group>"; };
 		E40C1F9321F0B96E00530718 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScrollingTreeFrameScrollingNodeRemoteIOS.h; sourceTree = "<group>"; };
@@ -8821,7 +8826,7 @@
 		F4DF71D82B0689A5009A4522 /* WKExtendedTextInputTraits.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKExtendedTextInputTraits.mm; sourceTree = "<group>"; };
 		F4DF72102B0C324F009A4522 /* WKBaseScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKBaseScrollView.h; sourceTree = "<group>"; };
 		F4DF72112B0C324F009A4522 /* WKBaseScrollView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKBaseScrollView.mm; sourceTree = "<group>"; };
-		F4E038F72F230567003A8F3A /* WKWebView+SystemTextExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WKWebView+SystemTextExtraction.swift"; sourceTree = "<group>"; };
+		F4E038F72F230567003A8F3A /* $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WKWebView+SystemTextExtraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WKWebView+SystemTextExtraction.swift"; sourceTree = "<group>"; };
 		F4E07AC52D84701600322226 /* WKIdentityDocumentPresentmentController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIdentityDocumentPresentmentController.h; sourceTree = "<group>"; };
 		F4E08FDA2D84AE0500322226 /* WKIdentityDocumentPresentmentRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIdentityDocumentPresentmentRequest.h; sourceTree = "<group>"; };
 		F4E08FDE2D84B55600322226 /* WKIdentityDocumentPresentmentMobileDocumentRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKIdentityDocumentPresentmentMobileDocumentRequest.h; sourceTree = "<group>"; };
@@ -9316,9 +9321,9 @@
 		0753694A2DC589F4006446F8 /* TextExtraction */ = {
 			isa = PBXGroup;
 			children = (
+				F4E038F72F230567003A8F3A /* $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WKWebView+SystemTextExtraction.swift */,
 				F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */,
 				F48EC3542B7585A300D1B886 /* WKTextExtractionUtilities.mm */,
-				F4E038F72F230567003A8F3A /* WKWebView+SystemTextExtraction.swift */,
 				073A63D72DC344F40057A3F5 /* WKWebView+TextExtraction.swift */,
 			);
 			path = TextExtraction;
@@ -13117,6 +13122,9 @@
 				2D1087621D2C641B00B85F82 /* LoadParametersCocoa.mm */,
 				2D440B8325EF235E00A98D87 /* PDFKitSoftLink.h */,
 				2D440B8225EF235E00A98D87 /* PDFKitSoftLink.mm */,
+				E343ABB82F30DE4000324372 /* ProcessStartupSandboxExtensions.h */,
+				E3F0F3CC2F30E98D003D51DD /* ProcessStartupSandboxExtensions.mm */,
+				E343ABB92F30E28B00324372 /* ProcessStartupSandboxExtensions.serialization.in */,
 				442E7BEA27B4581300C69AC1 /* RevealItem.h */,
 				442E7BE827B4572B00C69AC1 /* RevealItem.mm */,
 				86AA5253293676AA0065399E /* RevealItem.serialization.in */,
@@ -18244,6 +18252,7 @@
 				5CB9310926E8439A0032B1C0 /* PrivateClickMeasurementXPCUtilities.h in Headers */,
 				86F9536518FF58F5001DB2EF /* ProcessAssertion.h in Headers */,
 				BC1A7C581136E19C00FB7167 /* ProcessLauncher.h in Headers */,
+				E343ABBA2F30E75900324372 /* ProcessStartupSandboxExtensions.h in Headers */,
 				93E05E40282CD560000B69EB /* ProcessStateMonitor.h in Headers */,
 				463FD4821EB94EC000A2982C /* ProcessTerminationReason.h in Headers */,
 				86E67A251910B9D100004AB7 /* ProcessThrottler.h in Headers */,
@@ -21509,6 +21518,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F4E038F82F230571003A8F3A /* $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/WKWebView+SystemTextExtraction.swift in Sources */,
 				5790A67125679F1A0077C5A7 /* _WKAuthenticationExtensionsClientInputs.mm in Sources */,
 				5790A67D2567A13E0077C5A7 /* _WKAuthenticationExtensionsClientOutputs.mm in Sources */,
 				5790A6892567A28A0077C5A7 /* _WKAuthenticatorAssertionResponse.mm in Sources */,
@@ -21591,6 +21601,7 @@
 				A1D4D2092B7DE6D00008C40E /* PlaybackSessionInterfaceLMK.mm in Sources */,
 				C15CBB3723F37ECB00300CC7 /* PreferenceObserver.mm in Sources */,
 				2D54C31B212F4DA60049C174 /* ProcessLauncher.cpp in Sources */,
+				E3F0F3CD2F30E98D003D51DD /* ProcessStartupSandboxExtensions.mm in Sources */,
 				517B5F7B275E97A9002DC22D /* PushClientConnection.mm in Sources */,
 				EB36B16927A7B4500050E00D /* PushService.mm in Sources */,
 				EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */,
@@ -21963,7 +21974,6 @@
 				079A4DB02D73EA4A00CA387F /* WKURLSchemeHandlerAdapter.swift in Sources */,
 				079A4DA52D72CE3F00CA387F /* WKWebpagePreferences+Extras.swift in Sources */,
 				07642AEF2DEABBA100561888 /* WKWebsiteDataStore+SwiftOverlay.swift in Sources */,
-				F4E038F82F230571003A8F3A /* WKWebView+SystemTextExtraction.swift in Sources */,
 				075369492DC589E1006446F8 /* WKWebView+TextExtraction.swift in Sources */,
 				079A4DA32D72CDB400CA387F /* WKWebViewConfiguration+Extras.swift in Sources */,
 				C14D306924B79BE000480387 /* XPCEndpoint.mm in Sources */,

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -880,7 +880,6 @@ private:
     std::unique_ptr<WebCore::CPUMonitor> m_cpuMonitor;
     std::optional<double> m_cpuLimit;
 
-    String m_uiProcessName;
     WebCore::RegistrableDomain m_registrableDomain;
 #endif
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -676,7 +676,7 @@ void WebProcess::platformSetWebsiteDataStoreParameters(WebProcessDataStoreParame
 void WebProcess::initializeProcessName(const AuxiliaryProcessInitializationParameters& parameters)
 {
 #if PLATFORM(MAC)
-    m_uiProcessName = parameters.uiProcessName;
+    setUIProcessName(parameters.uiProcessName);
 #else
     UNUSED_PARAM(parameters);
 #endif
@@ -704,19 +704,19 @@ void WebProcess::updateProcessName(IsInProcessInitialization isInProcessInitiali
     RetainPtr<NSString> applicationName;
     switch (m_processType) {
     case ProcessType::Inspector:
-        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
+        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Inspector", "Visible name of Web Inspector's web process. The argument is the application name."), uiProcessName().createNSString().get()]).get();
         break;
     case ProcessType::ServiceWorker:
-        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), m_uiProcessName.createNSString().get(), m_registrableDomain.string().createNSString().get()]).get();
+        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Service Worker (%@)", "Visible name of Service Worker process. The argument is the application name."), uiProcessName().createNSString().get(), m_registrableDomain.string().createNSString().get()]).get();
         break;
     case ProcessType::PrewarmedWebContent:
-        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
+        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Prewarmed)", "Visible name of the web process. The argument is the application name."), uiProcessName().createNSString().get()]).get();
         break;
     case ProcessType::CachedWebContent:
-        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
+        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content (Cached)", "Visible name of the web process. The argument is the application name."), uiProcessName().createNSString().get()]).get();
         break;
     case ProcessType::WebContent:
-        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), m_uiProcessName.createNSString().get()]).get();
+        SUPPRESS_UNRETAINED_ARG applicationName = adoptNS([[NSString alloc] initWithFormat:WEB_UI_NSSTRING(@"%@ Web Content", "Visible name of the web process. The argument is the application name."), uiProcessName().createNSString().get()]).get();
         break;
     }
 

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -373,6 +373,10 @@ static void setVideoDecoderBehaviors(OptionSet<VideoDecoderBehavior> videoDecode
 
 void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& parameters)
 {
+#if PLATFORM(MAC)
+    parameters.processStartupSandboxExtensions.consumeSandboxExtensions();
+#endif
+
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
     // Set JSC options early, before any VM creation
     if (parameters.shouldEnableWebAssemblyDebugger) [[unlikely]] {

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -913,10 +913,6 @@
 
 (allow-reading-global-preferences)
 
-;; On-disk WebKit2 framework location, to account for debug installations outside of /System/Library/Frameworks,
-;; and to allow issuing extensions.
-(allow-read-directory-and-issue-read-extensions (param "WEBKIT2_FRAMEWORK_DIR"))
-
 ;; Allow issuing extensions to system libraries that the Network process can already read.
 ;; This is to avoid warnings attempting to create extensions for these resources.
 (allow-read-directory-and-issue-read-extensions "/System/Library/PrivateFrameworks/WebInspectorUI.framework")
@@ -943,12 +939,6 @@
     (allow mach-register
         (global-name-regex #"^_oglprof_attach_<[0-9]+>$"))
 )
-
-(if (positive? (string-length (param "DARWIN_USER_CACHE_DIR")))
-    (allow-read-write-directory-and-issue-read-write-extensions (param "DARWIN_USER_CACHE_DIR")))
-
-(if (positive? (string-length (param "DARWIN_USER_TEMP_DIR")))
-    (allow-read-write-directory-and-issue-read-write-extensions (param "DARWIN_USER_TEMP_DIR")))
 
 ;; IOKit user clients
 (deny IOKIT_OPEN_USER_CLIENT (with no-report)


### PR DESCRIPTION
#### 89960b13d889cb91643b5663a7425d11d65bb469
<pre>
[macOS] Create sandbox extension for temp and cache folders instead of using sandbox parameters
<a href="https://rdar.apple.com/169474190">rdar://169474190</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306799">https://bugs.webkit.org/show_bug.cgi?id=306799</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.h:
* Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.mm:
(WebKit::ProcessStartupSandboxExtensions::createSandboxExtensions):
(WebKit::ProcessStartupSandboxExtensions::createCacheDirectorySandboxExtension):
(WebKit::ProcessStartupSandboxExtensions::createTempDirectorySandboxExtension):
(WebKit::ProcessStartupSandboxExtensions::consumeSandboxExtensions const):
* Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in:
</pre>
----------------------------------------------------------------------
#### 023191efe036a721971e042be46a21ca453d3c05
<pre>
[macOS] Create sandbox extension for temp and cache folders instead of using sandbox parameters
<a href="https://rdar.apple.com/169474190">rdar://169474190</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306799">https://bugs.webkit.org/show_bug.cgi?id=306799</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/mac/GPUProcessMac.mm:
(WebKit::GPUProcess::initializeProcessName):
(WebKit::GPUProcess::updateProcessName):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm:
(WebKit::NetworkProcess::initializeProcessName):
(WebKit::NetworkProcess::updateProcessName):
* Source/WebKit/Shared/AuxiliaryProcess.h:
(WebKit::AuxiliaryProcess::uiProcessName const):
(WebKit::AuxiliaryProcess::setUIProcessName):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
</pre>
----------------------------------------------------------------------
#### 96b511680431d177feb74c9be6050958cc86a722
<pre>
[macOS] Create sandbox extension for temp and cache folders instead of using sandbox parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=306799">https://bugs.webkit.org/show_bug.cgi?id=306799</a>
<a href="https://rdar.apple.com/169474190">rdar://169474190</a>

Reviewed by NOBODY (OOPS!).

Sandbox compilation and evaluation is faster when using sandbox extensions.

* Source/WebCore/PAL/pal/spi/cocoa/CoreServicesSPI.h:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.serialization.in:
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/mac/NetworkProcessMac.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcess):
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in:
* Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.h: Added.
* Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.mm: Added.
(WebKit::ProcessStartupSandboxExtensions::createSandboxExtensions):
(WebKit::ProcessStartupSandboxExtensions::createCacheDirectorySandboxExtension):
(WebKit::ProcessStartupSandboxExtensions::createTempDirectorySandboxExtension):
(WebKit::ProcessStartupSandboxExtensions::consumeSandboxExtensions const):
* Source/WebKit/Shared/Cocoa/ProcessStartupSandboxExtensions.serialization.in: Copied from Source/WebKit/Shared/AuxiliaryProcessCreationParameters.serialization.in.
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::populateSandboxInitializationParameters):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::auxiliaryProcessParameters):
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::platformInitializeGPUProcessParameters):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::sendCreationParametersToNewProcess):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89960b13d889cb91643b5663a7425d11d65bb469

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142343 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14739 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150987 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95520 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afd6e90f-d83d-4a37-b5b3-94813043a0b5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109457 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95520 "An unexpected error occured. Recent messages:Printed configuration") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cfb7e36-2f64-4e69-9316-d6ca7cd3511f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11976 "Passed tests") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90358 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8c8dacc-c084-4467-97ac-2e3688cdebc3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11493 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9148 "Found 32 new API test failures: TestWebKitAPI.WebPushDInjectedPushTest.HandleInjectedEmptyPush, TestWebKitAPI.WebPushD.WKWebPushDaemonConnectionRequestPushPermission, TestWebKitAPI.WebPushDBuiltInTest.TestPermissionsAfterSubscribe, TestWebKitAPI.WebPushDBuiltInTest.TestPermissionsAfterNotificatonRequestPermission, TestWebKitAPI.WebPushDBuiltInTest.ImplicitSilentPushTimerCausesUnsubscribe, TestWebKitAPI.WebPushDTest.UnsubscribesOnClearingAllWebsiteData, TestWebKitAPI.WebPushDTest.UnsubscribesOnServiceWorkerUnregisterTest, TestWebKitAPI.WebPushDNavigatorTest.SubscribeFailureTest, TestWebKitAPI.WebPushD.BasicCommunication, TestWebKitAPI.WebPushDTest.SubscribeFailureTest ... (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1009 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120842 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153326 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14418 "Built successfully") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117497 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117821 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13872 "Passed tests") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70120 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14467 "Built successfully") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78183 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14244 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->