### PR TITLE
[GTK] Remove WTF_ALLOW_UNSAFE_BUFFER_USAGE from WebKit/UIProcess/gtk/ClipboardGtk4.cpp

### DIFF
--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp
@@ -67,16 +67,13 @@ Clipboard::Type Clipboard::type() const
 
 void Clipboard::formats(CompletionHandler<void(Vector<String>&&)>&& completionHandler)
 {
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK port
     gsize mimeTypesCount;
-    const char* const* mimeTypes = gdk_content_formats_get_mime_types(gdk_clipboard_get_formats(m_clipboard), &mimeTypesCount);
+    const char* const* mimeTypesPointer = gdk_content_formats_get_mime_types(gdk_clipboard_get_formats(m_clipboard), &mimeTypesCount);
+    auto mimeTypes = unsafeMakeSpan(mimeTypesPointer, mimeTypesCount);
 
-    Vector<String> result(mimeTypesCount, [&](size_t i) {
+    completionHandler(Vector<String>(mimeTypes.size(), [&mimeTypes](size_t i) {
         return String::fromUTF8(mimeTypes[i]);
-    });
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-    completionHandler(WTF::move(result));
+    }));
 }
 
 class ClipboardTask final : public RefCounted<ClipboardTask> {


### PR DESCRIPTION
#### 3ce45f625cdbbe20bac111e7a2d3b0b050f21729
<pre>
[GTK] Remove WTF_ALLOW_UNSAFE_BUFFER_USAGE from WebKit/UIProcess/gtk/ClipboardGtk4.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=306846">https://bugs.webkit.org/show_bug.cgi?id=306846</a>

Reviewed by Carlos Garcia Campos.

This removes the last instances of WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END}
left under Source/WebKit/UIProcess/gtk/.

* Source/WebKit/UIProcess/gtk/ClipboardGtk4.cpp:
(WebKit::Clipboard::formats): Use a std::span to provide bounded access
to the array of MIME types. While at it, simplify the code a little bit.

Canonical link: <a href="https://commits.webkit.org/306697@main">https://commits.webkit.org/306697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd10358f8c719517ff4c0ca0583aff4351950ca0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150669 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11728 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11267 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8929 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120597 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153041 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117270 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117590 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/29974 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13632 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124258 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69833 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14182 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3359 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77898 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->