### PR TITLE
AX: VoiceOver typing echo doesn't work in remote frames with site isolation enabled

### DIFF
--- a/LayoutTests/accessibility/ios-simulator/focus-change-notifications.html
+++ b/LayoutTests/accessibility/ios-simulator/focus-change-notifications.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test.js"></script>
 </head>
 <body>
@@ -9,35 +10,35 @@
 <h2 tabindex=0 id="h2">H2</h2>
 
 <script>
+window.jsTestIsAsync = true;
+
 description("This tests that notifications are fired for focus changes");
 
 var focusChangeCount = 0;
-var rootElement = null;
-function focusCallback(notification) {
-    if (notification === "AXFocusChanged") {
+function notificationCallback(element, notificationName) {
+    if (notificationName === "AXFocusChanged") {
         focusChangeCount++;
-        if (focusChangeCount === 1)
-            document.getElementById("h1").focus();
+        if (focusChangeCount === 1) {
+            setTimeout(() => {
+                // Avoid dirtying style in the middle of AXObjectCache::performDeferredCacheUpdate by doing the next
+                // focus asynchronously.
+                document.getElementById("h1").focus();
+            }, 5);
+        }
 
         // We should get a total of 2 focus changes.
         if (focusChangeCount === 2) {
-           rootElement.removeNotificationListener();
-           finishJSTest();
+            accessibilityController.removeNotificationListener();
+            finishJSTest();
         }
     }
 }
 
 if (window.accessibilityController) {
     // Make sure AX gets turned on.
-    rootElement = accessibilityController.rootElement.childAtIndex(0);
-    jsTestIsAsync = true;
+    touchAccessibilityTree(accessibilityController.rootElement);
 
-    var addedNotification = rootElement.addNotificationListener(focusCallback);
-    if (!addedNotification) {
-        rootElement = accessibilityController.rootElement;
-        addedNotification = rootElement.addNotificationListener(focusCallback);
-    }
-
+    var addedNotification = accessibilityController.addNotificationListener(notificationCallback);
     shouldBe("addedNotification", "true");
 
     document.getElementById("h2").focus();

--- a/LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame-expected.txt
@@ -1,0 +1,10 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Ensures that accessibility returns a remote element from the focused-ui-element API when focus moves into a remote frame.
+PASS: addedNotification === true
+PASS: focusedObject.role.toLowerCase().includes('link') === true
+PASS: focusedObject.isRemotePlatformElement === false
+PASS: focusedObject.isRemotePlatformElement === true
+
+Pre-iframe focusable element

--- a/LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame.html
@@ -1,0 +1,58 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<a id="link" href="#url">Pre-iframe focusable element</a>
+
+<iframe src="http://localhost:8000/site-isolation/resources/iframe-with-text-input.html" onload="runTest();"></iframe>
+
+<script>
+var output = "Ensures that accessibility returns a remote element from the focused-ui-element API when focus moves into a remote frame.\n";
+
+window.jsTestIsAsync = true;
+
+var addedNotification, focusedObject;
+var focusChangeCount = 0;
+function notificationCallback(element, notificationName) {
+    if (notificationName === "AXFocusChanged") {
+        focusChangeCount++;
+        if (focusChangeCount === 1) {
+            focusedObject = accessibilityController.focusedElement;
+            output += expect("focusedObject.role.toLowerCase().includes('link')", "true");
+            output += expect("focusedObject.isRemotePlatformElement", "false");
+            setTimeout(() => {
+                // Use the tab key to move focus into the iframe. Do this asynchronously, as otherwise we would dirty
+                // style in the middle of AXObjectCache::performDeferredCacheUpdate, violating its invariant that layout
+                // and style remain clean, causing crashes. Note this is a layout-test only problem, as actual ATs can't
+                // synchronously trigger JS in response to notifications like our testing infrastructure allows for tests.
+                eventSender.keyDown("\t");
+            }, 5);
+        }
+
+        // We should get a total of 2 focus changes.
+        if (focusChangeCount === 2) {
+            focusedObject = accessibilityController.focusedElement;
+            output += expect("focusedObject.isRemotePlatformElement", "true");
+
+            accessibilityController.removeNotificationListener();
+            finishJSTest();
+            debug(output);
+        }
+    }
+}
+
+function runTest() {
+    if (!window.accessibilityController)
+        return;
+    touchAccessibilityTree(accessibilityController.rootElement)
+
+    addedNotification = accessibilityController.addNotificationListener(notificationCallback);
+    output += expect("addedNotification", "true");
+    document.getElementById("link").focus();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/iframe-with-text-input.html
+++ b/LayoutTests/http/tests/site-isolation/resources/iframe-with-text-input.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Site Isolation frame test</title>
+    </head>
+    <body>
+        <h1 id="text" style="font-size: 200px; margin: 0;">Hello, world!</h1>
+        <label for="input">Type anything you want</label>
+        <input id="input" type="text" />
+    </body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1279,6 +1279,7 @@ public:
 
     AccessibilityObjectWrapper* wrapper() const { return m_wrapper.get(); }
 #if PLATFORM(COCOA)
+    WEBCORE_EXPORT RetainPtr<id> platformElement() const;
     WEBCORE_EXPORT RetainPtr<AccessibilityObjectWrapper> protectedWrapper() const;
 #endif
     void setWrapper(AccessibilityObjectWrapper* wrapper) { m_wrapper = wrapper; }

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -630,6 +630,12 @@ TextStream& operator<<(TextStream& stream, AXNotification notification)
     return stream;
 }
 
+TextStream& operator<<(TextStream& stream, const AXNotificationWithData& notification)
+{
+    stream << notification.debugDescription();
+    return stream;
+}
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 WTF::TextStream& operator<<(WTF::TextStream& stream, const AXPropertyVector& properties)
 {

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -76,6 +76,7 @@ bool isVisibilityHidden(const RenderStyle&);
 const RenderStyle* safeStyleFrom(Element&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, AXNotification);
+WTF::TextStream& operator<<(WTF::TextStream&, const AXNotificationWithData&);
 
 void dumpAccessibilityTreeToStderr(Document&);
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3192,12 +3192,7 @@ AccessibilityObject* AccessibilityObject::focusedUIElementInAnyLocalFrame() cons
     CheckedPtr axObjectCache = focusedDocument->axObjectCache();
     if (!axObjectCache)
         return nullptr;
-
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
-    return axObjectCache->focusedObjectForLocalFrame();
-#else
     return axObjectCache->focusedObjectForPage(page.get());
-#endif
 }
 
 void AccessibilityObject::setSelectedRows(AccessibilityChildrenVector&& selectedRows)

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -269,14 +269,14 @@ void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView
     }
 }
 
-void AXObjectCache::platformHandleFocusedUIElementChanged(Element* oldFocus, Element* newFocus)
+void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject* oldFocus, AccessibilityObject* newFocus)
 {
-    if (auto* axObject = get(oldFocus)) {
-        if (auto* wrapper = axObject->wrapper())
+    if (oldFocus) {
+        if (auto* wrapper = oldFocus->wrapper())
             wrapper->stateChanged("focused", false);
     }
-    if (auto* axObject = getOrCreate(newFocus)) {
-        if (auto* wrapper = axObject->wrapper())
+    if (newFocus) {
+        if (auto* wrapper = newFocus->wrapper())
             wrapper->stateChanged("focused", true);
     }
 }

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -63,6 +63,13 @@ SOFT_LINK_CONSTANT(AXRuntime, UIAccessibilityTokenAttachment, NSString *);
 
 namespace WebCore {
 
+RetainPtr<id> AXCoreObject::platformElement() const
+{
+    if (isRemoteFrame()) [[unlikely]]
+        return remoteFramePlatformElement();
+    return wrapper();
+}
+
 String AXCoreObject::speechHint() const
 {
     auto speakAs = this->speakAs();

--- a/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
+++ b/Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm
@@ -217,9 +217,13 @@ void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView
     }
 }
 
-void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element* newElement)
+void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject* oldFocus, AccessibilityObject* newFocus)
 {
-    postNotification(newElement, AXNotification::FocusedUIElementChanged);
+    RefPtr notificationTarget = newFocus;
+    if (!notificationTarget)
+        notificationTarget = oldFocus ? oldFocus : rootWebArea();
+
+    postNotification(notificationTarget.get(), AXNotification::FocusedUIElementChanged);
 }
 
 void AXObjectCache::handleScrolledToAnchor(const Node&)

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -1886,8 +1886,8 @@ static void appendStringToResult(NSMutableString *result, NSString *string)
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    auto* focus = self.axBackingObject->focusedUIElementInAnyLocalFrame();
-    return focus ? focus->wrapper() : nil;
+    RefPtr focus = self.axBackingObject->focusedUIElementInAnyLocalFrame();
+    return focus ? focus->platformElement().autorelease() : nil;
 }
 
 - (id)_accessibilityWebDocumentView

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -184,6 +184,7 @@ bool isDefaultValue(AXProperty property, AXPropertyValueVariant& value)
         [](DateComponentsType& typedValue) { return typedValue == DateComponentsType::Invalid; },
         [](AccessibilityOrientation) { return false; },
         [](Style::SpeakAs& typedValue) { return typedValue.isNormal(); },
+        [](FrameIdentifier&) { return false; },
         [](auto&) {
             AX_ASSERT_NOT_REACHED();
             return false;
@@ -1706,6 +1707,7 @@ AXIsolatedObject* AXIsolatedObject::crossFrameParentObject() const
 
     auto parentObjectID = *markableParentObjectID;
 
+    // FIXME: We don't actually hold the lock here.
     RefPtr parentTree = AXIsolatedTree::treeForFrameIDAlreadyLocked(*parentFrameID);
     if (!parentTree)
         return nullptr;
@@ -1723,6 +1725,7 @@ AXIsolatedObject* AXIsolatedObject::crossFrameChildObject() const
         return nullptr;
 
     RefPtr<AXIsolatedTree> childTree;
+    // FIXME: We don't actually hold the lock here.
     childTree = AXIsolatedTree::treeForFrameIDAlreadyLocked(*frameID);
     if (!childTree)
         return nullptr;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -178,12 +178,7 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     if (axRoot)
         tree->generateSubtree(*axRoot);
 
-#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
-    RefPtr axFocus = axObjectCache.focusedObjectForLocalFrame();
-#else
-    RefPtr axFocus = axObjectCache.focusedObjectForPage(document->page());
-#endif
-    if (axFocus)
+    if (RefPtr axFocus = axObjectCache.focusedObjectForPage(document->page()))
         tree->setFocusedNodeID(axFocus->objectID());
     tree->setSelectedTextMarkerRange(document->selection().selection());
     tree->setInitialSortedLiveRegions(axIDs(axObjectCache.sortedLiveRegions()));
@@ -295,6 +290,8 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::treeForFrameID(FrameIdentifier frameID)
 
 RefPtr<AXIsolatedTree> AXIsolatedTree::treeForFrameIDAlreadyLocked(FrameIdentifier frameID)
 {
+    AX_BROKEN_ASSERT(s_storeLock.isHeld());
+
     return treeFrameCache().get(frameID);
 }
 

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -34,6 +34,7 @@
 #import "AXNotifications.h"
 #import "AXObjectCacheInlines.h"
 #import "AXSearchManager.h"
+#import "AXUtilities.h"
 #import "AccessibilityObject.h"
 #import "CocoaAccessibilityConstants.h"
 #import "DeprecatedGlobalSettings.h"
@@ -693,7 +694,7 @@ void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView
     }
 }
 
-void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element*)
+void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject*, AccessibilityObject*)
 {
     NSAccessibilityHandleFocusChanged();
     // AXFocusChanged is a test specific notification name and not something a real AT will be listening for

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2090,7 +2090,7 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
         return nil;
 
     RefPtr focusedObject = backingObject->focusedUIElementInAnyLocalFrame();
-    return focusedObject ? focusedObject->wrapper() : nil;
+    return focusedObject ? focusedObject->platformElement().autorelease() : nil;
 }
 
 - (id)accessibilityHitTest:(NSPoint)point
@@ -3703,10 +3703,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSString *)debugDescription
 {
+    String backingObjectDescription = "null backingObject"_s;
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
-    if (!backingObject)
-        return nil;
-    return backingObject->debugDescription().createNSString().autorelease();
+    if (backingObject)
+        backingObjectDescription = backingObject->debugDescription();
+    return makeString("PID: "_s, getpid(), ", "_s, backingObjectDescription).createNSString().autorelease();
 }
 @end
 

--- a/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
+++ b/Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp
@@ -142,12 +142,12 @@ void AXObjectCache::handleScrolledToAnchor(const Node& scrolledToNode)
         postPlatformNotification(*object, AXNotification::ScrolledToAnchor);
 }
 
-void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element* newFocus)
+void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject*, AccessibilityObject* newFocus)
 {
     if (!newFocus)
         return;
 
-    Page* page = newFocus->document().page();
+    Page* page = newFocus->page();
     if (!page || !page->chrome().platformPageClient())
         return;
 

--- a/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
+++ b/Source/WebCore/accessibility/win/AXObjectCacheWin.cpp
@@ -153,12 +153,12 @@ void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView
     }
 }
 
-void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element* newFocus)
+void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject*, AccessibilityObject* newFocus)
 {
     if (!newFocus)
         return;
 
-    Page* page = newFocus->document().page();
+    Page* page = newFocus->page();
     if (!page || !page->chrome().platformPageClient())
         return;
 

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -504,6 +504,10 @@ void FocusController::setFocusedFrame(Frame* frame, BroadcastFocusedFrame broadc
                 localFrame->document()->updateServiceWorkerClientData();
             frame = frame->tree().parent();
         } while (frame);
+    } else if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(frame)) {
+        RefPtr focusedOrMainFrame = this->focusedOrMainFrame();
+        if (CheckedPtr cache = focusedOrMainFrame ? focusedOrMainFrame->document()->existingAXObjectCache() : nullptr)
+            cache->onRemoteFrameGainedFocus(*remoteFrame);
     }
 
     if (shouldBroadcast)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -147,6 +147,8 @@ public:
 
     virtual void reportMixedContentViolation(bool blocked, const URL& target) const = 0;
 
+    virtual String debugDescription() const = 0;
+
     void stopForBackForwardCache();
 
     WEBCORE_EXPORT void updateFrameTreeSyncData(Ref<FrameTreeSyncData>&&);

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -196,7 +196,7 @@ public:
 
     bool requestDOMPasteAccess(DOMPasteAccessCategory = DOMPasteAccessCategory::General);
 
-    String debugDescription() const;
+    String debugDescription() const override;
 
     WEBCORE_EXPORT static LocalFrame* fromJSContext(JSContextRef);
     WEBCORE_EXPORT static LocalFrame* contentFrameFromWindowOrFrameElement(JSContextRef, JSValueRef);

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -39,6 +39,8 @@
 #include "RemoteFrameView.h"
 #include "SecurityOrigin.h"
 #include <wtf/CompletionHandler.h>
+#include <wtf/HexNumber.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
@@ -222,6 +224,17 @@ float RemoteFrame::usedZoomForChild(const Frame& child) const
 {
     auto maybeInfo = frameTreeSyncData().childrenFrameLayoutInfo.getOptional(child.frameID());
     return maybeInfo.transform([] (auto& info) { return info.usedZoom; }).value_or(1.0);
+}
+
+String RemoteFrame::debugDescription() const
+{
+    StringBuilder builder;
+
+    builder.append("RemoteFrame 0x"_s, hex(reinterpret_cast<uintptr_t>(this), Lowercase));
+    if (isMainFrame())
+        builder.append(" (main frame)"_s);
+
+    return builder.toString();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -91,6 +91,8 @@ public:
 
     void updateScrollingMode() final;
     void reportMixedContentViolation(bool blocked, const URL& target) const final;
+
+    String debugDescription() const final;
     const SecurityOrigin& frameDocumentSecurityOriginOrOpaque() const;
 
 private:

--- a/Source/WebCore/page/cocoa/PageCocoa.mm
+++ b/Source/WebCore/page/cocoa/PageCocoa.mm
@@ -59,6 +59,7 @@ void Page::platformInitialize()
     std::call_once(onceFlag, [] {
 #if ENABLE(TREE_DEBUGGING)
         PAL::registerNotifyCallback("com.apple.WebKit.dumpAccessibilityTreeToStderr"_s, printAccessibilityTreeForLiveDocuments);
+        PAL::registerNotifyCallback("com.apple.WebKit.dumpAccessibilityTreeToStderrAfterDelay"_s, printAccessibilityTreeForLiveDocumentsAfterDelay);
         PAL::registerNotifyCallback("com.apple.WebKit.showRenderTree"_s, printRenderTreeForLiveDocuments);
         PAL::registerNotifyCallback("com.apple.WebKit.showLayerTree"_s, printLayerTreeForLiveDocuments);
         PAL::registerNotifyCallback("com.apple.WebKit.showGraphicsLayerTree"_s, printGraphicsLayerTreeForLiveDocuments);

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -89,6 +89,8 @@ public:
 
     USING_CAN_MAKE_WEAKPTR(Widget);
 
+    String debugDescription() const override;
+
     // ScrollableArea functions.
     WEBCORE_EXPORT void setScrollOffset(const ScrollOffset&) final;
     bool isScrollCornerVisible() const final;
@@ -491,7 +493,6 @@ private:
     bool setHasScrollbarInternal(RefPtr<Scrollbar>&, ScrollbarOrientation, bool hasBar, bool* contentSizeAffected);
 
     bool isScrollView() const final { return true; }
-    String debugDescription() const override;
 
     void init();
     void destroy();

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -94,7 +94,9 @@
 #include <algorithm>
 #include <stdio.h>
 #include <wtf/HexNumber.h>
+#include <wtf/Seconds.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/WeakRandomNumber.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -3137,6 +3139,17 @@ void printLayerTreeForLiveDocuments()
     }
 }
 
+void printAccessibilityTreeForLiveDocumentsAfterDelay()
+{
+    // This is useful when debugging pages with frames and site isolation enabled. If all processes
+    // dump their tree at once, they will interleave in stderr, making it hard to understand.
+    // It's still possible for this to happen with this random delay, but is much less likely.
+    auto randomSeconds = Seconds { static_cast<double>(weakRandomNumber<unsigned>() % 21) };
+    sleep(randomSeconds);
+
+    printAccessibilityTreeForLiveDocuments();
+}
+
 void printAccessibilityTreeForLiveDocuments()
 {
     for (auto& document : Document::allDocuments()) {
@@ -3144,9 +3157,9 @@ void printAccessibilityTreeForLiveDocuments()
             continue;
         if (document->frame()) {
             if (document->frame()->isRootFrame())
-                WTFLogAlways("Accessibility tree for root document %p %s", document.ptr(), document->url().string().utf8().data());
+                WTFLogAlways("\nPID %d: Accessibility tree for root document %p %s", getpid(), document.ptr(), document->url().string().utf8().data());
             else
-                WTFLogAlways("Accessibility tree for non-root document %p %s", document.ptr(), document->url().string().utf8().data());
+                WTFLogAlways("\nPID %d: Accessibility tree for non-root document %p %s", getpid(), document.ptr(), document->url().string().utf8().data());
             dumpAccessibilityTreeToStderr(document.get());
         }
     }

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1493,6 +1493,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, const RenderObject::RepaintRects&)
 
 #if ENABLE(TREE_DEBUGGING)
 void printAccessibilityTreeForLiveDocuments();
+void printAccessibilityTreeForLiveDocumentsAfterDelay();
 void printPaintOrderTreeForLiveDocuments();
 void printRenderTreeForLiveDocuments();
 void printLayerTreeForLiveDocuments();

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -283,14 +283,14 @@ id WebProcess::accessibilityFocusedUIElement()
         }
 
         RefPtr object = (*isolatedTree)->focusedNode();
-        RetainPtr objectWrapper = object ? object->wrapper() : nil;
-        if (objectWrapper) {
+        RetainPtr platformElement = object ? object->platformElement() : nil;
+        if (platformElement) {
             ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            if (RetainPtr associatedParent = [objectWrapper accessibilityAttributeValue:@"_AXAssociatedPluginParent"])
-                objectWrapper = WTF::move(associatedParent);
+            if (RetainPtr associatedParent = [platformElement accessibilityAttributeValue:@"_AXAssociatedPluginParent"])
+                platformElement = WTF::move(associatedParent);
             ALLOW_DEPRECATED_DECLARATIONS_END
         }
-        return objectWrapper.autorelease();
+        return platformElement.autorelease();
     }
 #endif
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -404,7 +404,10 @@ public:
     virtual bool isDeletion() const;
     virtual bool isFirstItemInSuggestion() const;
     virtual bool isLastItemInSuggestion() const;
+    // True if the element backing |this| is the WebAccessibilityObjectWrapper associated with an AXRemoteFrame.
     virtual bool isRemoteFrame() const;
+    // True if the element backing |this| is a platform remote element (e.g. NSAccessibilityRemoteUIElement on macOS).
+    virtual bool isRemotePlatformElement() const { return false; }
 
     virtual bool isMarkAnnotation() const;
 protected:

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -126,6 +126,7 @@ interface AccessibilityUIElement {
     readonly attribute boolean isFirstItemInSuggestion;
     readonly attribute boolean isLastItemInSuggestion;
     readonly attribute boolean isRemoteFrame;
+    readonly attribute boolean isRemotePlatformElement;
 
     readonly attribute long pageX;
     readonly attribute long pageY;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -328,6 +328,7 @@ public:
     bool isFirstItemInSuggestion() const override;
     bool isLastItemInSuggestion() const override;
     bool isRemoteFrame() const override;
+    bool isRemotePlatformElement() const final;
 
 private:
     AccessibilityUIElementMac(PlatformUIElement);

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -38,6 +38,7 @@
 #import <WebCore/CocoaAccessibilityConstants.h>
 #import <WebCore/DateComponents.h>
 #import <WebKit/WKBundleFrame.h>
+#import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -3080,11 +3081,18 @@ bool AccessibilityUIElementMac::isLastItemInSuggestion() const
 bool AccessibilityUIElementMac::isRemoteFrame() const
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    auto value = attributeValue(@"AXIsRemoteFrame");
+    RetainPtr value = attributeValue(@"AXIsRemoteFrame");
     if ([value isKindOfClass:[NSNumber class]])
         return [value boolValue];
     END_AX_OBJC_EXCEPTIONS
     return false;
+}
+
+bool AccessibilityUIElementMac::isRemotePlatformElement() const
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    return [m_element isKindOfClass:NSAccessibilityRemoteUIElement.class];
+    END_AX_OBJC_EXCEPTIONS
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### 199c27a50c096c48bd68cdc6ac692776cc4a8141
<pre>
AX: VoiceOver typing echo doesn&apos;t work in remote frames with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306807">https://bugs.webkit.org/show_bug.cgi?id=306807</a>
<a href="https://rdar.apple.com/169478834">rdar://169478834</a>

Reviewed by Joshua Hoffman.

Prior to this commit, VoiceOver typing echo didn&apos;t work in remote frames
with site isolation enabled. This happened because when focus moved into
a remote frame, the hosting web content process didn&apos;t denote its
focused UI element to be the AXRemoteFrame, instead simply returning its
own web area. This meant that VoiceOver and other ATs didn&apos;t know they
needed to traverse to another process to find the true deepest focus UI
element, in turn also preventing them from registering for notifications
on the remote web content process.

This commit adds various debugging utilities and methods that were
useful to me when working on this.

* LayoutTests/accessibility/ios-simulator/focus-change-notifications.html:
Update test to not expect notifications on a certain element. This only implicitly worked before, relying on the fact
that calling AXObjectCache::get() (not getOrCreate) via DOM ancestry traversal only succeeded for the web area.
* LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/focus-in-remote-frame.html: Added.
* LayoutTests/http/tests/site-isolation/resources/iframe-with-text-input.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXNotificationWithData::debugDescription const):
(WebCore::AXObjectCache::focusedObjectForLocalFrame):
(WebCore::AXObjectCache::setIsolatedTreeFocusedObject):
(WebCore::AXObjectCache::onFocusChange):
(WebCore::AXObjectCache::handleFocusedUIElementChanged):
(WebCore::AXObjectCache::onRemoteFrameGainedFocus):
(WebCore::AXObjectCache::handleRemoteFrameGainedFocus):
(WebCore::AXObjectCache::prepareForDocumentDestruction):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::handleDeferredNotification):
(WebCore::AXObjectCache::treeData):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AXTreeData::dumpToStderr const):
(WebCore::AriaNotifyData::debugDescription const):
(WebCore::LiveRegionAnnouncementData::debugDescription const):
* Source/WebCore/accessibility/AXUtilities.h:
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::platformElement const):
* Source/WebCore/accessibility/ios/AXObjectCacheIOS.mm:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityFocusedUIElement]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::isDefaultValue):
(WebCore::AXIsolatedObject::crossFrameParentObject const):
(WebCore::AXIsolatedObject::crossFrameChildObject const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::treeForFrameIDAlreadyLocked):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityFocusedUIElement]):
(-[WebAccessibilityObjectWrapper debugDescription]):
* Source/WebCore/accessibility/playstation/AXObjectCachePlayStation.cpp:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/accessibility/win/AXObjectCacheWin.cpp:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::debugDescription const):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/cocoa/PageCocoa.mm:
(WebCore::Page::platformInitialize):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::printAccessibilityTreeForLiveDocumentsAfterDelay):
(WebCore::printAccessibilityTreeForLiveDocuments):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
(WTR::AccessibilityUIElement::isRemotePlatformElement const):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElementMac::isRemoteFrame const):
(WTR::AccessibilityUIElementMac::isRemotePlatformElement const):

Canonical link: <a href="https://commits.webkit.org/307008@main">https://commits.webkit.org/307008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82a01f7064a33b7994d02ea50b2fab72aa33f202

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142645 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95834 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abd6092a-d9be-4a2e-8190-555160979c9e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79121 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb25a529-6715-47a9-8ee6-6d9512256148) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90615 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3d7b618-a3fb-44dd-baec-81fd3377fd7e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9360 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1314 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153628 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117728 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14782 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12830 "Found 1 new test failure: ipc/insufficient-svgfilter-inputs-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118059 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30323 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14075 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70441 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14787 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3895 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14522 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78496 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14730 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14584 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->