### PR TITLE
Revise frozen Safari UA macOS version to match actual last-shipped macOS security SU version

### DIFF
--- a/Source/WebCore/page/NavigatorUAData.cpp
+++ b/Source/WebCore/page/NavigatorUAData.cpp
@@ -182,7 +182,7 @@ void NavigatorUAData::getHighEntropyValues(const Vector<String>& hints, Navigato
 #elif PLATFORM(IOS_FAMILY)
             values->platformVersion = systemMarketingVersionForUserAgentString();
 #elif OS(MACOS)
-            values->platformVersion = "10.15.7"_s;
+            values->platformVersion = "10.15.8"_s;
 #else
             values->platformVersion = ""_s;
 #endif

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1794,7 +1794,7 @@ bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 #if PLATFORM(COCOA)
 
 #if !PLATFORM(IOS_FAMILY)
-static constexpr auto frozenVersion = "10_15_7"_s;
+static constexpr auto frozenVersion = "10_15_8"_s;
 #elif PLATFORM(WATCHOS)
 static constexpr auto frozenVersion = "11_6_1"_s;
 #elif PLATFORM(APPLETV)

--- a/Source/WebCore/platform/ios/UserAgentIOS.mm
+++ b/Source/WebCore/platform/ios/UserAgentIOS.mm
@@ -94,7 +94,7 @@ String standardUserAgentWithApplicationName(const String& applicationName, const
     auto separator = applicationName.isEmpty() ? ""_s : " "_s;
 
     if (type == UserAgentType::Desktop)
-        return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, separator, applicationName);
+        return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_8) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, separator, applicationName);
 
     if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DoesNotOverrideUAFromNSUserDefault)) {
         if (auto override = dynamic_cf_cast<CFStringRef>(adoptCF(CFPreferencesCopyAppValue(CFSTR("UserAgent"), CFSTR("com.apple.WebFoundation"))))) {

--- a/Source/WebCore/platform/mac/UserAgentMac.mm
+++ b/Source/WebCore/platform/mac/UserAgentMac.mm
@@ -36,7 +36,7 @@ String standardUserAgentWithApplicationName(const String& applicationName, const
 {
     String appNameSuffix = applicationName.isEmpty() ? emptyString() : makeString(' ', applicationName);
 
-    return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, appNameSuffix);
+    return makeString("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_8) AppleWebKit/605.1.15 (KHTML, like Gecko)"_s, appNameSuffix);
 }
 
 } // namespace WebCore

--- a/Source/WebInspectorUI/UserInterface/Views/OverrideDeviceSettingsPopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OverrideDeviceSettingsPopover.js
@@ -145,12 +145,12 @@ WI.OverrideDeviceSettingsPopover = class OverrideDeviceSettingsPopover extends W
                 {name: WI.UIString("Default"), value: WI.DeviceSettingsManager.DefaultValue},
             ],
             [
-                {name: "Safari 26", value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26 Safari/605.1.15"},
+                {name: "Safari 26", value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_8) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26 Safari/605.1.15"},
             ],
             [
                 {name: `Safari ${emDash} iOS 26 ${emDash} iPhone`, value: "Mozilla/5.0 (iPhone; CPU iPhone OS 19_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"},
                 {name: `Safari ${emDash} iPadOS 26 ${emDash} iPad mini`, value: "Mozilla/5.0 (iPad; CPU OS 19_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1"},
-                {name: `Safari ${emDash} iPadOS 26 ${emDash} iPad`, value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26 Safari/605.1.15"},
+                {name: `Safari ${emDash} iPadOS 26 ${emDash} iPad`, value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_8) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26 Safari/605.1.15"},
             ],
             [
                 {name: `Microsoft Edge ${emDash} macOS`, value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0"},


### PR DESCRIPTION
#### edd2c31e929fc328d637f21faa9d74967c4bef25
<pre>
Revise frozen Safari UA macOS version to match actual last-shipped macOS security SU version
<a href="https://bugs.webkit.org/show_bug.cgi?id=306804">https://bugs.webkit.org/show_bug.cgi?id=306804</a>
<a href="https://rdar.apple.com/169478232">rdar://169478232</a>

Reviewed by NOBODY (OOPS!).

Today, we shipped macOS Catalina Security Update 2026-001, which bumps its version number from 10.15.7 to 10.15.8. This means
updating from macOS Catalina 10.15.8 to macOS Tahoe 26.2 causes theuser agent to roll back the reported OS string from 10_15_8 to
10_15_7.

To resolve this, update the frozen OS version in user agent from 10_15_7 to 10_15_8. This applies to both macOS and iPadOS.

* Source/WebCore/page/NavigatorUAData.cpp:
(WebCore::NavigatorUAData::getHighEntropyValues const):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/platform/ios/UserAgentIOS.mm:
(WebCore::standardUserAgentWithApplicationName):
* Source/WebCore/platform/mac/UserAgentMac.mm:
(WebCore::standardUserAgentWithApplicationName):
* Source/WebInspectorUI/UserInterface/Views/OverrideDeviceSettingsPopover.js:
(WI.OverrideDeviceSettingsPopover.prototype._createUserAgentSection):
Same as above.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edd2c31e929fc328d637f21faa9d74967c4bef25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150594 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109133 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144935 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/11673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90029 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/652 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152969 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14061 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117213 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12264 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117530 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13574 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124131 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69755 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14110 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3250 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13842 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/77826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->