### PR TITLE
[Safer CPP] Address unretained local variable warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -142,8 +142,8 @@ void NetworkProcess::platformInitializeNetworkProcessCocoa(const NetworkProcessC
     if (auto auditToken = protect(parentProcessConnection())->getAuditToken()) {
         bool isNetworkAccessBlockedInUIProcess = (1 == sandbox_check_by_audit_token(*auditToken, "network-outbound", SANDBOX_FILTER_PATH, "/private/var/run/mDNSResponder"));
 
-        auto xpcConnection = protect(parentProcessConnection())->xpcConnection();
-        auto [signingIdentifier, isPlatformBinary] = codeSigningIdentifierAndPlatformBinaryStatus(xpcConnection);
+        OSObjectPtr xpcConnection = protect(parentProcessConnection())->xpcConnection();
+        auto [signingIdentifier, isPlatformBinary] = codeSigningIdentifierAndPlatformBinaryStatus(xpcConnection.get());
         if (!isPlatformBinary && isNetworkAccessBlockedInUIProcess) {
             RELEASE_LOG(Process, "Setting sandbox state flag to block network access");
             if (auto auditTokenForSelf = WTF::auditTokenForSelf()) {

--- a/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
+++ b/Source/WebKit/Platform/cocoa/LayerHostingContext.mm
@@ -191,7 +191,7 @@ RetainPtr<BELayerHierarchyHostingTransactionCoordinator> LayerHostingContext::cr
 {
     // We are leaking the send right here, since [BELayerHierarchyHostingTransactionCoordinator coordinatorWithPort] takes ownership of the send right, even in the error case.
     NSError *error = nil;
-    auto coordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithPort:sendRightAnnotated.sendRight.leakSendRight() data:toNSData(sendRightAnnotated.data.span()).get() error:&error];
+    RetainPtr coordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithPort:sendRightAnnotated.sendRight.leakSendRight() data:toNSData(sendRightAnnotated.data.span()).get() error:&error];
     if (error)
         RELEASE_LOG_ERROR(Process, "Could not create update coordinator, error = %@", error);
     return coordinator;
@@ -212,7 +212,7 @@ RetainPtr<BELayerHierarchyHandle> LayerHostingContext::createHostingHandle(WTF::
 {
     // We are leaking the send right here, since [BELayerHierarchyHandle handleWithPort] takes ownership of the send right, even in the error case.
     NSError *error = nil;
-    auto handle = [BELayerHierarchyHandle handleWithPort:sendRightAnnotated.sendRight.leakSendRight() data:toNSData(sendRightAnnotated.data.span()).get() error:&error];
+    RetainPtr handle = [BELayerHierarchyHandle handleWithPort:sendRightAnnotated.sendRight.leakSendRight() data:toNSData(sendRightAnnotated.data.span()).get() error:&error];
     if (error)
         RELEASE_LOG_ERROR(Process, "Could not create layer hierarchy handle, error = %@", error);
     return handle;

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -531,7 +531,7 @@ void WebPaymentCoordinatorProxy::platformEndApplePaySetup()
 
 void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupConfiguration& configuration, const PaymentSetupFeatures& features, CompletionHandler<void(bool)>&& reply)
 {
-    UIViewController *presentingViewController = checkedClient()->paymentCoordinatorPresentingViewController(*this);
+    RetainPtr presentingViewController = checkedClient()->paymentCoordinatorPresentingViewController(*this);
     if (!presentingViewController) {
         reply(false);
         return;

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -200,8 +200,8 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-            if (auto containerEnvironmentVariables = xpc_dictionary_get_value(event, "ContainerEnvironmentVariables")) {
-                xpc_dictionary_apply(containerEnvironmentVariables, ^(const char *key, xpc_object_t value) {
+            if (RetainPtr containerEnvironmentVariables = xpc_dictionary_get_value(event, "ContainerEnvironmentVariables")) {
+                xpc_dictionary_apply(containerEnvironmentVariables.get(), ^(const char *key, xpc_object_t value) {
                     setenv(key, xpc_string_get_string_ptr(value), 1);  // NOLINT
                     return true;
                 });

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1657,7 +1657,7 @@ struct WKWebsiteData {
         return NO;
 
     dispatch_async(mainDispatchQueueSingleton(), ^{
-        WKWebsiteDataStore *dataStore = _WKWebsiteDataStoreBSActionHandler.shared->_webPushActionHandler.get()(webPushAction.get());
+        RetainPtr dataStore = _WKWebsiteDataStoreBSActionHandler.shared->_webPushActionHandler.get()(webPushAction.get());
         [dataStore _handleWebPushAction:webPushAction.get()];
     });
 
@@ -1676,7 +1676,7 @@ struct WKWebsiteData {
             continue;
         }
 
-        WKWebsiteDataStore *dataStoreForPushAction = _webPushActionHandler.get()(pushAction);
+        RetainPtr dataStoreForPushAction = _webPushActionHandler.get()(pushAction);
         if (dataStoreForPushAction) {
             [dataStoreForPushAction _handleWebPushAction:pushAction];
             if (action.canSendResponse)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm
@@ -428,18 +428,18 @@ static _WKElementActionType uiActionIdentifierToElementActionType(UIActionIdenti
 - (UIAction *)uiActionForElementInfo:(_WKActivatedElementInfo *)elementInfo
 {
     UIImage *image = [_WKElementAction imageForElementActionType:self.type];
-    UIActionIdentifier identifier = elementActionTypeToUIActionIdentifier(self.type);
+    RetainPtr identifier = elementActionTypeToUIActionIdentifier(self.type);
 
-    UIAction *action = [UIAction actionWithTitle:self.title image:image identifier:identifier handler:[retainedSelf = retainPtr(self), retainedInfo = retainPtr(elementInfo)] (UIAction *) {
+    RetainPtr action = [UIAction actionWithTitle:self.title image:image identifier:identifier.get() handler:[retainedSelf = retainPtr(self), retainedInfo = retainPtr(elementInfo)] (UIAction *) {
         auto elementAction = retainedSelf.get();
         RELEASE_LOG(ContextMenu, "Executing action for type: %s", elementActionTypeToUIActionIdentifier([elementAction type]).UTF8String);
         [elementAction runActionWithElementInfo:retainedInfo.get()];
     }];
 
     if (self.disabled)
-        action.attributes |= UIMenuElementAttributesDisabled;
+        action.get().attributes |= UIMenuElementAttributesDisabled;
 
-    return action;
+    return action.autorelease();
 }
 #else
 + (UIImage *)imageForElementActionType:(_WKElementActionType)actionType

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm
@@ -386,10 +386,10 @@ static void delayBetweenMove(int eventIndex, double elapsed)
         return;
 
     CFIndex callbackID = IOHIDEventGetIntegerValue(event, kIOHIDEventFieldVendorDefinedData);
-    NSNumber *key = @(callbackID);
-    void (^completionBlock)() = [_eventCallbacks objectForKey:key];
+    RetainPtr key = @(callbackID);
+    void (^completionBlock)() = [_eventCallbacks objectForKey:key.get()];
     if (completionBlock) {
-        [_eventCallbacks removeObjectForKey:key];
+        [_eventCallbacks removeObjectForKey:key.get()];
         completionBlock();
         Block_release(completionBlock);
     }

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1256,9 +1256,9 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
     }
 
     if (_perProcessState.pendingFindLayerID) {
-        CALayer *layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).remoteLayerTreeHost().layerForID(*_perProcessState.pendingFindLayerID);
-        if (layer.superlayer)
-            [self _didAddLayerForFindOverlay:layer];
+        RetainPtr layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).remoteLayerTreeHost().layerForID(*_perProcessState.pendingFindLayerID);
+        if (layer.get().superlayer)
+            [self _didAddLayerForFindOverlay:layer.get()];
     }
 
 }
@@ -3546,13 +3546,13 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
     if (!_findOverlaysOutsideContentView)
         return;
 
-    UIScrollView *scrollView = _scrollView.get();
+    RetainPtr scrollView = _scrollView.get();
     CGRect contentViewBounds = [_contentView bounds];
     CGRect contentViewFrame = [_contentView frame];
-    CGFloat minX = std::min<CGFloat>(0, scrollView.contentOffset.x);
-    CGFloat minY = std::min<CGFloat>(0, scrollView.contentOffset.y);
-    CGFloat maxX = std::max<CGFloat>(scrollView.bounds.size.width + scrollView.contentOffset.x, contentViewBounds.size.width);
-    CGFloat maxY = std::max<CGFloat>(scrollView.bounds.size.height + scrollView.contentOffset.y, contentViewBounds.size.height);
+    CGFloat minX = std::min<CGFloat>(0, scrollView.get().contentOffset.x);
+    CGFloat minY = std::min<CGFloat>(0, scrollView.get().contentOffset.y);
+    CGFloat maxX = std::max<CGFloat>(scrollView.get().bounds.size.width + scrollView.get().contentOffset.x, contentViewBounds.size.width);
+    CGFloat maxY = std::max<CGFloat>(scrollView.get().bounds.size.height + scrollView.get().contentOffset.y, contentViewBounds.size.height);
 
     [_findOverlaysOutsideContentView->top setFrame:CGRectMake(
         CGRectGetMinX(contentViewFrame),
@@ -4590,14 +4590,14 @@ static bool isLockdownModeWarningNeeded()
     if (_customContentView) {
         UIGraphicsBeginImageContextWithOptions(imageSize, YES, 1);
 
-        UIView *customContentView = _customContentView.get();
-        [customContentView.backgroundColor set];
+        RetainPtr customContentView = _customContentView.get();
+        [customContentView.get().backgroundColor set];
         UIRectFill(CGRectMake(0, 0, imageWidth, imageHeight));
 
-        CGContextRef context = UIGraphicsGetCurrentContext();
-        CGContextTranslateCTM(context, -snapshotRectInContentCoordinates.origin.x * imageScale, -snapshotRectInContentCoordinates.origin.y * imageScale);
-        CGContextScaleCTM(context, imageScale, imageScale);
-        [customContentView.layer renderInContext:context];
+        RetainPtr context = UIGraphicsGetCurrentContext();
+        CGContextTranslateCTM(context.get(), -snapshotRectInContentCoordinates.origin.x * imageScale, -snapshotRectInContentCoordinates.origin.y * imageScale);
+        CGContextScaleCTM(context.get(), imageScale, imageScale);
+        [customContentView.get().layer renderInContext:context.get()];
 
         completionHandler([UIGraphicsGetImageFromCurrentImageContext() CGImage]);
 
@@ -5081,9 +5081,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id <_WKWebViewPrintProvider>)_printProvider
 {
-    id printProvider = _customContentView ? _customContentView.get() : _contentView.get();
+    RetainPtr printProvider = _customContentView ? _customContentView.get() : _contentView.get();
     if ([printProvider conformsToProtocol:@protocol(_WKWebViewPrintProvider)])
-        return printProvider;
+        return (id<_WKWebViewPrintProvider>)printProvider.autorelease();
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -245,20 +245,20 @@ void ApplicationStateTracker::setWindow(UIWindow *window)
 
     case ApplicationType::Extension:
     case ApplicationType::ViewService: {
-        UIViewController *serviceViewController = nil;
+        RetainPtr<UIViewController> serviceViewController;
 
         for (RetainPtr view = m_view.get(); view; view = view.get().superview) {
-            auto viewController = WebCore::viewController(view.get());
+            RetainPtr viewController = WebCore::viewController(view.get());
 
-            if (viewController._hostProcessIdentifier) {
-                serviceViewController = viewController;
+            if (viewController.get()._hostProcessIdentifier) {
+                serviceViewController = WTF::move(viewController);
                 break;
             }
         }
 
         ASSERT(serviceViewController);
         setScene(nil);
-        setViewController(serviceViewController);
+        setViewController(serviceViewController.get());
         break;
     }
     }

--- a/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
+++ b/Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm
@@ -210,17 +210,17 @@ void WebAutomationSession::platformSimulateTouchInteraction(WebPageProxy& page, 
     });
 
     _WKTouchEventGenerator *generator = [_WKTouchEventGenerator sharedTouchEventGenerator];
-    UIWindow *window = [page.cocoaView() window];
+    RetainPtr window = [page.cocoaView() window];
 
     switch (interaction) {
     case TouchInteraction::TouchDown:
-        [generator touchDown:locationOnScreen window:window completionBlock:interactionFinished.get()];
+        [generator touchDown:locationOnScreen window:window.get() completionBlock:interactionFinished.get()];
         break;
     case TouchInteraction::LiftUp:
-        [generator liftUp:locationOnScreen window:window completionBlock:interactionFinished.get()];
+        [generator liftUp:locationOnScreen window:window.get() completionBlock:interactionFinished.get()];
         break;
     case TouchInteraction::MoveTo:
-        [generator moveToPoint:locationOnScreen duration:duration.value_or(0_s).seconds() window:window completionBlock:interactionFinished.get()];
+        [generator moveToPoint:locationOnScreen duration:duration.value_or(0_s).seconds() window:window.get() completionBlock:interactionFinished.get()];
         break;
     }
 }

--- a/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
@@ -58,9 +58,9 @@ bool shouldAllowAutoFillForCellularIdentifiers(const URL& topURL)
             return false;
 
         auto entitlementValue = adoptCF(SecTaskCopyValueForEntitlement(task.get(), CFSTR("com.apple.CommCenter.fine-grained"), nullptr));
-        auto entitlementValueAsArray = (__bridge NSArray *)dynamic_cf_cast<CFArrayRef>(entitlementValue.get());
-        for (id value in entitlementValueAsArray) {
-            if (auto string = dynamic_objc_cast<NSString>(value); [string isEqualToString:@"public-cellular-plan"])
+        RetainPtr entitlementValueAsArray = (__bridge NSArray *)dynamic_cf_cast<CFArrayRef>(entitlementValue.get());
+        for (id value in entitlementValueAsArray.get()) {
+            if (RetainPtr string = dynamic_objc_cast<NSString>(value); [string isEqualToString:@"public-cellular-plan"])
                 return true;
         }
         return false;
@@ -84,7 +84,7 @@ bool shouldAllowAutoFillForCellularIdentifiers(const URL& topURL)
 #else
     static NeverDestroyed cachedClient = adoptNS([PAL::allocCoreTelephonyClientInstance() initWithQueue:mainDispatchQueueSingleton()]);
 #endif
-    auto client = cachedClient->get();
+    RetainPtr client = cachedClient->get();
 
     static NeverDestroyed<String> lastQueriedHost;
     static bool lastQueriedHostResult = false;

--- a/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm
@@ -218,16 +218,16 @@ void alertForPermission(WebPageProxy& page, MediaPermissionReason reason, const 
     }];
 #else
     auto alert = WebKit::createUIAlertController(alertTitle.get(), nil);
-    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:allowButtonString.get() style:UIAlertActionStyleDefault handler:[completionBlock](UIAlertAction *action) {
+    RetainPtr allowAction = [UIAlertAction actionWithTitle:allowButtonString.get() style:UIAlertActionStyleDefault handler:[completionBlock](UIAlertAction *action) {
         completionBlock(true);
     }];
 
-    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:doNotAllowButtonString.get() style:UIAlertActionStyleCancel handler:[completionBlock](UIAlertAction *action) {
+    RetainPtr doNotAllowAction = [UIAlertAction actionWithTitle:doNotAllowButtonString.get() style:UIAlertActionStyleCancel handler:[completionBlock](UIAlertAction *action) {
         completionBlock(false);
     }];
 
-    [alert addAction:doNotAllowAction];
-    [alert addAction:allowAction];
+    [alert addAction:doNotAllowAction.get()];
+    [alert addAction:allowAction.get()];
 
 #if PLATFORM(VISION)
     page.dispatchWillPresentModalUI();

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -432,8 +432,8 @@ void ProcessAssertion::init(const String& environmentIdentifier)
     else
         target = [RBSTarget targetWithPid:m_pid environmentIdentifier:environmentIdentifier.createNSString().get()];
 
-    RBSDomainAttribute *domainAttribute = [RBSDomainAttribute attributeWithDomain:runningBoardDomainForAssertionType(m_assertionType).createNSString().get() name:runningBoardAssertionName.createNSString().get()];
-    m_rbsAssertion = adoptNS([[RBSAssertion alloc] initWithExplanation:m_reason.createNSString().get() target:target attributes:@[domainAttribute]]);
+    RetainPtr domainAttribute = [RBSDomainAttribute attributeWithDomain:runningBoardDomainForAssertionType(m_assertionType).createNSString().get() name:runningBoardAssertionName.createNSString().get()];
+    m_rbsAssertion = adoptNS([[RBSAssertion alloc] initWithExplanation:m_reason.createNSString().get() target:target attributes:@[domainAttribute.get()]]);
 
     m_delegate = adoptNS([[WKRBSAssertionDelegate alloc] init]);
     [m_rbsAssertion addObserver:m_delegate.get()];

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -421,7 +421,7 @@ void SOAuthorizationSession::presentViewController(SOAuthorizationViewController
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    UIViewController *presentingViewController = page->uiClient().presentingViewController();
+    RetainPtr presentingViewController = page->uiClient().presentingViewController();
 #if PLATFORM(VISION)
     page->dispatchWillPresentModalUI();
 #else

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -447,7 +447,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
                 return completionHandler();
 
             auto protectedThis = weakThis.get();
-            _WKDataTask *dataTask = wrapper(task);
+            RetainPtr dataTask = wrapper(task);
             protectedThis->m_wkSystemPreviewDataTaskDelegate = adoptNS([[_WKSystemPreviewDataTaskDelegate alloc] initWithSystemPreviewController:protectedThis]);
             [dataTask setDelegate:protectedThis->m_wkSystemPreviewDataTaskDelegate.get()];
             protectedThis->takeActivityToken();
@@ -477,22 +477,22 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
         successHandler(success);
     });
     auto alert = WebKit::createUIAlertController(WEB_UI_NSSTRING(@"View in AR?", "View in AR?"), WEB_UI_NSSTRING(@"You can view this object in 3D and place it in your surroundings using augmented reality.", "You can view this object in 3D and place it in your surroundings using augmented reality."));
-    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"View in AR", @"View in AR (usdz QuickLook Preview)", "Allow displaying QuickLook Preview of 3D model") style:UIAlertActionStyleDefault handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
+    RetainPtr allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"View in AR", @"View in AR (usdz QuickLook Preview)", "Allow displaying QuickLook Preview of 3D model") style:UIAlertActionStyleDefault handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
         if (!weakThis)
             return;
 
         std::exchange(weakThis->m_allowPreviewCallback, nullptr)(true);
     }];
 
-    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"Cancel", @"Cancel (usdz QuickLook Preview)", "Cancel displaying QuickLook Preview of 3D model") style:UIAlertActionStyleCancel handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
+    RetainPtr doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"Cancel", @"Cancel (usdz QuickLook Preview)", "Cancel displaying QuickLook Preview of 3D model") style:UIAlertActionStyleCancel handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
         if (!weakThis)
             return;
 
         std::exchange(weakThis->m_allowPreviewCallback, nullptr)(false);
     }];
 
-    [alert addAction:doNotAllowAction];
-    [alert addAction:allowAction];
+    [alert addAction:doNotAllowAction.get()];
+    [alert addAction:allowAction.get()];
 
     if (m_testingCallback)
         std::exchange(m_allowPreviewCallback, nullptr)(true);

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -238,16 +238,16 @@ void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSStrin
 #else
     auto alert = WebKit::createUIAlertController(alertTitle, informativeText);
 
-    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:allowButtonString.get() style:UIAlertActionStyleCancel handler:[completionBlock](UIAlertAction *action) {
+    RetainPtr allowAction = [UIAlertAction actionWithTitle:allowButtonString.get() style:UIAlertActionStyleCancel handler:[completionBlock](UIAlertAction *action) {
         completionBlock(true);
     }];
 
-    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:doNotAllowButtonString.get() style:UIAlertActionStyleDefault handler:[completionBlock](UIAlertAction *action) {
+    RetainPtr doNotAllowAction = [UIAlertAction actionWithTitle:doNotAllowButtonString.get() style:UIAlertActionStyleDefault handler:[completionBlock](UIAlertAction *action) {
         completionBlock(false);
     }];
 
-    [alert addAction:doNotAllowAction];
-    [alert addAction:allowAction];
+    [alert addAction:doNotAllowAction.get()];
+    [alert addAction:allowAction.get()];
 
 #if PLATFORM(VISION)
     [webView _page]->dispatchWillPresentModalUI();

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -407,9 +407,8 @@ bool WebProcessProxy::WebProcessXPCEventHandler::handleXPCEvent(xpc_object_t eve
         if (!subsystem.isEmpty() && !category.isEmpty())
             osLog = adoptOSObject(os_log_create(subsystem.utf8().data(), category.utf8().data()));
 
-        auto osLogPointer = osLog ? osLog.get() : OS_LOG_DEFAULT;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        os_log_with_type(osLogPointer, static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", static_cast<int>(pid), messageString.utf8().data());
+        os_log_with_type(osLog ? osLog.get() : OS_LOG_DEFAULT, static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", static_cast<int>(pid), messageString.utf8().data());
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         webProcess->m_didReceiveLogsDuringLaunchForTesting = true;
     } else if (messageName == disableLogMessageName) {

--- a/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
+++ b/Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm
@@ -41,8 +41,8 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto firstResponder = [[[UIApplication sharedApplication] keyWindow] firstResponder];
 ALLOW_DEPRECATED_DECLARATIONS_END
 
-    if (auto *view = dynamic_objc_cast<WKContentView>(firstResponder))
-        return view.page;
+    if (RetainPtr view = dynamic_objc_cast<WKContentView>(firstResponder))
+        return view.get().page;
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
     if (auto* page = WebProcessProxy::webPageWithActiveXRSession())

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -110,7 +110,7 @@ void RemoteLayerTreeNode::detachFromParent()
     removeInteractionRegionsContainer();
 #endif
 #if PLATFORM(IOS_FAMILY)
-    if (auto view = uiView()) {
+    if (RetainPtr view = uiView()) {
         [view removeFromSuperview];
         return;
     }
@@ -138,12 +138,12 @@ void RemoteLayerTreeNode::applyBackingStore(RemoteLayerTreeHost* host, RemoteLay
     if (asyncContentsIdentifier() && properties.contentsRenderingResourceIdentifier() && *asyncContentsIdentifier() >= *properties.contentsRenderingResourceIdentifier())
         return;
 
-    UIView* hostingView = nil;
+    RetainPtr<UIView> hostingView;
 #if PLATFORM(IOS_FAMILY)
     hostingView = uiView();
 #endif
 
-    properties.applyBackingStoreToNode(*this, host->replayDynamicContentScalingDisplayListsIntoBackingStore(), hostingView);
+    properties.applyBackingStoreToNode(*this, host->replayDynamicContentScalingDisplayListsIntoBackingStore(), hostingView.get());
 
     if (auto identifier = properties.contentsRenderingResourceIdentifier())
         setAsyncContentsIdentifier(*identifier);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -333,14 +333,14 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
         || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollOrigin)
         || scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        auto scrollView = this->scrollView();
+        RetainPtr scrollView = this->scrollView();
         if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
             if (!m_scrollViewDelegate)
                 m_scrollViewDelegate = adoptNS([[WKScrollingNodeScrollViewDelegate alloc] initWithScrollingTreeNodeDelegate:*this]);
 
-            scrollView.scrollsToTop = NO;
-            scrollView.delegate = m_scrollViewDelegate.get();
-            scrollView.baseScrollViewDelegate = m_scrollViewDelegate.get();
+            scrollView.get().scrollsToTop = NO;
+            scrollView.get().delegate = m_scrollViewDelegate.get();
+            scrollView.get().baseScrollViewDelegate = m_scrollViewDelegate.get();
 
 #if HAVE(UISCROLLVIEW_DECELERATION_TRACKING_BEHAVIOR)
             if ([scrollView respondsToSelector:@selector(_setDecelerationTrackingBehavior:)])
@@ -350,12 +350,12 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
 
         bool recomputeInsets = scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize);
         if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ReachableContentsSize)) {
-            scrollView.contentSize = scrollingStateNode.reachableContentsSize();
+            scrollView.get().contentSize = scrollingStateNode.reachableContentsSize();
             recomputeInsets = true;
         }
         if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
             auto params = scrollingStateNode.scrollableAreaParameters();
-            updateScrollViewForOverscrollBehavior(scrollView, params.horizontalOverscrollBehavior, params.verticalOverscrollBehavior, AllowOverscrollToPreventScrollPropagation::Yes);
+            updateScrollViewForOverscrollBehavior(scrollView.get(), params.horizontalOverscrollBehavior, params.verticalOverscrollBehavior, AllowOverscrollToPreventScrollPropagation::Yes);
         }
         if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollOrigin))
             recomputeInsets = true;
@@ -369,7 +369,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
             if (scrollOrigin().y())
                 insets.top = reachableContentsSize().height() - totalContentsSize().height();
 
-            scrollView.contentInset = insets;
+            scrollView.get().contentInset = insets;
         }
         END_BLOCK_OBJC_EXCEPTIONS
     }
@@ -384,7 +384,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
 
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollableAreaParams)) {
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        UIScrollView *scrollView = this->scrollView();
+        RetainPtr scrollView = this->scrollView();
 
         [scrollView setShowsHorizontalScrollIndicator:!(scrollingNode->horizontalNativeScrollbarVisibility() == NativeScrollbarVisibility::HiddenByStyle)];
         [scrollView setShowsVerticalScrollIndicator:!(scrollingNode->verticalNativeScrollbarVisibility() == NativeScrollbarVisibility::HiddenByStyle)];
@@ -402,7 +402,7 @@ void ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren(const Scrol
         auto scrollbarWidth = scrollingStateNode.scrollbarWidth();
 
         BEGIN_BLOCK_OBJC_EXCEPTIONS
-        UIScrollView *scrollView = this->scrollView();
+        RetainPtr scrollView = this->scrollView();
 
         [scrollView setShowsHorizontalScrollIndicator:(scrollbarWidth != ScrollbarWidth::None && scrollingNode->horizontalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle)];
         [scrollView setShowsVerticalScrollIndicator:(scrollbarWidth != ScrollbarWidth::None && scrollingNode->horizontalNativeScrollbarVisibility() != NativeScrollbarVisibility::HiddenByStyle)];

--- a/Source/WebKit/UIProcess/WKImagePreviewViewController.mm
+++ b/Source/WebKit/UIProcess/WKImagePreviewViewController.mm
@@ -99,12 +99,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 {
     NSMutableArray<UIPreviewAction *> *previewActions = [NSMutableArray array];
     for (_WKElementAction *imageAction in _imageActions.get()) {
-        UIPreviewAction *previewAction = [UIPreviewAction actionWithTitle:imageAction.title style:UIPreviewActionStyleDefault handler:^(UIPreviewAction *action, UIViewController *previewViewController) {
+        RetainPtr previewAction = [UIPreviewAction actionWithTitle:imageAction.title style:UIPreviewActionStyleDefault handler:^(UIPreviewAction *action, UIViewController *previewViewController) {
             [imageAction runActionWithElementInfo:_activatedElementInfo.get()];
         }];
-        previewAction.image = [_WKElementAction imageForElementActionType:imageAction.type];
+        previewAction.get().image = [_WKElementAction imageForElementActionType:imageAction.type];
 
-        [previewActions addObject:previewAction];
+        [previewActions addObject:previewAction.get()];
     }
 
     return previewActions;

--- a/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
+++ b/Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm
@@ -189,27 +189,27 @@
     if (!self.pageCount)
         return;
 
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextSaveGState(context);
+    RetainPtr context = UIGraphicsGetCurrentContext();
+    CGContextSaveGState(context.get());
 
-    CGImageRef documentImage = _printPreviewImage.get();
+    RetainPtr documentImage = _printPreviewImage.get();
 
-    CGFloat pageImageWidth = CGImageGetWidth(documentImage);
-    CGFloat pageImageHeight = CGImageGetHeight(documentImage) / self.pageCount;
+    CGFloat pageImageWidth = CGImageGetWidth(documentImage.get());
+    CGFloat pageImageHeight = CGImageGetHeight(documentImage.get()) / self.pageCount;
 
     if (!pageImageWidth || !pageImageHeight) {
-        CGContextRestoreGState(context);
+        CGContextRestoreGState(context.get());
         return;
     }
 
-    RetainPtr pageImage = adoptCF(CGImageCreateWithImageInRect(documentImage, CGRectMake(0, pageIndex * pageImageHeight, pageImageWidth, pageImageHeight)));
+    RetainPtr pageImage = adoptCF(CGImageCreateWithImageInRect(documentImage.get(), CGRectMake(0, pageIndex * pageImageHeight, pageImageWidth, pageImageHeight)));
 
-    CGContextTranslateCTM(context, CGRectGetMinX(rect), CGRectGetMaxY(rect));
-    CGContextScaleCTM(context, 1, -1);
-    CGContextScaleCTM(context, CGRectGetWidth(rect) / pageImageWidth, CGRectGetHeight(rect) / pageImageHeight);
-    CGContextDrawImage(context, CGRectMake(0, 0, pageImageWidth, pageImageHeight), pageImage.get());
+    CGContextTranslateCTM(context.get(), CGRectGetMinX(rect), CGRectGetMaxY(rect));
+    CGContextScaleCTM(context.get(), 1, -1);
+    CGContextScaleCTM(context.get(), CGRectGetWidth(rect) / pageImageWidth, CGRectGetHeight(rect) / pageImageHeight);
+    CGContextDrawImage(context.get(), CGRectMake(0, 0, pageImageWidth, pageImageHeight), pageImage.get());
 
-    CGContextRestoreGState(context);
+    CGContextRestoreGState(context.get());
 }
 
 - (void)_drawInRectUsingPDF:(CGRect)rect forPageAtIndex:(NSInteger)pageIndex
@@ -226,20 +226,20 @@
     if (offsetFromStartPage < 0)
         return;
 
-    CGPDFPageRef page = CGPDFDocumentGetPage(printedDocument.get(), offsetFromStartPage + 1);
+    RetainPtr page = CGPDFDocumentGetPage(printedDocument.get(), offsetFromStartPage + 1);
     if (!page)
         return;
 
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextSaveGState(context);
+    RetainPtr context = UIGraphicsGetCurrentContext();
+    CGContextSaveGState(context.get());
 
-    CGContextTranslateCTM(context, CGRectGetMinX(rect), CGRectGetMaxY(rect));
-    CGContextScaleCTM(context, 1, -1);
-    CGContextConcatCTM(context, CGPDFPageGetDrawingTransform(page, kCGPDFCropBox, CGRectMake(0, 0, CGRectGetWidth(rect), CGRectGetHeight(rect)), 0, true));
-    CGContextClipToRect(context, CGPDFPageGetBoxRect(page, kCGPDFCropBox));
-    CGContextDrawPDFPage(context, page);
+    CGContextTranslateCTM(context.get(), CGRectGetMinX(rect), CGRectGetMaxY(rect));
+    CGContextScaleCTM(context.get(), 1, -1);
+    CGContextConcatCTM(context.get(), CGPDFPageGetDrawingTransform(page.get(), kCGPDFCropBox, CGRectMake(0, 0, CGRectGetWidth(rect), CGRectGetHeight(rect)), 0, true));
+    CGContextClipToRect(context.get(), CGPDFPageGetBoxRect(page.get(), kCGPDFCropBox));
+    CGContextDrawPDFPage(context.get(), page.get());
 
-    CGContextRestoreGState(context);
+    CGContextRestoreGState(context.get());
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -231,7 +231,7 @@ void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, CG
     for (size_t i = 0; i < placeholderRects.size(); ++i) {
         UIDragItem *item = [items objectAtIndex:i];
         auto& placeholderRect = placeholderRects[i];
-        auto defaultPreview = defaultDropPreview(item);
+        RetainPtr defaultPreview = defaultDropPreview(item);
         auto defaultPreviewSize = [defaultPreview size];
         if (!defaultPreview || defaultPreviewSize.width <= 0 || defaultPreviewSize.height <= 0 || placeholderRect.isEmpty())
             continue;
@@ -396,12 +396,12 @@ void DragDropInteractionState::updatePreviewsForActiveDragSources()
         if (!canUpdatePreviewForActiveDragSource(source))
             continue;
 
-        UIDragItem *dragItem = dragItemMatchingIdentifier(m_dragSession.get(), source.itemIdentifier);
+        RetainPtr dragItem = dragItemMatchingIdentifier(m_dragSession.get(), source.itemIdentifier);
         if (!dragItem)
             continue;
 
         if (source.action.contains(DragSourceAction::Link)) {
-            dragItem.previewProvider = [title = source.linkTitle.createNSString(), url = source.linkURL.createNSURL()] () -> UIDragPreview * {
+            dragItem.get().previewProvider = [title = source.linkTitle.createNSString(), url = source.linkURL.createNSURL()] () -> UIDragPreview * {
                 RetainPtr preview = [UIDragPreview previewForURL:url.get() title:title.get()];
 #if PLATFORM(VISION)
                 // FIXME: This is a slightly unfortunate since we end up copying the preview parameters,
@@ -419,7 +419,7 @@ void DragDropInteractionState::updatePreviewsForActiveDragSources()
         }
         else if (source.action.contains(DragSourceAction::Color)) {
             if (auto* draggedImage = std::get_if<RetainPtr<UIImage>>(&source.dragPreviewContent)) {
-                dragItem.previewProvider = [image = *draggedImage] {
+                dragItem.get().previewProvider = [image = *draggedImage] {
                     RetainPtr imageView = adoptNS([[UIImageView alloc] initWithImage:image.get()]);
                     RetainPtr parameters = adoptNS([[UIDragPreviewParameters alloc] initWithTextLineRects:@[ [NSValue valueWithCGRect:[imageView bounds]] ]]);
                     return adoptNS([[UIDragPreview alloc] initWithView:imageView.get() parameters:parameters.get()]).autorelease();

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -137,8 +137,8 @@ void PageClientImpl::requestScroll(const FloatPoint& scrollPosition, const IntPo
 
 WebCore::FloatPoint PageClientImpl::viewScrollPosition()
 {
-    if (UIScrollView *scroller = [contentView() _scroller])
-        return scroller.contentOffset;
+    if (RetainPtr scroller = [contentView() _scroller])
+        return scroller.get().contentOffset;
 
     return { };
 }
@@ -412,8 +412,8 @@ void PageClientImpl::handleSmartMagnificationInformationForPotentialTap(WebKit::
 
 double PageClientImpl::minimumZoomScale() const
 {
-    if (UIScrollView *scroller = [webView() scrollView])
-        return scroller.minimumZoomScale;
+    if (RetainPtr scroller = [webView() scrollView])
+        return scroller.get().minimumZoomScale;
 
     return 1;
 }
@@ -443,7 +443,7 @@ void PageClientImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, Und
     auto actionName = command->label();
     auto commandObjC = adoptNS([[WKEditCommand alloc] initWithWebEditCommandProxy:WTF::move(command)]);
     
-    NSUndoManager *undoManager = [contentView() undoManagerForWebView];
+    RetainPtr undoManager = [contentView() undoManagerForWebView];
     [undoManager registerUndoWithTarget:m_undoTarget.get() selector:((undoOrRedo == UndoOrRedo::Undo) ? @selector(undoEditing:) : @selector(redoEditing:)) object:commandObjC.get()];
     if (!actionName.isEmpty())
         [undoManager setActionName:actionName.createNSString().get()];

--- a/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
+++ b/Source/WebKit/UIProcess/ios/UIKitUtilities.mm
@@ -259,11 +259,11 @@ static UIAxis axesForDelta(WebCore::FloatSize delta)
 
 - (UIViewController *)_wk_viewControllerForFullScreenPresentation
 {
-    auto controller = self.window.rootViewController;
-    UIViewController *nextPresentedController = nil;
-    while ((nextPresentedController = controller.presentedViewController))
-        controller = nextPresentedController;
-    return controller.viewIfLoaded.window == self.window ? controller : nil;
+    RetainPtr<UIViewController> controller = self.window.rootViewController;
+    RetainPtr<UIViewController> nextPresentedController;
+    while ((nextPresentedController = controller.get().presentedViewController))
+        controller = WTF::move(nextPresentedController);
+    return controller.get().viewIfLoaded.window == self.window ? controller.autorelease() : nil;
 }
 
 - (WebCore::FloatQuad)_wk_convertQuad:(const WebCore::FloatQuad&)quad toCoordinateSpace:(id<UICoordinateSpace>)destination

--- a/Source/WebKit/UIProcess/ios/WKActionSheet.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheet.mm
@@ -111,19 +111,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!view)
         return NO;
 
-    UIViewController *presentedViewController = _presentedViewControllerWhileRotating.get() ? _presentedViewControllerWhileRotating.get() : self;
-    presentedViewController.modalPresentationStyle = UIModalPresentationPopover;
+    RetainPtr presentedViewController = _presentedViewControllerWhileRotating.get() ? _presentedViewControllerWhileRotating.get() : self;
+    presentedViewController.get().modalPresentationStyle = UIModalPresentationPopover;
 
-    UIPopoverPresentationController *presentationController = presentedViewController.popoverPresentationController;
-    presentationController.sourceView = view;
-    presentationController.sourceRect = presentationRect;
-    presentationController.permittedArrowDirections = _arrowDirections;
+    RetainPtr<UIPopoverPresentationController> presentationController = presentedViewController.get().popoverPresentationController;
+    presentationController.get().sourceView = view;
+    presentationController.get().sourceRect = presentationRect;
+    presentationController.get().permittedArrowDirections = _arrowDirections;
 
     if (_popoverPresentationControllerDelegateWhileRotating)
-        presentationController.delegate = _popoverPresentationControllerDelegateWhileRotating.get();
+        presentationController.get().delegate = _popoverPresentationControllerDelegateWhileRotating.get();
 
     _currentPresentingViewController = view._wk_viewControllerForFullScreenPresentation;
-    [_currentPresentingViewController presentViewController:presentedViewController animated:YES completion:nil];
+    [_currentPresentingViewController presentViewController:presentedViewController.get() animated:YES completion:nil];
 
     return YES;
 }
@@ -210,7 +210,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)updateSheetPosition
 {
-    UIViewController *presentedViewController = _presentedViewControllerWhileRotating.get() ? _presentedViewControllerWhileRotating.get() : self;
+    RetainPtr presentedViewController = _presentedViewControllerWhileRotating.get() ? _presentedViewControllerWhileRotating.get() : self;
 
     // There are two asynchronous events which might trigger this call, and we have to wait for both of them before doing something.
     // - One runloop iteration after rotation (to let the Web content re-layout, see below)

--- a/Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm
@@ -46,8 +46,8 @@
 {
     [super touchesBegan:touches withEvent:event];
 
-    if (auto scrollView = WebKit::scrollViewForTouches(touches))
-        _lastTouchedScrollView = scrollView;
+    if (RetainPtr scrollView = WebKit::scrollViewForTouches(touches))
+        _lastTouchedScrollView = scrollView.get();
 }
 
 - (UIScrollView *)lastTouchedScrollView

--- a/Source/WebKit/UIProcess/ios/WKImageAnalysisGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKImageAnalysisGestureRecognizer.mm
@@ -65,8 +65,8 @@
 {
     [super touchesBegan:touches withEvent:event];
 
-    if (auto scrollView = WebKit::scrollViewForTouches(touches))
-        _lastTouchedScrollView = scrollView;
+    if (RetainPtr scrollView = WebKit::scrollViewForTouches(touches))
+        _lastTouchedScrollView = scrollView.get();
 
     [self beginAfterExceedingForceThresholdIfNeeded:touches];
 }

--- a/Source/WebKit/UIProcess/ios/WKPasswordView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPasswordView.mm
@@ -125,9 +125,9 @@ const CGFloat passwordEntryFieldPadding = 10;
     [[_passwordView passwordField] setText:@""];
     auto alert = WebKit::createUIAlertController(WEB_UI_STRING("The document could not be opened with that password.", "document password failure alert message").createNSString().get(), @"");
 
-    UIAlertAction *defaultAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("OK", "OK (password failure alert)", "OK button label in document password failure alert").createNSString().get() style:UIAlertActionStyleDefault handler:[](UIAlertAction *) { }];
+    RetainPtr defaultAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("OK", "OK (password failure alert)", "OK button label in document password failure alert").createNSString().get() style:UIAlertActionStyleDefault handler:[](UIAlertAction *) { }];
 
-    [alert addAction:defaultAction];
+    [alert addAction:defaultAction.get()];
 
     [self.window.rootViewController presentViewController:alert.get() animated:YES completion:nil];
 }

--- a/Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.mm
@@ -43,8 +43,8 @@
 {
     [super touchesBegan:touches withEvent:event];
 
-    if (auto scrollView = WebKit::scrollViewForTouches(touches))
-        _lastTouchedScrollView = scrollView;
+    if (RetainPtr scrollView = WebKit::scrollViewForTouches(touches))
+        _lastTouchedScrollView = scrollView.get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
@@ -84,8 +84,8 @@
     if (!_supportingTouchEventsGestureRecognizer)
         return;
 
-    NSMapTable<NSNumber *, UITouch *> *activeTouches = [_supportingTouchEventsGestureRecognizer activeTouchesByIdentifier];
-    for (NSNumber *touchIdentifier in activeTouches) {
+    RetainPtr activeTouches = [_supportingTouchEventsGestureRecognizer activeTouchesByIdentifier];
+    for (NSNumber *touchIdentifier in activeTouches.get()) {
         UITouch *touch = [activeTouches objectForKey:touchIdentifier];
         if ([touch.gestureRecognizers containsObject:self]) {
             _lastActiveTouchIdentifier = touchIdentifier;

--- a/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
+++ b/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
@@ -167,25 +167,25 @@
         }
     }
 
-    auto context = UIGraphicsGetCurrentContext();
-    CGContextSaveGState(context);
+    RetainPtr context = UIGraphicsGetCurrentContext();
+    CGContextSaveGState(context.get());
 
     if (!_innerQuads.isEmpty())
-        CGContextSetLineWidth(context, 4 * _minimumCornerRadius);
+        CGContextSetLineWidth(context.get(), 4 * _minimumCornerRadius);
 
-    CGContextSetLineJoin(context, kCGLineJoinRound);
+    CGContextSetLineJoin(context.get(), kCGLineJoinRound);
 
     auto alpha = CGColorGetAlpha([_color CGColor]);
 
     [[_color colorWithAlphaComponent:1] set];
 
-    CGContextSetAlpha(context, alpha);
-    CGContextBeginTransparencyLayer(context, nil);
-    CGContextAddPath(context, path.CGPath);
-    CGContextDrawPath(context, kCGPathFillStroke);
-    CGContextEndTransparencyLayer(context);
+    CGContextSetAlpha(context.get(), alpha);
+    CGContextBeginTransparencyLayer(context.get(), nil);
+    CGContextAddPath(context.get(), path.CGPath);
+    CGContextDrawPath(context.get(), kCGPathFillStroke);
+    CGContextEndTransparencyLayer(context.get());
 
-    CGContextRestoreGState(context);
+    CGContextRestoreGState(context.get());
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event

--- a/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm
@@ -307,7 +307,7 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
 
     for (UITouch *touch in touches) {
         // Get the identifier of this touch. Or create one if one did not exist.
-        auto associatedIdentifier = dynamic_objc_cast<NSNumber>(objc_getAssociatedObject(touch, &associatedTouchIdentifierKey));
+        RetainPtr associatedIdentifier = dynamic_objc_cast<NSNumber>(objc_getAssociatedObject(touch, &associatedTouchIdentifierKey));
 
         // Create a new identifier for trackpad events in the Begin phase regardless, because the UITouch
         // instance persists between trackpad clicks, and there is existing web content that does not expect subsequent
@@ -319,10 +319,10 @@ static CGFloat rollAngleOrDefault(UITouch *touch, bool shouldReadRollAngle)
 
         if (!associatedIdentifier) {
             associatedIdentifier = [NSNumber numberWithUnsignedInt:nextTouchIdentifier()];
-            objc_setAssociatedObject(touch, &associatedTouchIdentifierKey, associatedIdentifier, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            objc_setAssociatedObject(touch, &associatedTouchIdentifierKey, associatedIdentifier.get(), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         }
 
-        [_activeTouchesByIdentifier setObject:touch forKey:associatedIdentifier];
+        [_activeTouchesByIdentifier setObject:touch forKey:associatedIdentifier.get()];
 
         // iPhone WebKit works as if it is full screen. Therefore Web coords are Global coords.
         auto& touchPoint = _lastTouchEvent.touchPoints[touchIndex];

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
@@ -96,7 +96,7 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
 
     RetainPtr alert = WebKit::createUIAlertController(WEB_UI_NSSTRING(@"View 3D Object?", "View 3D Object?"), WEB_UI_NSSTRING(@"You can see a preview of this object before viewing in 3D.", "You can see a preview of this object before viewing in 3D."));
 
-    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"View 3D Object", @"View 3D Object (QuickLook Preview)", "Allow displaying QuickLook Preview of 3D object") style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKUSDPreviewView>(self), completionHandler = makeBlockPtr(completionHandler)](UIAlertAction *) mutable {
+    RetainPtr allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"View 3D Object", @"View 3D Object (QuickLook Preview)", "Allow displaying QuickLook Preview of 3D object") style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKUSDPreviewView>(self), completionHandler = makeBlockPtr(completionHandler)](UIAlertAction *) mutable {
         RetainPtr strongSelf = weakSelf.get();
         if (!strongSelf) {
             completionHandler();
@@ -126,12 +126,12 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
         completionHandler();
     }];
 
-    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"Cancel", @"Cancel (QuickLook Preview)", "Cancel displaying QuickLook Preview of 3D object") style:UIAlertActionStyleCancel handler:[completionHandler = makeBlockPtr(completionHandler)](UIAlertAction *) {
+    RetainPtr doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"Cancel", @"Cancel (QuickLook Preview)", "Cancel displaying QuickLook Preview of 3D object") style:UIAlertActionStyleCancel handler:[completionHandler = makeBlockPtr(completionHandler)](UIAlertAction *) {
         completionHandler();
     }];
 
-    [alert addAction:doNotAllowAction];
-    [alert addAction:allowAction];
+    [alert addAction:doNotAllowAction.get()];
+    [alert addAction:allowAction.get()];
 
     RefPtr page = _webView.get()->_page;
     UIViewController *presentingViewController = page->uiClient().presentingViewController();

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -190,17 +190,17 @@ struct PermissionRequest {
         RetainPtr denyActionTitle = WEB_UI_STRING_KEY("Don’t Allow", "Don’t Allow (website location dialog)", "Action denying a webpage access to the user’s location.").createNSString();
 
         RetainPtr alert = WebKit::createUIAlertController(title.get(), message.get());
-        UIAlertAction *denyAction = [UIAlertAction actionWithTitle:denyActionTitle.get() style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
+        RetainPtr denyAction = [UIAlertAction actionWithTitle:denyActionTitle.get() style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
             if (auto strongSelf = weakSelf.get())
                 [strongSelf _finishActiveChallenge:NO];
         }];
-        UIAlertAction *allowAction = [UIAlertAction actionWithTitle:allowActionTitle.get() style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
+        RetainPtr allowAction = [UIAlertAction actionWithTitle:allowActionTitle.get() style:UIAlertActionStyleDefault handler:[weakSelf = WeakObjCPtr<WKWebGeolocationPolicyDecider>(self)](UIAlertAction *) mutable {
             if (auto strongSelf = weakSelf.get())
                 [strongSelf _finishActiveChallenge:YES];
         }];
 
-        [alert addAction:denyAction];
-        [alert addAction:allowAction];
+        [alert addAction:denyAction.get()];
+        [alert addAction:allowAction.get()];
 
 #if PLATFORM(VISION)
         [_activeChallenge->view _page]->dispatchWillPresentModalUI();

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -538,16 +538,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     NSMutableArray *suggestions = [NSMutableArray arrayWithCapacity:self.suggestionsCount];
 
     for (NSInteger index = 0; index < self.suggestionsCount; index++) {
-        UIAction *suggestionAction = [UIAction actionWithTitle:[self suggestionAtIndex:index].createNSString().get() image:nil identifier:nil handler:[weakSelf = WeakObjCPtr<WKDataListSuggestionsDropdown>(self), index] (UIAction *) {
+        RetainPtr suggestionAction = [UIAction actionWithTitle:[self suggestionAtIndex:index].createNSString().get() image:nil identifier:nil handler:[weakSelf = WeakObjCPtr<WKDataListSuggestionsDropdown>(self), index] (UIAction *) {
             auto strongSelf = weakSelf.get();
             if (!strongSelf)
                 return;
 
             [strongSelf didSelectOptionAtIndex:index];
         }];
-        suggestionAction.subtitle = [self suggestionLabelAtIndex:index].createNSString().get();
+        suggestionAction.get().subtitle = [self suggestionLabelAtIndex:index].createNSString().get();
 
-        [suggestions addObject:suggestionAction];
+        [suggestions addObject:suggestionAction.get()];
     }
 
     _suggestionsMenuElements = adoptNS([suggestions copy]);

--- a/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm
@@ -101,13 +101,13 @@ static const UIMenuIdentifier WKCaptionStyleMenuSystemSettingsIdentifier = @"WKC
             if (auto strongSelf = weakSelf.get())
                 [strongSelf profileActionSelected:profileID];
         });
-        UIAction *profileAction = [UIAction actionWithTitle:title.createNSString().get() image:nil identifier:profileID.createNSString().get() handler:profileSelectedHandler.get()];
-        profileAction.attributes = UIMenuElementAttributesKeepsMenuPresented;
+        RetainPtr profileAction = [UIAction actionWithTitle:title.createNSString().get() image:nil identifier:profileID.createNSString().get() handler:profileSelectedHandler.get()];
+        profileAction.get().attributes = UIMenuElementAttributesKeepsMenuPresented;
 
         if ([profileID.createNSString().autorelease() isEqualToString:self.savedActiveProfileID])
-            profileAction.state = UIMenuElementStateOn;
+            profileAction.get().state = UIMenuElementStateOn;
 
-        [profileElements addObject:profileAction];
+        [profileElements addObject:profileAction.get()];
     }
     auto *profileGroup = [UIMenu menuWithTitle:@"" image:nil identifier:WKCaptionStyleMenuProfileGroupIdentifier options:UIMenuOptionsDisplayInline children:profileElements];
 
@@ -194,12 +194,12 @@ static bool menuHasMenuAncestor(UIMenu *targetMenu, UIMenu *ancestorMenu)
 - (void)profileActionSelected:(const WTF::String&)profileID
 {
     for (UIMenuElement *childMenu in [_menu children]) {
-        auto *childAction = dynamic_objc_cast<UIAction>(childMenu);
+        RetainPtr childAction = dynamic_objc_cast<UIAction>(childMenu);
         if (!childAction)
             continue;
 
-        String childActionIdentifier = childAction.identifier;
-        childAction.state = profileID == childActionIdentifier ? UIMenuElementStateOn : UIMenuElementStateOff;
+        String childActionIdentifier = childAction.get().identifier;
+        childAction.get().state = profileID == childActionIdentifier ? UIMenuElementStateOn : UIMenuElementStateOff;
     }
 
     self.savedActiveProfileID = profileID.createNSString().autorelease();

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -484,7 +484,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     for (NSURL *fileURL in fileURLs)
         filenames.append(String::fromUTF8(fileURL.fileSystemRepresentation));
 
-    NSData *png = UIImagePNGRepresentation(iconImage);
+    RetainPtr png = UIImagePNGRepresentation(iconImage);
     RefPtr iconImageDataRef = adoptRef(WebKit::toImpl(WKDataCreate(static_cast<const unsigned char*>([png bytes]), [png length])));
 
     protect(_listener)->chooseFiles(filenames, displayString, iconImageDataRef.get());
@@ -649,18 +649,18 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
 
 - (NSArray<NSString *> *)_mediaTypesForPickerSourceType:(UIImagePickerControllerSourceType)sourceType
 {
-    NSArray<NSString *> *availableMediaTypeUTIs = [UIImagePickerController availableMediaTypesForSourceType:sourceType];
-    NSSet<NSString *> *acceptedMediaTypeUTIs = _acceptedUTIs.get();
-    if (acceptedMediaTypeUTIs.count) {
-        NSMutableArray<NSString *> *mediaTypes = [NSMutableArray array];
-        for (NSString *availableMediaTypeUTI in availableMediaTypeUTIs) {
+    RetainPtr availableMediaTypeUTIs = [UIImagePickerController availableMediaTypesForSourceType:sourceType];
+    RetainPtr acceptedMediaTypeUTIs = _acceptedUTIs.get();
+    if (acceptedMediaTypeUTIs.get().count) {
+        RetainPtr<NSMutableArray<NSString *>> mediaTypes = [NSMutableArray array];
+        for (NSString *availableMediaTypeUTI in availableMediaTypeUTIs.get()) {
             if ([acceptedMediaTypeUTIs containsObject:availableMediaTypeUTI])
                 [mediaTypes addObject:availableMediaTypeUTI];
             else {
-                UTType *availableMediaType = [UTType typeWithIdentifier:availableMediaTypeUTI];
-                for (NSString *acceptedMediaTypeUTI in acceptedMediaTypeUTIs) {
-                    UTType *acceptedMediaType = [UTType typeWithIdentifier:acceptedMediaTypeUTI];
-                    if ([acceptedMediaType conformsToType:availableMediaType]) {
+                RetainPtr availableMediaType = [UTType typeWithIdentifier:availableMediaTypeUTI];
+                for (NSString *acceptedMediaTypeUTI in acceptedMediaTypeUTIs.get()) {
+                    RetainPtr acceptedMediaType = [UTType typeWithIdentifier:acceptedMediaTypeUTI];
+                    if ([acceptedMediaType conformsToType:availableMediaType.get()]) {
                         [mediaTypes addObject:availableMediaTypeUTI];
                         break;
                     }
@@ -668,13 +668,13 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
             }
         }
 
-        ASSERT(mediaTypes.count);
-        if (mediaTypes.count)
-            return mediaTypes;
+        ASSERT(mediaTypes.get().count);
+        if (mediaTypes.get().count)
+            return mediaTypes.autorelease();
     }
 
     // Fallback to every supported media type if there is no filter.
-    return availableMediaTypeUTIs;
+    return availableMediaTypeUTIs.autorelease();
 }
 
 #if HAVE(PHOTOS_UI)
@@ -740,12 +740,12 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
             return nil;
 
         strongSelf->_isPresentingSubMenu = NO;
-        UIAction *chooseAction = [UIAction actionWithTitle:[strongSelf _chooseFilesButtonLabel] image:[UIImage systemImageNamed:@"folder"] identifier:@"choose" handler:^(__kindof UIAction *action) {
+        RetainPtr chooseAction = [UIAction actionWithTitle:[strongSelf _chooseFilesButtonLabel] image:[UIImage systemImageNamed:@"folder"] identifier:@"choose" handler:^(__kindof UIAction *action) {
             strongSelf->_isPresentingSubMenu = YES;
             [strongSelf showFilePickerMenu];
         }];
 
-        UIAction *photoAction = [UIAction actionWithTitle:[strongSelf _photoLibraryButtonLabel] image:[UIImage systemImageNamed:@"photo.on.rectangle"] identifier:@"photo" handler:^(__kindof UIAction *action) {
+        RetainPtr photoAction = [UIAction actionWithTitle:[strongSelf _photoLibraryButtonLabel] image:[UIImage systemImageNamed:@"photo.on.rectangle"] identifier:@"photo" handler:^(__kindof UIAction *action) {
             strongSelf->_isPresentingSubMenu = YES;
             [strongSelf _showPhotoPicker];
         }];
@@ -753,14 +753,14 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
         NSArray *actions;
         if ([UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera]) {
             NSString *cameraString = [strongSelf _cameraButtonLabel];
-            UIAction *cameraAction = [UIAction actionWithTitle:cameraString image:[UIImage systemImageNamed:@"camera"] identifier:@"camera" handler:^(__kindof UIAction *action) {
+            RetainPtr cameraAction = [UIAction actionWithTitle:cameraString image:[UIImage systemImageNamed:@"camera"] identifier:@"camera" handler:^(__kindof UIAction *action) {
                 strongSelf->_usingCamera = YES;
                 strongSelf->_isPresentingSubMenu = YES;
                 [strongSelf _showCamera];
             }];
-            actions = @[photoAction, cameraAction, chooseAction];
+            actions = @[photoAction.get(), cameraAction.get(), chooseAction.get()];
         } else
-            actions = @[photoAction, chooseAction];
+            actions = @[photoAction.get(), chooseAction.get()];
 
         return [UIMenu menuWithTitle:@"" children:actions];
     };

--- a/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm
@@ -117,11 +117,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self updateColorPickerState];
     [self configurePresentation];
 
-    auto presentingViewController = _view._wk_viewControllerForFullScreenPresentation;
+    RetainPtr<UIViewController> presentingViewController = _view._wk_viewControllerForFullScreenPresentation;
 #if PLATFORM(VISION)
     [_view page]->dispatchWillPresentModalUI();
 #endif
-    [presentingViewController presentViewController:_colorPickerViewController.get() animated:YES completion:nil];
+    [presentingViewController.get() presentViewController:_colorPickerViewController.get() animated:YES completion:nil];
 }
 
 - (void)controlUpdateEditing

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -585,9 +585,9 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 - (UIMenu *)createMenu
 {
     if (!_view.focusedSelectElementOptions.size()) {
-        UIAction *emptyAction = [UIAction actionWithTitle:WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list").createNSString().get() image:nil identifier:nil handler:^(__kindof UIAction *action) { }];
-        emptyAction.attributes = UIMenuElementAttributesDisabled;
-        return [UIMenu menuWithTitle:@"" children:@[emptyAction]];
+        RetainPtr emptyAction = [UIAction actionWithTitle:WEB_UI_STRING_KEY("No Options", "No Options Select Popover", "Empty select list").createNSString().get() image:nil identifier:nil handler:^(__kindof UIAction *action) { }];
+        emptyAction.get().attributes = UIMenuElementAttributesDisabled;
+        return [UIMenu menuWithTitle:@"" children:@[emptyAction.get()]];
     }
 
     NSMutableArray *items = [NSMutableArray array];
@@ -629,17 +629,17 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 
 - (UIAction *)actionForOptionItem:(const OptionItem&)option withIndex:(NSInteger)optionIndex
 {
-    UIAction *optionAction = [UIAction actionWithTitle:option.text.createNSString().get() image:nil identifier:nil handler:^(__kindof UIAction *action) {
+    RetainPtr optionAction = [UIAction actionWithTitle:option.text.createNSString().get() image:nil identifier:nil handler:^(__kindof UIAction *action) {
         [self didSelectOptionIndex:optionIndex];
     }];
 
     if (option.disabled)
-        optionAction.attributes = UIMenuElementAttributesDisabled;
+        optionAction.get().attributes = UIMenuElementAttributesDisabled;
 
     if (option.isSelected)
-        optionAction.state = UIMenuElementStateOn;
+        optionAction.get().state = UIMenuElementStateOn;
 
-    return optionAction;
+    return optionAction.autorelease();
 }
 
 - (UIAction *)actionForOptionIndex:(NSInteger)optionIndex
@@ -759,12 +759,12 @@ static constexpr auto removeLineLimitForChildrenMenuOption = static_cast<UIMenuO
 #if USE(UICONTEXTMENU)
     NSMutableArray<NSString *> *itemTitles = [NSMutableArray array];
     for (UIMenuElement *menuElement in [_selectMenu children]) {
-        if (auto *action = dynamic_objc_cast<UIAction>(menuElement)) {
-            [itemTitles addObject:action.title];
+        if (RetainPtr action = dynamic_objc_cast<UIAction>(menuElement)) {
+            [itemTitles addObject:action.get().title];
             continue;
         }
 
-        if (auto *menu = dynamic_objc_cast<UIMenu>(menuElement)) {
+        if (RetainPtr menu = dynamic_objc_cast<UIMenu>(menuElement)) {
             for (UIMenuElement *groupedMenuElement in [menu children])
                 [itemTitles addObject:groupedMenuElement.title];
         }
@@ -1083,12 +1083,12 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     for (NSInteger i = 0; i < rowCount; i++)
         [indexPaths addObject:[NSIndexPath indexPathForRow:i inSection:section]];
 
-    NSNumber *object = @(section);
-    if ([_collapsedSections containsObject:object]) {
-        [_collapsedSections removeObject:object];
+    RetainPtr object = @(section);
+    if ([_collapsedSections containsObject:object.get()]) {
+        [_collapsedSections removeObject:object.get()];
         [self.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationFade];
     } else {
-        [_collapsedSections addObject:object];
+        [_collapsedSections addObject:object.get()];
         [self.tableView deleteRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationFade];
     }
 }
@@ -1262,10 +1262,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         UIPresentationController *presentationController = [_navigationController presentationController];
         presentationController.delegate = self;
 
-        if (auto sheetPresentationController = dynamic_objc_cast<UISheetPresentationController>(presentationController)) {
-            sheetPresentationController.detents = @[UISheetPresentationControllerDetent.mediumDetent, UISheetPresentationControllerDetent.largeDetent];
-            sheetPresentationController.widthFollowsPreferredContentSizeWhenEdgeAttached = YES;
-            sheetPresentationController.prefersEdgeAttachedInCompactHeight = YES;
+        if (RetainPtr sheetPresentationController = dynamic_objc_cast<UISheetPresentationController>(presentationController)) {
+            sheetPresentationController.get().detents = @[UISheetPresentationControllerDetent.mediumDetent, UISheetPresentationControllerDetent.largeDetent];
+            sheetPresentationController.get().widthFollowsPreferredContentSizeWhenEdgeAttached = YES;
+            sheetPresentationController.get().prefersEdgeAttachedInCompactHeight = YES;
         }
     } else {
         [_navigationController setModalPresentationStyle:UIModalPresentationPopover];
@@ -1291,11 +1291,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [_view startRelinquishingFirstResponderToFocusedElement];
 
     [self configurePresentation];
-    auto presentingViewController = _view._wk_viewControllerForFullScreenPresentation;
+    RetainPtr<UIViewController> presentingViewController = _view._wk_viewControllerForFullScreenPresentation;
 #if PLATFORM(VISION)
     [_view page]->dispatchWillPresentModalUI();
 #endif
-    [presentingViewController presentViewController:_navigationController.get() animated:YES completion:nil];
+    [presentingViewController.get() presentViewController:_navigationController.get() animated:YES completion:nil];
 }
 
 - (void)controlUpdateEditing

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -80,8 +80,8 @@ public:
 
     void rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState> playbackState, double /* playbackRate */, double /* defaultPlaybackRate */) override
     {
-        if (auto *controller = m_parent.getAutoreleased())
-            controller.playing = playbackState.contains(WebCore::PlaybackSessionModel::PlaybackState::Playing);
+        if (RetainPtr controller = m_parent.getAutoreleased())
+            controller.get().playing = playbackState.contains(WebCore::PlaybackSessionModel::PlaybackState::Playing);
     }
 
     void isPictureInPictureSupportedChanged(bool) override
@@ -90,8 +90,8 @@ public:
 
     void pictureInPictureActiveChanged(bool active) override
     {
-        if (auto *controller = m_parent.getAutoreleased())
-            controller.pictureInPictureActive = active;
+        if (RetainPtr controller = m_parent.getAutoreleased())
+            controller.get().pictureInPictureActive = active;
     }
 
     void setInterface(WebCore::PlaybackSessionInterfaceIOS* interface)
@@ -1146,7 +1146,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         page->suspendActiveDOMObjectsAndAnimations();
     }
 
-    UIAlertAction* exitAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Exit Full Screen", "Exit Full Screen (Element Full Screen)", "Full Screen Deceptive Website Exit Action").createNSString().get() style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
+    RetainPtr exitAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Exit Full Screen", "Exit Full Screen (Element Full Screen)", "Full Screen Deceptive Website Exit Action").createNSString().get() style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
         [self _cancelAction:action];
         if (RefPtr page = self._webView._page.get()) {
             page->resumeActiveDOMObjectsAndAnimations();
@@ -1154,7 +1154,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     }];
 
-    UIAlertAction* stayAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Stay in Full Screen", "Stay in Full Screen (Element Full Screen)", "Full Screen Deceptive Website Stay Action").createNSString().get() style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+    RetainPtr stayAction = [UIAlertAction actionWithTitle:WEB_UI_STRING_KEY("Stay in Full Screen", "Stay in Full Screen (Element Full Screen)", "Full Screen Deceptive Website Stay Action").createNSString().get() style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
         if (RefPtr page = self._webView._page.get()) {
             page->resumeActiveDOMObjectsAndAnimations();
             page->resumeAllMediaPlayback([] { });
@@ -1162,8 +1162,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         _secheuristic.reset();
     }];
 
-    [alert addAction:exitAction];
-    [alert addAction:stayAction];
+    [alert addAction:exitAction.get()];
+    [alert addAction:stayAction.get()];
     [self presentViewController:alert.get() animated:YES completion:nil];
 }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -985,10 +985,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return completionHandler(false);
         }
 
-        UIWindowScene *windowScene;
-        if (UIWindowScene *presentingWindowScene = viewController.view.window.windowScene) {
+        RetainPtr<UIWindowScene> windowScene;
+        if (RetainPtr<UIWindowScene> presentingWindowScene = viewController.view.window.windowScene) {
             OBJC_ALWAYS_LOG_WITH_SELF(strongSelf, logIdentifier, "using window scene from presenting view controller");
-            windowScene = presentingWindowScene;
+            windowScene = WTF::move(presentingWindowScene);
         } else {
             OBJC_ALWAYS_LOG_WITH_SELF(strongSelf, logIdentifier, "using window scene from web view");
             windowScene = [strongSelf _webView].window.windowScene;
@@ -1000,7 +1000,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             return completionHandler(false);
         }
 
-        [strongSelf _enterFullScreen:mediaDimensions windowScene:windowScene completionHandler:WTF::move(completionHandler)];
+        [strongSelf _enterFullScreen:mediaDimensions windowScene:windowScene.get() completionHandler:WTF::move(completionHandler)];
     });
 }
 
@@ -1828,17 +1828,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     ASSERT(!_EVOrganizationName.get());
     _EVOrganizationNameIsValid = YES;
 
-    SecTrustRef trust = [self _serverTrust];
+    RetainPtr trust = [self _serverTrust];
     if (!trust)
         return nil;
 
-    auto infoDictionary = adoptCF(SecTrustCopyInfo(trust));
+    auto infoDictionary = adoptCF(SecTrustCopyInfo(trust.get()));
     // If SecTrustCopyInfo returned NULL then it's likely that the SecTrustRef has not been evaluated
     // and the only way to get the information we need is to call SecTrustEvaluate ourselves.
     if (!infoDictionary) {
-        if (!SecTrustEvaluateWithError(trust, nullptr))
+        if (!SecTrustEvaluateWithError(trust.get(), nullptr))
             return nil;
-        infoDictionary = adoptCF(SecTrustCopyInfo(trust));
+        infoDictionary = adoptCF(SecTrustCopyInfo(trust.get()));
         if (!infoDictionary)
             return nil;
     }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -757,7 +757,7 @@ void WebProcess::updateProcessName(IsInProcessInitialization isInProcessInitiali
 #if PLATFORM(IOS_FAMILY)
 static NSString *webProcessLoaderAccessibilityBundlePath()
 {
-    NSString *path = (__bridge NSString *)GSSystemRootDirectory();
+    RetainPtr path = (__bridge NSString *)GSSystemRootDirectory();
 #if PLATFORM(MACCATALYST)
     path = [path stringByAppendingPathComponent:@"System/iOSSupport"];
 #endif
@@ -766,7 +766,7 @@ static NSString *webProcessLoaderAccessibilityBundlePath()
 
 static NSString *webProcessAccessibilityBundlePath()
 {
-    NSString *path = (__bridge NSString *)GSSystemRootDirectory();
+    RetainPtr path = (__bridge NSString *)GSSystemRootDirectory();
 #if PLATFORM(MACCATALYST)
     path = [path stringByAppendingPathComponent:@"System/iOSSupport"];
 #endif
@@ -781,20 +781,20 @@ static void registerWithAccessibility()
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    NSString *bundlePath = webProcessLoaderAccessibilityBundlePath();
+    RetainPtr bundlePath = webProcessLoaderAccessibilityBundlePath();
     NSError *error = nil;
-    if (![[NSBundle bundleWithPath:bundlePath] loadAndReturnError:&error])
-        LOG_ERROR("Failed to load accessibility bundle at %@: %@", bundlePath, error);
+    if (![[NSBundle bundleWithPath:bundlePath.get()] loadAndReturnError:&error])
+        LOG_ERROR("Failed to load accessibility bundle at %@: %@", bundlePath.get(), error);
 
     // This code will eagerly start the in-process AX server.
     // This enables us to revoke the Mach bootstrap sandbox extension.
-    NSString *webProcessAXBundlePath = webProcessAccessibilityBundlePath();
-    NSBundle *bundle = [NSBundle bundleWithPath:webProcessAXBundlePath];
+    RetainPtr webProcessAXBundlePath = webProcessAccessibilityBundlePath();
+    RetainPtr bundle = [NSBundle bundleWithPath:webProcessAXBundlePath.get()];
     error = nil;
     if ([bundle loadAndReturnError:&error])
         [[bundle principalClass] safeValueForKey:@"accessibilityInitializeBundle"];
     else
-        LOG_ERROR("Failed to load accessibility bundle at %@: %@", webProcessAXBundlePath, error);
+        LOG_ERROR("Failed to load accessibility bundle at %@: %@", webProcessAXBundlePath.get(), error);
 #endif
 }
 

--- a/Source/WebKit/webpushd/WebClipCache.mm
+++ b/Source/WebKit/webpushd/WebClipCache.mm
@@ -51,11 +51,11 @@ static bool webClipExists(const String& webClipIdentifier)
         return false;
 
     @autoreleasepool {
-        NSString *path = [UIWebClip pathForWebClipWithIdentifier:webClipIdentifier.createNSString().get()];
+        RetainPtr path = [UIWebClip pathForWebClipWithIdentifier:webClipIdentifier.createNSString().get()];
         if (!path)
             return false;
         path = [path stringByAppendingPathComponent:@"Info.plist"];
-        return [[NSFileManager defaultManager] fileExistsAtPath:path];
+        return [[NSFileManager defaultManager] fileExistsAtPath:path.get()];
     }
 }
 
@@ -148,15 +148,15 @@ static RetainPtr<NSArray> loadWebClipCachePropertyList(NSString *path)
             return nil;
         }
 
-        NSArray *entries = (NSArray *)propertyList;
-        for (id entry in entries) {
+        RetainPtr entries = (NSArray *)propertyList;
+        for (id entry in entries.get()) {
             if (![entry isKindOfClass:[NSArray class]] || [entry count] != 3) {
                 RELEASE_LOG_ERROR(Push, "WebClipCache::load failed to deserialize %{public}@: entry isn't an array", path);
                 return nil;
             }
 
-            NSArray *array = (NSArray *)entry;
-            for (id val in array) {
+            RetainPtr array = (NSArray *)entry;
+            for (id val in array.get()) {
                 if (![val isKindOfClass:[NSString class]] || ![val length]) {
                     RELEASE_LOG_ERROR(Push, "WebClipCache::load failed to deserialize %{public}@: value isn't a string", path);
                     return nil;
@@ -164,7 +164,7 @@ static RetainPtr<NSArray> loadWebClipCachePropertyList(NSString *path)
             }
         }
 
-        return entries;
+        return entries.autorelease();
     }
 }
 
@@ -247,11 +247,11 @@ bool WebClipCache::isWebClipVisible(const String& bundleIdentifier, const String
     if (bundleIdentifier == "com.apple.SafariViewService"_s)
         return true;
 
-    UIWebClip *webClip = [UIWebClip webClipWithIdentifier:webClipIdentifier.createNSString().get()];
+    RetainPtr webClip = [UIWebClip webClipWithIdentifier:webClipIdentifier.createNSString().get()];
     if (![webClip respondsToSelector:@selector(trustedClientBundleIdentifiers)])
         return true;
 
-    return [webClip.trustedClientBundleIdentifiers containsObject:bundleIdentifier.createNSString().get()];
+    return [webClip.get().trustedClientBundleIdentifiers containsObject:bundleIdentifier.createNSString().get()];
 }
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -644,13 +644,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
-    NSDictionary *settingsInfo = @{
+    RetainPtr settingsInfo = @{
         pushActionVersionKeySingleton(): currentPushActionVersionSingleton(),
         pushActionPartitionKeySingleton(): subscriptionSetIdentifier.pushPartition.createNSString().get(),
         pushActionTypeKeySingleton(): _WKWebPushActionTypePushEvent
     };
     RetainPtr<BSMutableSettings> bsSettings = adoptNS([[BSMutableSettings alloc] init]);
-    [bsSettings setObject:settingsInfo forSetting:WebKit::WebPushD::pushActionSetting];
+    [bsSettings setObject:settingsInfo.get() forSetting:WebKit::WebPushD::pushActionSetting];
 
     RetainPtr bsResponder = [BSActionResponder responderWithHandler:^void (BSActionResponse *response) {
         if (response.error)


### PR DESCRIPTION
#### 1ef6d14977d15a0432310f82e6eaab09664c7928
<pre>
[Safer CPP] Address unretained local variable warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=306934">https://bugs.webkit.org/show_bug.cgi?id=306934</a>

Reviewed by Geoffrey Garen.

Address safer cpp unretained local variable warnings in Source/WebKit
on iOS.

* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformInitializeNetworkProcessCocoa):
* Source/WebKit/Platform/cocoa/LayerHostingContext.mm:
(WebKit::LayerHostingContext::createHostingUpdateCoordinator):
(WebKit::LayerHostingContext::createHostingHandle):
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformBeginApplePaySetup):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[_WKWebsiteDataStoreBSActionHandler handleNotificationResponse:]):
(-[_WKWebsiteDataStoreBSActionHandler _respondToApplicationActions:fromTransitionContext:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKElementAction.mm:
(-[_WKElementAction uiActionForElementInfo:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTouchEventGenerator.mm:
(-[_WKTouchEventGenerator receivedHIDEvent:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLayerTree:mainFrameData:pageData:transactionID:]):
(-[WKWebView _updateFindOverlayPosition]):
(-[WKWebView _snapshotRectAfterScreenUpdates:rectInViewCoordinates:intoImageOfWidth:completionHandler:]):
(-[WKWebView _printProvider]):
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::ApplicationStateTracker::setWindow):
* Source/WebKit/UIProcess/Automation/ios/WebAutomationSessionIOS.mm:
(WebKit::WebAutomationSession::platformSimulateTouchInteraction):
* Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm:
(WebKit::shouldAllowAutoFillForCellularIdentifiers):
* Source/WebKit/UIProcess/Cocoa/MediaPermissionUtilities.mm:
(WebKit::alertForPermission):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::ProcessAssertion::init):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::presentViewController):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::invalidateInterface):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::returnVideoView):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(WebKit::displayStorageAccessAlert):
* Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm:
(WebKit::WebProcessProxy::WebProcessXPCEventHandler::handleXPCEvent):
* Source/WebKit/UIProcess/Gamepad/ios/UIGamepadProviderIOS.mm:
(WebKit::UIGamepadProvider::platformWebPageProxyForGamepadInput):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::detachFromParent):
(WebKit::RemoteLayerTreeNode::applyBackingStore):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):
* Source/WebKit/UIProcess/WKImagePreviewViewController.mm:
(-[WKImagePreviewViewController previewActionItems]):
* Source/WebKit/UIProcess/_WKWebViewPrintFormatter.mm:
(-[_WKWebViewPrintFormatter _drawInRectUsingBitmap:forPageAtIndex:]):
(-[_WKWebViewPrintFormatter _drawInRectUsingPDF:forPageAtIndex:]):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::deliverDelayedDropPreview):
(WebKit::DragDropInteractionState::updatePreviewsForActiveDragSources):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::viewScrollPosition):
(WebKit::PageClientImpl::minimumZoomScale const):
(WebKit::PageClientImpl::registerEditCommand):
* Source/WebKit/UIProcess/ios/UIKitUtilities.mm:
(-[UIView _wk_viewControllerForFullScreenPresentation]):
* Source/WebKit/UIProcess/ios/WKActionSheet.mm:
(-[WKActionSheet presentSheetFromRect:]):
(-[WKActionSheet updateSheetPosition]):
* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant superviewForSheet]):
(-[WKActionSheetAssistant _appendAppLinkOpenActionsForURL:actions:elementInfo:]):
(-[WKActionSheetAssistant _elementActionForDDAction:]):
(-[WKActionSheetAssistant showDataDetectorsUIForPositionInformation:]):
(-[WKActionSheetAssistant _uiMenuElementsForMediaControlContextMenuItems:]):
(-[WKActionSheetAssistant captionStyleMenu:didSelectProfile:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _hasEnclosingScrollView:matchingCriteria:]):
(-[WKContentView isScrollableForKeyboardScrollViewAnimator:]):
(allPasteboardItemOriginsMatchOrigin):
(-[WKContentView _didPerformDragOperation:]):
(-[WKContentView _prepareToDragPromisedAttachment:]):
(-[WKContentView dropInteraction:performDrop:]):
(-[WKContentView menuWithInlineAction:image:identifier:handler:]):
(-[WKContentView performTextSearchWithQueryString:usingOptions:resultAggregator:]):
* Source/WebKit/UIProcess/ios/WKHighlightLongPressGestureRecognizer.mm:
(-[WKHighlightLongPressGestureRecognizer touchesBegan:withEvent:]):
* Source/WebKit/UIProcess/ios/WKImageAnalysisGestureRecognizer.mm:
(-[WKImageAnalysisGestureRecognizer touchesBegan:withEvent:]):
* Source/WebKit/UIProcess/ios/WKPasswordView.mm:
(-[WKPasswordView showPasswordFailureAlert]):
* Source/WebKit/UIProcess/ios/WKScrollViewTrackingTapGestureRecognizer.mm:
(-[WKScrollViewTrackingTapGestureRecognizer touchesBegan:withEvent:]):
* Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm:
(-[WKSyntheticTapGestureRecognizer touchesEnded:withEvent:]):
* Source/WebKit/UIProcess/ios/WKTapHighlightView.mm:
(-[WKTapHighlightView drawRect:]):
* Source/WebKit/UIProcess/ios/WKTouchEventsGestureRecognizer.mm:
(-[WKTouchEventsGestureRecognizer _recordTouches:ofType:forEvent:]):
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:completionHandler:]):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(-[WKWebGeolocationPolicyDecider _executeNextChallenge]):
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsDropdown _updateSuggestionsMenuElements]):
* Source/WebKit/UIProcess/ios/_WKCaptionStyleMenuControllerIOS.mm:
(-[WKCaptionStyleMenuController rebuildMenu]):
(-[WKCaptionStyleMenuController profileActionSelected:]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:
(-[WKFileUploadPanel _chooseFiles:displayString:iconImage:]):
* Source/WebKit/UIProcess/ios/forms/WKFormColorControl.mm:
(-[WKColorPicker controlBeginEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker createMenu]):
(-[WKSelectPicker actionForOptionItem:withIndex:]):
(-[WKSelectPicker menuItemTitles]):
(-[WKSelectPickerTableViewController didTapSelectPickerGroupHeaderView:]):
(-[WKSelectMultiplePicker configurePresentation]):
(-[WKSelectMultiplePicker controlBeginEditing]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController _showPhishingAlert]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:completionHandler:]):
(-[WKFullScreenWindowController _EVOrganizationName]):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::accessibilityFocusedUIElement):
* Source/WebKit/webpushd/WebClipCache.mm:
(WebPushD::webClipExists):
(WebPushD::loadWebClipCachePropertyList):
(WebPushD::WebClipCache::isWebClipVisible):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::notifyClientPushMessageIsAvailable):

Canonical link: <a href="https://commits.webkit.org/306809@main">https://commits.webkit.org/306809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/074837e9a2868071c289f6bde163a3d787cc4a49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142289 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/4987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150929 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95465 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/057e8416-fddb-48d3-baf1-cc75575fb5c2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109409 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95465 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2348c8c-931f-48c6-b916-535f9d2a53cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127358 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90308 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2245db25-42f3-42be-bd97-3479cc3db115) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11448 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9107 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/955 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120795 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153272 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14364 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4413 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117454 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117777 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30055 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13828 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70064 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14413 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3601 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14145 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78129 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14350 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14190 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->