### PR TITLE
Some Swift code assumes specific framework versions

### DIFF
--- a/Source/WebGPU/WebGPU/ModelBridge.swift
+++ b/Source/WebGPU/WebGPU/ModelBridge.swift
@@ -24,7 +24,7 @@
 import Metal
 internal import WebGPU_Private.ModelTypes
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDStageKit, _version: 34)
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
 @_spi(SwiftAPI) import DirectResource
@@ -795,7 +795,7 @@ extension WebBridgeLiteral {
     }
 }
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDStageKit, _version: 34)
 
 internal func toData<T>(_ input: [T]) -> Data {
     unsafe input.withUnsafeBytes { bufferPointer in

--- a/Source/WebGPU/WebGPU/ModelIBLTextures.swift
+++ b/Source/WebGPU/WebGPU/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDStageKit, _version: 34)
 
 import Metal
 @_spi(RealityCoreRendererAPI) import RealityKit

--- a/Source/WebGPU/WebGPU/ModelParameters.swift
+++ b/Source/WebGPU/WebGPU/ModelParameters.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDStageKit, _version: 34)
 
 @_spi(RealityCoreRendererAPI) import RealityKit
 

--- a/Source/WebGPU/WebGPU/ModelRenderer.swift
+++ b/Source/WebGPU/WebGPU/ModelRenderer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDStageKit, _version: 34)
 
 import QuartzCore
 @_spi(RealityCoreRendererAPI) @_spi(Private) import RealityKit

--- a/Source/WebGPU/WebGPU/ModelUtils.swift
+++ b/Source/WebGPU/WebGPU/ModelUtils.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDStageKit, _version: 34)
 
 import DirectResource
 import Metal

--- a/Source/WebGPU/WebGPU/USDModel.swift
+++ b/Source/WebGPU/WebGPU/USDModel.swift
@@ -26,7 +26,7 @@ internal import OSLog
 internal import WebGPU_Private.ModelTypes
 internal import simd
 
-#if canImport(RealityCoreRenderer, _version: 6) && canImport(_USDKit_RealityKit)
+#if canImport(RealityCoreRenderer, _version: 6) && canImport(USDStageKit, _version: 34)
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(RealityCoreTextureProcessingAPI) import RealityCoreTextureProcessing
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit


### PR DESCRIPTION
#### 30456cc3ad1452c4328874ced5d1cafd50de2cc5
<pre>
Some Swift code assumes specific framework versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=306973">https://bugs.webkit.org/show_bug.cgi?id=306973</a>
<a href="https://rdar.apple.com/169641776">rdar://169641776</a>

Unreviewed build fix, the presence of _USDKit_RealityKit is not
equivalent to USDStageKit-34 which some of the code assumes exist.

We don&apos;t need to check for both as USDStageKit-34 implies _USDKit_RealityKit
exists as well.

* Source/WebGPU/WebGPU/ModelBridge.swift:
* Source/WebGPU/WebGPU/ModelIBLTextures.swift:
* Source/WebGPU/WebGPU/ModelParameters.swift:
* Source/WebGPU/WebGPU/ModelRenderer.swift:
* Source/WebGPU/WebGPU/ModelUtils.swift:
* Source/WebGPU/WebGPU/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/306806@main">https://commits.webkit.org/306806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7320a992094da46ec5bedc72cffadd44df05cc0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151046 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10079688-3f5c-4c5b-b04c-bd5aaab4663e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109500 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f52e5c40-8134-4e27-b45e-ae3edf4fb64a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90405 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11529 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120882 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153383 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4560 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117541 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117868 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30048 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 16.4; Checked out pull request; Skipped because there are no valid reviewers; Compiled WebKit (warnings); 4 flakes 2 failures; Uploaded test results; 9 flakes 3 failures; Compiled WebKit (cancelled)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13912 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124736 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70187 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21965 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14524 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3701 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->