### PR TITLE
[JSC] Enable AsyncStackTrace

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt
@@ -6,12 +6,16 @@ FAIL :iff_uncaptured:useOnuncapturederror=true;errorType="out-of-memory" assert_
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
     finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:119:11
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :iff_uncaptured:useOnuncapturederror=true;errorType="validation" assert_unreached:
   - EXCEPTION: Error: there were outstanding immediateAsyncExpectations (e.g. expectUncapturedError) at the end of the test
     assert@http://127.0.0.1:8000/webgpu/common/util/util.js:37:20
     finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:119:11
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :only_original_device_is_event_target:
 PASS :uncapturederror_from_non_originating_thread:

--- a/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt
@@ -160,6 +160,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -168,6 +172,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -176,6 +184,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -184,6 +196,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -192,6 +208,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -200,6 +220,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -208,6 +232,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -216,6 +244,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -224,6 +256,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -232,6 +268,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -240,6 +280,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -248,6 +292,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -256,6 +304,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -264,6 +316,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimi
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="atDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -442,6 +498,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -450,6 +510,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -458,6 +522,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -466,6 +534,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -474,6 +546,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -482,6 +558,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -490,6 +570,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -498,6 +582,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -506,6 +594,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -514,6 +606,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -522,6 +618,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -530,6 +630,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -538,6 +642,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: DID NOT REJECT
@@ -546,6 +654,10 @@ FAIL :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overL
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:697:24
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="underDefault";testValueName="overLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -731,6 +843,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -740,6 +856,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -749,6 +869,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -758,6 +882,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -767,6 +895,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -776,6 +908,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -785,6 +921,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -794,6 +934,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -803,6 +947,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -812,6 +960,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -821,6 +973,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -830,6 +986,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -839,6 +999,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -848,6 +1012,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -857,6 +1025,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -866,6 +1038,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -875,6 +1051,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -884,6 +1064,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -893,6 +1077,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -902,6 +1090,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -911,6 +1103,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -920,6 +1116,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -929,6 +1129,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -938,6 +1142,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -947,6 +1155,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -956,6 +1168,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -965,6 +1181,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -974,6 +1194,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -983,6 +1207,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -992,6 +1220,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1001,6 +1233,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1010,6 +1246,10 @@ FAIL :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValu
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="betweenDefaultAndMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true
@@ -1243,6 +1483,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1252,6 +1496,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1261,6 +1509,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1270,6 +1522,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1279,6 +1535,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1288,6 +1548,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1297,6 +1561,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1306,6 +1574,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1315,6 +1587,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1324,6 +1600,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1333,6 +1613,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1342,6 +1626,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1351,6 +1639,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1360,6 +1652,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1369,6 +1665,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=false;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1378,6 +1678,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1387,6 +1691,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1396,6 +1704,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1405,6 +1717,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1414,6 +1730,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1423,6 +1743,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1432,6 +1756,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1441,6 +1769,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=false;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1450,6 +1782,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1459,6 +1795,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1468,6 +1808,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1477,6 +1821,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=false;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1486,6 +1834,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1495,6 +1847,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1504,6 +1860,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=false assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1513,6 +1873,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit";async=true;pointList=true;frontFacing=true;sampleIndex=true;sampleMaskIn=true;sampleMaskOut=true assert_unreached:
   - EXPECTATION FAILED: REJECTED
@@ -1522,6 +1886,10 @@ FAIL :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="atLimit"
     shouldRejectConditionally@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:699:25
     testCreateRenderPipeline@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:938:43
     @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:134:39
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:657:17
+    _testThenDestroyDevice@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:580:13
+    testDeviceWithRequestedMaximumLimits@http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/limit_utils.js:653:38
+    @http://127.0.0.1:8000/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.js:120:47
  Reached unreachable code
 PASS :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=false
 PASS :createRenderPipeline,at_over:limitTest="atMaximum";testValueName="overLimit";async=false;pointList=false;frontFacing=false;sampleIndex=false;sampleMaskIn=false;sampleMaskOut=true

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/execution/flow_control/eval_order-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/execution/flow_control/eval_order-expected.txt
@@ -17,6 +17,8 @@ FAIL :array_index_lhs_assignment: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:244:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {
@@ -73,6 +75,8 @@ FAIL :array_index_lhs_member_assignment: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:276:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {
@@ -132,6 +136,8 @@ FAIL :array_index_via_ptrs: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:309:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {
@@ -193,6 +199,8 @@ FAIL :matrix_index_via_ptr: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:399:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {
@@ -259,6 +267,8 @@ FAIL :1d_array_assignment: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:862:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {
@@ -308,6 +318,8 @@ FAIL :2d_array_assignment: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:885:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {
@@ -365,6 +377,8 @@ FAIL :1d_array_compound_assignment: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:916:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {
@@ -414,6 +428,8 @@ FAIL :2d_array_compound_assignment: assert_unreached:
     runFlowControlTest@http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/harness.js:102:39
     @http://127.0.0.1:8000/webgpu/webgpu/shader/execution/flow_control/eval_order.spec.js:939:21
     runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:530:22
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
     WGSL:
 
     struct Outputs {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -646,7 +646,7 @@ bool hasCapacityToUseLargeGigacage();
     /* Feature Flags */\
     \
     /* Restricted so some app doesn't set this environment variable and start using it. */ \
-    v(Bool, useAsyncStackTrace, false, Normal, "Enable async stack traces") \
+    v(Bool, useAsyncStackTrace, true, Normal, "Enable async stack traces") \
     v(Bool, disallowMixedWasmExceptions, true, Restricted, "Disallow using both legacy and modern (try_table) wasm exception specs in the same module."_s) \
     v(Bool, useExplicitResourceManagement, false, Normal, "Enable explicit resource management builtins and syntax."_s) \
     v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \


### PR DESCRIPTION
#### 10d5c981ca81ba04cc436e5c64eb1f5ce9bd42e0
<pre>
[JSC] Enable AsyncStackTrace
<a href="https://bugs.webkit.org/show_bug.cgi?id=306918">https://bugs.webkit.org/show_bug.cgi?id=306918</a>
<a href="https://rdar.apple.com/169587801">rdar://169587801</a>

Reviewed by Sosuke Suzuki.

We carefully did A/B test and confirmed it is neutral. So let&apos;s enable
it. AsyncStackTrace will offer stack trace with asynchronous context
which keeps entries connected from the previous async execution.

* LayoutTests/http/tests/webgpu/webgpu/api/operation/uncapturederror-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/execution/flow_control/eval_order-expected.txt:
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/306759@main">https://commits.webkit.org/306759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab535ac8ada0149506985c2391c1ab3bb1d18636

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150897 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0aff0507-9448-494b-a1c6-29663d98e0fe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90279 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2371f5a8-b4c6-467b-9ce3-cba74b8de1fc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11424 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/930 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134248 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3743 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153247 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3068 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117431 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12509 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117754 "Found 1 new API test failure: TestWTF:WTF.DragonBox (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13809 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124561 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21945 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14388 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3577 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173553 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14120 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78104 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44913 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14325 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->