### PR TITLE
REGRESSION(304526@main): Can't click link in Apple Maps on the Web business listing

### DIFF
--- a/LayoutTests/fast/inline/hittest-inline-background-expected.txt
+++ b/LayoutTests/fast/inline/hittest-inline-background-expected.txt
@@ -1,0 +1,2 @@
+PASS if click takes you to apple.com
+link

--- a/LayoutTests/fast/inline/hittest-inline-background.html
+++ b/LayoutTests/fast/inline/hittest-inline-background.html
@@ -1,0 +1,15 @@
+<style>
+#child {
+  pointer-events: none;
+}
+.container {
+  position: relative;
+}
+</style>
+<div class=container><a href="https://www.apple.com/" id=link><div id=child>PASS if click takes you to apple.com</div></a></div>
+<pre id=log></pre>
+<script>
+window.testRunner?.dumpAsText();
+const id = document.elementFromPoint(child.offsetLeft + 10, child.offsetTop+ 10).id;
+log.textContent = id ? id : "FAIL";
+</script>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1298,11 +1298,11 @@ bool LineLayout::hitTest(const HitTestRequest& request, HitTestResult& result, c
         auto shouldHitTestForPhase = [&] {
             switch (hitTestAction) {
             case HitTestForeground:
-                // Inline boxes around block-in-inline are hit tested in block background phase.
+                // Inline boxes around block-in-inline are hit tested in block background phases.
                 return !m_inlineContent->isInlineBoxWrapperForBlockLevelBox(box);
             case HitTestChildBlockBackground:
-                return box.isBlockLevelBox() || m_inlineContent->isInlineBoxWrapperForBlockLevelBox(box);
             case HitTestChildBlockBackgrounds:
+                return box.isBlockLevelBox() || m_inlineContent->isInlineBoxWrapperForBlockLevelBox(box);
             case HitTestFloat:
                 return box.isBlockLevelBox();
             case HitTestBlockBackground:


### PR DESCRIPTION
#### 9abd7a26e0c8da1c748600c3ccf9f84ce1319220
<pre>
REGRESSION(304526@main): Can&apos;t click link in Apple Maps on the Web business listing
<a href="https://bugs.webkit.org/show_bug.cgi?id=306806">https://bugs.webkit.org/show_bug.cgi?id=306806</a>
<a href="https://rdar.apple.com/169437370">rdar://169437370</a>

Reviewed by Alan Baradlay.

Test: fast/inline/hittest-inline-background.html
* LayoutTests/fast/inline/hittest-inline-background-expected.txt: Added.
* LayoutTests/fast/inline/hittest-inline-background.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::hitTest):

The behavior in HitTestChildBlockBackground and HitTestChildBlockBackgrounds phases should be the same.
The former is used for the block that is the hit testing entry point from the layer tree, thus affected
by the element having a layer.

Canonical link: <a href="https://commits.webkit.org/306675@main">https://commits.webkit.org/306675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de534bfa4b795acb0ebf403a4876e7024a0ed3c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150615 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/671fb17f-9de3-449c-80ed-30ba1f0ef9c0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15121 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109154 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71199605-fded-44ca-97b5-c57890918599) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11693 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90051 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98b06a92-0ad9-4bad-894a-dcdfa724977f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8887 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/673 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152990 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14082 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117233 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14104 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117550 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29957 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13597 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69776 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14131 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14067 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->