### PR TITLE
[iOS] MediaPlayerPrivateWirelessPlayback should attempt to load a media element's current source URL

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/load-url-source-element-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-source-element-expected.txt
@@ -1,0 +1,10 @@
+Test that a video's first <source> element's URL is passed to a MediaDeviceRoute when the route activates.
+
+
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EXPECTED (actualURL == '/LayoutTests/media/content/test.mp4') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/load-url-source-element.html
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-source-element.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+            var actualURL;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.createElement('video');
+
+                const mediaType = 'video/mp4';
+                const mediaURL = findMediaFile('video', '../content/test');
+
+                const source = document.createElement('source');
+                source.src = mediaURL;
+                source.type = mediaType;
+                video.appendChild(source);
+
+                document.body.appendChild(video);
+
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const loadedURL = await urlPromise;
+                const expectedURL = new URL(mediaURL, document.baseURI).href.substring(document.baseURI.indexOf('/LayoutTests/'));
+                actualURL = loadedURL.substring(loadedURL.indexOf('/LayoutTests/'));
+
+                testExpected('actualURL', expectedURL);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <p>Test that a video's first &lt;source&gt; element's URL is passed to a MediaDeviceRoute when the route activates.</p>
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/load-url-src-attr-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-src-attr-expected.txt
@@ -1,0 +1,10 @@
+Test that a video's src attribute URL is passed to a MediaDeviceRoute when the route activates.
+
+
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EXPECTED (actualURL == '/LayoutTests/media/content/test.mp4') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/load-url-src-attr.html
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-src-attr.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+            var actualURL;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.createElement('video');
+                const mediaURL = findMediaFile('video', '../content/test');
+                video.src = mediaURL;
+                document.body.appendChild(video);
+
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const loadedURL = await urlPromise;
+                const expectedURL = new URL(mediaURL, document.baseURI).href.substring(document.baseURI.indexOf('/LayoutTests/'));
+                actualURL = loadedURL.substring(loadedURL.indexOf('/LayoutTests/'));
+
+                testExpected('actualURL', expectedURL);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <p>Test that a video's src attribute URL is passed to a MediaDeviceRoute when the route activates.</p>
+    </body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1178,6 +1178,11 @@ private:
     void maybeUpdatePlayerPreload() const;
     void canProduceAudioChanged();
 
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    void scheduleRebuildMediaEngineForWirelessPlayback();
+    void rebuildMediaEngineForWirelessPlayback();
+#endif
+
     Timer m_progressEventTimer;
     Timer m_playbackProgressTimer;
     Timer m_scanTimer;

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -132,7 +132,7 @@ public:
     const WTF::UUID& identifier() const { return m_identifier; }
     WebMediaDevicePlatformRoute *platformRoute() const;
 
-    void loadURL(const String&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
+    void loadURL(const URL&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
 
     float minValue() const;
     float maxValue() const;

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -74,13 +74,13 @@ String MediaPlaybackTargetWirelessPlayback::deviceName() const
     return { };
 }
 
-void MediaPlaybackTargetWirelessPlayback::loadURL(const String& urlString, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&& completionHandler)
+void MediaPlaybackTargetWirelessPlayback::loadURL(const URL& url, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&& completionHandler)
 {
     RefPtr route = m_route;
     if (!route)
         return completionHandler(makeUnexpected(MediaDeviceRouteLoadURLError::NoRoute));
 
-    route->loadURL(urlString, WTF::move(completionHandler));
+    route->loadURL(url, WTF::move(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -29,6 +29,7 @@
 
 #include <WebCore/MediaDeviceRouteLoadURLResult.h>
 #include <WebCore/MediaPlaybackTarget.h>
+#include <wtf/Forward.h>
 #include <wtf/UUID.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ public:
 
     MediaDeviceRoute* route() const;
 
-    void loadURL(const String&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
+    void loadURL(const URL&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
 
 private:
     MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&&, bool hasActiveRoute);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -35,6 +35,7 @@
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/URL.h>
 
 namespace WebCore {
 
@@ -61,6 +62,11 @@ private:
 
     explicit MediaPlayerPrivateWirelessPlayback(MediaPlayer&);
 
+    void updateURLIfNeeded();
+
+    void setNetworkState(MediaPlayer::NetworkState);
+    void setReadyState(MediaPlayer::ReadyState);
+
     // MediaPlayerPrivateInterface
     constexpr MediaPlayerType mediaPlayerType() const final { return MediaPlayerType::WirelessPlayback; }
     void load(const String&) final;
@@ -80,8 +86,8 @@ private:
     void seekToTarget(const SeekTarget&) final { }
     bool seeking() const final { return false; }
     bool paused() const final { return true; }
-    MediaPlayer::NetworkState networkState() const final { return MediaPlayer::NetworkState::Empty; }
-    MediaPlayer::ReadyState readyState() const final { return MediaPlayer::ReadyState::HaveNothing; }
+    MediaPlayer::NetworkState networkState() const final { return m_networkState; }
+    MediaPlayer::ReadyState readyState() const final { return m_readyState; }
     const PlatformTimeRanges& buffered() const final { return m_buffered; }
     bool didLoadingProgress() const final { return false; }
     void paint(GraphicsContext&, const FloatRect&) final { }
@@ -99,8 +105,6 @@ private:
     void setShouldPlayToPlaybackTarget(bool) final;
 #endif
 
-    void updateURLStringIfNeeded();
-
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper
     const Logger& logger() const final { return m_logger.get(); }
@@ -111,7 +115,9 @@ private:
 
     ThreadSafeWeakPtr<MediaPlayer> m_player;
     PlatformTimeRanges m_buffered;
-    String m_urlString;
+    URL m_url;
+    MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
+    MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     bool m_allowsWirelessVideoPlayback { true };
     bool m_shouldPlayToTarget { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -3318,7 +3318,7 @@ bool MediaPlayerPrivateAVFoundationObjC::isCurrentPlaybackTargetWireless() const
 
 #if !PLATFORM(IOS_FAMILY) || ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     if (RefPtr playbackTarget = m_playbackTarget) {
-        if (playbackTarget->type() == MediaPlaybackTarget::Type::WirelessPlayback)
+        if (playbackTarget->targetType() == MediaPlaybackTarget::Type::AVOutputContext)
             wirelessTarget = m_avPlayer && m_avPlayer.get().externalPlaybackActive;
         else
             wirelessTarget = m_shouldPlayToPlaybackTarget && playbackTarget->hasActiveRoute();
@@ -3427,7 +3427,7 @@ String MediaPlayerPrivateAVFoundationObjC::wirelessPlaybackTargetName() const
 #if !PLATFORM(IOS_FAMILY) || ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     if (RefPtr playbackTarget = m_playbackTarget) {
 #if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
-        if (playbackTarget->type() == MediaPlaybackTarget::Type::AVOutputContext)
+        if (playbackTarget->targetType() == MediaPlaybackTarget::Type::AVOutputContext)
             wirelessTargetName = externalDeviceDisplayNameForPlayer(m_avPlayer.get()).get();
         else
 #endif
@@ -3504,7 +3504,7 @@ void MediaPlayerPrivateAVFoundationObjC::setShouldPlayToPlaybackTarget(bool shou
     INFO_LOG(LOGIDENTIFIER, shouldPlay);
 
 #if !PLATFORM(IOS_FAMILY)
-    if (playbackTarget->type() == MediaPlaybackTarget::Type::AVOutputContext) {
+    if (playbackTarget->targetType() == MediaPlaybackTarget::Type::AVOutputContext) {
         RetainPtr<AVOutputContext> newContext = shouldPlay ? m_outputContext.get() : nil;
 
         if (!m_avPlayer)


### PR DESCRIPTION
#### 3028fdda999a0597d6c5cc45bae92555b9a5d36f
<pre>
[iOS] MediaPlayerPrivateWirelessPlayback should attempt to load a media element&apos;s current source URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=306897">https://bugs.webkit.org/show_bug.cgi?id=306897</a>
<a href="https://rdar.apple.com/169560043">rdar://169560043</a>

Reviewed by Jer Noble.

HTMLMediaPlayer was previously taught how to fall back to an AirPlay-compatible &lt;source&gt; element
URL when a MediaDeviceRoute activated during non-AirPlay-compatible playback (e.g., MSE). However,
it did not know how to handle the case where a route activates when the current source *is*
AirPlay-compatible. This change makes it so by introducing
HTMLMediaElement::rebuildMediaEngineForWirelessPlayback. It creates a new MediaPlayer, then either
loads currentSrc() if the element has a src attribute, or resets m_currentSourceNode and
m_nextChildNodeToConsider and calls loadNextSourceChild() if the element has &lt;source&gt; element
children.

Tests: media/wireless-playback-media-player/load-url-source-element.html
       media/wireless-playback-media-player/load-url-src-attr.html

* LayoutTests/media/wireless-playback-media-player/load-url-source-element-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/load-url-source-element.html: Added.
* LayoutTests/media/wireless-playback-media-player/load-url-src-attr-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/load-url-src-attr.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::checkPlaybackTargetCompatibility):
(WebCore::HTMLMediaElement::scheduleRebuildMediaEngineForWirelessPlayback):
(WebCore::inferredContentTypeFromURL):
(WebCore::HTMLMediaElement::rebuildMediaEngineForWirelessPlayback):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp:
(WebCore::MediaPlaybackTargetWirelessPlayback::loadURL):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::supportsURL):
(WebCore::MediaPlayerPrivateWirelessPlayback::load):
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded):
(WebCore::MediaPlayerPrivateWirelessPlayback::setNetworkState):
(WebCore::MediaPlayerPrivateWirelessPlayback::setReadyState):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLStringIfNeeded): Deleted.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::wirelessPlaybackTargetName const):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setShouldPlayToPlaybackTarget):

Canonical link: <a href="https://commits.webkit.org/306752@main">https://commits.webkit.org/306752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38df01cecdd84615bc4a226c582919e3eae4cc55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150826 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95372 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03555a1a-f086-4f6a-9e26-d6e2058dec96) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109320 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/78995 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6c42b58-7283-485c-85e5-e8934ba637a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11843 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90220 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13cdb20d-3d94-406b-aaa9-d7e5ba30438f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9037 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/862 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153179 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14271 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117379 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30010 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13748 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124468 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69971 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14320 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14052 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78036 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14256 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14097 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->