### PR TITLE
[Win][Skia] Attempt to unbreak Win/Skia build after 306777@main

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.h
@@ -62,7 +62,7 @@ enum class Algorithm {
 
 // Pack rectangles into a fixed-size atlas.
 // Returns packed rectangles with positions, or empty vector if images don't fit.
-Vector<PackedRect> pack(std::span<const IntSize> sizes, const IntSize& atlasSize, Algorithm = Algorithm::MaxRects);
+WEBCORE_EXPORT Vector<PackedRect> pack(std::span<const IntSize> sizes, const IntSize& atlasSize, Algorithm = Algorithm::MaxRects);
 
 }; // namespace SkiaTextureAtlasPacker
 


### PR DESCRIPTION
#### 28d1f702b17e0caf7dd8d7d9c178a80b5d433e50
<pre>
[Win][Skia] Attempt to unbreak Win/Skia build after <a href="https://commits.webkit.org/306777@main">306777@main</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306968">https://bugs.webkit.org/show_bug.cgi?id=306968</a>

Reviewed by NOBODY (OOPS!).

Add WEBCORE_EXPORT to Vector&lt;PackedRect&gt; pack(...) in
SkiaTextureAtlasPacker to unbreak the Win/Skia build.

* Source/WebCore/platform/graphics/skia/SkiaTextureAtlasPacker.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28d1f702b17e0caf7dd8d7d9c178a80b5d433e50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151030 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95571 "Failed to checkout and rebase branch from PR 57873") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109488 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95571 "Failed to checkout and rebase branch from PR 57873") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11522 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9178 "Found 1 new API test failure: TestWebKitAPI.WebKit2.GetUserMediaAfterMuting (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1050 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153367 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14459 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117527 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14481 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117852 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13898 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70171 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14508 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3696 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78224 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->