### PR TITLE
[iOS] Only increase Web process cache capacity when Site Isolation is enabled

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -324,8 +324,10 @@ void WebProcessCache::updateCapacity(WebProcessPool& processPool)
     } else if (capacityOverride >= 0) {
         m_capacity = capacityOverride;
     } else {
-        constexpr unsigned maxProcesses = 32;
+        unsigned maxProcesses = 32;
 #if PLATFORM(IOS_FAMILY)
+        if (!processPool.hasUsedSiteIsolation())
+            maxProcesses = 10;
         size_t memorySize = WTF::ramSizeDisregardingJetsamLimit();
 #else
         size_t memorySize = WTF::ramSize();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2165,8 +2165,10 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
     Site site { navigation.currentRequest().url() };
 
     bool siteIsolationEnabled = protect(page.preferences())->siteIsolationEnabled();
-    if (siteIsolationEnabled && !m_hasUsedSiteIsolation)
+    if (siteIsolationEnabled && !m_hasUsedSiteIsolation) {
         m_hasUsedSiteIsolation = true;
+        m_webProcessCache->updateCapacity(*this);
+    }
 
     bool isMainFrameNavigation = frame.isMainFrame();
     Ref sourceProcess = frame.process();

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -638,6 +638,8 @@ public:
     void setPLTResourceDelayInterval(Seconds interval) { m_pltResourceDelayInterval = interval; }
     Seconds pltResourceDelayInterval() const { return m_pltResourceDelayInterval; }
 
+    bool hasUsedSiteIsolation() const { return m_hasUsedSiteIsolation; }
+
 private:
     enum class NeedsGlobalStaticInitialization : bool { No, Yes };
     void platformInitialize(NeedsGlobalStaticInitialization);


### PR DESCRIPTION
#### 8721945979337b7b410a8b8985dd51924071a143
<pre>
[iOS] Only increase Web process cache capacity when Site Isolation is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=306887">https://bugs.webkit.org/show_bug.cgi?id=306887</a>
<a href="https://rdar.apple.com/169546362">rdar://169546362</a>

Reviewed by Ben Nham and Sihui Liu.

In &lt;<a href="https://commits.webkit.org/306363@main">https://commits.webkit.org/306363@main</a>&gt;, we increased the Web process cache capacity for the purpose of
Site Isolation. However, we did so unconditionally. The intention behind this commit was to make the Web
process cache also include the iframe Web processes when Site Isolation is enabled, and not increase the
cache size when Site Isolation is disabled.  This PR fixes this by only increasing the capacity when Site
Isolation is enabled.

* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::updateCapacity):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/UIProcess/WebProcessPool.h:

Canonical link: <a href="https://commits.webkit.org/307041@main">https://commits.webkit.org/307041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7235ba4b3f4444a0512edaaeb73c9ddec9b49c15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150795 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95330 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78b7ce72-d396-4f46-bdad-21813b1e8b42) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109296 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78980 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50bce577-76d3-461a-b109-65e1dd141309) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127237 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90195 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d22179a9-951a-46ba-94f1-4975ca3855eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11343 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9007 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/820 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120682 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153137 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117345 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117666 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13717 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69929 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22077 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14278 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3474 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/77994 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14055 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->