### PR TITLE
[GTK][WPE] Add UseBGRALayout flag to BitmapTexture/MemoryMappedGPUBuffer

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp
@@ -75,7 +75,8 @@ std::unique_ptr<MemoryMappedGPUBuffer> MemoryMappedGPUBuffer::create(const IntSi
         return nullptr;
     }
 
-    constexpr FourCC preferredDMABufFormat = DRM_FORMAT_ABGR8888;
+    bool preferBGRA = flags.contains(BufferFlag::UseBGRALayout);
+    const auto preferredDMABufFormat = FourCC(preferBGRA ? DRM_FORMAT_ARGB8888 : DRM_FORMAT_ABGR8888);
 
     auto negotiateBufferFormat = [&]() -> std::optional<GLDisplay::BufferFormat> {
         const auto& supportedFormats = PlatformDisplay::sharedDisplay().bufferFormats();

--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -50,7 +50,8 @@ public:
 
     enum class BufferFlag : uint8_t {
         ForceLinear = 1 << 0,
-        ForceVivanteSuperTiled = 1 << 1
+        ForceVivanteSuperTiled = 1 << 1,
+        UseBGRALayout = 1 << 2
     };
 
     // Will only return a MemoryMappedGPUBuffer, if gbm_bo allocation + mapping to userland + EGLImage creation succeeded.

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -60,6 +60,7 @@ public:
         ForceLinearBuffer = 1 << 3,
         ForceVivanteSuperTiledBuffer = 1 << 4,
 #endif
+        UseBGRALayout = 1 << 5,
     };
 
     static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })
@@ -119,6 +120,7 @@ private:
     void clearIfNeeded();
     void createFboIfNeeded();
 
+    GLenum textureFormat() const;
     void createTexture();
     void allocateTexture();
 #if USE(GBM)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -60,6 +60,7 @@ Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Option
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::ForceLinearBuffer) == flags.contains(BitmapTexture::Flags::ForceLinearBuffer)
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer) == flags.contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer)
 #endif
+                && entry.m_texture->flags().contains(BitmapTexture::Flags::UseBGRALayout) == flags.contains(BitmapTexture::Flags::UseBGRALayout)
                 && entry.m_texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer);
         });
 


### PR DESCRIPTION
#### a8586ad55bcbfd4bd3556acbacf88ea02efd2eaf
<pre>
[GTK][WPE] Add UseBGRALayout flag to BitmapTexture/MemoryMappedGPUBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=306861">https://bugs.webkit.org/show_bug.cgi?id=306861</a>

Reviewed by Adrian Perez de Castro.

Add &apos;UseBGRALayout&apos; to BitmapTexture/MemoryMappedGPUBuffer, allowing
to allocate textures / dma-bufs with a non-standard BGRA layout (RGBA
remains the default).

Not testable by default will be needed by raster image batching
support in future.

* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::MemoryMappedGPUBuffer::create):
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::textureFormat const):
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::allocateTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::updateContents):
(WebCore::BitmapTexture::colorConvertFlags const):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::acquireTexture):

Canonical link: <a href="https://commits.webkit.org/306770@main">https://commits.webkit.org/306770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0932c4820b00e84f07627cd9c7b2ea7227951cb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142302 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150939 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95478 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14852 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109418 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95478 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11458 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/968 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14377 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117465 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14399 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117788 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30027 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13835 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70077 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14426 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3620 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78142 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14363 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14203 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->