### PR TITLE
[JSC] Optimize `Intl.Segmenter` segment data object creation with pre-built Structure

### DIFF
--- a/JSTests/microbenchmarks/intl-segmenter-grapheme.js
+++ b/JSTests/microbenchmarks/intl-segmenter-grapheme.js
@@ -1,0 +1,27 @@
+function test() {
+    const segmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+    const testStrings = [
+        "Hello, World!",
+        "こんにちは世界",
+        "👨‍👩‍👧‍👦🏳️‍🌈",
+        "The quick brown fox jumps over the lazy dog.",
+        "日本語テキストのセグメンテーション",
+        "Mixed: 日本語 and English テキスト",
+        "Emoji: 😀😃😄😁😆😅🤣😂🙂🙃",
+    ];
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        for (const str of testStrings) {
+            const segments = segmenter.segment(str);
+            for (const segment of segments) {
+                count++;
+            }
+        }
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 1270000)
+    throw new Error("Bad result: " + result);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -941,6 +941,7 @@
 		37AAC094279F1C0500D64842 /* WasmBranchHints.h in Headers */ = {isa = PBXBuildFile; fileRef = 37AAC091279F124200D64842 /* WasmBranchHints.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37C738D21EDB56E4003F2B0B /* ParseInt.h in Headers */ = {isa = PBXBuildFile; fileRef = 37C738D11EDB5672003F2B0B /* ParseInt.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3910AB742F3087FD00BAA633 /* LexerUnicodeProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 3910AB732F3087FD00BAA633 /* LexerUnicodeProperties.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3910AB842F3203AD00BAA633 /* IntlSegmentDataObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3910AB832F3203AD00BAA633 /* IntlSegmentDataObject.h */; };
 		412952771D2CF6BC00E78B89 /* builtins_generate_internals_wrapper_header.py in Headers */ = {isa = PBXBuildFile; fileRef = 412952731D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_header.py */; settings = {ATTRIBUTES = (Private, ); }; };
 		412952781D2CF6BC00E78B89 /* builtins_generate_internals_wrapper_implementation.py in Headers */ = {isa = PBXBuildFile; fileRef = 412952741D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_implementation.py */; settings = {ATTRIBUTES = (Private, ); }; };
 		412952791D2CF6BC00E78B89 /* builtins_generate_wrapper_header.py in Headers */ = {isa = PBXBuildFile; fileRef = 412952751D2CF6AC00E78B89 /* builtins_generate_wrapper_header.py */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4152,6 +4153,8 @@
 		37C738D11EDB5672003F2B0B /* ParseInt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParseInt.h; sourceTree = "<group>"; };
 		3910AB722F3087E500BAA633 /* LexerUnicodeProperties.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LexerUnicodeProperties.cpp; sourceTree = "<group>"; };
 		3910AB732F3087FD00BAA633 /* LexerUnicodeProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LexerUnicodeProperties.h; sourceTree = "<group>"; };
+		3910AB822F3203A200BAA633 /* IntlSegmentDataObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntlSegmentDataObject.cpp; sourceTree = "<group>"; };
+		3910AB832F3203AD00BAA633 /* IntlSegmentDataObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntlSegmentDataObject.h; sourceTree = "<group>"; };
 		412952731D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_header.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = builtins_generate_internals_wrapper_header.py; sourceTree = "<group>"; };
 		412952741D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_implementation.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = builtins_generate_internals_wrapper_implementation.py; sourceTree = "<group>"; };
 		412952751D2CF6AC00E78B89 /* builtins_generate_wrapper_header.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = builtins_generate_wrapper_header.py; sourceTree = "<group>"; };
@@ -8684,6 +8687,8 @@
 				A3BF884E24480BE0001B9F35 /* IntlRelativeTimeFormatConstructor.h */,
 				A3BF884B24480BDE001B9F35 /* IntlRelativeTimeFormatPrototype.cpp */,
 				A3BF884C24480BDF001B9F35 /* IntlRelativeTimeFormatPrototype.h */,
+				3910AB822F3203A200BAA633 /* IntlSegmentDataObject.cpp */,
+				3910AB832F3203AD00BAA633 /* IntlSegmentDataObject.h */,
 				E307178024C7824700DF0644 /* IntlSegmenter.cpp */,
 				E307178124C7824700DF0644 /* IntlSegmenter.h */,
 				E307178224C7824700DF0644 /* IntlSegmenterConstructor.cpp */,
@@ -11613,6 +11618,7 @@
 				E307178324C7827100DF0644 /* IntlRelativeTimeFormat.h in Headers */,
 				E307178424C7827700DF0644 /* IntlRelativeTimeFormatConstructor.h in Headers */,
 				E307178524C7827900DF0644 /* IntlRelativeTimeFormatPrototype.h in Headers */,
+				3910AB842F3203AD00BAA633 /* IntlSegmentDataObject.h in Headers */,
 				E307178724C7827E00DF0644 /* IntlSegmenter.h in Headers */,
 				E307178624C7827C00DF0644 /* IntlSegmenterConstructor.h in Headers */,
 				E307178824C7828100DF0644 /* IntlSegmenterPrototype.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -878,6 +878,7 @@ runtime/IntlRelativeTimeFormatConstructor.cpp
 runtime/IntlRelativeTimeFormatPrototype.cpp
 runtime/IntlSegmentIterator.cpp
 runtime/IntlSegmentIteratorPrototype.cpp
+runtime/IntlSegmentDataObject.cpp
 runtime/IntlSegmenter.cpp
 runtime/IntlSegmenterConstructor.cpp
 runtime/IntlSegmenterPrototype.cpp

--- a/Source/JavaScriptCore/runtime/IntlSegmentDataObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentDataObject.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IntlSegmentDataObject.h"
+
+#include "JSCInlines.h"
+
+namespace JSC {
+
+Structure* createSegmentDataObjectStructure(VM& vm, JSGlobalObject& globalObject)
+{
+    constexpr unsigned inlineCapacity = 3;
+    Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), inlineCapacity);
+    PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->segment, 0, offset);
+    RELEASE_ASSERT(offset == segmentDataObjectSegmentPropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->index, 0, offset);
+    RELEASE_ASSERT(offset == segmentDataObjectIndexPropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->input, 0, offset);
+    RELEASE_ASSERT(offset == segmentDataObjectInputPropertyOffset);
+    return structure;
+}
+
+Structure* createSegmentDataObjectWithIsWordLikeStructure(VM& vm, JSGlobalObject& globalObject)
+{
+    constexpr unsigned inlineCapacity = 4;
+    Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), inlineCapacity);
+    PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->segment, 0, offset);
+    RELEASE_ASSERT(offset == segmentDataObjectSegmentPropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->index, 0, offset);
+    RELEASE_ASSERT(offset == segmentDataObjectIndexPropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->input, 0, offset);
+    RELEASE_ASSERT(offset == segmentDataObjectInputPropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->isWordLike, 0, offset);
+    RELEASE_ASSERT(offset == segmentDataObjectIsWordLikePropertyOffset);
+    return structure;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlSegmentDataObject.h
+++ b/Source/JavaScriptCore/runtime/IntlSegmentDataObject.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IntlSegmenter.h"
+#include "JSGlobalObject.h"
+#include "ObjectConstructor.h"
+
+namespace JSC {
+
+static constexpr PropertyOffset segmentDataObjectSegmentPropertyOffset = 0;
+static constexpr PropertyOffset segmentDataObjectIndexPropertyOffset = 1;
+static constexpr PropertyOffset segmentDataObjectInputPropertyOffset = 2;
+static constexpr PropertyOffset segmentDataObjectIsWordLikePropertyOffset = 3;
+
+Structure* createSegmentDataObjectStructure(VM&, JSGlobalObject&);
+Structure* createSegmentDataObjectWithIsWordLikeStructure(VM&, JSGlobalObject&);
+
+ALWAYS_INLINE JSObject* createSegmentDataObject(JSGlobalObject* globalObject, JSString* string, int32_t startIndex, int32_t endIndex, UBreakIterator& segmenter, IntlSegmenter::Granularity granularity)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSString* segment = jsSubstring(globalObject, string, startIndex, endIndex - startIndex);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    Structure* structure = (granularity == IntlSegmenter::Granularity::Word)
+        ? globalObject->segmentDataObjectWithIsWordLikeStructure()
+        : globalObject->segmentDataObjectStructure();
+
+    JSObject* result = constructEmptyObject(vm, structure);
+    result->putDirectOffset(vm, segmentDataObjectSegmentPropertyOffset, segment);
+    result->putDirectOffset(vm, segmentDataObjectIndexPropertyOffset, jsNumber(startIndex));
+    result->putDirectOffset(vm, segmentDataObjectInputPropertyOffset, string);
+
+    if (granularity == IntlSegmenter::Granularity::Word) {
+        int32_t ruleStatus = ubrk_getRuleStatus(&segmenter);
+        result->putDirectOffset(vm, segmentDataObjectIsWordLikePropertyOffset,
+            jsBoolean(!(ruleStatus >= UBRK_WORD_NONE && ruleStatus <= UBRK_WORD_NONE_LIMIT)));
+    }
+
+    return result;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlSegmentIterator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmentIterator.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IntlSegmentIterator.h"
 
+#include "IntlSegmentDataObject.h"
 #include "IteratorOperations.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
@@ -77,7 +78,7 @@ JSObject* IntlSegmentIterator::next(JSGlobalObject* globalObject)
     int32_t endIndex = ubrk_next(m_segmenter.get());
     if (endIndex == UBRK_DONE)
         return createIteratorResultObject(globalObject, jsUndefined(), true);
-    JSObject* object = IntlSegmenter::createSegmentDataObject(globalObject, m_string.get(), startIndex, endIndex, *m_segmenter, m_granularity);
+    JSObject* object = createSegmentDataObject(globalObject, m_string.get(), startIndex, endIndex, *m_segmenter, m_granularity);
     RETURN_IF_EXCEPTION(scope, { });
     return createIteratorResultObject(globalObject, object, false);
 }

--- a/Source/JavaScriptCore/runtime/IntlSegmenter.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegmenter.cpp
@@ -27,6 +27,7 @@
 #include "IntlSegmenter.h"
 
 #include "IntlObjectInlines.h"
+#include "IntlSegmentDataObject.h"
 #include "IntlSegments.h"
 #include "IntlWorkaround.h"
 #include "JSCInlines.h"
@@ -162,23 +163,6 @@ ASCIILiteral IntlSegmenter::granularityString(Granularity granularity)
     }
     ASSERT_NOT_REACHED();
     return { };
-}
-
-JSObject* IntlSegmenter::createSegmentDataObject(JSGlobalObject* globalObject, JSString* string, int32_t startIndex, int32_t endIndex, UBreakIterator& segmenter, Granularity granularity)
-{
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    JSObject* result = constructEmptyObject(globalObject);
-    JSString* substring = jsSubstring(globalObject, string, startIndex, endIndex - startIndex);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    result->putDirect(vm, vm.propertyNames->segment, substring);
-    result->putDirect(vm, vm.propertyNames->index, jsNumber(startIndex));
-    result->putDirect(vm, vm.propertyNames->input, string);
-    if (granularity == IntlSegmenter::Granularity::Word) {
-        int32_t ruleStatus = ubrk_getRuleStatus(&segmenter);
-        result->putDirect(vm, vm.propertyNames->isWordLike, jsBoolean(!(ruleStatus >= UBRK_WORD_NONE && ruleStatus <= UBRK_WORD_NONE_LIMIT)));
-    }
-    return result;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlSegmenter.h
+++ b/Source/JavaScriptCore/runtime/IntlSegmenter.h
@@ -62,8 +62,6 @@ public:
     JSValue segment(JSGlobalObject*, JSValue) const;
     JSObject* resolvedOptions(JSGlobalObject*) const;
 
-    static JSObject* createSegmentDataObject(JSGlobalObject*, JSString*, int32_t startIndex, int32_t endIndex, UBreakIterator&, Granularity);
-
 private:
     IntlSegmenter(VM&, Structure*);
     DECLARE_DEFAULT_FINISH_CREATION;

--- a/Source/JavaScriptCore/runtime/IntlSegments.cpp
+++ b/Source/JavaScriptCore/runtime/IntlSegments.cpp
@@ -27,6 +27,7 @@
 #include "IntlSegments.h"
 
 #include "IntlObjectInlines.h"
+#include "IntlSegmentDataObject.h"
 #include "IntlSegmentIterator.h"
 #include "IntlWorkaround.h"
 #include "JSCInlines.h"
@@ -84,7 +85,7 @@ JSValue IntlSegments::containing(JSGlobalObject* globalObject, JSValue indexValu
         endIndex = m_buffer->size();
 
     scope.release();
-    return IntlSegmenter::createSegmentDataObject(globalObject, m_string.get(), startIndex, endIndex, *m_segmenter, m_granularity);
+    return createSegmentDataObject(globalObject, m_string.get(), startIndex, endIndex, *m_segmenter, m_granularity);
 }
 
 // https://tc39.es/proposal-intl-segmenter/#sec-%segmentsprototype%-@@iterator

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -108,6 +108,7 @@
 #include "IntlPluralRulesPrototype.h"
 #include "IntlRelativeTimeFormat.h"
 #include "IntlRelativeTimeFormatPrototype.h"
+#include "IntlSegmentDataObject.h"
 #include "IntlSegmentIterator.h"
 #include "IntlSegmentIteratorPrototype.h"
 #include "IntlSegmenter.h"
@@ -1620,6 +1621,14 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
             IntlSegmentsPrototype* segmentsPrototype = IntlSegmentsPrototype::create(init.vm, globalObject, IntlSegmentsPrototype::createStructure(init.vm, globalObject, globalObject->objectPrototype()));
             init.set(IntlSegments::createStructure(init.vm, globalObject, segmentsPrototype));
         });
+    m_segmentDataObjectStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            init.set(createSegmentDataObjectStructure(init.vm, *init.owner));
+        });
+    m_segmentDataObjectWithIsWordLikeStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            init.set(createSegmentDataObjectWithIsWordLikeStructure(init.vm, *init.owner));
+        });
 
     m_dateTimeFormatStructure.initLater(
         [] (LazyClassStructure::Initializer& init) {
@@ -2847,6 +2856,8 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_segmentIteratorStructure.visit(visitor);
     thisObject->m_segmenterStructure.visit(visitor);
     thisObject->m_segmentsStructure.visit(visitor);
+    thisObject->m_segmentDataObjectStructure.visit(visitor);
+    thisObject->m_segmentDataObjectWithIsWordLikeStructure.visit(visitor);
     thisObject->m_dateTimeFormatStructure.visit(visitor);
     thisObject->m_numberFormatStructure.visit(visitor);
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -272,6 +272,8 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_segmentIteratorStructure;
     LazyProperty<JSGlobalObject, Structure> m_segmenterStructure;
     LazyProperty<JSGlobalObject, Structure> m_segmentsStructure;
+    LazyProperty<JSGlobalObject, Structure> m_segmentDataObjectStructure;
+    LazyProperty<JSGlobalObject, Structure> m_segmentDataObjectWithIsWordLikeStructure;
     LazyClassStructure m_dateTimeFormatStructure;
     LazyClassStructure m_numberFormatStructure;
 
@@ -966,6 +968,8 @@ public:
     Structure* segmentIteratorStructure() { return m_segmentIteratorStructure.get(this); }
     Structure* segmenterStructure() { return m_segmenterStructure.get(this); }
     Structure* segmentsStructure() { return m_segmentsStructure.get(this); }
+    Structure* segmentDataObjectStructure() { return m_segmentDataObjectStructure.get(this); }
+    Structure* segmentDataObjectWithIsWordLikeStructure() { return m_segmentDataObjectWithIsWordLikeStructure.get(this); }
     Structure* trustedScriptStructure() { return m_trustedScriptStructure.get(); }
 
     JSObject* dateTimeFormatConstructor() { return m_dateTimeFormatStructure.constructor(this); }


### PR DESCRIPTION
#### 31d781e3386c2d49388d3c0274abd1baa52f5e28
<pre>
[JSC] Optimize `Intl.Segmenter` segment data object creation with pre-built Structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=306853">https://bugs.webkit.org/show_bug.cgi?id=306853</a>

Reviewed by Yusuke Suzuki.

This patch optimizes the creation of segment data objects returned by
Intl.Segmenter by using pre-built Structures with known property offsets,
similar to the pattern used in RegExpMatchesArray.

                                 TipOfTree                  Patched

intl-segmenter-grapheme       96.5302+-2.6148     ^     79.4703+-1.1308        ^ definitely 1.2147x faster

Test: JSTests/microbenchmarks/intl-segmenter-grapheme.js

* JSTests/microbenchmarks/intl-segmenter-grapheme.js: Added.
(test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/IntlSegmentDataObject.cpp: Added.
(JSC::createSegmentDataObjectStructure):
(JSC::createSegmentDataObjectWithIsWordLikeStructure):
* Source/JavaScriptCore/runtime/IntlSegmentDataObject.h: Added.
(JSC::createSegmentDataObject):
* Source/JavaScriptCore/runtime/IntlSegmentIterator.cpp:
(JSC::IntlSegmentIterator::next):
* Source/JavaScriptCore/runtime/IntlSegmenter.cpp:
(JSC::IntlSegmenter::createSegmentDataObject): Deleted.
* Source/JavaScriptCore/runtime/IntlSegmenter.h:
* Source/JavaScriptCore/runtime/IntlSegments.cpp:
(JSC::IntlSegments::containing):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::segmentDataObjectStructure):
(JSC::JSGlobalObject::segmentDataObjectWithIsWordLikeStructure):

Canonical link: <a href="https://commits.webkit.org/306748@main">https://commits.webkit.org/306748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a4ef2aa19377409fadab672d4b3c323979355e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95264 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109222 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78941 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90119 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11293 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8955 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/754 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134072 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120627 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153071 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2892 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14163 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117294 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117614 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13662 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69863 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14212 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3407 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173377 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77928 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44877 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/13989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->