### PR TITLE
WebAuthn: Respect AbortSignal reason in navigator.credentials.create()

### DIFF
--- a/LayoutTests/http/wpt/webauthn/credential-create-abort-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/credential-create-abort-expected.txt
@@ -1,0 +1,8 @@
+
+PASS create() after abort (no reason)
+PASS create() before abort (no reason)
+PASS create() after abort (string reason)
+PASS create() before abort (string reason)
+PASS create() after abort (Error reason)
+PASS create() before abort (Error reason)
+

--- a/LayoutTests/http/wpt/webauthn/credential-create-abort.html
+++ b/LayoutTests/http/wpt/webauthn/credential-create-abort.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ WebAuthenticationModernEnabled=true allowTestOnlyIPC=true ] -->
+<title>Web Authentication API: PublicKeyCredential's [[create]] abort cases with a mock ccid authenticator.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./resources/util.js"></script>
+<script>
+    function baseOptions() {
+        return {
+            publicKey: {
+                rp: { name: "localhost" },
+                user: {
+                    name: "John Appleseed",
+                    id: Base64URL.parse(testUserhandleBase64),
+                    displayName: "Appleseed",
+                },
+                challenge: Base64URL.parse("MTIzNDU2"),
+                pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            }
+        };
+    }
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "info", subStage: "init", error: "data-not-sent" } });
+        const ac = new AbortController();
+        ac.abort();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        await promise_rejects_dom(t, "AbortError", p);
+    }, "create() after abort (no reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        ac.abort();
+        await promise_rejects_dom(t, "AbortError", p);
+    }, "create() before abort (no reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        ac.abort("CustomError");
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        await promise_rejects_exactly(t, "CustomError", p);
+    }, "create() after abort (string reason)");
+    
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        ac.abort("CustomError");
+        await promise_rejects_exactly(t, "CustomError", p);
+    }, "create() before abort (string reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        ac.abort(new Error("error"));
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        await promise_rejects_js(t, Error, p);
+    }, "create() after abort (Error reason)");
+
+    promise_test(async t => {
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", payloadBase64: [testCreationMessageBase64] } });
+        const ac = new AbortController();
+        const p = navigator.credentials.create(Object.assign(baseOptions(), { signal: ac.signal }));
+        ac.abort(new Error("error"));
+        await promise_rejects_js(t, Error, p);
+    }, "create() before abort (Error reason)");
+</script>

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "AuthenticatorCoordinator.h"
 
+#include "IDLTypes.h"
+
 #if ENABLE(WEB_AUTHN)
 
 #include "AbortSignal.h"
@@ -242,9 +244,17 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
         });
     }
 
-    auto callback = [promise = WTF::move(promise), abortSignal = WTF::move(abortSignal)](AuthenticatorResponseData&& data, AuthenticatorAttachment attachment, ExceptionData&& exception) mutable {
+    JSC::Strong<JSC::JSObject> abortSignalStrong;
+    if (abortSignal) {
+        auto& vm = abortSignal->wrapper()->vm();
+        abortSignalStrong.set(vm, abortSignal->wrapper());
+    }
+
+    auto callback = [promise = WTF::move(promise), abortSignal = WTF::move(abortSignal), abortSignalStrong = WTF::move(abortSignalStrong)](AuthenticatorResponseData&& data, AuthenticatorAttachment attachment, ExceptionData&& exception) mutable {
+        if (abortSignalStrong.get())
+            abortSignalStrong.clear();
         if (abortSignal && abortSignal->aborted()) {
-            promise.reject(Exception { ExceptionCode::AbortError, "Aborted by AbortSignal."_s });
+            promise.rejectType<IDLAny>(abortSignal->reason().getValue());
             return;
         }
 


### PR DESCRIPTION
#### bb2ca2fe76eabcfccf41a8c93a6f7c9e9facd115
<pre>
WebAuthn: Respect AbortSignal reason in navigator.credentials.create()
<a href="https://bugs.webkit.org/show_bug.cgi?id=306878">https://bugs.webkit.org/show_bug.cgi?id=306878</a>

Reviewed by NOBODY (OOPS!).

This change intends to fix web-platform-tests/webauthn/createcredential-abort.https.html?label=experimental&amp;label=master&amp;aligned

The abort reason passed to abort() is now propagated.

Reference:
“If `options.signal` is aborted, then return a promise
rejected with `options.signal`’s abort reason”
in <a href="https://w3c.github.io/webappsec-credential-management/#algorithm-create">https://w3c.github.io/webappsec-credential-management/#algorithm-create</a>

* LayoutTests/http/wpt/webauthn/credential-create-abort-expected.txt: Added.
* LayoutTests/http/wpt/webauthn/credential-create-abort.html: Added.
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9f32a4de389fbd21d85479074f4bc67587cae2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113563 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80991 "Exiting early after 60 failures. 15426 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14959 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12743 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3468 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158359 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1497 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121591 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121790 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132034 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75818 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17319 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8821 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83206 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->