### PR TITLE
Add support for transferring transform streams

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transfer-with-messageport.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transfer-with-messageport.window-expected.txt
@@ -1,11 +1,11 @@
 
 PASS Transferring a MessagePort with a ReadableStream should set `.ports`
 PASS Transferring a MessagePort with a WritableStream should set `.ports`
-FAIL Transferring a MessagePort with a TransformStream should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Transferring a MessagePort with a TransformStream should set `.ports`
 PASS Transferring a MessagePort with a ReadableStream should set `.ports`, advanced
 PASS Transferring a MessagePort with a WritableStream should set `.ports`, advanced
-FAIL Transferring a MessagePort with a TransformStream should set `.ports`, advanced promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Transferring a MessagePort with multiple streams should set `.ports` promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Transferring a MessagePort with a TransformStream should set `.ports`, advanced
+PASS Transferring a MessagePort with multiple streams should set `.ports`
 PASS ReadableStream must not be serializable
 PASS WritableStream must not be serializable
 PASS TransformStream must not be serializable

--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transform-stream-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/transform-stream-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL window.postMessage should be able to transfer a TransformStream The object can not be cloned.
+PASS window.postMessage should be able to transfer a TransformStream
 PASS a TransformStream with a locked writable should not be transferable
 PASS a TransformStream with a locked readable should not be transferable
 PASS a TransformStream with both sides locked should not be transferable
-FAIL piping through transferred transforms should work The object can not be cloned.
+PASS piping through transferred transforms should work
 

--- a/Source/WebCore/Modules/streams/TransformStream.h
+++ b/Source/WebCore/Modules/streams/TransformStream.h
@@ -36,13 +36,20 @@ class InternalReadableStream;
 class InternalTransformStream;
 class InternalWritableStream;
 class JSDOMGlobalObject;
+class MessagePort;
 class ReadableStream;
 class WritableStream;
 template<typename> class ExceptionOr;
 
+struct DetachedTransformStream {
+    Ref<MessagePort> readablePort;
+    Ref<MessagePort> writablePort;
+};
+
 class TransformStream : public RefCounted<TransformStream> {
 public:
     static ExceptionOr<Ref<TransformStream>> create(JSC::JSGlobalObject&, JSC::Strong<JSC::JSObject>&&, JSC::Strong<JSC::JSObject>&&, JSC::Strong<JSC::JSObject>&&);
+    static Ref<TransformStream> create(Ref<ReadableStream>&&, Ref<WritableStream>&&);
 
     ~TransformStream();
 
@@ -50,6 +57,10 @@ public:
     WritableStream& writable() { return m_writable.get(); }
 
     JSValueInWrappedObject& internalTransformStream() { return m_internalTransformStream; }
+
+    bool canTransfer() const;
+    ExceptionOr<DetachedTransformStream> runTransferSteps(JSDOMGlobalObject&);
+    static ExceptionOr<Ref<TransformStream>> runTransferReceivingSteps(JSDOMGlobalObject&, DetachedTransformStream&&);
 
 private:
     TransformStream(JSC::JSValue, Ref<ReadableStream>&&, Ref<WritableStream>&&);


### PR DESCRIPTION
#### 555f359331111c17b9838ed251b09039df8e7edc
<pre>
Add support for transferring transform streams
<a href="https://rdar.apple.com/169526119">rdar://169526119</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306858">https://bugs.webkit.org/show_bug.cgi?id=306858</a>

Reviewed by Chris Dumez.

We continue with transform streams, as per streams spec.
Since, in this case, we need to transfer the readable and writable of a transform,
we need to check that there are no redundant readables or writables, transferred directly or via transform.
We encode the transform index and we recompute on deserialization side the message ports of the readable and writable
Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/306946@main">https://commits.webkit.org/306946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a70c6c4d88e3a696e182520503cc5c68b2498d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5812 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96027 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1fc19b3-f23c-4eec-9ca9-8c3baf415014) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109842 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79161 "7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36217c92-9326-4a6f-a7fc-fec686d6a2db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90751 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68cec652-af72-4389-831a-b719ef4ca202) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11801 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9484 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1508 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121181 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153822 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117858 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118192 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30218 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14179 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70630 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14976 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4041 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14711 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14919 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->