### PR TITLE
MarkableTraits<LayoutUnit>::emptyValue() should use a less common value

### DIFF
--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -698,7 +698,7 @@ template<> struct DefaultHash<WebCore::LayoutUnit> {
 // good candidates to represent the deleted and empty values in HashMaps as well.
 template<> struct HashTraits<WebCore::LayoutUnit> : GenericHashTraits<WebCore::LayoutUnit> {
     static constexpr bool emptyValueIsZero = false;
-    static WebCore::LayoutUnit emptyValue()
+    static constexpr WebCore::LayoutUnit emptyValue()
     {
         return WebCore::LayoutUnit::fromRawValue(std::numeric_limits<int>::min());
     }
@@ -708,14 +708,14 @@ template<> struct HashTraits<WebCore::LayoutUnit> : GenericHashTraits<WebCore::L
 
 template<>
 struct MarkableTraits<WebCore::LayoutUnit> {
-    static bool isEmptyValue(WebCore::LayoutUnit value)
+    static constexpr bool isEmptyValue(WebCore::LayoutUnit value)
     {
-        return value == WebCore::LayoutUnit(-1);
+        return value == emptyValue();
     }
 
-    static WebCore::LayoutUnit emptyValue()
+    static constexpr WebCore::LayoutUnit emptyValue()
     {
-        return WebCore::LayoutUnit(-1);
+        return HashTraits<WebCore::LayoutUnit>::emptyValue();
     }
 };
 


### PR DESCRIPTION
#### 2d2d923db943747b4b3b381f337501a37039b6f6
<pre>
MarkableTraits&lt;LayoutUnit&gt;::emptyValue() should use a less common value
<a href="https://bugs.webkit.org/show_bug.cgi?id=306935">https://bugs.webkit.org/show_bug.cgi?id=306935</a>
<a href="https://rdar.apple.com/169599360">rdar://169599360</a>

Reviewed by Ryosuke Niwa.

MarkableTraits&lt;WebCore::LayoutUnit&gt;::emptyValue() was returning
LayoutUnit(-1), which is actually quite a valid value corresponding to
-1/64 pixels.
Instead it now uses a less common value, the same as
HashTraits&lt;WebCore::LayoutUnit&gt;::emptyValue() (which is justified in the
comment above.)

* Source/WebCore/platform/LayoutUnit.h:
(WTF::HashTraits&lt;WebCore::LayoutUnit&gt;::emptyValue):
(WTF::MarkableTraits&lt;WebCore::LayoutUnit&gt;::isEmptyValue):
(WTF::MarkableTraits&lt;WebCore::LayoutUnit&gt;::emptyValue):

Canonical link: <a href="https://commits.webkit.org/306813@main">https://commits.webkit.org/306813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0fb45557dceee4b2cf52a813a911525e4eead59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150948 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95487 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ae9294e-e1fd-4973-919d-f09a5ac13ca5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109426 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95487 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1760ef5d-c0e7-43e4-a14a-0ced9d9f8f92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90327 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c8de18d-44ab-46b5-a4e6-e52869d4f987) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11467 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9126 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/977 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153294 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14386 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117473 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117797 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13846 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124627 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70086 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14435 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3627 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78151 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14212 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->