### PR TITLE
[GTK][WPE] Add texture atlas layout computation for batching raster image uploads

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -17,6 +17,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/PathSkia.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h
+    platform/graphics/skia/SkiaImageAtlasLayout.h
     platform/graphics/skia/SkiaPaintingEngine.h
     platform/graphics/skia/SkiaRecordingResult.h
     platform/graphics/skia/SkiaReplayCanvas.h

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -60,6 +60,8 @@ platform/graphics/skia/PlatformDisplaySkia.cpp
 platform/graphics/skia/ShareableBitmapSkia.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp
 platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
+platform/graphics/skia/SkiaImageAtlasLayout.cpp
+platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
 platform/graphics/skia/SkiaPaintingEngine.cpp
 platform/graphics/skia/SkiaRecordingResult.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -29,6 +29,7 @@
 
 #include "GLFence.h"
 #include "GraphicsContext.h"
+#include "SkiaRecordingResult.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkImage.h>
@@ -43,8 +44,8 @@ class SkSurface;
 namespace WebCore {
 
 class Pattern;
-
-using SkiaImageToFenceMap = HashMap<const SkImage*, std::unique_ptr<GLFence>>;
+class SkiaImageAtlasLayoutBuilder;
+struct SkiaRecordingData;
 
 class WEBCORE_EXPORT GraphicsContextSkia final : public GraphicsContext {
     friend class ImageBufferSkiaAcceleratedBackend;
@@ -58,7 +59,7 @@ public:
     const DestinationColorSpace& colorSpace() const final;
 
     void beginRecording();
-    SkiaImageToFenceMap endRecording();
+    SkiaRecordingData endRecording();
 
     void enableStateReplayTracking();
     void replayStateOnCanvas(SkCanvas&) const;
@@ -201,7 +202,7 @@ private:
     Vector<SkiaState, 1> m_skiaStateStack;
     SkiaImageToFenceMap m_imageToFenceMap;
     bool m_enableStateReplayTracking : 1 { false };
-
+    std::unique_ptr<SkiaImageAtlasLayoutBuilder> m_atlasLayoutBuilder;
     const DestinationColorSpace m_colorSpace;
 };
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -193,10 +193,10 @@ std::unique_ptr<GLFence> ImageBufferSkiaAcceleratedBackend::flushCanvasRecording
         return nullptr;
 
     IntRect recordRect(IntPoint(), size());
-    auto imageToFenceMap = m_canvasRecordingContext->endRecording();
+    auto recordingData = m_canvasRecordingContext->endRecording();
     auto picture = m_pictureRecorder.finishRecordingAsPicture();
 
-    RefPtr<SkiaRecordingResult> recording = SkiaRecordingResult::create(WTF::move(picture), WTF::move(imageToFenceMap), recordRect, RenderingMode::Accelerated, false, 1.0);
+    RefPtr<SkiaRecordingResult> recording = SkiaRecordingResult::create(WTF::move(picture), WTF::move(recordingData), recordRect, RenderingMode::Accelerated, false, 1.0);
 
     // Save the surface canvas save count before playback so we can undo any
     // unbalanced saves that the picture introduces.

--- a/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayout.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayout.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Igalia S.L.
+ * Copyright (C) 2025, 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,41 +24,21 @@
  */
 
 #include "config.h"
-#include "SkiaRecordingResult.h"
+#include "SkiaImageAtlasLayout.h"
 
 #if USE(SKIA)
 
 namespace WebCore {
 
-SkiaRecordingResult::SkiaRecordingResult(sk_sp<SkPicture>&& picture, SkiaRecordingData&& recordingData, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale)
-    : m_picture(WTF::move(picture))
-    , m_imageToFenceMap(WTF::move(recordingData.imageToFenceMap))
-    , m_atlasLayouts(WTF::move(recordingData.atlasLayouts))
-    , m_recordRect(recordRect)
-    , m_renderingMode(renderingMode)
-    , m_contentsOpaque(contentsOpaque)
-    , m_contentsScale(contentsScale)
+SkiaImageAtlasLayout::SkiaImageAtlasLayout(const IntSize& atlasSize, Vector<Entry>&& entries)
+    : m_atlasSize(atlasSize)
+    , m_entries(WTF::move(entries))
 {
 }
 
-SkiaRecordingResult::~SkiaRecordingResult() = default;
-
-Ref<SkiaRecordingResult> SkiaRecordingResult::create(sk_sp<SkPicture>&& picture, SkiaRecordingData&& recordingData, const IntRect& recordRect, RenderingMode renderingMode, bool contentsOpaque, float contentsScale)
+Ref<SkiaImageAtlasLayout> SkiaImageAtlasLayout::create(const IntSize& atlasSize, Vector<Entry>&& entries)
 {
-    return adoptRef(*new SkiaRecordingResult(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale));
-}
-
-bool SkiaRecordingResult::hasFences()
-{
-    Locker locker { m_imageToFenceMapLock };
-    return !m_imageToFenceMap.isEmpty();
-}
-
-void SkiaRecordingResult::waitForFenceIfNeeded(const SkImage& image)
-{
-    Locker locker { m_imageToFenceMapLock };
-    if (auto fence = m_imageToFenceMap.get(&image))
-        fence->serverWait();
+    return adoptRef(*new SkiaImageAtlasLayout(atlasSize, WTF::move(entries)));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaImageAtlasLayoutBuilder.h"
+
+#if USE(SKIA)
+
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaImageAtlasLayoutBuilder);
+
+SkiaImageAtlasLayoutBuilder::SkiaImageAtlasLayoutBuilder() = default;
+SkiaImageAtlasLayoutBuilder::~SkiaImageAtlasLayoutBuilder() = default;
+
+void SkiaImageAtlasLayoutBuilder::collectRasterImage(const sk_sp<SkImage>& image)
+{
+    if (!image)
+        return;
+
+    ASSERT(!image->isTextureBacked());
+
+    // Check size constraints.
+    int width = image->width();
+    if (width < minImageSize || width > maxImageSize)
+        return;
+
+    int height = image->height();
+    if (height < minImageSize || height > maxImageSize)
+        return;
+
+    // Don't collect duplicates.
+    if (!m_collectedSet.add(image.get()).isNewEntry)
+        return;
+
+    m_collectedImages.append({ image, IntSize(width, height) });
+}
+
+// Compute tight bounding box area for packed rectangles.
+static size_t computeBoundingBoxArea(const Vector<SkiaTextureAtlasPacker::PackedRect>& packedRects)
+{
+    int maxX = 0;
+    int maxY = 0;
+    for (const auto& packed : packedRects) {
+        maxX = std::max(maxX, packed.rect.maxX());
+        maxY = std::max(maxY, packed.rect.maxY());
+    }
+    return static_cast<size_t>(maxX) * maxY;
+}
+
+// Try both packing algorithms at a given atlas size and return the result with smaller bounding box.
+static Vector<SkiaTextureAtlasPacker::PackedRect> packWithBestAlgorithm(const Vector<IntSize>& sizes, const IntSize& atlasSize)
+{
+    auto maxRectsResult = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::MaxRects);
+    auto shelfResult = SkiaTextureAtlasPacker::pack(sizes, atlasSize, SkiaTextureAtlasPacker::Algorithm::ShelfNextFit);
+
+    if (!maxRectsResult.isEmpty() && !shelfResult.isEmpty()) {
+        if (computeBoundingBoxArea(shelfResult) < computeBoundingBoxArea(maxRectsResult))
+            return shelfResult;
+        return maxRectsResult;
+    }
+
+    if (!maxRectsResult.isEmpty())
+        return maxRectsResult;
+
+    return shelfResult;
+}
+
+Vector<Ref<SkiaImageAtlasLayout>> SkiaImageAtlasLayoutBuilder::finalize()
+{
+    ASSERT(!m_finalized);
+    m_finalized = true;
+
+    // Not enough images for atlasing.
+    if (m_collectedImages.size() < minImagesForAtlas)
+        return { };
+
+    // Extract sizes for packing.
+    Vector<IntSize> sizes(m_collectedImages.size(), [&](size_t index) {
+        return m_collectedImages[index].size;
+    });
+
+    // Calculate optimal atlas size based on total image area.
+    // This prevents wasting GPU memory and upload bandwidth on sparse atlases.
+    auto optimalSide = calculateOptimalAtlasSize(sizes);
+    IntSize atlasSize(optimalSide, optimalSide);
+
+    // Try both packing algorithms and pick the one with smaller bounding box.
+    // MaxRects is better for variable sizes, ShelfNextFit for similar sizes.
+    auto bestResult = packWithBestAlgorithm(sizes, atlasSize);
+    if (!bestResult.isEmpty())
+        return { createAtlasLayout(bestResult) };
+
+    // Fallback: try max atlas size if optimal size failed.
+    bestResult = packWithBestAlgorithm(sizes, IntSize(maxAtlasSize, maxAtlasSize));
+    if (!bestResult.isEmpty())
+        return { createAtlasLayout(bestResult) };
+
+    // Single atlas failed - use multi-atlas fallback.
+    return packMultipleAtlases(sizes);
+}
+
+int SkiaImageAtlasLayoutBuilder::calculateOptimalAtlasSize(const Vector<IntSize>& sizes)
+{
+    // Calculate total pixel area of all images.
+    uint64_t totalArea = 0;
+    int maxWidth = 0;
+    int maxHeight = 0;
+
+    for (const auto& size : sizes) {
+        totalArea += size.unclampedArea();
+        maxWidth = std::max(maxWidth, size.width());
+        maxHeight = std::max(maxHeight, size.height());
+    }
+
+    // Add overhead for packing inefficiency (typically 15-30% waste).
+    // Use 1.3x to be safe with various image size distributions.
+    constexpr float packingOverhead = 1.3f;
+    uint64_t targetArea = static_cast<uint64_t>(totalArea * packingOverhead);
+
+    // Compute square atlas side length.
+    int side = static_cast<int>(std::ceil(std::sqrt(static_cast<double>(targetArea))));
+
+    // Ensure atlas can fit the largest image.
+    side = std::max(side, maxWidth);
+    side = std::max(side, maxHeight);
+
+    // Clamp to valid range.
+    side = std::clamp(side, minAtlasSize, maxAtlasSize);
+    return side;
+}
+
+Vector<Ref<SkiaImageAtlasLayout>> SkiaImageAtlasLayoutBuilder::packMultipleAtlases(const Vector<IntSize>& allSizes)
+{
+    Vector<Ref<SkiaImageAtlasLayout>> result;
+    Vector<bool> packed(allSizes.size(), false);
+    size_t totalPacked = 0;
+
+    // Sort indices by area (largest first) for better packing.
+    Vector<size_t> sortedIndices(allSizes.size(), [](size_t index) {
+        return index;
+    });
+
+    std::ranges::sort(sortedIndices, [&allSizes](size_t a, size_t b) {
+        return allSizes[a].unclampedArea() > allSizes[b].unclampedArea();
+    });
+
+    IntSize atlasSize(maxAtlasSize, maxAtlasSize);
+    while (totalPacked < allSizes.size() && result.size() < maxAtlasCount) {
+        // Collect unpacked images for this atlas.
+        Vector<IntSize> batchSizes;
+        Vector<size_t> batchOriginalIndices;
+
+        for (size_t index : sortedIndices) {
+            if (packed[index])
+                continue;
+            batchSizes.append(allSizes[index]);
+            batchOriginalIndices.append(index);
+        }
+
+        if (batchSizes.isEmpty())
+            break;
+
+        // Try to pack this batch.
+        auto packedRects = SkiaTextureAtlasPacker::pack(batchSizes, atlasSize);
+        if (packedRects.isEmpty()) {
+            // Even a single image doesn't fit - try reducing batch size.
+            // Binary search for max batch that fits.
+            size_t maxBatch = findMaxPackableBatch(batchSizes, atlasSize);
+            if (!maxBatch)
+                break; // Can't pack any more images.
+
+            batchSizes.shrink(maxBatch);
+            batchOriginalIndices.shrink(maxBatch);
+            packedRects = SkiaTextureAtlasPacker::pack(batchSizes, atlasSize);
+            if (packedRects.isEmpty())
+                break;
+        }
+
+        // Mark packed images.
+        for (const auto& rect : packedRects) {
+            size_t originalIndex = batchOriginalIndices[rect.imageIndex];
+            packed[originalIndex] = true;
+            ++totalPacked;
+        }
+
+        // Create atlas layout with remapped indices.
+        Vector<SkiaTextureAtlasPacker::PackedRect> remappedRects(packedRects.size(), [&](size_t index) -> SkiaTextureAtlasPacker::PackedRect {
+            return { packedRects[index].rect, batchOriginalIndices[packedRects[index].imageIndex] };
+        });
+        result.append(createAtlasLayout(remappedRects));
+    }
+
+    // Only return atlases if we packed enough images.
+    if (totalPacked < minImagesForAtlas)
+        return { };
+
+    return result;
+}
+
+size_t SkiaImageAtlasLayoutBuilder::findMaxPackableBatch(const Vector<IntSize>& sizes, const IntSize& atlasSize)
+{
+    // Early return for empty input.
+    if (sizes.isEmpty())
+        return 0;
+
+    // Binary search for the maximum batch size that can be packed.
+    size_t lo = 1;
+    size_t hi = sizes.size();
+    size_t maxPackable = 0;
+
+    while (lo <= hi) {
+        size_t mid = lo + (hi - lo) / 2;
+
+        Vector<IntSize> testBatch(mid, [&sizes](size_t index) {
+            return sizes[index];
+        });
+
+        auto packed = SkiaTextureAtlasPacker::pack(testBatch, atlasSize);
+        if (!packed.isEmpty()) {
+            maxPackable = mid;
+            lo = mid + 1;
+        } else {
+            // Can't pack this many - try fewer.
+            // Since lo starts at 1, mid is always >= 1 here.
+            hi = mid - 1;
+        }
+    }
+
+    return maxPackable;
+}
+
+Ref<SkiaImageAtlasLayout> SkiaImageAtlasLayoutBuilder::createAtlasLayout(const Vector<SkiaTextureAtlasPacker::PackedRect>& packedRects)
+{
+    // Build atlas entries from packed results.
+    Vector<SkiaImageAtlasLayout::Entry> entries(packedRects.size(), [&](size_t index) -> SkiaImageAtlasLayout::Entry {
+        return { m_collectedImages[packedRects[index].imageIndex].image, packedRects[index].rect };
+    });
+
+    // Compute actual atlas size needed (tight bounds).
+    int actualWidth = 0;
+    int actualHeight = 0;
+    for (const auto& packed : packedRects) {
+        actualWidth = std::max(actualWidth, packed.rect.maxX());
+        actualHeight = std::max(actualHeight, packed.rect.maxY());
+    }
+
+    return SkiaImageAtlasLayout::create(IntSize(actualWidth, actualHeight), WTF::move(entries));
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include "IntSize.h"
+#include "SkiaImageAtlasLayout.h"
+#include "SkiaTextureAtlasPacker.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkImage.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#include <wtf/HashSet.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// Builds SkiaImageAtlasLayout objects from raster images collected during tile recording.
+// Used by GraphicsContextSkia in RecordingMode.
+class SkiaImageAtlasLayoutBuilder {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaImageAtlasLayoutBuilder);
+public:
+    // Configuration constants.
+    static constexpr int minAtlasSize = 256;
+    static constexpr int maxAtlasSize = 4096;
+    static constexpr int minImageSize = 8;
+    static constexpr int maxImageSize = 512;
+    static constexpr int minImagesForAtlas = 4;
+    static constexpr int maxAtlasCount = 4;
+
+    SkiaImageAtlasLayoutBuilder();
+    ~SkiaImageAtlasLayoutBuilder();
+
+    // Called during recording when a raster image is drawn.
+    void collectRasterImage(const sk_sp<SkImage>&);
+
+    // Check if an image was collected.
+    bool isCollected(const SkImage* image) const { return m_collectedSet.contains(image); }
+
+    // Number of collected images.
+    size_t imageCount() const { return m_collectedImages.size(); }
+
+    // Finalize: compute atlas packing, may create multiple atlases.
+    // Returns vector of atlas layouts (empty if not enough images for atlasing).
+    Vector<Ref<SkiaImageAtlasLayout>> finalize();
+
+private:
+    struct CollectedImage {
+        sk_sp<SkImage> image;
+        IntSize size;
+    };
+
+    // Multi-atlas packing when single atlas fails.
+    Vector<Ref<SkiaImageAtlasLayout>> packMultipleAtlases(const Vector<IntSize>& sizes);
+
+    // Binary search for max batch size that fits in atlas.
+    size_t findMaxPackableBatch(const Vector<IntSize>& sizes, const IntSize& atlasSize);
+
+    // Create atlas layout from packed rectangles.
+    Ref<SkiaImageAtlasLayout> createAtlasLayout(const Vector<SkiaTextureAtlasPacker::PackedRect>& packedRects);
+
+    // Calculate optimal atlas size based on total image area.
+    static int calculateOptimalAtlasSize(const Vector<IntSize>& sizes);
+
+    Vector<CollectedImage> m_collectedImages;
+    HashSet<const SkImage*> m_collectedSet;
+    bool m_finalized { false };
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -32,6 +32,7 @@
 #include "CoordinatedPlatformLayer.h"
 #include "CoordinatedTileBuffer.h"
 #include "GLContext.h"
+#include "GraphicsContextSkia.h"
 #include "GraphicsLayerCoordinated.h"
 #include "PlatformDisplay.h"
 #include "ProcessCapabilities.h"
@@ -164,11 +165,11 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     GraphicsContextSkia recordingContext(*recordingCanvas, renderingMode, RenderingPurpose::LayerBacking);
     recordingContext.beginRecording();
     paintIntoGraphicsContext(layer, recordingContext, recordRect, contentsOpaque, contentsScale);
-    auto imageToFenceMap = recordingContext.endRecording();
+    auto recordingData = recordingContext.endRecording();
     auto picture = pictureRecorder.finishRecordingAsPicture();
     WTFEndSignpost(this, RecordTile);
 
-    return SkiaRecordingResult::create(WTF::move(picture), WTF::move(imageToFenceMap), recordRect, renderingMode, contentsOpaque, contentsScale);
+    return SkiaRecordingResult::create(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale);
 }
 
 Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordinated& layer, const RefPtr<SkiaRecordingResult>& recording, const IntRect& dirtyRect)


### PR DESCRIPTION
#### 67526aee79823a036158c5b198798d2ac4b01c7d
<pre>
[GTK][WPE] Add texture atlas layout computation for batching raster image uploads
<a href="https://bugs.webkit.org/show_bug.cgi?id=306901">https://bugs.webkit.org/show_bug.cgi?id=306901</a>

Reviewed by Carlos Garcia Campos.

During Skia canvas recording, raster (non-GPU backed) images drawn via
drawNativeImage() are now collected by a new SkiaImageAtlasLayoutBuilder.
When recording ends, the builder computes optimal packing layouts that
group multiple small-to-medium raster images (8x8 to 512x512) into
shared atlas textures (up to 4096x4096). This precomputed layout is
stored as SkiaImageAtlasLayout objects in the recording result. In
future this will be used to batch individual texture uploads into fewer,
larger GPU texture transfers.

The packing uses SkiaTextureAtlasPacker with both MaxRects and ShelfNextFit
algorithms, selecting whichever produces a tighter bounding box. When
all images don&apos;t fit in a single atlas, multiple ones are created.

SkiaImageAtlasLayout is ThreadSafeRefCounted and read-only after creation,
allowing it to be shared across worker threads during parallel replay
without synchronization. It stores the computed atlas dimensions and the
mapping of each raster SkImage to its rectangle within the atlas.

Not testable yet, still preparing.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImage):
(WebCore::GraphicsContextSkia::beginRecording):
(WebCore::GraphicsContextSkia::endRecording):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::flushCanvasRecordingContextIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayout.cpp: Copied from Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp.
(WebCore::SkiaImageAtlasLayout::SkiaImageAtlasLayout):
(WebCore::SkiaImageAtlasLayout::create):
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayout.h: Copied from Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h.
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp: Added.
(WebCore::SkiaImageAtlasLayoutBuilder::collectRasterImage):
(WebCore::computeBoundingBoxArea):
(WebCore::packWithBestAlgorithm):
(WebCore::SkiaImageAtlasLayoutBuilder::finalize):
(WebCore::SkiaImageAtlasLayoutBuilder::calculateOptimalAtlasSize):
(WebCore::SkiaImageAtlasLayoutBuilder::packMultipleAtlases):
(WebCore::SkiaImageAtlasLayoutBuilder::findMaxPackableBatch):
(WebCore::SkiaImageAtlasLayoutBuilder::createAtlasLayout):
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.h: Added.
(WebCore::SkiaImageAtlasLayoutBuilder::isCollected const):
(WebCore::SkiaImageAtlasLayoutBuilder::imageCount const):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::record):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp:
(WebCore::SkiaRecordingResult::SkiaRecordingResult):
(WebCore::SkiaRecordingResult::create):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h:

Canonical link: <a href="https://commits.webkit.org/308117@main">https://commits.webkit.org/308117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44dbf9031678aee83cac26aae078b779f97e2c9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12478 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155009 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99787 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112623 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99787 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131484 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14246 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12001 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2455 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157330 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120653 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31014 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74635 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8021 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82209 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18244 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->