### PR TITLE
[Skia] Add SkiaTextureAtlasPacker for 2D bin packing

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -22,6 +22,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/SkiaReplayCanvas.h
     platform/graphics/skia/SkiaSpanExtras.h
     platform/graphics/skia/SkiaSystemFallbackFontCache.h
+    platform/graphics/skia/SkiaTextureAtlasPacker.h
 )
 
 list(APPEND WebCore_LIBRARIES

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -64,5 +64,6 @@ platform/graphics/skia/SkiaPaintingEngine.cpp
 platform/graphics/skia/SkiaRecordingResult.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp
 platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
+platform/graphics/skia/SkiaTextureAtlasPacker.cpp
 
 platform/skia/SharedBufferSkia.cpp

--- a/Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.cpp
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaTextureAtlasPacker.h"
+
+#if USE(SKIA)
+
+#include <algorithm>
+#include <limits>
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+namespace SkiaTextureAtlasPacker {
+
+static Vector<PackedRect> shelfNextFitAlgorithm(std::span<const IntSize> sizes, const IntSize& atlasSize)
+{
+    if (sizes.empty())
+        return { };
+
+    if (auto it = std::ranges::find_if(sizes, &IntSize::isEmpty); it != sizes.end())
+        return { };
+
+    // Create indices sorted by height (descending) for better shelf packing.
+    Vector<size_t, 32> sortedIndices(sizes.size(), [](size_t index) {
+        return index;
+    });
+
+    std::ranges::sort(sortedIndices, [&sizes](size_t a, size_t b) {
+        return sizes[a].unclampedArea() > sizes[b].unclampedArea();
+    });
+
+    Vector<PackedRect> result;
+    result.reserveInitialCapacity(sizes.size());
+
+    int shelfY = 0;
+    int shelfX = 0;
+    int shelfHeight = 0;
+
+    for (size_t index : sortedIndices) {
+        const auto& size = sizes[index];
+
+        // Check if image fits on current shelf.
+        if (shelfX + size.width() > atlasSize.width()) {
+            // Start new shelf.
+            shelfY += shelfHeight;
+            shelfX = 0;
+            shelfHeight = 0;
+        }
+
+        // Check if image fits vertically.
+        if (shelfY + size.height() > atlasSize.height())
+            return { };
+
+        result.append({ IntRect(shelfX, shelfY, size.width(), size.height()), index });
+        shelfX += size.width();
+        shelfHeight = std::max(shelfHeight, size.height());
+    }
+
+    return result;
+}
+
+// Prune free rectangles: remove any rectangle fully contained within another.
+// Two-pass approach: first mark contained rectangles, then remove them.
+// This is O(n^2) but keeps the free list small for better performance overall.
+static void pruneFreeRectangles(Vector<IntRect, 16>& freeRectangles)
+{
+    Vector<bool, 16> shouldRemove(freeRectangles.size(), false);
+
+    for (size_t i = 0; i < freeRectangles.size(); ++i) {
+        if (shouldRemove[i])
+            continue;
+        for (size_t j = i + 1; j < freeRectangles.size(); ++j) {
+            if (shouldRemove[j])
+                continue;
+            if (freeRectangles[i].contains(freeRectangles[j]))
+                shouldRemove[j] = true;
+            else if (freeRectangles[j].contains(freeRectangles[i])) {
+                shouldRemove[i] = true;
+                break;
+            }
+        }
+    }
+
+    for (size_t i = freeRectangles.size(); i-- > 0;) {
+        if (shouldRemove[i])
+            freeRectangles.removeAt(i);
+    }
+}
+
+// MAXRECTS-BSSF (Best Short Side Fit) implementation.
+//
+// The algorithm maintains a list of free rectangles representing available space.
+// When placing a rectangle:
+// 1. Find the free rectangle where the shorter leftover side is minimized (BSSF)
+// 2. Split affected free rectangles around the placed rectangle
+// 3. Prune free rectangles that are fully contained within others
+//
+// Reference: Jukka Jylänki, "A Thousand Ways to Pack the Bin", Section 2.1.1
+static Vector<PackedRect> maxRectsAlgorithm(std::span<const IntSize> sizes, const IntSize& atlasSize)
+{
+    if (sizes.empty())
+        return { };
+
+    if (auto it = std::ranges::find_if(sizes, &IntSize::isEmpty); it != sizes.end())
+        return { };
+
+    // Free rectangles representing available space - starting with the entire atlas.
+    Vector<IntRect, 16> freeRectangles;
+    freeRectangles.append({ IntPoint::zero(), atlasSize });
+
+    // Sort input by area, descending - larger rectangles first improves packing.
+    Vector<size_t, 32> sortedIndices(sizes.size(), [](size_t index) {
+        return index;
+    });
+
+    std::ranges::sort(sortedIndices, [&sizes](size_t a, size_t b) {
+        return sizes[a].unclampedArea() > sizes[b].unclampedArea();
+    });
+
+    constexpr int maxInteger = std::numeric_limits<int>::max();
+    constexpr size_t maxSize = std::numeric_limits<size_t>::max();
+
+    Vector<PackedRect> result;
+    result.reserveInitialCapacity(sizes.size());
+
+    for (size_t index : sortedIndices) {
+        const auto& size = sizes[index];
+
+        // Find best free rectangle using BSSF (Best Short Side Fit) heuristic.
+        // This minimizes the shorter leftover side after placement.
+        int bestShortSideFit = maxInteger;
+        int bestLongSideFit = maxInteger;
+        size_t bestIndex = maxSize;
+        IntPoint bestPosition;
+
+        for (size_t i = 0; i < freeRectangles.size(); ++i) {
+            auto& freeRectangle = freeRectangles[i];
+
+            // Check if rectangle fits in this free rectangle.
+            if (size.width() <= freeRectangle.width() && size.height() <= freeRectangle.height()) {
+                int leftoverHorizontal = freeRectangle.width() - size.width();
+                int leftoverVertical = freeRectangle.height() - size.height();
+                int shortSideFit = std::min(leftoverHorizontal, leftoverVertical);
+                int longSideFit = std::max(leftoverHorizontal, leftoverVertical);
+
+                if (shortSideFit < bestShortSideFit || (shortSideFit == bestShortSideFit && longSideFit < bestLongSideFit)) {
+                    bestShortSideFit = shortSideFit;
+                    bestLongSideFit = longSideFit;
+                    bestIndex = i;
+                    bestPosition = freeRectangle.location();
+
+                    // Perfect fit found, stop searching.
+                    if (!shortSideFit && !longSideFit)
+                        break;
+                }
+            }
+        }
+
+        // No suitable free rectangle found - packing failed.
+        if (bestIndex == maxSize)
+            return { };
+
+        // Place the rectangle.
+        IntRect placedRectangle(bestPosition, size);
+        result.append({ placedRectangle, index });
+
+        // Split all free rectangles that intersect with the placed rectangle.
+        // This generates new free rectangles from the non-overlapping parts.
+        // We iterate only over original rectangles and collect results in a new vector.
+        Vector<IntRect, 16> newFreeRectangles;
+        for (const auto& freeRectangle : freeRectangles) {
+            if (!freeRectangle.intersects(placedRectangle)) {
+                newFreeRectangles.append(freeRectangle);
+                continue;
+            }
+
+            // Generate up to 4 new free rectangles from the non-overlapping parts.
+
+            // Left part
+            if (placedRectangle.x() > freeRectangle.x())
+                newFreeRectangles.append({ freeRectangle.x(), freeRectangle.y(), placedRectangle.x() - freeRectangle.x(), freeRectangle.height() });
+
+            // Right part
+            if (placedRectangle.maxX() < freeRectangle.maxX())
+                newFreeRectangles.append({ placedRectangle.maxX(), freeRectangle.y(), freeRectangle.maxX() - placedRectangle.maxX(), freeRectangle.height() });
+
+            // Top part
+            if (placedRectangle.y() > freeRectangle.y())
+                newFreeRectangles.append({ freeRectangle.x(), freeRectangle.y(), freeRectangle.width(), placedRectangle.y() - freeRectangle.y() });
+
+            // Bottom part
+            if (placedRectangle.maxY() < freeRectangle.maxY())
+                newFreeRectangles.append({ freeRectangle.x(), placedRectangle.maxY(), freeRectangle.width(), freeRectangle.maxY() - placedRectangle.maxY() });
+        }
+        freeRectangles = WTF::move(newFreeRectangles);
+
+        pruneFreeRectangles(freeRectangles);
+    }
+
+    return result;
+}
+
+Vector<PackedRect> pack(std::span<const IntSize> sizes, const IntSize& atlasSize, Algorithm algorithm)
+{
+    if (atlasSize.isEmpty())
+        return { };
+
+    switch (algorithm) {
+    case Algorithm::ShelfNextFit:
+        return shelfNextFitAlgorithm(sizes, atlasSize);
+    case Algorithm::MaxRects:
+        return maxRectsAlgorithm(sizes, atlasSize);
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+} // namespace SkiaTextureAtlasPacker
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include "IntRect.h"
+#include "IntSize.h"
+#include <span>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// 2D bin packing algorithms for texture atlas layout computation.
+//
+// References:
+// - Jukka Jylänki, "A Thousand Ways to Pack the Bin - A Practical Approach to Two-Dimensional Rectangle Bin Packing", 2010.
+//   https://github.com/juj/RectangleBinPack
+//
+// Algorithms:
+// - SHELF-NF (Shelf Next Fit): O(n log n) time, O(1) space.
+//   Simple and fast, best for similar-sized rectangles. ~70-80% occupancy.
+//
+// - MAXRECTS-BSSF (MaxRects Best Short Side Fit): O(n^2) time, O(n) space.
+//   Tracks all maximal free rectangles. Best for variable-sized rectangles.
+//   ~94% occupancy on benchmarks.
+//
+namespace SkiaTextureAtlasPacker {
+
+struct PackedRect {
+    IntRect rect;
+    size_t imageIndex { 0 };
+};
+
+enum class Algorithm {
+    ShelfNextFit,
+    MaxRects
+};
+
+// Pack rectangles into a fixed-size atlas.
+// Returns packed rectangles with positions, or empty vector if images don't fit.
+Vector<PackedRect> pack(std::span<const IntSize> sizes, const IntSize& atlasSize, Algorithm = Algorithm::MaxRects);
+
+}; // namespace SkiaTextureAtlasPacker
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -238,6 +238,12 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/WritingModeTests.cpp
     )
 
+    if (USE_SKIA)
+        list(APPEND TestWebCore_SOURCES
+            Tests/WebCore/skia/SkiaTextureAtlasPackerTests.cpp
+        )
+    endif ()
+
     set(TestWebCore_LIBRARIES
         WebKit::gtest
     )

--- a/Tools/TestWebKitAPI/Tests/WebCore/skia/SkiaTextureAtlasPackerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/skia/SkiaTextureAtlasPackerTests.cpp
@@ -1,0 +1,382 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Test.h"
+#include <WebCore/SkiaTextureAtlasPacker.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+// Helper to verify packed rectangles don't overlap.
+static bool rectanglesOverlap(const Vector<SkiaTextureAtlasPacker::PackedRect>& packed)
+{
+    for (size_t i = 0; i < packed.size(); ++i) {
+        const auto& rectA = packed[i].rect;
+        for (size_t j = i + 1; j < packed.size(); ++j) {
+            const auto& rectB = packed[j].rect;
+            if (rectA.intersects(rectB))
+                return true;
+        }
+    }
+    return false;
+}
+
+// Helper to verify all packed rectangles are within atlas bounds.
+static bool allWithinBounds(const Vector<SkiaTextureAtlasPacker::PackedRect>& packed, const IntSize& atlasSize)
+{
+    IntRect atlasBounds(0, 0, atlasSize.width(), atlasSize.height());
+    for (const auto& packedRect : packed) {
+        if (!atlasBounds.contains(packedRect.rect))
+            return false;
+    }
+    return true;
+}
+
+// Helper to verify all input rectangles are present in output.
+static bool allInputsPresent(const Vector<SkiaTextureAtlasPacker::PackedRect>& packed, std::span<const IntSize> sizes)
+{
+    if (packed.size() != sizes.size())
+        return false;
+
+    Vector<bool> found(sizes.size(), false);
+    for (const auto& packedRect : packed) {
+        if (packedRect.imageIndex >= sizes.size())
+            return false;
+        if (found[packedRect.imageIndex])
+            return false;
+        if (packedRect.rect.size() != sizes[packedRect.imageIndex])
+            return false;
+        found[packedRect.imageIndex] = true;
+    }
+    return true;
+}
+
+// MaxRects algorithm tests
+
+TEST(SkiaTextureAtlasPackerMaxRects, EmptyInput)
+{
+    Vector<IntSize> sizes;
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, SingleRectangle)
+{
+    Vector<IntSize> sizes { { 50, 50 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_EQ(0U, result[0].imageIndex);
+    EXPECT_EQ(50, result[0].rect.width());
+    EXPECT_EQ(50, result[0].rect.height());
+    EXPECT_EQ(0, result[0].rect.x());
+    EXPECT_EQ(0, result[0].rect.y());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, ExactFit)
+{
+    Vector<IntSize> sizes { { 100, 100 } };
+    IntSize atlasSize(100, 100);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, RectangleTooLarge)
+{
+    Vector<IntSize> sizes { { 300, 300 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, MultipleSimilarSized)
+{
+    Vector<IntSize> sizes { { 50, 50 }, { 50, 50 }, { 50, 50 }, { 50, 50 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(4U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, MultipleVariableSized)
+{
+    Vector<IntSize> sizes { { 100, 50 }, { 30, 80 }, { 60, 60 }, { 20, 20 }, { 45, 90 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(5U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, ManySmallRectangles)
+{
+    Vector<IntSize> sizes(20, { 20, 20 });
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(20U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, TotalAreaExceedsAtlas)
+{
+    Vector<IntSize> sizes(10, { 100, 100 });
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, WideRectangle)
+{
+    Vector<IntSize> sizes { { 200, 30 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, TallRectangle)
+{
+    Vector<IntSize> sizes { { 30, 200 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, MixedWideAndTall)
+{
+    Vector<IntSize> sizes { { 120, 30 }, { 30, 120 }, { 120, 30 }, { 30, 120 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(4U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerMaxRects, MinimumSizeRectangles)
+{
+    Vector<IntSize> sizes(10, { 1, 1 });
+    IntSize atlasSize(32, 32);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(10U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+// ShelfNextFit algorithm tests
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, EmptyInput)
+{
+    Vector<IntSize> sizes;
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, SingleRectangle)
+{
+    Vector<IntSize> sizes { { 50, 50 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_EQ(0U, result[0].imageIndex);
+    EXPECT_EQ(50, result[0].rect.width());
+    EXPECT_EQ(50, result[0].rect.height());
+    EXPECT_EQ(0, result[0].rect.x());
+    EXPECT_EQ(0, result[0].rect.y());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, ExactFit)
+{
+    Vector<IntSize> sizes { { 100, 100 } };
+    IntSize atlasSize(100, 100);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, RectangleTooLarge)
+{
+    Vector<IntSize> sizes { { 300, 300 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, MultipleSimilarSized)
+{
+    Vector<IntSize> sizes { { 50, 50 }, { 50, 50 }, { 50, 50 }, { 50, 50 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(4U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, MultipleVariableSized)
+{
+    Vector<IntSize> sizes { { 100, 50 }, { 30, 80 }, { 60, 60 }, { 20, 20 }, { 45, 90 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(5U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, ManySmallRectangles)
+{
+    Vector<IntSize> sizes(20, { 20, 20 });
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(20U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, TotalAreaExceedsAtlas)
+{
+    Vector<IntSize> sizes(10, { 100, 100 });
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_TRUE(result.isEmpty());
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, WideRectangle)
+{
+    Vector<IntSize> sizes { { 200, 30 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, TallRectangle)
+{
+    Vector<IntSize> sizes { { 30, 200 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(1U, result.size());
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, MixedWideAndTall)
+{
+    Vector<IntSize> sizes { { 120, 30 }, { 30, 120 }, { 120, 30 }, { 30, 120 } };
+    IntSize atlasSize(256, 256);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(4U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+    EXPECT_TRUE(allInputsPresent(result, sizes));
+}
+
+TEST(SkiaTextureAtlasPackerShelfNextFit, MinimumSizeRectangles)
+{
+    Vector<IntSize> sizes(10, { 1, 1 });
+    IntSize atlasSize(32, 32);
+
+    auto result = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_EQ(10U, result.size());
+    EXPECT_FALSE(rectanglesOverlap(result));
+    EXPECT_TRUE(allWithinBounds(result, atlasSize));
+}
+
+// General tests
+
+// Verify that the default algorithm is MaxRects by constructing a case where
+// ShelfNextFit fails but MaxRects succeeds. The atlas is 200x100 (area 20000)
+// and the four rectangles tile it exactly:
+//
+//   +--------+------+
+//   | 100x80 |100x60|  <- MaxRects fills the gap at (100,60) with 100x40
+//   |        +------+
+//   |        |100x40|
+//   +--------+------+
+//   |100x20  |         <- and places 100x20 at (0,80)
+//   +--------+
+//
+// ShelfNextFit sorts by height and creates a shelf of height 80, wasting 20px
+// next to the 100x60. The remaining 20px of atlas height can't fit 100x40.
+TEST(SkiaTextureAtlasPacker, DefaultAlgorithmIsMaxRects)
+{
+    Vector<IntSize> sizes { { 100, 80 }, { 100, 60 }, { 100, 40 }, { 100, 20 } };
+    IntSize atlasSize(200, 100);
+
+    auto resultShelf = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+    EXPECT_TRUE(resultShelf.isEmpty());
+
+    auto resultMaxRects = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    EXPECT_EQ(4U, resultMaxRects.size());
+    EXPECT_FALSE(rectanglesOverlap(resultMaxRects));
+    EXPECT_TRUE(allWithinBounds(resultMaxRects, atlasSize));
+    EXPECT_TRUE(allInputsPresent(resultMaxRects, sizes));
+
+    // Default algorithm (no explicit algorithm) should also succeed, proving it uses MaxRects.
+    auto resultDefault = SkiaTextureAtlasPacker::pack(sizes, atlasSize);
+    EXPECT_EQ(4U, resultDefault.size());
+    EXPECT_FALSE(rectanglesOverlap(resultDefault));
+    EXPECT_TRUE(allWithinBounds(resultDefault, atlasSize));
+    EXPECT_TRUE(allInputsPresent(resultDefault, sizes));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### fbb1d5713846cf40fe934a980ead70f4115f4193
<pre>
[Skia] Add SkiaTextureAtlasPacker for 2D bin packing
<a href="https://bugs.webkit.org/show_bug.cgi?id=306859">https://bugs.webkit.org/show_bug.cgi?id=306859</a>

Reviewed by Fujii Hironori.

Introduce SkiaTextureAtlasPacker::pack, a utility function to compute
optimal 2D rectangle layouts in texture atlases. This is useful for
batching multiple smaller images into a single GPU texture.

It provides two packing algorithms. The first is Shelf Next Fit
(SHELF-NF), a simple O(n log n) algorithm that places rectangles in
horizontal shelves. It works best for similarly-sized rectangles and
achieves around 70-80% space utilization.

The second algorithm is MaxRects with Best Short Side Fit heuristic
(MAXRECTS-BSSF). This more sophisticated O(n^2) approach maintains a
list of all maximal free rectangles and selects placements that minimize
wasted space. It handles variable-sized rectangles well and achieves
approximately 94% utilization on standard benchmarks.

Both algorithms are based on Jukka Jylänki&apos;s paper &quot;A Thousand Ways to
Pack the Bin - A Practical Approach to Two-Dimensional Rectangle Bin
Packing&quot; (2010).

Covered by new API tests, testing various situations with both
algorithms.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.cpp: Added.
(WebCore::SkiaTextureAtlasPacker::shelfNextFitAlgorithm):
(WebCore::SkiaTextureAtlasPacker::pruneFreeRectangles):
(WebCore::SkiaTextureAtlasPacker::maxRectsAlgorithm):
(WebCore::SkiaTextureAtlasPacker::pack):
* Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.h: Added.
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WebCore/skia/SkiaTextureAtlasPackerTests.cpp: Added.
(TestWebKitAPI::rectanglesOverlap):
(TestWebKitAPI::allWithinBounds):
(TestWebKitAPI::allInputsPresent):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, EmptyInput)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, SingleRectangle)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, ExactFit)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, RectangleTooLarge)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, MultipleSimilarSized)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, MultipleVariableSized)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, ManySmallRectangles)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, TotalAreaExceedsAtlas)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, WideRectangle)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, TallRectangle)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, MixedWideAndTall)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerMaxRects, MinimumSizeRectangles)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, EmptyInput)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, SingleRectangle)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, ExactFit)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, RectangleTooLarge)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, MultipleSimilarSized)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, MultipleVariableSized)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, ManySmallRectangles)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, TotalAreaExceedsAtlas)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, WideRectangle)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, TallRectangle)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, MixedWideAndTall)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPackerShelfNextFit, MinimumSizeRectangles)):
(TestWebKitAPI::TEST(SkiaTextureAtlasPacker, DefaultAlgorithmIsMaxRects)):

Canonical link: <a href="https://commits.webkit.org/306777@main">https://commits.webkit.org/306777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d650103a82e33cadafa22d7c3daf8e25471d880

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150980 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95514 "Hash 3d650103 for PR 57775 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144204 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14887 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109450 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95514 "Hash 3d650103 for PR 57775 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127402 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11488 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1003 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117492 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12578 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117816 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30032 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13865 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70113 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14461 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3651 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14193 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78177 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14398 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14238 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->