### PR TITLE
[WebXR][GTK][WPE] Unable to enter sessions when makeXRCompatible is used

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp
@@ -365,10 +365,7 @@ bool GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensions()
 
     return enableExtensionsImpl({
         "GL_OES_EGL_image"_s,
-        "GL_OES_EGL_image_external"_s,
-        "EGL_KHR_image_base"_s,
-        "EGL_EXT_image_dma_buf_import"_s,
-        "EGL_KHR_surfaceless_context"_s
+        "GL_OES_EGL_image_external"_s
     });
 }
 #endif // ENABLE(WEBXR)


### PR DESCRIPTION
#### aaa8686f00cc3ef183fced194bf2a013f601d06b
<pre>
[WebXR][GTK][WPE] Unable to enter sessions when makeXRCompatible is used
<a href="https://bugs.webkit.org/show_bug.cgi?id=306882">https://bugs.webkit.org/show_bug.cgi?id=306882</a>

Reviewed by Adrian Perez de Castro.

Every time a JS app requested an XR-compatible canvas using
makeXRCompatible() the promise returned by that method was rejected and
thus no XR session could be started. That was not happening if the
xrCompatible GL context attribute was specified though. The difference
was that the former was checking whether or not the graphics subsystem
supported all the required extensions to make XR content work. That call
was returning false (meaning not all the extensions are available) in
several platforms.

It turns out that many of them are not actually required. They were just
there because at some point were used for the Android port but they are
not really required for Linux. Android already has a different list of
required extensions for what is worth.

By removing those unused extensions we can make all the experiences
using makeXRCompatible work again. It&apos;s worth noting that this only
happened whenever the GBM graphics context was used.

This cannot be easily tested as it requires a Graphics GL context with
GBM support. Tests use the ANGLE one which does not have this issue.

* Source/WebCore/platform/graphics/gbm/GraphicsContextGLTextureMapperGBM.cpp:
(WebCore::GraphicsContextGLTextureMapperGBM::enableRequiredWebXRExtensions):

Canonical link: <a href="https://commits.webkit.org/306781@main">https://commits.webkit.org/306781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b19aabf78883811bbad565f7dd5489cd4392395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95327 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109286 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78979 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9004 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153134 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/2955 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117342 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/141569 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14248 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117662 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30039 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13713 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69926 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14275 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77991 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->