### PR TITLE
Fix failing WPT streams/transferable/readable-stream.html subtests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/readable-stream-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/streams/transferable/readable-stream-expected.txt
@@ -6,8 +6,8 @@ PASS sending ten chunks on demand should work
 PASS transferring a stream should relieve backpressure
 PASS transferring a stream should add one chunk to the queue size
 PASS the extra queue from transferring is counted in chunks
-FAIL cancel should be propagated to the original assert_array_equals: cancel() should have been called lengths differ, expected array ["pull", "cancel", "message"] length 3, got ["pull", "pull", "cancel", "message"] length 4
-FAIL cancel should abort a pending read() assert_array_equals: events should match lengths differ, expected array ["pull", "cancel", "done"] length 3, got ["pull", "pull", "cancel", "done"] length 4
+PASS cancel should be propagated to the original
+PASS cancel should abort a pending read()
 PASS stream cancel should not wait for underlying source cancel
 PASS serialization should not happen until the value is read
 PASS transferring a non-serializable chunk should error both sides

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.h
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.h
@@ -53,7 +53,6 @@ private:
 };
 
 ExceptionOr<Ref<InternalWritableStreamWriter>> acquireWritableStreamDefaultWriter(JSDOMGlobalObject&, WritableStream&);
-int writableStreamDefaultWriterGetDesiredSize(InternalWritableStreamWriter&);
 RefPtr<DOMPromise> writableStreamDefaultWriterCloseWithErrorPropagation(InternalWritableStreamWriter&);
 void writableStreamDefaultWriterRelease(InternalWritableStreamWriter&);
 RefPtr<DOMPromise> writableStreamDefaultWriterWrite(InternalWritableStreamWriter&, JSC::JSValue);


### PR DESCRIPTION
#### 43f9966cb6feadbbc2182a4d55ffd7b7129a14f7
<pre>
Fix failing WPT streams/transferable/readable-stream.html subtests
<a href="https://rdar.apple.com/169533462">rdar://169533462</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306873">https://bugs.webkit.org/show_bug.cgi?id=306873</a>

Reviewed by Chris Dumez.

We were waiting on writer ready promise to start reading when doing piping.
While this is ok, the spec says we just have to wait for writer desired size to be greater than 0.
This difference of behavior is visible in one of the WPT streams/transferable/readable-stream.html test.
We align with other browsers by checking desired size explicitely and if so we read directly.
Otherwise, we wait for writer ready promise.

This impacts the WPT subtests as the race between reading and starting the readable stream can either cause to pull once (if read happens before starting is finished) or twice (if starting happens before the read).

Covered by rebased test.

Canonical link: <a href="https://commits.webkit.org/306911@main">https://commits.webkit.org/306911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/206660e0bd910f0d2eed4d4837d34b2d394cddb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150933 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95472 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c97f82fb-ce5b-4b99-aa43-d83c1639a594) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109414 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95472 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f028d713-514f-4c64-8a2d-509daaebc202) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127368 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90313 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3fb0bcd-51da-4203-bcd6-fef572ce5259) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11450 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9115 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/962 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153279 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14371 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117461 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117784 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30129 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13833 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124604 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70071 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14420 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3615 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78136 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14357 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->