### PR TITLE
Speculation Rules: ensure that non-visible anchors with visible descendants get prefetched

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules-visibility.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules-visibility.https-expected.txt
@@ -1,0 +1,8 @@
+
+PASS test that link with display:contents and text content is prefetched
+PASS test that link with display:contents and visible child element is prefetched
+PASS test that customized built-in anchor element with shadow DOM is prefetched
+PASS test that slotted anchor inside custom element is prefetched
+PASS test that empty link with display:contents is NOT prefetched
+PASS test that link with display:contents and only hidden children is NOT prefetched
+

--- a/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules-visibility.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules-visibility.https.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="../resources/utils.js"></script>
+<script src="resources/utils.sub.js"></script>
+
+<body>
+<div id="test-container"></div>
+<script>
+  setup(() => assertSpeculationRulesIsSupported());
+
+  // Helper to clean up after each test
+  function cleanup(t, elements) {
+    t.add_cleanup(() => {
+      for (const el of elements) {
+        el.remove();
+      }
+    });
+  }
+
+  // Helper to add link to test container instead of body
+  function addTestLink(url, container = document.getElementById('test-container')) {
+    const a = document.createElement('a');
+    a.href = url;
+    container.appendChild(a);
+    return a;
+  }
+
+  // Helper to insert a document rule that only matches links with a specific class
+  function insertDocumentRuleForClass(className) {
+    const script = document.createElement('script');
+    script.type = 'speculationrules';
+    script.textContent = JSON.stringify({
+      prefetch: [{
+        source: 'document',
+        eagerness: 'immediate',
+        where: { selector_matches: `a.${className}` }
+      }]
+    });
+    document.head.appendChild(script);
+    return script;
+  }
+
+  promise_test(async t => {
+    // Add a link with display:contents - the link itself has no renderer
+    // but its children do.
+    const style = document.createElement('style');
+    style.textContent = '.display-contents-link { display: contents; }';
+    document.head.appendChild(style);
+
+    const url = getPrefetchUrl();
+    const link = addTestLink(url);
+    link.className = 'display-contents-link';
+    link.textContent = 'Click me';
+
+    const rule = insertDocumentRuleForClass('display-contents-link');
+    cleanup(t, [style, link, rule]);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that link with display:contents and text content is prefetched');
+
+  promise_test(async t => {
+    // Add a link with display:contents containing a visible child element.
+    const style = document.createElement('style');
+    style.textContent = '.display-contents-link-2 { display: contents; }';
+    document.head.appendChild(style);
+
+    const url = getPrefetchUrl();
+    const link = addTestLink(url);
+    link.className = 'display-contents-link-2';
+    const span = document.createElement('span');
+    span.textContent = 'Visible child';
+    link.appendChild(span);
+
+    const rule = insertDocumentRuleForClass('display-contents-link-2');
+    cleanup(t, [style, link, rule]);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that link with display:contents and visible child element is prefetched');
+
+  promise_test(async t => {
+    // A custom element that renders via shadow DOM.
+    // Note: custom elements can only be defined once, so we use a unique name per test run
+    const customElementName = 'custom-link-' + token().substring(0, 8);
+    class CustomLink extends HTMLAnchorElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = '<span>Shadow content</span>';
+      }
+    }
+    customElements.define(customElementName, CustomLink, { extends: 'a' });
+
+    const url = getPrefetchUrl();
+    const link = document.createElement('a', { is: customElementName });
+    link.href = url;
+    link.className = 'custom-shadow-link';
+    document.getElementById('test-container').appendChild(link);
+
+    const rule = insertDocumentRuleForClass('custom-shadow-link');
+    cleanup(t, [link, rule]);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that customized built-in anchor element with shadow DOM is prefetched');
+
+  promise_test(async t => {
+    // An autonomous custom element wrapping an anchor.
+    // The anchor is slotted and should be prefetched.
+    const wrapperName = 'link-wrapper-' + token().substring(0, 8);
+    class LinkWrapper extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = '<div class="wrapper"><slot></slot></div>';
+      }
+    }
+    customElements.define(wrapperName, LinkWrapper);
+
+    const wrapper = document.createElement(wrapperName);
+    document.getElementById('test-container').appendChild(wrapper);
+
+    const url = getPrefetchUrl();
+    const link = document.createElement('a');
+    link.href = url;
+    link.className = 'slotted-link';
+    wrapper.appendChild(link);
+
+    const rule = insertDocumentRuleForClass('slotted-link');
+    cleanup(t, [wrapper, rule]);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 1);
+  }, 'test that slotted anchor inside custom element is prefetched');
+
+  promise_test(async t => {
+    // Link with display:contents but no children - should NOT be prefetched
+    // because it has no rendered descendants.
+    const style = document.createElement('style');
+    style.textContent = '.empty-display-contents { display: contents; }';
+    document.head.appendChild(style);
+
+    const url = getPrefetchUrl();
+    const link = addTestLink(url);
+    link.className = 'empty-display-contents';
+    // No text content or children
+
+    const rule = insertDocumentRuleForClass('empty-display-contents');
+    cleanup(t, [style, link, rule]);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'test that empty link with display:contents is NOT prefetched');
+
+  promise_test(async t => {
+    // Link with display:contents but all children are also display:none.
+    const style = document.createElement('style');
+    style.textContent = `
+      .contents-with-hidden-children { display: contents; }
+      .contents-with-hidden-children > * { display: none; }
+    `;
+    document.head.appendChild(style);
+
+    const url = getPrefetchUrl();
+    const link = addTestLink(url);
+    link.className = 'contents-with-hidden-children';
+    const span = document.createElement('span');
+    span.textContent = 'Hidden child';
+    link.appendChild(span);
+
+    const rule = insertDocumentRuleForClass('contents-with-hidden-children');
+    cleanup(t, [style, link, rule]);
+
+    await new Promise(resolve => t.step_timeout(resolve, 2000));
+
+    assert_equals(await isUrlPrefetched(url), 0);
+  }, 'test that link with display:contents and only hidden children is NOT prefetched');
+</script>
+</body>


### PR DESCRIPTION
#### c685d23096c9c4e1c678672029df7db0e99ded2d
<pre>
Speculation Rules: ensure that non-visible anchors with visible descendants get prefetched
<a href="https://bugs.webkit.org/show_bug.cgi?id=306860">https://bugs.webkit.org/show_bug.cgi?id=306860</a>

Reviewed by Alex Christensen.

Anchor elements with `display: contents` may not be visible but could have visible descendants.
The current speculation rules logic doesn&apos;t account for that, and prevents prefetches on such elements from working.
This fixes that by looking at their descendants and seeing if they are rendered.

Test: imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules-visibility.https.html

* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules-visibility.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/speculation-rules/prefetch/document-rules-visibility.https.html: Added.
* Source/WebCore/dom/SpeculationRulesMatcher.cpp:
(WebCore::hasRenderedDescendants): Check if any descendant is rendered.
(WebCore::SpeculationRulesMatcher::hasMatchingRule): Expand on the visibility logic to include descendant check.

Canonical link: <a href="https://commits.webkit.org/306730@main">https://commits.webkit.org/306730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/823a6d1b2cdbebf15f819ae3dc1ea765f85b9eba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109258 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11325 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/8988 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153116 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14208 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117648 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13698 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69908 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14257 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/13989 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77973 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->