### PR TITLE
Promote WKNavigationAction._mainFrameNavigation and WKNavigationResponse._navigation to API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h
@@ -34,6 +34,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class WKFrameInfo;
+@class WKNavigation;
 
 /*! @enum WKNavigationType
  @abstract The type of action triggering a navigation.
@@ -84,6 +85,11 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
 /*! @abstract Whether or not the navigation is a redirect from a content rule list.
  */
 @property (nonatomic, readonly) BOOL isContentRuleListRedirect WK_API_AVAILABLE(macos(16.0), ios(19.0), visionos(3.0));
+
+/*! @abstract The most recent main frame navigation that took place that encompasses this navigation action.
+@discussion If this WKNavigationAction represents a request to open a new WKWebView or it represents a frame load that is not in the main frame of an existing WKWebView, then mainFrameNavigation will be nil.
+ */
+@property (nonatomic, readonly, nullable) WKNavigation *mainFrameNavigation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 #if TARGET_OS_IPHONE
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -130,6 +130,11 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
     return _navigationAction->shouldPerformDownload();
 }
 
+- (WKNavigation *)mainFrameNavigation
+{
+    return wrapper(protect(_navigationAction->mainFrameNavigation()).get());
+}
+
 #if PLATFORM(IOS_FAMILY)
 - (WKSyntheticClickType)_syntheticClickType
 {
@@ -236,9 +241,8 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKNavigation *)_mainFrameNavigation
 {
-    return wrapper(protect(_navigationAction->mainFrameNavigation()).get());
+    return [self mainFrameNavigation];
 }
-
 
 - (void)_storeSKAdNetworkAttribution
 {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h
@@ -30,6 +30,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class WKFrameInfo;
+@class WKNavigation;
 
 /*! Contains information about a navigation response, used for making policy decisions.
  */
@@ -49,6 +50,10 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  @discussion Allowing a navigation response with a MIME type that can't be shown will cause the navigation to fail.
  */
 @property (nonatomic, readonly) BOOL canShowMIMEType;
+
+/*! @abstract The most recent main frame navigation that took place that encompasses this navigation response.
+ */
+@property (nonatomic, readonly, nullable) WKNavigation *mainFrameNavigation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm
@@ -64,6 +64,11 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     return _navigationResponse->canShowMIMEType();
 }
 
+- (WKNavigation *)mainFrameNavigation
+{
+    return wrapper(_navigationResponse->navigation());
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -88,7 +93,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (WKNavigation *)_navigation
 {
-    return wrapper(_navigationResponse->navigation());
+    return [self mainFrameNavigation];
 }
 
 - (NSURLRequest *)_request

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -538,7 +538,9 @@ TEST(WKNavigation, DecidePolicyForPageCacheNavigation)
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
     EXPECT_TRUE(!!navigationAction._mainFrameNavigation);
+    EXPECT_TRUE(!!navigationAction.mainFrameNavigation);
     EXPECT_EQ(navigationAction._mainFrameNavigation, navigation);
+    EXPECT_EQ(navigationAction.mainFrameNavigation, navigation);
     decisionHandler(WKNavigationActionPolicyAllow);
 }
 


### PR DESCRIPTION
#### bafa51b86cb435a3ec122d63fc484532affd7d55
<pre>
Promote WKNavigationAction._mainFrameNavigation and WKNavigationResponse._navigation to API
<a href="https://rdar.apple.com/169546232">rdar://169546232</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306886">https://bugs.webkit.org/show_bug.cgi?id=306886</a>

Reviewed by Alex Christensen.

This SPI has been valuable for SPI-using apps, and has been requested by 3rd parties.
It deserves to be promoted to API.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm

* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction mainFrameNavigation]):
(-[WKNavigationAction _mainFrameNavigation]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponse.mm:
(-[WKNavigationResponse navigation]):
(-[WKNavigationResponse _navigation]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(-[NavigationActionHasNavigationDelegate webView:decidePolicyForNavigationAction:decisionHandler:]):
(-[MyNavigationDelegate webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):
(-[MyNavigationDelegate webView:decidePolicyForNavigationResponse:decisionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm:
(-[WKNavigationResponseTestNavigationDelegate webView:decidePolicyForNavigationResponse:decisionHandler:]):
(TEST(WebKit, WKNavigationResponseJSONMIMEType)):
(TEST(WebKit, WKNavigationResponseJSONMIMEType2)):
(TEST(WebKit, WKNavigationResponseUnknownMIMEType)):
(TEST(WebKit, WKNavigationResponsePDFType)):

Canonical link: <a href="https://commits.webkit.org/306818@main">https://commits.webkit.org/306818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daa5512510310091d7e51b249f0ab18871e8c7de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151007 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95546 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cda58316-c519-41d9-8b8c-ad3a966bb2f4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109475 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95546 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f4cf275-4479-487d-b749-6a5238f69905) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90377 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70ab73a8-b716-4940-8582-a4a89acfd5d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11507 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9161 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1027 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153344 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14436 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117515 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117839 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13886 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70146 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14485 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3679 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14422 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->