### PR TITLE
REGRESSION(306676@main): Broke Apple Internal builds

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1107,6 +1107,36 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
     crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h
+    crypto/parameters/CryptoAlgorithmAesCtrParams.h
+    crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h
+    crypto/parameters/CryptoAlgorithmAesGcmParams.h
+    crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h
+    crypto/parameters/CryptoAlgorithmAesKeyParams.h
+    crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h
+    crypto/parameters/CryptoAlgorithmEcKeyParams.h
+    crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h
+    crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
+    crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h
+    crypto/parameters/CryptoAlgorithmEcdsaParams.h
+    crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h
+    crypto/parameters/CryptoAlgorithmHkdfParams.h
+    crypto/parameters/CryptoAlgorithmHkdfParamsInit.h
+    crypto/parameters/CryptoAlgorithmHmacKeyParams.h
+    crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h
+    crypto/parameters/CryptoAlgorithmPbkdf2Params.h
+    crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h
+    crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
+    crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h
+    crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
+    crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h
+    crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
+    crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h
+    crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+    crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h
+    crypto/parameters/CryptoAlgorithmRsaPssParams.h
+    crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
+    crypto/parameters/CryptoAlgorithmX25519Params.h
+    crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
 
     css/CSSAttrValue.h
     css/CSSColorValue.h

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmAesCtrParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmAesCtrParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmAesGcmParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmAesGcmParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "CryptoAlgorithmAesKeyParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
+#include <WebCore/CryptoAlgorithmAesKeyParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "CryptoAlgorithmEcKeyParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
+#include <WebCore/CryptoAlgorithmEcKeyParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "CryptoAlgorithmEcdhKeyDeriveParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
+#include <WebCore/CryptoAlgorithmEcdhKeyDeriveParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "CryptoAlgorithmEcdsaParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmEcdsaParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmHkdfParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmHkdfParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParamsInit.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParametersInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "CryptoAlgorithmHmacKeyParamsInit.h"
-#include "CryptoAlgorithmParameters.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmHmacKeyParamsInit.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 #include <optional>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
@@ -25,11 +25,11 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParameters.h"
-#include "CryptoAlgorithmPbkdf2ParamsInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
+#include <WebCore/CryptoAlgorithmPbkdf2ParamsInit.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParametersInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParameters.h"
-#include "CryptoAlgorithmRsaHashedImportParamsInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
+#include <WebCore/CryptoAlgorithmRsaHashedImportParamsInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h
@@ -25,10 +25,10 @@
 
 #pragma once
 
-#include "CryptoAlgorithmRsaHashedKeyGenParamsInit.h"
-#include "CryptoAlgorithmRsaKeyGenParams.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmRsaHashedKeyGenParamsInit.h>
+#include <WebCore/CryptoAlgorithmRsaKeyGenParams.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "CryptoAlgorithmRsaKeyGenParamsInit.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmRsaKeyGenParamsInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParameters.h"
-#include "CryptoAlgorithmRsaKeyGenParamsInit.h"
 #include <JavaScriptCore/Uint8Array.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
+#include <WebCore/CryptoAlgorithmRsaKeyGenParamsInit.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
 #include <JavaScriptCore/Uint8Array.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParameters.h"
-#include "CryptoAlgorithmRsaOaepParamsInit.h"
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
+#include <WebCore/CryptoAlgorithmRsaOaepParamsInit.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "BufferSource.h"
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/BufferSource.h>
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 #include <optional>
 
 namespace WebCore {

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParameters.h"
-#include "CryptoAlgorithmRsaPssParamsInit.h"
+#include <WebCore/CryptoAlgorithmParameters.h>
+#include <WebCore/CryptoAlgorithmRsaPssParamsInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
+#include <WebCore/CryptoAlgorithmParametersInit.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParameters.h"
-#include "CryptoAlgorithmX25519ParamsInit.h"
-#include "CryptoKey.h"
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/CryptoAlgorithmParameters.h>
+#include <WebCore/CryptoAlgorithmX25519ParamsInit.h>
+#include <WebCore/CryptoKey.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmX25519ParamsInit.h
@@ -19,8 +19,8 @@
 
 #pragma once
 
-#include "CryptoAlgorithmParametersInit.h"
-#include "CryptoKey.h"
+#include <WebCore/CryptoAlgorithmParametersInit.h>
+#include <WebCore/CryptoKey.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {


### PR DESCRIPTION
#### e767ea1b5563a6cebfe809f76e2b88e1f7e709e7
<pre>
REGRESSION(306676@main): Broke Apple Internal builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=306836">https://bugs.webkit.org/show_bug.cgi?id=306836</a>
<a href="https://rdar.apple.com/169501482">rdar://169501482</a>

Unreviewed, fix the build after 306676@main.

* Source/WebCore/Headers.cmake:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesKeyParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcKeyParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdhKeyDeriveParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmEcdsaParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHmacKeyParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2ParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedImportParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaHashedKeyGenParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaPssParamsInit.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519Params.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmX25519ParamsInit.h:

Canonical link: <a href="https://commits.webkit.org/306682@main">https://commits.webkit.org/306682@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57d9ca7f4e395e78fc7ae849f5a686b2d55893b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14432 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/4539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150646 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a68e149f-a7fb-479f-abce-6372f1935b8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143903 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/15150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14585 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fc0fe3d-ca44-4038-8af7-79e122927c52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144985 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/15150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/4539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/90073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff75208c-c50e-410c-8575-52d97514b640) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/15150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8913 "Build is in progress. Recent messages:") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/702 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/15150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/4539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153019 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/4539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/14133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117570 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/4539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21917 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/14160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/4539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77876 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13937 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->