### PR TITLE
Digital Credentials: abort signal's algorithm should be cleared

### DIFF
--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.h
@@ -67,6 +67,7 @@ public:
 
 private:
     void dismissPickerAndSettle(ExceptionOr<RefPtr<BasicCredential>>&&);
+    void clearAbortAlgorithm();
 
     class PickerStateGuard final {
     public:
@@ -104,7 +105,9 @@ private:
     explicit CredentialRequestCoordinator(Ref<CredentialRequestCoordinatorClient>&&, Page&);
     const Ref<CredentialRequestCoordinatorClient> m_client;
     PickerState m_state { PickerState::Idle };
+    RefPtr<AbortSignal> m_abortSignal;
     std::optional<CredentialPromise> m_currentPromise;
+    std::optional<uint32_t> m_abortAlgorithmIdentifier;
     WeakPtr<Page> m_page;
 };
 


### PR DESCRIPTION
#### bf4f370ebe89015a09b7c588390817438281a20c
<pre>
Digital Credentials: abort signal&apos;s algorithm should be cleared
<a href="https://bugs.webkit.org/show_bug.cgi?id=306907">https://bugs.webkit.org/show_bug.cgi?id=306907</a>
<a href="https://rdar.apple.com/169572382">rdar://169572382</a>

Reviewed by Pascoe.

* Adds clearAbortAlgorithm() method, which removes abort algorithms using stored a identifier.
* Calls clearAbortAlgorithm() from dismissPickerAndSettle, abortPicker, and destructor.
* Added abort check after signal handler setup to handle timing issues.

* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequest):
(WebCore::CredentialRequestCoordinator::handleDigitalCredentialsPickerResult):
(WebCore::CredentialRequestCoordinator::dismissPickerAndSettle):
(WebCore::CredentialRequestCoordinator::clearAbortAlgorithm):
(WebCore::CredentialRequestCoordinator::abortPicker):
(WebCore::CredentialRequestCoordinator::~CredentialRequestCoordinator):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/307191@main">https://commits.webkit.org/307191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e6001dbc33dccdad901275c71da1d11b01e6f8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96800 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e2c9d6d-f55d-4afd-89f1-6f15332932a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110393 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79453 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/beb18cd1-7719-4ff3-8999-74b3de6c7316) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91312 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10047 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2231 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154541 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118401 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118757 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14695 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71506 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15713 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5345 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79485 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15660 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->