### PR TITLE
Migrate PKShippingMethod to Wrapped WKKeyedCoder

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -362,6 +362,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readwrite) PKShippingMethod *shippingMethod;
 @end
 
+@interface PKShippingMethod () <NSSecureCoding>
+@end
+
 @interface PKPaymentMerchantSession () <NSSecureCoding>
 @end
 

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -271,6 +271,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKDateComponentsRange.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentToken.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKShippingMethod.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPassKit.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPlist.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -677,6 +677,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in \
 	Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in \
 	Shared/Cocoa/CoreIPCPKPaymentToken.serialization.in \
+	Shared/Cocoa/CoreIPCPKShippingMethod.serialization.in \
 	Shared/Cocoa/CoreIPCPlist.serialization.in \
 	Shared/Cocoa/CoreIPCPresentationIntent.serialization.in \
 	Shared/Cocoa/CoreIPCSecureCoding.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -39,6 +39,9 @@
 #if HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
 #include "CoreIPCPKPaymentSetupFeature.h"
 #endif
+#if HAVE(WK_SECURE_CODING_PKSHIPPINGMETHOD)
+#include "CoreIPCPKShippingMethod.h"
+#endif
 #endif
 #include <wtf/RetainPtr.h>
 #include <wtf/UniqueRef.h>
@@ -62,7 +65,9 @@ class CoreIPCPKPayment;
 #if !HAVE(WK_SECURE_CODING_PKPAYMENTTOKEN)
 class CoreIPCPKPaymentToken;
 #endif
+#if !HAVE(WK_SECURE_CODING_PKSHIPPINGMETHOD)
 class CoreIPCPKShippingMethod;
+#endif
 class CoreIPCCNContact;
 class CoreIPCCNPhoneNumber;
 class CoreIPCCNPostalAddress;

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/RetainPtr.h>
+
+OBJC_CLASS PKDateComponentsRange;
+OBJC_CLASS PKShippingMethod;
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKSHIPPINGMETHOD)
+
+namespace WebKit {
+
+enum class PKPaymentSummaryItemType : uint8_t {
+    Final = 0,
+    Pending = 1,
+};
+
+struct CoreIPCPKShippingMethodData {
+    RetainPtr<NSString> label;
+    RetainPtr<NSNumber> amount;
+    std::optional<PKPaymentSummaryItemType> type;
+    RetainPtr<NSString> localizedTitle;
+    RetainPtr<NSString> localizedAmount;
+    std::optional<bool> useDarkColor;
+    std::optional<bool> useLargeFont;
+    RetainPtr<NSString> identifier;
+    RetainPtr<NSString> detail;
+    RetainPtr<PKDateComponentsRange> dateComponentsRange;
+};
+
+class CoreIPCPKShippingMethod {
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCPKShippingMethod);
+public:
+    CoreIPCPKShippingMethod(PKShippingMethod *);
+    CoreIPCPKShippingMethod(std::optional<CoreIPCPKShippingMethodData>&&);
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCPKShippingMethod>;
+
+    std::optional<CoreIPCPKShippingMethodData> m_data;
+};
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.mm
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCPKShippingMethod.h"
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKSHIPPINGMETHOD)
+
+#import "ArgumentCodersCocoa.h"
+#import "Logging.h"
+#import "WKKeyedCoder.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <pal/cocoa/PassKitSoftLink.h>
+
+namespace WebKit {
+
+CoreIPCPKShippingMethod::CoreIPCPKShippingMethod(PKShippingMethod *shippingMethod)
+{
+    if (!shippingMethod)
+        return;
+
+    RetainPtr archiver = adoptNS([WKKeyedCoder new]);
+    [shippingMethod encodeWithCoder:archiver.get()];
+    RetainPtr dictionary = [archiver accumulatedDictionary];
+
+    CoreIPCPKShippingMethodData data;
+
+    if (RetainPtr label = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"label"]))
+        data.label = WTF::move(label);
+
+    if (RetainPtr amount = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"amount"]))
+        data.amount = WTF::move(amount);
+
+    if (RetainPtr typeNumber = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"type"])) {
+        auto value = [typeNumber unsignedCharValue];
+        if (isValidEnum<PKPaymentSummaryItemType>(value))
+            data.type = static_cast<PKPaymentSummaryItemType>(value);
+    }
+
+    if (RetainPtr localizedTitle = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"localizedTitle"]))
+        data.localizedTitle = WTF::move(localizedTitle);
+
+    if (RetainPtr localizedAmount = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"localizedAmount"]))
+        data.localizedAmount = WTF::move(localizedAmount);
+
+    if (RetainPtr useDarkColor = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"useDarkColor"]))
+        data.useDarkColor = [useDarkColor boolValue];
+
+    if (RetainPtr useLargeFont = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"useLargeFont"]))
+        data.useLargeFont = [useLargeFont boolValue];
+
+    if (RetainPtr identifier = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"identifier"]))
+        data.identifier = WTF::move(identifier);
+
+    if (RetainPtr detail = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"detail"]))
+        data.detail = WTF::move(detail);
+
+    if (id dateComponentsRange = [dictionary.get() objectForKey:@"dateComponentsRange"]) {
+        if ([dateComponentsRange isKindOfClass:PAL::getPKDateComponentsRangeClassSingleton()])
+            data.dateComponentsRange = dateComponentsRange;
+    }
+
+    m_data = WTF::move(data);
+}
+
+CoreIPCPKShippingMethod::CoreIPCPKShippingMethod(std::optional<CoreIPCPKShippingMethodData>&& data)
+    : m_data { WTF::move(data) }
+{
+}
+
+RetainPtr<id> CoreIPCPKShippingMethod::toID() const
+{
+    if (!m_data)
+        return { };
+
+    RetainPtr dictionary = [NSMutableDictionary dictionaryWithCapacity:10];
+
+    if (m_data->label)
+        [dictionary setObject:m_data->label.get() forKey:@"label"];
+    if (m_data->amount)
+        [dictionary setObject:m_data->amount.get() forKey:@"amount"];
+    if (m_data->type)
+        [dictionary setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(*m_data->type)] forKey:@"type"];
+    if (m_data->localizedTitle)
+        [dictionary setObject:m_data->localizedTitle.get() forKey:@"localizedTitle"];
+    if (m_data->localizedAmount)
+        [dictionary setObject:m_data->localizedAmount.get() forKey:@"localizedAmount"];
+    if (m_data->useDarkColor)
+        [dictionary setObject:@(*m_data->useDarkColor) forKey:@"useDarkColor"];
+    if (m_data->useLargeFont)
+        [dictionary setObject:@(*m_data->useLargeFont) forKey:@"useLargeFont"];
+    if (m_data->identifier)
+        [dictionary setObject:m_data->identifier.get() forKey:@"identifier"];
+    if (m_data->detail)
+        [dictionary setObject:m_data->detail.get() forKey:@"detail"];
+    if (m_data->dateComponentsRange)
+        [dictionary setObject:m_data->dateComponentsRange.get() forKey:@"dateComponentsRange"];
+
+    RetainPtr unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:dictionary.get()]);
+    RetainPtr shippingMethod = adoptNS([[PAL::getPKShippingMethodClassSingleton() alloc] initWithCoder:unarchiver.get()]);
+    if (!shippingMethod)
+        RELEASE_LOG_ERROR(IPC, "CoreIPCPKShippingMethod was not able to reconstruct a PKShippingMethod object");
+    return shippingMethod;
+}
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.serialization.in
@@ -1,0 +1,50 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKSHIPPINGMETHOD)
+
+header: "CoreIPCPKShippingMethod.h"
+webkit_platform_headers: "CoreIPCPKShippingMethod.h"
+
+[CustomHeader, WebKitPlatform] enum class WebKit::PKPaymentSummaryItemType : uint8_t {
+    Final,
+    Pending,
+}
+
+[CustomHeader, WebKitPlatform] struct WebKit::CoreIPCPKShippingMethodData {
+    RetainPtr<NSString> label;
+    RetainPtr<NSNumber> amount;
+    std::optional<WebKit::PKPaymentSummaryItemType> type;
+    RetainPtr<NSString> localizedTitle;
+    RetainPtr<NSString> localizedAmount;
+    std::optional<bool> useDarkColor;
+    std::optional<bool> useLargeFont;
+    RetainPtr<NSString> identifier;
+    RetainPtr<NSString> detail;
+    RetainPtr<PKDateComponentsRange> dateComponentsRange;
+}
+
+[WebKitPlatform] class WebKit::CoreIPCPKShippingMethod {
+    std::optional<WebKit::CoreIPCPKShippingMethodData> m_data;
+}
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -84,6 +84,7 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
 }
 #endif
 
+#if !HAVE(WK_SECURE_CODING_PKSHIPPINGMETHOD)
 [WebKitSecureCodingClass=PAL::getPKShippingMethodClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKShippingMethod {
     label: String
     amount: Number
@@ -96,6 +97,7 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
     detail: String
     dateComponentsRange: PKDateComponentsRange
 }
+#endif
 
 #if !HAVE(WK_SECURE_CODING_PKDATECOMPONENTSRANGE)
 [WebKitSecureCodingClass=PAL::getPKDateComponentsRangeClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKDateComponentsRange {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2609,6 +2609,8 @@
 		F4E727232A547F0400CE34FD /* WKTouchEventsGestureRecognizerTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E727222A547E2100CE34FD /* WKTouchEventsGestureRecognizerTypes.h */; };
 		F4E89F5C2EFC702000E4D96E /* TextExtractionURLCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E89F5A2EFC702000E4D96E /* TextExtractionURLCache.h */; };
 		F4EB4AFD269CD7F300D297AE /* OSStateSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EB4AFC269CD23600D297AE /* OSStateSPI.h */; };
+		F4EBCF642F33E87800BFAC3C /* CoreIPCPKShippingMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EBCF612F33E86F00BFAC3C /* CoreIPCPKShippingMethod.h */; };
+		F4EBCF652F33E87E00BFAC3C /* CoreIPCPKShippingMethod.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4EBCF622F33E86F00BFAC3C /* CoreIPCPKShippingMethod.mm */; };
 		F4EC69CC2D0D1E3A001F903E /* CursorContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4EC69C92D0D001A001F903E /* CursorContext.h */; };
 		F4EC94E32356CC57000BB614 /* ApplicationServicesSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 29D04E2821F7C73D0076741D /* ApplicationServicesSPI.h */; };
 		F4ED2BBD29B9803E00B8AE22 /* PrivateClickMeasurementPersistentStore.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ED2BBB29B9803E00B8AE22 /* PrivateClickMeasurementPersistentStore.h */; };
@@ -8867,6 +8869,9 @@
 		F4E89F5A2EFC702000E4D96E /* TextExtractionURLCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextExtractionURLCache.h; sourceTree = "<group>"; };
 		F4E89F5B2EFC702000E4D96E /* TextExtractionURLCache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TextExtractionURLCache.cpp; sourceTree = "<group>"; };
 		F4EB4AFC269CD23600D297AE /* OSStateSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSStateSPI.h; sourceTree = "<group>"; };
+		F4EBCF612F33E86F00BFAC3C /* CoreIPCPKShippingMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPKShippingMethod.h; sourceTree = "<group>"; };
+		F4EBCF622F33E86F00BFAC3C /* CoreIPCPKShippingMethod.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPKShippingMethod.mm; sourceTree = "<group>"; };
+		F4EBCF632F33E86F00BFAC3C /* CoreIPCPKShippingMethod.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPKShippingMethod.serialization.in; sourceTree = "<group>"; };
 		F4EC69C92D0D001A001F903E /* CursorContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CursorContext.h; path = ios/CursorContext.h; sourceTree = "<group>"; };
 		F4EC69CB2D0D001A001F903E /* CursorContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; name = CursorContext.serialization.in; path = ios/CursorContext.serialization.in; sourceTree = "<group>"; };
 		F4ED2BBB29B9803E00B8AE22 /* PrivateClickMeasurementPersistentStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrivateClickMeasurementPersistentStore.h; sourceTree = "<group>"; };
@@ -13099,6 +13104,9 @@
 				F4AF72482F22CE2B00861236 /* CoreIPCPKPaymentToken.serialization.in */,
 				FAF27D2E2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.h */,
 				FAF27D2F2D2850D400F1F0BB /* CoreIPCPKSecureElementPass.mm */,
+				F4EBCF612F33E86F00BFAC3C /* CoreIPCPKShippingMethod.h */,
+				F4EBCF622F33E86F00BFAC3C /* CoreIPCPKShippingMethod.mm */,
+				F4EBCF632F33E86F00BFAC3C /* CoreIPCPKShippingMethod.serialization.in */,
 				F4B63E162C49586700BC59EF /* CoreIPCPlist.serialization.in */,
 				F4F12CB12C48B8BB00BC1254 /* CoreIPCPlistArray.h */,
 				F4F12CB22C48B8BB00BC1254 /* CoreIPCPlistArray.mm */,
@@ -17890,6 +17898,7 @@
 				F458B8EA2E8F46E900948328 /* CoreIPCPKDateComponentsRange.h in Headers */,
 				F4AF77882F27CFC800861236 /* CoreIPCPKPaymentSetupFeature.h in Headers */,
 				F4AF724A2F23025700861236 /* CoreIPCPKPaymentToken.h in Headers */,
+				F4EBCF642F33E87800BFAC3C /* CoreIPCPKShippingMethod.h in Headers */,
 				564599992B71C3D100BC59E6 /* CoreIPCPresentationIntent.h in Headers */,
 				5C5786922B6EFFFF005D51D5 /* CoreIPCRetainPtr.h in Headers */,
 				561A54532B61E49E00073A72 /* CoreIPCSecCertificate.h in Headers */,
@@ -21514,6 +21523,7 @@
 				F4AF77892F27CFCF00861236 /* CoreIPCPKPaymentSetupFeature.mm in Sources */,
 				F4AF72492F22FCC400861236 /* CoreIPCPKPaymentToken.mm in Sources */,
 				FAF27D302D2851EB00F1F0BB /* CoreIPCPKSecureElementPass.mm in Sources */,
+				F4EBCF652F33E87E00BFAC3C /* CoreIPCPKShippingMethod.mm in Sources */,
 				F4F12CB32C48B8C100BC1254 /* CoreIPCPlistArray.mm in Sources */,
 				F4F12CB02C48B2C800BC1254 /* CoreIPCPlistDictionary.mm in Sources */,
 				F4F12CAD2C485BE200BC1254 /* CoreIPCPlistObject.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -29,6 +29,7 @@
 #import "CoreIPCCFDictionary.h"
 #import "CoreIPCError.h"
 #import "CoreIPCPKPaymentSetupFeature.h"
+#import "CoreIPCPKShippingMethod.h"
 #import "CoreIPCPlistDictionary.h"
 #import "Encoder.h"
 #import "MessageSenderInlines.h"
@@ -2018,6 +2019,43 @@ TEST(IPCSerialization, SecureCoding)
 
     runTestNS({ payment.get() });
 }
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKSHIPPINGMETHOD)
+TEST(IPCSerialization, PKShippingMethod)
+{
+    RetainPtr<NSDateComponents> startComponents = adoptNS([NSDateComponents new]);
+    startComponents.get().day = 15;
+    startComponents.get().month = 6;
+    startComponents.get().year = 2026;
+    startComponents.get().calendar = NSCalendar.currentCalendar;
+
+    RetainPtr<NSDateComponents> endComponents = adoptNS([NSDateComponents new]);
+    endComponents.get().day = 20;
+    endComponents.get().month = 6;
+    endComponents.get().year = 2026;
+    endComponents.get().calendar = NSCalendar.currentCalendar;
+
+    RetainPtr<PKDateComponentsRange> dateRange = adoptNS([[PAL::getPKDateComponentsRangeClassSingleton() alloc] initWithStartDateComponents:startComponents.get() endDateComponents:endComponents.get()]);
+
+    WebKit::CoreIPCPKShippingMethodData data;
+    data.label = @"Standard Shipping";
+    data.amount = [NSDecimalNumber decimalNumberWithString:@"5.99"];
+    data.type = WebKit::PKPaymentSummaryItemType::Final;
+    data.localizedTitle = @"Standard";
+    data.localizedAmount = @"$5.99";
+    data.useDarkColor = false;
+    data.useLargeFont = false;
+    data.identifier = @"standard-shipping";
+    data.detail = @"Arrives in 3-5 business days";
+    data.dateComponentsRange = dateRange;
+
+    WebKit::CoreIPCPKShippingMethod shippingMethod { std::optional { WTF::move(data) } };
+    RetainPtr<PKShippingMethod> method = shippingMethod.toID();
+
+    runTestNS({ method.get() });
+}
+
+#endif
 
 #endif // PLATFORM(MAC)
 


### PR DESCRIPTION
#### aa47c51dac027423b4ffaec35ce4deb3614d58d1
<pre>
Migrate PKShippingMethod to Wrapped WKKeyedCoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=306990">https://bugs.webkit.org/show_bug.cgi?id=306990</a>
<a href="https://rdar.apple.com/137149866">rdar://137149866</a>

Reviewed by Abrar Rahman Protyasha.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.h: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.mm: Added.
(WebKit::CoreIPCPKShippingMethod::CoreIPCPKShippingMethod):
(WebKit::CoreIPCPKShippingMethod::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKShippingMethod.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, PKShippingMethod)):

Canonical link: <a href="https://commits.webkit.org/306978@main">https://commits.webkit.org/306978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fb6a8e61c9540bdecae95606a9645c8fb127a25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151621 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a298e7e-ac58-411b-9521-8968aaa73816) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109932 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7443d856-e597-491f-8a51-e991132e99e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90842 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c621fb37-21ec-4c99-a496-d0e6a92a277e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9562 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1620 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153934 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15045 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117946 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118283 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30254 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14256 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125243 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15088 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4144 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78799 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14885 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->