### PR TITLE
Web Inspector: Update styling of search input icons

### DIFF
--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -421,12 +421,8 @@ String InspectorFrontendHost::platform() const
 
 String InspectorFrontendHost::platformVersionName() const
 {
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
-    return "monterey"_s;
-#elif PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 110000
-    return "big-sur"_s;
-#elif PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
-    return "catalina"_s;
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
+    return "tahoe"_s;
 #else
     return emptyString();
 #endif

--- a/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
@@ -83,10 +83,6 @@
     appearance: none;
 }
 
-:is(.filter-bar, .search-bar) > input[type="search"]::-webkit-search-results-button {
-    margin-inline-end: 4px;
-}
-
 /* FIXME: use a different image for ::-webkit-search-decoration when :not(:placeholder-shown) */
 
 :is(.filter-bar, .search-bar) > input[type="search"]::placeholder {

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
@@ -79,10 +79,6 @@
     height: 22px;
 }
 
-.navigation-bar > .item.find-banner.console > input[type="search"]::-webkit-textfield-decoration-container {
-    margin-inline-start: 4px;
-}
-
 .navigation-bar > .item.find-banner.console > input[type="search"]:focus,
 .navigation-bar > .item.find-banner.console > input[type="search"]:focus ~ button,
 .navigation-bar > .item.find-banner.console > input[type="search"]:not(:placeholder-shown),

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -106,6 +106,11 @@ body.docked.left #docked-resizer {
     cursor: col-resize;
 }
 
+body.mac-platform.tahoe input[type=search]::-webkit-search-cancel-button,
+body.mac-platform.tahoe input[type=search]::-webkit-search-results-button {
+    margin-inline: 3px;
+}
+
 input[type=range] {
     appearance: none;
 }


### PR DESCRIPTION
#### 4f4b6333b8ed5cfcd0b10652548d5296874b313b
<pre>
Web Inspector: Update styling of search input icons
<a href="https://bugs.webkit.org/show_bug.cgi?id=306880">https://bugs.webkit.org/show_bug.cgi?id=306880</a>
<a href="https://rdar.apple.com/169539512">rdar://169539512</a>

Reviewed by BJ Burg and Brandon Stewart.

Default styling for HTML search input fields has changed in macOS Tahoe
The spacing around icons has been reduced because the default input
has more padding and pronounced rounded corners.

Web Inspector overrides the default styles and didn&apos;t account for
the change in spacing. The icons for revealing the search history
and clearing the input are touching the sides of the input field.

This patch updates the spacing for icons in search input fields.

There were some leftover adjustments from a time predating macOS Tahoe,
Sequoia and even Sonoma which made search history icons appear misaligned.
This patch also removes those obsolete adjustments, fixing the alignment for
Web Inspector on those older macOS versions.

* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::platformVersionName const):
* Source/WebInspectorUI/UserInterface/Views/FilterBar.css:
(:is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]::-webkit-search-results-button): Deleted.
* Source/WebInspectorUI/UserInterface/Views/LogContentView.css:
(.navigation-bar &gt; .item.find-banner.console &gt; input[type=&quot;search&quot;]::-webkit-textfield-decoration-container): Deleted.
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(body.mac-platform.tahoe input[type=search]::-webkit-search-cancel-button):
(body.mac-platform.tahoe input[type=search]::-webkit-search-results-button):

Canonical link: <a href="https://commits.webkit.org/306799@main">https://commits.webkit.org/306799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f2c1192aa6a7710eee5f316d32fc23672e2e2b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142382 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14778 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151028 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b14c2b6-d516-4af3-993b-efdfc2effb70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109486 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a51b6cd-b4e0-4632-b4ad-cbb763bb3bf6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12004 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/5184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90388 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8d740d3-3133-4d30-91dc-f66995adb45a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11520 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1048 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120872 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/5184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14457 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117526 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14479 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117851 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30045 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13896 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/5184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70169 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14506 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78222 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14283 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->