### PR TITLE
Digital Credentials: Build ISO 18013 request with request info

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -477,8 +477,12 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/identity/DigitalCredentialGetRequest.h
     Modules/identity/DigitalCredentialPresentationProtocol.h
     Modules/identity/DigitalCredentialRequestOptions.h
+    Modules/identity/DigitalCredentialsMobileDocumentRequestData.h
+    Modules/identity/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h
     Modules/identity/DigitalCredentialsRequestData.h
+    Modules/identity/DigitalCredentialsRequestDataBuilder.h
     Modules/identity/DigitalCredentialsResponseData.h
+    Modules/identity/DigitalCredentialsSecurityOriginData.h
 
     Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -44,7 +44,6 @@ class CredentialRequestCoordinatorClient;
 class Document;
 class LocalFrame;
 class Page;
-struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
 struct ExceptionData;
 

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include <WebCore/DigitalCredentialsProtocols.h>
+#include <WebCore/DigitalCredentialsRequestData.h>
 #include <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMalloc.h>
@@ -39,8 +40,6 @@ class SecurityOrigin;
 class SecurityOriginData;
 class Document;
 template<typename T> class ExceptionOr;
-
-struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
 struct DigitalCredentialsRevalidationResult;
 struct ExceptionData;
@@ -53,7 +52,7 @@ class CredentialRequestCoordinatorClient : public RefCounted<CredentialRequestCo
 public:
     CredentialRequestCoordinatorClient() = default;
     virtual ~CredentialRequestCoordinatorClient() = default;
-    virtual void showDigitalCredentialsPicker(Vector<UnvalidatedDigitalCredentialRequest>&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&) = 0;
+    virtual void showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&) = 0;
     virtual void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&) = 0;
     virtual ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const SecurityOrigin&, const Document&, const Vector<UnvalidatedDigitalCredentialRequest>&) = 0;
 

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -33,6 +33,7 @@
 #include "CredentialRequestOptions.h"
 #include "DigitalCredentialPresentationProtocol.h"
 #include "DocumentPage.h"
+#include "DocumentSecurityOrigin.h"
 #include "ExceptionOr.h"
 #include "FrameDestructionObserverInlines.h"
 #include "IDLTypes.h"

--- a/Source/WebCore/Modules/identity/DigitalCredentialsMobileDocumentRequestData.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsMobileDocumentRequestData.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/DigitalCredentialsSecurityOriginData.h>
+#include <WebCore/ValidatedMobileDocumentRequest.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct DigitalCredentialsMobileDocumentRequestData : DigitalCredentialsSecurityOriginData {
+    Vector<ValidatedMobileDocumentRequest> requests;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+#include <WebCore/DigitalCredentialsSecurityOriginData.h>
+#include <WebCore/ExceptionOr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+enum class ResponseType : uint8_t {
+    Attestation,
+    Disclosure,
+};
+
+struct DigitalCredentialsMobileDocumentRequestDataWithRequestInfo : DigitalCredentialsSecurityOriginData {
+    ResponseType responseType;
+    String matchingHint;
+};
+
+using RawDigitalCredentialsWithRequestInfo = Vector<String>;
+
+} // namespace WebCore
+
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)

--- a/Source/WebCore/Modules/identity/DigitalCredentialsRequestData.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsRequestData.h
@@ -25,9 +25,14 @@
 
 #pragma once
 
+#include <WebCore/DigitalCredentialsMobileDocumentRequestData.h>
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+#include <WebCore/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h>
+#endif
 #include <WebCore/MobileDocumentRequest.h>
-#include <WebCore/SecurityOriginData.h>
+#include <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #include <WebCore/ValidatedMobileDocumentRequest.h>
+#include <wtf/Variant.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -35,10 +40,18 @@ namespace WebCore {
 using DigitalCredentialRequestTypes = MobileDocumentRequest;
 using ValidatedDigitalCredentialRequest = ValidatedMobileDocumentRequest;
 
-struct DigitalCredentialsRequestData {
-    Vector<ValidatedMobileDocumentRequest> requests;
-    SecurityOriginData topOrigin;
-    SecurityOriginData documentOrigin;
-};
+using DigitalCredentialsRequestData = Variant<
+    DigitalCredentialsMobileDocumentRequestData
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    , DigitalCredentialsMobileDocumentRequestDataWithRequestInfo
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+>;
+
+using DigitalCredentialsRawRequests = Variant<
+    Vector<UnvalidatedDigitalCredentialRequest>
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    , RawDigitalCredentialsWithRequestInfo
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    >;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DigitalCredentialsRequestDataBuilder.h"
+
+#include <WebCore/DigitalCredentialsRequestData.h>
+#include <WebCore/DocumentSecurityOrigin.h>
+#include <WebCore/ISO18013DocumentRequest.h>
+#include <WebCore/SecurityOrigin.h>
+#include <WebCore/SecurityOriginData.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+#include <WebCore/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h>
+#include <WebCore/ISO18013DocumentRequestInfo.h>
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+namespace WebCore {
+
+ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>> DigitalCredentialsRequestDataBuilder::build(Vector<ValidatedMobileDocumentRequest> validatedCredentialRequests, const Document& document, Vector<UnvalidatedDigitalCredentialRequest>&& unvalidatedRequests)
+{
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    auto allRequests = flatMap(validatedCredentialRequests, [](auto& validatedRequest) {
+        return flatMap(validatedRequest.presentmentRequests, [](auto& presentmentRequest) {
+            return flatMap(presentmentRequest.documentRequestSets, [](auto& documentSet) {
+                return documentSet.requests;
+            });
+        });
+    });
+
+    auto results = compactMap(allRequests, [&document](auto& request) -> std::optional<ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>>> {
+        if (!request.requestInfo.has_value() || request.documentType != ISO18013RequestInfoDocType)
+            return std::nullopt;
+
+        auto result = buildAndValidateRequestDataWithRequestInfo(request, document);
+        if (result.hasException())
+            return result.releaseException();
+
+        auto [requestDataWithRequestInfo, rawRequestStrings] = result.releaseReturnValue();
+        return std::make_pair(
+            DigitalCredentialsRequestData { WTF::move(requestDataWithRequestInfo) },
+            DigitalCredentialsRawRequests { WTF::move(rawRequestStrings) });
+    });
+
+    std::optional<ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>>> firstException = std::nullopt;
+    for (auto result : results) {
+        // return the first matching result without exception
+        if (!result.hasException())
+            return result.releaseReturnValue();
+
+        if (result.hasException() && !firstException)
+            firstException = result.releaseException();
+    }
+    if (firstException)
+        return firstException.value();
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+    // otherwise send all requests
+    return std::make_pair(
+        DigitalCredentialsRequestData {
+            DigitalCredentialsMobileDocumentRequestData {
+                { protect(document.topOrigin())->data(), protect(document.securityOrigin())->data() },
+                WTF::move(validatedCredentialRequests) } },
+        DigitalCredentialsRawRequests { WTF::move(unvalidatedRequests) });
+}
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+ExceptionOr<std::pair<DigitalCredentialsMobileDocumentRequestDataWithRequestInfo, RawDigitalCredentialsWithRequestInfo>> DigitalCredentialsRequestDataBuilder::buildAndValidateRequestDataWithRequestInfo(const ISO18013DocumentRequest& documentRequest, const Document& document)
+{
+    auto responseType = parseRequestedDataElements(documentRequest);
+    if (responseType.hasException())
+        return responseType.releaseException();
+
+    auto matchingHintAndRawRequests = parseMatchingHintAndRawRequests(documentRequest);
+    if (matchingHintAndRawRequests.hasException())
+        return matchingHintAndRawRequests.releaseException();
+
+    auto [ matchingHint, rawRequests ] = matchingHintAndRawRequests.releaseReturnValue();
+
+    auto requestData = DigitalCredentialsMobileDocumentRequestDataWithRequestInfo {
+        { protect(document.topOrigin())->data(), protect(document.securityOrigin())->data() },
+        responseType.releaseReturnValue(),
+        matchingHint
+    };
+
+    return std::make_pair(WTF::move(requestData), WTF::move(rawRequests));
+}
+
+ExceptionOr<std::pair<String, RawDigitalCredentialsWithRequestInfo>> DigitalCredentialsRequestDataBuilder::parseMatchingHintAndRawRequests(const ISO18013DocumentRequest& documentRequest)
+{
+    if (documentRequest.requestInfo->extension.isEmpty())
+        return Exception { ExceptionCode::TypeError, "Missing data in request info"_s };
+
+    auto extension = documentRequest.requestInfo->extension.begin()->value;
+
+    return switchOn(extension.data,
+        [](const HashMap<String, Box<ISO18013Any>>& extensionMap) -> ExceptionOr<std::pair<String, RawDigitalCredentialsWithRequestInfo>> {
+            auto rawRequests = parseRawRequests(extensionMap);
+            if (rawRequests.hasException())
+                return rawRequests.releaseException();
+
+            auto matchingHint = parseMatchingHint(extensionMap);
+            if (matchingHint.hasException())
+                return matchingHint.releaseException();
+
+            return std::make_pair(matchingHint.releaseReturnValue(), rawRequests.releaseReturnValue());
+        },
+        [](const auto& value) -> ExceptionOr<std::pair<String, RawDigitalCredentialsWithRequestInfo>> {
+            UNUSED_PARAM(value);
+            return Exception { ExceptionCode::TypeError, "Extension is wrong type"_s };
+        }
+    );
+}
+
+ExceptionOr<RawDigitalCredentialsWithRequestInfo> DigitalCredentialsRequestDataBuilder::parseRawRequests(const HashMap<String, Box<ISO18013Any>>& extension)
+{
+    auto rawRequests = extension.getOptional(rawRequestKey);
+    if (!rawRequests)
+        return Exception { ExceptionCode::TypeError, "Missing raw request key"_s };
+
+    return WTF::switchOn((*rawRequests)->data,
+        [](const Vector<Box<ISO18013Any>>& rawRequestsVec) -> ExceptionOr<RawDigitalCredentialsWithRequestInfo> {
+            // Try to convert Vector<Box<ISO18013Any>> to Vector<String>
+            Vector<String> rawRequestsVector;
+            rawRequestsVector.reserveInitialCapacity(rawRequestsVec.size());
+
+            for (auto rawRequest : rawRequestsVec) {
+                auto stringResult = WTF::switchOn(rawRequest->data,
+                    [](const String& str) -> std::optional<String> {
+                        return str;
+                    },
+                    [](const auto& value) -> std::optional<String> {
+                        UNUSED_PARAM(value);
+                        return std::nullopt;
+                    }
+                );
+
+                if (!stringResult)
+                    return Exception { ExceptionCode::TypeError, "Raw request element is not a String"_s };
+
+                rawRequestsVector.append(stringResult.value());
+            }
+
+            return rawRequestsVector;
+        },
+        [](const auto& value) -> ExceptionOr<RawDigitalCredentialsWithRequestInfo> {
+            UNUSED_PARAM(value);
+            return Exception { ExceptionCode::TypeError, "Raw requests are wrong type"_s };
+        }
+    );
+}
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/DigitalCredentialsRequestDataBuilderAdditions.cpp>)
+#include <WebKitAdditions/DigitalCredentialsRequestDataBuilderAdditions.cpp>
+#else
+static inline bool isValidMatchingHint(StringView matchingHint)
+{
+    return true;
+}
+#endif
+
+ExceptionOr<String> DigitalCredentialsRequestDataBuilder::parseMatchingHint(const HashMap<String, Box<ISO18013Any>>& extension)
+{
+    auto matchingHint = extension.getOptional(matchingHintKey);
+    if (!matchingHint)
+        return Exception { ExceptionCode::TypeError, "Missing matching hint key"_s };
+
+    return WTF::switchOn((*matchingHint)->data, [](String matchingHint) -> ExceptionOr<String> {
+        if (!isValidMatchingHint(matchingHint))
+            return Exception { ExceptionCode::TypeError, "Invalid matching hint value"_s };
+        return matchingHint;
+    }, [](const auto& value) -> ExceptionOr<String> {
+        UNUSED_PARAM(value);
+        return Exception { ExceptionCode::TypeError, "Matching hint the is wrong type"_s };
+        }
+    );
+}
+
+ExceptionOr<ResponseType> DigitalCredentialsRequestDataBuilder::parseRequestedDataElements(const ISO18013DocumentRequest& documentRequest)
+{
+    auto requestInfoNamespaceVector = [&documentRequest]() -> ExceptionOr<const ISO18013ElementNamespaceVector&> {
+        for (auto& nameSpace : documentRequest.namespaces) {
+            if (nameSpace.first == requestInfoNamespace)
+                return nameSpace.second;
+        }
+        return Exception { ExceptionCode::TypeError, makeString("Unable to find request info namespace: \""_s, requestInfoNamespace, "\""_s) };
+    }();
+
+    if (requestInfoNamespaceVector.hasException())
+        return requestInfoNamespaceVector.releaseException();
+
+    auto containsDataElementIdentifier = [&requestInfoNamespaceVector](const ASCIILiteral& dataElementIdentifier) {
+        return requestInfoNamespaceVector.returnValue().containsIf([&dataElementIdentifier](const auto& item) {
+            auto [requestedDataElementIdentifier, isRetaining] = item;
+            UNUSED_PARAM(isRetaining);
+            return requestedDataElementIdentifier == dataElementIdentifier;
+        });
+    };
+
+    bool requestingAttestation = containsDataElementIdentifier(attestationElementIdentifier);
+    bool requestingDisclosure = containsDataElementIdentifier(disclosureElementIdentifier);
+
+    if (requestingAttestation && requestingDisclosure)
+        return ResponseType::Disclosure;
+
+    if (requestingAttestation)
+        return ResponseType::Attestation;
+
+    return Exception { ExceptionCode::TypeError, "Missing supported data element identifiers"_s };
+}
+
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/DigitalCredentialsRequestData.h>
+#include <WebCore/Document.h>
+#include <WebCore/ExceptionOr.h>
+#include <WebCore/ISO18013DocumentRequest.h>
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+#include <WebCore/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h>
+#include <WebCore/ISO18013DocumentRequestInfo.h>
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+#include <WebCore/SecurityOriginData.h>
+#include <WebCore/ValidatedMobileDocumentRequest.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class DigitalCredentialsRequestDataBuilder {
+
+public:
+    static ExceptionOr<std::pair<DigitalCredentialsRequestData, DigitalCredentialsRawRequests>> build(Vector<ValidatedMobileDocumentRequest>, const Document&, Vector<UnvalidatedDigitalCredentialRequest>&&);
+
+private:
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
+    static ExceptionOr<std::pair<DigitalCredentialsMobileDocumentRequestDataWithRequestInfo, RawDigitalCredentialsWithRequestInfo>> buildAndValidateRequestDataWithRequestInfo(const ISO18013DocumentRequest&, const Document&);
+
+    static ExceptionOr<std::pair<String, RawDigitalCredentialsWithRequestInfo>> parseMatchingHintAndRawRequests(const ISO18013DocumentRequest&);
+
+    static ExceptionOr<RawDigitalCredentialsWithRequestInfo> parseRawRequests(const HashMap<String, Box<ISO18013Any>>&);
+
+    static ExceptionOr<String> parseMatchingHint(const HashMap<String, Box<ISO18013Any>>&);
+
+    static ExceptionOr<ResponseType> parseRequestedDataElements(const ISO18013DocumentRequest&);
+
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/DigitalCredentialsRequestDataBuilderAdditions.h>)
+// FIXME: Properly support using WKA in modules.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnon-modular-include-in-module"
+#include <WebKitAdditions/DigitalCredentialsRequestDataBuilderAdditions.cpp>
+#pragma clang diagnostic pop
+#else
+    static constexpr ASCIILiteral ISO18013RequestInfoDocType = "org.iso.mdoc.requestInfo";
+    static constexpr ASCIILiteral requestInfoNamespace = "mdoc.requestInfo"_s;
+
+    static constexpr ASCIILiteral attestationElementIdentifier = "attestation"_s;
+    static constexpr ASCIILiteral disclosureElementIdentifier = "disclosure"_s;
+
+    static constexpr ASCIILiteral rawRequestKey = "rawRequest"_s;
+    static constexpr ASCIILiteral matchingHintKey = "matchingHint"_s;
+#endif
+
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredentialsSecurityOriginData.h
+++ b/Source/WebCore/Modules/identity/DigitalCredentialsSecurityOriginData.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/SecurityOriginData.h>
+
+namespace WebCore {
+
+struct DigitalCredentialsSecurityOriginData {
+    SecurityOriginData topOrigin;
+    SecurityOriginData documentOrigin;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
+++ b/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
@@ -45,7 +45,7 @@ Ref<DummyCredentialRequestCoordinatorClient> DummyCredentialRequestCoordinatorCl
     return adoptRef(*new DummyCredentialRequestCoordinatorClient);
 }
 
-void DummyCredentialRequestCoordinatorClient::showDigitalCredentialsPicker(Vector<WebCore::UnvalidatedDigitalCredentialRequest>&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
+void DummyCredentialRequestCoordinatorClient::showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
 {
     completionHandler(makeUnexpected(WebCore::ExceptionData { WebCore::ExceptionCode::NotSupportedError, "Empty client."_s }));
 }

--- a/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
+++ b/Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h
@@ -27,6 +27,7 @@
 #include <WebCore/CredentialRequestCoordinatorClient.h>
 
 #if ENABLE(WEB_AUTHN)
+#include <WebCore/DigitalCredentialsRequestData.h>
 #include <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/TZoneMalloc.h>
@@ -44,7 +45,7 @@ public:
     static Ref<DummyCredentialRequestCoordinatorClient> create();
 
 private:
-    void showDigitalCredentialsPicker(Vector<WebCore::UnvalidatedDigitalCredentialRequest>&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&);
+    void showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&&);
     void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&) final;
     ExceptionOr<Vector<ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const SecurityOrigin&, const Document&, const Vector<UnvalidatedDigitalCredentialRequest>&) final;
 };

--- a/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
@@ -28,6 +28,7 @@
 #include "IDBCursorInfo.h"
 #include "MemoryBackingStoreTransaction.h"
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -32,6 +32,7 @@
 #include "JSTransformStream.h"
 #include "JSWritableStream.h"
 #include "MessagePort.h"
+#include "StreamTransferUtilities.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/JSObjectInlines.h>
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -156,6 +156,7 @@ Modules/highlight/Highlight.cpp
 Modules/highlight/HighlightRegistry.cpp
 Modules/identity/CredentialRequestCoordinator.cpp
 Modules/identity/DigitalCredential.cpp
+Modules/identity/DigitalCredentialsRequestDataBuilder.cpp
 Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp
 Modules/indexeddb/IDBCursor.cpp
 Modules/indexeddb/IDBCursorWithValue.cpp

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -498,7 +498,7 @@ public:
         return adoptRef(*new EmptyCredentialRequestCoordinatorClient);
     }
 
-    void showDigitalCredentialsPicker(Vector<WebCore::UnvalidatedDigitalCredentialRequest>&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
+    void showDigitalCredentialsPicker(DigitalCredentialsRawRequests&&, const DigitalCredentialsRequestData&, CompletionHandler<void(Expected<DigitalCredentialsResponseData, ExceptionData>&&)>&& completionHandler)
     {
         callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(makeUnexpected(ExceptionData { ExceptionCode::NotSupportedError, "Empty client."_s }));

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <WebCore/Cursor.h>
+#include <WebCore/DigitalCredentialsRequestData.h>
 #include <WebCore/DisabledAdaptations.h>
 #include <WebCore/FocusDirection.h>
 #include <WebCore/HostWindow.h>
@@ -33,6 +34,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/Variant.h>
 #include <wtf/Vector.h>
 
 #if PLATFORM(COCOA)
@@ -95,8 +97,6 @@ struct WindowFeatures;
 
 #if ENABLE(WEB_AUTHN)
 class SecurityOriginData;
-
-struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
 struct ExceptionData;
 struct MobileDocumentRequest;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -140,7 +140,7 @@ class Widget;
 class WorkerClient;
 
 #if ENABLE(WEB_AUTHN)
-struct DigitalCredentialsRequestData;
+struct DigitalCredentialsMobileDocumentRequestData;
 struct MobileDocumentRequest;
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5435,11 +5435,11 @@ header: <WebCore/SecurityPolicyViolationEvent.h>
     uint64_t columnNumber();
 };
 
-class WebCore::SecurityOriginData {
+[AdditionalEncoder=StreamConnectionEncoder] class WebCore::SecurityOriginData {
     Variant<WebCore::SecurityOriginData::Tuple, WebCore::OpaqueOriginIdentifierProcessQualified> data();
 };
 
-[Nested] class WebCore::SecurityOriginData::Tuple {
+[Nested, AdditionalEncoder=StreamConnectionEncoder] class WebCore::SecurityOriginData::Tuple {
     [Validator='!protocol->isHashTableDeletedValue()'] String protocol;
     String host;
     std::optional<uint16_t> port;
@@ -6443,11 +6443,27 @@ struct WebCore::MobileDocumentRequest {
     Vector<WebCore::ISO18013PresentmentRequest> presentmentRequests;
 };
 
-struct WebCore::DigitalCredentialsRequestData {
-    Vector<WebCore::ValidatedMobileDocumentRequest> requests;
+header: <WebCore/DigitalCredentialsRequestData.h>
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::DigitalCredentialsSecurityOriginData {
     [Validator='!topOrigin->isNull()'] WebCore::SecurityOriginData topOrigin;
     [Validator='!documentOrigin->isNull()'] WebCore::SecurityOriginData documentOrigin;
+}
+
+struct WebCore::DigitalCredentialsMobileDocumentRequestData : WebCore::DigitalCredentialsSecurityOriginData {
+    Vector<WebCore::ValidatedMobileDocumentRequest> requests;
 };
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+[Nested] enum class WebCore::ResponseType : uint8_t {
+    Attestation,
+    Disclosure,
+};
+
+[AdditionalEncoder=StreamConnectionEncoder] struct WebCore::DigitalCredentialsMobileDocumentRequestDataWithRequestInfo : WebCore::DigitalCredentialsSecurityOriginData {
+    WebCore::ResponseType responseType;
+    String matchingHint;
+}
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
 
 struct WebCore::DigitalCredentialsResponseData {
     WebCore::DigitalCredentialPresentationProtocol protocol;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -39,6 +39,7 @@
 #import <WebCore/CocoaWritingToolsTypes.h>
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/CornerRadii.h>
+#import <WebCore/DigitalCredentialsRequestData.h>
 #import <WebCore/FixedContainerEdges.h>
 #import <WebCore/LayerHostingContextIdentifier.h>
 #import <WebCore/TextExtractionTypes.h>
@@ -132,7 +133,6 @@ enum class TextSuggestionState : uint8_t;
 }
 
 #if ENABLE(WEB_AUTHN)
-struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
 struct MobileDocumentRequest;
 #endif

--- a/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.h
+++ b/Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.h
@@ -32,6 +32,7 @@
 #import <UIKit/UIKit.h>
 #endif
 #import <WebCore/DigitalCredential.h>
+#import <WebCore/DigitalCredentialsRequestData.h>
 #import <wtf/Forward.h>
 
 OBJC_CLASS WKWebView;
@@ -43,7 +44,6 @@ class WebPageProxy;
 @class WKDigitalCredentialsPicker;
 
 namespace WebCore {
-struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
 struct ExceptionData;
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -29,6 +29,7 @@
 // Use forward declarations and WebPageProxyInternals.h instead.
 #include "APIObject.h"
 #include "MessageReceiver.h"
+#include <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
@@ -358,7 +359,26 @@ struct WrappedCryptoKey;
 
 #if ENABLE(WEB_AUTHN)
 struct MockWebAuthenticationConfiguration;
-struct DigitalCredentialsRequestData;
+struct DigitalCredentialsMobileDocumentRequestData;
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+struct DigitalCredentialsMobileDocumentRequestDataWithRequestInfo;
+using RawDigitalCredentialsWithRequestInfo = Vector<String>;
+#endif
+
+struct MobileDocumentRequest;
+using UnvalidatedDigitalCredentialRequest = MobileDocumentRequest;
+using DigitalCredentialsRequestData = Variant<
+    WebCore::DigitalCredentialsMobileDocumentRequestData
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    , WebCore::DigitalCredentialsMobileDocumentRequestDataWithRequestInfo
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+>;
+using DigitalCredentialsRawRequests = Variant<Vector<UnvalidatedDigitalCredentialRequest>
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+        , RawDigitalCredentialsWithRequestInfo
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    >;
 struct DigitalCredentialsResponseData;
 struct MobileDocumentRequest;
 #endif
@@ -2359,7 +2379,7 @@ public:
 
     // Digital Credentials API
     void dismissDigitalCredentialsPicker(IPC::Connection&, CompletionHandler<void(bool)>&&);
-    void fetchRawDigitalCredentialRequests(CompletionHandler<void(Vector<WebCore::MobileDocumentRequest>)>&&);
+    void fetchRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests)>&&);
     void showDigitalCredentialsPicker(IPC::Connection&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&);
 #endif
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -79,7 +79,12 @@ messages -> WebPageProxy {
     [EnabledBy=ContactPickerAPIEnabled] ShowContactPicker(struct WebCore::ContactsRequestData requestData) -> (std::optional<Vector<WebCore::ContactInfo>> info)
 
 #if ENABLE(WEB_AUTHN)
-    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsPicker(struct WebCore::DigitalCredentialsRequestData requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsPicker(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData, WebCore::DigitalCredentialsMobileDocumentRequestDataWithRequestInfo> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
+#endif
+#if !ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    [EnabledBy=DigitalCredentialsEnabled] ShowDigitalCredentialsPicker(Variant<WebCore::DigitalCredentialsMobileDocumentRequestData> requestData) -> (Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData> response)
+#endif
     [EnabledBy=DigitalCredentialsEnabled] DismissDigitalCredentialsPicker() -> (bool didDismiss)
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -68,6 +68,7 @@
 #import <WebCore/ActivityState.h>
 #import <WebCore/Color.h>
 #import <WebCore/DataOwnerType.h>
+#import <WebCore/DigitalCredentialsRequestData.h>
 #import <WebCore/FloatQuad.h>
 #import <WebCore/MediaControlsContextMenuItem.h>
 #import <WebCore/PointerID.h>
@@ -102,7 +103,7 @@ class IntSize;
 class SelectionRect;
 struct ContactInfo;
 struct ContactsRequestData;
-struct DigitalCredentialsRequestData;
+
 struct DigitalCredentialsResponseData;
 struct MediaPlayerClientIdentifierType;
 struct PromisedAttachmentInfo;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -39,6 +39,7 @@
 #include "WKLayoutMode.h"
 #include "WebMouseEvent.h"
 #include <WebCore/DOMPasteAccess.h>
+#include <WebCore/DigitalCredentialsRequestData.h>
 #include <WebCore/FocusDirection.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
 #include <WebCore/KeypressCommand.h>
@@ -205,7 +206,7 @@ struct DragItem;
 struct ResolvedCaptionDisplaySettingsOptions;
 
 #if ENABLE(WEB_AUTHN)
-struct DigitalCredentialsRequestData;
+struct DigitalCredentialsMobileDocumentRequestData;
 struct DigitalCredentialsResponseData;
 #endif
 

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h
@@ -30,6 +30,7 @@
 #include "MessageReceiver.h"
 #include <WebCore/CredentialRequestCoordinatorClient.h>
 #include <WebCore/DigitalCredentialsProtocols.h>
+#include <WebCore/DigitalCredentialsRequestData.h>
 #include <WebCore/Document.h>
 #include <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #include <wtf/Vector.h>
@@ -37,7 +38,6 @@
 
 namespace WebCore {
 class SecurityOriginData;
-struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
 struct ExceptionData;
 struct MobileDocumentRequest;
@@ -59,10 +59,10 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void showDigitalCredentialsPicker(Vector<WebCore::UnvalidatedDigitalCredentialRequest>&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
+    void showDigitalCredentialsPicker(WebCore::DigitalCredentialsRawRequests&&, const WebCore::DigitalCredentialsRequestData&, CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&&) final;
     void dismissDigitalCredentialsPicker(CompletionHandler<void(bool)>&&) final;
     WebCore::ExceptionOr<Vector<WebCore::ValidatedDigitalCredentialRequest>> validateAndParseDigitalCredentialRequests(const WebCore::SecurityOrigin&, const WebCore::Document&, const Vector<WebCore::UnvalidatedDigitalCredentialRequest>&) final;
-    void provideRawDigitalCredentialRequests(CompletionHandler<void(Vector<WebCore::UnvalidatedDigitalCredentialRequest>&&)>&&);
+    void provideRawDigitalCredentialRequests(CompletionHandler<void(WebCore::DigitalCredentialsRawRequests&&)>&&);
 
 private:
     explicit DigitalCredentialsCoordinator(WebPage&);
@@ -72,7 +72,7 @@ private:
 
     WeakPtr<WebPage> m_page;
     const WebCore::PageIdentifier m_pageIdentifier;
-    Vector<WebCore::UnvalidatedDigitalCredentialRequest> m_rawRequests;
+    WebCore::DigitalCredentialsRawRequests m_rawRequests;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.messages.in
+++ b/Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.messages.in
@@ -29,7 +29,12 @@
     DispatchedTo=WebContent
 ]
 messages -> DigitalCredentialsCoordinator {
-    ProvideRawDigitalCredentialRequests() -> (Vector<WebCore::MobileDocumentRequest> rawRequests)
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    ProvideRawDigitalCredentialRequests() -> (Variant<Vector<WebCore::MobileDocumentRequest>, Vector<String>> rawRequests)
+#endif
+#if !ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    ProvideRawDigitalCredentialRequests() -> (Variant<Vector<WebCore::MobileDocumentRequest>> rawRequests)
+#endif
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -137,6 +137,10 @@ OBJC_CLASS PDFSelection;
 OBJC_CLASS WKAccessibilityWebPageObject;
 #endif
 
+#if ENABLE(WEB_AUTHN)
+#include <WebCore/DigitalCredentialsRequestData.h>
+#endif
+
 #define ENABLE_VIEWPORT_RESIZING PLATFORM(IOS_FAMILY)
 
 namespace WTF {
@@ -350,7 +354,6 @@ struct TranslationContextMenuInfo;
 struct UserMediaRequestIdentifierType;
 struct ViewportArguments;
 
-struct DigitalCredentialsRequestData;
 struct DigitalCredentialsResponseData;
 struct MobileDocumentRequest;
 

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -182,10 +182,11 @@ Vector<WebCore::ValidatedMobileDocumentRequest> DigitalCredentials::validateRequ
                 MessageLevel::Warning,
                 errorMessage));
 
-            LOG(DigitalCredentials, "Validation failed for request: %@", error);
+            LOG(DigitalCredentials, "DigitalCredentials::validateRequests() - WebProcess: Validation failed for request: %@", error);
         }
     }
 
+    LOG(DigitalCredentials, "DigitalCredentials::validateRequests() - WebProcess: returning %zu validated requests", validatedRequests.size());
     return validatedRequests;
 }
 


### PR DESCRIPTION
#### 624c17eecf71abfed94b60773350a689482308d3
<pre>
Digital Credentials: Build ISO 18013 request with request info
<a href="https://bugs.webkit.org/show_bug.cgi?id=306837">https://bugs.webkit.org/show_bug.cgi?id=306837</a>
<a href="https://rdar.apple.com/169504454">rdar://169504454</a>

Reviewed by Abrar Rahman Protyasha.

This patch adds support for parsing and constructing ISO 18013 requests which
use the requestInfo field defined in the ISO 18013 spec.

First, any requests with the requestInfo field are filtered out and processed.
Then the requests are parsed into concrete WebCore types before being sent over
IPC to the UI Process.

Instead of changing the DigitalCredentials coordination logic, the request data
types have been changed to be generic across the requests with request info
using WTF::Variant.

Handling of these requests types in the UI Process are left unimplemented until
a later patch.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequest):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h:
* Source/WebCore/Modules/identity/CredentialRequestCoordinatorClient.h:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
* Source/WebCore/Modules/identity/DigitalCredentialsMobileDocumentRequestData.h: Copied from Source/WebCore/Modules/identity/DigitalCredentialsRequestData.h.
* Source/WebCore/Modules/identity/DigitalCredentialsMobileDocumentRequestDataWithRequestInfo.h: Copied from Source/WebCore/Modules/identity/DigitalCredentialsRequestData.h.
* Source/WebCore/Modules/identity/DigitalCredentialsRequestData.h:
* Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.cpp: Added.
(WebCore::DigitalCredentialsRequestDataBuilder::build):
(WebCore::DigitalCredentialsRequestDataBuilder::buildAndValidateRequestDataWithRequestInfo):
(WebCore::DigitalCredentialsRequestDataBuilder::parseMatchingHintAndRawRequests):
(WebCore::DigitalCredentialsRequestDataBuilder::parseRawRequests):
(WebCore::isValidMatchingHint):
(WebCore::DigitalCredentialsRequestDataBuilder::parseMatchingHint):
(WebCore::DigitalCredentialsRequestDataBuilder::parseRequestedDataElements):
* Source/WebCore/Modules/identity/DigitalCredentialsRequestDataBuilder.h: Added.
* Source/WebCore/Modules/identity/DigitalCredentialsSecurityOriginData.h: Copied from Source/WebCore/Modules/identity/DigitalCredentialsRequestData.h.
* Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.cpp:
(WebCore::DummyCredentialRequestCoordinatorClient::showDigitalCredentialsPicker):
* Source/WebCore/Modules/identity/dummy/DummyCredentialRequestCoordinatorClient.h:
* Source/WebCore/Modules/indexeddb/server/MemoryCursor.h:
* Source/WebCore/Modules/streams/TransformStream.cpp:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.h:
* Source/WebKit/UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm:
(-[WKDigitalCredentialsPicker fetchRawRequestsWithCompletionHandler:]):
(-[WKDigitalCredentialsPicker presentWithRequestData:completionHandler:]):
(-[WKDigitalCredentialsPicker dismissWithCompletionHandler:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showDigitalCredentialsPicker):
(WebKit::WebPageProxy::fetchRawDigitalCredentialRequests):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.cpp:
(WebKit::DigitalCredentialsCoordinator::showDigitalCredentialsPicker):
(WebKit::DigitalCredentialsCoordinator::dismissDigitalCredentialsPicker):
(WebKit::DigitalCredentialsCoordinator::provideRawDigitalCredentialRequests):
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.h:
* Source/WebKit/WebProcess/DigitalCredentials/DigitalCredentialsCoordinator.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm:
(WebKit::logApplicationSpecificExtensions):
(WebKit::buildDocumentRequest):

Canonical link: <a href="https://commits.webkit.org/307383@main">https://commits.webkit.org/307383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d2bf0fc872fe75215f7212d1fdc8827d390d03c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97303 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f96bab5f-1a5e-4de2-b4c1-508e7a42ad86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110776 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79652 "Exiting early after 60 failures. 15382 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad73ee07-163b-4552-a226-f2e0611b01a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5726504c-6186-4591-b39f-2fb7fb6ad31e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12660 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10390 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/180 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122137 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155046 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16595 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7143 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119147 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15042 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72016 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22247 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16217 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5741 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79996 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16162 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16017 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->