### PR TITLE
[JSC][Yarr] Clean up FixedCount parentheses

### DIFF
--- a/JSTests/stress/regexp-variable-counted-parentheses-with-min.js
+++ b/JSTests/stress/regexp-variable-counted-parentheses-with-min.js
@@ -1,0 +1,277 @@
+//@ runDefault
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// Test 1: Two quantified parentheses - matching cases
+(function() {
+    var re = /(x){1,2}(a){2,4}c/;
+    shouldBe(re.exec("xaaaac"), ["xaaaac", "x", "a"], "Greedy 2-4 matches 4 a's");
+    shouldBe(re.exec("xaaac"), ["xaaac", "x", "a"], "Greedy 2-4 matches 3 a's");
+    shouldBe(re.exec("xaac"), ["xaac", "x", "a"], "Greedy 2-4 matches 2 a's");
+    // Single non-match is OK, just don't do it in a loop
+    shouldBe(re.exec("xac"), null, "Greedy 2-4 fails with only 1 a");
+    shouldBe(re.exec("xaaaaac"), null, "Greedy 2-4 on 5 a's fails (extra a before c)");
+})();
+
+// Test 2: Two x's with {2,3}
+(function() {
+    var re = /(x){1,2}(a){2,3}c/;
+    shouldBe(re.exec("xxaaac"), ["xxaaac", "x", "a"], "Two x's with three a's");
+    shouldBe(re.exec("xxaaaac"), null, "Four a's fails (extra a before c)");
+})();
+
+// Test 3: Non-greedy with two quantified parentheses
+(function() {
+    var re = /(x){1,2}(a){2,4}?c/;
+    shouldBe(re.exec("xaac"), ["xaac", "x", "a"], "Non-greedy uses min 2");
+    shouldBe(re.exec("xaaac"), ["xaaac", "x", "a"], "Non-greedy forced to use 3");
+    shouldBe(re.exec("xaaaac"), ["xaaaac", "x", "a"], "Non-greedy forced to max");
+    shouldBe(re.exec("xac"), null, "Non-greedy fails below min");
+})();
+
+// Test 4: Non-capturing groups with variable count
+(function() {
+    var re = /(x){1,2}(?:ab){2,4}c/;
+    shouldBe(re.exec("xababababc"), ["xababababc", "x"], "Non-capturing 2-4 matches 4");
+    shouldBe(re.exec("xababc"), ["xababc", "x"], "Non-capturing 2-4 matches min 2");
+})();
+
+// Test 5: Large min values
+(function() {
+    var re = /(x){1,2}(a){5,8}c/;
+    shouldBe(re.exec("xaaaaaaaac"), ["xaaaaaaaac", "x", "a"], "Large min 5-8 matches 8");
+    shouldBe(re.exec("xaaaac"), null, "Large min 5-8 fails with 4 a's");
+    shouldBe(re.exec("xaaaaac"), ["xaaaaac", "x", "a"], "Large min 5-8 matches exactly 5");
+})();
+
+// Test 6: Stress test with iterations (reusing same regexp, MATCHING cases only)
+(function() {
+    var re = /(x){1,2}(a){2,5}b/;
+    for (var i = 0; i < 100; i++) {
+        var result = re.exec("xaaaaab");
+        if (result[0] !== "xaaaaab" || result[1] !== "x" || result[2] !== "a")
+            throw new Error("Stress test failed at iteration " + i);
+    }
+})();
+
+// Test 7: Infinite max with non-zero min
+(function() {
+    var re = /(x){1,2}(a){2,}c/;
+    shouldBe(re.exec("xaaaaac"), ["xaaaaac", "x", "a"], "{2,} matches all available");
+    shouldBe(re.exec("xaac"), ["xaac", "x", "a"], "{2,} matches exactly min");
+    shouldBe(re.exec("xac"), null, "{2,} fails below min");
+})();
+
+// Test 8: Edge cases
+(function() {
+    var re = /(x){1,2}(a){2,4}c/;
+    shouldBe(re.exec(""), null, "Empty string fails");
+
+    var re2 = /(x){1,2}(a){3,4}c/;
+    shouldBe(re2.exec("xaaaac"), ["xaaaac", "x", "a"], "{3,4} matches 4");
+    shouldBe(re2.exec("xaaac"), ["xaaac", "x", "a"], "{3,4} matches 3");
+    shouldBe(re2.exec("xaac"), null, "{3,4} fails with 2");
+
+    var re3 = /(x){1,2}(a){2,4}c/i;
+    shouldBe(re3.exec("XaAaC"), ["XaAaC", "X", "a"], "Case insensitive");
+})();
+
+// Test 9: Simple patterns without trailing literal (no bug)
+(function() {
+    var re = /(a){2,4}/;
+    shouldBe(re.exec("aaaa"), ["aaaa", "a"], "Split pattern greedy");
+    shouldBe(re.exec(""), null, "0 chars fails min 2");
+    shouldBe(re.exec("a"), null, "1 char fails min 2");
+    shouldBe(re.exec("aa"), ["aa", "a"], "2 chars meets min 2");
+    shouldBe(re.exec("aaa"), ["aaa", "a"], "3 chars exceeds min 2");
+    shouldBe(re.exec("aaaaa"), ["aaaa", "a"], "5 chars limited to max 4");
+
+    // Can do repeated non-match here since no trailing literal
+    for (var i = 0; i < 100; i++) {
+        re.exec("a");  // Below minimum
+    }
+})();
+
+// Test 10: Simple non-greedy pattern
+(function() {
+    var re = /(a){2,4}?/;
+    shouldBe(re.exec("aaaa"), ["aa", "a"], "Split pattern non-greedy");
+    shouldBe(re.exec("a"), null, "1 char fails non-greedy min 2");
+    shouldBe(re.exec("aa"), ["aa", "a"], "2 chars meets non-greedy min");
+    shouldBe(re.exec("aaa"), ["aa", "a"], "3 chars - non-greedy stops at min");
+})();
+
+// Test 11: Anchored patterns (no bug with anchors)
+(function() {
+    var re = /^(a){2,4}$/;
+    shouldBe(re.exec("aaa"), ["aaa", "a"], "Split pattern with anchors");
+    shouldBe(re.exec("a"), null, "1 char fails anchored min 2");
+    shouldBe(re.exec("aa"), ["aa", "a"], "2 chars meets anchored min");
+    shouldBe(re.exec("aaaa"), ["aaaa", "a"], "4 chars at anchored max");
+    shouldBe(re.exec("aaaaa"), null, "5 chars fails anchored max");
+
+    // Can do repeated non-match with anchors
+    for (var i = 0; i < 100; i++) {
+        re.exec("a");
+    }
+})();
+
+// Test 12: Larger minimum without trailing literal
+(function() {
+    var re = /(a){3,5}/;
+    shouldBe(re.exec("aa"), null, "2 chars fails min 3");
+    shouldBe(re.exec("aaa"), ["aaa", "a"], "3 chars meets min 3");
+    shouldBe(re.exec("aaaa"), ["aaaa", "a"], "4 chars between min and max");
+    shouldBe(re.exec("aaaaa"), ["aaaaa", "a"], "5 chars at max");
+    shouldBe(re.exec("aaaaaa"), ["aaaaa", "a"], "6 chars limited to max 5");
+})();
+
+// Test 13: Two quantified groups without trailing literal
+(function() {
+    var re = /(x){1,2}(a){2,4}/;
+    shouldBe(re.exec("xa"), null, "x + 1 a fails second group min");
+    shouldBe(re.exec("xaa"), ["xaa", "x", "a"], "x + 2 a's succeeds");
+    shouldBe(re.exec("xxaa"), ["xxaa", "x", "a"], "xx + 2 a's succeeds");
+    shouldBe(re.exec("xxaaa"), ["xxaaa", "x", "a"], "xx + 3 a's succeeds");
+})();
+
+// Test 14: Non-capturing group minimum enforcement
+(function() {
+    var re = /(?:ab){2,4}/;
+    shouldBe(re.exec("ab"), null, "1 ab fails min 2");
+    shouldBe(re.exec("abab"), ["abab"], "2 ab's meets min");
+    shouldBe(re.exec("ababab"), ["ababab"], "3 ab's between min and max");
+    shouldBe(re.exec("abababab"), ["abababab"], "4 ab's at max");
+    shouldBe(re.exec("ababababab"), ["abababab"], "5 ab's limited to max");
+})();
+
+// Test 15: Capture group correctness - capture should reflect last iteration
+(function() {
+    var re = /(ab){2,4}/;
+    shouldBe(re.exec("abab"), ["abab", "ab"], "Capture is last 'ab' with 2 iterations");
+    shouldBe(re.exec("ababab"), ["ababab", "ab"], "Capture is last 'ab' with 3 iterations");
+    shouldBe(re.exec("abababab"), ["abababab", "ab"], "Capture is last 'ab' with 4 iterations");
+})();
+
+// Test 16: Nested capture groups
+(function() {
+    var re = /((a)b){2,4}/;
+    shouldBe(re.exec("abab"), ["abab", "ab", "a"], "Nested captures correct");
+    shouldBe(re.exec("ababab"), ["ababab", "ab", "a"], "Nested captures with 3 iterations");
+})();
+
+// Test 17: Alternation in quantified group
+(function() {
+    var re = /(a|b){2,4}/;
+    shouldBe(re.exec("ab"), ["ab", "b"], "Alternation capture is last match");
+    shouldBe(re.exec("ba"), ["ba", "a"], "Alternation capture is last match");
+    shouldBe(re.exec("abab"), ["abab", "b"], "Alternation with 4 chars");
+})();
+
+// Test 18: Regression test for infinite loop bug in JIT backtracking
+// Bug: When pattern `/(a){2,4}c/` failed to match "ac", the JIT would enter
+// an infinite loop due to loading beginIndex instead of endIndex in BEGIN.bt.
+// This test runs non-matching cases in a loop to catch any infinite loop.
+(function() {
+    var re = /(a){2,4}c/;
+    // This specific case triggered the infinite loop: min not met + trailing literal
+    for (var i = 0; i < 1000; i++) {
+        if (re.exec("ac") !== null)
+            throw new Error("Should not match 'ac' - only 1 'a' but min is 2");
+    }
+    // Also test other non-matching cases in loops
+    for (var i = 0; i < 1000; i++) {
+        if (re.exec("c") !== null)
+            throw new Error("Should not match 'c' - no 'a' at all");
+    }
+    for (var i = 0; i < 1000; i++) {
+        if (re.exec("ab") !== null)
+            throw new Error("Should not match 'ab' - wrong trailing char");
+    }
+})();
+
+// Test 19: Regression test for double-decrement bug in matchAmount
+// Bug: matchAmount was decremented in both BEGIN.bt and END.bt, causing
+// incorrect backtracking behavior. Test patterns that require precise
+// iteration counting during backtracking.
+(function() {
+    // Pattern that requires backtracking into previous iteration
+    var re = /(a+){2}b/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec("aab");
+        if (!result || result[0] !== "aab")
+            throw new Error("(a+){2}b should match 'aab'");
+    }
+    // Non-matching case that exercises backtracking
+    for (var i = 0; i < 1000; i++) {
+        if (re.exec("ab") !== null)
+            throw new Error("(a+){2}b should not match 'ab' - only 1 iteration possible");
+    }
+})();
+
+// Test 20: Multi-alternative FixedCount backtracking
+// Tests the simplified backtracking code for multi-alt FixedCount patterns
+(function() {
+    var re = /(?:aa|a){2}b/;
+    // Matching cases
+    for (var i = 0; i < 100; i++) {
+        var result = re.exec("aab");
+        if (!result || result[0] !== "aab")
+            throw new Error("(?:aa|a){2}b should match 'aab'");
+    }
+    for (var i = 0; i < 100; i++) {
+        var result = re.exec("aaab");
+        if (!result || result[0] !== "aaab")
+            throw new Error("(?:aa|a){2}b should match 'aaab'");
+    }
+    // Non-matching cases
+    for (var i = 0; i < 100; i++) {
+        if (re.exec("ab") !== null)
+            throw new Error("(?:aa|a){2}b should not match 'ab'");
+    }
+})();
+
+// Test 21: Content backtracking in FixedCount patterns
+// Tests that content inside parentheses can be properly backtracked
+(function() {
+    // (a*b){2} needs to backtrack content (a*) to find valid split
+    var re = /(a*b){2}/;
+    for (var i = 0; i < 100; i++) {
+        var result = re.exec("abab");
+        if (!result || result[0] !== "abab")
+            throw new Error("(a*b){2} should match 'abab'");
+    }
+    for (var i = 0; i < 100; i++) {
+        var result = re.exec("aabab");
+        if (!result || result[0] !== "aabab")
+            throw new Error("(a*b){2} should match 'aabab'");
+    }
+    for (var i = 0; i < 100; i++) {
+        var result = re.exec("aabaab");
+        if (!result || result[0] !== "aabaab")
+            throw new Error("(a*b){2} should match 'aabaab'");
+    }
+})();
+
+// Test 22: FixedCount with exactly matching min==max (no split needed)
+(function() {
+    var re = /(a){3}b/;
+    for (var i = 0; i < 100; i++) {
+        var result = re.exec("aaab");
+        if (!result || result[0] !== "aaab")
+            throw new Error("(a){3}b should match 'aaab'");
+    }
+    for (var i = 0; i < 100; i++) {
+        if (re.exec("aab") !== null)
+            throw new Error("(a){3}b should not match 'aab'");
+    }
+    // Note: /(a){3}b/ on "aaaab" DOES match ("aaab" starting at position 1)
+    for (var i = 0; i < 100; i++) {
+        var result4 = re.exec("aaaab");
+        if (!result4 || result4[0] !== "aaab")
+            throw new Error("(a){3}b should match 'aaab' within 'aaaab'");
+    }
+})();


### PR DESCRIPTION
#### 4a3cd3e0ea929f160210fa682f5a88903e3224d5
<pre>
[JSC][Yarr] Clean up FixedCount parentheses
<a href="https://bugs.webkit.org/show_bug.cgi?id=306951">https://bugs.webkit.org/show_bug.cgi?id=306951</a>
<a href="https://rdar.apple.com/169611825">rdar://169611825</a>

Reviewed by Yijia Huang.

We found a bit wrong matchAmount decrement code in Yarr JIT with
FixedCount from the previous change. So let&apos;s stop super complicated
things and just do a bit simpler form. This patch cleans up
backtrackable / non-backtrackable difference and basically assume that
we need to do backtrack in FixedCount parentheses all the time (e.g.
/(a+){3}b/). We removed weird code reseting m_reentry in the
backtracking side.

Test: JSTests/stress/regexp-variable-counted-parentheses-with-min.js

* JSTests/stress/regexp-variable-counted-parentheses-with-min.js: Added.
(shouldBe):
(re):
(re2):
(re3):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/306789@main">https://commits.webkit.org/306789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73f5338ff936f8c3106dfaaa5529748ee074d375

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/150960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95494 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38cf3ce9-df6e-45d2-a649-55f68cff97da) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109433 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79030 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1f37931-a3e5-4203-8ebb-e8363b2a0560) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/11954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90334 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/666e563c-24d6-4927-91b9-b6b35d2ea713) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11472 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9130 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/984 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134302 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153301 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3122 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117476 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117800 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13850 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70093 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21952 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14442 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3631 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173607 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78158 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44921 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14379 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->