### PR TITLE
[GLIB] Enable IPC testing API

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -69,6 +69,7 @@
 # * XML
 # * XHR
 # * EME feature
+# * IPC Testing
 # * UNSUPPORTED tests
 #   * Things we do not test. (i.e. Skipped)
 # * NEEDS TRIAGING
@@ -2628,7 +2629,6 @@ webkit.org/b/251195 webgl/1.0.x/conformance/extensions/ext-color-buffer-half-flo
 
 # Not applicable.
 webgl/webgl-backend-type.html [ Skip ]
-ipc/restrictedendpoints/allow-access-webGPU.html  [ Skip ]
 
 # Failing with ANGLE backend
 fast/canvas/webgl/oes-texture-float-linear.html [ Failure ]
@@ -3561,6 +3561,65 @@ imported/w3c/web-platform-tests/encrypted-media/clearkey-update-non-ascii-input.
 # End of EME feature
 #////////////////////////////////////////////////////////////////////////////////////////
 
+#////////////////////////////////////////////////////////////////////////////////////////
+# IPC testing
+#////////////////////////////////////////////////////////////////////////////////////////
+
+### TESTS TO BE SKIPPED
+
+# Specific to Cocoa-ports.
+ipc/networksessioncocoa-empty-resource-request.html [ Skip ]
+ipc/send-invalid-message.html [ Skip ]
+ipc/pasteboard-write-custom-data.html [ Skip ]
+ipc/remotedisplaylistrecorder-drawcontrolpart-slidertrackpart-crash.html [ Skip ]
+http/tests/ipc/gpu-load-error-empty-user-info-crssh.html [ Skip ]
+
+# ATTACHMENT_ELEMENT is disabled in glib ports.
+ipc/restrictedendpoints/allow-access-attachmentElement.html [ Skip ]
+
+# libwebrtc-specific.
+ipc/videoEncode.html [ Skip ]
+
+# WebAuthn not enabled
+ipc/web-authenticator-get-assertion.html [ Skip ]
+
+# These tests require UseGPUProcessForMediaEnabled
+ipc/restrictedendpoints/allow-access-testOnlyIPC.html [ Skip ]
+
+# Assorted crashes
+ipc/convert-to-luminance-mask-float16.html [ Crash ]
+ipc/empty-svgfilterrenderer-expression-crash.html [ Crash ]
+ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html [ Crash ]
+
+### FAILING TESTS
+
+# Read-Only shared-memory handle not supported, see https://bugs.webkit.org/show_bug.cgi?id=131542
+ipc/stream-sync-reply-shared-memory.html [ Failure ]
+
+
+### NEEDS PROPER TRIAGGING/GARDENING
+
+ipc/decode-feConvolveMatrix-kernelSize-overflow.html [ Failure ]
+ipc/invalid-addSourceBuffer-to-GPU-process-crash.html [ Failure ]
+ipc/invalid-message-to-web-process-crash.html [ Failure ]
+ipc/restore-empty-stack-crash.html [ Failure ]
+ipc/restrictedendpoints/deny-access-attachmentElement.html [ Failure ]
+ipc/serialized-type-info.html [ Failure ]
+http/tests/ipc/null-port-on-sharedmemoryhandle-creation.html [ Failure ]
+
+ipc/restrictedendpoints/deny-access-testOnlyIPC.html [ Crash ]
+ipc/restrictedendpoints/deny-access-webGPU.html [ Crash ]
+ipc/validate-message-check-in-networkconnectiontowebproces-crash.html [ Crash ]
+
+ipc/insufficient-svgfilter-inputs-crash.html [ Timeout ]
+ipc/invalid-feConvolveMatrix-crash.html [ Timeout ]
+ipc/invalid-svgfilter-expression-crash.html [ Timeout ]
+ipc/restrictedendpoints/deny-access-updateQuotaBasedOnSpaceUsageForTesting.html [ Timeout ]
+ipc/restrictedendpoints/deny-access-webPush.html [ Timeout ]
+
+#////////////////////////////////////////////////////////////////////////////////////////
+# End of IPC testing
+#////////////////////////////////////////////////////////////////////////////////////////
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # UNSUPPORTED tests. Things we must skip.

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -301,8 +301,10 @@
 #endif
 
 #if !defined(ENABLE_IPC_TESTING_API)
-/* Enable IPC testing on all ASAN builds and debug builds. */
-#if (ASAN_ENABLED || !defined(NDEBUG)) && PLATFORM(COCOA)
+/* Enable IPC testing on all ASAN builds and debug builds. Enable it in GLib ports when assertions are enabled. */
+/* In GLib ports, only enable for GCC builds, as this is what we currently test in EWS and clang-18 is significantly */
+/* slow to build when IPC testing is enabled. */
+#if ((ASAN_ENABLED || !defined(NDEBUG)) && PLATFORM(COCOA)) || (ASSERT_ENABLED && (PLATFORM(GTK) || PLATFORM(WPE)) && COMPILER(GCC))
 #define ENABLE_IPC_TESTING_API 1
 #endif
 #endif

--- a/Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp
+++ b/Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp
@@ -29,13 +29,15 @@
 #if ENABLE(GPU_PROCESS) && (PLATFORM(GTK) || PLATFORM(WPE))
 
 #include "GPUProcessCreationParameters.h"
-
+#include <glib.h>
 #if USE(GBM)
 #include <WebCore/DRMDevice.h>
 #include <WebCore/DRMDeviceManager.h>
 #include <WebCore/GBMDevice.h>
 #include <WebCore/PlatformDisplayGBM.h>
 #endif
+#include <WebCore/PlatformDisplaySurfaceless.h>
+#include <wtf/text/CStringView.h>
 
 namespace WebKit {
 
@@ -51,6 +53,10 @@ void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& para
 #else
     UNUSED_PARAM(parameters);
 #endif
+    if (auto display = WebCore::PlatformDisplaySurfaceless::create()) {
+        WebCore::PlatformDisplay::setSharedDisplay(WTF::move(display));
+        return;
+    }
 
     WTFLogAlways("Could not create EGL display for GPU process: no supported platform available. Aborting...");
     CRASH();

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.cpp
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.cpp
@@ -158,11 +158,14 @@ JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, u
     return jsValueForDecodedNumericArgumentValue(globalObject, value, "uint64_t"_s);
 }
 
+// In 64-bit Linux size_t and uint64_t are the same type, so this is a redefinition of the above method.
+#if !OS(LINUX) || !CPU(ADDRESS64)
 template<>
 JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, size_t value)
 {
     return jsValueForDecodedNumericArgumentValue(globalObject, value, "size_t"_s);
 }
+#endif
 
 template<typename RectType>
 JSC::JSValue jsValueForDecodedArgumentRect(JSC::JSGlobalObject* globalObject, const RectType& value, const String& type)

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -77,6 +77,7 @@ template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, Web
 template<typename T, std::enable_if_t<std::is_arithmetic<T>::value>* = nullptr>
 JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, T)
 {
+    return JSC::JSValue();
 }
 
 template<typename E, std::enable_if_t<std::is_enum<E>::value>* = nullptr>

--- a/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h
@@ -38,6 +38,7 @@ namespace IPC {
 class Encoder;
 template<> struct ArgumentCoder<WebCore::RealtimeMediaSourceCenter::ValidDevices> {
     static void encode(Encoder&, const WebCore::RealtimeMediaSourceCenter::ValidDevices&);
+    static std::optional<WebCore::RealtimeMediaSourceCenter::ValidDevices> decode(Decoder&);
 };
 }
 


### PR DESCRIPTION
#### 6b12b478a26f8e1c205628ec2aea67681cc04661
<pre>
[GLIB] Enable IPC testing API
<a href="https://bugs.webkit.org/show_bug.cgi?id=306955">https://bugs.webkit.org/show_bug.cgi?id=306955</a>

Reviewed by Adrian Perez de Castro.

Enable the IPC testing API for WPE/GTK builds that have
assertions enabled. Most tests are already passing but some
that are Apple-specific are skipped, while others that are
failing/crashing are marked as such for now so that we
can later triagge them and fix them properly.

Only enable when building with GCC, as clang-18 is significantly
slow to build GeneratedSerializers.cpp, and we are only testing
GCC builds in EWS, so there&apos;s no need to enable IPC testing in
clang builds.

Because the IPC tests need to spawn a GPU process to test
IPC messages to/from the GPU process, and currently the GLib
GPU process implementation depends on GBM, we need to add a
fallback case using a headless display that can be used when
GBM is not available. Otherwise the GPU process fails to
initialize.

GCC 13 complains that the default template for
jsValueForDecodedArgumentValue() doesn&apos;t have a return value even
if it&apos;s not instantiated (clang doesn&apos;t). For this reason add
a default return value.

Also, because in 64-bit Linux size_t is the same as uint64_t,
only include the size_t jsValueForDecodedArgumentValue() version
for other platforms, otherwise this causes a method redefinition
build error.

Also add a decoder for RealtimeMediaSourceCenter::ValidDevices,
since this is now needed.

* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebKit/GPUProcess/glib/GPUProcessGLib.cpp:
(WebKit::GPUProcess::platformInitializeGPUProcess):
* Source/WebKit/Platform/IPC/JSIPCBinding.cpp:
* Source/WebKit/Platform/IPC/JSIPCBinding.h:
(IPC::jsValueForDecodedArgumentValue):
* Source/WebKit/WebProcess/glib/UserMediaCaptureManager.h:

Canonical link: <a href="https://commits.webkit.org/311570@main">https://commits.webkit.org/311570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f79621dd965548d6b02cc56c21b0c09d6ea0701

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111113 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121612 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85392 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141015 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102280 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/22911 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13626 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/149081 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168339 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/17866 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12498 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129738 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35249 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140637 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87698 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17441 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/188994 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93617 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48516 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->