### PR TITLE
[JSC] RegExp should have offset vector for common use

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -921,12 +921,12 @@ private:
                     lastIndex = regExpObjectNode->child1()->asUInt32();
 
                 MatchResult result;
-                Vector<int> ovector;
+                Vector<int> ovector(regExp->offsetVectorSize());
                 // We have to call the kind of match function that the main thread would have called.
                 // Otherwise, we might not have the desired Yarr code compiled, and the match will fail.
                 if (m_node->op() == RegExpExec || m_node->op() == RegExpExecNonGlobalOrSticky) {
                     int position;
-                    if (!regExp->matchConcurrently(vm(), string, lastIndex, position, ovector)) {
+                    if (!regExp->matchConcurrently(vm(), string, lastIndex, position, ovector.mutableSpan())) {
                         dataLogLnIf(verbose, "Giving up because match failed.");
                         return false;
                     }
@@ -1208,7 +1208,7 @@ private:
             bool ok = true;
             do {
                 MatchResult result;
-                Vector<int> ovector;
+                Vector<int> ovector(regExp->offsetVectorSize());
                 // Model which version of match() is called by the main thread.
                 if (replace.isEmpty() && regExp->global()) {
                     if (!regExp->matchConcurrently(vm(), string, startPosition, result)) {
@@ -1217,11 +1217,11 @@ private:
                     }
                 } else {
                     int position;
-                    if (!regExp->matchConcurrently(vm(), string, startPosition, position, ovector)) {
+                    if (!regExp->matchConcurrently(vm(), string, startPosition, position, ovector.mutableSpan())) {
                         ok = false;
                         break;
                     }
-                    
+
                     result.start = position;
                     result.end = ovector[1];
                 }

--- a/Source/JavaScriptCore/runtime/RegExpGlobalData.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalData.h
@@ -55,10 +55,8 @@ public:
 
     static constexpr ptrdiff_t offsetOfCachedResult() { return OBJECT_OFFSETOF(RegExpGlobalData, m_cachedResult); }
 
-    const Vector<int>& ovector() const { return m_ovector; }
-
     inline MatchResult matchResult() const;
-    void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, MatchResult, Vector<int>&&);
+    void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, MatchResult, std::span<const int> ovector);
 
     RegExpSubstringGlobalAtomCache& substringGlobalAtomCache() { return m_substringGlobalAtomCache; }
 
@@ -66,7 +64,6 @@ private:
     RegExpCachedResult m_cachedResult;
     RegExpSubstringGlobalAtomCache m_substringGlobalAtomCache;
     bool m_multiline { false };
-    Vector<int> m_ovector;
 };
 
 }

--- a/Source/JavaScriptCore/runtime/RegExpInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpInlines.h
@@ -111,8 +111,8 @@ ALWAYS_INLINE void RegExp::compileIfNecessary(VM& vm, Yarr::CharSize charSize, s
     compile(&vm, charSize, sampleString);
 }
 
-template<typename VectorType, Yarr::MatchFrom matchFrom>
-ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm, StringView s, unsigned startOffset, VectorType& ovector)
+template<Yarr::MatchFrom matchFrom>
+ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm, StringView s, unsigned startOffset, std::span<int> ovector)
 {
 #if ENABLE(REGEXP_TRACING)
     m_rtMatchCallCount++;
@@ -136,8 +136,8 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
     if (m_state == ParseError)
         return throwError();
 
-    ovector.resize(offsetVectorSize());
-    int* offsetVector = ovector.mutableSpan().data();
+    ASSERT(ovector.size() >= static_cast<size_t>(offsetVectorSize()));
+    int* offsetVector = ovector.data();
 
     if constexpr (matchFrom == Yarr::MatchFrom::VMThread) {
         if (hasValidAtom()) {

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
@@ -67,13 +67,13 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
     if constexpr (validateDFGDoesGC)
         vm.verifyCanGC();
 
-    Vector<int, 32> subpatternResults;
-    int position = regExp->matchInline(globalObject, vm, inputValue, startOffset, subpatternResults);
+    int position = regExp->matchInline<Yarr::MatchFrom::VMThread>(globalObject, vm, inputValue, startOffset, regExp->ovectorSpan());
     if (position == -1) {
         result = MatchResult::failed();
         return nullptr;
     }
 
+    auto subpatternResults = regExp->ovectorSpan();
     result.start = position;
     result.end = subpatternResults[1];
     

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -737,7 +737,7 @@ ALWAYS_INLINE JSCellButterfly* addToRegExpSearchCache(VM& vm, JSGlobalObject* gl
     if (auto* entry = vm.stringReplaceCache.get(source, regExp)) {
         auto lastMatch = entry->m_lastMatch;
         auto matchResult = entry->m_matchResult;
-        globalObject->regExpGlobalData().resetResultFromCache(globalObject, regExp, string, matchResult, WTF::move(lastMatch));
+        globalObject->regExpGlobalData().resetResultFromCache(globalObject, regExp, string, matchResult, lastMatch.span());
         RELEASE_AND_RETURN(scope, entry->m_result);
     }
 
@@ -795,7 +795,7 @@ ALWAYS_INLINE JSCellButterfly* addToRegExpSearchCache(VM& vm, JSGlobalObject* gl
         return nullptr;
     }
 
-    vm.stringReplaceCache.set(source, regExp, result, globalObject->regExpGlobalData().matchResult(), globalObject->regExpGlobalData().ovector());
+    vm.stringReplaceCache.set(source, regExp, result, globalObject->regExpGlobalData().matchResult(), regExp->ovectorSpan());
     RELEASE_AND_RETURN(scope, result);
 }
 

--- a/Source/JavaScriptCore/runtime/StringReplaceCache.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCache.h
@@ -58,7 +58,7 @@ public:
     };
 
     Entry* get(const String& subject, RegExp*);
-    void set(const String& subject, RegExp*, JSCellButterfly*, MatchResult, const Vector<int>&);
+    void set(const String& subject, RegExp*, JSCellButterfly*, MatchResult, std::span<const int> lastMatch);
 
     DECLARE_VISIT_AGGREGATE;
 

--- a/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
@@ -53,7 +53,7 @@ inline StringReplaceCache::Entry* StringReplaceCache::get(const String& subject,
     return nullptr;
 }
 
-inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSCellButterfly* result, MatchResult matchResult, const Vector<int>& lastMatch)
+inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSCellButterfly* result, MatchResult matchResult, std::span<const int> lastMatch)
 {
     AssertNoGC assertNoGC;
     if (!subject.impl() || !subject.impl()->isAtom())
@@ -66,7 +66,7 @@ inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSCel
         if (!entry1.m_subject) {
             entry1.m_subject = subjectImpl;
             entry1.m_regExp = regExp;
-            entry1.m_lastMatch = lastMatch;
+            entry1.m_lastMatch = Vector<int>(lastMatch);
             entry1.m_matchResult = matchResult;
             entry1.m_result = result;
         } else {
@@ -74,14 +74,14 @@ inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSCel
             if (!entry2.m_subject) {
                 entry2.m_subject = subjectImpl;
                 entry2.m_regExp = regExp;
-                entry2.m_lastMatch = lastMatch;
+                entry2.m_lastMatch = Vector<int>(lastMatch);
                 entry2.m_matchResult = matchResult;
                 entry2.m_result = result;
             } else {
                 entry2 = { };
                 entry1.m_subject = subjectImpl;
                 entry1.m_regExp = regExp;
-                entry1.m_lastMatch = lastMatch;
+                entry1.m_lastMatch = Vector<int>(lastMatch);
                 entry1.m_matchResult = matchResult;
                 entry1.m_result = result;
             }


### PR DESCRIPTION
#### e9964c3c018a061aa17b6fb60f9b8ffbbfbcbabf
<pre>
[JSC] RegExp should have offset vector for common use
<a href="https://bugs.webkit.org/show_bug.cgi?id=306925">https://bugs.webkit.org/show_bug.cgi?id=306925</a>
<a href="https://rdar.apple.com/169589861">rdar://169589861</a>

Reviewed by Sosuke Suzuki.

Since RegExp can determine how large the offset vector is, we can just
hold Vector&lt;int&gt; in RegExp object and use it for normal matching. This
is efficient compared to allocating Vector frequently for each matching.

This accepts std::span&lt;int&gt; as offset output, and from the main thread,
we pass regExp-&gt;ovectorSpan(). But for concurrent execution (e.g.
execution from the JIT compiler), caller set up Vector&lt;int&gt; and passing
mutableSpan to this matching function.

We also remove m_ovector in RegExpGlobalData. It is actually not used in
a meaningful way.

* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
(JSC::RegExp::estimatedSize):
(JSC::RegExp::match):
(JSC::RegExp::matchConcurrently):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/RegExpGlobalData.h:
(JSC::RegExpGlobalData::ovector const): Deleted.
* Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h:
(JSC::RegExpGlobalData::performMatch):
(JSC::RegExpGlobalData::resetResultFromCache):
* Source/JavaScriptCore/runtime/RegExpInlines.h:
(JSC::RegExp::matchInline):
* Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
(JSC::createRegExpMatchesArray):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::addToRegExpSearchCache):
* Source/JavaScriptCore/runtime/StringReplaceCache.h:
* Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h:
(JSC::StringReplaceCache::set):

Canonical link: <a href="https://commits.webkit.org/306758@main">https://commits.webkit.org/306758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25cc621788bbc8d03abb982ec31fd0716b6b6c00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150895 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0029d4d5-aa72-402c-b1ce-a98e8ca0f655) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14812 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e029b280-ce0f-46ec-88a2-ae5ba006c90d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90278 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b6bb178-f6b9-47fd-bf4e-46824e0d00a9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/929 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134247 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153246 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3067 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14338 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4384 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12507 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13808 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70038 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21944 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14387 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3576 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173552 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78103 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44912 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14324 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->