### PR TITLE
[SVG2] Change default value of `fx` and `fy` to `50%` for SVGRadialGradient

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt
@@ -91,10 +91,10 @@ PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (r
 PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.cy (invalid value)
 PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (remove)
 PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.r (invalid value)
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (remove) assert_equals: initial before expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (invalid value) assert_equals: initial before expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (remove) assert_equals: initial before expected "50%" but got "0"
-FAIL SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (invalid value) assert_equals: initial before expected "50%" but got "0"
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (remove)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fx (invalid value)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (remove)
+PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fy (invalid value)
 PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (remove)
 PASS SVGAnimatedLength, initial values, SVGRadialGradientElement.prototype.fr (invalid value)
 PASS SVGAnimatedLength, initial values, SVGRectElement.prototype.x (remove)

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -67,8 +67,8 @@ private:
     Ref<SVGAnimatedLength> m_cx { SVGAnimatedLength::create(this, SVGLengthMode::Width, "50%"_s) };
     Ref<SVGAnimatedLength> m_cy { SVGAnimatedLength::create(this, SVGLengthMode::Height, "50%"_s) };
     Ref<SVGAnimatedLength> m_r { SVGAnimatedLength::create(this, SVGLengthMode::Other, "50%"_s) };
-    Ref<SVGAnimatedLength> m_fx { SVGAnimatedLength::create(this, SVGLengthMode::Width) };
-    Ref<SVGAnimatedLength> m_fy { SVGAnimatedLength::create(this, SVGLengthMode::Height) };
+    Ref<SVGAnimatedLength> m_fx { SVGAnimatedLength::create(this, SVGLengthMode::Width, "50%"_s) };
+    Ref<SVGAnimatedLength> m_fy { SVGAnimatedLength::create(this, SVGLengthMode::Height, "50%"_s) };
     Ref<SVGAnimatedLength> m_fr { SVGAnimatedLength::create(this, SVGLengthMode::Other, "0%"_s) };
 };
 


### PR DESCRIPTION
#### 42a0c2981cc0f0b8b33f6d4dea33197a531f1021
<pre>
[SVG2] Change default value of `fx` and `fy` to `50%` for SVGRadialGradient
<a href="https://bugs.webkit.org/show_bug.cgi?id=306976">https://bugs.webkit.org/show_bug.cgi?id=306976</a>
<a href="https://rdar.apple.com/169645572">rdar://169645572</a>

Reviewed by Said Abou-Hallawa.

This patch aligns with Web Specification [1]:

As per web specification change, the initial value for &apos;fx&apos; and &apos;fy&apos; is
now &apos;50%&apos; and this change follows it.

[1] <a href="https://github.com/w3c/svgwg/commit/762c87597d29af3fe45a810155e9b54749229d79">https://github.com/w3c/svgwg/commit/762c87597d29af3fe45a810155e9b54749229d79</a>

* Source/WebCore/svg/SVGRadialGradientElement.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedLength-initial-values-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/306811@main">https://commits.webkit.org/306811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e1ed9ad9fe1abc415788542dcb6e9990f8b0560

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151054 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/905309d2-9f82-4ebe-86c2-40199fb0276b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109507 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f1b184a-3db2-4cac-8f57-65cd6660f5ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12020 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90412 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abdb9a58-9c02-4a24-adff-0378ef3eb3e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11533 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9190 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1072 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120886 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153389 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14481 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117547 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117874 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30056 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13920 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124743 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70193 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14530 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3708 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14262 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14307 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->