### PR TITLE
Address remaining Safer CPP casting warnings in WKScrollView.mm

### DIFF
--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -120,7 +120,6 @@ template<typename T> inline T *checked_objc_cast(id object)
 
 template<typename T, typename U> inline T *checked_objc_cast(U *object)
 {
-    static_assert(std::is_base_of_v<U, T>);
     if (!object)
         return nullptr;
 
@@ -138,7 +137,6 @@ template<typename T, typename U>
     requires (std::is_base_of_v<U, T>)
 RetainPtr<T> dynamic_objc_cast(RetainPtr<U>&& object)
 {
-    static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);
     if (!is_objc<T>(object.get()))
         return nullptr;
@@ -156,7 +154,6 @@ template<typename T, typename U>
     requires (std::is_base_of_v<U, T>)
 RetainPtr<T> dynamic_objc_cast(const RetainPtr<U>& object)
 {
-    static_assert(std::is_base_of_v<U, T>);
     static_assert(!std::is_same_v<U, T>);
     if (!is_objc<T>(object.get()))
         return nullptr;

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -36,10 +36,12 @@
 #import "WKDeferringGestureRecognizer.h"
 #import "WKUIScrollEdgeEffect.h"
 #import "WKWebViewIOS.h"
+#import "WKWebViewInternal.h"
 #import "WebPage.h"
 #import <pal/spi/cg/CoreGraphicsSPI.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 #if HAVE(PEPPER_UI_CORE)
@@ -594,22 +596,22 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
 
 - (UIScrollEdgeEffect *)topEdgeEffect
 {
-    return static_cast<UIScrollEdgeEffect *>(self._wk_topEdgeEffect);
+    return checked_objc_cast<UIScrollEdgeEffect>(self._wk_topEdgeEffect);
 }
 
 - (UIScrollEdgeEffect *)leftEdgeEffect
 {
-    return static_cast<UIScrollEdgeEffect *>(self._wk_leftEdgeEffect);
+    return checked_objc_cast<UIScrollEdgeEffect>(self._wk_leftEdgeEffect);
 }
 
 - (UIScrollEdgeEffect *)bottomEdgeEffect
 {
-    return static_cast<UIScrollEdgeEffect *>(self._wk_bottomEdgeEffect);
+    return checked_objc_cast<UIScrollEdgeEffect>(self._wk_bottomEdgeEffect);
 }
 
 - (UIScrollEdgeEffect *)rightEdgeEffect
 {
-    return static_cast<UIScrollEdgeEffect *>(self._wk_rightEdgeEffect);
+    return checked_objc_cast<UIScrollEdgeEffect>(self._wk_rightEdgeEffect);
 }
 
 - (WKUIScrollEdgeEffect *)_wk_topEdgeEffect


### PR DESCRIPTION
#### 710bef9faaee848ac98d26204b7c9406de8e6172
<pre>
Address remaining Safer CPP casting warnings in WKScrollView.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=306930">https://bugs.webkit.org/show_bug.cgi?id=306930</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
(WTF::checked_objc_cast):
(WTF::dynamic_objc_cast):
Drop `std::is_base_of_v&lt;U, T&gt;` static assertion in ObjC safe casting functions.
While this assertion stands in C++, it is actually too restrictive in ObjC.
For example, `WKUIScrollEdgeEffect` inherits `NSObject` can can be casted
safely to a `UIScrollEdgeEffect` still. This is because `WKUIScrollEdgeEffect`
acts as a proxy/wrapper around `UIScrollEdgeEffect`` using Objective-C&apos;s
message forwarding mechanism. `[wkWrapper isKindOfClass:[UIScrollEdgeEffect class]]`
will actually return YES.

* Source/WebKit/UIProcess/ios/WKScrollView.mm:
Add a include to attempt to fix an unsafe cast warning on this:
`static_cast&lt;NSObject *&gt;(_internalDelegate)`. This is a perfectly safe
upcast since `_internalDelegate` is a `WKWebView *` but my bet is that
the static analyzer did not know enough about the `WKWebView` type to
figure that out. I&apos;m trying the include for now but if this doesn&apos;t work,
we may have to suppress the warning instead.

(-[WKScrollView topEdgeEffect]):
(-[WKScrollView leftEdgeEffect]):
(-[WKScrollView bottomEdgeEffect]):
(-[WKScrollView rightEdgeEffect]):
Adopt `checked_objc_cast()` for safety.

Canonical link: <a href="https://commits.webkit.org/306766@main">https://commits.webkit.org/306766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06f28fde1a48e6987681ec3568291b23b0089ba6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150908 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f3ba6c7-f826-40b5-a2f6-699e9a08ddc7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109389 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56d3523e-1fe1-4d69-b310-0f77f1b2e8da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90288 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1fce8d3-3973-43d2-b43c-f086b4fe0cdd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11431 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9096 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/940 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134258 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120777 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153257 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3078 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14349 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117441 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117764 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13813 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70049 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14398 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3581 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173563 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14130 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78114 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44915 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14335 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14175 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->