### PR TITLE
Fix forward declaration safer cpp warnings on iOS in Source/WebKit

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #import "APIFindClient.h"
+#import "DataDetectionResult.h"
 #import "FrontBoardServicesSPI.h"
 #import "ImageOptions.h"
 #import "LayerProperties.h"

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -42,6 +42,7 @@
 
 #if PLATFORM(COCOA)
 #include <wtf/BlockPtr.h>
+#include <wtf/WeakObjCPtr.h>
 #endif
 
 #if PLATFORM(GTK)
@@ -432,7 +433,7 @@ private:
 
     BlockPtr<void (CGRect)> m_didMoveSwipeSnapshotCallback;
 #elif PLATFORM(IOS_FAMILY)
-    UIView* m_liveSwipeView { nullptr };
+    WeakObjCPtr<UIView> m_liveSwipeView;
     RetainPtr<UIView> m_liveSwipeViewClippingView;
     RetainPtr<UIView> m_snapshotView;
     RetainPtr<UIView> m_transitionContainerView;

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.h
@@ -31,6 +31,7 @@
 #include <WebCore/FloatRect.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS WKContentView;
 OBJC_CLASS UIScrollView;
@@ -65,7 +66,7 @@ private:
     std::tuple<WebCore::FloatRect, double, double> smartMagnificationTargetRectAndZoomScales(WebCore::FloatRect targetRect, double minimumScale, double maximumScale, bool addMagnificationPadding);
 
     WeakPtr<WebPageProxy> m_webPageProxy;
-    WKContentView *m_contentView;
+    WeakObjCPtr<WKContentView> m_contentView;
 };
     
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -224,7 +224,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
             backForwardList.currentItem()->setSnapshot(currentViewHistoryItem->snapshot());
     }
 
-    CGRect liveSwipeViewFrame = [m_liveSwipeView frame];
+    CGRect liveSwipeViewFrame = [m_liveSwipeView.get() frame];
 
     RetainPtr<UIViewController> snapshotViewController = adoptNS([[UIViewController alloc] init]);
     m_snapshotView = adoptNS([[UIView alloc] initWithFrame:liveSwipeViewFrame]);
@@ -279,7 +279,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
 
     [m_snapshotView setBackgroundColor:backgroundColor.get()];
     [m_snapshotView layer].contentsGravity = kCAGravityTopLeft;
-    [m_snapshotView layer].contentsScale = m_liveSwipeView.window.screen.scale;
+    [m_snapshotView layer].contentsScale = [m_liveSwipeView.get() window].screen.scale;
     [snapshotViewController setView:m_snapshotView.get()];
 
     m_transitionContainerView = adoptNS([[UIView alloc] initWithFrame:liveSwipeViewFrame]);
@@ -289,9 +289,9 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
 
     [m_liveSwipeViewClippingView setClipsToBounds:YES];
 
-    [m_liveSwipeView.superview insertSubview:m_transitionContainerView.get() belowSubview:m_liveSwipeView];
+    [[m_liveSwipeView.get() superview] insertSubview:m_transitionContainerView.get() belowSubview:m_liveSwipeView.get().get()];
     [m_transitionContainerView addSubview:m_liveSwipeViewClippingView.get()];
-    [m_liveSwipeViewClippingView addSubview:m_liveSwipeView];
+    [m_liveSwipeViewClippingView addSubview:m_liveSwipeView.get().get()];
 
     RetainPtr<UIViewController> targettedViewController = adoptNS([[UIViewController alloc] init]);
     [targettedViewController setView:m_liveSwipeViewClippingView.get()];
@@ -380,7 +380,7 @@ void ViewGestureController::endSwipeGesture(WebBackForwardListItem* targetItem, 
     [context _setAnimator:nil];
     
     [[m_transitionContainerView superview] insertSubview:m_snapshotView.get() aboveSubview:m_transitionContainerView.get()];
-    [[m_transitionContainerView superview] insertSubview:m_liveSwipeView aboveSubview:m_transitionContainerView.get()];
+    [[m_transitionContainerView superview] insertSubview:m_liveSwipeView.get().get() aboveSubview:m_transitionContainerView.get()];
     [m_liveSwipeViewClippingView removeFromSuperview];
     m_liveSwipeViewClippingView = nullptr;
     [m_transitionContainerView removeFromSuperview];


### PR DESCRIPTION
#### ade94517f293aa21ec98cb8de73b0e208fb5f58c
<pre>
Fix forward declaration safer cpp warnings on iOS in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=306838">https://bugs.webkit.org/show_bug.cgi?id=306838</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.h:
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
(WebKit::SmartMagnificationController::handleResetMagnificationGesture):
(WebKit::SmartMagnificationController::zoomFactorForTargetRect):
(WebKit::SmartMagnificationController::didCollectGeometryForSmartMagnificationGesture):
(WebKit::SmartMagnificationController::scrollToRect):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):

Canonical link: <a href="https://commits.webkit.org/306693@main">https://commits.webkit.org/306693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bd612d8e208b9ba94217d52f65c75b5a2936a1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150650 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109179 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aacdfa5f-6a50-4580-b179-89031ad05cba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/144989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11717 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90076 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6879f80-ba56-4142-b77f-4c8c21486a8e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11258 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8917 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/706 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120588 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153023 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117575 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29971 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13622 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124246 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69815 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14164 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3343 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77880 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14100 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->