### PR TITLE
AX: WebKit's accname computation can double-include text from a node pointed to by aria-labelledby

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
@@ -238,18 +238,7 @@ PASS heading name from content for each child including nested button with neste
 PASS heading name from content for each child including nested link with nested image
 PASS heading name from content for each child including nested link using aria-label with nested image
 PASS heading name from content for each child including nested link using aria-labelledby with nested image
-FAIL heading name from content for each child including two nested links using aria-labelledby with nested image assert_equals: <h3 data-expectedlabel="image link2 link3" data-testname="heading name from content for each child including two nested links using aria-labelledby with nested image" class="ex">
-  <a href="#" aria-labelledby="nested_image_label2">
-    link1<!-- this text is skipped because of aria-labelledby -->
-  </a>
-  <a href="#" data-expectedlabel="link2 image link3" data-testname="link name from content for each child including nested image (referenced elsewhere via labelledby)" class="ex">
-    link2
-    <img id="nested_image_label2" alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-    <!-- image skipped in this link (when computing heading text) because it was already referenced by the first link within this heading label recursion cycle. -->
-    <!-- but image not skipped when computing the text of the link itself since it has not been referenced in that context -->
-    link3
-  </a>
-</h3> expected "image link2 link3" but got "image link2 image link3"
+PASS heading name from content for each child including two nested links using aria-labelledby with nested image
 PASS link name from content for each child including nested image (referenced elsewhere via labelledby)
 PASS button name from content for each child (no space, inline)
 PASS heading name from content for each child (no space, inline)

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -321,6 +321,10 @@ struct TextUnderElementMode {
     DescendIntoContainers descendIntoContainers { DescendIntoContainers::No };
     TrimWhitespace trimWhitespace { TrimWhitespace::Yes };
     CheckedPtr<Node> ignoredChildNode { nullptr };
+    // Tracks nodes that have already been referenced via aria-labelledby during
+    // the current name computation. These nodes should be skipped when encountered
+    // directly in the tree to avoid double-counting.
+    HashSet<const Node*>* nodesReferencedViaLabeledby { nullptr };
 
     bool isHidden() { return considerHiddenState && inHiddenSubtree; }
 };


### PR DESCRIPTION
#### d6d2686c24a7aaedebadd9eba30cfb0b408b7639
<pre>
AX: WebKit&apos;s accname computation can double-include text from a node pointed to by aria-labelledby
<a href="https://bugs.webkit.org/show_bug.cgi?id=306927">https://bugs.webkit.org/show_bug.cgi?id=306927</a>
<a href="https://rdar.apple.com/169593121">rdar://169593121</a>

Reviewed by Joshua Hoffman.

When computing the accessible name for an element, if a child references another
element via aria-labelledby, that referenced element was being counted twice:
once when processing the aria-labelledby reference, and again when traversing
the DOM tree and encountering the element directly.

Fix this by tracking nodes that have been processed via aria-labelledby during
name computation, and skipping them when encountered again in the tree traversal.

* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt:
Mark testcase as fixed.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::visibleText const):
(WebCore::AccessibilityNodeObject::textUnderElement const):

Canonical link: <a href="https://commits.webkit.org/306873@main">https://commits.webkit.org/306873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/699137c09f43f00b82ebf2da97c592e5d3c316c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150901 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95444 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109385 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95444 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90284 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c78ad8bc-3d95-4846-b4aa-6f252f2c83d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11434 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9092 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153251 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14343 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117436 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117759 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30105 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13805 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70043 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14392 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3578 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14124 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14329 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->