### PR TITLE
[Safer CPP] Address uncounted local variable warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -242,17 +242,17 @@ bool RemoteAudioSessionProxyManager::tryToSetActiveForProcess(RemoteAudioSession
     // Otherwise, this proxy wants to become active, but there are other
     // proxies who are already active. Walk over the proxies, and interrupt
     // those proxies whose categories indicate they cannot mix with others.
-    for (auto& otherProxy : m_proxies) {
-        if (otherProxy.processIdentifier() == proxy.processIdentifier())
+    for (Ref otherProxy : m_proxies) {
+        if (otherProxy->processIdentifier() == proxy.processIdentifier())
             continue;
 
-        if (!otherProxy.isActive())
+        if (!otherProxy->isActive())
             continue;
 
-        if (categoryCanMixWithOthers(otherProxy.category()))
+        if (categoryCanMixWithOthers(otherProxy->category()))
             continue;
 
-        otherProxy.beginInterruption();
+        otherProxy->beginInterruption();
     }
 #endif
     return true;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1403,11 +1403,11 @@ SessionWrapper& NetworkSessionCocoa::sessionWrapperForTask(std::optional<WebPage
 #if ENABLE(APP_BOUND_DOMAINS)
 SessionWrapper& NetworkSessionCocoa::appBoundSession(std::optional<WebPageProxyIdentifier> webPageProxyID, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {
-    auto& sessionSet = sessionSetForPage(webPageProxyID);
-    
-    if (!sessionSet.appBoundSession) {
-        sessionSet.appBoundSession = makeUnique<IsolatedSession>();
-        sessionSet.appBoundSession->checkedSessionWithCredentialStorage()->initialize(sessionSet.sessionWithCredentialStorage->session.get().configuration, *this, WebCore::StoredCredentialsPolicy::Use, NavigatingToAppBoundDomain::Yes);
+    Ref sessionSet = sessionSetForPage(webPageProxyID);
+
+    if (!sessionSet->appBoundSession) {
+        sessionSet->appBoundSession = makeUnique<IsolatedSession>();
+        sessionSet->appBoundSession->checkedSessionWithCredentialStorage()->initialize(sessionSet->sessionWithCredentialStorage->session.get().configuration, *this, WebCore::StoredCredentialsPolicy::Use, NavigatingToAppBoundDomain::Yes);
     }
 
     auto& sessionWrapper = [&](auto storedCredentialsPolicy) -> SessionWrapper& {
@@ -1415,7 +1415,7 @@ SessionWrapper& NetworkSessionCocoa::appBoundSession(std::optional<WebPageProxyI
         case WebCore::StoredCredentialsPolicy::Use:
         case WebCore::StoredCredentialsPolicy::DoNotUse:
             LOG(NetworkSession, "Using app-bound NSURLSession.");
-            return sessionSet.appBoundSession->sessionWithCredentialStorage.get();
+            return sessionSet->appBoundSession->sessionWithCredentialStorage.get();
         case WebCore::StoredCredentialsPolicy::EphemeralStateless:
             return initializeEphemeralStatelessSessionIfNeeded(webPageProxyID, NavigatingToAppBoundDomain::Yes);
         }

--- a/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
+++ b/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -59,7 +59,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
         paymentRequest = platformPaymentRequest(originatingURL, linkIconURLs, request);
 
     checkedClient()->getPaymentCoordinatorEmbeddingUserAgent(webPageProxyID, [webPageProxyID, paymentRequest, weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](const String& userAgent) mutable {
-        auto paymentCoordinatorProxy = weakThis.get();
+        RefPtr paymentCoordinatorProxy = weakThis.get();
         if (!paymentCoordinatorProxy)
             return completionHandler(false);
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -632,7 +632,7 @@ void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& 
             return true;
         if (properties.children.isEmpty())
             return false;
-        auto* childNode = relatedLayers.get(properties.children.first());
+        RefPtr childNode = relatedLayers.get(properties.children.first());
         ASSERT(childNode);
         return childNode && childNode->uiView();
     };

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2533,7 +2533,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 {
     BOOL sizeChanged = NO;
     if (_page) {
-        if (auto drawingArea = _page->drawingArea())
+        if (RefPtr drawingArea = _page->drawingArea())
             sizeChanged = drawingArea->setSize(WebCore::IntSize(self.bounds.size));
     }
 
@@ -4312,7 +4312,7 @@ static bool isLockdownModeWarningNeeded()
 
 - (void)_hideContentUntilNextUpdate
 {
-    if (auto* area = _page->drawingArea())
+    if (RefPtr area = _page->drawingArea())
         area->hideContentUntilAnyUpdate();
 }
 
@@ -4493,7 +4493,7 @@ static bool isLockdownModeWarningNeeded()
     _perProcessState.lastSentMinimumEffectiveDeviceWidth = newMinimumEffectiveDeviceWidth;
 
     _page->dynamicViewportSizeUpdate({ newViewLayoutSize, newMinimumUnobscuredSize, newMaximumUnobscuredSize, visibleRectInContentCoordinates, unobscuredRectInContentCoordinates, futureUnobscuredRectInSelfCoordinates, unobscuredSafeAreaInsetsExtent, targetScale, newOrientation, newMinimumEffectiveDeviceWidth, ++_currentDynamicViewportSizeUpdateID });
-    if (WebKit::DrawingAreaProxy* drawingArea = _page->drawingArea())
+    if (RefPtr drawingArea = _page->drawingArea())
         drawingArea->setSize(WebCore::IntSize(newBounds.size));
 
     _perProcessState.waitingForCommitAfterAnimatedResize = YES;
@@ -4732,7 +4732,7 @@ static std::optional<WebCore::ViewportArguments> viewportArgumentsFromDictionary
     if (_page->backForwardList().currentItem() == &item._item)
         _page->recordNavigationSnapshot(*_page->backForwardList().currentItem());
 
-    if (auto* viewSnapshot = item._item.snapshot())
+    if (RefPtr viewSnapshot = item._item.snapshot())
         return viewSnapshot->asLayerContents();
 
     return nil;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -446,7 +446,7 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
 {
 #if USE(SYSTEM_PREVIEW)
     if (_page) {
-        if (auto* previewController = _page->systemPreviewController())
+        if (RefPtr previewController = _page->systemPreviewController())
             previewController->triggerSystemPreviewActionWithTargetForTesting(elementID, documentID, pageID);
     }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
@@ -278,7 +278,7 @@ void ExtensionCapabilityGranter::setMediaCapabilityActive(MediaCapability& capab
 #endif
         return ExtensionCapabilityActivationPromise::createAndReject(ExtensionCapabilityGrantError::PlatformError);
     })->whenSettled(RunLoop::mainSingleton(), [weakCapability = WeakPtr { capability }, isActive](auto&& result) {
-        auto capability = weakCapability.get();
+        RefPtr capability = weakCapability.get();
         if (!capability)
             return;
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -453,7 +453,7 @@ static bool isMarketplaceKitURL(const URL& url)
 static void interceptMarketplaceKitNavigation(Ref<API::NavigationAction>&& action, WebPageProxy& page)
 {
     std::optional<FrameIdentifier> sourceFrameID;
-    if (auto sourceFrame = action->sourceFrame())
+    if (RefPtr sourceFrame = action->sourceFrame())
         sourceFrameID = sourceFrame->handle()->frameID();
 
     auto addConsoleError = [sourceFrameID, url = action->request().url(), weakPage = WeakPtr { page }](const String& error) {

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -435,7 +435,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
         if (!success || !weakThis)
             return completionHandler();
 
-        auto protectedThis = weakThis.get();
+        RefPtr protectedThis = weakThis.get();
         RefPtr webPageProxy = protectedThis->m_webPageProxy.get();
         if (!webPageProxy)
             return completionHandler();
@@ -446,7 +446,7 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
             if (!weakThis)
                 return completionHandler();
 
-            auto protectedThis = weakThis.get();
+            RefPtr protectedThis = weakThis.get();
             RetainPtr dataTask = wrapper(task);
             protectedThis->m_wkSystemPreviewDataTaskDelegate = adoptNS([[_WKSystemPreviewDataTaskDelegate alloc] initWithSystemPreviewController:protectedThis]);
             [dataTask setDelegate:protectedThis->m_wkSystemPreviewDataTaskDelegate.get()];

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1106,7 +1106,7 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    auto* rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*page->drawingArea()).remoteLayerTreeHost().rootNode();
+    RefPtr rootNode = downcast<RemoteLayerTreeDrawingAreaProxy>(*page->drawingArea()).remoteLayerTreeHost().rootNode();
     RetainPtr parentView = rootNode ? rootNode->uiView() : nil;
     interface->setupFullscreen(screenRect, videoDimensions, parentView.get(), videoFullscreenMode, allowsPictureInPicture, standby, blocksReturnToFullscreenFromPictureInPicture);
 #else

--- a/Source/WebKit/UIProcess/Cocoa/WebGeolocationManagerProxyCocoa.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/WebGeolocationManagerProxyCocoa.cpp
@@ -43,8 +43,8 @@ void WebGeolocationManagerProxy::positionChanged(const String& websiteIdentifier
 
     auto& perDomainData = *it->value;
     perDomainData.lastPosition = WTF::move(position);
-    for (auto& webProcessProxy : perDomainData.watchers)
-        webProcessProxy.send(Messages::WebGeolocationManager::DidChangePosition(registrableDomain, perDomainData.lastPosition.value()), 0);
+    for (Ref webProcessProxy : perDomainData.watchers)
+        webProcessProxy->send(Messages::WebGeolocationManager::DidChangePosition(registrableDomain, perDomainData.lastPosition.value()), 0);
 }
 
 void WebGeolocationManagerProxy::errorOccurred(const String& websiteIdentifier, const String& errorMessage)
@@ -55,8 +55,8 @@ void WebGeolocationManagerProxy::errorOccurred(const String& websiteIdentifier, 
         return;
 
     auto& perDomainData = *it->value;
-    for (auto& webProcessProxy : perDomainData.watchers)
-        webProcessProxy.send(Messages::WebGeolocationManager::DidFailToDeterminePosition(registrableDomain, errorMessage), 0);
+    for (Ref webProcessProxy : perDomainData.watchers)
+        webProcessProxy->send(Messages::WebGeolocationManager::DidFailToDeterminePosition(registrableDomain, errorMessage), 0);
 }
 
 void WebGeolocationManagerProxy::resetGeolocation(const String& websiteIdentifier)
@@ -67,8 +67,8 @@ void WebGeolocationManagerProxy::resetGeolocation(const String& websiteIdentifie
         return;
 
     auto& perDomainData = *it->value;
-    for (auto& webProcessProxy : perDomainData.watchers)
-        webProcessProxy.send(Messages::WebGeolocationManager::ResetPermissions(registrableDomain), 0);
+    for (Ref webProcessProxy : perDomainData.watchers)
+        webProcessProxy->send(Messages::WebGeolocationManager::ResetPermissions(registrableDomain), 0);
 }
 
 #endif

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -773,7 +773,7 @@ void GPUProcessProxy::terminateWebProcess(WebCore::ProcessIdentifier webProcessI
 void GPUProcessProxy::didCreateContextForVisibilityPropagation(WebPageProxyIdentifier webPageProxyID, WebCore::PageIdentifier pageID, LayerHostingContextID contextID)
 {
     RELEASE_LOG(Process, "%p - GPUProcessProxy::didCreateContextForVisibilityPropagation: webPageProxyID: %" PRIu64 ", pagePID: %" PRIu64 ", contextID: %u", this, webPageProxyID.toUInt64(), pageID.toUInt64(), contextID);
-    auto page = WebProcessProxy::webPage(webPageProxyID);
+    RefPtr page = WebProcessProxy::webPage(webPageProxyID);
     if (!page) {
         RELEASE_LOG(Process, "%p - GPUProcessProxy::didCreateContextForVisibilityPropagation() No WebPageProxy with this identifier", this);
         return;
@@ -782,7 +782,7 @@ void GPUProcessProxy::didCreateContextForVisibilityPropagation(WebPageProxyIdent
         page->didCreateContextInGPUProcessForVisibilityPropagation(contextID);
         return;
     }
-    auto* provisionalPage = page->provisionalPageProxy();
+    RefPtr provisionalPage = page->provisionalPageProxy();
     if (provisionalPage && provisionalPage->webPageID() == pageID) {
         provisionalPage->didCreateContextInGPUProcessForVisibilityPropagation(contextID);
         return;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1769,7 +1769,7 @@ void NetworkProcessProxy::clearAppBoundSession(PAL::SessionID sessionID, Complet
 
 void NetworkProcessProxy::getAppBoundDomains(PAL::SessionID sessionID, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&& completionHandler)
 {
-    if (auto* store = websiteDataStoreFromSessionID(sessionID)) {
+    if (RefPtr store = websiteDataStoreFromSessionID(sessionID)) {
         store->getAppBoundDomains([completionHandler = WTF::move(completionHandler)] (auto& appBoundDomains) mutable {
             auto appBoundDomainsCopy = appBoundDomains;
             completionHandler(WTF::move(appBoundDomainsCopy));

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -95,7 +95,7 @@ static void collectDescendantViewsAtPoint(Vector<RetainPtr<UIView>, 16>& viewsAt
 
             if (![view isKindOfClass:[WKCompositingView class]])
                 return true;
-            if (auto* node = RemoteLayerTreeNode::forCALayer([view layer]))
+            if (RefPtr node = RemoteLayerTreeNode::forCALayer([view layer]))
                 return node->eventRegion().contains(WebCore::IntPoint(subviewPoint));
             return false;
         }();
@@ -138,7 +138,7 @@ static void collectDescendantViewsInRect(Vector<RetainPtr<UIView>, 16>& viewsInR
 
             if (![view isKindOfClass:WKCompositingView.class])
                 return true;
-            if (auto* node = RemoteLayerTreeNode::forCALayer([view layer]))
+            if (RefPtr node = RemoteLayerTreeNode::forCALayer([view layer]))
                 return node->eventRegion().intersects(WebCore::IntRect { subviewRect });
             return false;
         }();
@@ -163,7 +163,7 @@ bool mayContainEditableElementsInRect(UIView *rootView, const WebCore::FloatRect
     for (RetainPtr view : viewsInRect | std::views::reverse) {
         if (![view isKindOfClass:WKCompositingView.class])
             continue;
-        auto* node = RemoteLayerTreeNode::forCALayer([view layer]);
+        RefPtr node = RemoteLayerTreeNode::forCALayer([view layer]);
         if (!node)
             continue;
         WebCore::IntRect rectToTest { [view convertRect:rect fromView:rootView] };
@@ -188,7 +188,7 @@ static bool isScrolledBy(WKChildScrollView* scrollView, UIView *hitView)
         if (view == scrollView)
             return true;
 
-        auto* node = RemoteLayerTreeNode::forCALayer(view.layer);
+        RefPtr node = RemoteLayerTreeNode::forCALayer(view.layer);
         if (node && scrollLayerID) {
             if (node->actingScrollContainerID() == scrollLayerID)
                 return true;
@@ -226,7 +226,7 @@ OptionSet<WebCore::TouchAction> touchActionsForPoint(UIView *rootView, const Web
 
     CGPoint hitViewPoint = [hitView convertPoint:point fromView:rootView];
 
-    auto* node = RemoteLayerTreeNode::forCALayer(hitView.get().layer);
+    RefPtr node = RemoteLayerTreeNode::forCALayer(hitView.get().layer);
     if (!node)
         return { WebCore::TouchAction::Auto };
 
@@ -255,7 +255,7 @@ OptionSet<WebCore::EventListenerRegionType> eventListenerTypesAtPoint(UIView *ro
 
     CGPoint hitViewPoint = [hitView convertPoint:point fromView:rootView];
 
-    auto* node = RemoteLayerTreeNode::forCALayer(hitView.get().layer);
+    RefPtr node = RemoteLayerTreeNode::forCALayer(hitView.get().layer);
     if (!node)
         return { };
 
@@ -272,7 +272,7 @@ UIScrollView *findActingScrollParent(UIScrollView *scrollView, const RemoteLayer
             // FIXME: Ideally we would return the scroller we want in all cases but the current UIKit SPI only allows returning a non-ancestor.
             return nil;
         }
-        if (auto* node = RemoteLayerTreeNode::forCALayer(view.layer)) {
+        if (RefPtr node = RemoteLayerTreeNode::forCALayer(view.layer)) {
             if (auto* actingParent = host.nodeForID(node->actingScrollContainerID())) {
                 if (auto scrollView = dynamic_objc_cast<UIScrollView>(actingParent->uiView()))
                     return scrollView;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -93,7 +93,7 @@ void RemoteScrollingCoordinatorProxyIOS::clearTouchActionsForTouchIdentifier(uns
 
 UIScrollView *RemoteScrollingCoordinatorProxyIOS::scrollViewForScrollingNodeID(std::optional<ScrollingNodeID> nodeID) const
 {
-    auto* treeNode = scrollingTree().nodeForID(nodeID);
+    RefPtr treeNode = scrollingTree().nodeForID(nodeID);
 
     if (RefPtr overflowScrollingNode = dynamicDowncast<ScrollingTreeOverflowScrollingNodeIOS>(treeNode))
         return overflowScrollingNode->scrollView();
@@ -373,7 +373,7 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
     for (auto& currNode : stateTree.nodeMap().values()) {
         if (currNode->hasChangedProperty(ScrollingStateNode::Property::Layer)) {
             auto platformLayerID = currNode->layer().layerID();
-            auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
+            RefPtr remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
             if (remoteLayerTreeNode)
                 currNode->setLayer(remoteLayerTreeNode->layer());
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
@@ -396,56 +396,56 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
 
         switch (currNode->nodeType()) {
         case ScrollingNodeType::Overflow: {
-            auto& scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode.get());
+            Ref scrollingStateNode = downcast<ScrollingStateOverflowScrollingNode>(currNode.get());
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
-                auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();
-                auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
+                auto platformLayerID = scrollingStateNode->scrollContainerLayer().layerID();
+                RefPtr remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
                 if (remoteLayerTreeNode)
-                    scrollingStateNode.setScrollContainerLayer(remoteLayerTreeNode->layer());
+                    scrollingStateNode->setScrollContainerLayer(remoteLayerTreeNode->layer());
             }
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
-                scrollingStateNode.setScrolledContentsLayer(layerTreeHost.layerForID(scrollingStateNode.scrolledContentsLayer().layerID()));
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
+                scrollingStateNode->setScrolledContentsLayer(layerTreeHost.layerForID(scrollingStateNode->scrolledContentsLayer().layerID()));
             break;
         };
         case ScrollingNodeType::MainFrame:
         case ScrollingNodeType::Subframe: {
-            auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode.get());
+            Ref scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(currNode.get());
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
-                auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();
-                auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
+                auto platformLayerID = scrollingStateNode->scrollContainerLayer().layerID();
+                RefPtr remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
                 if (remoteLayerTreeNode)
-                    scrollingStateNode.setScrollContainerLayer(remoteLayerTreeNode->layer());
+                    scrollingStateNode->setScrollContainerLayer(remoteLayerTreeNode->layer());
             }
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
-                scrollingStateNode.setScrolledContentsLayer(layerTreeHost.layerForID(scrollingStateNode.scrolledContentsLayer().layerID()));
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
+                scrollingStateNode->setScrolledContentsLayer(layerTreeHost.layerForID(scrollingStateNode->scrolledContentsLayer().layerID()));
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer))
-                scrollingStateNode.setCounterScrollingLayer(layerTreeHost.layerForID(scrollingStateNode.counterScrollingLayer().layerID()));
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer))
+                scrollingStateNode->setCounterScrollingLayer(layerTreeHost.layerForID(scrollingStateNode->counterScrollingLayer().layerID()));
 
             // FIXME: we should never have header and footer layers coming from the WebProcess.
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HeaderLayer))
-                scrollingStateNode.setHeaderLayer(layerTreeHost.layerForID(scrollingStateNode.headerLayer().layerID()));
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::HeaderLayer))
+                scrollingStateNode->setHeaderLayer(layerTreeHost.layerForID(scrollingStateNode->headerLayer().layerID()));
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::FooterLayer))
-                scrollingStateNode.setFooterLayer(layerTreeHost.layerForID(scrollingStateNode.footerLayer().layerID()));
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::FooterLayer))
+                scrollingStateNode->setFooterLayer(layerTreeHost.layerForID(scrollingStateNode->footerLayer().layerID()));
             break;
         }
         case ScrollingNodeType::PluginScrolling: {
-            auto& scrollingStateNode = downcast<ScrollingStatePluginScrollingNode>(currNode.get());
+            Ref scrollingStateNode = downcast<ScrollingStatePluginScrollingNode>(currNode.get());
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
-                auto platformLayerID = scrollingStateNode.scrollContainerLayer().layerID();
-                auto remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)) {
+                auto platformLayerID = scrollingStateNode->scrollContainerLayer().layerID();
+                RefPtr remoteLayerTreeNode = layerTreeHost.nodeForID(platformLayerID);
                 if (remoteLayerTreeNode)
-                    scrollingStateNode.setScrollContainerLayer(remoteLayerTreeNode->layer());
+                    scrollingStateNode->setScrollContainerLayer(remoteLayerTreeNode->layer());
             }
 
-            if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
-                scrollingStateNode.setScrolledContentsLayer(layerTreeHost.layerForID(scrollingStateNode.scrolledContentsLayer().layerID()));
+            if (scrollingStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
+                scrollingStateNode->setScrolledContentsLayer(layerTreeHost.layerForID(scrollingStateNode->scrolledContentsLayer().layerID()));
             break;
         }
         case ScrollingNodeType::OverflowProxy:
@@ -499,7 +499,7 @@ void RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeDidEndScroll(Scrolling
 void RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations(const RemoteLayerTreeHost& remoteLayerTreeHost)
 {
     for (auto layerID : m_layersWithScrollingRelations) {
-        if (auto* layerNode = remoteLayerTreeHost.nodeForID(layerID)) {
+        if (RefPtr layerNode = remoteLayerTreeHost.nodeForID(layerID)) {
             layerNode->setActingScrollContainerID(std::nullopt);
             layerNode->setStationaryScrollContainerIDs({ });
         }
@@ -513,26 +513,26 @@ void RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations(co
         Vector<PlatformLayerIdentifier> stationaryScrollContainerIDs;
 
         for (auto overflowNodeID : positionedNode->relatedOverflowScrollingNodes()) {
-            auto* node = scrollingTree().nodeForID(overflowNodeID);
-            auto* overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(node);
+            RefPtr node = scrollingTree().nodeForID(overflowNodeID);
+            RefPtr overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(node.get());
             MESSAGE_CHECK(overflowNode);
             auto layerID = RemoteLayerTreeNode::layerID(static_cast<CALayer*>(overflowNode->scrollContainerLayer()));
             MESSAGE_CHECK(layerID);
             stationaryScrollContainerIDs.append(*layerID);
         }
 
-        if (auto* layerNode = RemoteLayerTreeNode::forCALayer(positionedNode->layer())) {
+        if (RefPtr layerNode = RemoteLayerTreeNode::forCALayer(positionedNode->layer())) {
             layerNode->setStationaryScrollContainerIDs(WTF::move(stationaryScrollContainerIDs));
             m_layersWithScrollingRelations.add(layerNode->layerID());
         }
     }
 
     for (auto& scrollProxyNode : scrollingTree().activeOverflowScrollProxyNodes()) {
-        auto* node = scrollingTree().nodeForID(scrollProxyNode->overflowScrollingNodeID());
-        auto* overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(node);
+        RefPtr node = scrollingTree().nodeForID(scrollProxyNode->overflowScrollingNodeID());
+        RefPtr overflowNode = dynamicDowncast<ScrollingTreeOverflowScrollingNode>(node.get());
         MESSAGE_CHECK(overflowNode);
 
-        if (auto* layerNode = RemoteLayerTreeNode::forCALayer(scrollProxyNode->layer())) {
+        if (RefPtr layerNode = RemoteLayerTreeNode::forCALayer(scrollProxyNode->layer())) {
             layerNode->setActingScrollContainerID(RemoteLayerTreeNode::layerID(static_cast<CALayer*>(overflowNode->scrollContainerLayer())));
             m_layersWithScrollingRelations.add(layerNode->layerID());
         }
@@ -570,7 +570,7 @@ bool RemoteScrollingCoordinatorProxyIOS::shouldSetScrollViewDecelerationRateFast
 void RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll(bool value)
 {
     // FIXME: Locking
-    auto* rootNode = scrollingTree().rootNode();
+    RefPtr rootNode = scrollingTree().rootNode();
     if (!rootNode)
         return;
 
@@ -584,7 +584,7 @@ void RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll(bool value)
 
 bool RemoteScrollingCoordinatorProxyIOS::shouldSnapForMainFrameScrolling(ScrollEventAxis axis) const
 {
-    auto* rootNode = scrollingTree().rootNode();
+    RefPtr rootNode = scrollingTree().rootNode();
     if (rootNode)
         return rootNode->snapOffsetsInfo().offsetsForAxis(axis).size();
 
@@ -593,7 +593,7 @@ bool RemoteScrollingCoordinatorProxyIOS::shouldSnapForMainFrameScrolling(ScrollE
 
 std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling(ScrollEventAxis axis, float currentScrollOffset, FloatPoint scrollDestination, float velocity) const
 {
-    auto* rootNode = scrollingTree().rootNode();
+    RefPtr rootNode = scrollingTree().rootNode();
     const auto& snapOffsetsInfo = rootNode->snapOffsetsInfo();
 
     auto zoomScale = [protect(webPageProxy())->cocoaView() scrollView].zoomScale;
@@ -605,7 +605,7 @@ std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxyIOS::cl
 
 bool RemoteScrollingCoordinatorProxyIOS::hasActiveSnapPoint() const
 {
-    auto* rootNode = scrollingTree().rootNode();
+    RefPtr rootNode = scrollingTree().rootNode();
     if (!rootNode)
         return false;
 
@@ -627,7 +627,7 @@ CGPoint RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSna
 {
     CGPoint activePoint = currentPoint;
 
-    auto* rootNode = scrollingTree().rootNode();
+    RefPtr rootNode = scrollingTree().rootNode();
     if (!rootNode)
         return CGPointZero;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1037,7 +1037,7 @@ void PageClientImpl::navigationGestureDidBegin()
 {
     if (auto webView = this->webView()) {
         [webView _navigationGestureDidBegin];
-        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+        if (RefPtr navigationState = NavigationState::fromWebPage(*webView->_page))
             navigationState->navigationGestureDidBegin();
     }
 }
@@ -1045,7 +1045,7 @@ void PageClientImpl::navigationGestureDidBegin()
 void PageClientImpl::navigationGestureWillEnd(bool willNavigate, WebBackForwardListItem& item)
 {
     if (auto webView = this->webView()) {
-        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+        if (RefPtr navigationState = NavigationState::fromWebPage(*webView->_page))
             navigationState->navigationGestureWillEnd(willNavigate, item);
     }
 }
@@ -1053,7 +1053,7 @@ void PageClientImpl::navigationGestureWillEnd(bool willNavigate, WebBackForwardL
 void PageClientImpl::navigationGestureDidEnd(bool willNavigate, WebBackForwardListItem& item)
 {
     if (auto webView = this->webView()) {
-        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+        if (RefPtr navigationState = NavigationState::fromWebPage(*webView->_page))
             navigationState->navigationGestureDidEnd(willNavigate, item);
         [webView _navigationGestureDidEnd];
     }
@@ -1067,7 +1067,7 @@ void PageClientImpl::navigationGestureDidEnd()
 void PageClientImpl::willRecordNavigationSnapshot(WebBackForwardListItem& item)
 {
     if (auto webView = this->webView()) {
-        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+        if (RefPtr navigationState = NavigationState::fromWebPage(*webView->_page))
             navigationState->willRecordNavigationSnapshot(item);
     }
 }
@@ -1075,7 +1075,7 @@ void PageClientImpl::willRecordNavigationSnapshot(WebBackForwardListItem& item)
 void PageClientImpl::didRemoveNavigationGestureSnapshot()
 {
     if (auto webView = this->webView()) {
-        if (auto* navigationState = NavigationState::fromWebPage(*webView->_page))
+        if (RefPtr navigationState = NavigationState::fromWebPage(*webView->_page))
             navigationState->navigationGestureSnapshotWasRemoved();
     }
 }

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -222,7 +222,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
     // Copy the snapshot from this view to the one that owns the back forward list, so that
     // swiping forward will have the correct snapshot.
     if (m_webPageProxyForBackForwardListForCurrentSwipe != page.get()) {
-        if (auto* currentViewHistoryItem = page->backForwardList().currentItem())
+        if (RefPtr currentViewHistoryItem = page->backForwardList().currentItem())
             backForwardList.currentItem()->setSnapshot(currentViewHistoryItem->snapshot());
     }
 
@@ -238,7 +238,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
     [m_snapshotView layer].name = @"SwipeSnapshot";
 
     RetainPtr<UIColor> backgroundColor = [UIColor whiteColor];
-    if (ViewSnapshot* snapshot = targetItem->snapshot()) {
+    if (RefPtr snapshot = targetItem->snapshot()) {
         float deviceScaleFactor = page->deviceScaleFactor();
         WebCore::FloatSize swipeLayerSizeInDeviceCoordinates(liveSwipeViewFrame.size);
         swipeLayerSizeInDeviceCoordinates.scale(deviceScaleFactor);
@@ -339,13 +339,13 @@ void ViewGestureController::willEndSwipeGesture(WebBackForwardListItem& targetIt
         return;
 
     m_snapshotRemovalTargetRenderTreeSize = 0;
-    if (ViewSnapshot* snapshot = targetItem.snapshot())
+    if (RefPtr snapshot = targetItem.snapshot())
         m_snapshotRemovalTargetRenderTreeSize = snapshot->renderTreeSize() * swipeSnapshotRemovalRenderTreeSizeTargetFraction;
 
     m_didStartProvisionalLoad = false;
     m_pendingNavigation = protect(m_webPageProxyForBackForwardListForCurrentSwipe)->goToBackForwardItem(targetItem);
 
-    auto* currentItem = m_webPageProxyForBackForwardListForCurrentSwipe->backForwardList().currentItem();
+    RefPtr currentItem = m_webPageProxyForBackForwardListForCurrentSwipe->backForwardList().currentItem();
     // The main frame will not be navigated so hide the snapshot right away.
     if (currentItem && currentItem->itemIsClone(targetItem)) {
         removeSwipeSnapshot();
@@ -362,7 +362,7 @@ void ViewGestureController::willEndSwipeGesture(WebBackForwardListItem& targetIt
             protectedThis->removeSwipeSnapshot();
     });
 
-    if (ViewSnapshot* snapshot = targetItem.snapshot()) {
+    if (RefPtr snapshot = targetItem.snapshot()) {
         m_backgroundColorForCurrentSnapshot = snapshot->backgroundColor();
         if (RefPtr page = m_webPageProxy.get())
             page->didChangeBackgroundColor();
@@ -424,7 +424,7 @@ void ViewGestureController::endSwipeGesture(WebBackForwardListItem* targetItem, 
             return;
 
         RefPtr page = protectedThis->m_webPageProxy.get();
-        auto* drawingArea = page ? page->provisionalDrawingArea() : nullptr;
+        RefPtr drawingArea = page ? page->provisionalDrawingArea() : nullptr;
         if (!drawingArea) {
             protectedThis->removeSwipeSnapshot();
             return;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -385,7 +385,7 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 #if ENABLE(GPU_PROCESS)
 - (void)_setupVisibilityPropagationForGPUProcess
 {
-    auto* gpuProcess = _page->configuration().processPool().gpuProcess();
+    RefPtr gpuProcess = _page->configuration().processPool().gpuProcess();
     if (!gpuProcess)
         return;
 
@@ -412,7 +412,7 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 #if ENABLE(MODEL_PROCESS)
 - (void)_setupVisibilityPropagationForModelProcess
 {
-    auto* modelProcess = _page->configuration().processPool().modelProcess();
+    RefPtr modelProcess = _page->configuration().processPool().modelProcess();
     if (!modelProcess)
         return;
     auto processIdentifier = modelProcess->processID();
@@ -433,7 +433,7 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 - (void)_removeVisibilityPropagationViewForWebProcess
 {
 #if USE(EXTENSIONKIT)
-    if (auto page = _page.get()) {
+    if (RefPtr page = _page.get()) {
         for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
             [visibilityPropagationView stopPropagatingVisibilityToProcess:page->legacyMainFrameProcess()];
     }
@@ -450,8 +450,8 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 - (void)_removeVisibilityPropagationViewForGPUProcess
 {
 #if USE(EXTENSIONKIT)
-    auto page = _page.get();
-    if (auto gpuProcess = page ? page->configuration().processPool().gpuProcess() : nullptr) {
+    RefPtr page = _page.get();
+    if (RefPtr gpuProcess = page ? page->configuration().processPool().gpuProcess() : nullptr) {
         for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
             [visibilityPropagationView stopPropagatingVisibilityToProcess:*gpuProcess];
     }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2718,22 +2718,22 @@ static inline WebCore::FloatSize tapHighlightBorderRadius(WebCore::FloatSize bor
 
 - (void)_handleSmartMagnificationInformationForPotentialTap:(WebKit::TapIdentifier)requestID renderRect:(const WebCore::FloatRect&)renderRect fitEntireRect:(BOOL)fitEntireRect viewportMinimumScale:(double)viewportMinimumScale viewportMaximumScale:(double)viewportMaximumScale nodeIsRootLevel:(BOOL)nodeIsRootLevel nodeIsPluginElement:(BOOL)nodeIsPluginElement
 {
-    const auto& preferences = _page->preferences();
+    Ref preferences = _page->preferences();
 
-    ASSERT(preferences.fasterClicksEnabled());
+    ASSERT(preferences->fasterClicksEnabled());
     if (!_potentialTapInProgress)
         return;
 
     // We check both the system preference and the page preference, because we only want this
     // to apply in "desktop" mode.
-    if (preferences.preferFasterClickOverDoubleTap() && _page->preferFasterClickOverDoubleTap()) {
+    if (preferences->preferFasterClickOverDoubleTap() && _page->preferFasterClickOverDoubleTap()) {
         RELEASE_LOG(ViewGestures, "Potential tap found an element and fast taps are preferred. Trigger click. (%p, pageProxyID=%llu)", self, _page->identifier().toUInt64());
-        if (preferences.zoomOnDoubleTapWhenRoot() && nodeIsRootLevel) {
+        if (preferences->zoomOnDoubleTapWhenRoot() && nodeIsRootLevel) {
             RELEASE_LOG(ViewGestures, "The click handler was on a root-level element, so don't disable double-tap. (%p, pageProxyID=%llu)", self, _page->identifier().toUInt64());
             return;
         }
 
-        if (preferences.alwaysZoomOnDoubleTap()) {
+        if (preferences->alwaysZoomOnDoubleTap()) {
             RELEASE_LOG(ViewGestures, "DTTZ is forced on, so don't disable double-tap. (%p, pageProxyID=%llu)", self, _page->identifier().toUInt64());
             return;
         }
@@ -10844,7 +10844,7 @@ static NSArray<NSItemProvider *> *extractItemProvidersFromDropSession(id <UIDrop
     if (!textIndicator->contentImage())
         return;
 
-    auto snapshotWithoutSelection = textIndicator->contentImageWithoutSelection();
+    RefPtr snapshotWithoutSelection = textIndicator->contentImageWithoutSelection();
     if (!snapshotWithoutSelection)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -634,7 +634,7 @@ void WebPageProxy::applicationDidEnterBackground()
     // We normally delay process suspension when the app is backgrounded until the current page load completes. However,
     // we do not want to do so when the screen is locked for power reasons.
     if (isSuspendedUnderLock) {
-        if (auto* navigationState = NavigationState::fromWebPage(*this))
+        if (RefPtr navigationState = NavigationState::fromWebPage(*this))
             navigationState->releaseNetworkActivity(NavigationState::NetworkActivityReleaseReason::ScreenLocked);
     }
 #endif
@@ -1599,17 +1599,17 @@ String WebPageProxy::predictedUserAgentForRequest(const WebCore::ResourceRequest
     if (!customUserAgent().isEmpty())
         return customUserAgent();
 
-    const API::WebsitePolicies& policies = m_configuration->defaultWebsitePolicies();
-    if (!policies.customUserAgent().isEmpty())
-        return policies.customUserAgent();
+    Ref policies = m_configuration->defaultWebsitePolicies();
+    if (!policies->customUserAgent().isEmpty())
+        return policies->customUserAgent();
 
-    if (policies.applicationNameForDesktopUserAgent().isEmpty())
+    if (policies->applicationNameForDesktopUserAgent().isEmpty())
         return userAgent();
 
     if (!useDesktopClassBrowsing(policies, request))
         return userAgent();
 
-    return standardUserAgentWithApplicationName(policies.applicationNameForDesktopUserAgent(), emptyString(), UserAgentType::Desktop);
+    return standardUserAgentWithApplicationName(policies->applicationNameForDesktopUserAgent(), emptyString(), UserAgentType::Desktop);
 }
 
 WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::WebsitePolicies& policies, const WebCore::ResourceRequest& request)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -909,7 +909,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self._webView.frame = self.view.bounds;
     [_animatingView insertSubview:self._webView atIndex:0];
 
-    if (auto* manager = self._manager)
+    if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager)
         manager->setFullscreenAutoHideDuration(Seconds(showHideAnimationDuration));
 
     [super viewWillAppear:animated];
@@ -1022,7 +1022,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (RefPtr<WebCore::PlatformPlaybackSessionInterface>)_playbackSessionInterface
 {
-    auto page = [self._webView _page];
+    RefPtr page = [self._webView _page].get();
     if (!page)
         return nullptr;
 
@@ -1122,7 +1122,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_updateWebViewFullscreenInsets
 {
     ASSERT(_valid);
-    if (auto* manager = self._manager)
+    if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager)
         manager->setFullscreenInsets(self._effectiveFullscreenInsets);
 }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1039,7 +1039,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     RetainPtr<WKWebView> webView = self._webView;
     RefPtr page = [webView _page].get();
-    auto* manager = self._manager;
+    RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager;
     if (!page || !manager)
         return completionHandler(false);
 
@@ -1188,7 +1188,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [webView setNeedsLayout];
         [webView layoutIfNeeded];
 
-        if (auto* manager = self._manager)
+        if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager)
             manager->setAnimatingFullScreen(true);
 
         page->updateRenderingWithForcedRepaint([protectedSelf, self, logIdentifier = logIdentifier, completionHandler = WTF::move(completionHandler)] mutable {
@@ -1221,7 +1221,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)updateImageSource
 {
     RetainPtr<WKWebView> webView = self._webView;
-    auto* manager = self._manager;
+    RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager;
     if (!manager)
         return;
 
@@ -1288,7 +1288,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
 
         RefPtr page = [[strongSelf _webView] _page].get();
-        auto* manager = [strongSelf _manager];
+        RefPtr manager = [strongSelf _manager];
 
         if (page && manager) {
             OBJC_ALWAYS_LOG_WITH_SELF(strongSelf, logIdentifier, "presentation completed");
@@ -1313,7 +1313,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             }
 #endif
 
-            if (auto* videoPresentationManager = [strongSelf _videoPresentationManager]) {
+            if (RefPtr videoPresentationManager = [strongSelf _videoPresentationManager]) {
                 if (!strongSelf->_pipObserver) {
                     strongSelf->_pipObserver = WebKit::VideoPresentationManagerProxy::VideoInPictureInPictureDidChangeObserver::create([weakSelf = WeakObjCPtr { strongSelf.get() }] (bool inPiP) {
                         RetainPtr strongSelf = weakSelf.get();
@@ -1358,10 +1358,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     // Switch the active tab if needed
-    if (auto* page = [self._webView _page].get())
+    if (RefPtr page = [self._webView _page].get())
         page->fullscreenMayReturnToInline();
 
-    if (auto* manager = self._manager) {
+    if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager) {
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
         manager->requestRestoreFullScreen(WTF::move(completionHandler));
         return;
@@ -1380,7 +1380,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     }
 
-    if (auto* manager = self._manager) {
+    if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager) {
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
         manager->requestExitFullScreen();
         _exitingFullScreen = YES;
@@ -1435,7 +1435,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _fullScreenState = WebKit::WaitingToExitFullScreen;
     _exitingFullScreen = YES;
 
-    if (auto* manager = self._manager) {
+    if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager) {
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
         manager->setAnimatingFullScreen(true);
         [self _startWatchdogTimer];
@@ -1527,7 +1527,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _reinsertWebViewUnderPlaceholder];
 
-    if (auto* manager = self._manager)
+    if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager)
         manager->setAnimatingFullScreen(false);
     completionHandler();
 
@@ -1576,7 +1576,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [CATransaction commit];
     });
 
-    auto* page = [self._webView _page].get();
+    RefPtr page = [self._webView _page].get();
     if (page && page->isViewFocused())
         page->updateRenderingWithForcedRepaint(WTF::move(completionHandlerAfterRenderingUpdateIfFocused));
     else
@@ -1783,7 +1783,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _reinsertWebViewUnderPlaceholder];
 
-    if (auto* manager = self._manager)
+    if (RefPtr<WebKit::WebFullScreenManagerProxy> manager = self._manager)
         manager->requestExitFullScreen();
 
     [_webViewPlaceholder removeFromSuperview];

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -344,7 +344,7 @@ void RemoteGraphicsContextProxy::drawSystemImage(SystemImage& systemImage, const
 {
     appendStateChangeItemIfNecessary();
 #if USE(SYSTEM_PREVIEW)
-    if (auto* badgeSystemImage = dynamicDowncast<ARKitBadgeSystemImage>(systemImage)) {
+    if (RefPtr badgeSystemImage = dynamicDowncast<ARKitBadgeSystemImage>(systemImage)) {
         if (auto image = badgeSystemImage->image()) {
             auto nativeImage = image->nativeImage();
             if (!nativeImage)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1437,8 +1437,8 @@ void WebLocalFrameLoaderClient::saveViewStateToItem(HistoryItem& historyItem)
 void WebLocalFrameLoaderClient::restoreViewState()
 {
 #if PLATFORM(IOS_FAMILY)
-    auto* currentItem = m_localFrame->loader().history().currentItem();
-    if (auto* view =  m_localFrame->view()) {
+    RefPtr currentItem = m_localFrame->loader().history().currentItem();
+    if (RefPtr view = m_localFrame->view()) {
         if (m_frame->isMainFrame())
             protect(m_frame->page())->restorePageState(*currentItem);
         else if (!view->wasScrolledByUser())

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebPreviewLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebPreviewLoaderClient.cpp
@@ -51,7 +51,7 @@ WebPreviewLoaderClient::~WebPreviewLoaderClient() = default;
 
 void WebPreviewLoaderClient::didReceiveData(const SharedBuffer& buffer)
 {
-    auto webPage = WebProcess::singleton().webPage(m_pageID);
+    RefPtr webPage = WebProcess::singleton().webPage(m_pageID);
     if (!webPage)
         return;
 
@@ -63,7 +63,7 @@ void WebPreviewLoaderClient::didReceiveData(const SharedBuffer& buffer)
 
 void WebPreviewLoaderClient::didFinishLoading()
 {
-    auto webPage = WebProcess::singleton().webPage(m_pageID);
+    RefPtr webPage = WebProcess::singleton().webPage(m_pageID);
     if (!webPage)
         return;
 
@@ -77,7 +77,7 @@ void WebPreviewLoaderClient::didFail()
 
 void WebPreviewLoaderClient::didRequestPassword(Function<void(const String&)>&& completionHandler)
 {
-    auto webPage = WebProcess::singleton().webPage(m_pageID);
+    RefPtr webPage = WebProcess::singleton().webPage(m_pageID);
     if (!webPage) {
         completionHandler({ });
         return;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1063,7 +1063,7 @@ URL WebPage::allowedQueryParametersForAdvancedPrivacyProtections(const URL& url)
 void WebPage::setMediaEnvironment(const String& mediaEnvironment)
 {
     m_mediaEnvironment = mediaEnvironment;
-    if (auto gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
+    if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
         gpuProcessConnection->setMediaEnvironment(identifier(), mediaEnvironment);
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1304,10 +1304,10 @@ bool WebFrame::shouldEnableInAppBrowserPrivacyProtections()
 
 std::optional<NavigatingToAppBoundDomain> WebFrame::isTopFrameNavigatingToAppBoundDomain() const
 {
-    auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
     if (!localFrame)
         return std::nullopt;
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(localFrame->mainFrame());
     if (!localMainFrame)
         return std::nullopt;
     return fromCoreFrame(*localMainFrame)->isNavigatingToAppBoundDomain();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1521,12 +1521,12 @@ WebPage::~WebPage()
     WebStorageNamespaceProvider::decrementUseCount(sessionStorageNamespaceIdentifier());
 
 #if ENABLE(GPU_PROCESS) && HAVE(VISIBILITY_PROPAGATION_VIEW)
-    if (auto* gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
+    if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
         gpuProcessConnection->destroyVisibilityPropagationContextForPage(*this);
 #endif // ENABLE(GPU_PROCESS)
 
 #if ENABLE(MODEL_PROCESS) && HAVE(VISIBILITY_PROPAGATION_VIEW)
-    if (auto* modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
+    if (RefPtr modelProcessConnection = WebProcess::singleton().existingModelProcessConnection())
         modelProcessConnection->destroyVisibilityPropagationContextForPage(*this);
 #endif // ENABLE(MODEL_PROCESS) && HAVE(VISIBILITY_PROPAGATION_VIEW)
 

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -79,7 +79,7 @@ void FindIndicatorOverlayClientIOS::drawRect(PageOverlay& overlay, GraphicsConte
     if (!m_textIndicator)
         return;
 
-    Image* indicatorImage = m_textIndicator->contentImage();
+    RefPtr indicatorImage = m_textIndicator->contentImage();
     if (!indicatorImage)
         return;
 
@@ -149,8 +149,8 @@ void FindController::resetMatchIndex()
 
 static void setSelectionChangeUpdatesEnabledInAllFrames(WebPage& page, bool enabled)
 {
-    for (auto* coreFrame = page.mainFrame(); coreFrame; coreFrame = coreFrame->tree().traverseNext()) {
-        auto* localFrame = dynamicDowncast<LocalFrame>(coreFrame);
+    for (RefPtr coreFrame = page.mainFrame(); coreFrame; coreFrame = coreFrame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(coreFrame.get());
         if (!localFrame)
             continue;
         protect(localFrame)->editor().setIgnoreSelectionChanges(enabled);


### PR DESCRIPTION
#### 48f7f916673c78d9197f5efaea882d13fbd27c5d
<pre>
[Safer CPP] Address uncounted local variable warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=306946">https://bugs.webkit.org/show_bug.cgi?id=306946</a>

Reviewed by Anne van Kesteren.

Address Safer CPP uncounted local variable warnings in Source/WebKit on iOS.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::tryToSetActiveForProcess):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::appBoundSession):
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyHierarchyUpdates):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateDrawingAreaSize]):
(-[WKWebView _hideContentUntilNextUpdate]):
(-[WKWebView _beginAnimatedResizeWithUpdates:]):
(-[WKWebView _snapshotLayerContentsForBackForwardListItem:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _triggerSystemPreviewActionOnElement:document:page:]):
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
(WebKit::ExtensionCapabilityGranter::setMediaCapabilityActive):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::interceptMarketplaceKitNavigation):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
* Source/WebKit/UIProcess/Cocoa/WebGeolocationManagerProxyCocoa.cpp:
(WebKit::WebGeolocationManagerProxy::positionChanged):
(WebKit::WebGeolocationManagerProxy::errorOccurred):
(WebKit::WebGeolocationManagerProxy::resetGeolocation):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didCreateContextForVisibilityPropagation):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::getAppBoundDomains):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::collectDescendantViewsAtPoint):
(WebKit::collectDescendantViewsInRect):
(WebKit::mayContainEditableElementsInRect):
(WebKit::isScrolledBy):
(WebKit::touchActionsForPoint):
(WebKit::eventListenerTypesAtPoint):
(WebKit::findActingScrollParent):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollViewForScrollingNodeID const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
(WebKit::RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations):
(WebKit::RemoteScrollingCoordinatorProxyIOS::setRootNodeIsInUserScroll):
(WebKit::RemoteScrollingCoordinatorProxyIOS::shouldSnapForMainFrameScrolling const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::hasActiveSnapPoint const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSnapOffset const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::navigationGestureDidBegin):
(WebKit::PageClientImpl::navigationGestureWillEnd):
(WebKit::PageClientImpl::navigationGestureDidEnd):
(WebKit::PageClientImpl::willRecordNavigationSnapshot):
(WebKit::PageClientImpl::didRemoveNavigationGestureSnapshot):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::willEndSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _setupVisibilityPropagationForGPUProcess]):
(-[WKContentView _setupVisibilityPropagationForModelProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _handleSmartMagnificationInformationForPotentialTap:renderRect:fitEntireRect:viewportMinimumScale:viewportMaximumScale:nodeIsRootLevel:nodeIsPluginElement:]):
(-[WKContentView _deliverDelayedDropPreviewIfPossible:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::applicationDidEnterBackground):
(WebKit::WebPageProxy::predictedUserAgentForRequest const):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController viewWillAppear:]):
(-[WKFullScreenViewController _playbackSessionInterface]):
(-[WKFullScreenViewController _updateWebViewFullscreenInsets]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
(-[WKFullScreenWindowController updateImageSource]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController requestRestoreFullScreen:]):
(-[WKFullScreenWindowController requestExitFullScreen]):
(-[WKFullScreenWindowController exitFullScreen:]):
(-[WKFullScreenWindowController _completedExitFullScreen:]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::drawSystemImage):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::restoreViewState):
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebPreviewLoaderClient.cpp:
(WebKit::WebPreviewLoaderClient::didReceiveData):
(WebKit::WebPreviewLoaderClient::didFinishLoading):
(WebKit::WebPreviewLoaderClient::didRequestPassword):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::setMediaEnvironment):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::isTopFrameNavigatingToAppBoundDomain const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::~WebPage):
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindIndicatorOverlayClientIOS::drawRect):
(WebKit::setSelectionChangeUpdatesEnabledInAllFrames):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::computeEditableRootHasContentAndPlainText):
(WebKit::WebPage::restorePageState):
(WebKit::WebPage::rectForElementAtInteractionLocation const):
(WebKit::WebPage::updateSelectionAppearance):
(WebKit::WebPage::handleSyntheticClick):
(WebKit::WebPage::completeSyntheticClick):
(WebKit::WebPage::attemptSyntheticClick):
(WebKit::WebPage::handleDoubleTapForDoubleClickAtPoint):
(WebKit::WebPage::sendTapHighlightForNodeIfNecessary):
(WebKit::WebPage::requestEvasionRectsAboveSelection):
(WebKit::boundsPositionInformation):
(WebKit::elementPositionInformation):
(WebKit::canForceCaretForPosition):
(WebKit::animationPositionInformation):
(WebKit::WebPage::positionInformation):
(WebKit::WebPage::dynamicViewportSizeUpdate):
(WebKit::WebPage::resetIdempotentTextAutosizingIfNeeded):
(WebKit::WebPage::resetTextAutosizing):
(WebKit::WebPage::viewportConfigurationChanged):
(WebKit::WebPage::textInputContextsInRect):

Canonical link: <a href="https://commits.webkit.org/306819@main">https://commits.webkit.org/306819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22172dea47610b9769500ef70ff999b42cb2ec8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151076 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d275dc0a-c0e1-46f0-aeac-d20b04e84468) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109525 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dcc6f33-49db-4ae6-91aa-331d1f98ee76) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90430 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/464ef12b-da23-429b-8329-3e36f74eacbf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11547 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1092 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120901 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153409 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14501 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117559 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30061 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13932 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124763 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70213 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14550 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3725 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14487 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14327 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->