### PR TITLE
Add "Convert to Simplified Chinese" and "Convert to Traditional Chinese" text transformations

### DIFF
--- a/LayoutTests/editing/mac/context-menu/text-transformations-menu-actions-expected.txt
+++ b/LayoutTests/editing/mac/context-menu/text-transformations-menu-actions-expected.txt
@@ -1,0 +1,23 @@
+This test verifies that the Transformations context menu items correctly transform the selected text.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Test 1: Make Upper Case transforms text to uppercase
+PASS actualText is "HELLO WORLD"
+
+Test 2: Make Lower Case transforms text to lowercase
+PASS actualText is "hello world"
+
+Test 3: Capitalize transforms text to title case
+PASS actualText is "Hello World"
+
+Test 4: Convert to Traditional Chinese transforms simplified to traditional
+PASS actualText is "圖書館"
+
+Test 5: Convert to Simplified Chinese transforms traditional to simplified
+PASS actualText is "图书馆"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/mac/context-menu/text-transformations-menu-actions.html
+++ b/LayoutTests/editing/mac/context-menu/text-transformations-menu-actions.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        .test-field {
+            font-size: 20px;
+            padding: 10px;
+            margin: 10px;
+            width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <p id="description"></p>
+    <div id="editable" class="test-field" contenteditable>test</div>
+    <div id="console"></div>
+    <script>
+        description("This test verifies that the Transformations context menu items correctly transform the selected text.");
+
+        window.jsTestIsAsync = true;
+
+        var actualText;
+
+        function findMenuItem(items, title) {
+            for (let item of items) {
+                if (item.title === title)
+                    return item;
+            }
+            return null;
+        }
+
+        function findTransformationsSubmenu(items) {
+            return findMenuItem(items, "Transformations");
+        }
+
+        function getTransformationItems(items) {
+            let menu = findTransformationsSubmenu(items);
+            if (!menu)
+                return null;
+            return menu.children;
+        }
+
+        async function selectAllAndContextClick(elementId) {
+            let element = document.getElementById(elementId);
+            let range = document.createRange();
+            range.selectNodeContents(element);
+            window.getSelection().removeAllRanges();
+            window.getSelection().addRange(range);
+
+            let rect = element.getBoundingClientRect();
+            eventSender.mouseMoveTo(rect.left + 2, rect.top + 2);
+            return eventSender.contextClick();
+        }
+
+        async function selectFirstCharacterAndContextClick(elementId) {
+            let element = document.getElementById(elementId);
+            let textNode = element.firstChild;
+            let range = document.createRange();
+            range.setStart(textNode, 0);
+            range.setEnd(textNode, 1);
+            window.getSelection().removeAllRanges();
+            window.getSelection().addRange(range);
+
+            let rect = element.getBoundingClientRect();
+            eventSender.mouseMoveTo(rect.left + 2, rect.top + 2);
+            return eventSender.contextClick();
+        }
+
+        async function runTests() {
+            if (!window.eventSender || !window.testRunner) {
+                debug("This test requires eventSender and testRunner.");
+                finishJSTest();
+                return;
+            }
+
+            debug("Test 1: Make Upper Case transforms text to uppercase");
+            editable.innerText = "hello world";
+            let items = await selectAllAndContextClick("editable");
+            let transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                let menuItem = findMenuItem(transformItems, "Make Upper Case");
+                if (!menuItem) {
+                    testFailed("Make Upper Case menu item not found");
+                } else {
+                    menuItem.click();
+                    actualText = editable.innerText;
+                    shouldBeEqualToString("actualText", "HELLO WORLD");
+                }
+            }
+            debug("");
+
+            debug("Test 2: Make Lower Case transforms text to lowercase");
+            editable.innerText = "HELLO WORLD";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                let menuItem = findMenuItem(transformItems, "Make Lower Case");
+                if (!menuItem) {
+                    testFailed("Make Lower Case menu item not found");
+                } else {
+                    menuItem.click();
+                    actualText = editable.innerText;
+                    shouldBeEqualToString("actualText", "hello world");
+                }
+            }
+            debug("");
+
+            debug("Test 3: Capitalize transforms text to title case");
+            editable.innerText = "hello world";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                let menuItem = findMenuItem(transformItems, "Capitalize");
+                if (!menuItem) {
+                    testFailed("Capitalize menu item not found");
+                } else {
+                    menuItem.click();
+                    actualText = editable.innerText;
+                    shouldBeEqualToString("actualText", "Hello World");
+                }
+            }
+            debug("");
+
+            debug("Test 4: Convert to Traditional Chinese transforms simplified to traditional");
+            editable.innerText = "图书馆";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                let menuItem = findMenuItem(transformItems, "Convert to Traditional Chinese");
+                if (!menuItem) {
+                    testFailed("Convert to Traditional Chinese menu item not found");
+                } else {
+                    menuItem.click();
+                    actualText = editable.innerText;
+                    shouldBeEqualToString("actualText", "圖書館");
+                }
+            }
+            debug("");
+
+            debug("Test 5: Convert to Simplified Chinese transforms traditional to simplified");
+            editable.innerText = "圖書館";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                let menuItem = findMenuItem(transformItems, "Convert to Simplified Chinese");
+                if (!menuItem) {
+                    testFailed("Convert to Simplified Chinese menu item not found");
+                } else {
+                    menuItem.click();
+                    actualText = editable.innerText;
+                    shouldBeEqualToString("actualText", "图书馆");
+                }
+            }
+
+            editable.innerText = "";
+            finishJSTest();
+        }
+
+        window.addEventListener("load", runTests);
+    </script>
+</body>
+</html>

--- a/LayoutTests/editing/mac/context-menu/text-transformations-menu-items-expected.txt
+++ b/LayoutTests/editing/mac/context-menu/text-transformations-menu-items-expected.txt
@@ -1,0 +1,53 @@
+This test verifies that the Transformations context menu shows appropriate items based on the selected text.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Test 1: Latin characters should show case transformations but not Chinese conversions
+PASS hasMenuItem(transformItems, 'Make Upper Case') is true
+PASS hasMenuItem(transformItems, 'Make Lower Case') is true
+PASS hasMenuItem(transformItems, 'Capitalize') is true
+PASS hasMenuItem(transformItems, 'Convert to Traditional Chinese') is false
+PASS hasMenuItem(transformItems, 'Convert to Simplified Chinese') is false
+
+Test 2: Simplified Chinese text should show conversion to Traditional Chinese
+PASS hasMenuItem(transformItems, 'Make Upper Case') is false
+PASS hasMenuItem(transformItems, 'Make Lower Case') is false
+PASS hasMenuItem(transformItems, 'Capitalize') is false
+PASS hasMenuItem(transformItems, 'Convert to Traditional Chinese') is true
+PASS hasMenuItem(transformItems, 'Convert to Simplified Chinese') is false
+
+Test 3: Traditional Chinese text should show conversion to Simplified Chinese
+PASS hasMenuItem(transformItems, 'Make Upper Case') is false
+PASS hasMenuItem(transformItems, 'Make Lower Case') is false
+PASS hasMenuItem(transformItems, 'Capitalize') is false
+PASS hasMenuItem(transformItems, 'Convert to Traditional Chinese') is false
+PASS hasMenuItem(transformItems, 'Convert to Simplified Chinese') is true
+
+Test 4: Traditional Chinese text and Simplified Chinese text should should show both conversion options
+PASS hasMenuItem(transformItems, 'Make Upper Case') is false
+PASS hasMenuItem(transformItems, 'Make Lower Case') is false
+PASS hasMenuItem(transformItems, 'Capitalize') is false
+PASS hasMenuItem(transformItems, 'Convert to Traditional Chinese') is true
+PASS hasMenuItem(transformItems, 'Convert to Simplified Chinese') is true
+
+Test 5: Traditional Chinese characters, Simplified Chinese character, and latin characters should should show all transformation options.
+PASS hasMenuItem(transformItems, 'Make Upper Case') is true
+PASS hasMenuItem(transformItems, 'Make Lower Case') is true
+PASS hasMenuItem(transformItems, 'Capitalize') is true
+PASS hasMenuItem(transformItems, 'Convert to Traditional Chinese') is true
+PASS hasMenuItem(transformItems, 'Convert to Simplified Chinese') is true
+
+Test 6: Case transformations are shown as fallback when selection exceeds 200 characters.
+PASS hasMenuItem(transformItems, 'Make Upper Case') is true
+PASS hasMenuItem(transformItems, 'Make Lower Case') is true
+PASS hasMenuItem(transformItems, 'Capitalize') is true
+PASS hasMenuItem(transformItems, 'Convert to Traditional Chinese') is true
+PASS hasMenuItem(transformItems, 'Convert to Simplified Chinese') is true
+
+Test 7: Numbers only should not show Transformations submenu at all
+PASS transformationsMenu is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/mac/context-menu/text-transformations-menu-items.html
+++ b/LayoutTests/editing/mac/context-menu/text-transformations-menu-items.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        .test-field {
+            font-size: 20px;
+            padding: 10px;
+            margin: 10px;
+            width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <p id="description"></p>
+    <div id="editable" class="test-field" contenteditable>Library</div>
+    <div id="console"></div>
+    <script>
+        description("This test verifies that the Transformations context menu shows appropriate items based on the selected text.");
+
+        window.jsTestIsAsync = true;
+
+        var transformItems;
+        var transformationsMenu;
+
+        function findMenuItem(items, title) {
+            for (let item of items) {
+                if (item.title === title)
+                    return item;
+            }
+            return null;
+        }
+
+        function findTransformationsSubmenu(items) {
+            return findMenuItem(items, "Transformations");
+        }
+
+        function hasMenuItem(items, title) {
+            return findMenuItem(items, title) !== null;
+        }
+
+        function getTransformationItems(items) {
+            let menu = findTransformationsSubmenu(items);
+            if (!menu)
+                return null;
+            return menu.children;
+        }
+
+        async function selectAllAndContextClick(elementId) {
+            let element = document.getElementById(elementId);
+            let range = document.createRange();
+            range.selectNodeContents(element);
+            window.getSelection().removeAllRanges();
+            window.getSelection().addRange(range);
+
+            let rect = element.getBoundingClientRect();
+            eventSender.mouseMoveTo(rect.left + 2, rect.top + 2);
+            return eventSender.contextClick();
+        }
+
+        async function runTests() {
+            if (!window.eventSender || !window.testRunner) {
+                debug("This test requires eventSender and testRunner.");
+                finishJSTest();
+                return;
+            }
+
+            debug("Test 1: Latin characters should show case transformations but not Chinese conversions");
+            let items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                shouldBeTrue("hasMenuItem(transformItems, 'Make Upper Case')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Make Lower Case')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Capitalize')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Convert to Traditional Chinese')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Convert to Simplified Chinese')");
+            }
+            debug("");
+
+            debug("Test 2: Simplified Chinese text should show conversion to Traditional Chinese");
+            editable.innerText = "图书馆";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                shouldBeFalse("hasMenuItem(transformItems, 'Make Upper Case')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Make Lower Case')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Capitalize')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Traditional Chinese')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Convert to Simplified Chinese')");
+            }
+            debug("");
+
+            debug("Test 3: Traditional Chinese text should show conversion to Simplified Chinese");
+            editable.innerText = "圖書館";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                shouldBeFalse("hasMenuItem(transformItems, 'Make Upper Case')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Make Lower Case')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Capitalize')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Convert to Traditional Chinese')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Simplified Chinese')");
+            }
+            debug("");
+
+            debug("Test 4: Traditional Chinese text and Simplified Chinese text should should show both conversion options");
+            editable.innerText = "图书馆 圖書館";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                shouldBeFalse("hasMenuItem(transformItems, 'Make Upper Case')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Make Lower Case')");
+                shouldBeFalse("hasMenuItem(transformItems, 'Capitalize')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Traditional Chinese')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Simplified Chinese')");
+            }
+            debug("");
+
+            debug("Test 5: Traditional Chinese characters, Simplified Chinese character, and latin characters should should show all transformation options.");
+            editable.innerText = "Library 图书馆 圖書館";
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                shouldBeTrue("hasMenuItem(transformItems, 'Make Upper Case')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Make Lower Case')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Capitalize')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Traditional Chinese')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Simplified Chinese')");
+            }
+            debug("");
+
+            debug("Test 6: Case transformations are shown as fallback when selection exceeds 200 characters.");
+            editable.innerText = ""
+            let longText = "图书馆 圖書館 ".repeat(30);
+            editable.innerText = longText;
+            items = await selectAllAndContextClick("editable");
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                shouldBeTrue("hasMenuItem(transformItems, 'Make Upper Case')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Make Lower Case')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Capitalize')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Traditional Chinese')");
+                shouldBeTrue("hasMenuItem(transformItems, 'Convert to Simplified Chinese')");
+            }
+            debug("");
+
+            debug("Test 7: Numbers only should not show Transformations submenu at all");
+            editable.innerText = "12345";
+            items = await selectAllAndContextClick("editable");
+            transformationsMenu = findTransformationsSubmenu(items);
+            shouldBeNull("transformationsMenu");
+
+            editable.innerText = "";
+            finishJSTest();
+        }
+
+        window.addEventListener("load", runTests);
+    </script>
+</body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1912,7 +1912,43 @@ void Editor::capitalizeWord()
     if (client())
         client()->capitalizeWord();
 }
-    
+
+bool Editor::canApplyCaseTransformations(const String& selection)
+{
+    if (client())
+        return client()->canApplyCaseTransformations(selection);
+
+    return true;
+}
+
+bool Editor::canConvertToSimplifiedChinese(const String& selection)
+{
+    if (client())
+        return client()->canConvertToSimplifiedChinese(selection);
+
+    return false;
+}
+
+bool Editor::canConvertToTraditionalChinese(const String& selection)
+{
+    if (client())
+        return client()->canConvertToTraditionalChinese(selection);
+
+    return false;
+}
+
+void Editor::convertToTraditionalChinese()
+{
+    if (client())
+        client()->convertToTraditionalChinese();
+}
+
+void Editor::convertToSimplifiedChinese()
+{
+    if (client())
+        client()->convertToSimplifiedChinese();
+}
+
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -560,6 +560,11 @@ public:
     WEBCORE_EXPORT void uppercaseWord();
     WEBCORE_EXPORT void lowercaseWord();
     WEBCORE_EXPORT void capitalizeWord();
+    WEBCORE_EXPORT void convertToTraditionalChinese();
+    WEBCORE_EXPORT void convertToSimplifiedChinese();
+    WEBCORE_EXPORT bool canApplyCaseTransformations(const String&);
+    WEBCORE_EXPORT bool canConvertToSimplifiedChinese(const String&);
+    WEBCORE_EXPORT bool canConvertToTraditionalChinese(const String&);
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -373,6 +373,12 @@
 /* Undo action name */
 "Convert to Ordered List (Undo action name)" = "Convert to Ordered List";
 
+/* Convert to Simplified Chinese context menu item */
+"Convert to Simplified Chinese" = "Convert to Simplified Chinese";
+
+/* Convert to Traditional Chinese context menu item */
+"Convert to Traditional Chinese" = "Convert to Traditional Chinese";
+
 /* Undo action name */
 "Convert to Unordered List (Undo action name)" = "Convert to Unordered List";
 

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -361,6 +361,11 @@ private:
     void uppercaseWord() final { }
     void lowercaseWord() final { }
     void capitalizeWord() final { }
+    bool canApplyCaseTransformations(const String&) final { return true; }
+    bool canConvertToTraditionalChinese(const String&) final { return false; }
+    bool canConvertToSimplifiedChinese(const String&) final { return false; }
+    void convertToTraditionalChinese() final { }
+    void convertToSimplifiedChinese() final { }
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -93,7 +93,7 @@ private:
 #if PLATFORM(COCOA)
     void createAndAppendSpeechSubMenu(ContextMenuItem&);
     void createAndAppendSubstitutionsSubMenu(ContextMenuItem&);
-    void createAndAppendTransformationsSubMenu(ContextMenuItem&);
+    bool createAndAppendTransformationsSubMenu(ContextMenuItem&);
 #endif
 #if PLATFORM(GTK)
     void createAndAppendUnicodeSubMenu(ContextMenuItem&);

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -167,6 +167,11 @@ public:
     virtual void uppercaseWord() = 0;
     virtual void lowercaseWord() = 0;
     virtual void capitalizeWord() = 0;
+    virtual bool canApplyCaseTransformations(const String&) = 0;
+    virtual bool canConvertToTraditionalChinese(const String&) = 0;
+    virtual bool canConvertToSimplifiedChinese(const String&) = 0;
+    virtual void convertToTraditionalChinese() = 0;
+    virtual void convertToSimplifiedChinese() = 0;
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -253,6 +253,8 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagMakeLowerCase:
     case ContextMenuAction::ContextMenuItemTagCapitalize:
     case ContextMenuAction::ContextMenuItemTagChangeBack:
+    case ContextMenuAction::ContextMenuItemTagConvertToTraditionalChinese:
+    case ContextMenuAction::ContextMenuItemTagConvertToSimplifiedChinese:
 #endif
     case ContextMenuAction::ContextMenuItemTagOpenMediaInNewWindow:
     case ContextMenuAction::ContextMenuItemTagDownloadMediaToDisk:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -172,7 +172,9 @@ enum ContextMenuAction {
     ContextMenuItemCaptionDisplayStyleSubmenu,
 #if PLATFORM(COCOA)
     ContextMenuItemTagSmartLists,
-    ContextMenuItemLastNonCustomTag = ContextMenuItemTagSmartLists,
+    ContextMenuItemTagConvertToTraditionalChinese,
+    ContextMenuItemTagConvertToSimplifiedChinese,
+    ContextMenuItemLastNonCustomTag = ContextMenuItemTagConvertToSimplifiedChinese,
 #else
     ContextMenuItemLastNonCustomTag = ContextMenuItemCaptionDisplayStyleSubmenu,
 #endif

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -146,6 +146,8 @@ namespace WebCore {
     WEBCORE_EXPORT String contextMenuItemTagMakeUpperCase();
     WEBCORE_EXPORT String contextMenuItemTagMakeLowerCase();
     WEBCORE_EXPORT String contextMenuItemTagCapitalize();
+    WEBCORE_EXPORT String contextMenuItemTagConvertToTraditionalChinese();
+    WEBCORE_EXPORT String contextMenuItemTagConvertToSimplifiedChinese();
     String contextMenuItemTagChangeBack(const String& replacedString);
 #endif
     String contextMenuItemTagOpenVideoInNewWindow();

--- a/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
+++ b/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
@@ -171,6 +171,16 @@ String contextMenuItemTagCapitalize()
     return WEB_UI_STRING("Capitalize", "Capitalize context menu item");
 }
 
+String contextMenuItemTagConvertToTraditionalChinese()
+{
+    return WEB_UI_STRING("Convert to Traditional Chinese", "Convert to Traditional Chinese context menu item");
+}
+
+String contextMenuItemTagConvertToSimplifiedChinese()
+{
+    return WEB_UI_STRING("Convert to Simplified Chinese", "Convert to Simplified Chinese context menu item");
+}
+
 String contextMenuItemTagChangeBack(const String& replacedString)
 {
     notImplemented();

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -249,6 +249,12 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     case WebCore::ContextMenuItemTagCapitalize:
     case WebCore::ContextMenuItemTagTransformationsMenu:
         return symbolForTransformationItem("textformat.characters"_s);
+    case WebCore::ContextMenuItemTagConvertToSimplifiedChinese:
+    case WebCore::ContextMenuItemTagConvertToTraditionalChinese:
+    case WebCore::ContextMenuItemTagDefaultDirection:
+    case WebCore::ContextMenuItemTagTextDirectionDefault:
+    case WebCore::ContextMenuItemTagWritingDirectionMenu:
+        return { { SymbolType::Public, "arrow.left.arrow.right"_s } };
     case WebCore::ContextMenuItemTagChangeBack:
         return { { SymbolType::Public, "arrow.uturn.backward.circle"_s } };
     case WebCore::ContextMenuItemTagCopy:
@@ -258,10 +264,6 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
         return { { SymbolType::Public, "document.on.document"_s } };
     case WebCore::ContextMenuItemTagCut:
         return { { SymbolType::Public, "scissors"_s } };
-    case WebCore::ContextMenuItemTagDefaultDirection:
-    case WebCore::ContextMenuItemTagTextDirectionDefault:
-    case WebCore::ContextMenuItemTagWritingDirectionMenu:
-        return { { SymbolType::Public, "arrow.left.arrow.right"_s } };
     case WebCore::ContextMenuItemTagDownloadImageToDisk:
     case WebCore::ContextMenuItemTagDownloadLinkToDisk:
     case WebCore::ContextMenuItemTagDownloadMediaToDisk:

--- a/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
@@ -139,6 +139,8 @@ enum {
     kWKContextMenuItemTagRewrite,
     kWKContextMenuItemTagSummarize,
     kWKContextMenuItemCaptionDisplayStyleSubmenu,
+    kWKContextMenuItemTagConvertToTraditionalChinese,
+    kWKContextMenuItemTagConvertToSimplifiedChinese,
     kWKContextMenuItemBaseApplicationTag = 10000
 };
 typedef uint32_t WKContextMenuItemTag;

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -611,6 +611,10 @@ inline WKContextMenuItemTag toAPI(WebCore::ContextMenuAction action)
         return kWKContextMenuItemTagCapitalize;
     case WebCore::ContextMenuItemTagChangeBack:
         return kWKContextMenuItemTagChangeBack;
+    case WebCore::ContextMenuItemTagConvertToTraditionalChinese:
+        return kWKContextMenuItemTagConvertToTraditionalChinese;
+    case WebCore::ContextMenuItemTagConvertToSimplifiedChinese:
+        return kWKContextMenuItemTagConvertToSimplifiedChinese;
 #endif
     case WebCore::ContextMenuItemTagShareMenu:
         return kWKContextMenuItemTagShareMenu;
@@ -839,6 +843,10 @@ inline WebCore::ContextMenuAction toImpl(WKContextMenuItemTag tag)
         return WebCore::ContextMenuItemTagChangeBack;
     case kWKContextMenuItemTagShareMenu:
         return WebCore::ContextMenuItemTagShareMenu;
+    case kWKContextMenuItemTagConvertToTraditionalChinese:
+        return WebCore::ContextMenuItemTagConvertToTraditionalChinese;
+    case kWKContextMenuItemTagConvertToSimplifiedChinese:
+        return WebCore::ContextMenuItemTagConvertToSimplifiedChinese;
 #endif
     case kWKContextMenuItemTagRevealImage:
         return WebCore::ContextMenuItemTagLookUpImage;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10570,6 +10570,22 @@ void WebPageProxy::capitalizeWord()
         return;
     sendToProcessContainingFrame(targetFrameID, Messages::WebPage::CapitalizeWord(*targetFrameID));
 }
+
+void WebPageProxy::convertToTraditionalChinese()
+{
+    auto targetFrameID = focusedOrMainFrame() ? std::optional(focusedOrMainFrame()->frameID()) : std::nullopt;
+    if (!targetFrameID)
+        return;
+    sendToProcessContainingFrame(targetFrameID, Messages::WebPage::ConvertToTraditionalChinese(*targetFrameID));
+}
+
+void WebPageProxy::convertToSimplifiedChinese()
+{
+    auto targetFrameID = focusedOrMainFrame() ? std::optional(focusedOrMainFrame()->frameID()) : std::nullopt;
+    if (!targetFrameID)
+        return;
+    sendToProcessContainingFrame(targetFrameID, Messages::WebPage::ConvertToSimplifiedChinese(*targetFrameID));
+}
 #endif
 
 void WebPageProxy::didGetImageForFindMatch(ImageBufferParameters&& parameters, ShareableBitmap::Handle&& contentImageHandle, uint32_t matchIndex)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1889,6 +1889,8 @@ public:
     void uppercaseWord();
     void lowercaseWord();
     void capitalizeWord();
+    void convertToTraditionalChinese();
+    void convertToSimplifiedChinese();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -956,8 +956,18 @@ void WebContextMenuProxyMac::getContextMenuItem(const WebContextMenuItemData& it
             return;
         }
 
-        getContextMenuFromItems(item.submenu(), [menuItem = WTF::move(menuItem), completionHandler = WTF::move(completionHandler)](NSMenu *menu) mutable {
+        getContextMenuFromItems(item.submenu(), [action = item.action(), menuItem = WTF::move(menuItem), completionHandler = WTF::move(completionHandler)](NSMenu *menu) mutable {
             [menuItem setSubmenu:menu];
+
+            // "Convert to Simplified Chinese" and "Convert to Traditional Chinese" are potential items which will
+            // display adjacent to one another with the same image. If both are present, keep only the top-most image.
+            if (action == ContextMenuItemTagTransformationsMenu) {
+                RetainPtr simplifiedChineseItem = [menu itemWithTag:ContextMenuItemTagConvertToSimplifiedChinese];
+                RetainPtr traditionalChineseItem = [menu itemWithTag:ContextMenuItemTagConvertToTraditionalChinese];
+                if (simplifiedChineseItem && traditionalChineseItem)
+                    [simplifiedChineseItem setImage:nil];
+            }
+
             completionHandler(menuItem.get());
         });
         return;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -481,6 +481,8 @@ public:
     void uppercaseWord();
     void lowercaseWord();
     void capitalizeWord();
+    void convertToTraditionalChinese();
+    void convertToSimplifiedChinese();
 
     void requestCandidatesForSelectionIfNeeded();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -131,6 +131,11 @@ private:
     void uppercaseWord() final;
     void lowercaseWord() final;
     void capitalizeWord() final;
+    bool canApplyCaseTransformations(const String&) final;
+    bool canConvertToTraditionalChinese(const String&) final;
+    bool canConvertToSimplifiedChinese(const String&) final;
+    void convertToTraditionalChinese() final;
+    void convertToSimplifiedChinese() final;
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6075,6 +6075,32 @@ void WebPage::capitalizeWord(FrameIdentifier frameID)
 
     coreFrame->protectedEditor()->capitalizeWord();
 }
+
+void WebPage::convertToTraditionalChinese(FrameIdentifier frameID)
+{
+    RefPtr frame = WebProcess::singleton().webFrame(frameID);
+    if (!frame)
+        return;
+
+    RefPtr coreFrame = frame->coreLocalFrame();
+    if (!coreFrame)
+        return;
+
+    coreFrame->protectedEditor()->convertToTraditionalChinese();
+}
+
+void WebPage::convertToSimplifiedChinese(FrameIdentifier frameID)
+{
+    RefPtr frame = WebProcess::singleton().webFrame(frameID);
+    if (!frame)
+        return;
+
+    RefPtr coreFrame = frame->coreLocalFrame();
+    if (!coreFrame)
+        return;
+
+    coreFrame->protectedEditor()->convertToSimplifiedChinese();
+}
 #endif
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2487,6 +2487,8 @@ private:
     void uppercaseWord(WebCore::FrameIdentifier);
     void lowercaseWord(WebCore::FrameIdentifier);
     void capitalizeWord(WebCore::FrameIdentifier);
+    void convertToTraditionalChinese(WebCore::FrameIdentifier);
+    void convertToSimplifiedChinese(WebCore::FrameIdentifier);
 #endif
 
     bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -437,6 +437,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     UppercaseWord(WebCore::FrameIdentifier frameID)
     LowercaseWord(WebCore::FrameIdentifier frameID)
     CapitalizeWord(WebCore::FrameIdentifier frameID)
+    ConvertToTraditionalChinese(WebCore::FrameIdentifier frameID)
+    ConvertToSimplifiedChinese(WebCore::FrameIdentifier frameID)
 #endif
 #if PLATFORM(COCOA)
     SetSmartInsertDeleteEnabled(bool isSmartInsertDeleteEnabled)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -91,6 +91,11 @@ private:
     void uppercaseWord() final;
     void lowercaseWord() final;
     void capitalizeWord() final;
+    bool canApplyCaseTransformations(const String&) final;
+    bool canConvertToTraditionalChinese(const String&) final;
+    bool canConvertToSimplifiedChinese(const String&) final;
+    void convertToTraditionalChinese() final;
+    void convertToSimplifiedChinese() final;
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm
@@ -502,6 +502,29 @@ void WebEditorClient::capitalizeWord()
     [m_webView capitalizeWord:nil];
 }
 
+bool WebEditorClient::canApplyCaseTransformations(const String&)
+{
+    return true;
+}
+
+bool WebEditorClient::canConvertToTraditionalChinese(const String&)
+{
+    return false;
+}
+
+bool WebEditorClient::canConvertToSimplifiedChinese(const String&)
+{
+    return false;
+}
+
+void WebEditorClient::convertToTraditionalChinese()
+{
+}
+
+void WebEditorClient::convertToSimplifiedChinese()
+{
+}
+
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)


### PR DESCRIPTION
#### 883a577fd38143b914f72c971f0f45e6fc9813e6
<pre>
Add &quot;Convert to Simplified Chinese&quot; and &quot;Convert to Traditional Chinese&quot; text transformations
<a href="https://bugs.webkit.org/show_bug.cgi?id=306845">https://bugs.webkit.org/show_bug.cgi?id=306845</a>
<a href="https://rdar.apple.com/156354464">rdar://156354464</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

When editing text in a NSTextView, &quot;Convert to Simplified Chinese&quot; and
&quot;Convert to Traditional Chinese&quot; appears under the transformations submenu
if the items are relevant to the selected text. These items are now available
in WebKit.

Add the two context menu items and use the same heuristic AppKit uses to determine
which transformations should actually be listed in the menu. Analyze the first 200
characters in the selection to see if Simplified Chinese characters, Traditional
Chinese characters, or latin characters are present. If the selection exceeds 200
characters, also include case-related transformations as a fallback.

Conversions are performed in the same way AppKit performs them. The selection is
converted to an NSString, and we then set the selection equal to
`stringByApplyingTransform` with a transform of either &quot;Hans-hant&quot; when converting
to Traditional Chinese, or &quot;Hant-hans&quot; when converting to Simplified Chinese.

Tests: editing/mac/context-menu/text-transformations-menu-actions.html
       editing/mac/context-menu/text-transformations-menu-items.html

* LayoutTests/editing/mac/context-menu/text-transformations-menu-actions-expected.txt: Added.
* LayoutTests/editing/mac/context-menu/text-transformations-menu-actions.html: Added.
* LayoutTests/editing/mac/context-menu/text-transformations-menu-items-expected.txt: Added.
* LayoutTests/editing/mac/context-menu/text-transformations-menu-items.html: Added.
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::canApplyCaseTransformations):
(WebCore::Editor::canConvertToSimplifiedChinese):
(WebCore::Editor::canConvertToTraditionalChinese):
(WebCore::Editor::convertToTraditionalChinese):
(WebCore::Editor::convertToSimplifiedChinese):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::createAndAppendTransformationsSubMenu):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/page/ContextMenuController.h:
* Source/WebCore/page/EditorClient.h:
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm:
(WebCore::contextMenuItemTagConvertToTraditionalChinese):
(WebCore::contextMenuItemTagConvertToSimplifiedChinese):
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameWithTypeForAction):
* Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::convertToTraditionalChinese):
(WebKit::WebPageProxy::convertToSimplifiedChinese):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::getContextMenuItem):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm:
(WebKit::applyTextTransformation):
(WebKit::WebEditorClient::uppercaseWord):
(WebKit::WebEditorClient::lowercaseWord):
(WebKit::WebEditorClient::capitalizeWord):
(WebKit::WebEditorClient::canApplyCaseTransformations):
(WebKit::WebEditorClient::canConvertToTraditionalChinese):
(WebKit::WebEditorClient::canConvertToSimplifiedChinese):
(WebKit::WebEditorClient::convertToTraditionalChinese):
(WebKit::WebEditorClient::convertToSimplifiedChinese):
(WebKit::changeWordCase): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::convertToTraditionalChinese):
(WebKit::WebPage::convertToSimplifiedChinese):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.mm:
(WebEditorClient::canApplyCaseTransformations):
(WebEditorClient::canConvertToTraditionalChinese):
(WebEditorClient::canConvertToSimplifiedChinese):
(WebEditorClient::convertToTraditionalChinese):
(WebEditorClient::convertToSimplifiedChinese):

Canonical link: <a href="https://commits.webkit.org/306761@main">https://commits.webkit.org/306761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96d8ef4ed0217b00ec2283608d1bb5c7f836816a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150906 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc0aed56-85d9-4288-a90e-f07f9f082bba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109392 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1913a01-aa26-4ef8-acbc-19770b2a8e91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90291 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c2a7fa9-a7a2-4774-9149-9a1ed10e86fe) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153256 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117443 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12519 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117766 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30018 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13814 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124571 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14397 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3585 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14129 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->