### PR TITLE
Address most unsafe cast issues on iOS in Source/WebKit

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASYNC_SCROLLING)
 
 #include <WebCore/ScrollingTreeScrollingNode.h>
@@ -60,6 +62,10 @@ public:
     virtual void viewSizeDidChange() { }
 
     virtual bool isScrollingTreeFrameScrollingNodeMac() const { return false; };
+
+#if PLATFORM(IOS_FAMILY)
+    virtual bool isScrollingTreeFrameScrollingNodeIOS() const { return false; }
+#endif
 
 protected:
     ScrollingTreeFrameScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASYNC_SCROLLING)
 
 #include <WebCore/ScrollingTreeScrollingNode.h>
@@ -36,6 +38,10 @@ class ScrollingTreeOverflowScrollingNode : public ScrollingTreeScrollingNode {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreeOverflowScrollingNode, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT virtual ~ScrollingTreeOverflowScrollingNode();
+
+#if PLATFORM(IOS_FAMILY)
+    virtual bool isScrollingTreeOverflowScrollingNodeIOS() const { return false; }
+#endif
 
 protected:
     WEBCORE_EXPORT ScrollingTreeOverflowScrollingNode(ScrollingTree&, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
 #if ENABLE(ASYNC_SCROLLING)
 
 #include <WebCore/ScrollingTreeScrollingNode.h>
@@ -39,6 +41,10 @@ class WEBCORE_EXPORT ScrollingTreePluginScrollingNode : public ScrollingTreeScro
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTreePluginScrollingNode, WEBCORE_EXPORT);
 public:
     virtual ~ScrollingTreePluginScrollingNode();
+
+#if PLATFORM(IOS_FAMILY)
+    virtual bool isScrollingTreePluginScrollingNodeIOS() const { return false; }
+#endif
 
 protected:
     ScrollingTreePluginScrollingNode(ScrollingTree&, ScrollingNodeID);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -139,7 +139,7 @@ void NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeede
     UNUSED_PARAM(contentEncodingSniffingPolicy);
 #endif
 
-    CheckedRef cocoaSession = static_cast<NetworkSessionCocoa&>(*networkSession());
+    CheckedRef cocoaSession = downcast<NetworkSessionCocoa>(*networkSession());
     auto& boundInterfaceIdentifier = cocoaSession->boundInterfaceIdentifier();
     if (shouldContentSniff
 #if USE(CFNETWORK_CONTENT_ENCODING_SNIFFING_OVERRIDE)
@@ -189,7 +189,7 @@ void NetworkDataTaskCocoa::updateFirstPartyInfoForSession(const URL& requestURL)
 NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
     : NetworkDataTask(session, client, parameters.request, parameters.storedCredentialsPolicy, parameters.shouldClearReferrerOnHTTPSToHTTPRedirect, parameters.isMainFrameNavigation, parameters.isInitiatedByDedicatedWorker)
     , NetworkTaskCocoa(session)
-    , m_sessionWrapper(static_cast<NetworkSessionCocoa&>(session).sessionWrapperForTask(parameters.webPageProxyID, parameters.request, parameters.storedCredentialsPolicy, parameters.isNavigatingToAppBoundDomain))
+    , m_sessionWrapper(downcast<NetworkSessionCocoa>(session).sessionWrapperForTask(parameters.webPageProxyID, parameters.request, parameters.storedCredentialsPolicy, parameters.isNavigatingToAppBoundDomain))
     , m_frameID(parameters.webFrameID)
     , m_pageID(parameters.webPageID)
     , m_webPageProxyID(parameters.webPageProxyID)
@@ -619,7 +619,7 @@ void NetworkDataTaskCocoa::resume()
         }
     }
 
-    CheckedRef cocoaSession = static_cast<NetworkSessionCocoa&>(*m_session);
+    CheckedRef cocoaSession = downcast<NetworkSessionCocoa>(*m_session);
     if (cocoaSession->deviceManagementRestrictionsEnabled() && m_isForMainResourceNavigationForAnyFrame) {
         auto didDetermineDeviceRestrictionPolicyForURL = makeBlockPtr([protectedThis = Ref { *this }](BOOL isBlocked) mutable {
             callOnMainRunLoop([protectedThis = WTF::move(protectedThis), isBlocked] {

--- a/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
+++ b/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
@@ -83,28 +83,28 @@ std::optional<SharedPreferencesForWebProcess> NetworkConnectionToWebProcess::sha
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorBoundInterfaceIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    if (auto* session = static_cast<NetworkSessionCocoa*>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->boundInterfaceIdentifier();
     return emptyString();
 }
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorCTDataConnectionServiceType(const WebPaymentCoordinatorProxy&)
 {
-    if (auto* session = static_cast<NetworkSessionCocoa*>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->dataConnectionServiceType();
     return emptyString();
 }
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationBundleIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    if (auto* session = static_cast<NetworkSessionCocoa*>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->sourceApplicationBundleIdentifier();
     return emptyString();
 }
 
 const String& NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationSecondaryIdentifier(const WebPaymentCoordinatorProxy&)
 {
-    if (auto* session = static_cast<NetworkSessionCocoa*>(networkSession()))
+    if (auto* session = downcast<NetworkSessionCocoa>(networkSession()))
         return session->sourceApplicationSecondaryIdentifier();
     return emptyString();
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -552,8 +552,10 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
     if (properties.changedProperties & LayerChange::VideoGravityChanged) {
         auto *playerLayer = layer;
 #if PLATFORM(IOS_FAMILY)
-        if (layerTreeNode && [layerTreeNode->uiView() isKindOfClass:WKVideoView.class])
-            playerLayer = [(WKVideoView*)layerTreeNode->uiView() playerLayer];
+        if (layerTreeNode) {
+            if (RetainPtr videoView = dynamic_objc_cast<WKVideoView>(layerTreeNode->uiView()))
+                playerLayer = [videoView playerLayer];
+        }
 #endif
         ASSERT([playerLayer respondsToSelector:@selector(setVideoGravity:)]);
         if (RetainPtr webAVPlayerLayer = dynamic_objc_cast<WebAVPlayerLayer>(playerLayer))

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4170,9 +4170,7 @@ static bool isLockdownModeWarningNeeded()
 
 - (_WKWebViewPrintFormatter *)_webViewPrintFormatter
 {
-    UIViewPrintFormatter *viewPrintFormatter = self.viewPrintFormatter;
-    ASSERT([viewPrintFormatter isKindOfClass:[_WKWebViewPrintFormatter class]]);
-    return (_WKWebViewPrintFormatter *)viewPrintFormatter;
+    return checked_objc_cast<_WKWebViewPrintFormatter>(self.viewPrintFormatter);
 }
 
 - (_WKDragInteractionPolicy)_dragInteractionPolicy

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -120,7 +120,7 @@
 }
 
 - (CALayerHost *)layerHost {
-    return (CALayerHost *)[self layer];
+    return checked_objc_cast<CALayerHost>([self layer]);
 }
 
 - (BOOL)clipsToBounds {
@@ -985,7 +985,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
 
         model->setVideoDimensions(nativeSize);
 
-        RetainPtr playerLayer { (WebAVPlayerLayer *)[playerView layer] };
+        RetainPtr playerLayer { checked_objc_cast<WebAVPlayerLayer>([playerView layer]) };
         [playerLayer setVideoDimensions:nativeSize];
         [playerLayer setPresentationModel:model.ptr()];
         [playerLayer setVideoSublayer:[view layer]];

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -489,16 +489,16 @@ static Class scrollViewScrollIndicatorClassSingleton()
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    if ([otherGestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
-        return [(WKDeferringGestureRecognizer *)otherGestureRecognizer shouldDeferGestureRecognizer:gestureRecognizer];
+    if (RetainPtr otherDeferringGestureRecognizer = dynamic_objc_cast<WKDeferringGestureRecognizer>(otherGestureRecognizer))
+        return [otherDeferringGestureRecognizer shouldDeferGestureRecognizer:gestureRecognizer];
 
     return NO;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
-        return [(WKDeferringGestureRecognizer *)gestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
+    if (RetainPtr deferringGestureRecognizer = dynamic_objc_cast<WKDeferringGestureRecognizer>(gestureRecognizer))
+        return [deferringGestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
 
     return NO;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -95,17 +95,14 @@ UIScrollView *RemoteScrollingCoordinatorProxyIOS::scrollViewForScrollingNodeID(s
 {
     auto* treeNode = scrollingTree().nodeForID(nodeID);
 
-    // All ScrollingTreeOverflowScrollingNodes are ScrollingTreeOverflowScrollingNodeIOS on iOS.
-    if (RefPtr overflowScrollingNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(treeNode))
-        return static_cast<ScrollingTreeOverflowScrollingNodeIOS*>(overflowScrollingNode.get())->scrollView();
+    if (RefPtr overflowScrollingNode = dynamicDowncast<ScrollingTreeOverflowScrollingNodeIOS>(treeNode))
+        return overflowScrollingNode->scrollView();
 
-    // All ScrollingTreeFrameScrollingNodes are ScrollingTreeFrameScrollingNodeRemoteIOS on iOS.
-    if (RefPtr frameScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNode>(treeNode))
-        return static_cast<ScrollingTreeFrameScrollingNodeRemoteIOS*>(frameScrollingNode.get())->scrollView();
+    if (RefPtr frameScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNodeRemoteIOS>(treeNode))
+        return frameScrollingNode->scrollView();
 
-    // All ScrollingTreePluginScrollingNodes are ScrollingTreePluginScrollingNodeIOS on iOS.
-    if (RefPtr pluginScrollingNode = dynamicDowncast<ScrollingTreePluginScrollingNode>(treeNode))
-        return static_cast<ScrollingTreePluginScrollingNodeIOS*>(pluginScrollingNode.get())->scrollView();
+    if (RefPtr pluginScrollingNode = dynamicDowncast<ScrollingTreePluginScrollingNodeIOS>(treeNode))
+        return pluginScrollingNode->scrollView();
 
     return nil;
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h
@@ -50,6 +50,8 @@ private:
 
     ScrollingTreeScrollingNodeDelegateIOS* delegate() const;
 
+    bool isScrollingTreeFrameScrollingNodeIOS() const final { return true; }
+
     bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) override;
     bool commitStateAfterChildren(const WebCore::ScrollingStateNode&) override;
 
@@ -65,5 +67,10 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::ScrollingTreeFrameScrollingNodeRemoteIOS)
+    static bool isType(const WebCore::ScrollingTreeFrameScrollingNode& node) { return node.isScrollingTreeFrameScrollingNodeIOS(); }
+    static bool isType(const WebCore::ScrollingTreeNode& node) { return is<WebCore::ScrollingTreeFrameScrollingNode>(node) && isType(uncheckedDowncast<WebCore::ScrollingTreeFrameScrollingNode>(node)); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h
@@ -48,6 +48,8 @@ private:
 
     ScrollingTreeScrollingNodeDelegateIOS& delegate() const;
 
+    bool isScrollingTreeOverflowScrollingNodeIOS() const final { return true; }
+
     bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) final;
     bool commitStateAfterChildren(const WebCore::ScrollingStateNode&) final;
     
@@ -55,5 +57,10 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::ScrollingTreeOverflowScrollingNodeIOS)
+    static bool isType(const WebCore::ScrollingTreeOverflowScrollingNode& node) { return node.isScrollingTreeOverflowScrollingNodeIOS(); }
+    static bool isType(const WebCore::ScrollingTreeNode& node) { return is<WebCore::ScrollingTreeOverflowScrollingNode>(node) && isType(uncheckedDowncast<WebCore::ScrollingTreeOverflowScrollingNode>(node)); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h
@@ -47,6 +47,8 @@ private:
 
     ScrollingTreeScrollingNodeDelegateIOS& delegate() const;
 
+    bool isScrollingTreePluginScrollingNodeIOS() const final { return true; }
+
     bool commitStateBeforeChildren(const WebCore::ScrollingStateNode&) final;
     bool commitStateAfterChildren(const WebCore::ScrollingStateNode&) final;
 
@@ -54,5 +56,10 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::ScrollingTreePluginScrollingNodeIOS)
+    static bool isType(const WebCore::ScrollingTreePluginScrollingNode& node) { return node.isScrollingTreePluginScrollingNodeIOS(); }
+    static bool isType(const WebCore::ScrollingTreeNode& node) { return is<WebCore::ScrollingTreePluginScrollingNode>(node) && isType(uncheckedDowncast<WebCore::ScrollingTreePluginScrollingNode>(node)); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -310,8 +310,8 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateBeforeChildren(const Scro
 
 void ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior(UIScrollView *scrollView, const WebCore::OverscrollBehavior horizontalOverscrollBehavior, WebCore::OverscrollBehavior verticalOverscrollBehavior, AllowOverscrollToPreventScrollPropagation allowPropogation)
 {
-    if ([scrollView isKindOfClass:[WKScrollView class]])
-        [(WKScrollView*)scrollView _setBouncesInternal:horizontalOverscrollBehavior != WebCore::OverscrollBehavior::None vertical: verticalOverscrollBehavior != WebCore::OverscrollBehavior::None];
+    if (RetainPtr wkScrollView = dynamic_objc_cast<WKScrollView>(scrollView))
+        [wkScrollView _setBouncesInternal:horizontalOverscrollBehavior != WebCore::OverscrollBehavior::None vertical: verticalOverscrollBehavior != WebCore::OverscrollBehavior::None];
     else {
         scrollView.bouncesHorizontally = horizontalOverscrollBehavior != OverscrollBehavior::None;
         scrollView.bouncesVertically = verticalOverscrollBehavior != OverscrollBehavior::None;

--- a/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
+++ b/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
@@ -68,9 +68,7 @@
 
 - (WKWebView *)_webView
 {
-    UIView *view = self.view;
-    ASSERT([view isKindOfClass:[WKWebView class]]);
-    return static_cast<WKWebView *>(view);
+    return checked_objc_cast<WKWebView>(self.view);
 }
 
 - (BOOL)_shouldDrawUsingBitmap

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -1244,19 +1244,15 @@ static NSMutableArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr
     if (item.title.length)
         result[@"title"] = item.title;
 
-    if ([item isKindOfClass:UIMenu.class]) {
-        UIMenu *menu = (UIMenu *)item;
-
-        NSMutableArray *children = [NSMutableArray arrayWithCapacity:menu.children.count];
-        for (UIMenuElement *child in menu.children)
+    if (RetainPtr menu = dynamic_objc_cast<UIMenu>(item)) {
+        NSMutableArray *children = [NSMutableArray arrayWithCapacity:[menu children].count];
+        for (UIMenuElement *child in [menu children])
             [children addObject:[self _contentsOfContextMenuItem:child]];
         result[@"children"] = children;
     }
 
-    if ([item isKindOfClass:UIAction.class]) {
-        UIAction *action = (UIAction *)item;
-
-        if (action.state == UIMenuElementStateOn)
+    if (RetainPtr action = dynamic_objc_cast<UIAction>(item)) {
+        if ([action state] == UIMenuElementStateOn)
             result[@"checked"] = @YES;
     }
 

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -72,9 +72,9 @@
     auto externalDelegate = _externalDelegate.get();
     NSMethodSignature *signature = [super methodSignatureForSelector:aSelector];
     if (!signature)
-        signature = [(NSObject *)_internalDelegate methodSignatureForSelector:aSelector];
+        signature = [static_cast<NSObject *>(_internalDelegate) methodSignatureForSelector:aSelector];
     if (!signature)
-        signature = [(NSObject *)externalDelegate.get() methodSignatureForSelector:aSelector];
+        signature = [static_cast<NSObject *>(externalDelegate.get()) methodSignatureForSelector:aSelector];
     return signature;
 }
 
@@ -223,16 +223,16 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    if ([otherGestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
-        return [(WKDeferringGestureRecognizer *)otherGestureRecognizer shouldDeferGestureRecognizer:gestureRecognizer];
+    if (RetainPtr otherDeferringGestureRecognizer = dynamic_objc_cast<WKDeferringGestureRecognizer>(otherGestureRecognizer))
+        return [otherDeferringGestureRecognizer shouldDeferGestureRecognizer:gestureRecognizer];
 
     return NO;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
-        return [(WKDeferringGestureRecognizer *)gestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
+    if (RetainPtr deferringGestureRecognizer = dynamic_objc_cast<WKDeferringGestureRecognizer>(gestureRecognizer))
+        return [deferringGestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
 
     return NO;
 }

--- a/Source/WebKit/UIProcess/ios/WKWebEvent.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebEvent.mm
@@ -49,7 +49,8 @@
         modifierFlags = 0;
         uiEvent = event;
     } else {
-        UIPhysicalKeyboardEvent *keyEvent = (UIPhysicalKeyboardEvent *)event;
+        // FIXME: `checked_objc_cast<UIPhysicalKeyboardEvent>(event)` causes a linking error.
+        SUPPRESS_MEMORY_UNSAFE_CAST UIPhysicalKeyboardEvent *keyEvent = (UIPhysicalKeyboardEvent *)event;
         keyCode = keyEvent._keyCode;
         inputFlags = keyEvent._inputFlags;
         modifierFlags = keyEvent._gsModifierFlags;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
@@ -91,14 +91,15 @@
     }
     if (!event._isKeyDown)
         return NO;
-    UIPhysicalKeyboardEvent *keyEvent = (UIPhysicalKeyboardEvent *)event;
-    if (keyEvent._inputFlags & kUIKeyboardInputModifierFlagsChanged)
+    // FIXME: `checked_objc_cast<UIPhysicalKeyboardEvent>(event)` causes a linking error.
+    SUPPRESS_MEMORY_UNSAFE_CAST RetainPtr keyEvent = (UIPhysicalKeyboardEvent *)event;
+    if (keyEvent.get()._inputFlags & kUIKeyboardInputModifierFlagsChanged)
         return NO;
-    if (_editing && (keyEvent._keyCode == kHIDUsage_KeyboardEscape || [keyEvent._unmodifiedInput isEqualToString:UIKeyInputEscape])) {
+    if (_editing && (keyEvent.get()._keyCode == kHIDUsage_KeyboardEscape || [keyEvent.get()._unmodifiedInput isEqualToString:UIKeyInputEscape])) {
         [_view accessoryDone];
         return YES;
     }
-    if (!_editing && keyEvent._keyCode == kHIDUsage_KeyboardSpacebar) {
+    if (!_editing && keyEvent.get()._keyCode == kHIDUsage_KeyboardSpacebar) {
         [_view accessoryOpen];
         return YES;
     }

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -650,19 +650,19 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
     for (UIMenuElement *menuElement in menuElements) {
         if ([menuElement isKindOfClass:UIAction.class]) {
             if (currentIndex == optionIndex)
-                return (UIAction *)menuElement;
+                return checked_objc_cast<UIAction>(menuElement);
 
-            currentIndex++;
+            ++currentIndex;
             continue;
         }
 
-        UIMenu *groupedMenu = (UIMenu *)menuElement;
-        NSUInteger numGroupedOptions = groupedMenu.children.count;
+        RetainPtr groupedMenu = checked_objc_cast<UIMenu>(menuElement);
+        NSUInteger numGroupedOptions = [groupedMenu children].count;
 
         if (currentIndex + numGroupedOptions <= (NSUInteger)optionIndex)
             currentIndex += numGroupedOptions;
         else
-            return (UIAction *)[groupedMenu.children objectAtIndex:(groupedMenu.children.count - numGroupedOptions) + (optionIndex - currentIndex)];
+            return checked_objc_cast<UIAction>([[groupedMenu children] objectAtIndex:([groupedMenu children].count - numGroupedOptions) + (optionIndex - currentIndex)]);
     }
 
     return nil;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -206,18 +206,18 @@ struct WKWebViewState {
 
         webView._obscuredInsetEdgesAffectedBySafeArea = _savedObscuredInsetEdgesAffectedBySafeArea;
 
-        auto* scrollView = (WKScrollView *)[webView scrollView];
+        RetainPtr scrollView = checked_objc_cast<WKScrollView>([webView scrollView]);
         if (_savedContentInsetWasExternallyOverridden)
-            scrollView.contentInset = _savedEdgeInset;
+            scrollView.get().contentInset = _savedEdgeInset;
         else
             [scrollView _resetContentInset];
 
-        scrollView.contentOffset = _savedContentOffset;
-        scrollView.scrollIndicatorInsets = _savedScrollIndicatorInsets;
+        scrollView.get().contentOffset = _savedContentOffset;
+        scrollView.get().scrollIndicatorInsets = _savedScrollIndicatorInsets;
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
         if (_savedContentInsetAdjustmentBehaviorWasExternallyOverridden)
-            scrollView.contentInsetAdjustmentBehavior = _savedContentInsetAdjustmentBehavior;
+            scrollView.get().contentInsetAdjustmentBehavior = _savedContentInsetAdjustmentBehavior;
         else
             [webView _resetScrollViewInsetAdjustmentBehavior];
 #endif
@@ -237,7 +237,7 @@ struct WKWebViewState {
             page->setForceAlwaysUserScalable(_savedForceAlwaysUserScalable);
         }
         [webView _setViewScale:_savedViewScale];
-        scrollView.bouncesZoom = _savedBouncesZoom;
+        scrollView.get().bouncesZoom = _savedBouncesZoom;
         webView._minimumEffectiveDeviceWidth = _savedMinimumEffectiveDeviceWidth;
     }
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1063,7 +1063,7 @@ void WebPage::completeSyntheticClick(std::optional<WebCore::FrameIdentifier> fra
 
 #if ENABLE(PDF_PLUGIN)
     if (RefPtr pluginElement = dynamicDowncast<HTMLPlugInElement>(nodeRespondingToClick)) {
-        if (RefPtr pluginWidget = static_cast<PluginView*>(pluginElement->pluginWidget()))
+        if (RefPtr pluginWidget = downcast<PluginView>(pluginElement->pluginWidget()))
             pluginWidget->handleSyntheticClick(WTF::move(releaseEvent));
     }
 #endif


### PR DESCRIPTION
#### 63bce446a4522b73f570b36aee0a2f2b99340672
<pre>
Address most unsafe cast issues on iOS in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=306843">https://bugs.webkit.org/show_bug.cgi?id=306843</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeOverflowScrollingNode.h:
(WebCore::ScrollingTreeOverflowScrollingNode::isScrollingTreeOverflowScrollingNodeIOS const):
* Source/WebCore/page/scrolling/ScrollingTreePluginScrollingNode.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded):
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::resume):
* Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm:
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorBoundInterfaceIdentifier):
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorCTDataConnectionServiceType):
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationBundleIdentifier):
(WebKit::NetworkConnectionToWebProcess::paymentCoordinatorSourceApplicationSecondaryIdentifier):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _webViewPrintFormatter]):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(-[WKLayerHostView layerHost]):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(-[WKChildScrollView gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]):
(-[WKChildScrollView gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollViewForScrollingNodeID const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeFrameScrollingNodeRemoteIOS.h:
(isType):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeOverflowScrollingNodeIOS.h:
(isType):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.h:
(isType):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::updateScrollViewForOverscrollBehavior):
* Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm:
(-[_WKWebViewPrintFormatter _webView]):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant _contentsOfContextMenuItem:]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollViewDelegateForwarder methodSignatureForSelector:]):
(-[WKScrollView gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]):
(-[WKScrollView gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):
* Source/WebKit/UIProcess/ios/WKWebEvent.mm:
(-[WKWebEvent initWithEvent:]):
* Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm:
(-[WKFormPeripheralBase handleKeyEvent:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker actionForOptionIndex:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::completeSyntheticClick):

Canonical link: <a href="https://commits.webkit.org/306705@main">https://commits.webkit.org/306705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71711783e362faf35cd147ac02e8d6a92de9841e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142051 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95227 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97bd49c1-552d-4902-bdec-b2e1bdff8498) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109191 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b9db878-326e-4d09-bce7-4d362015b985) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90088 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0d4456a-0837-4d09-bee6-5c503c9957c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8926 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/717 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153034 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14126 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4084 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117266 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117586 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29981 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13627 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124261 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69826 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14175 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3358 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13907 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14111 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13952 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->