### PR TITLE
[macOS] Assert that NSApplication has not been initialized in WebPage constructor

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -197,6 +197,10 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
         WebCore::setAdditionalSupportedImageTypes(parameters.additionalSupportedImageTypes);
         WebCore::setImageSourceAllowableTypes(WebCore::allowableImageTypes());
     }
+#if ENABLE(INITIALIZE_NSAPPLICATION_ON_DEMAND)
+    // Unless the accent color is valid, we should not have initialized NSApplication at this point, for performance reasons.
+    ASSERT(!NSApp || parameters.accentColor.isValid());
+#endif
 }
 
 #if HAVE(SANDBOX_STATE_FLAGS)


### PR DESCRIPTION
#### 224c02a76dfb398fd7b5aebcf0044cbf314e9e62
<pre>
[macOS] Assert that NSApplication has not been initialized in WebPage constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=306816">https://bugs.webkit.org/show_bug.cgi?id=306816</a>
<a href="https://rdar.apple.com/169486451">rdar://169486451</a>

Reviewed by NOBODY (OOPS!).

In <a href="https://commits.webkit.org/306288@main">https://commits.webkit.org/306288@main</a> we landed a change to avoid initializing NSApplication in the common case.
This patch is adding a debug assert in the WebPage constructor, asserting that it has not been initialized.

* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/224c02a76dfb398fd7b5aebcf0044cbf314e9e62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/141995 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14391 "Hash 224c02a7 for PR 57737 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95171 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109143 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78905 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90040 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11225 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8876 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/661 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120552 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152978 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14070 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117221 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14092 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12274 "Too many flaky failures: fast/dom/Geolocation/window-close-crash.html, fast/dom/Window/Location/set-location-after-close.html, http/tests/webgpu/webgpu/shader/validation/parse/blankspace.html, imported/w3c/web-platform-tests/content-security-policy/reporting/report-preload-and-consume.https.html, imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html, imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-contentwindow.html, imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/reload_document_open_write.html, imported/w3c/web-platform-tests/html/browsers/the-window-object/accessing-other-browsing-contexts/window_length.html, imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/range-restore-oninput-onchange-event.https.html, imported/w3c/web-platform-tests/html/syntax/speculative-parsing/expect-no-linked-resources/no-speculative-fetch.tentative.optional.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117538 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13588 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69764 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14119 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3262 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77835 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14055 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->