### PR TITLE
Address Safer CPP warnings about retainable members in Source/WebKit on iOS

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -543,7 +543,7 @@ constexpr double fasterTapSignificantZoomThreshold = 0.8;
     BOOL _isNone;
     BOOL _isRange;
     BOOL _isEditable;
-    NSArray<WKTextSelectionRect *>*_selectionRects;
+    RetainPtr<NSArray<WKTextSelectionRect *>> _selectionRects;
     NSUInteger _selectedTextLength;
 }
 @property (nonatomic) CGRect startRect;
@@ -15870,8 +15870,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)dealloc
 {
-    [_selectionRects release];
     [super dealloc];
+}
+
+- (NSArray<WKTextSelectionRect *> *)selectionRects
+{
+    return _selectionRects.get();
+}
+
+- (void)setSelectionRects:(NSArray<WKTextSelectionRect *> *)selectionRects
+{
+    _selectionRects = adoptNS([selectionRects copy]);
 }
 
 - (NSString *)description

--- a/Source/WebKit/UIProcess/ios/WKImageAnalysisGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKImageAnalysisGestureRecognizer.mm
@@ -29,10 +29,11 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(IMAGE_ANALYSIS)
 
 #import "UIKitUtilities.h"
+#import <wtf/WeakObjCPtr.h>
 
 @implementation WKImageAnalysisGestureRecognizer {
     __weak UIView <WKImageAnalysisGestureRecognizerDelegate> *_imageAnalysisGestureRecognizerDelegate;
-    __weak UIScrollView *_lastTouchedScrollView;
+    WeakObjCPtr<UIScrollView> _lastTouchedScrollView;
 }
 
 - (instancetype)initWithImageAnalysisGestureDelegate:(UIView <WKImageAnalysisGestureRecognizerDelegate> *)delegate
@@ -53,6 +54,11 @@
     [super reset];
 
     _lastTouchedScrollView = nil;
+}
+
+- (UIScrollView *)lastTouchedScrollView
+{
+    return _lastTouchedScrollView.getAutoreleased();
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
@@ -67,7 +67,7 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
     RetainPtr<NSString> _mimeType;
     RetainPtr<QLItem> _item;
     RetainPtr<ASVThumbnailView> _thumbnailView;
-    WKWebView *_webView;
+    WeakObjCPtr<WKWebView> _webView;
 }
 
 - (instancetype)web_initWithFrame:(CGRect)frame webView:(WKWebView *)webView mimeType:(NSString *)mimeType
@@ -133,7 +133,7 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
     [alert addAction:doNotAllowAction];
     [alert addAction:allowAction];
 
-    RefPtr page = _webView->_page;
+    RefPtr page = _webView.get()->_page;
     UIViewController *presentingViewController = page->uiClient().presentingViewController();
     [presentingViewController presentViewController:alert.get() animated:YES completion:nil];
 }
@@ -141,8 +141,9 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
 - (void)_layoutThumbnailView
 {
     if (_thumbnailView) {
-        UIEdgeInsets safeAreaInsets = _webView._computedUnobscuredSafeAreaInset;
-        UIEdgeInsets obscuredAreaInsets = _webView._computedObscuredInset;
+        RetainPtr webView = _webView.get();
+        UIEdgeInsets safeAreaInsets = [webView _computedUnobscuredSafeAreaInset];
+        UIEdgeInsets obscuredAreaInsets = [webView _computedObscuredInset];
 
         CGRect layoutFrame = UIEdgeInsetsInsetRect(self.frame, safeAreaInsets);
 
@@ -158,7 +159,7 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
 
 - (void)thumbnailView:(ASVThumbnailView *)thumbnailView wantsToPresentPreviewController:(QLPreviewController *)previewController forItem:(QLItem *)item
 {
-    RefPtr<WebKit::WebPageProxy> page = _webView->_page;
+    RefPtr<WebKit::WebPageProxy> page = _webView.get()->_page;
 
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
@@ -205,13 +206,13 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
 
 - (void)web_countStringMatches:(NSString *)string options:(_WKFindOptions)options maxCount:(NSUInteger)maxCount
 {
-    RefPtr<WebKit::WebPageProxy> page = _webView->_page;
+    RefPtr<WebKit::WebPageProxy> page = _webView.get()->_page;
     page->findClient().didCountStringMatches(page.get(), string, 0);
 }
 
 - (void)web_findString:(NSString *)string options:(_WKFindOptions)options maxCount:(NSUInteger)maxCount
 {
-    RefPtr<WebKit::WebPageProxy> page = _webView->_page;
+    RefPtr<WebKit::WebPageProxy> page = _webView.get()->_page;
     page->findClient().didFailToFindString(page.get(), string);
 }
 

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
@@ -31,6 +31,7 @@
 #import <pal/spi/ios/BrowserEngineKitSPI.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS WKContentView;
 
@@ -64,7 +65,7 @@ private:
     void handleKeydownWithIdentifier(const String&) final;
     void close() final;
 
-    WKContentView *m_contentView;
+    WeakObjCPtr<WKContentView> m_contentView;
     RetainPtr<WKDataListSuggestionsControl> m_suggestionsControl;
 };
 

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -117,16 +117,17 @@ void WebDataListSuggestionsDropdownIOS::show(WebCore::DataListSuggestionInformat
 
     WebCore::DataListSuggestionActivationType type = information.activationType;
 
-    if (m_contentView._shouldUseContextMenusForFormControls) {
-        m_suggestionsControl = adoptNS([[WKDataListSuggestionsDropdown alloc] initWithInformation:WTF::move(information) inView:m_contentView]);
+    RetainPtr contentView = m_contentView.get();
+    if ([contentView _shouldUseContextMenusForFormControls]) {
+        m_suggestionsControl = adoptNS([[WKDataListSuggestionsDropdown alloc] initWithInformation:WTF::move(information) inView:contentView.get()]);
         [m_suggestionsControl showSuggestionsDropdown:*this activationType:type];
         return;
     }
 
     if (PAL::currentUserInterfaceIdiomIsSmallScreen())
-        m_suggestionsControl = adoptNS([[WKDataListSuggestionsPicker alloc] initWithInformation:WTF::move(information) inView:m_contentView]);
+        m_suggestionsControl = adoptNS([[WKDataListSuggestionsPicker alloc] initWithInformation:WTF::move(information) inView:contentView.get()]);
     else
-        m_suggestionsControl = adoptNS([[WKDataListSuggestionsPopover alloc] initWithInformation:WTF::move(information) inView:m_contentView]);
+        m_suggestionsControl = adoptNS([[WKDataListSuggestionsPopover alloc] initWithInformation:WTF::move(information) inView:contentView.get()]);
 
     [m_suggestionsControl showSuggestionsDropdown:*this activationType:type];
 }

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm
@@ -33,6 +33,7 @@
 #import <pal/spi/cocoa/IOKitSPI.h>
 
 @implementation WKFormPeripheralBase {
+    WeakObjCPtr<WKContentView> _view;
     RetainPtr<NSObject <WKFormControl>> _control;
 }
 
@@ -80,6 +81,11 @@
 - (NSObject <WKFormControl> *)control
 {
     return _control.get();
+}
+
+- (WKContentView *)view
+{
+    return _view.getAutoreleased();
 }
 
 - (BOOL)handleKeyEvent:(UIEvent *)event


### PR DESCRIPTION
#### 9ca92cf27ff2ac98d56f41d3185bc43654e7f044
<pre>
Address Safer CPP warnings about retainable members in Source/WebKit on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=306929">https://bugs.webkit.org/show_bug.cgi?id=306929</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler initWithDrawingAreaProxy:]):
(-[WKDisplayLinkHandler invalidate]):
(-[WKDisplayLinkHandler schedule]):
(-[WKDisplayLinkHandler pause]):
(-[WKDisplayLinkHandler nominalFramesPerSecond]):
(-[WKDisplayLinkHandler updateFrameRate]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKTextRange dealloc]):
(-[WKTextRange selectionRects]):
(-[WKTextRange setSelectionRects:]):
* Source/WebKit/UIProcess/ios/WKImageAnalysisGestureRecognizer.mm:
(-[WKImageAnalysisGestureRecognizer lastTouchedScrollView]):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollViewDelegateForwarder methodSignatureForSelector:]):
(-[WKScrollViewDelegateForwarder respondsToSelector:]):
(-[WKScrollViewDelegateForwarder forwardInvocation:]):
(-[WKScrollViewDelegateForwarder forwardingTargetForSelector:]):
(-[WKScrollView internalDelegate]):
(-[WKScrollView setInternalDelegate:]):
(-[WKScrollView _updateDelegate]):
(-[WKScrollView setBackgroundColor:]):
(-[WKScrollView _setBackgroundColorInternal:]):
(-[WKScrollView setIndicatorStyle:]):
(-[WKScrollView setContentInset:]):
(-[WKScrollView _resetContentInset]):
(-[WKScrollView setContentInsetAdjustmentBehavior:]):
(-[WKScrollView _systemContentInset]):
(-[WKScrollView hitTest:withEvent:]):
(-[WKScrollView _didChangeTopScrollEdgeEffectStyle]):
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:completionHandler:]):
(-[WKUSDPreviewView _layoutThumbnailView]):
(-[WKUSDPreviewView thumbnailView:wantsToPresentPreviewController:forItem:]):
(-[WKUSDPreviewView web_countStringMatches:options:maxCount:]):
(-[WKUSDPreviewView web_findString:options:maxCount:]):
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h:
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(WebKit::WebDataListSuggestionsDropdownIOS::show):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker initWithView:inputType:]):
(-[WKDateTimePicker datePickerPopoverControllerDidReset:]):
(-[WKDateTimePicker handleDatePickerPresentationDismissal]):
(-[WKDateTimePicker removeDatePickerPresentation]):
(-[WKDateTimePicker showDateTimePicker]):
(-[WKDateTimePicker shouldForceGregorianCalendar]):
(-[WKDateTimePicker _sanitizeInputValueForFormatter:]):
(-[WKDateTimePicker dateFormatterForPicker]):
(-[WKDateTimePicker _dateChanged]):
(-[WKDateTimePicker setDateTimePickerToInitialValue]):
(-[WKDateTimePicker controlBeginEditing]):
(-[WKDateTimePicker controlEndEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormPeripheralBase.mm:
(-[WKFormPeripheralBase view]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPopover.mm:
(-[WKSelectTableViewController initWithView:hasGroups:]):
(-[WKSelectTableViewController tableView:numberOfRowsInSection:]):
(-[WKSelectTableViewController tableView:titleForHeaderInSection:]):
(-[WKSelectTableViewController findItemIndexAt:]):
(-[WKSelectTableViewController findItemAt:]):
(-[WKSelectTableViewController tableView:cellForRowAtIndexPath:]):
(-[WKSelectTableViewController tableView:didSelectRowAtIndexPath:]):
(-[WKSelectTableViewController shouldDismissWithAnimation]):
(-[WKSelectTableViewController popover]):
(-[WKSelectTableViewController setPopover:]):

Canonical link: <a href="https://commits.webkit.org/306807@main">https://commits.webkit.org/306807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25b26da57ad62299e6ec617615b9b11790765ce0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95496 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e70f8c6e-a99e-4d55-9940-294694cb9990) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109436 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79031 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdf72257-883b-41a9-a4e3-b1d24ea01e5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90337 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c48e0488-1221-4510-8725-a9d91e9521da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11473 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9132 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/986 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120821 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153303 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14395 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117478 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117802 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13851 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124641 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70095 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14444 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3635 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->