### PR TITLE
git-webkit update fails when run from a git worktree

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -447,7 +447,7 @@ class PullRequest(Command):
                 sys.stderr.write("Failed to rebase '{}' on '{},' please resolve conflicts\n".format(repository.branch, branch_point.branch))
                 return 1
             log.info("Rebased '{}' on '{}!'".format(repository.branch, branch_point.branch))
-            branch_point = repository.commit(branch=branch_point.branch)
+            branch_point = repository.commit(branch='{}/{}'.format(source_remote, branch_point.branch))
 
         if args.checks is None:
             args.checks = repository.config().get('webkitscmpy.auto-check', 'false') == 'true'


### PR DESCRIPTION
#### 6adb0db78d8f84537ee7861ba20ea57f276499cc
<pre>
git-webkit update fails when run from a git worktree
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=306957">https://bugs.webkit.org/show_bug.cgi?id=306957</a>&gt;
&lt;<a href="https://rdar.apple.com/169630851">rdar://169630851</a>&gt;

Reviewed by Jonathan Bedard.

The `pull()` method in `git.py` currently runs `git fetch origin
main:main` to update the local branch reference before rebasing.  Git
refuses to update a branch that is checked out in any worktree as a
safety mechanism to prevent data corruption.

To fix the bug, add an `is_worktree` property that detects git worktrees
by comparing git_directory to common_directory.  Skip the fetch call in
`pull()` when running in a worktree since `git pull origin main --rebase`
already updates the `origin/main` remote tracking ref.

Change `pull_request.py` to use the remote tracking ref `origin/main`
instead of the local `main` branch, which is always up-to-date after
the pull regardless of whether the fetch was skipped.

Fix `_maybe_update_default_branch_ref_from_fetch_head()` to read
`FETCH_HEAD` from `git_directory` instead of `common_directory` since
`FETCH_HEAD` is a per-worktree file.  This fixes a webkitscmpy warning
about non-fast-forward updates that only appeared in git worktrees.
Also add `capture_output=True` to the `filter-branch` command in
`pull()` to suppress git warnings.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.git_directory): Add.
- Add property that returns the result of `git rev-parse --git-dir`.
(Git.is_worktree): Add.
- Add property to detect git worktrees.
(Git._maybe_update_default_branch_ref_from_fetch_head):
- Read FETCH_HEAD from git_directory instead of common_directory.
(Git.pull):
- Skip fetch call when in a worktree.
- Add capture_output=True to filter-branch command.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__):
- Add mock for `git rev-parse --git-dir`.
- Add is_worktree kwargs parameter and instance attribute.
(Git._fetch_with_refspec): Add.
- Add mock for worktree fetch failure.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.create_pull_request):
- Use remote tracking ref instead of local branch.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
(TestGit.test_is_worktree_false_for_normal_repo): Add.
- Add test for normal repository.
(TestGit.test_is_worktree_true_for_worktree): Add.
- Add test for worktree repository.
(TestGit.test_fetch_fails_in_worktree): Add.
- Add test for fetch failure in worktree.
(TestGit.test_pull_rebase_with_branch): Add.
- Add test for normal repository pull.
(TestGit.test_pull_rebase_with_branch_checked_out_in_worktree): Add.
- Add test for worktree pull.
(TestGit.test_fetch_head_in_worktree_uses_git_directory): Add.
- Add test for FETCH_HEAD read from git_directory in worktree.

Canonical link: <a href="https://commits.webkit.org/307764@main">https://commits.webkit.org/307764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1dd94cd6eef14e598f89fcd56ed6b193851713e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98377 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/565fdf12-2c98-4f8c-b8f6-070f1c335822) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111295 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79787 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147705 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92190 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bc655dc-ceb5-4fcc-8962-988d21a363e4) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/144068 "Passed tests") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10784 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/858 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155725 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17273 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119300 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/144147 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119629 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15440 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127892 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72815 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22428 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16895 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6245 "Too many flaky failures: http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/misc/object-image-error-with-onload.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/security/canvas-remote-read-remote-image-allowed.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/register-bypassing-scheme.html, http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/websocket/tests/hybi/contentextensions/block-worker.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16631 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16695 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->