### PR TITLE
[Site Isolation] Cross site iframe fails to window.open the main frame's site

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -320,18 +320,4 @@ bool BrowsingContextGroup::hasRemotePages(const WebPageProxy& page)
     return it != m_remotePages.end() && !it->value.isEmpty();
 }
 
-bool BrowsingContextGroup::isFrameProcessInUseForMainFrame(const FrameProcess& process)
-{
-    for (Ref page : m_pages) {
-        RefPtr mainFrame = page->mainFrame();
-        if (!mainFrame)
-            continue;
-
-        if (&mainFrame->frameProcess() == &process)
-            return true;
-    }
-
-    return false;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -83,7 +83,6 @@ public:
     void transitionProvisionalPageToRemotePage(ProvisionalPageProxy&, const WebCore::Site& provisionalNavigationFailureSite);
 
     bool hasRemotePages(const WebPageProxy&);
-    bool isFrameProcessInUseForMainFrame(const FrameProcess&);
 
 private:
     BrowsingContextGroup();

--- a/Source/WebKit/UIProcess/FrameProcess.cpp
+++ b/Source/WebKit/UIProcess/FrameProcess.cpp
@@ -61,8 +61,15 @@ FrameProcess::FrameProcess(WebProcessProxy& process, BrowsingContextGroup& group
 
 FrameProcess::~FrameProcess()
 {
+    ASSERT(!m_frameCount);
+
     if (RefPtr group = m_browsingContextGroup.get())
         group->removeFrameProcess(*this);
+}
+
+BrowsingContextGroup* FrameProcess::browsingContextGroup() const
+{
+    return m_browsingContextGroup.get();
 }
 
 }

--- a/Source/WebKit/UIProcess/FrameProcess.h
+++ b/Source/WebKit/UIProcess/FrameProcess.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/Site.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
@@ -50,6 +51,12 @@ public:
     const WebCore::Site& sharedProcessMainFrameSite() const { ASSERT(!m_site); return m_mainFrameSite; }
     bool isArchiveProcess() const { return m_isArchiveProcess; }
 
+    BrowsingContextGroup* browsingContextGroup() const;
+
+    void incrementFrameCount() { m_frameCount++; }
+    void decrementFrameCount() { m_frameCount--; }
+    unsigned frameCount() const { return m_frameCount; }
+
 private:
     friend class BrowsingContextGroup; // FrameProcess should not be created except by BrowsingContextGroup.
     static Ref<FrameProcess> create(WebProcessProxy& process, BrowsingContextGroup& group, const std::optional<WebCore::Site>& site, const WebCore::Site& mainFrameSite,
@@ -64,6 +71,7 @@ private:
     const std::optional<WebCore::Site> m_site;
     const WebCore::Site m_mainFrameSite;
     bool m_isArchiveProcess;
+    Checked<unsigned> m_frameCount { 0 };
 };
 
 }


### PR DESCRIPTION
#### e4e510eeb1e1ec1a12945f291423d8cf77d930b3
<pre>
[Site Isolation] Cross site iframe fails to window.open the main frame&apos;s site
<a href="https://bugs.webkit.org/show_bug.cgi?id=306842">https://bugs.webkit.org/show_bug.cgi?id=306842</a>
<a href="https://rdar.apple.com/169509909">rdar://169509909</a>

Reviewed by Alex Christensen and Sihui Liu.

Imagine we have a main frame containing site1.com and an iframe containing
site2.com. Then, site2.com calls window.open(&quot;site.com&quot;). The end result must be:

          WebProcess1               |              WebProcess2
------------------------------------|------------------------------------------
Site1WindowA      Site1WindowB      |      Site1WindowA     Site1WindowB
Site2FrameA                         |      Site2FrameA
                                    |
WebPage1          WebPage2          |      WebPage3         WebPage4

(where Site1 is local to WebProcess1).

Both WebPage1 and WebPage2 should each have an associated WebPageProxy and both
WebPage3 and WebPage4 should each have an associated RemotePageProxy. But currently,
after the call to window.open, WebPage4 does not have an associated RemotePageProxy.

When the window.open call happens, the steps we follow should be:
1. Create WebPage2 and WebPage4.

2. Create a WebPageProxy associated with WebPage4 (because the window.open call
   occurred in WebProcess2).

3. Create a RemotePageProxy associated with WebPage2.

4. When the load starts, we realize the load should occur in WebProcess 1, so we
   create a ProvisionalPageProxy and give it the RemotePageProxy&apos;s message registration.
   So now the ProvisionalPageProxy is associated with WebPage2. The RemotePageProxy
   is then destroyed.

   (See ProvisionalPageProxy::initializeWebPage).

5. When the load commits, create a new RemotePageProxy and give it the WebPageProxy&apos;s
   messager registration. So now a RemotePageProxy is associated with WebPage4.

   (See ProvisionalPageProxy::didCommitLoadForFrame and
   BrowsingContextGroup::transitionPageToRemotePage).

6. Give the WebPageProxy the message registration of the ProvisionalPageProxy. So now
   the WebPageProxy is associated with WebPage2.

   (See WebPageProxy::swapToProvisionalPage).

The problem is that step 5 doesn&apos;t happen and so WebPage4 gets left without a
RemotePageProxy.

In ProvisionalPageProxy::didCommitLoadForFrame, we only setup the new RemotePageProxy
(by calling BrowsingContextGroup::transitionPageToRemotePage) if
&quot;m_browsingContextGroup-&gt;isFrameProcessInUseForMainFrame(pageMainFrameProcess.get())&quot;
is true. At this point the WebPageProxy is still associated with WebPage4 and so with
WebProcess2. WebProcess2 is not in use for the main frame. That&apos;s WebProcess1. So this
condition is false. The code assumes that this WebProcess2 won&apos;t be used after this
load commits, so there is no point in setting up the RemotePageProxy.

This condition is wrong. It doesn&apos;t account for the fact that after the load commits,
there will be 1 frame that is local to WebProcess2 (Site2FrameA). So WebProcess2 will
still exist and so will WebPage4, and it will need a RemotePageProxy.

To fix this, we make FrameProcess track the number of frames local to its associated
WebProcess. We amend the condition so that if there are any such frames at the time
of the load committing, we must set up the RemotePageProxy.

This is tested by a new API test SiteIsolation.CrossSiteIFrameWindowOpensMainFrameSite.

This changed caused the test
SiteIsolation.BrowsingContextGroupSwitchForIncompatibleCrossOriginOpenerPolicy to fail.
In that test, when the page with unsafe-none opens a page with same-origin-allow-popups,
we do not want the opener relationship to be preserved, and so the the two WebProcesses
are put in different BrowsingContentGroups. So we do not need the RemotePageProxy.
So we add an extra check. If the load causes the WebProcess to put into a different
BrowsingContextGroup, we do not setup the RemotePageProxy.

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::isFrameProcessInUseForMainFrame): Deleted.
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/FrameProcess.cpp:
(WebKit::FrameProcess::~FrameProcess):
(WebKit::FrameProcess::browsingContextGroup const):
* Source/WebKit/UIProcess/FrameProcess.h:
(WebKit::FrameProcess::incrementFrameCount):
(WebKit::FrameProcess::decrementFrameCount):
(WebKit::FrameProcess::frameCount const):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):

If the Frame Process&apos;s associated WebProcess has any frames that are local to it,
and is still in the same BrowsingContextGroup, we must setup the RemotePageProxy.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::WebFrameProxy):
(WebKit::WebFrameProxy::~WebFrameProxy):
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::WebFrameProxy::setProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, CrossSiteIFrameWindowOpensMainFrameSite)):

Canonical link: <a href="https://commits.webkit.org/306784@main">https://commits.webkit.org/306784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4023b0ed3eab7a4de689aad47d4211defe413bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142280 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150915 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95456 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b371079e-761b-4ffa-841f-8d6207aeb79b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109398 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95456 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac5dcd81-3a15-4e03-a65c-2292ac71b4ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90297 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19ccd8c3-5139-450c-8f65-fbd91d557104) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11439 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9101 "Found 1 new API test failure: TestWebKitAPI.WebKit2.GetUserMediaAfterMuting (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/946 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153263 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117448 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117771 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13819 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124577 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70055 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21949 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14404 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3590 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14341 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->