### PR TITLE
[JSC] Inlining `[...map.keys()]` and `[...map.values()]`

### DIFF
--- a/JSTests/stress/spread-map-iterator-inline-fast-path.js
+++ b/JSTests/stress/spread-map-iterator-inline-fast-path.js
@@ -1,0 +1,167 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Bad value: " + actual + " expected: " + expected);
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (let i = 0; i < expected.length; ++i) {
+        if (actual[i] !== expected[i] && !(Number.isNaN(actual[i]) && Number.isNaN(expected[i])))
+            throw new Error("Bad value at index " + i + ": " + actual[i] + " expected: " + expected[i]);
+    }
+}
+
+// Fresh iterator spread (entry == 0, fast path).
+{
+    function testKeys(map) {
+        return [...map.keys()];
+    }
+    function testValues(map) {
+        return [...map.values()];
+    }
+    noInline(testKeys);
+    noInline(testValues);
+
+    const map = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBeArray(testKeys(map), [1, 2, 3]);
+        shouldBeArray(testValues(map), ["a", "b", "c"]);
+    }
+}
+
+// Alternating between fast path (no deletions) and slow path (with deletions).
+{
+    function testKeys(map) {
+        return [...map.keys()];
+    }
+    noInline(testKeys);
+
+    const cleanMap = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    const dirtyMap = new Map([[10, "x"], [20, "y"], [30, "z"]]);
+    dirtyMap.delete(20);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        if (i % 2 === 0) {
+            shouldBeArray(testKeys(cleanMap), [1, 2, 3]);
+        } else {
+            shouldBeArray(testKeys(dirtyMap), [10, 30]);
+        }
+    }
+}
+
+// GC pressure during allocation.
+{
+    function testKeys(map) {
+        return [...map.keys()];
+    }
+    noInline(testKeys);
+
+    const map = new Map();
+    for (let i = 0; i < 10; ++i)
+        map.set(i, i * 10);
+    const garbage = [];
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        if (i % 100 === 0) {
+            for (let j = 0; j < 100; ++j)
+                garbage.push(new Array(1000));
+            if (garbage.length > 500)
+                garbage.length = 0;
+        }
+        const result = testKeys(map);
+        shouldBe(result.length, 10);
+    }
+}
+
+// Large map.
+{
+    function testValues(map) {
+        return [...map.values()];
+    }
+    noInline(testValues);
+
+    const map = new Map();
+    for (let i = 0; i < 1000; ++i)
+        map.set(i, i * 2);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const result = testValues(map);
+        shouldBe(result.length, 1000);
+        shouldBe(result[0], 0);
+        shouldBe(result[999], 1998);
+    }
+}
+
+// Empty map (edge case).
+{
+    function testKeys(map) {
+        return [...map.keys()];
+    }
+    noInline(testKeys);
+
+    const map = new Map();
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBeArray(testKeys(map), []);
+    }
+}
+
+// entries() should work correctly (uses slow path since Entries kind is not inlined).
+{
+    function testEntries(map) {
+        return [...map.entries()];
+    }
+    noInline(testEntries);
+
+    const map = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    for (let i = 0; i < testLoopCount; ++i) {
+        const result = testEntries(map);
+        shouldBe(result.length, 3);
+        shouldBeArray(result[0], [1, "a"]);
+        shouldBeArray(result[1], [2, "b"]);
+        shouldBeArray(result[2], [3, "c"]);
+    }
+}
+
+// entries() with deletions (slow path).
+{
+    function testEntries(map) {
+        return [...map.entries()];
+    }
+    noInline(testEntries);
+
+    const map = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+    map.delete(2);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const result = testEntries(map);
+        shouldBe(result.length, 2);
+        shouldBeArray(result[0], [1, "a"]);
+        shouldBeArray(result[1], [3, "c"]);
+    }
+}
+
+// Alternating between keys(), values(), and entries().
+{
+    function testKeys(map) {
+        return [...map.keys()];
+    }
+    function testValues(map) {
+        return [...map.values()];
+    }
+    function testEntries(map) {
+        return [...map.entries()];
+    }
+    noInline(testKeys);
+    noInline(testValues);
+    noInline(testEntries);
+
+    const map = new Map([[1, "a"], [2, "b"]]);
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBeArray(testKeys(map), [1, 2]);
+        shouldBeArray(testValues(map), ["a", "b"]);
+        const entries = testEntries(map);
+        shouldBe(entries.length, 2);
+        shouldBeArray(entries[0], [1, "a"]);
+        shouldBeArray(entries[1], [2, "b"]);
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9141,13 +9141,113 @@ void SpeculativeJIT::compileSpread(Node* node)
         cellResult(resultGPR, node);
 #endif // USE(JSVALUE64)
     } else if (node->child1().useKind() == MapIteratorObjectUse) {
-        // MapIterator spread does not use inline fast path; call the C++ operation directly.
+#if USE(JSVALUE64)
+        GPRTemporary result(this);
+        GPRTemporary scratch1(this);
+        GPRTemporary scratch2(this);
+        GPRTemporary length(this);
+        GPRTemporary kind(this);
+
+        GPRReg resultGPR = result.gpr();
+        GPRReg scratch1GPR = scratch1.gpr();
+        GPRReg scratch2GPR = scratch2.gpr();
+        GPRReg lengthGPR = length.gpr();
+        GPRReg kindGPR = kind.gpr();
+
+        JumpList slowPath;
+        JumpList done;
+
+        using Helper = JSMap::Helper;
+
+        // 1. Load entry from iterator, check entry == 0 (fast path only for fresh iterators).
+        load64(Address(argument, JSMapIterator::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Entry))), scratch1GPR);
+        slowPath.append(branchIfNotInt32(JSValueRegs(scratch1GPR)));
+        slowPath.append(branchTest32(NonZero, scratch1GPR));
+
+        // 2. Load storage from iterator.
+        loadPtr(Address(argument, JSMapIterator::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Storage))), scratch1GPR);
+        auto hasStorage = branchTestPtr(NonZero, scratch1GPR);
+
+        // 3. If storage is null, load from iteratedObject->storage.
+        loadPtr(Address(argument, JSMapIterator::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::IteratedObject))), scratch2GPR);
+        loadPtr(Address(scratch2GPR, JSMap::offsetOfStorage()), scratch1GPR);
+        slowPath.append(branchTestPtr(Zero, scratch1GPR));
+
+        hasStorage.link(this);
+
+        // 4. Get the data area of the storage JSCellButterfly.
+        addPtr(TrustedImm32(JSCellButterfly::offsetOfData()), scratch1GPR);
+
+        // 5. Load aliveEntryCount and check storage is not obsolete (slot 0 must be Int32).
+        load64(Address(scratch1GPR, Helper::aliveEntryCountIndex() * sizeof(EncodedJSValue)), lengthGPR);
+        slowPath.append(branchIfNotInt32(JSValueRegs(lengthGPR)));
+        zeroExtend32ToWord(lengthGPR, lengthGPR);
+
+        // 6. Check deletedEntryCount == 0.
+        load32(Address(scratch1GPR, Helper::deletedEntryCountIndex() * sizeof(EncodedJSValue)), scratch2GPR);
+        slowPath.append(branchTest32(NonZero, scratch2GPR));
+
+        // 7. Guard aliveEntryCount <= MAX_STORAGE_VECTOR_LENGTH.
+        slowPath.append(branch32(Above, lengthGPR, TrustedImm32(MAX_STORAGE_VECTOR_LENGTH)));
+
+        // 8. Load kind (must be Keys or Values, not Entries).
+        load32(Address(argument, JSMapIterator::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Kind))), kindGPR);
+        slowPath.append(branch32(Above, kindGPR, TrustedImm32(static_cast<uint32_t>(IterationKind::Values))));
+
+        // 9. Compute allocation size and allocate JSCellButterfly.
+        static_assert(sizeof(EncodedJSValue) == 8 && 1 << 3 == 8, "This is strongly assumed in the code below.");
+        lshift32(lengthGPR, TrustedImm32(3), scratch1GPR);
+        add32(TrustedImm32(JSCellButterfly::offsetOfData()), scratch1GPR);
+        emitAllocateVariableSizedCell<JSCellButterfly>(vm(), resultGPR, TrustedImmPtr(m_graph.registerStructure(vm().cellButterflyStructure(CopyOnWriteArrayWithContiguous))), scratch1GPR, scratch1GPR, scratch2GPR, slowPath, SlowAllocationResult::UndefinedBehavior);
+
+        // 10. Store publicLength and vectorLength.
+        static_assert(JSCellButterfly::offsetOfPublicLength() + static_cast<ptrdiff_t>(sizeof(uint32_t)) == JSCellButterfly::offsetOfVectorLength());
+        storePair32(lengthGPR, lengthGPR, resultGPR, TrustedImm32(JSCellButterfly::offsetOfPublicLength()));
+
+        // 11. Reload storage and compute source base pointer.
+        loadPtr(Address(argument, JSMapIterator::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::Storage))), scratch1GPR);
+        auto reloadHasStorage = branchTestPtr(NonZero, scratch1GPR);
+        loadPtr(Address(argument, JSMapIterator::offsetOfInternalField(static_cast<unsigned>(JSMapIterator::Field::IteratedObject))), scratch2GPR);
+        loadPtr(Address(scratch2GPR, JSMap::offsetOfStorage()), scratch1GPR);
+        reloadHasStorage.link(this);
+        addPtr(TrustedImm32(JSCellButterfly::offsetOfData()), scratch1GPR);
+
+        load32(Address(scratch1GPR, Helper::capacityIndex() * sizeof(EncodedJSValue)), scratch2GPR);
+        add32(TrustedImm32(Helper::hashTableStartIndex()), scratch2GPR);
+        lshiftPtr(TrustedImm32(3), scratch2GPR);
+        addPtr(scratch2GPR, scratch1GPR);
+
+        // 12. Copy loop: for i = length-1 down to 0.
+        static_assert(Helper::EntrySize == 3, "Map entries have stride 3 (key + value + chain).");
+        done.append(branchTest32(Zero, lengthGPR));
+        auto loopStart = label();
+        sub32(TrustedImm32(1), lengthGPR);
+
+        // Compute source index: lengthGPR * 3 + kindGPR (0 for Keys, 1 for Values).
+        lshift32(lengthGPR, TrustedImm32(1), scratch2GPR);
+        add32(lengthGPR, scratch2GPR);
+        add32(kindGPR, scratch2GPR);
+        load64(BaseIndex(scratch1GPR, scratch2GPR, TimesEight), scratch2GPR);
+        store64(scratch2GPR, BaseIndex(resultGPR, lengthGPR, TimesEight, JSCellButterfly::offsetOfData()));
+        branchTest32(NonZero, lengthGPR).linkTo(loopStart, this);
+
+        // Note: We use operationSpreadGeneric instead of operationSpreadMapIterator because the slow path
+        // may be reached when kind == Entries, which operationSpreadMapIterator doesn't support.
+        addSlowPathGenerator(slowPathCall(slowPath, this, operationSpreadGeneric, resultGPR, LinkableConstant::globalObject(*this, node), argument));
+
+        done.link(this);
+        mutatorFence(vm());
+        cellResult(resultGPR, node);
+#else
         flushRegisters();
 
         GPRFlushedCallResult result(this);
         GPRReg resultGPR = result.gpr();
-        callOperation(operationSpreadMapIterator, resultGPR, LinkableConstant::globalObject(*this, node), argument);
+        // Note: We use operationSpreadGeneric instead of operationSpreadMapIterator because the slow path
+        // may be reached when kind == Entries, which operationSpreadMapIterator doesn't support.
+        callOperation(operationSpreadGeneric, resultGPR, LinkableConstant::globalObject(*this, node), argument);
         cellResult(resultGPR, node);
+#endif // USE(JSVALUE64)
     } else {
         flushRegisters();
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10355,8 +10355,117 @@ IGNORE_CLANG_WARNINGS_END
             result = m_out.phi(pointerType(), fastResult, slowResult);
             mutatorFence();
         } else if (m_node->child1().useKind() == MapIteratorObjectUse) {
-            // MapIterator spread does not use inline fast path; call the C++ operation directly.
-            result = vmCall(pointerType(), operationSpreadMapIterator, weakPointer(globalObject), argument);
+            using Helper = JSMap::Helper;
+
+            LBasicBlock entryCheck = m_out.newBlock();
+            LBasicBlock loadStorage = m_out.newBlock();
+            LBasicBlock loadFromMap = m_out.newBlock();
+            LBasicBlock hasStorageBlock = m_out.newBlock();
+            LBasicBlock obsoleteCheck = m_out.newBlock();
+            LBasicBlock deletedCheck = m_out.newBlock();
+            LBasicBlock sizeCheck = m_out.newBlock();
+            LBasicBlock kindCheck = m_out.newBlock();
+            LBasicBlock allocBlock = m_out.newBlock();
+            LBasicBlock loopStart = m_out.newBlock();
+            LBasicBlock slowPath = m_out.newBlock();
+            LBasicBlock continuation = m_out.newBlock();
+
+            // 1. Load entry from iterator, check entry == 0.
+            LValue entryValue = m_out.load64(argument,
+                m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::Entry)]);
+            m_out.branch(isNotInt32(entryValue), rarely(slowPath), usually(entryCheck));
+
+            LBasicBlock lastNext = m_out.appendTo(entryCheck, loadStorage);
+            LValue entry = unboxInt32(entryValue);
+            m_out.branch(m_out.isZero32(entry), usually(loadStorage), rarely(slowPath));
+
+            // 2. Load storage from iterator.
+            m_out.appendTo(loadStorage, loadFromMap);
+            LValue storage = m_out.loadPtr(argument,
+                m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::Storage)]);
+            m_out.branch(m_out.isNull(storage), usually(loadFromMap), usually(hasStorageBlock));
+
+            // 3. If storage is null, load from iteratedObject->storage.
+            m_out.appendTo(loadFromMap, hasStorageBlock);
+            LValue iteratedObject = m_out.loadPtr(argument,
+                m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::IteratedObject)]);
+            LValue mapStorage = m_out.loadPtr(iteratedObject, m_heaps.JSMap_storage);
+            ValueFromBlock mapStorageResult = m_out.anchor(mapStorage);
+            m_out.branch(m_out.isNull(mapStorage), rarely(slowPath), usually(obsoleteCheck));
+
+            // 4. Merge storage sources.
+            m_out.appendTo(hasStorageBlock, obsoleteCheck);
+            ValueFromBlock iteratorStorageResult = m_out.anchor(storage);
+            m_out.jump(obsoleteCheck);
+
+            // 5. Check storage is not obsolete.
+            m_out.appendTo(obsoleteCheck, deletedCheck);
+            LValue finalStorage = m_out.phi(pointerType(), mapStorageResult, iteratorStorageResult);
+            LValue storageButterfly = toButterfly(finalStorage);
+            LValue aliveEntryCountValue = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, storageButterfly, m_out.constIntPtr(Helper::aliveEntryCountIndex())));
+            m_out.branch(isNotInt32(aliveEntryCountValue), rarely(slowPath), usually(deletedCheck));
+
+            // 6. Check deletedEntryCount == 0.
+            m_out.appendTo(deletedCheck, sizeCheck);
+            LValue length = unboxInt32(aliveEntryCountValue);
+            LValue deletedCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, storageButterfly, m_out.constIntPtr(Helper::deletedEntryCountIndex())));
+            m_out.branch(m_out.isZero32(deletedCount), usually(sizeCheck), rarely(slowPath));
+
+            // 7. Check length <= MAX_STORAGE_VECTOR_LENGTH.
+            m_out.appendTo(sizeCheck, kindCheck);
+            m_out.branch(m_out.above(length, m_out.constInt32(MAX_STORAGE_VECTOR_LENGTH)), rarely(slowPath), usually(kindCheck));
+
+            // 8. Check kind is Keys or Values.
+            m_out.appendTo(kindCheck, allocBlock);
+            LValue kind = m_out.load32(argument,
+                m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSMapIterator::Field::Kind)]);
+            m_out.branch(m_out.above(kind, m_out.constInt32(static_cast<uint32_t>(IterationKind::Values))), rarely(slowPath), usually(allocBlock));
+
+            // 9. Allocate JSCellButterfly.
+            m_out.appendTo(allocBlock, loopStart);
+            static_assert(sizeof(JSValue) == 8 && 1 << 3 == 8, "Assumed in the code below.");
+            LValue size = m_out.add(
+                m_out.shl(m_out.zeroExtPtr(length), m_out.constInt32(3)),
+                m_out.constIntPtr(JSCellButterfly::offsetOfData()));
+            LValue fastAllocation = allocateVariableSizedCell<JSCellButterfly>(size, m_graph.m_vm.cellButterflyStructure(CopyOnWriteArrayWithContiguous), slowPath);
+            LValue fastStorage = toButterfly(fastAllocation);
+            m_out.store32(length, fastStorage, m_heaps.Butterfly_vectorLength);
+            m_out.store32(length, fastStorage, m_heaps.Butterfly_publicLength);
+            ValueFromBlock fastResult = m_out.anchor(fastAllocation);
+
+            // 10. Compute dataTableStartIndex.
+            LValue capacity = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, storageButterfly, m_out.constIntPtr(Helper::capacityIndex())));
+            LValue dataTableStart = m_out.add(m_out.constInt32(Helper::hashTableStartIndex()), capacity);
+
+            ValueFromBlock startIndex = m_out.anchor(m_out.constIntPtr(0));
+            m_out.branch(m_out.isZero32(length), unsure(continuation), unsure(loopStart));
+
+            // 11. Copy loop: for i = 0..<length, dest[i] = storage[dataTableStart + i * 3 + kind].
+            m_out.appendTo(loopStart, slowPath);
+            static_assert(Helper::EntrySize == 3, "Map entries have stride 3 (key + value + chain).");
+            LValue index = m_out.phi(pointerType(), startIndex);
+            // srcIndex = dataTableStart + index * 3 + kind
+            LValue srcIndex = m_out.add(
+                m_out.add(m_out.zeroExtPtr(dataTableStart), m_out.mul(index, m_out.constIntPtr(3))),
+                m_out.zeroExtPtr(kind));
+            LValue value = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, storageButterfly, srcIndex));
+            m_out.store64(value, m_out.baseIndex(m_heaps.indexedContiguousProperties, fastStorage, index));
+
+            LValue nextIndex = m_out.add(index, m_out.constIntPtr(1));
+            m_out.addIncomingToPhi(index, m_out.anchor(nextIndex));
+            m_out.branch(m_out.below(nextIndex, m_out.zeroExtPtr(length)), unsure(loopStart), unsure(continuation));
+
+            // 12. Slow path.
+            // Note: We use operationSpreadGeneric instead of operationSpreadMapIterator because the slow path
+            // may be reached when kind == Entries, which operationSpreadMapIterator doesn't support.
+            m_out.appendTo(slowPath, continuation);
+            ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationSpreadGeneric, weakPointer(globalObject), argument));
+            m_out.jump(continuation);
+
+            // 13. Continuation.
+            m_out.appendTo(continuation, lastNext);
+            result = m_out.phi(pointerType(), fastResult, slowResult);
+            mutatorFence();
         } else
             result = vmCall(pointerType(), operationSpreadGeneric, weakPointer(globalObject), argument);
 


### PR DESCRIPTION
#### c63812e50c5ef7b7723542751fbdf24a669d2340
<pre>
[JSC] Inlining `[...map.keys()]` and `[...map.values()]`
<a href="https://bugs.webkit.org/show_bug.cgi?id=306917">https://bugs.webkit.org/show_bug.cgi?id=306917</a>

Reviewed by NOBODY (OOPS!).

This patch changes to inline `[...map.keys()]` and `[...map.values()]`.

                           TipOfTree                  Patched

spread-map-keys          1.5544+-0.2662     ^      0.9167+-0.1007        ^ definitely 1.6957x faster
spread-map-values        1.6212+-0.2032     ^      0.8795+-0.1034        ^ definitely 1.8434x faster

Test: JSTests/stress/spread-map-iterator-inline-fast-path.js

* JSTests/stress/spread-map-iterator-inline-fast-path.js: Added.
(shouldBe):
(shouldBeArray):
(throw.new.Error.testKeys):
(throw.new.Error.testValues):
(throw.new.Error):
(shouldBeArray.testKeys):
(shouldBe.testValues):
(shouldBe.testKeys):
(shouldBeArray.testEntries):
(shouldBeArray.testValues):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileSpread):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c63812e50c5ef7b7723542751fbdf24a669d2340

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95415 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109357 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79013 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145188 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127307 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90257 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11407 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9071 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/905 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134223 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153222 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3043 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14314 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117410 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117733 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13783 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14363 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3547 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173528 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78079 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44907 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->