### PR TITLE
[LibWebRTC] Incorrect video rotation handling for outgoing video sources

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -343,7 +343,7 @@ void RealtimeMediaSource::videoFrameAvailable(VideoFrame& videoFrame, VideoFrame
     bool shouldSwapAdaptorSize = false;
     Ref currentVideoFrame = [&] -> Ref<VideoFrame> {
 #if PLATFORM(COCOA)
-        if (!m_shouldApplyRotation || videoFrame.hasNoTransformation())
+        if (!m_isApplyingRotation || videoFrame.hasNoTransformation())
             return videoFrame;
 
         if (!m_rotationSession)
@@ -1537,16 +1537,18 @@ void RealtimeMediaSource::configurationChanged()
     });
 }
 
-bool RealtimeMediaSource::setShouldApplyRotation()
+void RealtimeMediaSource::setShouldApplyRotation()
 {
     ASSERT(isMainThread());
 
 #if PLATFORM(COCOA)
-    m_shouldApplyRotation = true;
-    return true;
-#else
-    return false;
+    m_isApplyingRotation = true;
 #endif
+}
+
+bool RealtimeMediaSource::isApplyingRotation() const
+{
+    return m_isApplyingRotation;
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -284,7 +284,9 @@ public:
     virtual void delaySamples(Seconds) { };
     virtual void setInterruptedForTesting(bool);
 
-    virtual bool setShouldApplyRotation();
+    virtual void setShouldApplyRotation();
+    bool isApplyingRotation() const;
+
     virtual void setIsInBackground(bool);
 
     std::optional<PageIdentifier> pageIdentifier() const { return m_pageIdentifier.asOptional(); }
@@ -423,7 +425,7 @@ private:
     bool m_captureDidFailed { false };
     bool m_isEnded { false };
     bool m_hasStartedProducingData { false };
-    std::atomic<bool> m_shouldApplyRotation { false };
+    std::atomic<bool> m_isApplyingRotation { false };
 
     unsigned m_videoFrameObserversWithAdaptors { 0 };
 };

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.cpp
@@ -97,8 +97,8 @@ void RealtimeOutgoingVideoSource::setSource(Ref<MediaStreamTrackPrivate>&& newSo
 
     if (!m_areSinksAskingToApplyRotation)
         return;
-    if (!m_videoSource->source().setShouldApplyRotation())
-        m_shouldApplyRotation = true;
+    m_videoSource->source().setShouldApplyRotation();
+    m_isApplyingRotation = m_videoSource->source().isApplyingRotation();
 }
 
 void RealtimeOutgoingVideoSource::applyRotation()
@@ -108,8 +108,8 @@ void RealtimeOutgoingVideoSource::applyRotation()
             return;
 
         m_areSinksAskingToApplyRotation = true;
-        if (!m_videoSource->source().setShouldApplyRotation())
-            m_shouldApplyRotation = true;
+        m_videoSource->source().setShouldApplyRotation();
+        m_isApplyingRotation = m_videoSource->source().isApplyingRotation();
     });
 }
 
@@ -232,7 +232,7 @@ void RealtimeOutgoingVideoSource::sendBlackFramesIfNeeded()
     if (!m_blackFrame) {
         auto width = m_width;
         auto height = m_height;
-        if (!m_shouldApplyRotation && (m_currentRotation == webrtc::kVideoRotation_270 || m_currentRotation == webrtc::kVideoRotation_90))
+        if (!m_isApplyingRotation && (m_currentRotation == webrtc::kVideoRotation_270 || m_currentRotation == webrtc::kVideoRotation_90))
             std::swap(width, height);
 
         m_blackFrame = WTF::toRef(createBlackFrame(width, height));
@@ -255,7 +255,7 @@ void RealtimeOutgoingVideoSource::sendOneBlackFrame()
 void RealtimeOutgoingVideoSource::sendFrame(webrtc::scoped_refptr<webrtc::VideoFrameBuffer>&& buffer)
 {
     MonotonicTime timestamp = MonotonicTime::now();
-    webrtc::VideoFrame frame(buffer, m_shouldApplyRotation ? webrtc::kVideoRotation_0 : m_currentRotation, static_cast<int64_t>(timestamp.secondsSinceEpoch().microseconds()));
+    webrtc::VideoFrame frame(buffer, m_isApplyingRotation ? webrtc::kVideoRotation_0 : m_currentRotation, static_cast<int64_t>(timestamp.secondsSinceEpoch().microseconds()));
 
 #if !RELEASE_LOG_DISABLED
     ++m_frameCount;

--- a/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeOutgoingVideoSource.h
@@ -79,7 +79,7 @@ protected:
 
     virtual webrtc::scoped_refptr<webrtc::VideoFrameBuffer> createBlackFrame(size_t width, size_t height) = 0;
 
-    bool m_shouldApplyRotation { false };
+    bool m_isApplyingRotation { false };
     webrtc::VideoRotation m_currentRotation { webrtc::kVideoRotation_0 };
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingVideoSourceCocoa.cpp
@@ -67,7 +67,7 @@ RealtimeOutgoingVideoSourceCocoa::~RealtimeOutgoingVideoSourceCocoa() = default;
 
 void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetadata)
 {
-    ASSERT(!m_shouldApplyRotation);
+    ASSERT(!m_isApplyingRotation);
 
 #if !RELEASE_LOG_DISABLED
     if (!(++m_numberOfFrames % 60))
@@ -90,8 +90,8 @@ void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFram
     }
 
     auto videoFrameScaling = this->videoFrameScaling();
-    bool shouldApplyRotation = m_shouldApplyRotation && m_currentRotation != webrtc::kVideoRotation_0;
-    if (!shouldApplyRotation) {
+    bool isApplyingRotation = m_isApplyingRotation && m_currentRotation != webrtc::kVideoRotation_0;
+    if (!isApplyingRotation) {
         if (videoFrame.isRemoteProxy()) {
             Ref remoteVideoFrame { videoFrame };
             auto size = videoFrame.presentationSize();
@@ -117,7 +117,7 @@ void RealtimeOutgoingVideoSourceCocoa::videoFrameAvailable(VideoFrame& videoFram
 #endif
 
     RefPtr<VideoFrame> rotatedVideoFrame;
-    if (shouldApplyRotation) {
+    if (isApplyingRotation) {
         if (!m_rotationSession)
             m_rotationSession = makeUnique<ImageRotationSessionVT>(ImageRotationSessionVT::ShouldUseIOSurface::No);
         rotatedVideoFrame = m_rotationSession->applyRotation(videoFrame);

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
@@ -58,10 +58,9 @@ RemoteRealtimeVideoSource::RemoteRealtimeVideoSource(RemoteRealtimeMediaSourcePr
 
 RemoteRealtimeVideoSource::~RemoteRealtimeVideoSource() = default;
 
-bool RemoteRealtimeVideoSource::setShouldApplyRotation()
+void RemoteRealtimeVideoSource::setShouldApplyRotation()
 {
     Ref { connection() }->send(Messages::UserMediaCaptureManagerProxy::SetShouldApplyRotation { identifier() }, 0);
-    return true;
 }
 
 Ref<RealtimeMediaSource> RemoteRealtimeVideoSource::clone()

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeVideoSource.h
@@ -53,7 +53,7 @@ private:
     RemoteRealtimeVideoSource(RemoteRealtimeMediaSourceProxy&&, WebCore::MediaDeviceHashSalts&&, UserMediaCaptureManager&, std::optional<WebCore::PageIdentifier>);
 
     Ref<RealtimeMediaSource> clone() final;
-    bool setShouldApplyRotation() final;
+    void setShouldApplyRotation() final;
     double observedFrameRate() const final { return m_observedFrameRate; }
 
     Deque<double> m_observedFrameTimeStamps;


### PR DESCRIPTION
#### 572723b91c3c52f89b84098a28053729e9ab39af
<pre>
[LibWebRTC] Incorrect video rotation handling for outgoing video sources
<a href="https://bugs.webkit.org/show_bug.cgi?id=306945">https://bugs.webkit.org/show_bug.cgi?id=306945</a>

Reviewed by Adrian Perez de Castro.

Add an accessor in RealtimeMediaSource to know whether the source is applying video rotation before
encoding or not. The RealtimeOutgoingVideoSource&apos;s m_isApplyingRotation value now mirrors the one
set in its inner RealtimeMediaSource instance. With this patch outgoing video frames are correctly
rotated when needed on Linux ports enabling LibWebRTC.

Canonical link: <a href="https://commits.webkit.org/307819@main">https://commits.webkit.org/307819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98ba3bc66b803ae98c577b8d7f7b36a138200be0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79926 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10980 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17523 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119491 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14623 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119819 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30851 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15619 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73170 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17144 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6503 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16880 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80923 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->