### PR TITLE
When HTMLVideoElement.showCaptionDisplaySettings() is called with no arguments, menu is not anchored by cursor

### DIFF
--- a/LayoutTests/media/caption-display-settings/caption-display-settings-default-anchorBounds-expected.txt
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings-default-anchorBounds-expected.txt
@@ -1,0 +1,29 @@
+
+Test anchorBounds during a mouse event:
+RUN(eventSender.mouseMoveTo(15, 25))
+RUN(eventSender.mouseDown(); eventSender.mouseUp())
+RUN(video.showCaptionDisplaySettings({}))
+EXPECTED (options.anchorBounds.x == '15') OK
+EXPECTED (options.anchorBounds.y == '25') OK
+EXPECTED (options.anchorBounds.width == '0') OK
+EXPECTED (options.anchorBounds.height == '0') OK
+-
+Test anchorBounds during a keyboard event:
+RUN(target.focus())
+RUN(eventSender.keyDown(" "))
+RUN(video.showCaptionDisplaySettings({}))
+EXPECTED (options.anchorBounds.x == '10') OK
+EXPECTED (options.anchorBounds.y == '20') OK
+EXPECTED (options.anchorBounds.width == '30') OK
+EXPECTED (options.anchorBounds.height == '40') OK
+-
+Test anchorBounds after a mouse event:
+RUN(eventSender.mouseMoveTo(35, 45))
+RUN(eventSender.mouseDown(); eventSender.mouseUp())
+RUN(video.showCaptionDisplaySettings({}))
+EXPECTED (options.anchorBounds.x == '35') OK
+EXPECTED (options.anchorBounds.y == '45') OK
+EXPECTED (options.anchorBounds.width == '0') OK
+EXPECTED (options.anchorBounds.height == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/caption-display-settings/caption-display-settings-default-anchorBounds.html
+++ b/LayoutTests/media/caption-display-settings/caption-display-settings-default-anchorBounds.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CaptionDisplaySettingsEnabled=true ] -->
+<html>
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>caption-display-settings</title>
+	<script src="../../resources/ui-helper.js"></script>
+	<script src="../video-test.js"></script>
+	<style>
+		#target {
+			position: absolute;
+			left: 10px;
+			top: 20px;
+			width: 30px;
+			height: 40px;
+			background-color: green;
+		}
+	</style>
+	<script>
+	async function runTest() {
+		findMediaElement();
+
+		window.options = null;
+		internals.setMockCaptionDisplaySettingsClientCallback(async (element, inOptions) => {
+			options = inOptions;
+		});
+
+		let waitForAndCallShowCaptionDisplaySettings = (target, type) => {
+			return new Promise(resolve => {
+				target.addEventListener(type, event => {
+					run('video.showCaptionDisplaySettings({})').then(resolve);
+				}, { once: true })
+			});
+		};
+
+		consoleWrite('Test anchorBounds during a mouse event:')
+
+		var promise = waitForAndCallShowCaptionDisplaySettings(window, 'mousedown');
+		run('eventSender.mouseMoveTo(15, 25)');
+		run('eventSender.mouseDown(); eventSender.mouseUp()');
+		await promise;
+
+		testExpected('options.anchorBounds.x', 15);
+		testExpected('options.anchorBounds.y', 25);
+		testExpected('options.anchorBounds.width', 0);
+		testExpected('options.anchorBounds.height', 0);
+
+		consoleWrite('-')
+		consoleWrite('Test anchorBounds during a keyboard event:')
+		promise = waitForAndCallShowCaptionDisplaySettings(target, 'keypress');
+		run('target.focus()');
+		run('eventSender.keyDown(" ")');
+		await promise;
+
+		testExpected('options.anchorBounds.x', 10);
+		testExpected('options.anchorBounds.y', 20);
+		testExpected('options.anchorBounds.width', 30);
+		testExpected('options.anchorBounds.height', 40);
+
+		consoleWrite('-')
+		consoleWrite('Test anchorBounds after a mouse event:')
+		promise = waitFor(window, 'mousedown', true);
+		run('eventSender.mouseMoveTo(35, 45)');
+		run('eventSender.mouseDown(); eventSender.mouseUp()');
+		await promise;
+		await sleepFor(10);
+		await run('video.showCaptionDisplaySettings({})');
+
+		testExpected('options.anchorBounds.x', 35);
+		testExpected('options.anchorBounds.y', 45);
+		testExpected('options.anchorBounds.width', 0);
+		testExpected('options.anchorBounds.height', 0);
+	}
+
+	window.addEventListener('load', event => {
+		requestAnimationFrame(() => {
+			runTest().then(endTest).catch(failTest);	
+		});
+	});
+	</script>
+</head>
+<body>
+	<video muted autoplay></video>
+	<button id=target></button>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8477,3 +8477,6 @@ webkit.org/b/306998 [ Debug ] inspector/injected-script/observable.html [ Skip ]
 webkit.org/b/306998 [ Debug ] inspector/page/filter-cookies-for-domain.html [ Skip ]
 
 webkit.org/b/307091 inspector/network/intercept-aborted-request.html [ Skip ]
+
+# Requires mousedown
+media/caption-display-settings/caption-display-settings-default-anchorBounds.html [ Skip ]


### PR DESCRIPTION
#### 63830c8668cf34ae45accbe05e4bb149fccfc488
<pre>
When HTMLVideoElement.showCaptionDisplaySettings() is called with no arguments, menu is not anchored by cursor
<a href="https://rdar.apple.com/165762212">rdar://165762212</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306899">https://bugs.webkit.org/show_bug.cgi?id=306899</a>

Reviewed by Eric Carlson.

When an anchorTarget is not included in the dictionary parameter to showCaptionDisplaySettings(),
do our best to provide a good place for the pop-up menu to be placed. We will try in the following order:
- Current mouse or touch location if the current event is a mouse or touch event
- Current event target if not
- Otherwise, the last known mouse location

Test: media/caption-display-settings/caption-display-settings-default-anchorBounds.html

* LayoutTests/media/caption-display-settings/caption-display-settings-default-anchorBounds-expected.txt: Added.
* LayoutTests/media/caption-display-settings/caption-display-settings-default-anchorBounds.html: Added.
* Source/WebCore/html/HTMLVideoElementCaptionDisplaySettings.cpp:
(WebCore::HTMLVideoElementCaptionDisplaySettings::showCaptionDisplaySettings):

Canonical link: <a href="https://commits.webkit.org/307185@main">https://commits.webkit.org/307185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f935751b41a7df39c830c6fd362e0a605b23b54c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96678 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c5aa713-3555-452a-8091-97076e296048) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110306 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79413 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/def034b9-c4df-4e3a-875f-b44887680b2d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91218 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08fafb1d-dd33-494c-9182-966f9bdf91f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9976 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2109 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121691 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154419 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15970 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118322 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118666 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30403 "Found 1 new test failure: fast/block/transparent-outline-with-and-without-border-radius.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14628 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71384 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15591 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5261 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79305 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->