### PR TITLE
[GFC] Use StyleSelfAlignmentData machinery for alignment.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -223,13 +223,10 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
 {
     PlacedGridItems placedGridItems;
     placedGridItems.reserveInitialCapacity(gridAreas.size());
-    CheckedRef gridContainerStyle = root().style();
+    CheckedRef formattingContextStyle = root().style();
     for (auto [ unplacedGridItem, gridAreaLines ] : gridAreas) {
 
         CheckedRef gridItemStyle = unplacedGridItem.m_layoutBox->style();
-
-        auto usedJustifySelf = gridItemStyle->justifySelf().resolve(gridContainerStyle.ptr());
-        auto usedAlignSelf = gridItemStyle->alignSelf().resolve(gridContainerStyle.ptr());
 
         ComputedSizes inlineAxisSizes {
             gridItemStyle->width(),
@@ -248,9 +245,8 @@ PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas&
         };
 
         auto& boxGeometry = geometryForGridItem(unplacedGridItem.m_layoutBox);
-        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes,
-            boxGeometry.horizontalBorderAndPadding(), boxGeometry.verticalBorderAndPadding(), usedJustifySelf,
-            usedAlignSelf, gridItemStyle->usedZoomForLength());
+        placedGridItems.constructAndAppend(unplacedGridItem, gridAreaLines, inlineAxisSizes, blockAxisSizes, boxGeometry.horizontalBorderAndPadding(), boxGeometry.verticalBorderAndPadding(),
+            gridItemStyle->justifySelf().resolve(formattingContextStyle.ptr()), gridItemStyle->alignSelf().resolve(formattingContextStyle.ptr()), gridItemStyle->writingMode(), gridItemStyle->usedZoomForLength());
     }
     return placedGridItems;
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -144,6 +144,8 @@ public:
 
     const Style::ZoomFactor zoomFactor() const { return m_gridBox->style().usedZoomForLength(); }
 
+    const WritingMode writingMode() const { return m_gridBox->style().writingMode(); }
+
 private:
     UnplacedGridItems constructUnplacedGridItems() const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -77,8 +77,8 @@ private:
     static Vector<UsedMargins> computeInlineMargins(const PlacedGridItems&, const Style::ZoomFactor&);
     static Vector<UsedMargins> computeBlockMargins(const PlacedGridItems&, const Style::ZoomFactor&);
 
-    static BorderBoxPositions performInlineAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&, const Vector<LayoutUnit>& gridAreaInlineSizes);
-    static BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&, const Vector<LayoutUnit>& gridAreaBlockSizes);
+    BorderBoxPositions performInlineAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&, const UsedInlineSizes&, const Vector<LayoutUnit>& gridAreasInlineSizeList);
+    BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&, const UsedBlockSizes&, const Vector<LayoutUnit>& gridAreasBlockSizeList);
 
     const GridFormattingContext& formattingContext() const { return m_gridFormattingContext; }
 

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -35,16 +35,17 @@ namespace Layout {
 PlacedGridItem::PlacedGridItem(const UnplacedGridItem& unplacedGridItem, GridAreaLines gridAreaLines,
     const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes, const LayoutUnit& usedInlineBorderAndPadding,
     const LayoutUnit& usedBlockBorderAndPadding, const StyleSelfAlignmentData& inlineAxisAlignment, const StyleSelfAlignmentData& blockAxisAlignment,
-    const Style::ZoomFactor& usedZoom)
-    : m_layoutBox(unplacedGridItem.m_layoutBox)
-    , m_inlineAxisSizes(inlineAxisSizes)
-    , m_blockAxisSizes(blockAxisSizes)
-    , m_usedInlineBorderAndPadding(usedInlineBorderAndPadding)
-    , m_usedBlockBorderAndPadding(usedBlockBorderAndPadding)
-    , m_inlineAxisAlignment(inlineAxisAlignment)
-    , m_blockAxisAlignment(blockAxisAlignment)
-    , m_usedZoom(usedZoom)
-    , m_gridAreaLines(gridAreaLines)
+    const WritingMode& writingMode, const Style::ZoomFactor& usedZoom)
+        : m_layoutBox(unplacedGridItem.m_layoutBox)
+        , m_inlineAxisSizes(inlineAxisSizes)
+        , m_blockAxisSizes(blockAxisSizes)
+        , m_usedInlineBorderAndPadding(usedInlineBorderAndPadding)
+        , m_usedBlockBorderAndPadding(usedBlockBorderAndPadding)
+        , m_inlineAxisAlignment(inlineAxisAlignment)
+        , m_blockAxisAlignment(blockAxisAlignment)
+        , m_writingMode(writingMode)
+        , m_usedZoom(usedZoom)
+        , m_gridAreaLines(gridAreaLines)
 {
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -52,7 +52,7 @@ class PlacedGridItem {
 public:
     PlacedGridItem(const UnplacedGridItem&, GridAreaLines, const ComputedSizes& inlineAxisSizes, const ComputedSizes& blockAxisSizes,
         const LayoutUnit& usedInlineBorderAndPadding, const LayoutUnit& usedBlockBorderAndPadding, const StyleSelfAlignmentData& inlineAxisAlignment,
-        const StyleSelfAlignmentData& blockAxisAlignment, const Style::ZoomFactor& usedZoom);
+        const StyleSelfAlignmentData& blockAxisAlignment, const WritingMode&, const Style::ZoomFactor& usedZoom);
 
     const ComputedSizes& inlineAxisSizes() const { return m_inlineAxisSizes; }
     const ComputedSizes& blockAxisSizes() const { return m_blockAxisSizes; }
@@ -68,6 +68,8 @@ public:
 
     LayoutUnit usedInlineBorderAndPadding() const { return m_usedInlineBorderAndPadding; }
     LayoutUnit usedBlockBorderAndPadding() const { return m_usedBlockBorderAndPadding; }
+
+    const WritingMode& writingMode() const { return m_writingMode; }
 
     // FIXME: Add support for grid item's with preferred aspect ratios.
     bool hasPreferredAspectRatio() const { return false; }
@@ -88,6 +90,8 @@ private:
 
     const StyleSelfAlignmentData m_inlineAxisAlignment;
     const StyleSelfAlignmentData m_blockAxisAlignment;
+
+    const WritingMode m_writingMode;
 
     const Style::ZoomFactor m_usedZoom { 1.0f };
 


### PR DESCRIPTION
#### ca88a69658d65166ef83b19e593252e139c5fc53
<pre>
[GFC] Use StyleSelfAlignmentData machinery for alignment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306817">https://bugs.webkit.org/show_bug.cgi?id=306817</a>
<a href="https://rdar.apple.com/169487049">rdar://169487049</a>

Reviewed by Elika Etemad.

StyleSelfAlignmentData provides a helper in the form of adjustmentFromStartEdge
that helps with the offset needed for alignment. Instead of enumerating the
various alignment values and duplicating the exact same logic that is
found here, we can just hook into it instead by passing in the
appropriate information.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::constructPlacedGridItems const):
We need to pass in the alignment subject&apos;s writing mode to the API so we
store this on the PlacedGridItem when we construct it so that later we
can access it during alignment.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
(WebCore::Layout::GridFormattingContext::writingMode const):
It also needs the alignment container&apos;s writing mode so add a function
on the formatting context that can be accessed at the same time as the
alignment subject&apos;s.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):
(WebCore::Layout::GridLayout::performInlineAxisSelfAlignment):
(WebCore::Layout::GridLayout::performBlockAxisSelfAlignment):
Add in the border box sizes of the items, the formatting context writing
mode, and the computed gap value since we will need this for alignment.
Besides that, all we need to do is compute the remaining space for
alignment by taking the grid item&apos;s margin box and subtracting it from
the grid area&apos;s size in the appropriate dimension. Then, we should have
all of the information needed to call StyleSelfAlignmentData::adjustmentFromStartEdge.

Canonical link: <a href="https://commits.webkit.org/307365@main">https://commits.webkit.org/307365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b3233c9bc4e7bfe9c523e049f68abbefa506f50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144109 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152779 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97348 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bafeb31e-266d-4127-8d1c-22f970bc11cc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110813 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79638 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91731 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c58fd034-e85d-4ce1-bd96-9c36f6572695) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10422 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/225 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155091 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16640 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118827 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119185 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30566 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15070 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127337 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72061 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16262 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5775 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15996 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16207 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16062 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->