### PR TITLE
`box-shadow` does not work when used on `display: table-row` elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display-expected.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Box-shadow on display: table-row</title>
+<style>
+  body {
+    margin: 50px;
+    background: white;
+  }
+
+  .block {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px #000;
+  }
+
+  .block-red {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px red;
+  }
+
+  .block-green {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px green;
+  }
+
+  .block-blue {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px blue;
+  }
+
+  .group {
+    margin-bottom: 40px;
+  }
+</style>
+</head>
+<body>
+
+<div class="group">
+  <div class="block"></div>
+</div>
+
+<div class="group">
+  <div class="block"></div>
+  <div class="block"></div>
+</div>
+
+<div class="group">
+  <div class="block-red"></div>
+  <div class="block-green"></div>
+  <div class="block-blue"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display-ref.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Box-shadow on display: table-row</title>
+<style>
+  body {
+    margin: 50px;
+    background: white;
+  }
+
+  .block {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px #000;
+  }
+
+  .block-red {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px red;
+  }
+
+  .block-green {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px green;
+  }
+
+  .block-blue {
+    width: 200px;
+    height: 200px;
+    background: #999;
+    box-shadow: 0 0 50px blue;
+  }
+
+  .group {
+    margin-bottom: 40px;
+  }
+</style>
+</head>
+<body>
+
+<div class="group">
+  <div class="block"></div>
+</div>
+
+<div class="group">
+  <div class="block"></div>
+  <div class="block"></div>
+</div>
+
+<div class="group">
+  <div class="block-red"></div>
+  <div class="block-green"></div>
+  <div class="block-blue"></div>
+</div>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Box-shadow on display: table-row</title>
+<link rel="match" href="table-row-box-shadow-ref.html">
+<meta name="fuzzy" content="maxDifference=0-15;totalPixels=0-2890">
+<style>
+  body {
+    margin: 50px;
+    background: white;
+  }
+
+  .table {
+    display: table;
+    margin-bottom: 40px;
+  }
+
+  .row {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px #000;
+  }
+
+  .row-red {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px red;
+  }
+
+  .row-green {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px green;
+  }
+
+  .row-blue {
+    display: table-row;
+    background: #999;
+    box-shadow: 0 0 50px blue;
+  }
+
+  .cell {
+    display: table-cell;
+    width: 200px;
+    height: 200px;
+  }
+</style>
+</head>
+<body>
+
+<div class="table">
+  <div class="row">
+    <div class="cell"></div>
+  </div>
+</div>
+
+<div class="table">
+  <div class="row">
+    <div class="cell"></div>
+  </div>
+  <div class="row">
+    <div class="cell"></div>
+  </div>
+</div>
+
+<div class="table">
+  <div class="row-red">
+    <div class="cell"></div>
+  </div>
+  <div class="row-green">
+    <div class="cell"></div>
+  </div>
+  <div class="row-blue">
+    <div class="cell"></div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -244,6 +244,19 @@ void RenderTableRow::paintOutlineForRowIfNeeded(PaintInfo& paintInfo, const Layo
     }
 }
 
+void RenderTableRow::paintShadowForRowIfNeeded(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+{
+    if (paintInfo.phase != PaintPhase::BlockBackground && paintInfo.phase != PaintPhase::ChildBlockBackground)
+        return;
+
+    auto adjustedPaintOffset = paintOffset + location();
+    LayoutRect rect(adjustedPaintOffset, size());
+    adjustBorderBoxRectForPainting(rect);
+
+    BackgroundPainter backgroundPainter { *this, paintInfo };
+    backgroundPainter.paintBoxShadow(rect, style(), Style::ShadowStyle::Normal);
+}
+
 void RenderTableRow::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     ASSERT(hasSelfPaintingLayer());

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -49,6 +49,7 @@ public:
     RenderTable* table() const;
 
     void paintOutlineForRowIfNeeded(PaintInfo&, const LayoutPoint&);
+    void paintShadowForRowIfNeeded(PaintInfo&, const LayoutPoint&);
 
     void setRowIndex(unsigned);
     bool rowIndexWasSet() const { return m_rowIndex != unsetRowIndex; }

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -1346,9 +1346,19 @@ void RenderTableSection::paintObject(PaintInfo& paintInfo, const LayoutPoint& pa
             row->paintOutlineForRowIfNeeded(paintInfo, paintOffset);
     };
 
+    auto paintRowShadow = [&](unsigned rowIndex, PaintPhase phase) {
+        if (phase != PaintPhase::BlockBackground && phase != PaintPhase::ChildBlockBackground)
+            return;
+
+        auto* row = m_grid[rowIndex].rowRenderer;
+        if (row && !row->hasSelfPaintingLayer() && !row->style().boxShadow().isNone())
+            row->paintShadowForRowIfNeeded(paintInfo, paintOffset);
+    };
+
     auto paintContiguousCells = [&]() {
         // Draw the dirty cells in the order that they appear.
         for (unsigned r = dirtiedRows.start; r < dirtiedRows.end; r++) {
+            paintRowShadow(r , paintInfo.phase);
             paintRowOutline(r, paintInfo.phase);
 
             for (unsigned c = dirtiedColumns.start; c < dirtiedColumns.end; c++) {


### PR DESCRIPTION
#### ecbdfc19cf68691b97a538e12baa8c0ee742ac21
<pre>
`box-shadow` does not work when used on `display: table-row` elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=74156">https://bugs.webkit.org/show_bug.cgi?id=74156</a>

Reviewed by Simon Fraser.

`Box-shadow` was not painted correctly when applied to table-row elements
because table rows do not have a code path for paint `box-shadow` property.

This patch adds the code path for painting shadows on table rows.

Test: imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display-ref.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/box-shadow-table-row-display-expected.html.
* Source/WebCore/rendering/RenderTableRow.h:
* Source/WebCore/rendering/RenderTableRow.cpp:
(WebCore::RenderTableCell::paintShadowForRowIfNeeded):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::paintObject):

Canonical link: <a href="https://commits.webkit.org/310609@main">https://commits.webkit.org/310609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e052b15f8b54adc351014adb6eb9c70180d9aced

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27417 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119340 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84373 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10895 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16425 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165535 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8744 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127436 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127581 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83662 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15010 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90830 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26308 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->