### PR TITLE
REGRESSION(305120@main): Fix colspan width distribution when auto columns are converted to percentages

### DIFF
--- a/LayoutTests/fast/table/colspan-width-distribution-auto-percent-expected.txt
+++ b/LayoutTests/fast/table/colspan-width-distribution-auto-percent-expected.txt
@@ -1,0 +1,5 @@
+100px div
+A	B
+
+PASS Colspan with 100px content over auto and 50% columns distributes width correctly
+

--- a/LayoutTests/fast/table/colspan-width-distribution-auto-percent.html
+++ b/LayoutTests/fast/table/colspan-width-distribution-auto-percent.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Colspan width distribution with auto and percentage columns</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<table id="test-table">
+    <tr>
+        <td colspan="2">
+            <div style="width: 100px; background: gold;">100px div</div>
+        </td>
+    </tr>
+    <tr id="test-row">
+        <td id="cell-a">A</td>
+        <td id="cell-b" width="50%">B</td>
+    </tr>
+</table>
+
+<script>
+test(function() {
+    var cellA = document.getElementById('cell-a');
+    var cellB = document.getElementById('cell-b');
+    
+    var cellAWidth = cellA.clientWidth;
+    var cellBWidth = cellB.clientWidth;
+    
+    assert_equals(cellAWidth + cellBWidth, 104, 
+        'Total width of cells should be 104px (100px content + borders/padding)');
+        
+}, 'Colspan with 100px content over auto and 50% columns distributes width correctly');
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### ce01b79ed142fc10b0097a7d71526f65bf026dea
<pre>
REGRESSION(305120@main): Fix colspan width distribution when auto columns are converted to percentages
<a href="https://bugs.webkit.org/show_bug.cgi?id=306809">https://bugs.webkit.org/show_bug.cgi?id=306809</a>
<a href="https://rdar.apple.com/168546944">rdar://168546944</a>

Reviewed by Alan Baradlay.

When a percentage-width colspan cell spans columns that include both
percentage and auto-width columns, the earlier code converts auto columns
to effective percentages to ensure proper distribution. However, a
subsequent non-percentage colspan over the same columns was incorrectly
applying percentage-based distribution even though no conversion had
occurred for that cell.

This caused regressions where auto columns were treated as if they had
been converted to percentages, leading to incorrect width calculations.

The fix adds a check to verify that auto columns have actually been
converted to effective percentages before applying percentage-based
distribution. This is done by checking if any column has logicalWidth
set to auto but effectiveLogicalWidth set to a percentage value, which
only happens when a previous percentage colspan has processed these
columns.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::calcEffectiveLogicalWidth):
* LayoutTests/fast/table/colspan-width-distribution-auto-percent-expected.txt: Added.
* LayoutTests/fast/table/colspan-width-distribution-auto-percent.html: Added.

Canonical link: <a href="https://commits.webkit.org/306780@main">https://commits.webkit.org/306780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7a5976694f14d73f30268c67ebfa72bfc84a970

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95159 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9dbd8983-fa59-4efd-b507-c0b3455750e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109132 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78899 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcacf99c-63bd-4fca-857b-224e80f49398) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90028 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a47792c9-8307-4951-979e-75d9ee7e47d0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8865 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/649 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3327 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152966 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14058 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117211 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117528 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30036 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13572 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124130 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69752 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14107 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3249 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13839 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13884 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->