### PR TITLE
[SaferCPP] Fixed [iOS] UncountedCallArgsChecker issues in /WebKit/

### DIFF
--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -79,7 +79,7 @@ bool GPUConnectionToWebProcess::setCaptureAttributionString()
 void GPUConnectionToWebProcess::setTCCIdentity()
 {
 #if !PLATFORM(MACCATALYST)
-    auto auditToken = gpuProcess().parentProcessConnection()->getAuditToken();
+    auto auditToken = protect(gpuProcess().parentProcessConnection())->getAuditToken();
     if (!auditToken) {
         RELEASE_LOG_ERROR(WebRTC, "getAuditToken returned null");
         return;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -185,7 +185,7 @@ static void providePresentingApplicationPID(RemoteAudioSessionProxy& proxy)
         return;
 #endif
 
-    ProcessID pid = GPUProcess::singleton().parentProcessConnection()->remoteProcessID();
+    ProcessID pid = protect(GPUProcess::singleton().parentProcessConnection())->remoteProcessID();
 
 #if !PLATFORM(APPLETV)
     // Presenting application audit tokens are per-page, but AudioSessions are per-web-process,
@@ -201,7 +201,7 @@ static void providePresentingApplicationPID(RemoteAudioSessionProxy& proxy)
 #endif
 #endif
 
-    MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid);
+    protect(MediaSessionHelper::sharedHelper())->providePresentingApplicationPID(pid);
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -75,7 +75,7 @@ PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, Netwo
     send(Messages::DownloadProxy::DidStart(m_networkLoad->currentRequest(), suggestedName));
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
-    m_urlFilter->isURLAllowed(m_networkLoad->currentRequest().url(), [this, protectedThis = Ref { *this }, startNetworkLoad = WTF::move(startNetworkLoad)] (bool allowed, NSData *) mutable {
+    protect(m_urlFilter)->isURLAllowed(m_networkLoad->currentRequest().url(), [this, protectedThis = Ref { *this }, startNetworkLoad = WTF::move(startNetworkLoad)] (bool allowed, NSData *) mutable {
         if (!allowed) {
             blockDueToContentFilter(ResourceResponse { m_networkLoad->currentRequest().url(), "application/octet-stream"_s, 0, ""_s }, nullptr);
             return;
@@ -132,7 +132,7 @@ void PendingDownload::willSendRedirectedRequest(WebCore::ResourceRequest&&, WebC
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     auto requestURL = redirectRequest.url();
-    m_urlFilter->isURLAllowed(requestURL, [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), redirectRequest = WTF::move(redirectRequest), redirectResponse = WTF::move(redirectResponse)] (bool allowed, NSData *) mutable {
+    protect(m_urlFilter)->isURLAllowed(requestURL, [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler), redirectRequest = WTF::move(redirectRequest), redirectResponse = WTF::move(redirectResponse)] (bool allowed, NSData *) mutable {
         if (allowed) {
             sendWithAsyncReply(Messages::DownloadProxy::WillSendRequest(WTF::move(redirectRequest), WTF::move(redirectResponse)), WTF::move(completionHandler));
             return;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -360,7 +360,7 @@ bool NetworkConnectionToWebProcess::dispatchMessage(IPC::Connection& connection,
 
 #if ENABLE(APPLE_PAY_REMOTE_UI)
     if (decoder.messageReceiverName() == Messages::WebPaymentCoordinatorProxy::messageReceiverName()) {
-        paymentCoordinator().didReceiveMessage(connection, decoder);
+        protect(paymentCoordinator())->didReceiveMessage(connection, decoder);
         return true;
     }
 #endif
@@ -441,7 +441,7 @@ bool NetworkConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connect
 
 #if ENABLE(APPLE_PAY_REMOTE_UI)
     if (decoder.messageReceiverName() == Messages::WebPaymentCoordinatorProxy::messageReceiverName()) {
-        paymentCoordinator().didReceiveSyncMessage(connection, decoder, reply);
+        protect(paymentCoordinator())->didReceiveSyncMessage(connection, decoder, reply);
         return true;
     }
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -175,7 +175,7 @@ std::optional<audit_token_t> NetworkProcess::sourceApplicationAuditToken() const
     ASSERT(parentProcessConnection());
     if (!parentProcessConnection())
         return { };
-    return parentProcessConnection()->getAuditToken();
+    return protect(parentProcessConnection())->getAuditToken();
 #else
     return { };
 #endif

--- a/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
+++ b/Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm
@@ -68,7 +68,7 @@ void NetworkConnectionToWebProcess::notifyWillPresentPaymentUI(WebPageProxyIdent
 
 void NetworkConnectionToWebProcess::getPaymentCoordinatorEmbeddingUserAgent(WebPageProxyIdentifier webPageProxyIdentifier, CompletionHandler<void(const String&)>&& completionHandler)
 {
-    networkProcess().parentProcessConnection()->sendWithAsyncReply(Messages::NetworkProcessProxy::GetPaymentCoordinatorEmbeddingUserAgent { webPageProxyIdentifier }, WTF::move(completionHandler));
+    protect(networkProcess().parentProcessConnection())->sendWithAsyncReply(Messages::NetworkProcessProxy::GetPaymentCoordinatorEmbeddingUserAgent { webPageProxyIdentifier }, WTF::move(completionHandler));
 }
 
 CocoaWindow *NetworkConnectionToWebProcess::paymentCoordinatorPresentingWindow(const WebPaymentCoordinatorProxy&) const

--- a/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
+++ b/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -38,7 +38,7 @@ namespace WebKit {
 
 void WebPaymentCoordinatorProxy::platformCanMakePayments(CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_canMakePaymentsQueue->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationControllerClassSingleton()), completionHandler = WTF::move(completionHandler)]() mutable {
+    protect(m_canMakePaymentsQueue)->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationControllerClassSingleton()), completionHandler = WTF::move(completionHandler)]() mutable {
         RunLoop::mainSingleton().dispatch([canMakePayments = [theClass canMakePayments], completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(canMakePayments);
         });
@@ -85,7 +85,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
         });
 #else
         UNUSED_VARIABLE(webPageProxyID);
-        paymentCoordinatorProxy->m_authorizationPresenter->present(paymentCoordinatorProxy->checkedClient()->paymentCoordinatorPresentingViewController(*paymentCoordinatorProxy), WTF::move(completionHandler));
+        protect(paymentCoordinatorProxy->m_authorizationPresenter)->present(paymentCoordinatorProxy->checkedClient()->paymentCoordinatorPresentingViewController(*paymentCoordinatorProxy), WTF::move(completionHandler));
 #endif
     });
 }
@@ -93,7 +93,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 void WebPaymentCoordinatorProxy::platformHidePaymentUI()
 {
     if (m_authorizationPresenter)
-        m_authorizationPresenter->dismiss();
+        protect(m_authorizationPresenter)->dismiss();
 }
 
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
@@ -58,7 +58,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (_WKActivatedElementInfo *)_activatedElementInfo
 {
-    return [_WKActivatedElementInfo activatedElementInfoWithInteractionInformationAtPosition:_elementInfo->interactionInformation() userInfo:_elementInfo->userInfo().get()];
+    return [_WKActivatedElementInfo activatedElementInfoWithInteractionInformationAtPosition:_elementInfo->interactionInformation() userInfo:protect(*_elementInfo)->userInfo().get()];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm
@@ -126,7 +126,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionCommand, WebExtensionCommand
 #if PLATFORM(IOS_FAMILY)
 - (UIKeyCommand *)keyCommand
 {
-    return _webExtensionCommand->keyCommand();
+    return protect(*_webExtensionCommand)->keyCommand();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -956,7 +956,7 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
     [_contentView _webViewDestroyed];
 
     if (_page && _remoteObjectRegistry)
-        _page->configuration().processPool().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier());
+        protect(_page->configuration().processPool())->removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier());
 #endif
 
     if (_page)
@@ -1685,10 +1685,11 @@ static WKMediaPlaybackState toWKMediaPlaybackState(WebKit::MediaPlaybackState me
     _allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures;
 
     if (allowsBackForwardNavigationGestures && !_gestureController) {
-        _gestureController = WebKit::ViewGestureController::create(*_page);
-        _gestureController->installSwipeHandler(self, [self scrollView]);
+        Ref gestureController = WebKit::ViewGestureController::create(*_page);
+        _gestureController = gestureController.ptr();
+        gestureController->installSwipeHandler(self, [self scrollView]);
         if (WKWebView *alternateWebView = [_configuration _alternateWebViewForNavigationGestures])
-            _gestureController->setAlternateBackForwardListSourcePage(alternateWebView->_page.get());
+            gestureController->setAlternateBackForwardListSourcePage(alternateWebView->_page.get());
     }
 
     if (_gestureController)
@@ -4313,7 +4314,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 #else
     if (!_remoteObjectRegistry) {
         _remoteObjectRegistry = adoptNS([[_WKRemoteObjectRegistry alloc] _initWithWebPageProxy:*_page]);
-        _page->configuration().processPool().addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier(), [_remoteObjectRegistry remoteObjectRegistry]);
+        protect(_page->configuration().processPool())->addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier(), protect([_remoteObjectRegistry remoteObjectRegistry]));
     }
 
     return _remoteObjectRegistry.get();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -382,9 +382,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #if PLATFORM(MAC)
     return _impl->beginBackSwipeForTesting();
 #else
-    if (!_gestureController)
-        return NO;
-    return _gestureController->beginSimulatedSwipeInDirectionForTesting(WebKit::ViewGestureController::SwipeDirection::Back);
+    if (RefPtr gestureController = _gestureController)
+        return gestureController->beginSimulatedSwipeInDirectionForTesting(WebKit::ViewGestureController::SwipeDirection::Back);
+    return NO;
 #endif
 }
 
@@ -393,9 +393,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #if PLATFORM(MAC)
     return _impl->completeBackSwipeForTesting();
 #else
-    if (!_gestureController)
-        return NO;
-    return _gestureController->completeSimulatedSwipeInDirectionForTesting(WebKit::ViewGestureController::SwipeDirection::Back);
+    if (RefPtr gestureController = _gestureController)
+        return gestureController->completeSimulatedSwipeInDirectionForTesting(WebKit::ViewGestureController::SwipeDirection::Back);
+    return NO;
 #endif
 }
 
@@ -414,8 +414,8 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (RefPtr gestureController = _impl->gestureController())
         gestureController->reset();
 #else
-    if (_gestureController)
-        _gestureController->reset();
+    if (RefPtr gestureController = _gestureController)
+        gestureController->reset();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1169,7 +1169,7 @@ struct WKWebsiteData {
 - (void)_appBoundDomains:(void (^)(NSArray<NSString *> *))completionHandler
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    _websiteDataStore->getAppBoundDomains([completionHandler = makeBlockPtr(completionHandler)](auto& domains) mutable {
+    protect(*_websiteDataStore)->getAppBoundDomains([completionHandler = makeBlockPtr(completionHandler)](auto& domains) mutable {
         auto apiDomains = WTF::map(domains, [](auto& domain) -> RefPtr<API::Object> {
             return API::String::create(domain.string());
         });
@@ -1183,7 +1183,7 @@ struct WKWebsiteData {
 - (void)_appBoundSchemes:(void (^)(NSArray<NSString *> *))completionHandler
 {
 #if ENABLE(APP_BOUND_DOMAINS)
-    _websiteDataStore->getAppBoundSchemes([completionHandler = makeBlockPtr(completionHandler)](auto& schemes) mutable {
+    protect(*_websiteDataStore)->getAppBoundSchemes([completionHandler = makeBlockPtr(completionHandler)](auto& schemes) mutable {
         auto apiSchemes = WTF::map(schemes, [](auto& scheme) -> RefPtr<API::Object> {
             return API::String::create(scheme);
         });
@@ -1460,7 +1460,7 @@ struct WKWebsiteData {
 -(void)_setBackupExclusionPeriodForTesting:(double)seconds completionHandler:(void(^)(void))completionHandler
 {
 #if PLATFORM(IOS_FAMILY)
-    _websiteDataStore->setBackupExclusionPeriodForTesting(Seconds(seconds), [completionHandler = makeBlockPtr(completionHandler)] {
+    protect(*_websiteDataStore)->setBackupExclusionPeriodForTesting(Seconds(seconds), [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 #else

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPosition.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPosition.mm
@@ -46,7 +46,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKGeolocationPosition.class, self))
         return;
 
-    _geolocationPosition->~WebGeolocationPosition();
+    SUPPRESS_UNCOUNTED_ARG _geolocationPosition->~WebGeolocationPosition();
 
     [super dealloc];
 }

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -116,9 +116,9 @@ void* WKUIWindowSceneObserverContext = &WKUIWindowSceneObserverContext;
 
         id scene = [change valueForKey:NSKeyValueChangeNewKey];
         if ([scene isKindOfClass:UIWindowScene.class])
-            _parent->setScene((UIWindowScene *)scene);
+            protect(_parent)->setScene((UIWindowScene *)scene);
         else
-            _parent->setScene(nil);
+            protect(_parent)->setScene(nil);
     });
 }
 @end

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -475,7 +475,7 @@ static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& actio
         return;
     }
 
-    RetainPtr requesterTopOriginURL = requester->topOrigin->toURL().createNSURL();
+    RetainPtr requesterTopOriginURL = protect(requester->topOrigin)->toURL().createNSURL();
     RetainPtr url = action->request().url().createNSURL();
 
     if (!requesterTopOriginURL || !url) {
@@ -1602,7 +1602,7 @@ void NavigationState::didChangeIsLoading()
         return;
 
 #if USE(RUNNINGBOARD)
-    if (webView->_page->pageLoadState().isLoading()) {
+    if (protect(*webView->_page)->pageLoadState().isLoading()) {
 #if PLATFORM(IOS_FAMILY)
         // We do not start a network activity if a load starts after the screen has been locked.
         if (UIApplication.sharedApplication.isSuspendedUnderLock)
@@ -1747,7 +1747,7 @@ void NavigationState::didSwapWebProcesses()
 #if USE(RUNNINGBOARD)
     // Transfer our background assertion from the old process to the new one.
     auto webView = this->webView();
-    if (webView && webView->_page->pageLoadState().isLoading())
+    if (webView && protect(*webView->_page)->pageLoadState().isLoading())
         webView->_page->takeNetworkActivity();
 #endif
 }

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -467,7 +467,7 @@ double ProcessAssertion::remainingRunTimeInSeconds(ProcessID pid)
 void ProcessAssertion::acquireAsync(CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(isMainRunLoop());
-    assertionsWorkQueue().dispatch([protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
+    protect(assertionsWorkQueue())->dispatch([protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
         protectedThis->acquireSync();
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)]() mutable {
             if (completionHandler)

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -250,7 +250,7 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
         kSOAuthorizationOptionInitiatingPath: initiatingPath.createNSString().get()
     };
 #if PLATFORM(IOS_FAMILY)
-    RetainPtr<WKWebView> webView = m_page->cocoaView();
+    RetainPtr<WKWebView> webView = protect(m_page)->cocoaView();
     id webViewUIDelegate = [webView UIDelegate];
     if ([webViewUIDelegate respondsToSelector:@selector(_hostSceneIdentifierForWebView:)]) {
         NSString *callerSceneID = [webViewUIDelegate _hostSceneIdentifierForWebView:webView.get()];

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -388,7 +388,7 @@ UIViewController *VideoPresentationModelContext::presentingViewController()
     if (!m_manager || !m_manager->m_page)
         return nullptr;
 
-    if (RefPtr pageClient = m_manager->m_page->pageClient())
+    if (RefPtr pageClient = protect(m_manager)->m_page->pageClient())
         return pageClient->presentingViewController();
     return nullptr;
 }
@@ -1688,7 +1688,7 @@ RefPtr<PlatformVideoPresentationInterface> VideoPresentationManagerProxy::bestVi
     if (!m_page)
         return nullptr;
 
-    RefPtr pageClient = m_page->pageClient();
+    RefPtr pageClient = protect(m_page)->pageClient();
     if (!pageClient)
         return nullptr;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -469,7 +469,7 @@ FloatRect RemoteScrollingCoordinatorProxyIOS::currentLayoutViewport() const
 {
     // FIXME: does this give a different value to the last value pushed onto us?
     Ref page = webPageProxy();
-    return page->computeLayoutViewportRect(page->unobscuredContentRect(), page->unobscuredContentRectRespectingInputViewBounds(), webPageProxy().layoutViewportRect(),
+    return page->computeLayoutViewportRect(page->unobscuredContentRect(), page->unobscuredContentRectRespectingInputViewBounds(), protect(webPageProxy())->layoutViewportRect(),
         page->displayedContentScale(), LayoutViewportConstraint::Unconstrained);
 }
 
@@ -596,7 +596,7 @@ std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxyIOS::cl
     auto* rootNode = scrollingTree().rootNode();
     const auto& snapOffsetsInfo = rootNode->snapOffsetsInfo();
 
-    auto zoomScale = [webPageProxy().cocoaView() scrollView].zoomScale;
+    auto zoomScale = [protect(webPageProxy())->cocoaView() scrollView].zoomScale;
     scrollDestination.scale(1.0 / zoomScale);
     float scaledCurrentScrollOffset = currentScrollOffset / zoomScale;
     auto [rawClosestSnapOffset, newIndex] = snapOffsetsInfo.closestSnapOffset(axis, rootNode->layoutViewport().size(), scrollDestination, velocity, scaledCurrentScrollOffset);
@@ -633,7 +633,7 @@ CGPoint RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSna
 
     const auto& horizontal = rootNode->snapOffsetsInfo().horizontalSnapOffsets;
     const auto& vertical = rootNode->snapOffsetsInfo().verticalSnapOffsets;
-    auto zoomScale = [webPageProxy().cocoaView() scrollView].zoomScale;
+    auto zoomScale = [protect(webPageProxy())->cocoaView() scrollView].zoomScale;
 
     // The bounds checking with maxScrollOffsets is to ensure that we won't interfere with rubber-banding when scrolling to the edge of the page.
     if (!horizontal.isEmpty() && m_currentHorizontalSnapPointIndex && *m_currentHorizontalSnapPointIndex < horizontal.size())
@@ -665,7 +665,7 @@ void RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode(RemoteLayerTr
 {
     m_animatedNodeLayerIDs.add(node.layerID());
     if (m_monotonicTimelineRegistry && !m_monotonicTimelineRegistry->isEmpty())
-        drawingAreaIOS().scheduleDisplayRefreshCallbacksForMonotonicAnimations();
+        protect(drawingAreaIOS())->scheduleDisplayRefreshCallbacksForMonotonicAnimations();
 }
 
 void RemoteScrollingCoordinatorProxyIOS::progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode& node)
@@ -677,7 +677,7 @@ void RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode(RemoteLay
 {
     m_animatedNodeLayerIDs.remove(node.layerID());
     if (m_animatedNodeLayerIDs.isEmpty() || !m_monotonicTimelineRegistry || m_monotonicTimelineRegistry->isEmpty())
-        drawingAreaIOS().pauseDisplayRefreshCallbacksForMonotonicAnimations();
+        protect(drawingAreaIOS())->pauseDisplayRefreshCallbacksForMonotonicAnimations();
 }
 
 void RemoteScrollingCoordinatorProxyIOS::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -453,7 +453,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEv
 {
     auto* scrollingCoordinatorProxy = downcast<WebKit::RemoteScrollingTree>(scrollingTree())->scrollingCoordinatorProxy();
     if (scrollingCoordinatorProxy) {
-        if (RefPtr pageClient = scrollingCoordinatorProxy->webPageProxy().pageClient())
+        if (RefPtr pageClient = protect(scrollingCoordinatorProxy->webPageProxy())->pageClient())
             pageClient->handleAsynchronousCancelableScrollEvent(scrollView, update, completion);
     }
 }
@@ -548,7 +548,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureR
     if (!scrollingCoordinatorProxy)
         return;
 
-    RefPtr pageClient = scrollingCoordinatorProxy->webPageProxy().pageClient();
+    RefPtr pageClient = protect(scrollingCoordinatorProxy->webPageProxy())->pageClient();
     if (!pageClient)
         return;
 
@@ -562,7 +562,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer(U
     if (!scrollingCoordinatorProxy)
         return;
 
-    if (RefPtr pageClient = scrollingCoordinatorProxy->webPageProxy().pageClient())
+    if (RefPtr pageClient = protect(scrollingCoordinatorProxy->webPageProxy())->pageClient())
         pageClient->cancelPointersForGestureRecognizer(gestureRecognizer);
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -950,9 +950,9 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     addAllMessageReceivers();
 
 #if PLATFORM(IOS_FAMILY)
-    DeprecatedGlobalSettings::setDisableScreenSizeOverride(m_preferences->disableScreenSizeOverride());
+    DeprecatedGlobalSettings::setDisableScreenSizeOverride(protect(m_preferences)->disableScreenSizeOverride());
 
-    if (m_configuration->preferences().serviceWorkerEntitlementDisabledForTesting())
+    if (protect(m_configuration)->preferences().serviceWorkerEntitlementDisabledForTesting())
         disableServiceWorkerEntitlementInNetworkProcess();
 #endif
 
@@ -1570,7 +1570,7 @@ void WebPageProxy::swapToProvisionalPage(Ref<ProvisionalPageProxy>&& provisional
 
     std::optional<FramesPerSecond> nominalFramesPerSecond;
     if (m_drawingArea)
-        nominalFramesPerSecond = m_drawingArea->displayNominalFramesPerSecond();
+        nominalFramesPerSecond = protect(m_drawingArea)->displayNominalFramesPerSecond();
     // FIXME: We may want to send WindowScreenDidChange on non-iOS platforms too.
     send(Messages::WebPage::WindowScreenDidChange(*m_displayID, nominalFramesPerSecond));
 #endif
@@ -8959,7 +8959,7 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
 
 #if USE(QUICK_LOOK) && ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
         if (policyAction == PolicyAction::Use && supportsMIMEType) {
-            auto auditToken = process->connection().getAuditToken();
+            auto auditToken = protect(process)->connection().getAuditToken();
             bool status = sandbox_enable_state_flag("EnableQuickLookSandboxResources", *auditToken);
             WEBPAGEPROXY_RELEASE_LOG(Sandbox, "Enabling EnableQuickLookSandboxResources state flag, status = %d", status);
         }
@@ -12440,7 +12440,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.textAutosizingWidth = textAutosizingWidth();
     parameters.mimeTypesWithCustomContentProviders = pageClient ? pageClient->mimeTypesWithCustomContentProviders() : Vector<String> { };
     parameters.deviceOrientation = m_deviceOrientation;
-    parameters.hardwareKeyboardState = m_configuration->processPool().cachedHardwareKeyboardState();
+    parameters.hardwareKeyboardState = protect(m_configuration)->processPool().cachedHardwareKeyboardState();
     parameters.canShowWhileLocked = m_configuration->canShowWhileLocked();
     parameters.insertionPointColor = pageClient ? pageClient->insertionPointColor() : WebCore::Color { };
 #endif

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -817,8 +817,8 @@ bool WebProcessProxy::shouldTakeNearSuspendedAssertion() const
     }
 
     for (auto& page : m_pageMap.values()) {
-        bool processSuppressionEnabled = page->preferences().pageVisibilityBasedProcessSuppressionEnabled();
-        bool nearSuspendedAssertionsEnabled = page->preferences().shouldTakeNearSuspendedAssertions();
+        bool processSuppressionEnabled = protect(page)->preferences().pageVisibilityBasedProcessSuppressionEnabled();
+        bool nearSuspendedAssertionsEnabled = protect(page)->preferences().shouldTakeNearSuspendedAssertions();
         if (nearSuspendedAssertionsEnabled || !processSuppressionEnabled)
             return true;
     }

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -210,7 +210,7 @@ UITargetedDragPreview *DragDropInteractionState::finalDropPreview(UIDragItem *it
 
 void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UIView *previewContainer, RefPtr<WebCore::TextIndicator>&& textIndicator)
 {
-    auto textIndicatorImage = uiImageForImage(textIndicator->contentImage());
+    auto textIndicatorImage = uiImageForImage(protect(textIndicator)->contentImage());
     auto preview = createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, textIndicator->textBoundingRectInRootViewCoordinates(), textIndicator->textRectsInBoundingRectCoordinates(), cocoaColor(textIndicator->estimatedBackgroundColor()).get(), nil, AddPreviewViewToContainer::No);
     if (!preview)
         return;
@@ -298,7 +298,7 @@ RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInte
         // If the context menu preview was created using the snapshot mechanism,
         // the drag preview should be created likewise, so that the size and position
         // of both previews match.
-        auto textIndicatorImage = uiImageForImage(indicator->contentImage());
+        auto textIndicatorImage = uiImageForImage(protect(indicator)->contentImage());
         return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicator->textBoundingRectInRootViewCoordinates(), indicator->textRectsInBoundingRectCoordinates(), cocoaColor(indicator->estimatedBackgroundColor()).get(), nil, addPreviewViewToContainer).autorelease();
     }
 
@@ -315,7 +315,7 @@ RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInte
 
     if (shouldUseTextIndicatorToCreatePreviewForDragSource(source)) {
         RefPtr textIndicator = source.textIndicator;
-        RetainPtr textIndicatorImage = uiImageForImage(textIndicator->contentImage());
+        RetainPtr textIndicatorImage = uiImageForImage(protect(textIndicator)->contentImage());
         return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, textIndicator->textBoundingRectInRootViewCoordinates(), textIndicator->textRectsInBoundingRectCoordinates(), cocoaColor(textIndicator->estimatedBackgroundColor()).get(), nil, addPreviewViewToContainer).autorelease();
     }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -835,7 +835,7 @@ bool PageClientImpl::handleRunOpenPanel(const WebPageProxy& page, const WebFrame
 #if ENABLE(MEDIA_CAPTURE)
     if (parameters.mediaCaptureType() != WebCore::MediaCaptureType::MediaCaptureTypeNone) {
         if (auto pid = page.configuration().processPool().configuration().presentingApplicationPID())
-            WebCore::MediaSessionHelper::sharedHelper().providePresentingApplicationPID(pid);
+            protect(WebCore::MediaSessionHelper::sharedHelper())->providePresentingApplicationPID(pid);
     }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -443,7 +443,7 @@ static bool isJavaScriptURL(NSURL *url)
     };
 
     if (_positionInformation->url.isEmpty() && _positionInformation->image && [delegate respondsToSelector:@selector(actionSheetAssistant:getAlternateURLForImage:completion:)]) {
-        RetainPtr<UIImage> uiImage = adoptNS([[UIImage alloc] initWithCGImage:_positionInformation->image->createPlatformImage().get()]);
+        RetainPtr<UIImage> uiImage = adoptNS([[UIImage alloc] initWithCGImage:protect(_positionInformation->image)->createPlatformImage().get()]);
 
         _hasPendingActionSheet = YES;
         RetainPtr<WKActionSheetAssistant> retainedSelf(self);

--- a/Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm
+++ b/Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm
@@ -57,7 +57,7 @@
 
     auto page = [_webViewToTrack _page];
     RELEASE_LOG(ViewState, "%p - WKApplicationStateTrackingView: View with page [%p, pageProxyID=%" PRIu64 "] was removed from a window, _lastObservedStateWasBackground=%d", self, page.get(), page ? page->identifier().toUInt64() : 0, page ? page->lastObservedStateWasBackground() : false);
-    _applicationStateTracker->setWindow(nil);
+    protect(*_applicationStateTracker)->setWindow(nil);
 }
 
 - (void)didMoveToWindow
@@ -68,7 +68,7 @@
     auto page = [_webViewToTrack _page];
     bool lastObservedStateWasBackground = page ? page->lastObservedStateWasBackground() : false;
 
-    _applicationStateTracker->setWindow(self._contentView.window);
+    protect(*_applicationStateTracker)->setWindow(self._contentView.window);
     RELEASE_LOG(ViewState, "%p - WKApplicationStateTrackingView: View with page [%p, pageProxyID=%" PRIu64 "] was added to a window, _lastObservedStateWasBackground=%d, isNowBackground=%d", self, page.get(), page ? page->identifier().toUInt64() : 0, lastObservedStateWasBackground, [self isBackground]);
 
     if (lastObservedStateWasBackground && ![self isBackground])
@@ -79,7 +79,7 @@
 
 - (void)_applicationDidEnterBackground
 {
-    auto page = [_webViewToTrack _page];
+    RefPtr page = [_webViewToTrack _page].get();
     if (!page)
         return;
 
@@ -89,7 +89,7 @@
 
 - (void)_applicationDidFinishSnapshottingAfterEnteringBackground
 {
-    auto page = [_webViewToTrack _page];
+    RefPtr page = [_webViewToTrack _page].get();
     if (!page)
         return;
 
@@ -99,7 +99,7 @@
 
 - (void)_applicationWillEnterForeground
 {
-    auto page = [_webViewToTrack _page];
+    RefPtr page = [_webViewToTrack _page].get();
     if (!page)
         return;
 
@@ -109,7 +109,7 @@
 
 - (void)_willBeginSnapshotSequence
 {
-    auto page = [_webViewToTrack _page];
+    RefPtr page = [_webViewToTrack _page].get();
     if (!page)
         return;
 
@@ -122,7 +122,7 @@
 
 - (void)_didCompleteSnapshotSequence
 {
-    auto page = [_webViewToTrack _page];
+    RefPtr page = [_webViewToTrack _page].get();
     if (!page)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm
@@ -109,7 +109,7 @@ static void setEnableHighAccuracy(WKGeolocationManagerRef geolocationManager, bo
     // If we have the last position, it is from the initialization or warm up. It is the last known
     // good position so we can return it directly.
     if (_lastActivePosition)
-        _geolocationManager->providerDidChangePosition(_lastActivePosition.get());
+        protect(_geolocationManager)->providerDidChangePosition(_lastActivePosition.get());
 }
 
 - (void)_stopUpdating
@@ -221,17 +221,17 @@ static void setEnableHighAccuracy(WKGeolocationManagerRef geolocationManager, bo
 - (void)positionChanged:(_WKGeolocationPosition *)position
 {
     _lastActivePosition = position->_geolocationPosition.get();
-    _geolocationManager->providerDidChangePosition(_lastActivePosition.get());
+    protect(_geolocationManager)->providerDidChangePosition(_lastActivePosition.get());
 }
 
 - (void)errorOccurred:(NSString *)errorMessage
 {
-    _geolocationManager->providerDidFailToDeterminePosition(errorMessage);
+    protect(_geolocationManager)->providerDidFailToDeterminePosition(errorMessage);
 }
 
 - (void)resetGeolocation
 {
-    _geolocationManager->resetPermissions();
+    protect(_geolocationManager)->resetPermissions();
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -147,7 +147,7 @@ void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOp
     if (!m_page)
         return;
 
-    m_page->didSelectOption(selectedOption);
+    protect(m_page)->didSelectOption(selectedOption);
     close();
 }
 
@@ -185,7 +185,7 @@ void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOp
 
 - (void)didSelectOptionAtIndex:(NSInteger)index
 {
-    _dropdown->didSelectOption(_suggestions[index].value);
+    protect(*_dropdown)->didSelectOption(_suggestions[index].value);
 }
 
 - (void)invalidate

--- a/Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm
@@ -72,7 +72,7 @@ void WebProcessProxy::platformInitialize()
         });
     }
 
-    throttler().setAllowsActivities(!m_processPool->processesShouldSuspend());
+    protect(throttler())->setAllowsActivities(!m_processPool->processesShouldSuspend());
 }
 
 bool WebProcessProxy::fullKeyboardAccessEnabled()

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -169,7 +169,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 - (void)datePickerPopoverControllerDidReset:(WKDatePickerPopoverController *)controller
 {
     [self setDateTimePickerToInitialValue];
-    [_view page]->setFocusedElementValue([_view focusedElementInformation].elementContext, { });
+    protect(*[_view page])->setFocusedElementValue([_view focusedElementInformation].elementContext, { });
 }
 
 - (void)handleDatePickerPresentationDismissal

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -437,8 +437,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_cancel
 {
-    if (_listener)
-        _listener->cancel();
+    if (RefPtr listener = _listener)
+        listener->cancel();
 
     [self _dispatchDidDismiss];
 }
@@ -487,7 +487,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     NSData *png = UIImagePNGRepresentation(iconImage);
     RefPtr iconImageDataRef = adoptRef(WebKit::toImpl(WKDataCreate(static_cast<const unsigned char*>([png bytes]), [png length])));
 
-    _listener->chooseFiles(filenames, displayString, iconImageDataRef.get());
+    protect(_listener)->chooseFiles(filenames, displayString, iconImageDataRef.get());
     [self _dispatchDidDismiss];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -88,7 +88,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)updateColorPickerState
 {
     [_colorPickerViewController setSelectedColor:cocoaColor(_view.focusedElementInformation.colorValue).get()];
-    [_colorPickerViewController setSupportsAlpha:_view.focusedElementInformation.supportsAlpha == WebKit::ColorControlSupportsAlpha::Yes && _view.page->preferences().inputTypeColorEnhancementsEnabled()];
+    [_colorPickerViewController setSupportsAlpha:_view.focusedElementInformation.supportsAlpha == WebKit::ColorControlSupportsAlpha::Yes && protect(_view.page)->preferences().inputTypeColorEnhancementsEnabled()];
     if ([_colorPickerViewController respondsToSelector:@selector(_setSuggestedColors:)])
         [_colorPickerViewController _setSuggestedColors:[self focusedElementSuggestedColors]];
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPopover.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPopover.mm
@@ -135,20 +135,21 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 {
     auto directions = [self popoverArrowDirections];
     CGRect presentationRect;
+    RetainPtr view = retainPtr(_view);
     if (CGPointEqualToPoint(self.presentationPoint, CGPointZero))
-        presentationRect = _view.focusedElementInformation.interactionRect;
+        presentationRect = view.get().focusedElementInformation.interactionRect;
     else {
-        auto scale = _view.page->pageScaleFactor();
+        auto scale = view.get().page->pageScaleFactor();
         presentationRect = CGRectMake(self.presentationPoint.x * scale, self.presentationPoint.y * scale, 1, 1);
     }
 
-    if (!CGRectIntersectsRect(presentationRect, _view.bounds))
+    if (!CGRectIntersectsRect(presentationRect, view.get().bounds))
         return;
 
 #if PLATFORM(MACCATALYST)
     [_view startRelinquishingFirstResponderToFocusedElement];
 #endif
-    [_popoverController presentPopoverFromRect:CGRectIntegral(presentationRect) inView:_view permittedArrowDirections:directions animated:animated];
+    [_popoverController presentPopoverFromRect:CGRectIntegral(presentationRect) inView:view.get() permittedArrowDirections:directions animated:animated];
 }
 
 - (void)dismissPopoverAnimated:(BOOL)animated
@@ -179,7 +180,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (_isRotating)
         return;
 
-    [_dismissionDelegate popoverWasDismissed:self];
+    [protect(_dismissionDelegate) popoverWasDismissed:self];
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -99,11 +99,15 @@ public:
         if (m_interface == interface)
             return;
 
-        if (m_interface && m_interface->playbackSessionModel())
-            m_interface->playbackSessionModel()->removeClient(*this);
+        if (RefPtr currentInterface = m_interface; currentInterface) {
+            if (CheckedPtr playbackSessionModel = currentInterface->playbackSessionModel())
+                playbackSessionModel->removeClient(*this);
+        }
         m_interface = interface;
-        if (m_interface && m_interface->playbackSessionModel())
-            m_interface->playbackSessionModel()->addClient(*this);
+        if (RefPtr currentInterface = m_interface; currentInterface) {
+            if (CheckedPtr playbackSessionModel = currentInterface->playbackSessionModel())
+                playbackSessionModel->addClient(*this);
+        }
     }
 
 private:
@@ -409,7 +413,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     WebCore::PlaybackSessionModel* playbackSessionModel = playbackSessionInterface ? playbackSessionInterface->playbackSessionModel() : nullptr;
     self.playing = playbackSessionModel ? playbackSessionModel->isPlaying() : NO;
     bool isPiPEnabled = false;
-    if (auto page = [self._webView _page])
+    if (RefPtr page = [self._webView _page].get())
         isPiPEnabled = page->preferences().pictureInPictureAPIEnabled() && page->preferences().allowsPictureInPictureMediaPlayback();
     bool isPiPSupported = playbackSessionModel && playbackSessionModel->isPictureInPictureSupported();
 #if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
@@ -745,7 +749,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     UIImage *doneImage;
 
     // FIXME: Rename `alternateFullScreenControlDesignEnabled` to something that explains it is for visionOS.
-    auto alternateFullScreenControlDesignEnabled = self._webView._page->preferences().alternateFullScreenControlDesignEnabled();
+    auto alternateFullScreenControlDesignEnabled = protect(*self._webView._page)->preferences().alternateFullScreenControlDesignEnabled();
     
     if (alternateFullScreenControlDesignEnabled) {
         buttonSize = CGSizeMake(44.0, 44.0);
@@ -999,7 +1003,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     ASSERT(_valid);
     if (auto page = [self._webView _page])
-        return page->fullScreenManager();
+        return protect(*page)->fullScreenManager();
     return nullptr;
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1428,7 +1428,7 @@ void WebLocalFrameLoaderClient::saveViewStateToItem(HistoryItem& historyItem)
 {
 #if PLATFORM(IOS_FAMILY)
     if (m_frame->isMainFrame())
-        m_frame->page()->savePageState(historyItem);
+        protect(m_frame->page())->savePageState(historyItem);
 #else
     UNUSED_PARAM(historyItem);
 #endif
@@ -1440,7 +1440,7 @@ void WebLocalFrameLoaderClient::restoreViewState()
     auto* currentItem = m_localFrame->loader().history().currentItem();
     if (auto* view =  m_localFrame->view()) {
         if (m_frame->isMainFrame())
-            m_frame->page()->restorePageState(*currentItem);
+            protect(m_frame->page())->restorePageState(*currentItem);
         else if (!view->wasScrolledByUser())
             view->setScrollPosition(currentItem->scrollPosition());
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
@@ -362,7 +362,7 @@ void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardWebConten
         protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(*updatedContent, pasteboardName, pageIdentifier(context)), 0);
         return;
     }
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(content, pasteboardName, pageIdentifier(context)), 0);
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPasteboardProxy::WriteWebContentToPasteboard(content, pasteboardName, pageIdentifier(context)), 0);
 }
 
 void WebPlatformStrategies::writeToPasteboard(const WebCore::PasteboardImage& image, const String& pasteboardName, const PasteboardContext* context)

--- a/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebChromeClientCocoa.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebChromeClientCocoa.mm
@@ -59,7 +59,7 @@ void AXRelayProcessSuspendedNotification::sendProcessSuspendMessage(bool suspend
 #else
     NSDictionary *message = @{ @"pid" : @(getpid()), @"suspended" : @(suspended) };
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:message requiringSecureCoding:YES error:nil];
-    m_page->relayAccessibilityNotification("AXProcessSuspended"_s, data);
+    protect(m_page)->relayAccessibilityNotification("AXProcessSuspended"_s, data);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -111,7 +111,7 @@ void WebDragClient::startDrag(DragItem dragItem, DataTransfer&, Frame& frame, co
 void WebDragClient::didConcludeEditDrag()
 {
 #if PLATFORM(IOS_FAMILY)
-    m_page->didConcludeEditDrag();
+    protect(m_page)->didConcludeEditDrag();
 #endif
 }
 
@@ -190,7 +190,7 @@ void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Eleme
 void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Element& element, const URL& url, const String& label, LocalFrame*)
 {
     if (RefPtr frame = element.document().frame())
-        frame->editor().writeImageToPasteboard(*Pasteboard::createForDragAndDrop(PagePasteboardContext::create(frame->pageID())), element, url, label);
+        protect(frame->editor())->writeImageToPasteboard(*Pasteboard::createForDragAndDrop(PagePasteboardContext::create(frame->pageID())), element, url, label);
 }
 
 #endif // USE(APPKIT)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -107,7 +107,7 @@ UseLosslessCompression RemoteLayerTreeContext::useIOSurfaceLosslessCompression()
 #if PLATFORM(IOS_FAMILY)
 bool RemoteLayerTreeContext::canShowWhileLocked() const
 {
-    return m_webPage->canShowWhileLocked();
+    return protect(m_webPage)->canShowWhileLocked();
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
@@ -68,7 +68,7 @@
 
 - (double)pageScale
 {
-    return m_page->pageScaleFactor();
+    return protect(m_page)->pageScaleFactor();
 }
 
 - (id)accessibilityHitTest:(NSPoint)point
@@ -88,10 +88,10 @@
     } else
 #endif // ENABLE(PDF_PLUGIN)
     {
-        convertedPoint = m_page->accessibilityScreenToRootView(WebCore::IntPoint(point));
+        convertedPoint = protect(m_page)->accessibilityScreenToRootView(WebCore::IntPoint(point));
         // If we are hit-testing a remote element (not the main frame), offset the hit test by the scroll of the web page.
         // We can't use focusedLocalFrame for this check, because that will always return a local frame (that isn't necessarily the main frame).
-        if (!is<WebCore::LocalFrame>(m_page->mainFrame())) {
+        if (!is<WebCore::LocalFrame>(protect(m_page)->mainFrame())) {
             if (CheckedPtr frameView = focusedLocalFrame ? focusedLocalFrame->view() : nullptr)
                 convertedPoint.moveBy(frameView->scrollPosition());
         }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5306,12 +5306,12 @@ void WebPage::startPlayingPredominantVideo(CompletionHandler<void(bool)>&& compl
 void WebPage::setSceneIdentifier(String&& sceneIdentifier)
 {
     AudioSession::singleton().setSceneIdentifier(sceneIdentifier);
-    m_page->setSceneIdentifier(WTF::move(sceneIdentifier));
+    protect(m_page)->setSceneIdentifier(WTF::move(sceneIdentifier));
 }
 
 void WebPage::setAllowsMediaDocumentInlinePlayback(bool allows)
 {
-    m_page->setAllowsMediaDocumentInlinePlayback(allows);
+    protect(m_page)->setAllowsMediaDocumentInlinePlayback(allows);
 }
 #endif
 
@@ -7220,7 +7220,7 @@ static bool isTextFormControlOrEditableContent(const WebCore::Element& element)
 #if PLATFORM(IOS_FAMILY) && ENABLE(FULLSCREEN_API)
 static bool shouldExitFullscreenAfterFocusingElement(const WebCore::Element& element)
 {
-    if (!element.document().fullscreen().isFullscreen())
+    if (!protect(element.document().fullscreen())->isFullscreen())
         return false;
 
     if (RefPtr input = dynamicDowncast<const HTMLInputElement>(element))
@@ -7254,7 +7254,7 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
 
 #if ENABLE(FULLSCREEN_API)
     if (shouldExitFullscreenAfterFocusingElement(element))
-        element.document().fullscreen().fullyExitFullscreen();
+        protect(element.document().fullscreen())->fullyExitFullscreen();
 #endif
         if (isChangingFocusedElement && (m_userIsInteracting || m_keyboardIsAttached))
             m_sendAutocorrectionContextAfterFocusingElement = true;
@@ -7265,7 +7265,7 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
 
         RefPtr<API::Object> userData;
 
-        m_formClient->willBeginInputSession(this, &element, WebFrame::fromCoreFrame(*element.document().frame()).get(), m_userIsInteracting, userData);
+        m_formClient->willBeginInputSession(this, &element, protect(WebFrame::fromCoreFrame(*element.document().frame())).get(), m_userIsInteracting, userData);
 
         if (!userData) {
             auto userInfo = element.userInfo();
@@ -7697,10 +7697,10 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_viewportConfiguration.setPrefersHorizontalScrollingBelowDesktopViewportWidths(shouldEnableViewportBehaviorsForResizableWindows());
 
     LOG_WITH_STREAM(VisibleRects, stream << "WebPage " << m_identifier.toUInt64() << " didCommitLoad setting content size to " << coreFrame->view()->contentsSize());
-    if (m_viewportConfiguration.setContentsSize(coreFrame->view()->contentsSize()))
+    if (m_viewportConfiguration.setContentsSize(protect(coreFrame->view())->contentsSize()))
         viewportChanged = true;
 
-    if (m_viewportConfiguration.setViewportArguments(coreFrame->document()->viewportArguments()))
+    if (m_viewportConfiguration.setViewportArguments(protect(coreFrame->document())->viewportArguments()))
         viewportChanged = true;
 
     if (m_viewportConfiguration.setIsKnownToLayOutWiderThanViewport(false))


### PR DESCRIPTION
#### e777761233c0ec1dbc6ce054bd657cf0a4ab4a95
<pre>
[SaferCPP] Fixed [iOS] UncountedCallArgsChecker issues in /WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=306881">https://bugs.webkit.org/show_bug.cgi?id=306881</a>
<a href="https://rdar.apple.com/169540052">rdar://169540052</a>

Reviewed by Rupin Mittal and David Kilzer.

Mechanical fixes dictated by the SaferCPP bot.

* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::setTCCIdentity):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::providePresentingApplicationPID):
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::PendingDownload):
(WebKit::PendingDownload::willSendRedirectedRequest):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::dispatchMessage):
(WebKit::NetworkConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::sourceApplicationAuditToken const):
* Source/WebKit/NetworkProcess/ios/NetworkConnectionToWebProcessIOS.mm:
(WebKit::NetworkConnectionToWebProcess::getPaymentCoordinatorEmbeddingUserAgent):
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCanMakePayments):
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
(WebKit::WebPaymentCoordinatorProxy::platformHidePaymentUI):
* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm:
(-[WKContextMenuElementInfo _activatedElementInfo]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommand.mm:
(-[WKWebExtensionCommand keyCommand]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView dealloc]):
(-[WKWebView setAllowsBackForwardNavigationGestures:]):
(-[WKWebView _remoteObjectRegistry]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _beginBackSwipeForTesting]):
(-[WKWebView _completeBackSwipeForTesting]):
(-[WKWebView _resetNavigationGestureStateForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _appBoundDomains:]):
(-[WKWebsiteDataStore _appBoundSchemes:]):
(-[WKWebsiteDataStore _setBackupExclusionPeriodForTesting:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPosition.mm:
(-[_WKGeolocationPosition dealloc]):
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(-[WKUIWindowSceneObserver observeValueForKeyPath:ofObject:change:context:]):
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
(WebKit::grantCapabilityInternal):
(WebKit::auxiliaryProcessesForPage):
(WebKit::ExtensionCapabilityGranter::setMediaCapabilityActive):
(WebKit::ExtensionCapabilityGranter::invalidateGrants):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::interceptMarketplaceKitNavigation):
(WebKit::NavigationState::didChangeIsLoading):
(WebKit::NavigationState::didSwapWebProcesses):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::acquireAsync):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationModelContext::presentingViewController):
(WebKit::VideoPresentationManagerProxy::bestVideoForElementFullscreen):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::shouldAllowAutoFillForCellularIdentifiers const):
(WebKit::WebPageProxy::setMediaCapability):
(WebKit::WebPageProxy::deactivateMediaCapability):
(WebKit::WebPageProxy::resetMediaCapability):
(WebKit::WebPageProxy::updateMediaCapability):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::currentLayoutViewport const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSnapOffset const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereAddedToNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::handleAsynchronousCancelableScrollEvent):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::computeActiveTouchActionsForGestureRecognizer):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::cancelPointersForGestureRecognizer):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::m_pageForTesting):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shouldTakeNearSuspendedAssertion const):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::appBoundDomainQueue):
(WebKit::WebsiteDataStore::initializeAppBoundDomains):
(WebKit::WebsiteDataStore::ensureAppBoundDomains const):
(WebKit::WebsiteDataStore::setBackupExclusionPeriodForTesting):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::deliverDelayedDropPreview):
(WebKit::DragDropInteractionState::createDragPreviewInternal const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::handleRunOpenPanel):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(-[WKSwipeTransitionController startInteractiveTransition:]):
(-[WKSwipeTransitionController shouldBeginInteractiveTransition:]):
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
(WebKit::ViewGestureController::resetState):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant showImageSheet]):
* Source/WebKit/UIProcess/ios/WKApplicationStateTrackingView.mm:
(-[WKApplicationStateTrackingView willMoveToWindow:]):
(-[WKApplicationStateTrackingView didMoveToWindow]):
(-[WKApplicationStateTrackingView _applicationDidEnterBackground]):
(-[WKApplicationStateTrackingView _applicationDidFinishSnapshottingAfterEnteringBackground]):
(-[WKApplicationStateTrackingView _applicationWillEnterForeground]):
(-[WKApplicationStateTrackingView _willBeginSnapshotSequence]):
(-[WKApplicationStateTrackingView _didCompleteSnapshotSequence]):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
(-[WKContentView _setupVisibilityPropagationForWebProcess]):
(-[WKContentView dealloc]):
(-[WKContentView _showInspectorHighlight:]):
(-[WKContentView didUpdateVisibleRect:sendEvenIfUnchanged:]):
(-[WKContentView _accessibilityRegisterUIProcessTokens]):
(-[WKContentView _createDrawingAreaProxy:]):
(-[WKContentView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
(-[WKContentView _applicationWillResignActive:]):
(-[WKContentView _applicationDidBecomeActive:]):
(-[WKContentView _applicationDidEnterBackground:]):
(-[WKContentView _applicationWillEnterForeground:]):
(-[WKContentView _displayScaleDidChange]):
(-[WKContentView _sceneCaptureStateDidChange]):
(-[WKContentView _shouldExposeRollAngleAsTwist]):
(-[WKContentView _attributesForPrintFormatter:]):
(-[WKContentView _createImage:printFormatter:]):
(-[WKContentView _createPDF:printFormatter:]):
(-[WKContentView _waitForDrawToPDFCallbackForPrintFormatterIfNeeded:]):
(-[WKContentView _waitForDrawToImageCallbackForPrintFormatterIfNeeded:]):
* Source/WebKit/UIProcess/ios/WKGeolocationProviderIOS.mm:
(-[WKGeolocationProviderIOS _startUpdating]):
(-[WKGeolocationProviderIOS positionChanged:]):
(-[WKGeolocationProviderIOS errorOccurred:]):
(-[WKGeolocationProviderIOS resetGeolocation]):
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(WebKit::WebDataListSuggestionsDropdownIOS::didSelectOption):
(-[WKDataListSuggestionsControl didSelectOptionAtIndex:]):
* Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm:
(WebKit::WebProcessProxy::platformInitialize):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker datePickerPopoverControllerDidReset:]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel _cancel]):
(-[WKFileUploadPanel _chooseFiles:displayString:iconImage:]):
* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
(-[WKColorPicker updateColorPickerState]):
* Source/WebKit/UIProcess/ios/forms/WKFormPopover.mm:
(-[WKRotatingPopover presentPopoverAnimated:]):
(-[WKRotatingPopover popoverControllerDidDismissPopover:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController videoControlsManagerDidChange]):
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController _manager]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(WebKit::WKWebViewState::applyTo):
(WebKit::WKWebViewState::store):
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController _reinsertWebViewUnderPlaceholder]):
(-[WKFullScreenWindowController _completedExitFullScreen:]):
(-[WKFullScreenWindowController didExitPictureInPicture]):
(-[WKFullScreenWindowController _manager]):
(-[WKFullScreenWindowController _videoPresentationManager]):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::takeFindStringFromSelection):
(WebKit::UnifiedPDFPlugin::accessibilityCoreObject):
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorVisibility):
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorLocation):
(WebKit::UnifiedPDFPlugin::updatePageNumberIndicatorCurrentPage):
(WebKit::UnifiedPDFPlugin::platformPopulateEditorStateIfNeeded const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::saveViewStateToItem):
(WebKit::WebLocalFrameLoaderClient::restoreViewState):
* Source/WebKit/WebProcess/WebCoreSupport/WebPlatformStrategies.cpp:
(WebKit::WebPlatformStrategies::writeToPasteboard):
* Source/WebKit/WebProcess/WebCoreSupport/cocoa/WebChromeClientCocoa.mm:
(WebKit::AXRelayProcessSuspendedNotification::sendProcessSuspendMessage):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::WebDragClient::didConcludeEditDrag):
(WebKit::WebDragClient::declareAndWriteDragImage):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::canShowWhileLocked const):
* Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm:
(-[WKAccessibilityWebPageObject pageScale]):
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setSceneIdentifier):
(WebKit::WebPage::setAllowsMediaDocumentInlinePlayback):
(WebKit::shouldExitFullscreenAfterFocusingElement):
(WebKit::WebPage::elementDidFocus):
(WebKit::WebPage::didCommitLoad):
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindController::updateFindIndicator):
(WebKit::FindController::hideFindIndicator):
(WebKit::setSelectionChangeUpdatesEnabledInAllFrames):
(WebKit::FindController::willFindString):
(WebKit::FindController::didFindString):
(WebKit::FindController::didFailToFindString):
(WebKit::FindController::didHideFindIndicator):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::platformInitializeAccessibility):
(WebKit::WebPage::restorePageState):
(WebKit::WebPage::rectForElementAtInteractionLocation const):
(WebKit::WebPage::attemptSyntheticClick):
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):
(WebKit::WebPage::requestAdditionalItemsForDragSession):
(WebKit::WebPage::handleTwoFingerTapAtPoint):
(WebKit::WebPage::potentialTapAtPosition):
(WebKit::WebPage::commitPotentialTapFailed):
(WebKit::WebPage::cancelPotentialTap):
(WebKit::WebPage::didRecognizeLongPress):
(WebKit::WebPage::tapHighlightAtPosition):
(WebKit::WebPage::inspectorNodeSearchMovedToPosition):
(WebKit::WebPage::inspectorNodeSearchEndedAtPosition):
(WebKit::WebPage::setIsShowingInputViewForFocusedElement):
(WebKit::WebPage::clearSelection):
(WebKit::WebPage::revealItemForCurrentSelection):
(WebKit::WebPage::willInsertFinalDictationResult):
(WebKit::WebPage::focusedElementInformation):
(WebKit::WebPage::updateTextAutosizingEnablementFromInitialScale):
(WebKit::WebPage::shrinkToFitContent):
(WebKit::WebPage::willStartUserTriggeredZooming):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):

Canonical link: <a href="https://commits.webkit.org/306746@main">https://commits.webkit.org/306746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97bd0769b4e15b5f86b7b140a5aefc27f8eacdd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150789 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95343 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1ad4c45-9e6e-41b8-aa75-bf228afaa9fe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109288 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/78986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/117925a4-bc90-4908-ae34-ac95479bcb95) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90187 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb828543-d2b0-4d62-b04c-4ddb2944dff5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11354 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9016 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/833 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120694 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153150 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14242 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117355 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117677 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13726 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69942 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21941 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14291 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3486 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78007 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14068 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->