### PR TITLE
Adopt in-memory USD loading APIs

### DIFF
--- a/Source/WebCore/Modules/model-element/WebModelPlayer.h
+++ b/Source/WebCore/Modules/model-element/WebModelPlayer.h
@@ -114,6 +114,7 @@ private:
     RetainPtr<WebBridgeModelLoader> m_modelLoader;
     Vector<MachSendRight> m_displayBuffers;
     RefPtr<WebCore::Mesh> m_currentModel;
+    RetainPtr<NSData> m_retainedData;
     WeakRef<Page> m_page;
     mutable RefPtr<ModelDisplayBufferDisplayDelegate> m_contentsDisplayDelegate;
     uint32_t m_currentTexture { 0 };

--- a/Source/WebCore/Modules/model-element/WebModelPlayer.mm
+++ b/Source/WebCore/Modules/model-element/WebModelPlayer.mm
@@ -295,7 +295,6 @@ void WebModelPlayer::load(Model& modelSource, LayoutSize size)
     });
 
     m_modelLoader = adoptNS([[WebBridgeModelLoader alloc] init]);
-    RetainPtr nsURL = modelSource.url().createNSURL();
     Ref protectedThis = Ref { *this };
     [m_modelLoader setCallbacksWithModelUpdatedCallback:^(WebBridgeUpdateMesh *updateRequest) {
         ensureOnMainThreadWithProtectedThis([updateRequest] (Ref<WebModelPlayer> protectedThis) {
@@ -338,7 +337,9 @@ void WebModelPlayer::load(Model& modelSource, LayoutSize size)
             [protectedThis->m_modelLoader requestCompleted:updateMaterial];
         });
     }];
-    [m_modelLoader loadModelFrom:nsURL.get()];
+
+    m_retainedData = modelSource.data()->createNSData();
+    [m_modelLoader loadModel:m_retainedData.get()];
 }
 
 void WebModelPlayer::notifyEntityTransformUpdated()

--- a/Source/WebGPU/WebGPU/Mesh.mm
+++ b/Source/WebGPU/WebGPU/Mesh.mm
@@ -190,7 +190,7 @@ Mesh::Mesh(const WebModelCreateMeshDescriptor& descriptor, WebGPU::Instance& ins
     , m_descriptor(descriptor)
 {
     id<MTLDevice> device = instance.device();
-    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm width:descriptor.width height:descriptor.height mipmapped:NO];
+    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm_sRGB width:descriptor.width height:descriptor.height mipmapped:NO];
     m_textures = [NSMutableArray array];
     for (RetainPtr ioSurface : descriptor.ioSurfaces)
         [m_textures addObject:[device newTextureWithDescriptor:textureDescriptor iosurface:ioSurface.get() plane:0]];

--- a/Source/WebGPU/WebGPU/ModelRenderer.swift
+++ b/Source/WebGPU/WebGPU/ModelRenderer.swift
@@ -122,7 +122,7 @@ nonisolated class Renderer {
 
         let target: _Proto_LowLevelRenderTarget_v1 = .texture(color: texture, sampleCount: 4)
         renderWorkload.camera = .mono(pose: cameraPose, projection: projection)
-        renderWorkload.camera.clearColor = .init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.1)
+        renderWorkload.camera.clearColor = .init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
         try renderWorkload.setMeshInstances(meshInstances)
 
         guard let renderCommandBuffer = commandQueue.makeCommandBuffer() else {

--- a/Source/WebGPU/WebGPU/ModelTypes.h
+++ b/Source/WebGPU/WebGPU/ModelTypes.h
@@ -693,6 +693,7 @@ NS_SWIFT_SENDABLE
 - (double)currentTime;
 - (double)duration;
 - (void)loadModelFrom:(NSURL *)url;
+- (void)loadModel:(NSData *)data;
 - (void)update:(double)deltaTime;
 - (void)requestCompleted:(NSObject *)request;
 - (void)setCallbacksWithModelUpdatedCallback:(void (^)(WebBridgeUpdateMesh *))modelUpdatedCallback textureUpdatedCallback:(void (^)(WebBridgeUpdateTexture *))textureUpdatedCallback materialUpdatedCallback:(void (^)(WebBridgeUpdateMaterial *))materialUpdatedCallback;


### PR DESCRIPTION
#### 5a57ba9e0e515b6524097b8dd51c1d532226e271
<pre>
Adopt in-memory USD loading APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=305865">https://bugs.webkit.org/show_bug.cgi?id=305865</a>
<a href="https://rdar.apple.com/168527219">rdar://168527219</a>

Reviewed by Etienne Segonzac.

Instead of loading from a URL, load from an NSData. We
need to retain the data for the lifetime of rendering the
USD file.

* Source/WebCore/Modules/model-element/WebModelPlayer.h:
* Source/WebCore/Modules/model-element/WebModelPlayer.mm:
(WebCore::WebModelPlayer::load):
* Source/WebGPU/WebGPU/Mesh.mm:
(WebModel::Mesh::Mesh):
* Source/WebGPU/WebGPU/ModelRenderer.swift:
* Source/WebGPU/WebGPU/ModelTypes.h:
* Source/WebGPU/WebGPU/USDModel.swift:
(WebUSDConfiguration.createMaterialCompiler):
(USDModelLoader.stage):
(USDModelLoader.loadModel(_:)):
(WebBridgeModelLoader.loadModel(_:)):

Canonical link: <a href="https://commits.webkit.org/306798@main">https://commits.webkit.org/306798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3021f0577fb66fdf8dbb3a0547afc622de072a87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151022 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81f035d6-91c4-43b2-8cbe-2a3429cd75ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109483 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e61d1282-01fd-4c9d-b953-b484f9325350) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90385 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbf8731f-748b-4d3e-a654-8f887c4852b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11518 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1042 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153359 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14451 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117522 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14473 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117847 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30044 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13894 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124728 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70163 "Built successfully") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/21959 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 16.4; Checked out pull request; Reviewed by Etienne Segonzac; Canonicalize Commit (cancelled)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14500 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14277 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->