### PR TITLE
[JSC] Optimize Intl formatToParts methods with pre-built Structure

### DIFF
--- a/JSTests/microbenchmarks/intl-date-time-format-to-parts.js
+++ b/JSTests/microbenchmarks/intl-date-time-format-to-parts.js
@@ -1,0 +1,33 @@
+function test() {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        second: 'numeric',
+        timeZoneName: 'short'
+    });
+    const testDates = [
+        new Date(2024, 0, 1, 12, 0, 0),
+        new Date(2024, 6, 15, 18, 30, 45),
+        new Date(2024, 11, 31, 23, 59, 59),
+        new Date(2000, 0, 1, 0, 0, 0),
+        new Date(1999, 11, 31, 12, 30, 0),
+        new Date(2024, 2, 15, 6, 45, 30),
+        new Date(2024, 8, 20, 14, 15, 0),
+    ];
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        for (const date of testDates) {
+            const parts = dtf.formatToParts(date);
+            count += parts.length;
+        }
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 1050000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-list-format-to-parts.js
+++ b/JSTests/microbenchmarks/intl-list-format-to-parts.js
@@ -1,0 +1,27 @@
+// This benchmark tests IntlListFormat.formatToParts which creates many {type, value} objects
+// Longer lists generate more part objects, maximizing the optimization benefit
+function test() {
+    const lf = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+
+    const lists = [
+        ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry'],
+        ['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet'],
+        ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+        ['January', 'February', 'March', 'April', 'May', 'June'],
+        ['Dog', 'Cat', 'Bird', 'Fish', 'Rabbit', 'Hamster', 'Turtle', 'Snake'],
+        ['One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten'],
+    ];
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        for (const list of lists) {
+            const parts = lf.formatToParts(list);
+            count += parts.length;
+        }
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 760000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-number-format-range-to-parts.js
+++ b/JSTests/microbenchmarks/intl-number-format-range-to-parts.js
@@ -1,0 +1,33 @@
+// This benchmark tests formatRangeToParts which creates {type, value, source} objects
+// The pre-built Structure optimization should show significant improvement here
+function test() {
+    const nf = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+
+    const ranges = [
+        [100, 200],
+        [1000, 5000],
+        [0.01, 0.99],
+        [10000, 50000],
+        [123.45, 678.90],
+        [-100, 100],
+        [1, 1000000],
+    ];
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        for (const [start, end] of ranges) {
+            const parts = nf.formatRangeToParts(start, end);
+            count += parts.length;
+        }
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 760000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-number-format-to-parts.js
+++ b/JSTests/microbenchmarks/intl-number-format-to-parts.js
@@ -1,0 +1,25 @@
+function test() {
+    const nf = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+    const testValues = [
+        12345.67,
+        -9876.54,
+        0.99,
+        1000000,
+        0.001,
+        -0.5,
+        123456789.12,
+    ];
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        for (const value of testValues) {
+            const parts = nf.formatToParts(value);
+            count += parts.length;
+        }
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 420000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-number-format-unit-to-parts.js
+++ b/JSTests/microbenchmarks/intl-number-format-unit-to-parts.js
@@ -1,0 +1,28 @@
+// This benchmark tests NumberFormat with unit style which creates {type, value, unit} objects
+// The pre-built Structure with unit property optimization should show improvement here
+function test() {
+    const formatters = [
+        new Intl.NumberFormat('en', { style: 'unit', unit: 'kilometer' }),
+        new Intl.NumberFormat('en', { style: 'unit', unit: 'kilogram' }),
+        new Intl.NumberFormat('en', { style: 'unit', unit: 'celsius' }),
+        new Intl.NumberFormat('en', { style: 'unit', unit: 'meter-per-second' }),
+        new Intl.NumberFormat('en', { style: 'unit', unit: 'liter' }),
+    ];
+
+    const values = [1, 10, 100, 1000, 12345.67, 0.5, -25];
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        for (const nf of formatters) {
+            for (const value of values) {
+                const parts = nf.formatToParts(value);
+                count += parts.length;
+            }
+        }
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 1430000)
+    throw new Error("Bad result: " + result);

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -942,6 +942,7 @@
 		37C738D21EDB56E4003F2B0B /* ParseInt.h in Headers */ = {isa = PBXBuildFile; fileRef = 37C738D11EDB5672003F2B0B /* ParseInt.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3910AB742F3087FD00BAA633 /* LexerUnicodeProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 3910AB732F3087FD00BAA633 /* LexerUnicodeProperties.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3910AB842F3203AD00BAA633 /* IntlSegmentDataObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 3910AB832F3203AD00BAA633 /* IntlSegmentDataObject.h */; };
+		39E4D7252F32F0DB00F3045F /* IntlPartObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 39E4D7242F32F0DB00F3045F /* IntlPartObject.h */; };
 		412952771D2CF6BC00E78B89 /* builtins_generate_internals_wrapper_header.py in Headers */ = {isa = PBXBuildFile; fileRef = 412952731D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_header.py */; settings = {ATTRIBUTES = (Private, ); }; };
 		412952781D2CF6BC00E78B89 /* builtins_generate_internals_wrapper_implementation.py in Headers */ = {isa = PBXBuildFile; fileRef = 412952741D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_implementation.py */; settings = {ATTRIBUTES = (Private, ); }; };
 		412952791D2CF6BC00E78B89 /* builtins_generate_wrapper_header.py in Headers */ = {isa = PBXBuildFile; fileRef = 412952751D2CF6AC00E78B89 /* builtins_generate_wrapper_header.py */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4157,6 +4158,8 @@
 		3910AB732F3087FD00BAA633 /* LexerUnicodeProperties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LexerUnicodeProperties.h; sourceTree = "<group>"; };
 		3910AB822F3203A200BAA633 /* IntlSegmentDataObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntlSegmentDataObject.cpp; sourceTree = "<group>"; };
 		3910AB832F3203AD00BAA633 /* IntlSegmentDataObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntlSegmentDataObject.h; sourceTree = "<group>"; };
+		39E4D7232F32F0D500F3045F /* IntlPartObject.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntlPartObject.cpp; sourceTree = "<group>"; };
+		39E4D7242F32F0DB00F3045F /* IntlPartObject.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntlPartObject.h; sourceTree = "<group>"; };
 		412952731D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_header.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = builtins_generate_internals_wrapper_header.py; sourceTree = "<group>"; };
 		412952741D2CF6AC00E78B89 /* builtins_generate_internals_wrapper_implementation.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = builtins_generate_internals_wrapper_implementation.py; sourceTree = "<group>"; };
 		412952751D2CF6AC00E78B89 /* builtins_generate_wrapper_header.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = builtins_generate_wrapper_header.py; sourceTree = "<group>"; };
@@ -8681,6 +8684,8 @@
 				A12BBFF31B044A9800664B69 /* IntlObject.cpp */,
 				A12BBFF11B044A8B00664B69 /* IntlObject.h */,
 				708EBE231CE8F35000453146 /* IntlObjectInlines.h */,
+				39E4D7232F32F0D500F3045F /* IntlPartObject.cpp */,
+				39E4D7242F32F0DB00F3045F /* IntlPartObject.h */,
 				7D5FB18F20744BF1005DDF64 /* IntlPluralRules.cpp */,
 				7D5FB19220744BF2005DDF64 /* IntlPluralRules.h */,
 				7D5FB18E20744BF0005DDF64 /* IntlPluralRulesConstructor.cpp */,
@@ -11620,6 +11625,7 @@
 				A1D793011B43864B004516F5 /* IntlNumberFormatPrototype.h in Headers */,
 				A12BBFF21B044A8B00664B69 /* IntlObject.h in Headers */,
 				708EBE241CE8F35800453146 /* IntlObjectInlines.h in Headers */,
+				39E4D7252F32F0DB00F3045F /* IntlPartObject.h in Headers */,
 				E307178B24C7828F00DF0644 /* IntlPluralRules.h in Headers */,
 				E307178A24C7828C00DF0644 /* IntlPluralRulesConstructor.h in Headers */,
 				E307178924C7828600DF0644 /* IntlPluralRulesPrototype.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -870,6 +870,7 @@ runtime/IntlNumberFormat.cpp @no-unify // Confine U_HIDE_DRAFT_API's effect in t
 runtime/IntlNumberFormatConstructor.cpp
 runtime/IntlNumberFormatPrototype.cpp
 runtime/IntlObject.cpp
+runtime/IntlPartObject.cpp
 runtime/IntlPluralRules.cpp @no-unify // Confine U_HIDE_DRAFT_API's effect to this file.
 runtime/IntlPluralRulesConstructor.cpp
 runtime/IntlPluralRulesPrototype.cpp

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -30,6 +30,7 @@
 #include "ISO8601.h"
 #include "IntlCache.h"
 #include "IntlObjectInlines.h"
+#include "IntlPartObject.h"
 #include "JSBoundFunction.h"
 #include "JSCInlines.h"
 #include "JSDateMath.h"
@@ -1367,11 +1368,9 @@ JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, double v
 
         if (previousEndIndex < beginIndex) {
             auto value = jsString(vm, resultStringView.substring(previousEndIndex, beginIndex - previousEndIndex));
-            JSObject* part = constructEmptyObject(globalObject);
-            part->putDirect(vm, vm.propertyNames->type, literalString);
-            part->putDirect(vm, vm.propertyNames->value, value);
-            if (sourceType)
-                part->putDirect(vm, vm.propertyNames->source, sourceType);
+            JSObject* part = sourceType
+                ? createIntlPartObjectWithSource(globalObject, literalString, value, sourceType)
+                : createIntlPartObject(globalObject, literalString, value);
             parts->push(globalObject, part);
             RETURN_IF_EXCEPTION(scope, { });
         }
@@ -1380,11 +1379,9 @@ JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, double v
         if (fieldType >= 0) {
             auto type = jsNontrivialString(vm, partTypeString(UDateFormatField(fieldType)));
             auto value = jsString(vm, resultStringView.substring(beginIndex, endIndex - beginIndex));
-            JSObject* part = constructEmptyObject(globalObject);
-            part->putDirect(vm, vm.propertyNames->type, type);
-            part->putDirect(vm, vm.propertyNames->value, value);
-            if (sourceType)
-                part->putDirect(vm, vm.propertyNames->source, sourceType);
+            JSObject* part = sourceType
+                ? createIntlPartObjectWithSource(globalObject, type, value, sourceType)
+                : createIntlPartObject(globalObject, type, value);
             parts->push(globalObject, part);
             RETURN_IF_EXCEPTION(scope, { });
         }
@@ -1704,11 +1701,7 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
         };
 
         auto value = jsString(vm, resultStringView.substring(beginIndex, length));
-        JSObject* part = constructEmptyObject(globalObject);
-        part->putDirect(vm, vm.propertyNames->type, type);
-        part->putDirect(vm, vm.propertyNames->value, value);
-        part->putDirect(vm, vm.propertyNames->source, sourceType(beginIndex));
-        return part;
+        return createIntlPartObjectWithSource(globalObject, type, value, sourceType(beginIndex));
     };
 
     int32_t resultLength = resultStringView.length();

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -28,6 +28,7 @@
 
 #include "IntlNumberFormatInlines.h"
 #include "IntlObjectInlines.h"
+#include "IntlPartObject.h"
 #include "IteratorOperations.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
@@ -759,10 +760,7 @@ JSValue IntlDurationFormat::formatToParts(JSGlobalObject* globalObject, ISO8601:
     auto literalString = jsNontrivialString(vm, "literal"_s);
 
     auto createPart = [&](JSString* type, JSString* value) {
-        JSObject* part = constructEmptyObject(globalObject);
-        part->putDirect(vm, vm.propertyNames->type, type);
-        part->putDirect(vm, vm.propertyNames->value, value);
-        return part;
+        return createIntlPartObject(globalObject, type, value);
     };
 
     auto pushElements = [&](JSArray* parts, unsigned elementIndex) -> void {

--- a/Source/JavaScriptCore/runtime/IntlListFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.cpp
@@ -27,6 +27,7 @@
 #include "IntlListFormat.h"
 
 #include "IntlObjectInlines.h"
+#include "IntlPartObject.h"
 #include "IteratorOperations.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
@@ -226,10 +227,7 @@ JSValue IntlListFormat::formatToParts(JSGlobalObject* globalObject, JSValue list
     auto elementString = jsNontrivialString(vm, "element"_s);
 
     auto createPart = [&] (JSString* type, JSString* value) {
-        JSObject* part = constructEmptyObject(globalObject);
-        part->putDirect(vm, vm.propertyNames->type, type);
-        part->putDirect(vm, vm.propertyNames->value, value);
-        return part;
+        return createIntlPartObject(globalObject, type, value);
     };
 
     int32_t resultLength = resultStringView.length();

--- a/Source/JavaScriptCore/runtime/IntlPartObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPartObject.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "IntlPartObject.h"
+
+#include "JSCInlines.h"
+
+namespace JSC {
+
+Structure* createIntlPartObjectStructure(VM& vm, JSGlobalObject& globalObject)
+{
+    constexpr unsigned inlineCapacity = 2;
+    Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), inlineCapacity);
+    PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectTypePropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->value, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectValuePropertyOffset);
+    return structure;
+}
+
+Structure* createIntlPartObjectWithSourceStructure(VM& vm, JSGlobalObject& globalObject)
+{
+    constexpr unsigned inlineCapacity = 3;
+    Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), inlineCapacity);
+    PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectTypePropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->value, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectValuePropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->source, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectWithSourceSourcePropertyOffset);
+    return structure;
+}
+
+Structure* createIntlPartObjectWithUnitStructure(VM& vm, JSGlobalObject& globalObject)
+{
+    constexpr unsigned inlineCapacity = 3;
+    Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), inlineCapacity);
+    PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectTypePropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->value, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectValuePropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "unit"_s), 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectWithUnitUnitPropertyOffset);
+    return structure;
+}
+
+Structure* createIntlPartObjectWithUnitAndSourceStructure(VM& vm, JSGlobalObject& globalObject)
+{
+    constexpr unsigned inlineCapacity = 4;
+    Structure* structure = globalObject.structureCache().emptyObjectStructureForPrototype(&globalObject, globalObject.objectPrototype(), inlineCapacity);
+    PropertyOffset offset;
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectTypePropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->value, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectValuePropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, Identifier::fromString(vm, "unit"_s), 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectWithUnitAndSourceUnitPropertyOffset);
+    structure = Structure::addPropertyTransition(vm, structure, vm.propertyNames->source, 0, offset);
+    RELEASE_ASSERT(offset == intlPartObjectWithUnitAndSourceSourcePropertyOffset);
+    return structure;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlPartObject.h
+++ b/Source/JavaScriptCore/runtime/IntlPartObject.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Anthropic PBC.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "JSGlobalObject.h"
+#include "ObjectConstructor.h"
+
+namespace JSC {
+
+// PropertyOffset definitions for pre-built Intl part object Structures.
+// {type, value}
+static constexpr PropertyOffset intlPartObjectTypePropertyOffset = 0;
+static constexpr PropertyOffset intlPartObjectValuePropertyOffset = 1;
+
+// {type, value, source}
+static constexpr PropertyOffset intlPartObjectWithSourceSourcePropertyOffset = 2;
+
+// {type, value, unit}
+static constexpr PropertyOffset intlPartObjectWithUnitUnitPropertyOffset = 2;
+
+// {type, value, unit, source}
+static constexpr PropertyOffset intlPartObjectWithUnitAndSourceUnitPropertyOffset = 2;
+static constexpr PropertyOffset intlPartObjectWithUnitAndSourceSourcePropertyOffset = 3;
+
+// Structure creation functions
+Structure* createIntlPartObjectStructure(VM&, JSGlobalObject&);
+Structure* createIntlPartObjectWithSourceStructure(VM&, JSGlobalObject&);
+Structure* createIntlPartObjectWithUnitStructure(VM&, JSGlobalObject&);
+Structure* createIntlPartObjectWithUnitAndSourceStructure(VM&, JSGlobalObject&);
+
+// Inline helper functions for creating Intl part objects
+ALWAYS_INLINE JSObject* createIntlPartObject(JSGlobalObject* globalObject, JSString* type, JSString* value)
+{
+    VM& vm = globalObject->vm();
+    Structure* structure = globalObject->intlPartObjectStructure();
+    JSObject* result = constructEmptyObject(vm, structure);
+    result->putDirectOffset(vm, intlPartObjectTypePropertyOffset, type);
+    result->putDirectOffset(vm, intlPartObjectValuePropertyOffset, value);
+    return result;
+}
+
+ALWAYS_INLINE JSObject* createIntlPartObjectWithSource(JSGlobalObject* globalObject, JSString* type, JSString* value, JSString* source)
+{
+    VM& vm = globalObject->vm();
+    Structure* structure = globalObject->intlPartObjectWithSourceStructure();
+    JSObject* result = constructEmptyObject(vm, structure);
+    result->putDirectOffset(vm, intlPartObjectTypePropertyOffset, type);
+    result->putDirectOffset(vm, intlPartObjectValuePropertyOffset, value);
+    result->putDirectOffset(vm, intlPartObjectWithSourceSourcePropertyOffset, source);
+    return result;
+}
+
+ALWAYS_INLINE JSObject* createIntlPartObjectWithUnit(JSGlobalObject* globalObject, JSString* type, JSString* value, JSString* unit)
+{
+    VM& vm = globalObject->vm();
+    Structure* structure = globalObject->intlPartObjectWithUnitStructure();
+    JSObject* result = constructEmptyObject(vm, structure);
+    result->putDirectOffset(vm, intlPartObjectTypePropertyOffset, type);
+    result->putDirectOffset(vm, intlPartObjectValuePropertyOffset, value);
+    result->putDirectOffset(vm, intlPartObjectWithUnitUnitPropertyOffset, unit);
+    return result;
+}
+
+ALWAYS_INLINE JSObject* createIntlPartObjectWithUnitAndSource(JSGlobalObject* globalObject, JSString* type, JSString* value, JSString* unit, JSString* source)
+{
+    VM& vm = globalObject->vm();
+    Structure* structure = globalObject->intlPartObjectWithUnitAndSourceStructure();
+    JSObject* result = constructEmptyObject(vm, structure);
+    result->putDirectOffset(vm, intlPartObjectTypePropertyOffset, type);
+    result->putDirectOffset(vm, intlPartObjectValuePropertyOffset, value);
+    result->putDirectOffset(vm, intlPartObjectWithUnitAndSourceUnitPropertyOffset, unit);
+    result->putDirectOffset(vm, intlPartObjectWithUnitAndSourceSourcePropertyOffset, source);
+    return result;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp
@@ -29,6 +29,7 @@
 
 #include "IntlNumberFormatInlines.h"
 #include "IntlObjectInlines.h"
+#include "IntlPartObject.h"
 #include "JSCInlines.h"
 #include "ObjectConstructor.h"
 #include <wtf/text/MakeString.h>
@@ -305,9 +306,7 @@ JSValue IntlRelativeTimeFormat::formatToParts(JSGlobalObject* globalObject, doub
 
         // Add initial literal if there is one.
         if (numberStart) {
-            JSObject* part = constructEmptyObject(globalObject);
-            part->putDirect(vm, vm.propertyNames->type, literalString);
-            part->putDirect(vm, vm.propertyNames->value, jsSubstring(vm, formattedRelativeTime, 0, numberStart));
+            JSObject* part = createIntlPartObject(globalObject, literalString, jsSubstring(vm, formattedRelativeTime, 0, numberStart));
             parts->push(globalObject, part);
             RETURN_IF_EXCEPTION(scope, { });
         }
@@ -320,9 +319,7 @@ JSValue IntlRelativeTimeFormat::formatToParts(JSGlobalObject* globalObject, doub
     // Add final literal if there is one.
     auto stringLength = formattedRelativeTime.length();
     if (numberEnd != stringLength) {
-        JSObject* part = constructEmptyObject(globalObject);
-        part->putDirect(vm, vm.propertyNames->type, literalString);
-        part->putDirect(vm, vm.propertyNames->value, jsSubstring(vm, formattedRelativeTime, numberEnd, stringLength - numberEnd));
+        JSObject* part = createIntlPartObject(globalObject, literalString, jsSubstring(vm, formattedRelativeTime, numberEnd, stringLength - numberEnd));
         parts->push(globalObject, part);
         RETURN_IF_EXCEPTION(scope, { });
     }

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -104,6 +104,7 @@
 #include "IntlNumberFormatConstructor.h"
 #include "IntlNumberFormatPrototype.h"
 #include "IntlObject.h"
+#include "IntlPartObject.h"
 #include "IntlPluralRules.h"
 #include "IntlPluralRulesPrototype.h"
 #include "IntlRelativeTimeFormat.h"
@@ -1629,6 +1630,22 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         [] (const Initializer<Structure>& init) {
             init.set(createSegmentDataObjectWithIsWordLikeStructure(init.vm, *init.owner));
         });
+    m_intlPartObjectStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            init.set(createIntlPartObjectStructure(init.vm, *init.owner));
+        });
+    m_intlPartObjectWithSourceStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            init.set(createIntlPartObjectWithSourceStructure(init.vm, *init.owner));
+        });
+    m_intlPartObjectWithUnitStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            init.set(createIntlPartObjectWithUnitStructure(init.vm, *init.owner));
+        });
+    m_intlPartObjectWithUnitAndSourceStructure.initLater(
+        [] (const Initializer<Structure>& init) {
+            init.set(createIntlPartObjectWithUnitAndSourceStructure(init.vm, *init.owner));
+        });
 
     m_dateTimeFormatStructure.initLater(
         [] (LazyClassStructure::Initializer& init) {
@@ -2858,6 +2875,10 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_segmentsStructure.visit(visitor);
     thisObject->m_segmentDataObjectStructure.visit(visitor);
     thisObject->m_segmentDataObjectWithIsWordLikeStructure.visit(visitor);
+    thisObject->m_intlPartObjectStructure.visit(visitor);
+    thisObject->m_intlPartObjectWithSourceStructure.visit(visitor);
+    thisObject->m_intlPartObjectWithUnitStructure.visit(visitor);
+    thisObject->m_intlPartObjectWithUnitAndSourceStructure.visit(visitor);
     thisObject->m_dateTimeFormatStructure.visit(visitor);
     thisObject->m_numberFormatStructure.visit(visitor);
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -274,6 +274,10 @@ public:
     LazyProperty<JSGlobalObject, Structure> m_segmentsStructure;
     LazyProperty<JSGlobalObject, Structure> m_segmentDataObjectStructure;
     LazyProperty<JSGlobalObject, Structure> m_segmentDataObjectWithIsWordLikeStructure;
+    LazyProperty<JSGlobalObject, Structure> m_intlPartObjectStructure;
+    LazyProperty<JSGlobalObject, Structure> m_intlPartObjectWithSourceStructure;
+    LazyProperty<JSGlobalObject, Structure> m_intlPartObjectWithUnitStructure;
+    LazyProperty<JSGlobalObject, Structure> m_intlPartObjectWithUnitAndSourceStructure;
     LazyClassStructure m_dateTimeFormatStructure;
     LazyClassStructure m_numberFormatStructure;
 
@@ -970,6 +974,10 @@ public:
     Structure* segmentsStructure() { return m_segmentsStructure.get(this); }
     Structure* segmentDataObjectStructure() { return m_segmentDataObjectStructure.get(this); }
     Structure* segmentDataObjectWithIsWordLikeStructure() { return m_segmentDataObjectWithIsWordLikeStructure.get(this); }
+    Structure* intlPartObjectStructure() { return m_intlPartObjectStructure.get(this); }
+    Structure* intlPartObjectWithSourceStructure() { return m_intlPartObjectWithSourceStructure.get(this); }
+    Structure* intlPartObjectWithUnitStructure() { return m_intlPartObjectWithUnitStructure.get(this); }
+    Structure* intlPartObjectWithUnitAndSourceStructure() { return m_intlPartObjectWithUnitAndSourceStructure.get(this); }
     Structure* trustedScriptStructure() { return m_trustedScriptStructure.get(); }
 
     JSObject* dateTimeFormatConstructor() { return m_dateTimeFormatStructure.constructor(this); }


### PR DESCRIPTION
#### a5dd9753d23cbb42e61ea7bc85860d0e7ed586a6
<pre>
[JSC] Optimize Intl formatToParts methods with pre-built Structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=306921">https://bugs.webkit.org/show_bug.cgi?id=306921</a>

Reviewed by Yusuke Suzuki.

This patch optimizes the creation of part objects returned by Intl formatToParts
methods by using pre-built Structures, following the same pattern as
IntlSegmentDataObject (introduced in 31d781e338)

                                           TipOfTree                  Patched

intl-number-format-range-to-parts       97.5536+-2.6448     ^     84.6148+-1.7409        ^ definitely 1.1529x faster
intl-number-format-unit-to-parts       220.2980+-13.2238         209.1234+-4.0800          might be 1.0534x faster
intl-number-format-to-parts             54.7243+-1.2841     ^     50.8049+-1.7732        ^ definitely 1.0771x faster
intl-list-format-to-parts               84.6818+-1.5119     ^     76.8525+-0.5202        ^ definitely 1.1019x faster
intl-date-time-format-to-parts         168.4584+-5.6350          161.2365+-9.2482          might be 1.0448x faster

Tests: JSTests/microbenchmarks/intl-date-time-format-to-parts.js
       JSTests/microbenchmarks/intl-list-format-to-parts.js
       JSTests/microbenchmarks/intl-number-format-range-to-parts.js
       JSTests/microbenchmarks/intl-number-format-to-parts.js
       JSTests/microbenchmarks/intl-number-format-unit-to-parts.js

* JSTests/microbenchmarks/intl-date-time-format-to-parts.js: Added.
(test):
* JSTests/microbenchmarks/intl-list-format-to-parts.js: Added.
(test):
* JSTests/microbenchmarks/intl-number-format-range-to-parts.js: Added.
(test):
* JSTests/microbenchmarks/intl-number-format-to-parts.js: Added.
(test):
* JSTests/microbenchmarks/intl-number-format-unit-to-parts.js: Added.
(test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::formatToParts const):
(JSC::IntlDateTimeFormat::formatRangeToParts):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlListFormat.cpp:
(JSC::IntlListFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::formatRangeToPartsInternal):
(JSC::IntlNumberFormat::formatToPartsInternal):
* Source/JavaScriptCore/runtime/IntlPartObject.cpp: Added.
(JSC::createIntlPartObjectStructure):
(JSC::createIntlPartObjectWithSourceStructure):
(JSC::createIntlPartObjectWithUnitStructure):
(JSC::createIntlPartObjectWithUnitAndSourceStructure):
* Source/JavaScriptCore/runtime/IntlPartObject.h: Added.
(JSC::createIntlPartObject):
(JSC::createIntlPartObjectWithSource):
(JSC::createIntlPartObjectWithUnit):
(JSC::createIntlPartObjectWithUnitAndSource):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::formatToParts const):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::intlPartObjectStructure):
(JSC::JSGlobalObject::intlPartObjectWithSourceStructure):
(JSC::JSGlobalObject::intlPartObjectWithUnitStructure):
(JSC::JSGlobalObject::intlPartObjectWithUnitAndSourceStructure):

Canonical link: <a href="https://commits.webkit.org/306999@main">https://commits.webkit.org/306999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2f64c7b62a20d3bd06f781e4539a1c57b44f056

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150882 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95426 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109371 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79021 "1 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11428 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9083 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/916 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134234 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153233 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3054 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117428 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30321 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13802 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70025 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14374 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3566 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173539 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78090 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44911 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->