### PR TITLE
[iOS] MediaPlayerPrivateWirelessPlayback should fall back to other sources if its MediaDeviceRoute rejects a URL

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-expected.txt
@@ -1,0 +1,10 @@
+Test that a video's second <source> element's URL is loaded if the MediaDeviceRoute rejects the first <source> element's URL.
+
+
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EXPECTED (actualURL == '/LayoutTests/media/content/test.mp4') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback.html
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+            var actualURL;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.createElement('video');
+
+                const mediaType = 'video/mp4';
+                const mediaURL = findMediaFile('video', '../content/test');
+                const mediaURLToReject = findMediaFile('video', '../content/test_yuv420');
+
+                const firstSource = document.createElement('source');
+                firstSource.src = mediaURLToReject;
+                firstSource.type = mediaType;
+                video.appendChild(firstSource);
+
+                const secondSource = document.createElement('source');
+                secondSource.src = mediaURL;
+                secondSource.type = mediaType;
+                video.appendChild(secondSource);
+
+                document.body.appendChild(video);
+
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        if (url === new URL(mediaURLToReject, document.baseURI).href)
+                            throw new Error('URL rejected');
+                        resolve(url);
+                    });
+                });
+
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const loadedURL = await urlPromise;
+                const expectedURL = new URL(mediaURL, document.baseURI).href.substring(document.baseURI.indexOf('/LayoutTests/'));
+                actualURL = loadedURL.substring(loadedURL.indexOf('/LayoutTests/'));
+
+                testExpected('actualURL', expectedURL);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <p>Test that a video's second &lt;source&gt; element's URL is loaded if the MediaDeviceRoute rejects the first &lt;source&gt; element's URL.</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -172,7 +172,16 @@ void MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded()
     if (!playbackTarget)
         return;
 
-    playbackTarget->loadURL(m_url, [](const MediaDeviceRouteLoadURLResult&) {
+    playbackTarget->loadURL(m_url, [weakThis = ThreadSafeWeakPtr { *this }](const MediaDeviceRouteLoadURLResult& result) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+
+        if (!result) {
+            protectedThis->setNetworkState(MediaPlayer::NetworkState::FormatError);
+            return;
+        }
+
         // FIXME: Advance networkState and readyState once the target has loaded the URL
     });
 }


### PR DESCRIPTION
#### 839256e6be1122512bd27ff50e67c02bd56a4d4d
<pre>
[iOS] MediaPlayerPrivateWirelessPlayback should fall back to other sources if its MediaDeviceRoute rejects a URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=306994">https://bugs.webkit.org/show_bug.cgi?id=306994</a>
<a href="https://rdar.apple.com/169653985">rdar://169653985</a>

Reviewed by Eric Carlson.

If a MediaDeviceRoute rejects a URL (because MediaPlaybackTargetWirelessPlayback::loadURL calls its
completion handler with an error), MediaPlayerPrivateWirelessPlayback should set its network state
to FormatError. This triggers HTMLMediaElement to attempt to load the next &lt;source&gt; (if available).

Test: media/wireless-playback-media-player/load-url-source-element-fallback.html

* LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback.html: Added.
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded):

Canonical link: <a href="https://commits.webkit.org/306821@main">https://commits.webkit.org/306821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16ce57a3e5ad3f399b37bb9808806b7fe7977eda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151086 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d8cf208-12f8-4df0-891d-256ba6aaf10f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/14985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109531 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67231ecb-424d-4669-8c1d-f0424613415c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90436 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1105 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153418 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4592 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12658 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13942 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124768 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14559 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3730 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14291 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14496 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->