### PR TITLE
Web Inspector: Unify CSS rule ID stringification across the codebase

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/CSSRule.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSRule.js
@@ -96,6 +96,11 @@ WI.CSSRule = class CSSRule extends WI.Object
             this._style.ownerRule = this;
     }
 
+    get stringId()
+    {
+        return WI.CSSStyleDeclaration.stringIdForStyleId(this._id);
+    }
+
     isEqualTo(rule)
     {
         if (!rule)

--- a/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js
@@ -57,6 +57,28 @@ WI.CSSStyleDeclaration = class CSSStyleDeclaration extends WI.Object
 
     // Public
 
+    static stringIdForStyleId(styleId, {inherited, pseudoId, type, node} = {})
+    {
+        if (!styleId)
+            return "";
+
+        let result = styleId.styleSheetId + "/" + styleId.ordinal;
+
+        if (pseudoId)
+            result += ":" + pseudoId;
+
+        if (inherited !== undefined)
+            result += ":" + (inherited ? "I" : "N");
+
+        if (node)
+            result += ":" + node.id;
+
+        if (type === WI.CSSStyleDeclaration.Type.Attribute && node)
+            result += ":attribute";
+
+        return result;
+    }
+
     get initialState() { return this._initialState; }
 
     get id()
@@ -66,10 +88,7 @@ WI.CSSStyleDeclaration = class CSSStyleDeclaration extends WI.Object
 
     get stringId()
     {
-        if (this._id)
-            return this._id.styleSheetId + "/" + this._id.ordinal;
-        else
-            return "";
+        return WI.CSSStyleDeclaration.stringIdForStyleId(this._id);
     }
 
     get ownerStyleSheet()

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -110,7 +110,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
 
             let ruleId = rule.id;
             if (ruleId) {
-                let ruleKey = `${ruleId.styleSheetId}:${ruleId.ordinal}`;
+                let ruleKey = rule.stringId;
                 if (seenRuleIds.has(ruleKey))
                     continue;
                 seenRuleIds.add(ruleKey);
@@ -610,11 +610,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         inherited = inherited || false;
 
         var id = payload.styleId;
-        var mapKey = id ? id.styleSheetId + ":" + id.ordinal : null;
-        if (pseudoId)
-            mapKey += ":" + pseudoId;
-        if (type === WI.CSSStyleDeclaration.Type.Attribute)
-            mapKey += ":" + node.id + ":attribute";
+        var mapKey = WI.CSSStyleDeclaration.stringIdForStyleId(id, {pseudoId, type, node});
 
         let style = rule ? rule.style : null;
         console.assert(matchesNode || style);
@@ -688,7 +684,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         // editability solely based on the existence of the id like the open source front-end does.
         var id = payload.ruleId || payload.style.styleId;
 
-        var mapKey = id ? id.styleSheetId + ":" + id.ordinal + ":" + (inherited ? "I" : "N") + ":" + (pseudoId ? pseudoId + ":" : "") + node.id : null;
+        var mapKey = WI.CSSStyleDeclaration.stringIdForStyleId(id, {inherited, pseudoId, node});
 
         // Rules can match multiple times if they have multiple selectors or because of inheritance. We keep a count
         // of occurrences so we have unique rules per occurrence, that way properties will be correctly marked as overridden.
@@ -744,7 +740,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
 
             let ruleIdForMap = null;
             if (ruleId) {
-                ruleIdForMap = `${ruleId.styleSheetId}-${ruleId.ordinal}`;
+                ruleIdForMap = WI.CSSStyleDeclaration.stringIdForStyleId(ruleId);
 
                 let existingGroupingForRuleId = this._groupingsMap.get(ruleIdForMap);
                 if (existingGroupingForRuleId) {


### PR DESCRIPTION
#### d417e3e4a176583cf1444165bea4eaebed261a09
<pre>
Web Inspector: Unify CSS rule ID stringification across the codebase
<a href="https://bugs.webkit.org/show_bug.cgi?id=306840">https://bugs.webkit.org/show_bug.cgi?id=306840</a>
<a href="https://rdar.apple.com/169507123">rdar://169507123</a>

Reviewed by Devin Rousso.

CSS rule IDs were being stringified inconsistently across the codebase some places
used &quot;:&quot; separators, others used &quot;-&quot; &amp; the logic was duplicated everywhere.

Add WI.CSSStyleDeclaration.stringIdForStyleId() as the single function to stringify
CSS rule IDs (styleSheetId/ordinal). Update all call sites to use this helper.
Also add WI.CSSRule.prototype.get stringId for consistency with the existing
WI.CSSStyleDeclaration.prototype.get stringId.

* Source/WebInspectorUI/UserInterface/Models/CSSRule.js:
(WI.CSSRule.prototype.get stringId):
* Source/WebInspectorUI/UserInterface/Models/CSSStyleDeclaration.js:
(WI.CSSStyleDeclaration.stringIdForStyleId):
(WI.CSSStyleDeclaration.prototype.get stringId):
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.uniqueOrderedStyles):
(WI.DOMNodeStyles.prototype._parseStyleDeclarationPayload):
(WI.DOMNodeStyles.prototype._parseRulePayload):

Canonical link: <a href="https://commits.webkit.org/306850@main">https://commits.webkit.org/306850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a693a16aea097dcc6858f89d38257cdd3e82639

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15029 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151236 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78af0e28-4710-482b-89f3-6d7ecd0167e8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15115 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/991a5259-b473-4afc-a74c-ee14e10698a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12112 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90552 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a44451c-e006-455c-b04f-bb160292a1ab) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1234 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120982 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153548 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14661 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117660 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117995 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30086 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/14017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14703 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78405 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14501 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->