### PR TITLE
BFCache fails to restore pages when iframe performs cross-site navigation.

### DIFF
--- a/LayoutTests/http/tests/navigation/cross-site-iframe-nav-with-bfcache-expected.txt
+++ b/LayoutTests/http/tests/navigation/cross-site-iframe-nav-with-bfcache-expected.txt
@@ -1,0 +1,23 @@
+Cross-site iframe history is preserved when the main frame navigates and pages are restored from back/forward cache.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Popup loaded
+Popup pageshow: not-persisted (initial load)
+Same-site iframe loaded
+Same-site iframe displayed (not-persisted).
+Cross-site iframe loaded
+Cross-site iframe displayed first time (not-persisted).
+Other page loaded
+Other page displayed (not-persisted).
+Popup pageshow: persisted (from BFCache)
+PASS Cross-site iframe restored from BFCache (persisted).
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with cross-site-iframe-nav-with-bfcache-popup.html. It has a same-site iframe initially.
+Navigate iframe to cross-site.
+Navigate main frame to other.
+Go back. (cross-site-iframe-nav-with-bfcache-popup.html with cross-site iframe restored from BFCache)
+... and ensures the page with cross-site iframe is correctly restored from BFCache.

--- a/LayoutTests/http/tests/navigation/cross-site-iframe-nav-with-bfcache.html
+++ b/LayoutTests/http/tests/navigation/cross-site-iframe-nav-with-bfcache.html
@@ -1,0 +1,92 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/navigation-utils.js"></script>
+<script>
+
+description("Cross-site iframe history is preserved when the main frame navigates and pages are restored from back/forward cache.");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("resources/cross-site-iframe-nav-with-bfcache-popup.html");
+}
+
+var crossSiteShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        load: () => debug("Popup loaded"),
+        pageshow: ({arg}) => {
+            if (arg === "persisted") {
+                debug("Popup pageshow: persisted (from BFCache)");
+            } else {
+                debug("Popup pageshow: not-persisted (initial load)");
+            }
+        },
+    },
+    samesite: {
+        load: () => debug("Same-site iframe loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Same-site iframe should not be loaded from back/forward cache on first load.");
+                finishJSTest();
+                return;
+            }
+            debug("Same-site iframe displayed (not-persisted).");
+            sendMessageToPopup("navigate-to-cross-site");
+        }
+    },
+    crosssite: {
+        load: () => debug("Cross-site iframe loaded"),
+        pageshow: ({arg}) => {
+            crossSiteShowCount++;
+            if (crossSiteShowCount == 1) {
+                if (arg !== "not-persisted") {
+                    testFailed("Cross-site iframe should not be loaded from back/forward cache on first load.");
+                    finishJSTest();
+                    return;
+                }
+                debug("Cross-site iframe displayed first time (not-persisted).");
+                sendMessageToPopup("navigate-to-other");
+            } else if (crossSiteShowCount == 2) {
+                if (arg !== "persisted") {
+                    testFailed("Cross-site iframe should be loaded from back/forward cache on second display.");
+                    finishJSTest();
+                    return;
+                }
+                testPassed("Cross-site iframe restored from BFCache (persisted).");
+                finishJSTest();
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Other page should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+            debug("Other page displayed (not-persisted).");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with cross-site-iframe-nav-with-bfcache-popup.html. It has a same-site iframe initially.</li>
+    <li>Navigate iframe to cross-site.</li>
+    <li>Navigate main frame to other.</li>
+    <li>Go back. (cross-site-iframe-nav-with-bfcache-popup.html with cross-site iframe restored from BFCache)</li>
+</ul>
+<p>... and ensures the page with cross-site iframe is correctly restored from BFCache.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-other.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-other.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "other";
+
+window.onload = () => sendMessageToOpener("load");
+window.onpageshow = () => sendMessageToOpener("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    opener: {
+        back1: () => history.back(),
+    },
+});
+
+</script>
+</head>
+<body>
+<h1>Other Page</h1>
+<p>This is the other page (no iframe).</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+
+window.onload = () => sendMessageToTop("load");
+window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+</script>
+</head>
+<body>
+<h1>Iframe Page</h1>
+<p id="host"></p>
+<script>
+document.getElementById("host").textContent = location.hostname + ":" + location.port;
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-popup.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="navigation-utils.js"></script>
+<script>
+
+const page = "popup";
+const iframeId = "test-iframe"
+
+window.onload = () => sendMessageToOpener("load");
+window.onpageshow = () => sendMessageToOpener("pageshow", event.persisted ? "persisted" : "not-persisted");
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    opener: {
+        'navigate-to-cross-site': () => navigateIframeTo(`http://${crossSiteHostname}:8000/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html`),
+        'navigate-to-other': () => navigateTo("cross-site-iframe-nav-with-bfcache-other.html"),
+        back2: () => history.back(),
+    },
+    samesite: () => forwardMessageToOpener(event.data),
+    crosssite: () => forwardMessageToOpener(event.data),
+    other: () => forwardMessageToOpener(event.data),
+});
+
+
+</script>
+</head>
+<body>
+<h1>Popup page</h1>
+<iframe src="cross-site-iframe-nav-with-bfcache-page.html" id="test-iframe"></iframe>
+</body>
+</html>

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/HistoryItem.h>
 #include <wtf/Forward.h>
@@ -56,7 +57,7 @@ public:
 
     WEBCORE_EXPORT std::unique_ptr<CachedPage> suspendPage(Page&);
     WEBCORE_EXPORT bool addIfCacheable(HistoryItem&, Page*); // Prunes if maxSize() is exceeded.
-    WEBCORE_EXPORT void remove(BackForwardItemIdentifier);
+    WEBCORE_EXPORT void remove(BackForwardFrameItemIdentifier);
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);
@@ -74,8 +75,8 @@ public:
     void markPagesForCaptionPreferencesChanged();
 #endif
 
-    bool isInBackForwardCache(BackForwardItemIdentifier) const;
-    bool hasCachedPageExpired(BackForwardItemIdentifier) const;
+    bool isInBackForwardCache(BackForwardFrameItemIdentifier) const;
+    bool hasCachedPageExpired(BackForwardFrameItemIdentifier) const;
 
 private:
     BackForwardCache();
@@ -88,8 +89,8 @@ private:
     void prune(PruningReason);
     void dump() const;
 
-    HashMap<BackForwardItemIdentifier, Variant<PruningReason, UniqueRef<CachedPage>>> m_cachedPageMap;
-    ListHashSet<BackForwardItemIdentifier> m_items;
+    HashMap<BackForwardFrameItemIdentifier, Variant<PruningReason, UniqueRef<CachedPage>>> m_cachedPageMap;
+    ListHashSet<BackForwardFrameItemIdentifier> m_items;
     unsigned m_maxSize {0};
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -153,12 +153,12 @@ const String& HistoryItem::alternateTitle() const
 
 bool HistoryItem::isInBackForwardCache() const
 {
-    return BackForwardCache::singleton().isInBackForwardCache(m_itemID);
+    return BackForwardCache::singleton().isInBackForwardCache(m_frameItemID);
 }
 
 bool HistoryItem::hasCachedPageExpired() const
 {
-    return BackForwardCache::singleton().hasCachedPageExpired(m_itemID);
+    return BackForwardCache::singleton().hasCachedPageExpired(m_frameItemID);
 }
 
 URL HistoryItem::url() const

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -591,7 +591,7 @@ void Page::firstTimeInitialization()
     });
 }
 
-void Page::clearPreviousItemFromAllPages(BackForwardItemIdentifier itemID)
+void Page::clearPreviousItemFromAllPages(BackForwardFrameItemIdentifier frameItemID)
 {
     for (auto& page : allPages()) {
         RefPtr localMainFrame = page->localMainFrame();
@@ -599,7 +599,7 @@ void Page::clearPreviousItemFromAllPages(BackForwardItemIdentifier itemID)
             return;
 
         Ref controller = localMainFrame->loader().history();
-        if (controller->previousItem() && controller->previousItem()->itemID() == itemID) {
+        if (controller->previousItem() && controller->previousItem()->frameItemID() == frameItemID) {
             controller->clearPreviousItem();
             return;
         }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -23,7 +23,7 @@
 #include <JavaScriptCore/Debugger.h>
 #include <WebCore/ActivityState.h>
 #include <WebCore/AnimationFrameRate.h>
-#include <WebCore/BackForwardItemIdentifier.h>
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BoxExtents.h>
 #include <WebCore/Color.h>
 #include <WebCore/DocumentEnums.h>
@@ -386,7 +386,7 @@ public:
 
     static void updateControlTintsForAllPages();
     WEBCORE_EXPORT static void updateStyleForAllPagesAfterGlobalChangeInEnvironment();
-    WEBCORE_EXPORT static void clearPreviousItemFromAllPages(BackForwardItemIdentifier);
+    WEBCORE_EXPORT static void clearPreviousItemFromAllPages(BackForwardFrameItemIdentifier);
 
     WEBCORE_EXPORT void setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& topOrigin, const String& referrerPolicy, OptionSet<AdvancedPrivacyProtections>);
 

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -29,7 +29,7 @@
 #include "Logging.h"
 #include "SuspendedPageProxy.h"
 #include "WebBackForwardCacheEntry.h"
-#include "WebBackForwardListItem.h"
+#include "WebBackForwardListFrameItem.h"
 #include "WebPageProxy.h"
 #include "WebProcessMessages.h"
 #include "WebProcessPool.h"
@@ -107,12 +107,12 @@ void WebBackForwardCache::addEntry(WebBackForwardListItem& item, Ref<WebBackForw
 void WebBackForwardCache::addEntry(WebBackForwardListItem& item, Ref<SuspendedPageProxy>&& suspendedPage)
 {
     auto coreProcessIdentifier = suspendedPage->process().coreProcessIdentifier();
-    addEntry(item, WebBackForwardCacheEntry::create(*this, item.identifier(), coreProcessIdentifier, WTF::move(suspendedPage)));
+    addEntry(item, WebBackForwardCacheEntry::create(*this, item.identifier(), item.mainFrameItem().identifier(), coreProcessIdentifier, WTF::move(suspendedPage)));
 }
 
 void WebBackForwardCache::addEntry(WebBackForwardListItem& item, WebCore::ProcessIdentifier processIdentifier)
 {
-    addEntry(item, WebBackForwardCacheEntry::create(*this, item.identifier(), WTF::move(processIdentifier), nullptr));
+    addEntry(item, WebBackForwardCacheEntry::create(*this, item.identifier(), item.mainFrameItem().identifier(), WTF::move(processIdentifier), nullptr));
 }
 
 void WebBackForwardCache::removeEntry(WebBackForwardListItem& item)

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <WebCore/BackForwardFrameItemIdentifier.h>
+#include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/CheckedRef.h>
@@ -43,7 +45,7 @@ class WebProcessProxy;
 class WebBackForwardCacheEntry : public RefCountedAndCanMakeWeakPtr<WebBackForwardCacheEntry> {
     WTF_MAKE_TZONE_ALLOCATED(WebBackForwardCacheEntry);
 public:
-    static Ref<WebBackForwardCacheEntry> create(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
+    static Ref<WebBackForwardCacheEntry> create(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
     ~WebBackForwardCacheEntry();
 
     WebBackForwardCache* backForwardCache() const;
@@ -54,13 +56,14 @@ public:
     RefPtr<WebProcessProxy> process() const;
 
 private:
-    WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
+    WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
 
     void expirationTimerFired();
 
     WeakPtr<WebBackForwardCache> m_backForwardCache;
     WebCore::ProcessIdentifier m_processIdentifier;
     Markable<WebCore::BackForwardItemIdentifier> m_backForwardItemID;
+    Markable<WebCore::BackForwardFrameItemIdentifier> m_backForwardFrameItemID;
     RefPtr<SuspendedPageProxy> m_suspendedPage;
     RunLoop::Timer m_expirationTimer;
 } SWIFT_SHARED_REFERENCE(refWebBackForwardCacheEntry, derefWebBackForwardCacheEntry);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -498,7 +498,7 @@ void WebBackForwardList::didRemoveItem(WebBackForwardListItem& backForwardListIt
 {
     backForwardListItem.wasRemovedFromBackForwardList();
 
-    protect(m_page)->backForwardRemovedItem(backForwardListItem.identifier());
+    protect(m_page)->backForwardRemovedItem(backForwardListItem.mainFrameItem().identifier());
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     backForwardListItem.setSnapshot(nullptr);
@@ -684,9 +684,9 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
         Ref process = *downcast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
         if (!!item->backForwardCacheEntry() != frameState->hasCachedPage) {
             if (frameState->hasCachedPage)
-            protect(webPageProxy->backForwardCache())->addEntry(*item, process->coreProcessIdentifier());
+                protect(webPageProxy->backForwardCache())->addEntry(*item, process->coreProcessIdentifier());
             else if (!item->suspendedPage())
-            protect(webPageProxy->backForwardCache())->removeEntry(*item);
+                protect(webPageProxy->backForwardCache())->removeEntry(*item);
         }
 
         auto oldFrameID = frameItem->frameID();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13897,9 +13897,9 @@ void WebPageProxy::didFinishLoadingDataForCustomContentProvider(String&& suggest
         pageClient->didFinishLoadingDataForCustomContentProvider(ResourceResponseBase::sanitizeSuggestedFilename(WTF::move(suggestedFilename)), dataReference);
 }
 
-void WebPageProxy::backForwardRemovedItem(BackForwardItemIdentifier itemID)
+void WebPageProxy::backForwardRemovedItem(BackForwardFrameItemIdentifier frameItemID)
 {
-    send(Messages::WebPage::DidRemoveBackForwardItem(itemID));
+    send(Messages::WebPage::DidRemoveBackForwardItem(frameItemID));
 }
 
 void WebPageProxy::setCanRunModal(bool canRunModal)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1733,7 +1733,7 @@ public:
     void receivedNavigationResponsePolicyDecision(WebCore::PolicyAction, API::Navigation*, const WebCore::ResourceRequest&, Ref<API::NavigationResponse>&&, CompletionHandler<void(PolicyDecision&&)>&&);
     void receivedNavigationActionPolicyDecision(WebProcessProxy&, WebCore::PolicyAction, API::Navigation&, Ref<API::NavigationAction>&&, ProcessSwapRequestedByClient, WebFrameProxy&, const FrameInfoData&, WasNavigationIntercepted, std::optional<PolicyDecisionConsoleMessage>&&, CompletionHandler<void(PolicyDecision&&)>&&);
 
-    void backForwardRemovedItem(WebCore::BackForwardItemIdentifier);
+    void backForwardRemovedItem(WebCore::BackForwardFrameItemIdentifier);
 
 #if ENABLE(DRAG_SUPPORT)    
     // Drag and drop support.

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -47,10 +47,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-void WebBackForwardListProxy::removeItem(BackForwardItemIdentifier itemID)
+void WebBackForwardListProxy::removeItem(BackForwardFrameItemIdentifier frameItemID)
 {
-    BackForwardCache::singleton().remove(itemID);
-    WebCore::Page::clearPreviousItemFromAllPages(itemID);
+    WebCore::Page::clearPreviousItemFromAllPages(frameItemID);
 }
 
 WebBackForwardListProxy::WebBackForwardListProxy(WebPage& page)

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -39,7 +39,7 @@ class WebBackForwardListProxy : public WebCore::BackForwardClient {
 public: 
     static Ref<WebBackForwardListProxy> create(WebPage& page) { return adoptRef(*new WebBackForwardListProxy(page)); }
 
-    static void removeItem(WebCore::BackForwardItemIdentifier);
+    static void removeItem(WebCore::BackForwardFrameItemIdentifier);
 
     void clearCachedListCounts();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6435,9 +6435,9 @@ void WebPage::setCustomTextEncodingName(const String& encoding)
         localMainFrame->loader().reloadWithOverrideEncoding(encoding);
 }
 
-void WebPage::didRemoveBackForwardItem(BackForwardItemIdentifier itemID)
+void WebPage::didRemoveBackForwardItem(BackForwardFrameItemIdentifier frameItemID)
 {
-    WebBackForwardListProxy::removeItem(itemID);
+    WebBackForwardListProxy::removeItem(frameItemID);
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -286,6 +286,7 @@ struct AccessibilityRemoteToken;
 struct AppHighlight;
 struct AriaNotifyData;
 struct AttributedString;
+struct BackForwardFrameItemIdentifierType;
 struct BackForwardItemIdentifierType;
 struct CharacterRange;
 struct CompositionHighlight;
@@ -354,6 +355,7 @@ struct FrameIdentifierType;
 using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
 
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
+using BackForwardFrameItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardFrameItemIdentifierType>>;
 using DictationContext = ObjectIdentifier<DictationContextType>;
 using DragEventTargetData = Variant<DragEventHandled, WebCore::FrameIdentifier>;
 using HTMLMediaElementIdentifier = ObjectIdentifier<MediaPlayerClientIdentifierType>;
@@ -2315,7 +2317,7 @@ private:
     void loadURLInFrame(URL&&, const String& referrer, WebCore::FrameIdentifier);
     void loadDataInFrame(std::span<const uint8_t>, String&& MIMEType, String&& encodingName, URL&& baseURL, WebCore::FrameIdentifier);
 
-    void didRemoveBackForwardItem(WebCore::BackForwardItemIdentifier);
+    void didRemoveBackForwardItem(WebCore::BackForwardFrameItemIdentifier);
     void setCurrentHistoryItemForReattach(Ref<FrameState>&&);
 
     void requestFontAttributesAtSelectionStart(CompletionHandler<void(const WebCore::FontAttributes&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -226,7 +226,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     SetCurrentHistoryItemForReattach(Ref<WebKit::FrameState> frameState)
 
-    DidRemoveBackForwardItem(WebCore::BackForwardItemIdentifier backForwardItemID)
+    DidRemoveBackForwardItem(WebCore::BackForwardFrameItemIdentifier backForwardFrameItemID)
 
     UpdateWebsitePolicies(struct WebKit::WebsitePoliciesData websitePolicies)
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2201,9 +2201,9 @@ void WebProcess::setBackForwardCacheCapacity(unsigned capacity)
     BackForwardCache::singleton().setMaxSize(capacity);
 }
 
-void WebProcess::clearCachedPage(BackForwardItemIdentifier backForwardItemID, CompletionHandler<void()>&& completionHandler)
+void WebProcess::clearCachedPage(BackForwardFrameItemIdentifier backForwardFrameItemID, CompletionHandler<void()>&& completionHandler)
 {
-    BackForwardCache::singleton().remove(backForwardItemID);
+    BackForwardCache::singleton().remove(backForwardFrameItemID);
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -38,7 +38,7 @@
 #include "WebPageProxyIdentifier.h"
 #include "WebSocketChannelManager.h"
 #include <WebCore/ActivityState.h>
-#include <WebCore/BackForwardItemIdentifier.h>
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/PageIdentifier.h>
@@ -646,7 +646,7 @@ private:
     void setMemoryCacheDisabled(bool);
 
     void setBackForwardCacheCapacity(unsigned);
-    void clearCachedPage(WebCore::BackForwardItemIdentifier, CompletionHandler<void()>&&);
+    void clearCachedPage(WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void()>&&);
 
 #if ENABLE(SERVICE_CONTROLS)
     void setEnabledServices(bool hasImageServices, bool hasSelectionServices, bool hasRichContentServices);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -171,7 +171,7 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     ClearCurrentModifierStateForTesting()
 
     SetBackForwardCacheCapacity(unsigned capacity);
-    ClearCachedPage(WebCore::BackForwardItemIdentifier backForwardItemID) -> ()
+    ClearCachedPage(WebCore::BackForwardFrameItemIdentifier backForwardFrameItemID) -> ()
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     SendMessageToWebProcessExtension(struct WebKit::UserMessage userMessage)


### PR DESCRIPTION
#### 94edb16b0b9cc57a7293a34a49af70d7675fd7b9
<pre>
BFCache fails to restore pages when iframe performs cross-site navigation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306900">https://bugs.webkit.org/show_bug.cgi?id=306900</a>
<a href="https://rdar.apple.com/169563332">rdar://169563332</a>

Reviewed by Charlie Wolfe.

When an iframe navigates to a cross-site URL, a new BackForwardList entry is created
with a new BackForwardItemIdentifier (itemID). However, the BackForwardCache (BFCache)
uses this itemID as its key, causing a mismatch between:
  - The itemID used when saving to BFCache (old itemID from before iframe navigation)
  - The itemID used when restoring from BFCache (new itemID after iframe navigation)

This results in BFCache misses even though the main frame content hasn&apos;t changed.

Steps to Reproduce:
1. Navigate to page A with an iframe (same-site HTML)
2. Navigate the iframe to a cross-site page B
3. Navigate the main frame to page C (no iframe)
4. Go back → Step 2 is displayed correctly
5. Go back again → Expected: Step 1 should be restored from BFCache, Actual: Page is
   reloaded (BFCache miss)

Change BFCache to use BackForwardFrameItemIdentifier instead of BackForwardItemIdentifier
as its key. BFCache stores/restores per-frame state, so using frame-specific identifiers
ensures correct matching even when iframes navigate cross-site.

New test: http/tests/navigation/cross-site-iframe-nav-with-bfcache.html

* LayoutTests/http/tests/navigation/cross-site-iframe-nav-with-bfcache-expected.txt: Added.
* LayoutTests/http/tests/navigation/cross-site-iframe-nav-with-bfcache.html: Added.
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-other.html: Added.
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html: Added.
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-popup.html: Added.
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::addIfCacheable):
(WebCore::BackForwardCache::take):
(WebCore::BackForwardCache::get):
(WebCore::BackForwardCache::remove):
(WebCore::BackForwardCache::isInBackForwardCache const):
(WebCore::BackForwardCache::hasCachedPageExpired const):
* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::isInBackForwardCache const):
(WebCore::HistoryItem::hasCachedPageExpired const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::clearPreviousItemFromAllPages):
* Source/WebCore/page/Page.h:
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::addEntry):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
(WebKit::WebBackForwardCacheEntry::create):
(WebKit::WebBackForwardCacheEntry::WebBackForwardCacheEntry):
(WebKit::WebBackForwardCacheEntry::~WebBackForwardCacheEntry):
(WebKit::WebBackForwardCacheEntry::takeSuspendedPage):
(WebKit::WebBackForwardCacheEntry::expirationTimerFired):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::didRemoveItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardRemovedItem):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::removeItem):
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didRemoveBackForwardItem):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::clearCachedPage):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/306880@main">https://commits.webkit.org/306880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e0ce7bad75ab9b98d147e5b8e401619b5d0a0a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95676 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e60c6cfc-b869-41ba-afa1-c74bfdf415c6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15039 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109576 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79072 "layout-tests (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a36c81a2-b3df-49e7-aaa6-042ed2e1024a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90484 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28f62baa-c734-470d-a680-ffeaf108d1d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11593 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9245 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153472 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4629 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117603 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13972 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70276 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14627 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3763 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78329 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14425 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->