### PR TITLE
[GFC] Enable flexible track sizing (fr units)

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -333,19 +333,25 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
 {
     auto& integrationUtils = formattingContext().integrationUtils();
 
+    // Compute gap values for columns and rows.
+    // These are needed by the track sizing algorithm to correctly compute free space.
+    CheckedRef formattingContextRootStyle = formattingContext().root().style();
+    auto columnsGap = GridLayoutUtils::computeGapValue(formattingContextRootStyle->columnGap());
+    auto rowsGap = GridLayoutUtils::computeGapValue(formattingContextRootStyle->rowGap());
+
     // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
     auto columnSpanList = placedGridItems.map([](const PlacedGridItem& gridItem) {
         return WTF::Range<size_t> { gridItem.columnStartLine(), gridItem.columnEndLine() };
     });
     auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, columnSpanList, columnTrackSizingFunctionsList, layoutConstraints.inlineAxisAvailableSpace,
-        GridLayoutUtils::inlineAxisGridItemSizingFunctions(), columnFreeSpaceScenario, integrationUtils);
+        GridLayoutUtils::inlineAxisGridItemSizingFunctions(), columnFreeSpaceScenario, columnsGap, integrationUtils);
 
     auto rowSpanList = placedGridItems.map([](const PlacedGridItem& gridItem) {
         return WTF::Range<size_t> { gridItem.rowStartLine(), gridItem.rowEndLine() };
     });
     // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
     auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, rowSpanList, rowTrackSizingFunctionsList, layoutConstraints.blockAxisAvailableSpace,
-        GridLayoutUtils::blockAxisGridItemSizingFunctions(), rowFreeSpaceScenario, integrationUtils);
+        GridLayoutUtils::blockAxisGridItemSizingFunctions(), rowFreeSpaceScenario, rowsGap, integrationUtils);
 
     // 3. Then, if the min-content contribution of any grid item has changed based on the
     // row sizes and alignment calculated in step 2, re-resolve the sizes of the grid

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -43,6 +43,14 @@ LayoutUnit computeGapValue(const Style::GapGutter& gap)
     return { };
 }
 
+LayoutUnit computeTotalGuttersSize(size_t trackCount, LayoutUnit gap)
+{
+    // For N tracks, there are (N-1) gaps between them
+    if (trackCount <= 1)
+        return 0_lu;
+    return gap * LayoutUnit(trackCount - 1);
+}
+
 static bool spansAutoMinTrackSizingFunction(WTF::Range<size_t> spannedTrackIndexes, const TrackSizingFunctionsList& trackSizingFunctions)
 {
     for (auto trackIndex : std::views::iota(spannedTrackIndexes.begin(), spannedTrackIndexes.end())) {

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -37,6 +37,7 @@ struct GridItemSizingFunctions;
 namespace GridLayoutUtils {
 
 LayoutUnit computeGapValue(const Style::GapGutter&);
+LayoutUnit computeTotalGuttersSize(size_t trackCount, LayoutUnit gap);
 
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit columnsSize);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, LayoutUnit rowsSize);

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TrackSizingAlgorithm.h"
 
+#include "GridLayoutUtils.h"
 #include "LayoutIntegrationUtils.h"
 #include "NotImplemented.h"
 #include "PlacedGridItem.h"
@@ -290,7 +291,7 @@ static void resolveIntrinsicTrackSizes(UnsizedTracks& unsizedTracks, const Place
     UNUSED_VARIABLE(setInfiniteGrowthLimitsToBaseSize);
 }
 
-TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions& gridItemSizingFunctions, FreeSpaceScenario freeSpaceScenario, const IntegrationUtils& integrationUtils)
+TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions& gridItemSizingFunctions, FreeSpaceScenario freeSpaceScenario, LayoutUnit gapSize, const IntegrationUtils& integrationUtils)
 {
     ASSERT(gridItems.size() == gridItemSpanList.size());
 
@@ -340,11 +341,22 @@ TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, co
         if (availableSpace.value() == 0_lu)
             return;
 
+        // Compute total gutters/gaps between tracks.
+        // https://www.w3.org/TR/css-grid-1/#algo-terms
+        // Per §11.2: "free space" = available grid space - sum of base sizes - gutters.
+        // We must subtract gutters before calling findSizeOfFr.
+        LayoutUnit totalGutters = GridLayoutUtils::computeTotalGuttersSize(unsizedTracks.size(), gapSize);
+        LayoutUnit spaceToFill = *availableSpace - totalGutters;
+
+        // If available space minus gutters is zero or negative, flex tracks get no space
+        if (spaceToFill <= 0_lu)
+            return;
+
         // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
         // Otherwise, if the free space is a definite length:
         // The used flex fraction is the result of finding the size of an fr using all of the
-        // grid tracks and a space to fill of the available grid space.
-        auto frSize = findSizeOfFr(unsizedTracks, *availableSpace);
+        // grid tracks and a space to fill of the available grid space (minus gutters).
+        auto frSize = findSizeOfFr(unsizedTracks, spaceToFill);
 
         // For each flexible track, if the product of the used flex fraction and the track's flex factor is greater than the track's base size, set its base size to that product.
         for (auto& flexTrack : flexTracks) {

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -48,7 +48,7 @@ struct GridItemSizingFunctions {
 
 class TrackSizingAlgorithm {
 public:
-    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions&, FreeSpaceScenario, const IntegrationUtils&);
+    static TrackSizes sizeTracks(const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions&, FreeSpaceScenario, LayoutUnit gapSize, const IntegrationUtils&);
 
 private:
 

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -230,13 +230,26 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             [&](const Style::GridTrackSize& trackSize) -> std::optional<GridAvoidanceReason> {
                 // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
                 // MaxTrackBreadth to the same value we only need to check one.
-                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                if (!trackSize.isBreadth())
                     return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
 
-                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
-                if (!gridTrackBreadthLength.isFixed())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
-                return std::nullopt;
+                auto& minBreadth = trackSize.minTrackBreadth();
+
+                // Support both fixed-length breadths (e.g., 100px) and flex breadths (e.g., 1fr)
+                if (minBreadth.isLength()) {
+                    auto& gridTrackBreadthLength = minBreadth.length();
+                    if (!gridTrackBreadthLength.isFixed())
+                        return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
+                    return std::nullopt;
+                }
+
+                if (minBreadth.isFlex()) {
+                    // Flex tracks (fr units) are now supported
+                    return std::nullopt;
+                }
+
+                // Other breadth types (auto, min-content, max-content, etc.) not yet supported
+                return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
             },
             [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
                 if (!names.isEmpty())
@@ -271,13 +284,26 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
             [&](const Style::GridTrackSize& trackSize) -> std::optional<GridAvoidanceReason> {
                 // Since a GridTrackSize type of Breadth sets the MinTrackBreadth and
                 // MaxTrackBreadth to the same value we only need to check one.
-                if (!trackSize.isBreadth() || !trackSize.minTrackBreadth().isLength())
+                if (!trackSize.isBreadth())
                     return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
 
-                auto& gridTrackBreadthLength = trackSize.minTrackBreadth().length();
-                if (!gridTrackBreadthLength.isFixed())
-                    return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
-                return std::nullopt;
+                auto& minBreadth = trackSize.minTrackBreadth();
+
+                // Support both fixed-length breadths (e.g., 100px) and flex breadths (e.g., 1fr)
+                if (minBreadth.isLength()) {
+                    auto& gridTrackBreadthLength = minBreadth.length();
+                    if (!gridTrackBreadthLength.isFixed())
+                        return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
+                    return std::nullopt;
+                }
+
+                if (minBreadth.isFlex()) {
+                    // Flex tracks (fr units) are now supported
+                    return std::nullopt;
+                }
+
+                // Other breadth types (auto, min-content, max-content, etc.) not yet supported
+                return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
             },
             [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
                 if (!names.isEmpty())


### PR DESCRIPTION
#### d13a1f1e1496ce771edff7d855685355caf00385
<pre>
[GFC] Enable flexible track sizing (fr units)
<a href="https://bugs.webkit.org/show_bug.cgi?id=306914">https://bugs.webkit.org/show_bug.cgi?id=306914</a>
&lt;<a href="https://rdar.apple.com/169577375">rdar://169577375</a>&gt;

 Reviewed by NOBODY (OOPS!).

 This PR enables flexible track sizing (fr units) in GFC.

GFC can now handle:
  grid-template-columns: 1fr 1fr;
  gap: 20px;

Note: Grid containers and items still require fixed sizes (width/height).
Intrinsic sizing support will be added in future patches.

* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
</pre>
----------------------------------------------------------------------
#### 6c8e9809fcd479659192a1eec8f27e455931ce25
<pre>
[GFC] Account for gaps when expanding flex tracks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306910">https://bugs.webkit.org/show_bug.cgi?id=306910</a>
&lt;<a href="https://rdar.apple.com/169317562">rdar://169317562</a>&gt;

Reviewed by NOBODY (OOPS!).

The CSS Grid specification (section 11.2) defines free space as &quot;the available
grid space minus the sum of the base sizes of all the grid tracks (including
gutters)&quot;. This PR updates GFC to subtract gutter sizes from the available space.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::computeTotalGuttersSize):
* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h:
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d13a1f1e1496ce771edff7d855685355caf00385

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14632 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/4891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150867 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14785 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145185 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/11884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/4891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/90254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/902 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/4891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/153219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/4891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/153219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/14333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/153219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/4891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14360 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/4891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/78076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/14137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->