### PR TITLE
Adopt the soft-mode/no-tagged-receive entitlements for the EnhancedSecurity WebContent variant

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -80,6 +80,12 @@ function mac_process_webcontent_enhancedsecurity_entitlements()
     plistbuddy Add :com.apple.security.fatal-exceptions array
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
 
+    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+    then
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
+    fi
+
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
         plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
@@ -433,6 +439,12 @@ function maccatalyst_process_webcontent_enhancedsecurity_entitlements()
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
     plistbuddy Add :com.apple.developer.hardened-process bool YES
 
+    if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 260000 ))
+    then
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES
+        plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
+    fi
+
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
     plistbuddy Add :com.apple.pac.shared_region_id string WebContent
     plistbuddy Add :com.apple.private.pac.exception bool YES
@@ -572,6 +584,8 @@ function ios_family_process_webcontent_enhancedsecurity_entitlements()
 {
     plistbuddy Add :com.apple.private.webkit.enhanced-security bool YES
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.soft-mode bool YES
+    plistbuddy Add :com.apple.security.hardened-process.checked-allocations.no-tagged-receive bool YES
 
     ios_family_process_webcontent_shared_entitlements
 }


### PR DESCRIPTION
#### 1b4dd17f517a1ecb3db037ca6bc588f946b28c56
<pre>
Adopt the soft-mode/no-tagged-receive entitlements for the EnhancedSecurity WebContent variant
<a href="https://bugs.webkit.org/show_bug.cgi?id=306867">https://bugs.webkit.org/show_bug.cgi?id=306867</a>
<a href="https://rdar.apple.com/169530270">rdar://169530270</a>

Reviewed by Per Arne Vollan.

Adopts the soft-mode/no-tagged-receive entitlements for the EnhancedSecurity WebContent variant
on all platforms. These force the process into soft mode and marks the process as never receiving
untagged aliases to MTE memory.

* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/306769@main">https://commits.webkit.org/306769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c2bbaa50ba2258c2d98552899be7af66b8b7eec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150777 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95334 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7683b10-3059-42a3-9417-86dd1a785563) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109279 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78984 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfaf0b89-f215-4d9c-907c-670e4ba3d44a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90178 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/373b1988-00b5-4979-b949-87d0ed687a4d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/141497 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9011 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/824 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120687 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153141 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14233 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117351 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117672 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30026 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13719 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69933 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14282 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3481 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14218 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14059 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->