### PR TITLE
Fix some internal builds

### DIFF
--- a/Source/WebGPU/WebGPU/ModelBridge.swift
+++ b/Source/WebGPU/WebGPU/ModelBridge.swift
@@ -24,7 +24,7 @@
 import Metal
 internal import WebGPU_Private.ModelTypes
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
 @_spi(SwiftAPI) import DirectResource
@@ -795,7 +795,7 @@ extension WebBridgeLiteral {
     }
 }
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
 
 internal func toData<T>(_ input: [T]) -> Data {
     unsafe input.withUnsafeBytes { bufferPointer in

--- a/Source/WebGPU/WebGPU/ModelIBLTextures.swift
+++ b/Source/WebGPU/WebGPU/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
 
 import Metal
 @_spi(RealityCoreRendererAPI) import RealityKit

--- a/Source/WebGPU/WebGPU/ModelParameters.swift
+++ b/Source/WebGPU/WebGPU/ModelParameters.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
 
 @_spi(RealityCoreRendererAPI) import RealityKit
 

--- a/Source/WebGPU/WebGPU/ModelRenderer.swift
+++ b/Source/WebGPU/WebGPU/ModelRenderer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
 
 import QuartzCore
 @_spi(RealityCoreRendererAPI) @_spi(Private) import RealityKit

--- a/Source/WebGPU/WebGPU/ModelUtils.swift
+++ b/Source/WebGPU/WebGPU/ModelUtils.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
 
 import DirectResource
 import Metal

--- a/Source/WebGPU/WebGPU/USDModel.swift
+++ b/Source/WebGPU/WebGPU/USDModel.swift
@@ -26,7 +26,7 @@ internal import OSLog
 internal import WebGPU_Private.ModelTypes
 internal import simd
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDKit, _version: 34)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(RealityCoreTextureProcessingAPI) import RealityCoreTextureProcessing
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit


### PR DESCRIPTION
#### 8bec2e02631dae5ca428e6b5d106f94b163b41dd
<pre>
Fix some internal builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=306962">https://bugs.webkit.org/show_bug.cgi?id=306962</a>
<a href="https://rdar.apple.com/169631575">rdar://169631575</a>

Unreviewed, version check was wrong, check for the presence
of _USDKit_RealityKit instead of a specific USDKit version.

* Source/WebGPU/WebGPU/ModelBridge.swift:
* Source/WebGPU/WebGPU/ModelIBLTextures.swift:
* Source/WebGPU/WebGPU/ModelParameters.swift:
* Source/WebGPU/WebGPU/ModelRenderer.swift:
* Source/WebGPU/WebGPU/ModelUtils.swift:
* Source/WebGPU/WebGPU/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/306787@main">https://commits.webkit.org/306787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92de2ec32ec716ceeafa6a9ac247f8c89a711a00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14760 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/151010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/15479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14914 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/151010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145313 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/15479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/5162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/151010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/15479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1030 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/15479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/5162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/153347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/153347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/14461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/12601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/153347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/5162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70149 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21951 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14488 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/5162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78204 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/14265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->