### PR TITLE
[EGL] Support logging debugging contexts

### DIFF
--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -109,6 +109,7 @@ namespace WebCore {
     M(Frames) \
     M(FTP) \
     M(Fullscreen) \
+    M(GLContext) \
     M(Gamepad) \
     M(GraphicsBuffer) \
     M(HDR) \

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -152,6 +152,10 @@ private:
 
     static bool getEGLConfig(EGLDisplay, EGLConfig*, int);
 
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
+    bool enableDebugLogging();
+#endif
+
     // GLContextWrapper
     GLContextWrapper::Type type() const override { return GLContextWrapper::Type::Native; }
     bool makeCurrentImpl() override;

--- a/Source/WebKit/glib/environment-variables.md.in
+++ b/Source/WebKit/glib/environment-variables.md.in
@@ -17,6 +17,9 @@ Defines a comma-separated list of logging channels and their levels for WebKit's
         - `WebDriverClassic` - For the HTTP-based [WebDriver](https://w3c.github.io/webdriver/) Classic prototol.
         - `WebDriverBiDi` - For the WebSockets-based [WebDriver BiDi](https://github.com/w3c/webdriver-bidi) protocol.
         - `SessionHost` - For messages related to the management of the Browser under automation.
+    - **OpenGL context debugging**: When the `GLContext` logging channel is enabled, WebKit creates
+      EGL contexts with [debug logging](https://wikis.khronos.org/opengl/Debug_Output) configured,
+      which may result in a small graphics performance penalty.
 
 ## Graphics-related variables
 


### PR DESCRIPTION
#### 26d6f98531c3f61d8c3a690a116d9f56a9f27e87
<pre>
[EGL] Support logging debugging contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=306911">https://bugs.webkit.org/show_bug.cgi?id=306911</a>

Reviewed by Nikolas Zimmermann.

Add a new GLContext logging channel which, when enabled, will cause GL
contexts to be created with the debugging flag set and install a callback
to funnel the messages emitted by the GL implementation to the logging
channel. The GL severity levels (high, medium, low, notification) are
mapped to the WTF log levels (error, warning, info, debug; respectively).

* Source/WebCore/platform/Logging.h: Add the GLContext logging channel.
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::logGLDebugMessage): Callback function invoked by the GL
implementation to log messages, which get forwarded to the GLContext
channel.
(WebCore::GLContext::enableDebugLogging): Helper function to enable
debug logging using a suitable GL extension or the built-int support
in GLES 3.2+.
(WebCore::shouldEnableDebugLogging): Helper function to check whether
the GL context debug loggging channel has been enabled.
(WebCore::GLContext::GLContext): Install the message logging callback
and enable GL_DEBUG_OUTPUT where appropriate, taking care of saving and
restoring the active GL context as needed.
(WebCore::GLContext::createContextForEGLVersion): Enable the
EGL_CONTEXT_OPENGL_DEBUG attribute if context debug logging is
enabled. Remove one use of WTF_ALLOW_UNSAFE_BUFFER_USAGE_{BEGIN,END}
while at it.
* Source/WebCore/platform/graphics/egl/GLContext.h: Add declaration for
the enableDebugLogging() function.
* Source/WebKit/glib/environment-variables.md.in: Document the GLContext
logging channel.

Canonical link: <a href="https://commits.webkit.org/306778@main">https://commits.webkit.org/306778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee49aa16360771bcfdadab148096e4cc8704e949

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109439 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79033 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145274 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9136 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/991 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153308 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14400 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117481 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12569 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117805 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30034 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13858 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70101 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14449 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3650 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14181 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78165 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->