### PR TITLE
[GTK][WPE] MemoryMappedGPUBuffer backed BitmapTexture occasionally hangs v3d GPU driver

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
+++ b/Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h
@@ -101,6 +101,10 @@ public:
         Mode m_mode { Mode::Read };
     };
 
+    // Detach the gbm_bo so that ~MemoryMappedGPUBuffer skips gbm_bo_destroy.
+    // Used when Mesa's glDeleteTextures will close the shared GEM handle.
+    void detachBufferObject() { m_bo = nullptr; }
+
     bool isMapped() const { return !!m_mappedData; }
     bool isLinear() const;
     bool isVivanteSuperTiled() const;

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -456,6 +456,16 @@ void BitmapTexture::bindAsSurface()
 
 BitmapTexture::~BitmapTexture()
 {
+#if USE(GBM)
+    // When backed by dma-buf, Mesa and GBM share the same DRM fd and thus
+    // the same GEM handle. glDeleteTextures will cause Mesa to close the
+    // GEM handle via DRM_IOCTL_GEM_CLOSE. If gbm_bo_destroy also tries to
+    // close the same handle, the double-close corrupts V3D driver state...
+    // Detach the gbm_bo so ~MemoryMappedGPUBuffer skips gbm_bo_destroy.
+    if (m_memoryMappedGPUBuffer)
+        m_memoryMappedGPUBuffer->detachBufferObject();
+#endif
+
     glDeleteTextures(1, &m_id);
 
     if (m_fbo)


### PR DESCRIPTION
#### bee95b4bbdc0125f80a61293973900af5ea272ff
<pre>
[GTK][WPE] MemoryMappedGPUBuffer backed BitmapTexture occasionally hangs v3d GPU driver
<a href="https://bugs.webkit.org/show_bug.cgi?id=306864">https://bugs.webkit.org/show_bug.cgi?id=306864</a>

Reviewed by NOBODY (OOPS!).

Fix regression introduced in <a href="https://commits.webkit.org/308458@main">308458@main</a>, that broke GPU rendering on
rpi4: Stop holding the gbm_bo for the lifetime of MemoryMappedGPUBuffer.

There was a double-close problem, inducing a use-after-free in the
driver. Both GBM and EGL were trying to close the same GEM handle,
leading to v3d driver-level corruption, requiring a power cycle to
recover.

Fix by destroying the gbm_bo immediately after exporting its dma-buf
file descriptors in create(). Cleanup the MemoryMappedGPUBuffer code,
to make it easier to understand/debug.

Covered by existing tests that run on the perf bots.

* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.cpp:
(WebCore::MemoryMappedGPUBuffer::~MemoryMappedGPUBuffer):
(WebCore::MemoryMappedGPUBuffer::create):
(WebCore::MemoryMappedGPUBuffer::allocate):
(WebCore::MemoryMappedGPUBuffer::isLinear const):
(WebCore::MemoryMappedGPUBuffer::isVivanteSuperTiled const):
(WebCore::MemoryMappedGPUBuffer::createDMABufFromGBMBufferObject):
(WebCore::MemoryMappedGPUBuffer::mapIfNeeded):
(WebCore::MemoryMappedGPUBuffer::createEGLImageFromDMABuf):
(WebCore::MemoryMappedGPUBuffer::exportGBMBufferObjectAsDMABuf):
(WebCore::MemoryMappedGPUBuffer::allocatedSize const): Deleted.
* Source/WebCore/platform/graphics/gbm/MemoryMappedGPUBuffer.h:
(WebCore::MemoryMappedGPUBuffer::allocatedSize const):
</pre>