### PR TITLE
Introducing a TZone Category using __builtin_tmo_get_type_descriptor.

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -103,7 +103,7 @@ namespace WTF {
 // - WTF_MAKE_COMPACT_TZONE_ALLOCATED(ClassName)
 // - WTF_MAKE_COMPACT_TZONE_ALLOCATED_EXPORT(ClassName, exportMacro)
 //     class / struct / template is allocated from a fixed set of shared libpas heaps with the same size and alignment. Each set of shared heaps is
-//     known as a TZoneTypeBuckets. The particular bucket is selected using SHA 256 hashing on a process startup value along with particulars of the
+//     known as a TZone Group. The particular bucket is selected using SHA 256 hashing on a process startup value along with particulars of the
 //     class / struct being allocated. This sharing provides protections from type confusion and use-after-free bugs, but with less memory overhead of
 //     IsoHeap allocated objects. This is the preferred allocation method.
 //     For example, if Event is annotated with WTF_MAKE_TZONE_ALLOCATED(Event), all derived classes of Event must be annotated with

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2020, 2026 Apple Inc. All rights reserved.
  * Copyright (C) 2008, 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
  * This library is free software; you can redistribute it and/or
@@ -123,6 +123,9 @@ class Node : public EventTarget, public CanMakeCheckedPtr<Node> {
     friend class Document;
     friend class TreeScope;
 public:
+    // This opts the entire Node family tree into being allocated in the BuiltinTypeDescriptor TZone category.
+    static constexpr bool usesBuiltinTypeDescriptorTZoneCategory = true;
+
     enum NodeType {
         ELEMENT_NODE = 1,
         ATTRIBUTE_NODE = 2,

--- a/Source/bmalloc/bmalloc/BCompiler.h
+++ b/Source/bmalloc/bmalloc/BCompiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024, 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,13 @@
 
 /* BCOMPILER() - the compiler being used to build the project */
 #define BCOMPILER(BFEATURE) (defined BCOMPILER_##BFEATURE && BCOMPILER_##BFEATURE)
+
+/* BCOMPILER_HAS_CLANG_BUILTIN() - whether the compiler supports a particular clang builtin. */
+#ifdef __has_builtin
+#define BCOMPILER_HAS_CLANG_BUILTIN(x) __has_builtin(x)
+#else
+#define BCOMPILER_HAS_CLANG_BUILTIN(x) 0
+#endif
 
 /* BCOMPILER_HAS_CLANG_FEATURE() - whether the compiler supports a particular language or library feature. */
 /* http://clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension */

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -67,6 +67,7 @@ public: \
             &s_heapRef, \
             TZoneSpecification::encodeSize<_type>(), \
             TZoneSpecification::encodeAlignment<_type>(), \
+            TZoneSpecification::encodeCategory<_type>(), \
             ::bmalloc::api::compactAllocationMode<_type>(), \
             TZoneSpecification::encodeDescriptor<_type>(), \
             TZONE_SPEC_NAME_ARG(#_type) \
@@ -109,6 +110,7 @@ const TZoneSpecification _type::s_heapSpec = { \
     &_type::s_heapRef, \
     TZoneSpecification::encodeSize<_type>(), \
     TZoneSpecification::encodeAlignment<_type>(), \
+    TZoneSpecification::encodeCategory<_type>(), \
     ::bmalloc::api::compactAllocationMode<_type>(), \
     TZoneSpecification::encodeDescriptor<_type>(), \
     TZONE_SPEC_NAME_ARG(#_type) \


### PR DESCRIPTION
#### f3f8a5374a00497279556db7d3e423668506dcba
<pre>
Introducing a TZone Category using __builtin_tmo_get_type_descriptor.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306883">https://bugs.webkit.org/show_bug.cgi?id=306883</a>
<a href="https://rdar.apple.com/169541053">rdar://169541053</a>

Reviewed by Marcus Plutowski.

This change redefines the 64-bit TZoneDescriptor into several bit fields:

   bits 0-35 [ 36 bits ]: TZone Category defined hash.
  bits 36-40 [  5 bits ]: log2(alignment)
  bits 41-61 [ 31 bits ]: sizeClass divided by 16
  bits 62-63 [  2 bits ]: TZone Category

We also clearly defines 2 TZone Categories:

1. SizeAndAlignment
   - sorts TZone types by size and alignment alone.
   - This is the default TZone category is the type is not opted into another category.

2. BuiltinTypeDescriptor
   - adds __builtin_tmo_get_type_descriptor to size and alignment for sorting TZone types.
   - TZone types can opt their entire class hierarchy into this category by declaring
     `static constexpr bool usesBuiltinTypeDescriptorTZoneCategory = true` in their root
     base class.
   - Each derived class still needs to be declared TZONE_ALLOCATED individually (in order
     to instantiate type specific TZone support methods and data structures), but with
     `usesBuiltinTypeDescriptorTZoneCategory`, they will be opted into the
     BuiltinTypeDescriptor category.
   - Currently, we&apos;re only opting DOM nodes into this new category.

AB tests show that this change is perf neutral on all benchmarks.

No new tests because we&apos;re changing the way we sort TZone types into heaps.  There&apos;s
currently no way to inquire as to which heap the type is sorted into.  This code was
manually tested by adding instrumentation to trace TZone type allocations, and then, decode
and check the TZoneDescriptor used for the types.  This instrumentation is too expensive in
terms of performance to keep in the build, and too intrusive to keep in the code base.

* Source/WTF/wtf/FastMalloc.h:
* Source/WebCore/dom/Node.h:
* Source/bmalloc/bmalloc/BCompiler.h:
* Source/bmalloc/bmalloc/TZoneHeap.h:
(bmalloc::api::TZoneSpecification::usesBuiltinTypeDescriptor):
(bmalloc::api::TZoneSpecification::encodeDefaultDescriptor):
(bmalloc::api::TZoneSpecification::encodeBuiltinTypeDescriptorHash):
(bmalloc::api::TZoneSpecification::encodeCategory):
(bmalloc::api::TZoneSpecification::encodeDescriptor):
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeapManager.cpp:
(bmalloc::api::TZoneDescriptorDecoder::category const):
(bmalloc::api::TZoneDescriptorDecoder::sizeClass const):
(bmalloc::api::TZoneDescriptorDecoder::alignment const):
(bmalloc::api::TZoneHeapManager::dumpRegisteredTypes):
(bmalloc::api::TZoneHeapManager::TZoneHeapManager::heapRefForTZoneTypeDifferentSize):

Canonical link: <a href="https://commits.webkit.org/306751@main">https://commits.webkit.org/306751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f43efd1ee53aa14b563d7358ee80827a7783909d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142213 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150844 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1f3a97f-c0bf-492a-a1d3-73db540697e8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109336 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90236 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db6e6f40-8cc8-4a9f-8b4d-a8211d091fef) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11390 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/879 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134197 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153196 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3017 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117395 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117718 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13766 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124495 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/69988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21942 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14337 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3530 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173502 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14069 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78053 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44903 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14114 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->