### PR TITLE
REGRESSION (305692@main): [WK1] ASSERTION FAILED: Constant crash under PlatformCALayerCocoa::shadowPath() on multiple tests

### DIFF
--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -385,7 +385,10 @@ Ref<PlatformCALayer> PlatformCALayerCocoa::clone(PlatformCALayerClient* owner) c
     newLayer->setBackdropRootIsOpaque(backdropRootIsOpaque());
     newLayer->copyFiltersFrom(*this);
     newLayer->updateCustomAppearance(customAppearance());
-    newLayer->setShadowPath(shadowPath());
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
+    if (RetainPtr shadowPath = [m_layer shadowPath])
+        newLayer->setShadowPath(this->shadowPath());
+    END_BLOCK_OBJC_EXCEPTIONS
 
     if (type == PlatformCALayer::LayerType::LayerTypeAVPlayerLayer) {
         ASSERT(PAL::isAVFoundationFrameworkAvailable() && [newLayer->platformLayer() isKindOfClass:PAL::getAVPlayerLayerClassSingleton()]);


### PR DESCRIPTION
#### c782e71fab8929f1cec9efae8c7f4a39284cb794
<pre>
REGRESSION (305692@main): [WK1] ASSERTION FAILED: Constant crash under PlatformCALayerCocoa::shadowPath() on multiple tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=306890">https://bugs.webkit.org/show_bug.cgi?id=306890</a>
<a href="https://rdar.apple.com/169548155">rdar://169548155</a>

Reviewed by Wenson Hsieh, Alexey Proskuryakov, and Tim Horton.

At least the following tests:

- css3/filters/backdrop/backdrop-filter-with-reflection.html
- compositing/reflections/direct-image-object-fit-reflected.html

are crashing due to this assertion failure:

```
ASSERTION FAILED: m_platformPath
/Source/WebCore/platform/graphics/cg/PathCG.cpp(372) : WebCore::PathCG::PathCG(RetainPtr&lt;CGMutablePathRef&gt; &amp;&amp;)
```

... following 305692@main. This assertion is harmless because it does
not hurt for us to clone a platform layer with a null shadow path.
However, PathCG construction has an existing assertion against null
CGPathRef arguments.

In this patch, we recover test coverage by simply not copying a shadow
path if the original platform layer&apos;s shadow path is nil.

* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::clone const):

Canonical link: <a href="https://commits.webkit.org/306747@main">https://commits.webkit.org/306747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/185f0c3b1864d91afa5470b37a0389a9fd11ab7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150819 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f87c7da-ea4e-4d8b-875b-79445cf1cf9f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15304 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109313 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69178cc6-c625-40db-b297-42f491654b12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90213 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d4270c4-a62f-4d5b-98d6-69803b5139ec) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11376 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9029 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/855 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153172 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14264 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117372 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12440 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30007 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13747 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/69964 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14313 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3501 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14045 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14249 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14090 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->