### PR TITLE
Add support for transferring writable streams

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/deserialize-error.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/deserialize-error.window-expected.txt
@@ -1,5 +1,5 @@
 
-Harness Error (FAIL), message = Unhandled rejection: The object can not be cloned.
+Harness Error (TIMEOUT), message = null
 
 TIMEOUT a WritableStream deserialization failure should result in a DataCloneError Test timed out
 TIMEOUT a ReadableStream deserialization failure should result in a DataCloneError Test timed out

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transfer-with-messageport.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transfer-with-messageport.window-expected.txt
@@ -1,9 +1,9 @@
 
 PASS Transferring a MessagePort with a ReadableStream should set `.ports`
-FAIL Transferring a MessagePort with a WritableStream should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Transferring a MessagePort with a WritableStream should set `.ports`
 FAIL Transferring a MessagePort with a TransformStream should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
 PASS Transferring a MessagePort with a ReadableStream should set `.ports`, advanced
-FAIL Transferring a MessagePort with a WritableStream should set `.ports`, advanced promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Transferring a MessagePort with a WritableStream should set `.ports`, advanced
 FAIL Transferring a MessagePort with a TransformStream should set `.ports`, advanced promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
 FAIL Transferring a MessagePort with multiple streams should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
 PASS ReadableStream must not be serializable

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/writable-stream-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/writable-stream-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL window.postMessage should be able to transfer a WritableStream The object can not be cloned.
+PASS window.postMessage should be able to transfer a WritableStream
 PASS a locked WritableStream should not be transferable
-FAIL window.postMessage should be able to transfer a {readable, writable} pair The object can not be cloned.
-FAIL desiredSize for a newly-transferred stream should be 1 promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL effective queue size of a transferred writable should be 2 promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL second write should wait for first underlying write to complete promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL abort() should work promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL writing a unclonable object should error the stream promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS window.postMessage should be able to transfer a {readable, writable} pair
+PASS desiredSize for a newly-transferred stream should be 1
+PASS effective queue size of a transferred writable should be 2
+PASS second write should wait for first underlying write to complete
+PASS abort() should work
+PASS writing a unclonable object should error the stream
 

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.h
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.h
@@ -25,16 +25,18 @@
 
 #pragma once
 
+#include <WebCore/Exception.h>
+
 namespace WebCore {
 
 class DeferredPromise;
 class JSDOMGlobalObject;
 class ReadableStream;
 class WritableStream;
-class ReadableStreamDefaultReader;
-class InternalWritableStreamWriter;
 
 struct StreamPipeOptions;
 
-void readableStreamPipeTo(JSDOMGlobalObject&, Ref<ReadableStream>&&, Ref<WritableStream>&&, Ref<ReadableStreamDefaultReader>&&, Ref<InternalWritableStreamWriter>&&, StreamPipeOptions&&, RefPtr<DeferredPromise>&&);
+// https://streams.spec.whatwg.org/#readable-stream-pipe-to
+std::optional<Exception> readableStreamPipeTo(JSDOMGlobalObject&, ReadableStream&, WritableStream&, StreamPipeOptions&&, RefPtr<DeferredPromise>&&);
+
 }

--- a/Source/WebCore/Modules/streams/WritableStream.h
+++ b/Source/WebCore/Modules/streams/WritableStream.h
@@ -36,8 +36,13 @@ namespace WebCore {
 class Exception;
 class InternalWritableStream;
 class JSDOMGlobalObject;
+class MessagePort;
 class WritableStreamSink;
 template<typename> class ExceptionOr;
+
+struct DetachedWritableStream {
+    Ref<MessagePort> writableStreamPort;
+};
 
 class WritableStream : public RefCountedAndCanMakeWeakPtr<WritableStream> {
 public:
@@ -65,6 +70,10 @@ public:
 
     enum class State : uint8_t { Writable, Closed, Errored };
     State state() const;
+
+    bool canTransfer() const;
+    ExceptionOr<DetachedWritableStream> runTransferSteps(JSDOMGlobalObject&);
+    static ExceptionOr<Ref<WritableStream>> runTransferReceivingSteps(JSDOMGlobalObject&, DetachedWritableStream&&);
 
 protected:
     static ExceptionOr<Ref<WritableStream>> create(JSC::JSGlobalObject&, JSC::JSValue, JSC::JSValue);


### PR DESCRIPTION
#### fa1d314c98274376e53ae8e694f7dc3490667833
<pre>
Add support for transferring writable streams
<a href="https://rdar.apple.com/169526004">rdar://169526004</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306857">https://bugs.webkit.org/show_bug.cgi?id=306857</a>

Reviewed by Chris Dumez.

We implement writable stream transfer support like done for readable streams.
We use the same feature flag and reuse the same MessagePort strategy.
Covered by rebased WPT test.s

Canonical link: <a href="https://commits.webkit.org/306930@main">https://commits.webkit.org/306930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18cc37d27060778f50366b15993c799dcccc6a1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151493 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f6c7f31-eec0-40c0-8f75-0a1de5f214b1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109833 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb19f215-9b09-46e9-887d-e1a291fb288c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12292 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90742 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4237f960-200f-4f32-9241-bd000eb27bd3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11793 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9471 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1492 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121172 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153806 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14917 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117848 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14954 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30204 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14169 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125070 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70614 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14960 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4026 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78669 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14903 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14757 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->