### PR TITLE
[WebDriver BiDi] Add preload script support in the UIProcess

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -87,7 +87,8 @@
                 "UnableToLoadExtension",
                 "UnableToUnloadExtension",
                 "NoSuchExtension",
-                "NoSuchUserContext"
+                "NoSuchUserContext",
+                "NoSuchScript"
             ]
         },
         {

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp
@@ -58,6 +58,7 @@ using BrowsingContext = Inspector::Protocol::BidiBrowsingContext::BrowsingContex
 using EvaluateResultType = Inspector::Protocol::BidiScript::EvaluateResultType;
 
 static RefPtr<Inspector::Protocol::BidiScript::RemoteValue> deserializeRemoteValue(const JSON::Value*);
+static Ref<JSON::Value> deserializeLocalValue(const JSON::Value&);
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BidiScriptAgent);
 
@@ -153,6 +154,155 @@ static RefPtr<Inspector::Protocol::BidiScript::RemoteValue> deserializeRemoteVal
     return resultValue.setType(RemoteValueType::Undefined).release();
 }
 
+static Ref<JSON::Value> deserializeLocalValue(const JSON::Value& jsonValue)
+{
+    // Deserializes a BiDi LocalValue into a JSON::Value that can be passed to evaluateJavaScriptFunction.
+    // Per WebDriver BiDi spec: https://w3c.github.io/webdriver-bidi/#type-script-LocalValue
+    // LocalValue represents primitive values (string, number, boolean, etc.) as well as structured
+    // types (array, object, map, set, date, regexp). This function converts them into a format
+    // that WebKit's script evaluation machinery can consume.
+    //
+    // FIXME: Implement RemoteReference and Channel types.
+    // https://bugs.webkit.org/show_bug.cgi?id=288057
+
+    auto object = jsonValue.asObject();
+    if (!object) {
+        // If it's not a LocalValue object, pass it through as-is (backwards compatibility).
+        return const_cast<JSON::Value&>(jsonValue);
+    }
+
+    String typeString = object->getString("type"_s);
+
+    // Primitive types: string, number, bigint, boolean, undefined, null
+    if (typeString == "string"_s)
+        return JSON::Value::create(object->getString("value"_s));
+
+    if (typeString == "number"_s) {
+        // Numbers can be represented as either a double or a special string (NaN, Infinity, -Infinity, -0).
+        if (auto num = object->getDouble("value"_s))
+            return JSON::Value::create(*num);
+        // Special number values like "NaN", "Infinity", "-Infinity", "-0" are strings in BiDi.
+        return JSON::Value::create(object->getString("value"_s));
+    }
+
+    if (typeString == "boolean"_s) {
+        if (auto b = object->getBoolean("value"_s))
+            return JSON::Value::create(*b);
+        return JSON::Value::create(false);
+    }
+
+    if (typeString == "bigint"_s) {
+        // BigInt values are represented as strings in BiDi (e.g., "42n").
+        // Pass them through as strings since JSON doesn't have native bigint support.
+        return JSON::Value::create(object->getString("value"_s));
+    }
+
+    if (typeString == "undefined"_s)
+        return JSON::Value::null(); // JSON doesn't have undefined, use null as proxy.
+
+    if (typeString == "null"_s)
+        return JSON::Value::null();
+
+    // Date type: ISO 8601 string
+    if (typeString == "date"_s)
+        return JSON::Value::create(object->getString("value"_s));
+
+    // RegExp type: object with pattern and flags
+    if (typeString == "regexp"_s) {
+        if (auto value = object->getValue("value"_s))
+            return value.releaseNonNull();
+        return JSON::Value::null();
+    }
+
+    // Array type: recursive deserialization
+    if (typeString == "array"_s) {
+        auto valueArray = object->getArray("value"_s);
+        if (!valueArray)
+            return JSON::Array::create();
+
+        auto resultArray = JSON::Array::create();
+        for (unsigned i = 0; i < valueArray->length(); ++i) {
+            Ref element = valueArray->get(i);
+            resultArray->pushValue(deserializeLocalValue(element.get()));
+        }
+        return resultArray;
+    }
+
+    // Object type: recursive deserialization of properties
+    if (typeString == "object"_s) {
+        auto valueArray = object->getArray("value"_s);
+        if (!valueArray)
+            return JSON::Object::create();
+
+        auto resultObject = JSON::Object::create();
+        // Per BiDi spec, object value is an array of [key, value] pairs.
+        for (unsigned i = 0; i < valueArray->length(); ++i) {
+            auto pairValue = valueArray->get(i);
+            auto pairArray = pairValue->asArray();
+            if (!pairArray || pairArray->length() < 2)
+                continue;
+
+            // Extract key (must be string or convertible to string)
+            String key;
+            Ref keyValue = pairArray->get(0);
+            if (auto keyObj = keyValue->asObject()) {
+                // If key is a LocalValue, deserialize it first
+                auto deserializedKey = deserializeLocalValue(keyValue.get());
+                key = deserializedKey->asString();
+            } else
+                key = keyValue->asString();
+
+            // Extract value
+            if (!key.isEmpty()) {
+                Ref valueElement = pairArray->get(1);
+                resultObject->setValue(key, deserializeLocalValue(valueElement.get()));
+            }
+        }
+        return resultObject;
+    }
+
+    // Map type: convert to array of [key, value] pairs
+    if (typeString == "map"_s) {
+        auto valueArray = object->getArray("value"_s);
+        if (!valueArray)
+            return JSON::Array::create();
+
+        auto resultArray = JSON::Array::create();
+        for (unsigned i = 0; i < valueArray->length(); ++i) {
+            auto pairValue = valueArray->get(i);
+            auto pairArray = pairValue->asArray();
+            if (!pairArray || pairArray->length() < 2)
+                continue;
+
+            auto entryArray = JSON::Array::create();
+            Ref keyElement = pairArray->get(0);
+            entryArray->pushValue(deserializeLocalValue(keyElement.get()));
+            Ref valueElement = pairArray->get(1);
+            entryArray->pushValue(deserializeLocalValue(valueElement.get()));
+
+            resultArray->pushArray(WTF::move(entryArray));
+        }
+        return resultArray;
+    }
+
+    // Set type: convert to array
+    if (typeString == "set"_s) {
+        auto valueArray = object->getArray("value"_s);
+        if (!valueArray)
+            return JSON::Array::create();
+
+        auto resultArray = JSON::Array::create();
+        for (unsigned i = 0; i < valueArray->length(); ++i) {
+            Ref element = valueArray->get(i);
+            resultArray->pushValue(deserializeLocalValue(element.get()));
+        }
+        return resultArray;
+    }
+
+    // For any unknown types or unsupported types, return null as a safe fallback.
+    return JSON::Value::null();
+}
+
 void BidiScriptAgent::callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& arguments, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&& callback)
 {
     RefPtr session = m_session.get();
@@ -172,10 +322,21 @@ void BidiScriptAgent::callFunction(const String& functionDeclaration, bool await
     // FIXME: handle custom `this` option.
     // FIXME: handle `userActivation` option.
 
-    Ref<JSON::Array> argumentsArray = arguments ? arguments.releaseNonNull() : JSON::Array::create();
+    // Deserialize LocalValue arguments into plain JSON values for script evaluation.
+    // FIXME: Implement RemoteReference and Channel types for arguments <https://webkit.org/b/288057>
+    auto argumentsArray = JSON::Array::create();
+    if (arguments) {
+        for (unsigned i = 0; i < arguments->length(); ++i) {
+            Ref argValue = arguments->get(i);
+            argumentsArray->pushValue(deserializeLocalValue(argValue.get()));
+        }
+    }
 
     String realmID = generateRealmIdForBrowsingContext(*browsingContext);
     session->evaluateJavaScriptFunction(topLevelContextHandle, frameHandle, functionDeclaration, WTF::move(argumentsArray), false, optionalUserActivation.value_or(false), std::nullopt, [callback = WTF::move(callback), realmID](Inspector::CommandResult<String>&& stringResult) {
+        // FIXME: Properly serialize RemoteValue types according to WebDriver BiDi spec.
+        // https://bugs.webkit.org/show_bug.cgi?id=301159
+
         // FIXME: Properly fill ExceptionDetails remaining fields once we have a way to get them instead of just the error message.
         // https://bugs.webkit.org/show_bug.cgi?id=288058
         if (!stringResult) {
@@ -422,6 +583,153 @@ void BidiScriptAgent::getRealms(const BrowsingContext& optionalBrowsingContext, 
     // Process pages asynchronously using getAllFrameTrees.
     processRealmsForPagesAsync(WTF::move(pagesToProcess), WTF::move(optionalRealmType), WTF::move(contextHandleFilter), { }, WTF::move(callback));
 }
+
+void BidiScriptAgent::addPreloadScript(const String& functionDeclaration, RefPtr<JSON::Array>&& optionalArguments, RefPtr<JSON::Array>&& optionalContexts, const String& optionalSandbox, RefPtr<JSON::Array>&& optionalUserContexts, Inspector::CommandCallback<String>&& callback)
+{
+    // FIXME: Add resource limits to prevent denial of service <https://webkit.org/b/288057>
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(functionDeclaration.isEmpty(), InvalidParameter, "functionDeclaration cannot be empty"_s);
+
+    auto scriptID = PreloadScriptIdentifier::generate();
+
+    // Validate mutual exclusion of contexts and userContexts
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(optionalContexts && optionalUserContexts, InvalidParameter, "contexts and userContexts are mutually exclusive"_s);
+
+    Variant<AllContextsTag, Vector<String>> contexts { AllContextsTag { } };
+    if (optionalContexts) {
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!optionalContexts->length(), InvalidParameter, "contexts array cannot be empty"_s);
+
+        Vector<String> contextList;
+        for (auto& value : *optionalContexts) {
+            String context;
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!value->asString(context), InvalidParameter, "contexts array must contain only strings"_s);
+
+            // Look up the context first, then check if it's a top-level context per spec.
+            RefPtr session = m_session.get();
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+
+            RefPtr page = session->webPageProxyForHandle(context);
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!page, FrameNotFound);
+
+            // Check if it's a top-level context (page handle format starts with "page-")
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!context.startsWith("page-"_s), InvalidParameter, "contexts must be top-level browsing contexts"_s);
+
+            contextList.append(context);
+        }
+        contexts = WTF::move(contextList);
+    }
+
+    std::optional<Vector<String>> userContexts;
+    if (optionalUserContexts) {
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!optionalUserContexts->length(), InvalidParameter, "userContexts array cannot be empty"_s);
+
+        Vector<String> userContextList;
+        for (auto& value : *optionalUserContexts) {
+            String userContext;
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!value->asString(userContext), InvalidParameter, "userContexts array must contain only strings"_s);
+
+            // Validate userContext ID actually exists
+            RefPtr session = m_session.get();
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
+            ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session->isValidUserContext(userContext), NoSuchUserContext);
+
+            userContextList.append(userContext);
+        }
+        userContexts = WTF::move(userContextList);
+    }
+
+    m_preloadScripts.append(std::make_pair(scriptID, PreloadScriptInfo {
+        functionDeclaration,
+        WTF::move(optionalArguments),
+        WTF::move(contexts),
+        optionalSandbox,
+        WTF::move(userContexts)
+    }));
+
+    callback(makeString("preload-"_s, scriptID.toUInt64()));
+}
+
+void BidiScriptAgent::removePreloadScript(const String& script, Inspector::CommandCallback<void>&& callback)
+{
+    // Parse the script ID from the string (format: "preload-{number}")
+    if (!script.startsWith("preload-"_s))
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR(NoSuchScript);
+
+    auto idString = script.substring(8); // Skip "preload-" prefix
+    auto idValue = parseInteger<uint64_t>(idString);
+    if (!idValue || !PreloadScriptIdentifier::isValidIdentifier(*idValue))
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR(NoSuchScript);
+
+    auto scriptID = PreloadScriptIdentifier(*idValue);
+    bool found = m_preloadScripts.removeFirstMatching([&scriptID](const auto& pair) {
+        return pair.first == scriptID;
+    });
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!found, NoSuchScript);
+
+    callback({ });
+}
+
+void BidiScriptAgent::executePreloadScriptsForContext(const String& browsingContext, const String& frameHandle)
+{
+    RefPtr session = m_session.get();
+    if (!session)
+        return;
+
+    for (const auto& [scriptID, scriptInfo] : m_preloadScripts) {
+        // Check if this script applies to the current browsing context
+        bool appliesToContext = WTF::switchOn(scriptInfo.contexts,
+            [&] (const AllContextsTag&) {
+                return true;
+            },
+            [&] (const Vector<String>& contextList) {
+                return contextList.contains(browsingContext);
+            });
+        if (!appliesToContext)
+            continue;
+
+        // Check if this script applies to the current user context
+        if (scriptInfo.userContexts) {
+            RefPtr page = session->webPageProxyForHandle(browsingContext);
+            if (!page)
+                continue; // Skip if page no longer exists
+
+            // Get the user context ID for this browsing context
+            String pageUserContextID;
+            if (page->sessionID() == PAL::SessionID::defaultSessionID())
+                pageUserContextID = "default"_s;
+            else
+                pageUserContextID = makeString(hex(page->sessionID().toUInt64(), 16));
+
+            // Check if the script's userContexts list includes this context
+            if (!scriptInfo.userContexts->contains(pageUserContextID))
+                continue;
+        }
+
+        // FIXME: Execute preload scripts in the sandbox realm specified by addPreloadScript. <https://webkit.org/b/305819>
+        // FIXME: Create channels and remote references for preload script arguments in the target realm. <https://webkit.org/b/288057>
+
+        // Deserialize LocalValue arguments into plain JSON values for script evaluation.
+        auto argumentsArray = JSON::Array::create();
+        if (scriptInfo.arguments) {
+            for (unsigned i = 0; i < scriptInfo.arguments->length(); ++i) {
+                Ref argValue = scriptInfo.arguments->get(i);
+                argumentsArray->pushValue(deserializeLocalValue(argValue.get()));
+            }
+        }
+
+        session->evaluateJavaScriptFunction(
+            browsingContext,
+            frameHandle,
+            scriptInfo.functionDeclaration,
+            WTF::move(argumentsArray),
+            false,
+            false,
+            std::nullopt,
+            [](auto) { }
+        );
+    }
+}
+
 
 RefPtr<Inspector::Protocol::BidiScript::RealmInfo> BidiScriptAgent::createRealmInfoForFrame(const FrameInfoData& frameInfo)
 {

--- a/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiScriptAgent.h
@@ -39,11 +39,16 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/ObjectIdentifier.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Variant.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {
+
+enum PreloadScriptIdentifierType { };
+using PreloadScriptIdentifier = ObjectIdentifier<PreloadScriptIdentifierType, uint64_t>;
 
 class WebAutomationSession;
 class WebFrameProxy;
@@ -67,6 +72,8 @@ public:
     ~BidiScriptAgent() override;
 
     // Inspector::BidiScriptBackendDispatcherHandler methods.
+    void addPreloadScript(const String& functionDeclaration, RefPtr<JSON::Array>&& optionalArguments, RefPtr<JSON::Array>&& optionalContexts, const String& optionalSandbox, RefPtr<JSON::Array>&& optionalUserContexts, Inspector::CommandCallback<String>&&) override;
+    void removePreloadScript(const String& script, Inspector::CommandCallback<void>&&) override;
     void callFunction(const String& functionDeclaration, bool awaitPromise, Ref<JSON::Object>&& target, RefPtr<JSON::Array>&& optionalArguments, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions, RefPtr<JSON::Object>&& optionalThis, std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
     void evaluate(const String& expression, bool awaitPromise, Ref<JSON::Object>&& target, std::optional<Inspector::Protocol::BidiScript::ResultOwnership>&&, RefPtr<JSON::Object>&& optionalSerializationOptions,  std::optional<bool>&& optionalUserActivation, Inspector::CommandCallbackOf<Inspector::Protocol::BidiScript::EvaluateResultType, String, RefPtr<Inspector::Protocol::BidiScript::RemoteValue>, RefPtr<Inspector::Protocol::BidiScript::ExceptionDetails>>&&) override;
     void getRealms(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext& optionalBrowsingContext , std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&) override;
@@ -84,7 +91,19 @@ public:
     // Access active realms for realm destruction without WebFrameProxy.
     const HashMap<RealmIdentifier, RealmInfo>& activeRealms() const { return m_activeRealms; }
 
+    void executePreloadScriptsForContext(const String& browsingContext, const String& frameHandle);
+
 private:
+    struct AllContextsTag { };
+
+    struct PreloadScriptInfo {
+        String functionDeclaration;
+        RefPtr<JSON::Array> arguments;
+        Variant<AllContextsTag, Vector<String>> contexts;
+        String sandbox;
+        std::optional<Vector<String>> userContexts;
+    };
+
     void sendRealmCreatedEvent(const String& realmID, const WebCore::SecurityOriginData&, Inspector::Protocol::BidiScript::RealmType, Inspector::Protocol::BidiBrowsingContext::BrowsingContext);
 
     void processRealmsForPagesAsync(Deque<Ref<WebPageProxy>>&& pagesToProcess, std::optional<Inspector::Protocol::BidiScript::RealmType>&& optionalRealmType, std::optional<String>&& contextHandleFilter, Vector<RefPtr<Inspector::Protocol::BidiScript::RealmInfo>>&& accumulated, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiScript::RealmInfo>>>&&);
@@ -106,6 +125,11 @@ private:
 
     // Store active realms (key: realm identifier, value: realm info).
     HashMap<RealmIdentifier, RealmInfo> m_activeRealms;
+
+    // Track realm counters for navigation detection: frame ID -> counter
+    HashMap<WebCore::FrameIdentifier, uint64_t> m_frameRealmCounters;
+
+    Vector<std::pair<PreloadScriptIdentifier, PreloadScriptInfo>> m_preloadScripts;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -1101,9 +1101,15 @@ void WebAutomationSession::navigationStartedForFrame(const WebFrameProxy& frame,
 
 void WebAutomationSession::navigationCommittedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
 {
+    auto frameHandle = effectiveHandleForWebFrameProxy(frame);
     m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::NavigationCommitted, { }, [&]() {
-        m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
+        m_bidiProcessor->browsingContextDomainNotifier().navigationCommitted(frameHandle, navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
     });
+
+    if (RefPtr page = frame.page()) {
+        auto pageHandle = handleForWebPageProxy(*page);
+        m_bidiProcessor->scriptAgent().executePreloadScriptsForContext(pageHandle, frame.isMainFrame() ? emptyString() : frameHandle);
+    }
 }
 
 void WebAutomationSession::navigationFailedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
@@ -1125,6 +1131,7 @@ void WebAutomationSession::fragmentNavigatedForFrame(const WebFrameProxy& frame,
     m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::FragmentNavigated, { }, [&]() {
         m_bidiProcessor->browsingContextDomainNotifier().fragmentNavigated(effectiveHandleForWebFrameProxy(frame), navigationIDToProtocolString(navigationID), WallTime::now().secondsSinceEpoch().milliseconds(), frame.url().string());
     });
+    // NOTE: fragment navigations don't create a new document, and therefore do not trigger preload scripts.
 }
 
 void WebAutomationSession::emitContextCreatedEvent(const WebPageProxy& page)
@@ -1175,7 +1182,7 @@ void WebAutomationSession::willDestroyFrame(const WebFrameProxy& frame)
 
 void WebAutomationSession::contextCreatedForFrame(const WebFrameProxy& frame)
 {
-    auto contextHandle = effectiveHandleForWebFrameProxy(frame);
+    auto frameHandle = effectiveHandleForWebFrameProxy(frame);
     auto url = frame.url().string();
     String parentHandle = "null"_s;
     if (RefPtr parentFrame = frame.parentFrame())
@@ -1192,7 +1199,7 @@ void WebAutomationSession::contextCreatedForFrame(const WebFrameProxy& frame)
     }
 
     m_bidiProcessor->emitEventIfEnabled(BidiEventNames::BrowsingContext::ContextCreated, { }, [&]() {
-        m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+        m_bidiProcessor->browsingContextDomainNotifier().contextCreated(frameHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
     });
 }
 

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -154,6 +154,8 @@ static String toBidiErrorCode(int errorCode, const String& inspectorInternalMsg)
         return "no such web extension"_s;
     case Inspector::Protocol::Automation::ErrorMessage::NoSuchUserContext:
         return "no such user context"_s;
+    case Inspector::Protocol::Automation::ErrorMessage::NoSuchScript:
+        return "no such script"_s;
     default:
         return "unknown error"_s;
     }

--- a/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
+++ b/Source/WebKit/UIProcess/Automation/protocol/BidiScript.json
@@ -187,6 +187,31 @@
     ],
     "commands": [
         {
+            "name": "addPreloadScript",
+            "description": "Adds a preload script to be evaluated on new document creation.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-script-addPreloadScript",
+            "async": true,
+            "parameters": [
+                { "name": "functionDeclaration", "type": "string" },
+                { "name": "arguments", "type": "array", "items": { "$ref": "BidiScript.LocalValue" }, "optional": true },
+                { "name": "contexts", "type": "array", "items": { "$ref": "BidiBrowsingContext.BrowsingContext" }, "optional": true },
+                { "name": "sandbox", "type": "string", "optional": true },
+                { "name": "userContexts", "type": "array", "items": { "$ref": "BidiBrowser.UserContext" }, "optional": true }
+            ],
+            "returns": [
+                { "name": "script", "type": "string" }
+            ]
+        },
+        {
+            "name": "removePreloadScript",
+            "description": "Removes a preload script.",
+            "spec": "https://w3c.github.io/webdriver-bidi/#command-script-removePreloadScript",
+            "async": true,
+            "parameters": [
+                { "name": "script", "type": "string" }
+            ]
+        },
+        {
             "name": "callFunction",
             "description": "Calls a provided function with given arguments in a given realm.",
             "spec": "https://w3c.github.io/webdriver-bidi/#command-script-callFunction",

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -3302,25 +3302,157 @@
     },
 
     "imported/w3c/webdriver/tests/bidi/script/add_preload_script/add_preload_script.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288057"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288057"}},
+        "subtests": {
+            "test_add_same_preload_script_twice": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/script/add_preload_script/arguments.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288057"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288057"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/add_preload_script/contexts.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288057"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288057"}},
+        "subtests": {
+            "test_page_script_context_isolation[tab]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_page_script_context_isolation[window]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_identical_contexts": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        }
     },
     "imported/w3c/webdriver/tests/bidi/script/add_preload_script/execution_order_tentative.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288057"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288057"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/add_preload_script/invalid.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288057"}}
+        "subtests": {
+            "test_params_function_declaration_invalid_type[None]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_function_declaration_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_function_declaration_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_function_declaration_invalid_type[function_declaration3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_function_declaration_invalid_type[function_declaration4]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_arguments_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_arguments_invalid_type[SOME_STRING]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_arguments_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_arguments_invalid_type[arguments3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_invalid_type[_UNKNOWN_]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_invalid_type[contexts3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_empty_list": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_context_invalid_type[None]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_context_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_context_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_context_invalid_type[value3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_context_invalid_type[value4]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_context_invalid_value[]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_contexts_context_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_sandbox_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_sandbox_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_sandbox_invalid_type[sandbox2]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_sandbox_invalid_type[sandbox3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_invalid_type[_UNKNOWN_]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_invalid_type[user_contexts3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_empty_list": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_entry_invalid_type[None]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_entry_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_entry_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_entry_invalid_type[value3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_entry_invalid_type[value4]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_entry_invalid_value[]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_contexts_entry_invalid_value[somestring]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_user_context_and_contexts": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288057"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/add_preload_script/sandbox.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288057"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288057"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/add_preload_script/user_contexts.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288057"}}
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288057"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/call_function/arguments.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288058"}}
@@ -3997,13 +4129,46 @@
         }
     },
     "imported/w3c/webdriver/tests/bidi/script/remove_preload_script/invalid.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288062"}}
+        "subtests": {
+            "test_params_script_invalid_type[None]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_script_invalid_type[False]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_script_invalid_type[42]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_script_invalid_type[script3]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_script_invalid_type[script4]": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_params_script_invalid_value": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288062"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/remove_preload_script/remove_preload_script.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288062"}}
+        "subtests": {
+            "test_remove_preload_script_twice": {
+                "expected": { "all": { "status": ["PASS"]}}
+            },
+            "test_remove_one_of_preload_scripts": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288062"}}
     },
     "imported/w3c/webdriver/tests/bidi/script/remove_preload_script/sandbox.py": {
-        "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288062"}}
+        "subtests": {
+            "test_remove_preload_script_from_sandbox": {
+                "expected": { "all": { "status": ["PASS"]}}
+            }
+        },
+        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288062"}}
     },
 
     "imported/w3c/webdriver/tests/bidi/session/capabilities/unhandled_prompt_behavior/file/accept.py": {


### PR DESCRIPTION
#### 17a80254d05ddb1a135e4357b1fa812539652ff0
<pre>
[WebDriver BiDi] Add preload script support in the UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=288057">https://bugs.webkit.org/show_bug.cgi?id=288057</a>

Reviewed by BJ Burg.

Add the initial UIProcess implementation for `script.addPreloadScript` and
`script.removePreloadScript`.

This patch adds the BiDi protocol entries, preload script storage and
identifier handling, basic parameter validation, and execution hooks for new
document creation. It also wires `NoSuchScript` through the Automation error
enum so invalid preload script removals map to the correct BiDi error.

`userContexts` and `contexts` are now validated and used to filter preload
script execution. Preload script arguments are deserialized from supported
BiDi `LocalValue` forms before evaluation.

Sandbox realm execution, channel / remote reference argument handling, and
resource limits remain follow-up work.

* Source/WebKit/UIProcess/Automation/protocol/BidiScript.json:
Add `addPreloadScript` and `removePreloadScript`. Extend
`addPreloadScript` with `arguments`, `contexts`, `sandbox`, and
`userContexts` parameters.

* Source/WebKit/UIProcess/Automation/Automation.json:
Add `NoSuchScript` to the Automation error enum.

* Source/WebKit/UIProcess/Automation/BidiScriptAgent.h:
Add preload script command handlers, `PreloadScriptIdentifier`,
`PreloadScriptInfo`, and storage for ordered preload script metadata.

* Source/WebKit/UIProcess/Automation/BidiScriptAgent.cpp:
(WebKit::BidiScriptAgent::addPreloadScript): Validate and store preload script
metadata and generate script identifiers.
(WebKit::BidiScriptAgent::removePreloadScript): Remove stored preload scripts
by identifier and return `NoSuchScript` for unknown ids.
(WebKit::BidiScriptAgent::executePreloadScriptsForContext): Filter preload
scripts by browsing context and user context, deserialize supported
`LocalValue` arguments, and execute matching scripts.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::navigationCommittedForFrame): Execute preload
scripts when navigation commits a new document.
(WebKit::WebAutomationSession::fragmentNavigatedForFrame): Document that
fragment navigations do not create a new document and therefore do not trigger
preload scripts.

* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
Expose `scriptAgent()` for preload script execution.

* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::toBidiErrorCode): Map `NoSuchScript` to the corresponding BiDi error
code.

* WebDriverTests/TestExpectations.json:
Update preload-script expectations to reflect the new preload script coverage,
including `PASS` overrides for subtests that now succeed and expected `FAIL`
entries for behavior still deferred to follow-up work.

Canonical link: <a href="https://commits.webkit.org/310815@main">https://commits.webkit.org/310815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/025f2e842dae83a0acb156ced418af0f706d43f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108481 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119926 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100619 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21278 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19314 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11596 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130940 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166246 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128028 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34787 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138838 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84447 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15633 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->