### PR TITLE
Use style-extractor-custom for outlineWidth

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7128,6 +7128,7 @@
             ],
             "codegen-properties": {
                 "style-builder-custom": "Initial",
+                "style-extractor-custom": true,
                 "computed-style-initial-constexpr": true,
                 "computed-style-initial-custom": true,
                 "computed-style-storage-path": ["m_nonInheritedData", "backgroundData", "outline"],

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -107,6 +107,7 @@ public:
     static Ref<CSSValue> extractBorderRightWidth(ExtractorState&);
     static Ref<CSSValue> extractBorderBottomWidth(ExtractorState&);
     static Ref<CSSValue> extractBorderLeftWidth(ExtractorState&);
+    static Ref<CSSValue> extractOutlineWidth(ExtractorState&);
     static Ref<CSSValue> extractHeight(ExtractorState&);
     static Ref<CSSValue> extractWidth(ExtractorState&);
     static Ref<CSSValue> extractMaxHeight(ExtractorState&);
@@ -205,6 +206,7 @@ public:
     static void extractBorderRightWidthSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractBorderBottomWidthSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractBorderLeftWidthSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
+    static void extractOutlineWidthSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractHeightSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractWidthSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractMaxHeightSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -856,6 +858,13 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyBorderLeftWidth> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
         return functor(state.style.usedBorderLeftWidth());
+    }
+};
+
+template<> struct PropertyExtractorAdaptor<CSSPropertyOutlineWidth> {
+    template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
+    {
+        return functor(state.style.usedOutlineWidth());
     }
 };
 
@@ -2066,6 +2075,16 @@ inline Ref<CSSValue> ExtractorCustom::extractBorderLeftWidth(ExtractorState& sta
 inline void ExtractorCustom::extractBorderLeftWidthSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
     extractSerialization<CSSPropertyBorderLeftWidth>(state, builder, context);
+}
+
+inline Ref<CSSValue> ExtractorCustom::extractOutlineWidth(ExtractorState& state)
+{
+    return extractCSSValue<CSSPropertyOutlineWidth>(state);
+}
+
+inline void ExtractorCustom::extractOutlineWidthSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
+{
+    extractSerialization<CSSPropertyOutlineWidth>(state, builder, context);
 }
 
 inline Ref<CSSValue> ExtractorCustom::extractHeight(ExtractorState& state)


### PR DESCRIPTION
#### c05351c6e6868c8a172c2ef2c5fef1a17fb6b26f
<pre>
Use style-extractor-custom for outlineWidth
<a href="https://bugs.webkit.org/show_bug.cgi?id=306818">https://bugs.webkit.org/show_bug.cgi?id=306818</a>

Reviewed by NOBODY (OOPS!).

If outlineStyle is none, getComputedStyle returned 3px for outlineWidth,
which is wrong. So i added custom extraction logic that calls
RenderStyle::usedOutlineWidth() instead of accessing the raw field
The fix follows the same pattern that border-width properties use

No new tests (OOPS!).

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyOutlineWidth&gt;::computedValue const):
(WebCore::Style::ExtractorCustom::extractOutlineWidth):
(WebCore::Style::ExtractorCustom::extractOutlineWidthSerialization):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c05351c6e6868c8a172c2ef2c5fef1a17fb6b26f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150608 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143867 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14549 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109148 "Found 8 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html fast/css/getComputedStyle/getComputedStyle-outline-shorthand.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width.html imported/w3c/web-platform-tests/css/css-ui/parsing/canonical-order-outline-sub-properties-001.html imported/w3c/web-platform-tests/css/css-ui/parsing/outline-width-computed.html media/video-mouse-focus.html svg/css/getComputedStyle-basic.xhtml (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78907 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144949 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11685 "Found 4 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html fast/css/getComputedStyle/getComputedStyle-outline-shorthand.html svg/css/getComputedStyle-basic.xhtml (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90045 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11252 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width.html imported/w3c/web-platform-tests/css/css-ui/parsing/canonical-order-outline-sub-properties-001.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8878 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/666 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/152983 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/3967 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117227 "Found 7 new test failures: fast/css/getComputedStyle/computed-style.html fast/css/getComputedStyle/getComputedStyle-outline-shorthand.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width.html imported/w3c/web-platform-tests/css/css-ui/parsing/canonical-order-outline-sub-properties-001.html imported/w3c/web-platform-tests/css/css-ui/parsing/outline-width-computed.html media/video-mouse-focus.html svg/css/getComputedStyle-basic.xhtml (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14097 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12276 "Found 8 new test failures: fast/css/getComputedStyle/computed-style-without-renderer.html fast/css/getComputedStyle/computed-style.html fast/css/getComputedStyle/getComputedStyle-outline-shorthand.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/outline-width.html imported/w3c/web-platform-tests/css/css-ui/parsing/canonical-order-outline-sub-properties-001.html imported/w3c/web-platform-tests/css/css-ui/parsing/outline-width-computed.html media/video-mouse-focus.html svg/css/getComputedStyle-basic.xhtml (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117544 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13591 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124152 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69769 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14124 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3270 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13856 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77840 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->