### PR TITLE
Drop more `protected*()` member functions in Source/WebCore/dom

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -1368,6 +1368,8 @@ namespace WTF {
 // lifetime threaded from JSC entrance. Until that, we explicitly suppress
 // Ref<VM> lifetime checking by using ThreadSafeRefCountedWithSuppressingSaferCPPChecking.
 template<> struct DefaultRefDerefTraits<JSC::VM> {
+    static constexpr bool isDefaultImplementation = false;
+
     static ALWAYS_INLINE JSC::VM* refIfNotNull(JSC::VM* ptr)
     {
         if (ptr) [[likely]]

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -46,6 +46,8 @@ namespace WTF {
 inline void adopted(const void*) { }
 
 template<typename T> struct DefaultRefDerefTraits {
+    static constexpr bool isDefaultImplementation = true;
+
     static ALWAYS_INLINE T* refIfNotNull(T* ptr)
     {
         if (ptr) [[likely]]
@@ -65,6 +67,9 @@ template<typename T> struct DefaultRefDerefTraits {
             ptr->deref();
     }
 };
+
+template<typename T>
+concept CanUseDefaultRefDerefTraits = HasRefPtrMemberFunctions<T>::value || !DefaultRefDerefTraits<T>::isDefaultImplementation;
 
 template<typename T, typename PtrTraits, typename RefDerefTraits> class Ref;
 template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>> Ref<T, PtrTraits, RefDerefTraits> adoptRef(T&);
@@ -347,7 +352,7 @@ inline Ref<T, _PtrTraits, RefDerefTraits> adoptRef(T& reference)
 }
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
-    requires HasRefPtrMemberFunctions<T>::value
+    requires CanUseDefaultRefDerefTraits<T>
 ALWAYS_INLINE CLANG_POINTER_CONVERSION Ref<T, PtrTraits, RefDerefTraits> protect(T& reference)
 {
     return Ref<T, PtrTraits, RefDerefTraits>(reference);

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -223,7 +223,7 @@ inline RefPtr<T, U, V> adoptRef(T* p)
 }
 
 template<typename T, typename PtrTraits = RawPtrTraits<T>, typename RefDerefTraits = DefaultRefDerefTraits<T>>
-    requires HasRefPtrMemberFunctions<T>::value
+    requires CanUseDefaultRefDerefTraits<T>
 ALWAYS_INLINE CLANG_POINTER_CONVERSION RefPtr<T, PtrTraits, RefDerefTraits> protect(T* ptr)
 {
     return RefPtr<T, PtrTraits, RefDerefTraits>(ptr);

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp
@@ -73,6 +73,7 @@
 #include "PaymentValidationErrors.h"
 #include "Settings.h"
 #include <JavaScriptCore/JSONObject.h>
+#include <JavaScriptCore/VM.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -448,7 +449,7 @@ Vector<Ref<ApplePayError>> ApplePayPaymentHandler::computeErrors(String&& error,
 
     computePayerErrors(WTF::move(payerErrors), errors);
 
-    auto scope = DECLARE_THROW_SCOPE(protectedScriptExecutionContext()->protectedVM().get());
+    auto scope = DECLARE_THROW_SCOPE(protect(protect(scriptExecutionContext())->vm()).get());
     auto exception = computePaymentMethodErrors(paymentMethodErrors, errors);
     if (exception.hasException())
         TRY_CLEAR_EXCEPTION(scope, errors);
@@ -460,7 +461,7 @@ Vector<Ref<ApplePayError>> ApplePayPaymentHandler::computeErrors(JSC::JSObject* 
 {
     Vector<Ref<ApplePayError>> errors;
 
-    auto scope = DECLARE_THROW_SCOPE(protectedScriptExecutionContext()->protectedVM().get());
+    auto scope = DECLARE_THROW_SCOPE(protect(protect(scriptExecutionContext())->vm()).get());
     auto exception = computePaymentMethodErrors(paymentMethodErrors, errors);
     if (exception.hasException())
         TRY_CLEAR_EXCEPTION(scope, errors);

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -68,7 +68,7 @@ TextMarkerData::TextMarkerData(AXObjectCache& cache, const VisiblePosition& visi
     zeroBytes(*this);
     treeID = cache.treeID().toUInt64();
     auto position = visiblePosition.deepEquivalent();
-    auto optionalObjectID = nodeID(cache, position.protectedAnchorNode().get());
+    auto optionalObjectID = nodeID(cache, protect(position.anchorNode()).get());
     objectID = optionalObjectID ? optionalObjectID->toUInt64() : 0;
     offset = !visiblePosition.isNull() ? std::max(position.deprecatedEditingOffset(), 0) : 0;
     anchorType = position.anchorType();

--- a/Source/WebCore/dom/AbstractRange.cpp
+++ b/Source/WebCore/dom/AbstractRange.cpp
@@ -52,14 +52,4 @@ std::optional<SimpleRange> makeSimpleRange(const RefPtr<AbstractRange>& range)
     return makeSimpleRange(range.get());
 }
 
-Ref<Node> AbstractRange::protectedStartContainer() const
-{
-    return startContainer();
-}
-
-Ref<Node> AbstractRange::protectedEndContainer() const
-{
-    return endContainer();
-}
-
 }

--- a/Source/WebCore/dom/AbstractRange.h
+++ b/Source/WebCore/dom/AbstractRange.h
@@ -42,10 +42,8 @@ public:
     virtual ~AbstractRange() = default;
 
     virtual Node& startContainer() const = 0;
-    Ref<Node> protectedStartContainer() const;
     virtual unsigned startOffset() const = 0;
     virtual Node& endContainer() const = 0;
-    Ref<Node> protectedEndContainer() const;
     virtual unsigned endOffset() const = 0;
     virtual bool collapsed() const = 0;
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2348,7 +2348,7 @@ std::optional<BoundaryPoint> Document::caretPositionFromPoint(const LayoutPoint&
         return std::nullopt;
 
     unsigned offset = rangeCompliantPosition.offsetInContainerNode();
-    node = retargetToScope(*rangeCompliantPosition.protectedContainerNode());
+    node = retargetToScope(*protect(rangeCompliantPosition.containerNode()));
     if (node != rangeCompliantPosition.containerNode())
         offset = 0;
 

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -66,7 +66,7 @@ static bool positionsHaveSameBlockAncestor(const VisiblePosition& a, const Visib
 static VisiblePosition beforeStartOfCurrentBlock(const VisiblePosition& visiblePosition)
 {
     auto position = visiblePosition.deepEquivalent();
-    Ref blockContainer = nearestBlockAncestor(*position.protectedContainerNode().get());
+    Ref blockContainer = nearestBlockAncestor(*protect(position.containerNode()).get());
     VisiblePosition firstPositionInBlock = firstPositionInNode(blockContainer.ptr());
     if (firstPositionInBlock == visiblePosition)
         return visiblePosition.previous();
@@ -76,7 +76,7 @@ static VisiblePosition beforeStartOfCurrentBlock(const VisiblePosition& visibleP
 static VisiblePosition afterEndOfCurrentBlock(const VisiblePosition& visiblePosition)
 {
     auto position = visiblePosition.deepEquivalent();
-    Ref blockContainer = nearestBlockAncestor(*position.protectedContainerNode().get());
+    Ref blockContainer = nearestBlockAncestor(*protect(position.containerNode()).get());
     VisiblePosition lastPositionInBlock = lastPositionInNode(blockContainer.ptr());
     if (lastPositionInBlock == visiblePosition)
         return visiblePosition.next();

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -204,11 +204,6 @@ Text* Position::containerText() const
     return nullptr;
 }
 
-RefPtr<Text> Position::protectedContainerText() const
-{
-    return containerText();
-}
-
 Element* Position::containerOrParentElement() const
 {
     auto* container = containerNode();
@@ -483,7 +478,7 @@ bool Position::atFirstEditingPositionForNode() const
         return true;
     case PositionIsAfterChildren:
     case PositionIsAfterAnchor:
-        return !lastOffsetForEditing(*protectedDeprecatedNode());
+        return !lastOffsetForEditing(*protect(deprecatedNode()));
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -494,7 +489,7 @@ bool Position::atLastEditingPositionForNode() const
     if (isNull())
         return true;
     // FIXME: Position after anchor shouldn't be considered as at the first editing position for node since that position resides outside of the node.
-    return m_anchorType == PositionIsAfterAnchor || m_anchorType == PositionIsAfterChildren || m_offset >= static_cast<unsigned>(lastOffsetForEditing(*protectedDeprecatedNode()));
+    return m_anchorType == PositionIsAfterAnchor || m_anchorType == PositionIsAfterChildren || m_offset >= static_cast<unsigned>(lastOffsetForEditing(*protect(deprecatedNode())));
 }
 
 // A position is considered at editing boundary if one of the following is true:
@@ -554,7 +549,7 @@ bool Position::atStartOfTree() const
     case PositionIsBeforeChildren:
         return true;
     case PositionIsAfterChildren:
-        return !lastOffsetForEditing(*protectedAnchorNode());
+        return !lastOffsetForEditing(*protect(anchorNode()));
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -571,13 +566,13 @@ bool Position::atEndOfTree() const
 
     switch (m_anchorType) {
     case PositionIsOffsetInAnchor:
-        return m_offset >= static_cast<unsigned>(lastOffsetForEditing(*protectedAnchorNode()));
+        return m_offset >= static_cast<unsigned>(lastOffsetForEditing(*protect(anchorNode())));
     case PositionIsBeforeAnchor:
         return false;
     case PositionIsAfterAnchor:
         return !m_anchorNode->nextSibling();
     case PositionIsBeforeChildren:
-        return !lastOffsetForEditing(*protectedAnchorNode());
+        return !lastOffsetForEditing(*protect(anchorNode()));
     case PositionIsAfterChildren:
         return true;
     }

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -82,9 +82,7 @@ public:
     // These are always DOM compliant values.  Editing positions like [img, 0] (aka [img, before])
     // will return img->parentNode() and img->computeNodeIndex() from these functions.
     WEBCORE_EXPORT Node* containerNode() const; // null for a before/after position anchored to a node with no parent
-    RefPtr<Node> protectedContainerNode() const { return containerNode(); }
     Text* containerText() const;
-    RefPtr<Text> protectedContainerText() const;
     Element* containerOrParentElement() const;
 
     int computeOffsetInContainerNode() const;  // O(n) for before/after-anchored positions, O(1) for parent-anchored positions
@@ -112,13 +110,11 @@ public:
     WEBCORE_EXPORT Node* computeNodeAfterPosition() const;
 
     Node* anchorNode() const { return m_anchorNode.get(); }
-    RefPtr<Node> protectedAnchorNode() const { return m_anchorNode; }
 
     // FIXME: Callers should be moved off of node(), node() is not always the container for this position.
     // For nodes which editingIgnoresContent(node()) returns true, positions like [ignoredNode, 0]
     // will be treated as before ignoredNode (thus node() is really after the position, not containing it).
     Node* deprecatedNode() const { return m_anchorNode.get(); }
-    RefPtr<Node> protectedDeprecatedNode() const { return m_anchorNode; }
 
     inline Document* document() const; // Defined in PositionInlines.h.
     inline TreeScope* treeScope() const;

--- a/Source/WebCore/dom/PositionIterator.h
+++ b/Source/WebCore/dom/PositionIterator.h
@@ -42,7 +42,6 @@ public:
     void decrement();
 
     Node* node() const { return m_anchorNode.get(); }
-    RefPtr<Node> protectedNode() const { return m_anchorNode; }
     int offsetInLeafNode() const { return m_offsetInAnchor; }
 
     bool atStart() const;

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -229,11 +229,6 @@ void ProcessingInstruction::setXSLStyleSheet(const String& href, const URL& base
 }
 #endif
 
-RefPtr<StyleSheet> ProcessingInstruction::protectedSheet() const
-{
-    return m_sheet;
-}
-
 void ProcessingInstruction::parseStyleSheet(const String& sheet)
 {
     Ref styleSheet = *m_sheet;

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -50,7 +50,6 @@ public:
 
     const String& localHref() const { return m_localHref; }
     StyleSheet* sheet() const { return m_sheet.get(); }
-    RefPtr<StyleSheet> protectedSheet() const;
 
     bool isCSS() const { return m_isCSS; }
 #if ENABLE(XSLT)

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -49,10 +49,8 @@ public:
     WEBCORE_EXPORT ~Range();
 
     Node& startContainer() const final { return m_start.container(); }
-    WEBCORE_EXPORT Ref<Node> protectedStartContainer() const;
     unsigned startOffset() const final { return m_start.offset(); }
     Node& endContainer() const final { return m_end.container(); }
-    WEBCORE_EXPORT Ref<Node> protectedEndContainer() const;
     unsigned endOffset() const final { return m_end.offset(); }
     bool collapsed() const final { return m_start == m_end; }
     WEBCORE_EXPORT Node* commonAncestorContainer() const;
@@ -144,7 +142,6 @@ private:
     void updateAssociatedSelection();
     void updateAssociatedHighlight();
     ExceptionOr<RefPtr<DocumentFragment>> processContents(ActionType);
-    Ref<Document> protectedOwnerDocument();
 
     Ref<Document> m_ownerDocument;
     RangeBoundaryPoint m_start;

--- a/Source/WebCore/dom/RangeBoundaryPoint.h
+++ b/Source/WebCore/dom/RangeBoundaryPoint.h
@@ -35,7 +35,6 @@ public:
     explicit RangeBoundaryPoint(Node& container);
 
     Node& container() const;
-    Ref<Node> protectedContainer() const { return container(); }
     unsigned offset() const;
     Node* childBefore() const;
 

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -134,7 +134,7 @@ void ScriptElement::handleAsyncAttribute()
 
 void ScriptElement::dispatchErrorEvent()
 {
-    protectedElement()->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    protect(element())->dispatchEvent(Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 static void reportSpeculationRulesError(LocalFrame& frame, const String& errorMessage)
@@ -323,11 +323,11 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
     } else if ((isClassicExternalScript || scriptType == ScriptType::Module) && !hasAsyncAttribute() && !m_forceAsync) {
         m_willExecuteInOrder = true;
         ASSERT(m_loadableScript);
-        protect(document->scriptRunner())->queueScriptForExecution(*this, *protectedLoadableScript(), ScriptRunner::IN_ORDER_EXECUTION);
+        protect(document->scriptRunner())->queueScriptForExecution(*this, *protect(loadableScript()), ScriptRunner::IN_ORDER_EXECUTION);
     } else if (hasSourceAttribute() || scriptType == ScriptType::Module) {
         ASSERT(m_loadableScript);
         ASSERT(hasAsyncAttribute() || m_forceAsync);
-        protect(document->scriptRunner())->queueScriptForExecution(*this, *protectedLoadableScript(), ScriptRunner::ASYNC_EXECUTION);
+        protect(document->scriptRunner())->queueScriptForExecution(*this, *protect(loadableScript()), ScriptRunner::ASYNC_EXECUTION);
     } else if (!hasSourceAttribute() && m_parserInserted == ParserInserted::Yes && !document->haveStylesheetsLoaded()) {
         ASSERT(scriptType == ScriptType::Classic || scriptType == ScriptType::ImportMap || scriptType == ScriptType::SpeculationRules);
         m_willBeParserExecuted = true;
@@ -630,7 +630,7 @@ bool ScriptElement::ignoresLoadRequest() const
 
 String ScriptElement::scriptContent() const
 {
-    return TextNodeTraversal::childTextContent(protectedElement());
+    return TextNodeTraversal::childTextContent(protect(element()));
 }
 
 void ScriptElement::setTrustedScriptText(const String& text)

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -49,7 +49,6 @@ public:
 
     Element& element() { return m_element; }
     const Element& element() const { return m_element; }
-    Ref<Element> protectedElement() const { return m_element; }
 
     bool prepareScript(const TextPosition& scriptStartPosition = TextPosition());
 
@@ -79,7 +78,6 @@ public:
     bool willExecuteWhenDocumentFinishedParsing() const { return m_willExecuteWhenDocumentFinishedParsing; }
     bool willExecuteInOrder() const { return m_willExecuteInOrder; }
     LoadableScript* loadableScript() { return m_loadableScript.get(); }
-    RefPtr<LoadableScript> protectedLoadableScript() { return m_loadableScript; }
 
     ScriptType scriptType() const { return m_scriptType; }
 

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -539,11 +539,6 @@ void ScriptExecutionContext::addConsoleMessage(MessageSource source, MessageLeve
     addMessage(source, level, message, sourceURL, lineNumber, columnNumber, nullptr, state, requestIdentifier);
 }
 
-Ref<SecurityOrigin> ScriptExecutionContext::protectedTopOrigin() const
-{
-    return topOrigin();
-}
-
 bool ScriptExecutionContext::dispatchErrorEvent(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, JSC::Exception* exception, CachedScript* cachedScript, bool fromModule)
 {
     RefPtr target = errorEventTarget();
@@ -571,21 +566,11 @@ int ScriptExecutionContext::circularSequentialID()
     return m_circularSequentialID;
 }
 
-Ref<JSC::VM> ScriptExecutionContext::protectedVM()
-{
-    return vm();
-}
-
 PublicURLManager& ScriptExecutionContext::publicURLManager()
 {
     if (!m_publicURLManager)
         m_publicURLManager = PublicURLManager::create(this);
     return *m_publicURLManager;
-}
-
-Ref<PublicURLManager> ScriptExecutionContext::protectedPublicURLManager()
-{
-    return publicURLManager();
 }
 
 void ScriptExecutionContext::adjustMinimumDOMTimerInterval(Seconds oldMinimumTimerInterval)
@@ -630,7 +615,7 @@ RejectedPromiseTracker* ScriptExecutionContext::ensureRejectedPromiseTrackerSlow
         if (!scriptController || scriptController->isTerminatingExecution())
             return nullptr;
     }
-    m_rejectedPromiseTracker = makeUnique<RejectedPromiseTracker>(*this, protectedVM());
+    m_rejectedPromiseTracker = makeUnique<RejectedPromiseTracker>(*this, protect(vm()));
     return m_rejectedPromiseTracker.get();
 }
 
@@ -970,11 +955,6 @@ GuaranteedSerialFunctionDispatcher& ScriptExecutionContext::nativePromiseDispatc
     return *m_nativePromiseDispatcher;
 }
 
-Ref<GuaranteedSerialFunctionDispatcher> ScriptExecutionContext::protectedNativePromiseDispatcher()
-{
-    return nativePromiseDispatcher();
-}
-
 bool ScriptExecutionContext::requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory category, IncludeConsoleLog includeConsoleLog)
 {
     RefPtr vm = vmIfExists();
@@ -1034,11 +1014,6 @@ bool ScriptExecutionContext::isAlwaysOnLoggingAllowed() const
 WebCoreOpaqueRoot root(ScriptExecutionContext* context)
 {
     return WebCoreOpaqueRoot { context };
-}
-
-RefPtr<SocketProvider> ScriptExecutionContext::protectedSocketProvider()
-{
-    return socketProvider();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -169,7 +169,6 @@ public:
     virtual IDBClient::IDBConnectionProxy* idbConnectionProxy() = 0;
 
     virtual SocketProvider* socketProvider() = 0;
-    RefPtr<SocketProvider> protectedSocketProvider();
 
     virtual GraphicsClient* graphicsClient() { return nullptr; }
 
@@ -193,12 +192,10 @@ public:
     virtual void addConsoleMessage(MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier = 0) = 0;
 
     virtual SecurityOrigin& topOrigin() const = 0;
-    Ref<SecurityOrigin> protectedTopOrigin() const;
 
     virtual bool shouldBypassMainWorldContentSecurityPolicy() const { return false; }
 
     PublicURLManager& publicURLManager();
-    Ref<PublicURLManager> protectedPublicURLManager();
 
     virtual void suspendActiveDOMObjects(ReasonForSuspension);
     virtual void resumeActiveDOMObjects(ReasonForSuspension);
@@ -299,7 +296,6 @@ public:
     inline DOMTimer* findTimeout(int timeoutId); // Defined in ScriptExecutionContextInlines.h
 
     virtual JSC::VM& vm() = 0;
-    virtual Ref<JSC::VM> protectedVM();
     virtual JSC::VM* vmIfExists() const = 0;
 
     void adjustMinimumDOMTimerInterval(Seconds oldMinimumTimerInterval);
@@ -427,7 +423,6 @@ private:
 
     void checkConsistency() const;
     WEBCORE_EXPORT GuaranteedSerialFunctionDispatcher& nativePromiseDispatcher();
-    WEBCORE_EXPORT Ref<GuaranteedSerialFunctionDispatcher> protectedNativePromiseDispatcher();
 
     WeakHashSet<MessagePort, WeakPtrImplWithEventTargetData> m_messagePorts;
     WeakHashSet<ContextDestructionObserver> m_destructionObservers;

--- a/Source/WebCore/dom/ScriptExecutionContextInlines.h
+++ b/Source/WebCore/dom/ScriptExecutionContextInlines.h
@@ -67,7 +67,7 @@ void ScriptExecutionContext::enqueueTaskWhenSettled(Ref<Promise>&& promise, Task
 {
     auto request = NativePromiseRequest::create();
     WeakPtr weakRequest { request.get() };
-    auto command = promise->whenSettled(protectedNativePromiseDispatcher(), [weakThis = WeakPtr { *this }, taskSource, task = WTF::move(task), request = WTF::move(request)] (auto&& result) mutable {
+    auto command = promise->whenSettled(protect(nativePromiseDispatcher()), [weakThis = WeakPtr { *this }, taskSource, task = WTF::move(task), request = WTF::move(request)] (auto&& result) mutable {
         request->complete();
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -68,11 +68,6 @@ SecurityOrigin* SecurityContext::securityOrigin() const
     return &policy->origin();
 }
 
-RefPtr<SecurityOrigin> SecurityContext::protectedSecurityOrigin() const
-{
-    return securityOrigin();
-}
-
 SecurityOriginPolicy* SecurityContext::securityOriginPolicy() const
 {
     if (!m_securityOriginPolicy && m_hasEmptySecurityOriginPolicy)

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -102,7 +102,6 @@ public:
     virtual void inheritPolicyContainerFrom(const PolicyContainer&);
 
     WEBCORE_EXPORT SecurityOrigin* securityOrigin() const;
-    WEBCORE_EXPORT RefPtr<SecurityOrigin> protectedSecurityOrigin() const;
 
     static SandboxFlags parseSandboxPolicy(StringView policy, String& invalidTokensErrorMessage);
     static bool isSupportedSandboxPolicy(StringView);

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -230,13 +230,13 @@ ExceptionOr<void> ShadowRoot::replaceChildrenWithMarkup(const String& markup, Op
         return { };
     }
 
-    auto fragment = createFragmentForInnerOuterHTML(*protectedHost(), markup, policy, customElementRegistry());
+    auto fragment = createFragmentForInnerOuterHTML(*protect(host()), markup, policy, customElementRegistry());
     if (fragment.hasException())
         return fragment.releaseException();
     bool usedFastPath = fragment.returnValue()->hasWasParsedWithFastPath();
     auto result = replaceChildrenWithFragment(*this, fragment.releaseReturnValue());
     if (!result.hasException() && usedFastPath)
-        document().updateCachedSetInnerHTML(markup, *this, *protectedHost());
+        document().updateCachedSetInnerHTML(markup, *this, *protect(host()));
     return result;
 }
 

--- a/Source/WebCore/dom/ShadowRoot.h
+++ b/Source/WebCore/dom/ShadowRoot.h
@@ -96,7 +96,6 @@ public:
     void setIsDeclarativeShadowRoot(bool flag) { m_isDeclarativeShadowRoot = flag; }
 
     Element* host() const { return m_host; }
-    RefPtr<Element> protectedHost() const { return m_host; }
     void setHost(WeakPtr<Element, WeakPtrImplWithEventTargetData>&& host) { m_host = WTF::move(host); }
 
     bool hasScopedCustomElementRegistry() const { return m_hasScopedCustomElementRegistry; }

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -49,10 +49,8 @@ struct SimpleRange {
     BoundaryPoint end;
 
     Node& startContainer() const { return start.container.get(); }
-    Ref<Node> protectedStartContainer() const { return start.container.copyRef(); }
     unsigned startOffset() const { return start.offset; }
     Node& endContainer() const { return end.container.get(); }
-    Ref<Node> protectedEndContainer() const { return end.container.copyRef(); }
     unsigned endOffset() const { return end.offset; }
     WeakSimpleRange makeWeakSimpleRange() const { return { WeakBoundaryPoint(start.container.get(), start.offset), WeakBoundaryPoint(end.container.get(), end.offset) }; }
 
@@ -156,8 +154,6 @@ public:
 
 private:
     void enforceEndInvariant();
-
-    RefPtr<Node> protectedNode() const { return m_node; }
 
     RefPtr<Node> m_node;
     RefPtr<Node> m_pastLastNode;

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -493,7 +493,7 @@ void ManualSlotAssignment::renameSlotElement(HTMLSlotElement&, const AtomString&
 void ManualSlotAssignment::addSlotElementByName(const AtomString&, HTMLSlotElement& slot, ShadowRoot& shadowRoot)
 {
     if (!m_slotElementCount)
-        shadowRoot.protectedHost()->setHasShadowRootContainingSlots(true);
+        protect(shadowRoot.host())->setHasShadowRootContainingSlots(true);
     ++m_slotElementCount;
     ++m_slottableVersion;
 

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -209,11 +209,6 @@ void StyledElement::invalidateStyleAttribute()
     }
 }
 
-RefPtr<StyleProperties> StyledElement::protectedInlineStyle() const
-{
-    return elementData() ? elementData()->m_inlineStyle : nullptr;
-}
-
 void StyledElement::inlineStyleChanged()
 {
     setDidMutateSubtreeAfterSetInnerHTMLOnAncestors();

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -52,8 +52,7 @@ public:
     void invalidateStyleAttribute();
 
     const StyleProperties* inlineStyle() const { return elementData() ? elementData()->m_inlineStyle.get() : nullptr; }
-    RefPtr<StyleProperties> protectedInlineStyle() const;
-    
+
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, CSSValueID identifier, IsImportant = IsImportant::No);
     bool setInlineStyleProperty(CSSPropertyID, CSSPropertyID identifier, IsImportant = IsImportant::No);
     WEBCORE_EXPORT bool setInlineStyleProperty(CSSPropertyID, double value, CSSUnitType, IsImportant = IsImportant::No);

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -426,7 +426,7 @@ RefPtr<Node> TreeScope::nodeFromPoint(const LayoutPoint& clientPoint, LayoutPoin
 
 RefPtr<Element> TreeScope::elementFromPoint(double clientX, double clientY, HitTestSource source)
 {
-    if (!protectedDocumentScope()->hasLivingRenderTree())
+    if (!protect(documentScope())->hasLivingRenderTree())
         return nullptr;
 
     auto node = nodeFromPoint(LayoutPoint { clientX, clientY }, nullptr, source);
@@ -795,11 +795,6 @@ RefPtr<SVGElement> TreeScope::takeElementFromPendingSVGResourcesForRemovalMap(co
         svgResourcesMap().pendingResourcesForRemoval.remove(id);
 
     return firstElement;
-}
-
-Ref<Document> TreeScope::protectedDocumentScope() const
-{
-    return m_documentScope.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -100,7 +100,6 @@ public:
     void removeElementByName(const AtomString&, Element&);
 
     Document& documentScope() const { return m_documentScope.get(); }
-    Ref<Document> protectedDocumentScope() const;
     static constexpr ptrdiff_t documentScopeMemoryOffset() { return OBJECT_OFFSETOF(TreeScope, m_documentScope); }
 
     // https://dom.spec.whatwg.org/#retarget

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -252,7 +252,7 @@ void ApplyStyleCommand::applyBlockStyle(EditingStyle& style)
     while (paragraphStart.isNotNull() && paragraphStart != beyondEnd) {
         StyleChange styleChange(&style, paragraphStart.deepEquivalent());
         if (styleChange.cssStyle() || m_removeOnly) {
-            RefPtr<Node> block = enclosingBlock(paragraphStart.deepEquivalent().protectedDeprecatedNode());
+            RefPtr<Node> block = enclosingBlock(protect(paragraphStart.deepEquivalent().deprecatedNode()));
             if (!m_removeOnly) {
                 RefPtr<Node> newBlock = moveParagraphContentsToNewBlockIfNecessary(paragraphStart.deepEquivalent());
                 if (newBlock)
@@ -1226,8 +1226,8 @@ void ApplyStyleCommand::splitTextElementAtStart(const Position& start, const Pos
     else
         newEnd = end;
 
-    splitTextNodeContainingElement(*start.protectedContainerText(), start.offsetInContainerNode());
-    updateStartEnd(positionBeforeNode(start.protectedContainerNode().get()), newEnd);
+    splitTextNodeContainingElement(*protect(start.containerText()), start.offsetInContainerNode());
+    updateStartEnd(positionBeforeNode(protect(start.containerNode()).get()), newEnd);
 }
 
 void ApplyStyleCommand::splitTextElementAtEnd(const Position& start, const Position& end)
@@ -1235,7 +1235,7 @@ void ApplyStyleCommand::splitTextElementAtEnd(const Position& start, const Posit
     ASSERT(is<Text>(end.containerNode()));
 
     bool shouldUpdateStart = start.containerNode() == end.containerNode();
-    splitTextNodeContainingElement(*end.protectedContainerText(), end.offsetInContainerNode());
+    splitTextNodeContainingElement(*protect(end.containerText()), end.offsetInContainerNode());
 
     RefPtr parentElement = end.containerNode()->parentNode();
     if (!parentElement || !parentElement->previousSibling())
@@ -1299,7 +1299,7 @@ bool ApplyStyleCommand::mergeStartWithPreviousIfIdentical(const Position& start,
     unsigned startOffset = startChild->computeNodeIndex();
     unsigned endOffset = end.deprecatedEditingOffset() + (startNode == end.deprecatedNode() ? startOffset : 0);
     updateStartEnd({ startNode.get(), startOffset, Position::PositionIsOffsetInAnchor },
-        { end.protectedDeprecatedNode(), endOffset, Position::PositionIsOffsetInAnchor });
+        { protect(end.deprecatedNode()), endOffset, Position::PositionIsOffsetInAnchor });
     return true;
 }
 

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -988,7 +988,7 @@ void CompositeEditCommand::prepareWhitespaceAtPositionForSplit(Position& positio
     if (!isRichlyEditablePosition(position))
         return;
 
-    auto textNode = dynamicDowncast<Text>(position.protectedDeprecatedNode());
+    auto textNode = dynamicDowncast<Text>(protect(position.deprecatedNode()));
     if (!textNode || !textNode->length())
         return;
     
@@ -1018,7 +1018,7 @@ void CompositeEditCommand::replaceCollapsibleWhitespaceWithNonBreakingSpaceIfNee
     Position pos = visiblePosition.deepEquivalent().downstream();
     if (!pos.containerNode() || !is<Text>(*pos.containerNode()) || is<HTMLBRElement>(*pos.deprecatedNode()))
         return;
-    replaceTextInNodePreservingMarkers(*pos.protectedContainerText(), pos.offsetInContainerNode(), 1, nonBreakingSpaceString());
+    replaceTextInNodePreservingMarkers(*protect(pos.containerText()), pos.offsetInContainerNode(), 1, nonBreakingSpaceString());
 }
 
 void CompositeEditCommand::rebalanceWhitespace()
@@ -1237,7 +1237,7 @@ RefPtr<Node> CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary(co
         return nullptr;
 
     // Perform some checks to see if we need to perform work in this function.
-    if (upstreamStart.deprecatedNode() && isBlock(*upstreamStart.protectedDeprecatedNode())) {
+    if (upstreamStart.deprecatedNode() && isBlock(*protect(upstreamStart.deprecatedNode()))) {
         // If the block is the root editable element, always move content to a new block,
         // since it is illegal to modify attributes on the root editable element for editing.
         if (upstreamStart.deprecatedNode() == editableRootForPosition(upstreamStart)) {
@@ -1245,16 +1245,16 @@ RefPtr<Node> CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary(co
             // block but don't try and move content into it, since there's nothing for moveParagraphs to move.
             if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(downcast<RenderElement>(*upstreamStart.deprecatedNode()->renderer())))
                 return insertNewDefaultParagraphElementAt(upstreamStart);
-        } else if (upstreamEnd.deprecatedNode() && isBlock(*upstreamEnd.protectedDeprecatedNode())) {
-            if (!upstreamEnd.protectedDeprecatedNode()->isDescendantOf(upstreamStart.protectedDeprecatedNode().get())) {
+        } else if (upstreamEnd.deprecatedNode() && isBlock(*protect(upstreamEnd.deprecatedNode()))) {
+            if (!protect(upstreamEnd.deprecatedNode())->isDescendantOf(protect(upstreamStart.deprecatedNode()).get())) {
                 // If the paragraph end is a descendant of paragraph start, then we need to run
                 // the rest of this function. If not, we can bail here.
                 return nullptr;
             }
-        } else if (enclosingBlock(upstreamEnd.protectedDeprecatedNode()) != upstreamStart.deprecatedNode()) {
+        } else if (enclosingBlock(protect(upstreamEnd.deprecatedNode())) != upstreamStart.deprecatedNode()) {
             // The visibleEnd. If it is an ancestor of the paragraph start, then
             // we can bail as we have a full block to work with.
-            if (upstreamStart.protectedDeprecatedNode()->isDescendantOf(enclosingBlock(upstreamEnd.protectedDeprecatedNode()).get()))
+            if (protect(upstreamStart.deprecatedNode())->isDescendantOf(enclosingBlock(protect(upstreamEnd.deprecatedNode())).get()))
                 return nullptr;
         } else if (isEndOfEditableOrNonEditableContent(visibleEnd)) {
             // At the end of the editable region. We can bail here as well.
@@ -1349,7 +1349,7 @@ void CompositeEditCommand::cloneParagraphUnderNewElement(const Position& start, 
             auto clonedNode = node->cloneNode(true);
             insertNodeAfter(clonedNode.copyRef(), *lastNode);
             lastNode = WTF::move(clonedNode);
-            if (node == end.deprecatedNode() || end.protectedDeprecatedNode()->isDescendantOf(*node))
+            if (node == end.deprecatedNode() || protect(end.deprecatedNode())->isDescendantOf(*node))
                 break;
         }
     }
@@ -1441,7 +1441,7 @@ void CompositeEditCommand::moveParagraphWithClones(const VisiblePosition& startO
     beforeParagraph = VisiblePosition(beforeParagraph.deepEquivalent());
     afterParagraph = VisiblePosition(afterParagraph.deepEquivalent());
 
-    if (beforeParagraph.isNotNull() && !isRenderedTable(beforeParagraph.deepEquivalent().protectedDeprecatedNode().get())
+    if (beforeParagraph.isNotNull() && !isRenderedTable(protect(beforeParagraph.deepEquivalent().deprecatedNode()).get())
         && ((!isEndOfParagraph(beforeParagraph) && !isStartOfParagraph(beforeParagraph)) || beforeParagraph == afterParagraph)
         && isEditablePosition(beforeParagraph.deepEquivalent())) {
         // FIXME: Trim text between beforeParagraph and afterParagraph if they aren't equal.
@@ -1704,7 +1704,7 @@ bool CompositeEditCommand::breakOutOfEmptyMailBlockquotedParagraph()
     ASSERT(caretPos.deprecatedNode()->hasTagName(brTag) || (caretPos.deprecatedNode()->isTextNode() && caretPos.deprecatedNode()->renderer()->style().preserveNewline()));
     
     if (caretPos.deprecatedNode()->hasTagName(brTag))
-        removeNodeAndPruneAncestors(*caretPos.protectedDeprecatedNode());
+        removeNodeAndPruneAncestors(*protect(caretPos.deprecatedNode()));
     else if (RefPtr textNode = dynamicDowncast<Text>(*caretPos.deprecatedNode())) {
         ASSERT(caretPos.deprecatedEditingOffset() == 0);
         RefPtr parentNode { textNode->parentNode() };
@@ -1751,7 +1751,7 @@ Position CompositeEditCommand::positionAvoidingSpecialElementBoundary(const Posi
             // Don't insert outside an anchor if doing so would skip over a line break.  It would
             // probably be safe to move the line break so that we could still avoid the anchor here.
             Position downstream(visiblePos.deepEquivalent().downstream());
-            if (lineBreakExistsAtVisiblePosition(visiblePos) && downstream.protectedDeprecatedNode()->isDescendantOf(enclosingAnchor.get()))
+            if (lineBreakExistsAtVisiblePosition(visiblePos) && protect(downstream.deprecatedNode())->isDescendantOf(enclosingAnchor.get()))
                 return original;
             
             result = positionInParentAfterNode(enclosingAnchor.get());

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -726,7 +726,7 @@ void DeleteSelectionCommand::handleGeneralDelete()
             && m_downstreamEnd.deprecatedEditingOffset() >= caretMinOffset(*m_downstreamEnd.deprecatedNode())) {
             if (m_downstreamEnd.atLastEditingPositionForNode() && !canHaveChildrenForEditing(*m_downstreamEnd.deprecatedNode())) {
                 // The node itself is fully selected, not just its contents.  Delete it.
-                removeNode(*m_downstreamEnd.protectedDeprecatedNode());
+                removeNode(*protect(m_downstreamEnd.deprecatedNode()));
             } else {
                 if (RefPtr text = dynamicDowncast<Text>(*m_downstreamEnd.deprecatedNode())) {
                     // in a text node that needs to be trimmed
@@ -747,8 +747,8 @@ void DeleteSelectionCommand::handleGeneralDelete()
                         if (n)
                             offset = n->computeNodeIndex() + 1;
                     }
-                    removeChildrenInRange(*m_downstreamEnd.protectedDeprecatedNode(), offset, m_downstreamEnd.deprecatedEditingOffset());
-                    m_downstreamEnd = makeDeprecatedLegacyPosition(m_downstreamEnd.protectedDeprecatedNode(), offset);
+                    removeChildrenInRange(*protect(m_downstreamEnd.deprecatedNode()), offset, m_downstreamEnd.deprecatedEditingOffset());
+                    m_downstreamEnd = makeDeprecatedLegacyPosition(protect(m_downstreamEnd.deprecatedNode()), offset);
                 }
             }
         }
@@ -803,7 +803,7 @@ void DeleteSelectionCommand::mergeParagraphs()
     
     // m_downstreamEnd's block has been emptied out by deletion.  There is no content inside of it to
     // move, so just remove it.
-    RefPtr endBlock { enclosingBlock(m_downstreamEnd.protectedDeprecatedNode()) };
+    RefPtr endBlock { enclosingBlock(protect(m_downstreamEnd.deprecatedNode())) };
     if (!endBlock)
         return;
 
@@ -813,7 +813,7 @@ void DeleteSelectionCommand::mergeParagraphs()
     }
     
     // We need to merge into m_upstreamStart's block, but it's been emptied out and collapsed by deletion.
-    if (!mergeDestination.deepEquivalent().deprecatedNode() || !mergeDestination.deepEquivalent().deprecatedNode()->isDescendantOf(enclosingBlock(m_upstreamStart.protectedContainerNode()).get()) || m_startsAtEmptyLine) {
+    if (!mergeDestination.deepEquivalent().deprecatedNode() || !mergeDestination.deepEquivalent().deprecatedNode()->isDescendantOf(enclosingBlock(protect(m_upstreamStart.containerNode())).get()) || m_startsAtEmptyLine) {
         insertNodeAt(HTMLBRElement::create(document()), m_upstreamStart);
         mergeDestination = VisiblePosition(m_upstreamStart);
     }
@@ -897,7 +897,7 @@ void DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows()
     if (endTableRow && endTableRow->isConnected() && endTableRow != m_startTableRow) {
         if (isTableRowEmpty(*endTableRow)) {
             // Don't remove m_endTableRow if it's where we're putting the ending selection.
-            if (!m_endingPosition.protectedDeprecatedNode()->isDescendantOf(*endTableRow)) {
+            if (!protect(m_endingPosition.deprecatedNode())->isDescendantOf(*endTableRow)) {
                 // FIXME: We probably shouldn't remove m_endTableRow unless it's fully selected, even if it is empty.
                 // We'll need to start adjusting the selection endpoints during deletion to know whether or not m_endTableRow
                 // was fully selected here.
@@ -1017,7 +1017,7 @@ void DeleteSelectionCommand::doApply()
         // and ends inside it (we do need placeholders to hold open empty cells, but that's
         // handled elsewhere).
         if (RefPtr table = isLastPositionBeforeTable(m_selectionToDelete.visibleStart())) {
-            if (m_selectionToDelete.end().protectedDeprecatedNode()->isDescendantOf(*table))
+            if (protect(m_selectionToDelete.end().deprecatedNode())->isDescendantOf(*table))
                 m_needPlaceholder = false;
         }
     }
@@ -1065,7 +1065,7 @@ void DeleteSelectionCommand::doApply()
 
     bool shouldRebalaceWhiteSpace = true;
     if (!document().editor().behavior().shouldRebalanceWhiteSpacesInSecureField()) {
-        if (RefPtr textNode = dynamicDowncast<Text>(m_endingPosition.protectedDeprecatedNode())) {
+        if (RefPtr textNode = dynamicDowncast<Text>(protect(m_endingPosition.deprecatedNode()))) {
             ScriptDisallowedScope::InMainThread scriptDisallowedScope;
             if (textNode->length() && textNode->renderer())
                 shouldRebalaceWhiteSpace = textNode->renderer()->style().textSecurity() == TextSecurity::None;

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -280,17 +280,17 @@ Position firstEditablePositionAfterPositionInRoot(const Position& position, Cont
     Position candidate = position;
 
     if (&position.deprecatedNode()->treeScope() != &highestRoot->treeScope()) {
-        RefPtr shadowAncestor = highestRoot->treeScope().ancestorNodeInThisScope(position.protectedDeprecatedNode().get());
+        RefPtr shadowAncestor = highestRoot->treeScope().ancestorNodeInThisScope(protect(position.deprecatedNode()).get());
         if (!shadowAncestor)
             return { };
 
         candidate = positionAfterNode(shadowAncestor.get());
     }
 
-    while (candidate.deprecatedNode() && !isEditablePosition(candidate) && candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
-        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentAfterNode(candidate.protectedDeprecatedNode().get()) : nextVisuallyDistinctCandidate(candidate);
+    while (candidate.deprecatedNode() && !isEditablePosition(candidate) && protect(candidate.deprecatedNode())->isDescendantOf(*highestRoot))
+        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentAfterNode(protect(candidate.deprecatedNode()).get()) : nextVisuallyDistinctCandidate(candidate);
 
-    if (candidate.deprecatedNode() && !candidate.protectedDeprecatedNode()->isInclusiveDescendantOf(*highestRoot))
+    if (candidate.deprecatedNode() && !protect(candidate.deprecatedNode())->isInclusiveDescendantOf(*highestRoot))
         return { };
 
     return candidate;
@@ -308,17 +308,17 @@ Position lastEditablePositionBeforePositionInRoot(const Position& position, Cont
     Position candidate = position;
 
     if (&position.deprecatedNode()->treeScope() != &highestRoot->treeScope()) {
-        RefPtr shadowAncestor = highestRoot->treeScope().ancestorNodeInThisScope(position.protectedDeprecatedNode().get());
+        RefPtr shadowAncestor = highestRoot->treeScope().ancestorNodeInThisScope(protect(position.deprecatedNode()).get());
         if (!shadowAncestor)
             return { };
 
         candidate = firstPositionInOrBeforeNode(shadowAncestor.get());
     }
 
-    while (candidate.deprecatedNode() && !isEditablePosition(candidate) && candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
-        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentBeforeNode(candidate.protectedDeprecatedNode().get()) : previousVisuallyDistinctCandidate(candidate);
-    
-    if (candidate.deprecatedNode() && !candidate.protectedDeprecatedNode()->isInclusiveDescendantOf(*highestRoot))
+    while (candidate.deprecatedNode() && !isEditablePosition(candidate) && protect(candidate.deprecatedNode())->isDescendantOf(*highestRoot))
+        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentBeforeNode(protect(candidate.deprecatedNode()).get()) : previousVisuallyDistinctCandidate(candidate);
+
+    if (candidate.deprecatedNode() && !protect(candidate.deprecatedNode())->isInclusiveDescendantOf(*highestRoot))
         return { };
     
     return candidate;
@@ -347,7 +347,7 @@ RefPtr<Element> enclosingBlock(RefPtr<Node> node, EditingBoundaryCrossingRule ru
 
 TextDirection directionOfEnclosingBlock(const Position& position)
 {
-    auto block = enclosingBlock(position.protectedContainerNode());
+    auto block = enclosingBlock(protect(position.containerNode()));
     if (!block)
         return TextDirection::LTR;
     auto renderer = block->renderer();
@@ -638,7 +638,7 @@ RefPtr<Node> enclosingListChild(Node* node)
 RefPtr<Node> enclosingEmptyListItem(const VisiblePosition& position)
 {
     // Check that position is on a line by itself inside a list item
-    RefPtr listChildNode = enclosingListChild(position.deepEquivalent().protectedDeprecatedNode().get());
+    RefPtr listChildNode = enclosingListChild(protect(position.deepEquivalent().deprecatedNode()).get());
     if (!listChildNode || !isStartOfParagraph(position) || !isEndOfParagraph(position))
         return nullptr;
 

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -466,7 +466,7 @@ EditingStyle::EditingStyle(Node* node, PropertiesToInclude propertiesToInclude)
 EditingStyle::EditingStyle(const Position& position, PropertiesToInclude propertiesToInclude)
     : EditingStyle()
 {
-    init(position.protectedDeprecatedNode().get(), propertiesToInclude);
+    init(protect(position.deprecatedNode()).get(), propertiesToInclude);
 }
 
 EditingStyle::EditingStyle(const CSSStyleProperties* style)
@@ -1248,7 +1248,7 @@ void EditingStyle::prepareToApplyAt(const Position& position, ShouldPreserveWrit
         mutableStyle->removeProperty(CSSPropertyCaretColor);
 
     if (hasTransparentBackgroundColor(mutableStyle.get())
-        || cssValueToColor(mutableStyle->getPropertyCSSValue(CSSPropertyBackgroundColor).get()) == rgbaBackgroundColorInEffect(position.protectedContainerNode().get()))
+        || cssValueToColor(mutableStyle->getPropertyCSSValue(CSSPropertyBackgroundColor).get()) == rgbaBackgroundColorInEffect(protect(position.containerNode()).get()))
         mutableStyle->removeProperty(CSSPropertyBackgroundColor);
 
     if (unicodeBidi) {
@@ -1308,7 +1308,7 @@ static inline bool elementMatchesAndPropertyIsNotInInlineStyleDecl(const HTMLEle
     if (mode != EditingStyle::CSSPropertyOverrideMode::OverrideValues && equivalent.propertyExistsInStyle(style))
         return false;
 
-    return !element.inlineStyle() || !equivalent.propertyExistsInStyle(EditingStyle::create(element.protectedInlineStyle().get()).get());
+    return !element.inlineStyle() || !equivalent.propertyExistsInStyle(EditingStyle::create(protect(element.inlineStyle()).get()).get());
 }
 
 static RefPtr<MutableStyleProperties> extractEditingProperties(const StyleProperties* style, EditingStyle::PropertiesToInclude propertiesToInclude)
@@ -1334,7 +1334,7 @@ void EditingStyle::mergeInlineAndImplicitStyleOfElement(StyledElement& element, 
     styleFromRules->mergeStyleFromRulesForSerialization(element, standardFontFamilySerializationMode);
 
     if (element.inlineStyle())
-        styleFromRules->protectedStyle()->mergeAndOverrideOnConflict(*element.protectedInlineStyle());
+        styleFromRules->protectedStyle()->mergeAndOverrideOnConflict(*protect(element.inlineStyle()));
 
     styleFromRules->m_mutableStyle = extractEditingProperties(styleFromRules->m_mutableStyle.get(), propertiesToInclude);
     mergeStyle(styleFromRules->m_mutableStyle.get(), mode);
@@ -1852,7 +1852,7 @@ WritingDirection EditingStyle::textDirectionForSelection(const VisibleSelection&
             return WritingDirection::Natural;
 
         // In the range case, make sure that the embedding element persists until the end of the range.
-        if (selection.isRange() && !end.protectedDeprecatedNode()->isDescendantOf(*node))
+        if (selection.isRange() && !protect(end.deprecatedNode())->isDescendantOf(*node))
             return WritingDirection::Natural;
         
         foundDirection = directionValue == CSSValueLtr ? WritingDirection::LeftToRight : WritingDirection::RightToLeft;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4415,7 +4415,7 @@ static RefPtr<Node> findFirstMarkable(Node* startingNode)
 
 bool Editor::selectionStartHasMarkerFor(DocumentMarkerType markerType, int from, int length) const
 {
-    auto node = findFirstMarkable(document().selection().selection().start().protectedDeprecatedNode().get());
+    auto node = findFirstMarkable(protect(document().selection().selection().start().deprecatedNode()).get());
     if (!node)
         return false;
 
@@ -4435,7 +4435,7 @@ bool Editor::selectionStartHasMarkerFor(DocumentMarkerType markerType, int from,
 
 void Editor::selectionStartSetMarkerForTesting(DocumentMarkerType markerType, int from, int length, const String& data)
 {
-    RefPtr node = findFirstMarkable(document().selection().selection().start().protectedDeprecatedNode().get());
+    RefPtr node = findFirstMarkable(protect(document().selection().selection().start().deprecatedNode()).get());
     if (!node)
         return;
 

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -587,7 +587,7 @@ static bool removingNodeRemovesPosition(Node& node, const Position& position)
         return true;
 
     RefPtr element = dynamicDowncast<Element>(node);
-    return element && element->isShadowIncludingInclusiveAncestorOf(position.protectedAnchorNode().get());
+    return element && element->isShadowIncludingInclusiveAncestorOf(protect(position.anchorNode()).get());
 }
 
 void DragCaretController::nodeWillBeRemoved(Node& node)
@@ -3101,8 +3101,8 @@ void FrameSelection::updateFromAssociatedLiveRange()
         disassociateLiveRange();
     else {
         // Don't use VisibleSelection's constructor that takes a SimpleRange, because it uses makeDeprecatedLegacyPosition instead of makeContainerOffsetPosition.
-        auto start = makeContainerOffsetPosition(m_associatedLiveRange->protectedStartContainer(), m_associatedLiveRange->startOffset());
-        auto end = makeContainerOffsetPosition(m_associatedLiveRange->protectedEndContainer(), m_associatedLiveRange->endOffset());
+        auto start = makeContainerOffsetPosition(protect(m_associatedLiveRange->startContainer()), m_associatedLiveRange->startOffset());
+        auto end = makeContainerOffsetPosition(protect(m_associatedLiveRange->endContainer()), m_associatedLiveRange->endOffset());
         setSelection({ start, end }, defaultSetSelectionOptions() | SetSelectionOption::MaintainLiveRange);
     }
 }

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -100,7 +100,7 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
         if (enclosingCell)
             return enclosingCell;
         if (enclosingList(start.containerNode()))
-            return enclosingBlock(start.protectedContainerNode());
+            return enclosingBlock(protect(start.containerNode()));
         return editableRootForPosition(start);
     }();
 

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -373,7 +373,7 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
 
 static RefPtr<HTMLElement> adjacentEnclosingList(const VisiblePosition& pos, const VisiblePosition& adjacentPos, const HTMLQualifiedName& listTag)
 {
-    RefPtr listNode = outermostEnclosingList(adjacentPos.deepEquivalent().protectedDeprecatedNode().get());
+    RefPtr listNode = outermostEnclosingList(protect(adjacentPos.deepEquivalent().deprecatedNode()).get());
 
     if (!listNode)
         return nullptr;
@@ -384,7 +384,7 @@ static RefPtr<HTMLElement> adjacentEnclosingList(const VisiblePosition& pos, con
     if (!listNode->hasTagName(listTag)
         || listNode->contains(pos.deepEquivalent().deprecatedNode())
         || previousCell != currentCell
-        || enclosingList(listNode.get()) != enclosingList(pos.deepEquivalent().protectedDeprecatedNode().get()))
+        || enclosingList(listNode.get()) != enclosingList(protect(pos.deepEquivalent().deprecatedNode()).get()))
         return nullptr;
 
     return listNode;

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -245,7 +245,7 @@ void InsertParagraphSeparatorCommand::doApply()
     
     Ref document = this->document();
     // FIXME: The parentAnchoredEquivalent conversion needs to be moved into enclosingBlock.
-    RefPtr<Element> startBlock = enclosingBlock(insertionPosition.parentAnchoredEquivalent().protectedContainerNode());
+    RefPtr<Element> startBlock = enclosingBlock(protect(insertionPosition.parentAnchoredEquivalent().containerNode()));
     Position canonicalPos = VisiblePosition(insertionPosition).deepEquivalent();
     if (!startBlock
         || !startBlock->nonShadowBoundaryParentNode()

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -151,24 +151,24 @@ static Position positionAvoidingPrecedingNodes(Position position)
     ASSERT(position.isNotNull());
 
     // If we're already on a break, it's probably a placeholder and we shouldn't change our position.
-    if (editingIgnoresContent(*position.protectedDeprecatedNode()))
+    if (editingIgnoresContent(*protect(position.deprecatedNode())))
         return position;
 
     // We also stop when changing block flow elements because even though the visual position is the
     // same.  E.g.,
     //   <div>foo^</div>^
     // The two positions above are the same visual position, but we want to stay in the same block.
-    RefPtr enclosingBlockNode { enclosingBlock(position.protectedContainerNode()) };
+    RefPtr enclosingBlockNode { enclosingBlock(protect(position.containerNode())) };
     for (Position nextPosition = position; nextPosition.containerNode() != enclosingBlockNode; position = nextPosition) {
         if (lineBreakExistsAtPosition(position))
             break;
 
         if (position.containerNode()->nonShadowBoundaryParentNode())
-            nextPosition = positionInParentAfterNode(position.protectedContainerNode().get());
+            nextPosition = positionInParentAfterNode(protect(position.containerNode()).get());
 
         if (nextPosition == position)
             break;
-        if (enclosingBlock(nextPosition.protectedContainerNode()) != enclosingBlockNode)
+        if (enclosingBlock(protect(nextPosition.containerNode())) != enclosingBlockNode)
             break;
         if (VisiblePosition(position) != VisiblePosition(nextPosition))
             break;
@@ -1123,7 +1123,7 @@ static bool isInlineNodeWithStyle(const Node& node)
 
 inline RefPtr<Node> nodeToSplitToAvoidPastingIntoInlineNodesWithStyle(const Position& insertionPos)
 {
-    auto containingBlock = enclosingBlock(insertionPos.protectedContainerNode());
+    auto containingBlock = enclosingBlock(protect(insertionPos.containerNode()));
     return highestEnclosingNodeOfType(insertionPos, isInlineNodeWithStyle, CannotCrossEditingBoundary, containingBlock.get());
 }
 
@@ -1181,7 +1181,7 @@ void ReplaceSelectionCommand::doApply()
     bool selectionEndWasEndOfParagraph = isEndOfParagraph(visibleEnd);
     bool selectionStartWasStartOfParagraph = isStartOfParagraph(visibleStart);
 
-    RefPtr startBlock { enclosingBlock(visibleStart.deepEquivalent().protectedDeprecatedNode()) };
+    RefPtr startBlock { enclosingBlock(protect(visibleStart.deepEquivalent().deprecatedNode())) };
 
     Position insertionPos = selection.start();
     bool shouldHandleMailBlockquote = enclosingNodeOfType(insertionPos, isMailBlockquote, CanCrossEditingBoundary) && !m_ignoreMailBlockquote;
@@ -1264,7 +1264,7 @@ void ReplaceSelectionCommand::doApply()
     if (endBR)
         originalVisPosBeforeEndBR = VisiblePosition(positionBeforeNode(endBR.get())).previous();
     
-    RefPtr<Node> insertionBlock = enclosingBlock(insertionPos.protectedDeprecatedNode());
+    RefPtr<Node> insertionBlock = enclosingBlock(protect(insertionPos.deprecatedNode()));
     
     // Adjust insertionPos to prevent nesting.
     // If the start was in a Mail blockquote, we will have already handled adjusting insertionPos above.
@@ -1345,7 +1345,7 @@ void ReplaceSelectionCommand::doApply()
     if (refNode)
         fragment.removeNode(*refNode);
 
-    RefPtr blockStart { enclosingBlock(insertionPos.protectedDeprecatedNode()) };
+    RefPtr blockStart { enclosingBlock(protect(insertionPos.deprecatedNode())) };
     bool isInsertingIntoList = (isListHTMLElement(refNode.get()) || (isLegacyAppleStyleSpan(refNode.get()) && isListHTMLElement(refNode->firstChild())))
     && blockStart && blockStart->renderer()->isRenderListItem() && blockStart->parentNode()->hasEditableStyle();
     if (isInsertingIntoList)
@@ -1490,7 +1490,7 @@ void ReplaceSelectionCommand::doApply()
         if (selectionEndWasEndOfParagraph || !isEndOfParagraph(endOfInsertedContent) || next.isNull()) {
             if (!isStartOfParagraph(endOfInsertedContent)) {
                 setEndingSelection(endOfInsertedContent);
-                RefPtr enclosingNode = enclosingBlock(endOfInsertedContent.deepEquivalent().protectedDeprecatedNode());
+                RefPtr enclosingNode = enclosingBlock(protect(endOfInsertedContent.deepEquivalent().deprecatedNode()));
                 if (enclosingNode && isListItem(*enclosingNode)) {
                     auto newListItem = HTMLLIElement::create(document());
                     insertNodeAfter(newListItem.copyRef(), *enclosingNode);

--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -255,7 +255,7 @@ bool selectionAllowsSmartLists(const String& text, const VisibleSelection& selec
         return false;
     }
 
-    if (enclosingList(selection.base().protectedAnchorNode().get())) {
+    if (enclosingList(protect(selection.base().anchorNode()).get())) {
         // Smart Lists can not be "activated" if the selection is already within a list.
         return false;
     }

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -462,7 +462,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrBefore(const VisiblePos
     RefPtr highestRoot = highestEditableRoot(deepEquivalent());
     
     // Return empty position if pos is not somewhere inside the editable region containing this position
-    if (highestRoot && !position.deepEquivalent().protectedDeprecatedNode()->isDescendantOf(*highestRoot)) {
+    if (highestRoot && !protect(position.deepEquivalent().deprecatedNode())->isDescendantOf(*highestRoot)) {
         if (reachedBoundary)
             *reachedBoundary = true;
         return VisiblePosition();
@@ -499,7 +499,7 @@ VisiblePosition VisiblePosition::honorEditingBoundaryAtOrAfter(const VisiblePosi
     RefPtr highestRoot = highestEditableRoot(deepEquivalent());
     
     // Return empty position if otherPosition is not somewhere inside the editable region containing this position
-    if (highestRoot && !otherPosition.deepEquivalent().protectedDeprecatedNode()->isDescendantOf(*highestRoot)) {
+    if (highestRoot && !protect(otherPosition.deepEquivalent().deprecatedNode())->isDescendantOf(*highestRoot)) {
         if (reachedBoundary)
             *reachedBoundary = true;
         return VisiblePosition();
@@ -727,7 +727,7 @@ Element* enclosingBlockFlowElement(const VisiblePosition& visiblePosition)
     if (visiblePosition.isNull())
         return nullptr;
 
-    return deprecatedEnclosingBlockFlowElement(visiblePosition.deepEquivalent().protectedDeprecatedNode().get());
+    return deprecatedEnclosingBlockFlowElement(protect(visiblePosition.deepEquivalent().deprecatedNode()).get());
 }
 
 bool isFirstVisiblePositionInNode(const VisiblePosition& visiblePosition, const Node* node)
@@ -735,11 +735,11 @@ bool isFirstVisiblePositionInNode(const VisiblePosition& visiblePosition, const 
     if (visiblePosition.isNull())
         return false;
 
-    if (!visiblePosition.deepEquivalent().protectedContainerNode()->isDescendantOf(node))
+    if (!protect(visiblePosition.deepEquivalent().containerNode())->isDescendantOf(node))
         return false;
 
     VisiblePosition previous = visiblePosition.previous();
-    return previous.isNull() || !previous.deepEquivalent().protectedDeprecatedNode()->isDescendantOf(node);
+    return previous.isNull() || !protect(previous.deepEquivalent().deprecatedNode())->isDescendantOf(node);
 }
 
 bool isLastVisiblePositionInNode(const VisiblePosition& visiblePosition, const Node* node)
@@ -747,16 +747,16 @@ bool isLastVisiblePositionInNode(const VisiblePosition& visiblePosition, const N
     if (visiblePosition.isNull())
         return false;
 
-    if (!visiblePosition.deepEquivalent().protectedContainerNode()->isDescendantOf(node))
+    if (!protect(visiblePosition.deepEquivalent().containerNode())->isDescendantOf(node))
         return false;
 
     VisiblePosition next = visiblePosition.next();
-    return next.isNull() || !next.deepEquivalent().protectedDeprecatedNode()->isDescendantOf(node);
+    return next.isNull() || !protect(next.deepEquivalent().deprecatedNode())->isDescendantOf(node);
 }
 
 bool areVisiblePositionsInSameTreeScope(const VisiblePosition& a, const VisiblePosition& b)
 {
-    return connectedInSameTreeScope(a.deepEquivalent().protectedAnchorNode().get(), b.deepEquivalent().protectedAnchorNode().get());
+    return connectedInSameTreeScope(protect(a.deepEquivalent().anchorNode()).get(), protect(b.deepEquivalent().anchorNode()).get());
 }
 
 bool VisiblePosition::equals(const VisiblePosition& other) const

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -234,7 +234,7 @@ bool VisibleSelection::isAll(EditingBoundaryCrossingRule rule) const
 
 void VisibleSelection::appendTrailingWhitespace()
 {
-    RefPtr scope = deprecatedEnclosingBlockFlowElement(m_end.protectedDeprecatedNode().get());
+    RefPtr scope = deprecatedEnclosingBlockFlowElement(protect(m_end.deprecatedNode()).get());
     if (!scope)
         return;
 
@@ -300,7 +300,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
             VisiblePosition wordEnd(endOfWord(originalEnd, side));
             VisiblePosition end(wordEnd);
             
-            if (isEndOfParagraph(originalEnd) && !isEmptyTableCell(m_start.protectedDeprecatedNode().get())) {
+            if (isEndOfParagraph(originalEnd) && !isEmptyTableCell(protect(m_start.deprecatedNode()).get())) {
                 // Select the paragraph break (the space from the end of a paragraph to the start of 
                 // the next one) to match TextEdit.
                 end = wordEnd.next();
@@ -484,7 +484,7 @@ Position VisibleSelection::adjustPositionForEnd(const Position& currentPosition,
 
     ASSERT(&currentPosition.containerNode()->treeScope() != treeScope.ptr());
 
-    if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(currentPosition.protectedContainerNode().get())) {
+    if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(protect(currentPosition.containerNode()).get())) {
         if (ancestor->contains(startContainerNode))
             return positionAfterNode(ancestor.get());
         return positionBeforeNode(ancestor.get());
@@ -502,7 +502,7 @@ Position VisibleSelection::adjustPositionForStart(const Position& currentPositio
 
     ASSERT(&currentPosition.containerNode()->treeScope() != treeScope.ptr());
     
-    if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(currentPosition.protectedContainerNode().get())) {
+    if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(protect(currentPosition.containerNode()).get())) {
         if (ancestor->contains(endContainerNode))
             return positionBeforeNode(ancestor.get());
         return positionAfterNode(ancestor.get());
@@ -546,10 +546,10 @@ void VisibleSelection::adjustSelectionToAvoidCrossingShadowBoundaries()
 
     // Correct the focus if necessary.
     if (m_anchorIsFirst) {
-        m_extent = adjustPositionForEnd(m_end, m_start.protectedContainerNode().get());
+        m_extent = adjustPositionForEnd(m_end, protect(m_start.containerNode()).get());
         m_end = m_extent;
     } else {
-        m_extent = adjustPositionForStart(m_start, m_end.protectedContainerNode().get());
+        m_extent = adjustPositionForStart(m_start, protect(m_end.containerNode()).get());
         m_start = m_extent;
     }
     m_focus = m_extent;
@@ -569,7 +569,7 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
     auto startRoot = highestEditableRoot(m_start);
     auto endRoot = highestEditableRoot(m_end);
     
-    RefPtr baseEditableAncestor = lowestEditableAncestor(m_base.protectedContainerNode().get());
+    RefPtr baseEditableAncestor = lowestEditableAncestor(protect(m_base.containerNode()).get());
     
     // The base, start and end are all in the same region.  No adjustment necessary.
     if (baseRoot == startRoot && baseRoot == endRoot)
@@ -604,17 +604,17 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
     
         // The selection ends in editable content or non-editable content inside a different editable ancestor, 
         // move backward until non-editable content inside the same lowest editable ancestor is reached.
-        RefPtr endEditableAncestor = lowestEditableAncestor(m_end.protectedContainerNode().get());
+        RefPtr endEditableAncestor = lowestEditableAncestor(protect(m_end.containerNode()).get());
         if (endRoot || endEditableAncestor != baseEditableAncestor) {
             
             Position p = previousVisuallyDistinctCandidate(m_end);
             RefPtr shadowAncestor = endRoot ? endRoot->shadowHost() : nullptr;
             if (p.isNull() && shadowAncestor)
                 p = positionAfterNode(shadowAncestor.get());
-            while (p.isNotNull() && !(lowestEditableAncestor(p.protectedContainerNode().get()) == baseEditableAncestor && !isEditablePosition(p))) {
+            while (p.isNotNull() && !(lowestEditableAncestor(protect(p.containerNode()).get()) == baseEditableAncestor && !isEditablePosition(p))) {
                 RefPtr root = editableRootForPosition(p);
                 shadowAncestor = root ? root->shadowHost() : nullptr;
-                p = isAtomicNode(p.protectedContainerNode().get()) ? positionInParentBeforeNode(p.protectedContainerNode().get()) : previousVisuallyDistinctCandidate(p);
+                p = isAtomicNode(protect(p.containerNode()).get()) ? positionInParentBeforeNode(protect(p.containerNode()).get()) : previousVisuallyDistinctCandidate(p);
                 if (p.isNull() && shadowAncestor)
                     p = positionAfterNode(shadowAncestor.get());
             }
@@ -629,16 +629,16 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
 
         // The selection starts in editable content or non-editable content inside a different editable ancestor, 
         // move forward until non-editable content inside the same lowest editable ancestor is reached.
-        RefPtr startEditableAncestor = lowestEditableAncestor(m_start.protectedContainerNode().get());
+        RefPtr startEditableAncestor = lowestEditableAncestor(protect(m_start.containerNode()).get());
         if (startRoot || startEditableAncestor != baseEditableAncestor) {
             Position p = nextVisuallyDistinctCandidate(m_start);
             RefPtr shadowAncestor = startRoot ? startRoot->shadowHost() : nullptr;
             if (p.isNull() && shadowAncestor)
                 p = positionBeforeNode(shadowAncestor.get());
-            while (p.isNotNull() && !(lowestEditableAncestor(p.protectedContainerNode().get()) == baseEditableAncestor && !isEditablePosition(p))) {
+            while (p.isNotNull() && !(lowestEditableAncestor(protect(p.containerNode()).get()) == baseEditableAncestor && !isEditablePosition(p))) {
                 RefPtr root = editableRootForPosition(p);
                 shadowAncestor = root ? root->shadowHost() : nullptr;
-                p = isAtomicNode(p.protectedContainerNode().get()) ? positionInParentAfterNode(p.protectedContainerNode().get()) : nextVisuallyDistinctCandidate(p);
+                p = isAtomicNode(protect(p.containerNode()).get()) ? positionInParentAfterNode(protect(p.containerNode()).get()) : nextVisuallyDistinctCandidate(p);
                 if (p.isNull() && shadowAncestor)
                     p = positionBeforeNode(shadowAncestor.get());
             }
@@ -653,7 +653,7 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
     }
     
     // Correct the focus if necessary.
-    if (baseEditableAncestor != lowestEditableAncestor(m_extent.protectedContainerNode().get())) {
+    if (baseEditableAncestor != lowestEditableAncestor(protect(m_extent.containerNode()).get())) {
         m_extent = m_anchorIsFirst ? m_end : m_start;
         m_focus = m_extent;
     }
@@ -753,7 +753,7 @@ String VisibleSelection::debugDescription() const
 void VisibleSelection::showTreeForThis() const
 {
     if (RefPtr startAnchorNode = start().anchorNode()) {
-        startAnchorNode->showTreeAndMark(startAnchorNode.get(), "S"_s, end().protectedAnchorNode().get(), "E"_s);
+        startAnchorNode->showTreeAndMark(startAnchorNode.get(), "S"_s, protect(end().anchorNode()).get(), "E"_s);
         SAFE_FPRINTF(stderr, "start: ");
         start().showAnchorTypeAndOffset();
         SAFE_FPRINTF(stderr, "end: ");

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -1365,7 +1365,7 @@ VisiblePosition startOfBlock(const VisiblePosition& visiblePosition, EditingBoun
 {
     Position position = visiblePosition.deepEquivalent();
     RefPtr<Node> startBlock;
-    if (!position.containerNode() || !(startBlock = enclosingBlock(position.protectedContainerNode(), rule)))
+    if (!position.containerNode() || !(startBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
     return firstPositionInNode(startBlock.get());
 }
@@ -1374,14 +1374,14 @@ VisiblePosition endOfBlock(const VisiblePosition& visiblePosition, EditingBounda
 {
     Position position = visiblePosition.deepEquivalent();
     RefPtr<Node> endBlock;
-    if (!position.containerNode() || !(endBlock = enclosingBlock(position.protectedContainerNode(), rule)))
+    if (!position.containerNode() || !(endBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
     return lastPositionInNode(endBlock.get());
 }
 
 bool inSameBlock(const VisiblePosition& a, const VisiblePosition& b)
 {
-    return !a.isNull() && enclosingBlock(a.deepEquivalent().protectedContainerNode()) == enclosingBlock(b.deepEquivalent().protectedContainerNode());
+    return !a.isNull() && enclosingBlock(protect(a.deepEquivalent().containerNode())) == enclosingBlock(protect(b.deepEquivalent().containerNode()));
 }
 
 bool isStartOfBlock(const VisiblePosition& pos)
@@ -1413,7 +1413,7 @@ VisiblePosition startOfDocument(const Node* node)
 
 VisiblePosition startOfDocument(const VisiblePosition& c)
 {
-    return startOfDocument(c.deepEquivalent().protectedDeprecatedNode().get());
+    return startOfDocument(protect(c.deepEquivalent().deprecatedNode()).get());
 }
 
 VisiblePosition endOfDocument(const Node* node)
@@ -1434,7 +1434,7 @@ VisiblePosition endOfDocument(const Node* node)
 
 VisiblePosition endOfDocument(const VisiblePosition& c)
 {
-    return endOfDocument(c.deepEquivalent().protectedDeprecatedNode().get());
+    return endOfDocument(protect(c.deepEquivalent().deprecatedNode()).get());
 }
 
 bool isStartOfDocument(const VisiblePosition& p)

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -398,8 +398,8 @@ public:
         if (m_highestNodeToBeSerialized && m_highestNodeToBeSerialized->hasTagName(bodyTag))
             return;
 
-        auto block = enclosingBlock(start.deepEquivalent().protectedContainerNode());
-        if (!block || block != enclosingBlock(end.deepEquivalent().protectedContainerNode()))
+        auto block = enclosingBlock(protect(start.deepEquivalent().containerNode()));
+        if (!block || block != enclosingBlock(protect(end.deepEquivalent().containerNode())))
             return;
 
         auto renderer = block->renderer();
@@ -815,7 +815,7 @@ RefPtr<Node> StyledMarkupAccumulator::serializeNodes(const Position& start, cons
         return nullptr;
     RefPtr pastEnd = end.computeNodeAfterPosition();
     if (!pastEnd && end.containerNode())
-        pastEnd = nextSkippingChildren(*end.protectedContainerNode());
+        pastEnd = nextSkippingChildren(*protect(end.containerNode()));
 
     if (!m_highestNodeToBeSerialized)
         m_highestNodeToBeSerialized = traverseNodesForSerialization(*startNode, pastEnd.get(), NodeTraversalMode::DoNotEmitString);

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -108,7 +108,7 @@ String DOMURL::createPublicURL(ScriptExecutionContext& scriptExecutionContext, U
     if (publicURL.isEmpty())
         return String();
 
-    scriptExecutionContext.protectedPublicURLManager()->registerURL(publicURL, registrable);
+    protect(scriptExecutionContext.publicURLManager())->registerURL(publicURL, registrable);
 
     return publicURL.string();
 }
@@ -128,7 +128,7 @@ void DOMURL::revokeObjectURL(ScriptExecutionContext& scriptExecutionContext, con
 
     MemoryCache::removeRequestFromSessionCaches(scriptExecutionContext, request);
 
-    scriptExecutionContext.protectedPublicURLManager()->revoke(request.url());
+    protect(scriptExecutionContext.publicURLManager())->revoke(request.url());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1217,7 +1217,7 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
     m_frame->selection().setSelectionByMouseIfDifferent(newSelection, m_frame->selection().granularity(),
         FrameSelection::EndPointsAdjustmentMode::AdjustAtBidiBoundary);
 
-    if (oldSelection != newSelection && ImageOverlay::isOverlayText(newSelection.start().protectedContainerNode().get()) && ImageOverlay::isOverlayText(newSelection.end().protectedContainerNode().get()))
+    if (oldSelection != newSelection && ImageOverlay::isOverlayText(protect(newSelection.start().containerNode()).get()) && ImageOverlay::isOverlayText(protect(newSelection.end().containerNode()).get()))
         invalidateClick();
 }
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -212,7 +212,7 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
             continue;
         // We have to process in-line style as it might contain some resources (typically background images).
         if (RefPtr styledElement = dynamicDowncast<StyledElement>(*element))
-            retrieveResourcesForProperties(styledElement->protectedInlineStyle().get(), document.get());
+            retrieveResourcesForProperties(protect(styledElement->inlineStyle()).get(), document.get());
 
         if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(*element)) {
             auto url = document->completeURL(imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr));

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -240,7 +240,7 @@ RefPtr<SVGClipPathElement> ReferencedSVGResources::referencedClipPathElement(Tre
 
 RefPtr<SVGMarkerElement> ReferencedSVGResources::referencedMarkerElement(TreeScope& treeScope, const Style::URL& markerResource)
 {
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, treeScope.protectedDocumentScope());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(markerResource, protect(treeScope.documentScope()));
     if (resourceID.isEmpty())
         return nullptr;
 
@@ -249,7 +249,7 @@ RefPtr<SVGMarkerElement> ReferencedSVGResources::referencedMarkerElement(TreeSco
 
 RefPtr<SVGMaskElement> ReferencedSVGResources::referencedMaskElement(TreeScope& treeScope, const StyleImage& maskImage)
 {
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImage.url(), treeScope.protectedDocumentScope());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(maskImage.url(), protect(treeScope.documentScope()));
     if (resourceID.isEmpty())
         return nullptr;
 
@@ -263,7 +263,7 @@ RefPtr<SVGMaskElement> ReferencedSVGResources::referencedMaskElement(TreeScope& 
 
 RefPtr<SVGElement> ReferencedSVGResources::referencedPaintServerElement(TreeScope& treeScope, const Style::URL& uri)
 {
-    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(uri, treeScope.protectedDocumentScope());
+    auto resourceID = SVGURIReference::fragmentIdentifierFromIRIString(uri, protect(treeScope.documentScope()));
     if (resourceID.isEmpty())
         return nullptr;
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -873,7 +873,7 @@ static inline RenderElement* rendererForScrollbar(RenderLayerModelObject& render
     if (RefPtr element = renderer.element()) {
         if (RefPtr shadowRoot = element->containingShadowRoot()) {
             if (shadowRoot->mode() == ShadowRootMode::UserAgent)
-                return shadowRoot->protectedHost()->renderer();
+                return protect(shadowRoot->host())->renderer();
         }
     }
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2454,7 +2454,7 @@ static bool usesVisuallyContiguousBidiTextSelection(const SimpleRange& range)
     UNUSED_PARAM(range);
     return false;
 #else
-    return protect(range.protectedStartContainer()->document())->settings().visuallyContiguousBidiTextSelectionEnabled();
+    return protect(range.startContainer().document())->settings().visuallyContiguousBidiTextSelectionEnabled();
 #endif
 }
 

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -190,7 +190,7 @@ static inline CheckedPtr<LegacyRenderSVGResourceContainer> paintingResourceFromS
     if (!paintURL)
         return nullptr;
 
-    id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, treeScope.protectedDocumentScope());
+    id = SVGURIReference::fragmentIdentifierFromIRIString(*paintURL, protect(treeScope.documentScope()));
     CheckedPtr container = getRenderSVGResourceContainerById(treeScope, id);
     if (!container) {
         hasPendingResource = true;

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -960,7 +960,7 @@ void XMLDocumentParser::endElementNs()
             else
                 scriptElement->registerImportMap(ScriptSourceCode(scriptElement->scriptContent(), scriptElement->sourceTaintedOrigin(), URL(document()->url()), m_scriptStartPosition, JSC::SourceProviderSourceType::ImportMap));
         } else if (scriptElement->willBeParserExecuted() && scriptElement->loadableScript()) {
-            m_pendingScript = PendingScript::create(*scriptElement, *scriptElement->protectedLoadableScript());
+            m_pendingScript = PendingScript::create(*scriptElement, *protect(scriptElement->loadableScript()));
             RefPtr { m_pendingScript }->setClient(*this);
 
             // m_pendingScript will be nullptr if script was already loaded and setClient() executed it.

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -194,7 +194,7 @@ static Ref<WebKit::WebFrame> protectedFrame(WKWebProcessPlugInFrame *frame)
     RefPtr coreFrame = protectedFrame(self)->coreLocalFrame();
     if (!coreFrame)
         return nil;
-    return coreFrame->protectedDocument()->protectedSecurityOrigin()->toString().createNSString().autorelease();
+    return protect(protect(coreFrame->document())->securityOrigin())->toString().createNSString().autorelease();
 }
 
 static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<WebCore::LinkIconType> iconTypes)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
@@ -103,7 +103,7 @@ static Ref<WebCore::Range> protectedImpl(WKDOMRange *range)
 
 - (WKDOMNode *)startContainer
 {
-    return WebKit::toWKDOMNode(protectedImpl(self)->protectedStartContainer().ptr());
+    return WebKit::toWKDOMNode(protect(protectedImpl(self)->startContainer()).ptr());
 }
 
 - (NSInteger)startOffset
@@ -113,7 +113,7 @@ static Ref<WebCore::Range> protectedImpl(WKDOMRange *range)
 
 - (WKDOMNode *)endContainer
 {
-    return WebKit::toWKDOMNode(protectedImpl(self)->protectedEndContainer().ptr());
+    return WebKit::toWKDOMNode(protect(protectedImpl(self)->endContainer()).ptr());
 }
 
 - (NSInteger)endOffset

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -319,7 +319,7 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 
     IntRect rangeRect = frame.protectedView()->contentsToWindow(quads[0].enclosingBoundingBox());
 
-    const CheckedPtr style = range.protectedStartContainer()->renderStyle();
+    const CheckedPtr style = protect(range.startContainer())->renderStyle();
     float scaledAscent = style ? style->metricsOfPrimaryFont().intAscent() * pageScaleFactor() : 0;
     dictionaryPopupInfo.origin = FloatPoint(rangeRect.x(), rangeRect.y() + scaledAscent);
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -502,7 +502,7 @@ void FindController::didFindString()
 
     CheckedRef selection = selectedFrame->selection();
     selection->revealSelection();
-    revealClosedDetailsAndHiddenUntilFoundAncestors(*selection->selection().start().protectedAnchorNode());
+    revealClosedDetailsAndHiddenUntilFoundAncestors(*protect(selection->selection().start().anchorNode()));
 }
 
 void FindController::didHideFindIndicator()

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -202,7 +202,7 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
         case FindDecorationStyle::Highlighted: {
             m_highlightedRange = range;
 
-            auto ancestorsRevealed = revealClosedDetailsAndHiddenUntilFoundAncestors(simpleRange->protectedStartContainer());
+            auto ancestorsRevealed = revealClosedDetailsAndHiddenUntilFoundAncestors(protect(simpleRange->startContainer()));
 
             if (m_findPageOverlay)
                 setTextIndicatorWithRange(*simpleRange);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -871,7 +871,7 @@ bool WebFrame::allowsFollowingLink(const URL& url) const
     if (!localFrame)
         return true;
 
-    return localFrame->protectedDocument()->protectedSecurityOrigin()->canDisplay(url, WebCore::OriginAccessPatternsForWebProcess::singleton());
+    return protect(protect(localFrame->document())->securityOrigin())->canDisplay(url, WebCore::OriginAccessPatternsForWebProcess::singleton());
 }
 
 JSGlobalContextRef WebFrame::jsContext()

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1723,8 +1723,8 @@ static bool insideImageOverlay(const VisiblePosition& position)
 
 static std::optional<SimpleRange> expandForImageOverlay(const SimpleRange& range)
 {
-    VisiblePosition expandedStart(makeContainerOffsetPosition(range.protectedStartContainer(), range.startOffset()));
-    VisiblePosition expandedEnd(makeContainerOffsetPosition(range.protectedEndContainer(), range.endOffset()));
+    VisiblePosition expandedStart(makeContainerOffsetPosition(protect(range.startContainer()), range.startOffset()));
+    VisiblePosition expandedEnd(makeContainerOffsetPosition(protect(range.endContainer()), range.endOffset()));
 
     for (auto start = expandedStart; insideImageOverlay(start); start = start.previous()) {
         if (RefPtr container = start.deepEquivalent().containerNode(); is<Text>(container)) {


### PR DESCRIPTION
#### 91dd963fc136bbac4182ed0331e3ac9114c25e76
<pre>
Drop more `protected*()` member functions in Source/WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=306848">https://bugs.webkit.org/show_bug.cgi?id=306848</a>

Reviewed by Ryosuke Niwa.

Drop more `protected*()` member functions in Source/WebCore/dom by adopting
`protect()` at call sites.

Also make `protect()` work with JSC::VM. Although, JSC::VM doesn&apos;t have
ref() / deref() functions, it has the suitable RefPtr Traits for work
with Ref and RefPtr. This was needed to get rid of `protectedVM()` in
the dom/ folder.

* Source/JavaScriptCore/runtime/VM.h:
* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::ApplePayPaymentHandler::computeErrors const):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
* Source/WebCore/dom/AbstractRange.cpp:
(WebCore::AbstractRange::protectedStartContainer const): Deleted.
(WebCore::AbstractRange::protectedEndContainer const): Deleted.
* Source/WebCore/dom/AbstractRange.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::caretPositionFromPoint):
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::beforeStartOfCurrentBlock):
(WebCore::afterEndOfCurrentBlock):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::atFirstEditingPositionForNode const):
(WebCore::Position::atLastEditingPositionForNode const):
(WebCore::Position::atStartOfTree const):
(WebCore::Position::atEndOfTree const):
(WebCore::Position::protectedContainerText const): Deleted.
* Source/WebCore/dom/Position.h:
(WebCore::Position::anchorNode const):
(WebCore::Position::deprecatedNode const):
(WebCore::Position::protectedContainerNode const): Deleted.
(WebCore::Position::protectedAnchorNode const): Deleted.
(WebCore::Position::protectedDeprecatedNode const): Deleted.
* Source/WebCore/dom/PositionIterator.h:
(WebCore::PositionIterator::node const):
(WebCore::PositionIterator::protectedNode const): Deleted.
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::protectedSheet const): Deleted.
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::Range):
(WebCore::Range::~Range):
(WebCore::Range::updateAssociatedSelection):
(WebCore::Range::updateAssociatedHighlight):
(WebCore::Range::updateDocument):
(WebCore::Range::processContents):
(WebCore::Range::cloneRange const):
(WebCore::Range::updateRangeForParentlessNodeMovedToNewDocument):
(WebCore::Range::expand):
(WebCore::makeSimpleRange):
(WebCore::Range::protectedOwnerDocument): Deleted.
(WebCore::Range::protectedStartContainer const): Deleted.
(WebCore::Range::protectedEndContainer const): Deleted.
* Source/WebCore/dom/Range.h:
* Source/WebCore/dom/RangeBoundaryPoint.h:
(WebCore::RangeBoundaryPoint::protectedContainer const): Deleted.
* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::element const):
(WebCore::ScriptElement::loadableScript):
(WebCore::ScriptElement::protectedElement const): Deleted.
(WebCore::ScriptElement::protectedLoadableScript): Deleted.
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::protectedTopOrigin const): Deleted.
(WebCore::ScriptExecutionContext::protectedVM): Deleted.
(WebCore::ScriptExecutionContext::protectedPublicURLManager): Deleted.
(WebCore::ScriptExecutionContext::protectedNativePromiseDispatcher): Deleted.
(WebCore::ScriptExecutionContext::protectedSocketProvider): Deleted.
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContextInlines.h:
(WebCore::ScriptExecutionContext::enqueueTaskWhenSettled):
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::protectedSecurityOrigin const): Deleted.
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/dom/ShadowRoot.h:
* Source/WebCore/dom/SimpleRange.h:
(WebCore::SimpleRange::startContainer const):
(WebCore::SimpleRange::endContainer const):
(WebCore::SimpleRange::protectedStartContainer const): Deleted.
(WebCore::SimpleRange::protectedEndContainer const): Deleted.
(WebCore::IntersectingNodeIterator::protectedNode const): Deleted.
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::ManualSlotAssignment::addSlotElementByName):
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::protectedInlineStyle const): Deleted.
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::elementFromPoint):
(WebCore::TreeScope::protectedDocumentScope const): Deleted.
* Source/WebCore/dom/TreeScope.h:
(WebCore::TreeScope::documentScope const):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::applyBlockStyle):
(WebCore::ApplyStyleCommand::splitTextElementAtStart):
(WebCore::ApplyStyleCommand::splitTextElementAtEnd):
(WebCore::ApplyStyleCommand::mergeStartWithPreviousIfIdentical):
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::prepareWhitespaceAtPositionForSplit):
(WebCore::CompositeEditCommand::replaceCollapsibleWhitespaceWithNonBreakingSpaceIfNeeded):
(WebCore::CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary):
(WebCore::CompositeEditCommand::cloneParagraphUnderNewElement):
(WebCore::CompositeEditCommand::moveParagraphWithClones):
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::handleGeneralDelete):
(WebCore::DeleteSelectionCommand::mergeParagraphs):
(WebCore::DeleteSelectionCommand::removePreviouslySelectedEmptyTableRows):
(WebCore::DeleteSelectionCommand::doApply):
* Source/WebCore/editing/Editing.cpp:
(WebCore::firstEditablePositionAfterPositionInRoot):
(WebCore::lastEditablePositionBeforePositionInRoot):
(WebCore::directionOfEnclosingBlock):
(WebCore::enclosingEmptyListItem):
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::EditingStyle):
(WebCore::EditingStyle::prepareToApplyAt):
(WebCore::elementMatchesAndPropertyIsNotInInlineStyleDecl):
(WebCore::EditingStyle::mergeInlineAndImplicitStyleOfElement):
(WebCore::EditingStyle::textDirectionForSelection):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectionStartHasMarkerFor const):
(WebCore::Editor::selectionStartSetMarkerForTesting):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::removingNodeRemovesPosition):
(WebCore::FrameSelection::updateFromAssociatedLiveRange):
* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::indentIntoBlockquote):
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::adjacentEnclosingList):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::InsertParagraphSeparatorCommand::doApply):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::positionAvoidingPrecedingNodes):
(WebCore::nodeToSplitToAvoidPastingIntoInlineNodesWithStyle):
(WebCore::ReplaceSelectionCommand::doApply):
* Source/WebCore/editing/TextListParser.cpp:
(WebCore::selectionAllowsSmartLists):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::honorEditingBoundaryAtOrBefore const):
(WebCore::VisiblePosition::honorEditingBoundaryAtOrAfter const):
(WebCore::enclosingBlockFlowElement):
(WebCore::isFirstVisiblePositionInNode):
(WebCore::isLastVisiblePositionInNode):
(WebCore::areVisiblePositionsInSameTreeScope):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::appendTrailingWhitespace):
(WebCore::VisibleSelection::adjustSelectionRespectingGranularity):
(WebCore::VisibleSelection::adjustPositionForEnd):
(WebCore::VisibleSelection::adjustPositionForStart):
(WebCore::VisibleSelection::adjustSelectionToAvoidCrossingShadowBoundaries):
(WebCore::VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries):
(WebCore::VisibleSelection::showTreeForThis const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::startOfBlock):
(WebCore::endOfBlock):
(WebCore::inSameBlock):
(WebCore::startOfDocument):
(WebCore::endOfDocument):
* Source/WebCore/editing/markup.cpp:
(WebCore::StyledMarkupAccumulator::serializeNodes):
* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::createPublicURL):
(WebCore::DOMURL::revokeObjectURL):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateSelectionForMouseDrag):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeFrame):
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::referencedMarkerElement):
(WebCore::ReferencedSVGResources::referencedMaskElement):
(WebCore::ReferencedSVGResources::referencedPaintServerElement):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::rendererForScrollbar):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::usesVisuallyContiguousBidiTextSelection):
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::paintingResourceFromSVGPaint):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::endElementNs):

Canonical link: <a href="https://commits.webkit.org/306750@main">https://commits.webkit.org/306750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3be78074e1cae0cd9331349565d25c80f3c58971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150832 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/178f7901-03ee-4f27-98c5-64496d2f5cc4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109330 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ffe9074-19c2-42c4-a865-85f0fb67dacc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90230 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d71e832-6413-4039-bba3-fcc215b2b6f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11384 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9047 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/868 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134186 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153185 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3006 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14277 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117388 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117711 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30009 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13763 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124488 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69977 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14326 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3524 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173491 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78042 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44900 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14103 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->