### PR TITLE
Back navigation may never complete when navigating to a site with subframe

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -112,7 +112,6 @@ static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnostic
 
     if (!document->frame()) {
         PCLOG("   -Document is detached from frame"_s);
-        ASSERT_NOT_REACHED();
         return false;
     }
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4598,10 +4598,9 @@ void FrameLoader::loadItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadTy
     m_requestedHistoryItem = item;
     RefPtr currentItem = history().currentItem();
 
-    bool sameDocumentNavigation = currentItem && item.shouldDoSameDocumentNavigationTo(*currentItem);
-
-    // If we're continuing this history navigation in a new process, then doing a same document navigation never makes sense.
-    ASSERT(!sameDocumentNavigation || shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No);
+    // If we're continuing this history navigation in a new process, we cannot perform a same document navigation.
+    // Otherwise, the load won't commit and navigation won't complete.
+    bool sameDocumentNavigation = currentItem && item.shouldDoSameDocumentNavigationTo(*currentItem) && shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::No;
 
     // Check if Navigation API should handle this traversal
     if (frame().document() && frame().document()->settings().navigationAPIEnabled() && shouldDispatchNavigateEventForHistoryTraversal(item, fromItem)) {


### PR DESCRIPTION
#### c8533d6a372369d5d5e205fd46ce87060a4b9737
<pre>
Back navigation may never complete when navigating to a site with subframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=306933">https://bugs.webkit.org/show_bug.cgi?id=306933</a>
<a href="https://rdar.apple.com/169597227">rdar://169597227</a>

Reviewed by Chris Dumez.

With current implementation, back navigation may never complete in the following case:
1. Navigate page / main frame a site that has an iframe (HistoryItem1 created in WebProcess1)
2. Navigate the iframe (HistoryItem2 created in WebProcess1)
3. Navigate main frame cross-site (HistoryItem3 created in WebProcess2)
4. Go back (going back to HistoryItem2)
Under PSON, there&apos;s a process swap when going back: UI process will tell WebProcess1, which has cached page for
HistoryItem2 to perform the navigation. In HistoryController::recursiveGoToItem(), the item and fromItem are the same
(as the cached page is at HistoryItem2 state), so itemsAreClones() will return false, and HistoryController will start
loading the HistoryItem2. Then in FrameLoader::loadItem(), sameDocumentNavigation will be true because the main frame
is actually at HistoryItem1 -- this means in HistoryItem::shouldDoSameDocumentNavigationTo(), itemIDs are different but
documentSequenceNumbers are the same (as main frame does not change document between HistoryItem1 and HistoryItem2).
Then FrameLoader is doing a same document navigation and the load is never committed (as no request is made for same
document navigation).

There is actually an assertion in FrameLoader::loadItem(), saying sameDocumentNavigation should never be true if we are
continuing a backforward navigation in new process. To fix this, turning the assertion into an actual resetting of
sameDocumentNavigation if we notice the load is in a new process. This patch also removes a debug assertion in
canCacheFrame() because if frame is already cached and being restored, its document might not have a frame; and this
frame is not in cacheable state.

Test: WKBackForwardList.PageCacheGoBackAfterNavigatingSameSiteIframe
      WKBackForwardList.NoPageCacheGoBackAfterNavigatingSameSiteIframe

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::canCacheFrame):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadItem):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(runGoBackAfterNavigatingSameSiteIframe):
(TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe)):
(TEST(WKBackForwardList, NoPageCacheGoBackAfterNavigatingSameSiteIframe)):

Canonical link: <a href="https://commits.webkit.org/307473@main">https://commits.webkit.org/307473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86b374a04aa91de656c12d827ed7cb18c85abc4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97648 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7b5cebe-8cac-4256-8953-64df91db570e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111045 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79724 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c9c3fd8-422b-4947-ad52-85673c73a9dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91960 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d33e59c9-3fac-42f6-9789-992329907923) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12843 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10597 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/525 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155391 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119048 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14189 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119411 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30628 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15244 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127590 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72361 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16562 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6001 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80341 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16507 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16362 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->