### PR TITLE
[GTK][WPE] Non composited renderer doesn't work on HiDPI screens

### DIFF
--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -39,6 +39,9 @@
 
 #if USE(SKIA)
 #include <skia/core/SkImageInfo.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
 namespace WebCore {
@@ -192,6 +195,10 @@ public:
     // This is only safe to use when we know that the contents of the shareable bitmap won't change.
     WEBCORE_EXPORT RefPtr<cairo_surface_t> createPersistentCairoSurface();
     WEBCORE_EXPORT RefPtr<cairo_surface_t> createCairoSurface();
+#endif
+
+#if USE(SKIA)
+    WEBCORE_EXPORT sk_sp<SkSurface> createSurface();
 #endif
 
 private:

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -235,7 +235,14 @@ public:
         return adoptRef(*new SkiaGLContext(display));
     }
 
-    ~SkiaGLContext() = default;
+    ~SkiaGLContext()
+    {
+        if (m_skiaGLContext) {
+            m_skiaGLContext->makeContextCurrent();
+            m_skiaGrContext = nullptr;
+            m_skiaGLContext = nullptr;
+        }
+    }
 
     GLContext* skiaGLContext() const
     {

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -57,7 +57,7 @@ CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& 
     return SkImageInfo::MakeN32Premul(size.width(), size.height(), colorSpace.platformColorSpace()).minRowBytes();
 }
 
-std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
+sk_sp<SkSurface> ShareableBitmap::createSurface()
 {
     ref();
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
@@ -69,6 +69,17 @@ std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
     if (!canvas)
         return nullptr;
 
+    return surface;
+}
+
+std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
+{
+    auto surface = createSurface();
+    if (!surface)
+        return nullptr;
+
+    auto* canvas = surface->getCanvas();
+    ASSERT(canvas);
     return makeUnique<GraphicsContextSkia>(*canvas, RenderingMode::Unaccelerated, RenderingPurpose::ShareableSnapshot, [surface = WTF::move(surface)] { });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -75,7 +75,6 @@ class RunLoop;
 
 namespace WebCore {
 class GLFence;
-class GraphicsContext;
 class ShareableBitmap;
 class ShareableBitmapHandle;
 }
@@ -123,7 +122,10 @@ public:
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
     bool usesGL() const { return m_swapChain.type() != SwapChain::Type::SharedMemoryWithoutGL; }
 #endif
-    WebCore::GraphicsContext* graphicsContext();
+
+#if USE(SKIA)
+    SkCanvas* canvas();
+#endif
 
     void willDestroyGLContext();
     void willRenderFrame(const WebCore::IntSize&);
@@ -165,7 +167,9 @@ private:
 
         uint64_t id() const { return m_id; }
 
-        virtual WebCore::GraphicsContext* graphicsContext() { RELEASE_ASSERT_NOT_REACHED(); }
+#if USE(SKIA)
+        virtual SkSurface* skiaSurface() { RELEASE_ASSERT_NOT_REACHED(); }
+#endif
 
         virtual void willRenderFrame() { }
         virtual void didRenderFrame(Vector<WebCore::IntRect, 1>&&) { }
@@ -184,12 +188,9 @@ private:
 
         uint64_t m_id { 0 };
         uint64_t m_surfaceID { 0 };
-        struct {
 #if USE(SKIA)
-            sk_sp<SkSurface> surface;
+        sk_sp<SkSurface> m_skiaSurface;
 #endif
-            std::unique_ptr<WebCore::GraphicsContext> context;
-        } m_graphicsContext;
 #if ENABLE(DAMAGE_TRACKING)
         std::optional<WebCore::Damage> m_damage;
 #endif
@@ -207,7 +208,9 @@ private:
     protected:
         RenderTargetShareableBuffer(uint64_t, const WebCore::IntSize&);
 
-        WebCore::GraphicsContext* graphicsContext() override;
+#if USE(SKIA)
+        SkSurface* skiaSurface() override;
+#endif
 
         void willRenderFrame() override;
         void didRenderFrame(Vector<WebCore::IntRect, 1>&&) override;
@@ -302,7 +305,9 @@ private:
         RenderTargetSHMImageWithoutGL(uint64_t, const WebCore::IntSize&, Ref<WebCore::ShareableBitmap>&&, WebCore::ShareableBitmapHandle&&);
         ~RenderTargetSHMImageWithoutGL();
 
-        WebCore::GraphicsContext* graphicsContext() override;
+#if USE(SKIA)
+        SkSurface* skiaSurface() override;
+#endif
 
     private:
         void didRenderFrame(Vector<WebCore::IntRect, 1>&&) override;


### PR DESCRIPTION
#### 8b2484152e387bd4c6c3ef30cc1d34879e349433
<pre>
[GTK][WPE] Non composited renderer doesn&apos;t work on HiDPI screens
<a href="https://bugs.webkit.org/show_bug.cgi?id=306851">https://bugs.webkit.org/show_bug.cgi?id=306851</a>

Reviewed by Nikolas Zimmermann and Miguel Gomez.

The non composited renderer is not applying the device scale factor.
This patch changes the way we render the frame to be similar to what we
do when rendering the tiles. So, instead of getting a GraphicsContext
from the AcceleratedSurface to render the page into, we get a SkCanvas
so that we can create a GraphicsContext and apply the device scale
factor there. We also ensure that the skia gl context is current before
destroying the GrContext to ensure gl resources are properly released.

* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::SkiaGLContext::~SkiaGLContext):
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmap::createSurface):
(WebCore::ShareableBitmap::createGraphicsContext):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::skiaSurface):
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::sync):
(WebKit::AcceleratedSurface::RenderTargetSHMImageWithoutGL::skiaSurface):
(WebKit::AcceleratedSurface::canvas):
(WebKit::AcceleratedSurface::RenderTargetShareableBuffer::graphicsContext): Deleted.
(WebKit::AcceleratedSurface::RenderTargetSHMImageWithoutGL::graphicsContext): Deleted.
(WebKit::AcceleratedSurface::graphicsContext): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::display):

Canonical link: <a href="https://commits.webkit.org/306709@main">https://commits.webkit.org/306709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64b7f148635c0517332685e00f60e0fbd1963104

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150695 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/143947 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109215 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90112 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11282 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/8947 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153063 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14155 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117287 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117607 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13655 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124312 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69855 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21926 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14204 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3391 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77920 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14140 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->