### PR TITLE
Fix repaint artifacts for non-scaling-stroke with animated transforms

### DIFF
--- a/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
+++ b/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
@@ -1,9 +1,5 @@
 Hello
  (repaint rects
   (rect 9 13 48 28)
-  (rect 9 13 4 28)
-  (rect 53 13 4 28)
-  (rect 9 13 48 4)
-  (rect 9 37 48 4)
 )
 

--- a/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
+++ b/LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
@@ -1,9 +1,5 @@
 Hello
  (repaint rects
   (rect 9 13 48 28)
-  (rect 9 13 4 28)
-  (rect 53 13 4 28)
-  (rect 9 13 48 4)
-  (rect 9 37 48 4)
 )
 

--- a/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
+++ b/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
@@ -1,9 +1,5 @@
 Hello
  (repaint rects
   (rect 9 12 48 29)
-  (rect 9 12 4 29)
-  (rect 53 12 4 29)
-  (rect 9 12 48 4)
-  (rect 9 37 48 4)
 )
 

--- a/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
+++ b/LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
@@ -1,9 +1,5 @@
 Hello
  (repaint rects
   (rect 9 12 48 29)
-  (rect 9 12 4 29)
-  (rect 53 12 4 29)
-  (rect 9 12 48 4)
-  (rect 9 37 48 4)
 )
 

--- a/LayoutTests/svg/custom/non-scaling-stroke-expected.txt
+++ b/LayoutTests/svg/custom/non-scaling-stroke-expected.txt
@@ -1,7 +1,7 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600
-  RenderSVGRoot {svg} at (12,0) size 287x488
+  RenderSVGRoot {svg} at (12,0) size 285x471
     RenderSVGHiddenContainer {defs} at (0,0) size 0x0
       RenderSVGResourceLinearGradient {linearGradient} [id="grad1"] [gradientUnits=objectBoundingBox] [start=(0,0)] [end=(1,1)]
         RenderSVGGradientStop {stop} [offset=0.00] [color=#0000FF]
@@ -22,7 +22,7 @@ layer at (0,0) size 800x600
       RenderSVGRect {rect} at (12,172) size 116x66 [stroke={[type=PATTERN] [id="pattern"] [stroke width=15.00]}] [x=0.00] [y=0.00] [width=400.00] [height=50.00]
     RenderSVGContainer {use} at (12,252) size 116x66 [transform={m=((0.25,0.00)(0.00,1.00)) t=(20.00,260.00)}]
       RenderSVGRect {rect} at (12,252) size 116x66 [stroke={[type=SOLID] [color=#008000] [stroke width=15.00]}] [x=0.00] [y=0.00] [width=400.00] [height=50.00]
-    RenderSVGContainer {use} at (134,12) size 165x66 [transform={m=((0.25,0.00)(0.25,1.00)) t=(160.00,20.00)}]
-      RenderSVGRect {rect} at (134,12) size 165x66 [stroke={[type=SOLID] [color=#008000] [stroke width=15.00]}] [x=0.00] [y=0.00] [width=400.00] [height=50.00]
-    RenderSVGContainer {use} at (152,0) size 116x488 [transform={m=((0.25,0.36)(0.00,1.00)) t=(160.00,100.00)}]
-      RenderSVGRect {rect} at (152,0) size 116x488 [stroke={[type=SOLID] [color=#008000] [stroke width=15.00]}] [x=0.00] [y=0.00] [width=400.00] [height=50.00]
+    RenderSVGContainer {use} at (136,12) size 161x66 [transform={m=((0.25,0.00)(0.25,1.00)) t=(160.00,20.00)}]
+      RenderSVGRect {rect} at (136,12) size 161x66 [stroke={[type=SOLID] [color=#008000] [stroke width=15.00]}] [x=0.00] [y=0.00] [width=400.00] [height=50.00]
+    RenderSVGContainer {use} at (152,0) size 116x471 [transform={m=((0.25,0.36)(0.00,1.00)) t=(160.00,100.00)}]
+      RenderSVGRect {rect} at (152,0) size 116x471 [stroke={[type=SOLID] [color=#008000] [stroke width=15.00]}] [x=0.00] [y=0.00] [width=400.00] [height=50.00]

--- a/LayoutTests/svg/repaint/non-scaling-stroke-transform-animation-expected.html
+++ b/LayoutTests/svg/repaint/non-scaling-stroke-transform-animation-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Non-scaling-stroke at scale(0.3)</title>
+  <style>
+    body { margin: 0; background: white; }
+  </style>
+</head>
+<body>
+  <svg width="400" height="300">
+    <g transform="scale(0.3)">
+      <rect x="100" y="80" width="200" height="120"
+            fill="none"
+            stroke="blue"
+            stroke-width="2"
+            vector-effect="non-scaling-stroke"/>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/svg/repaint/non-scaling-stroke-transform-animation.html
+++ b/LayoutTests/svg/repaint/non-scaling-stroke-transform-animation.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+  <title>Non-scaling-stroke with animated transform should not leave artifacts</title>
+  <script src="../../resources/ui-helper.js"></script>
+  <style>
+    body { margin: 0; background: white; }
+  </style>
+  <script>
+    if (window.testRunner) {
+      testRunner.waitUntilDone();
+      testRunner.dontForceRepaint();
+    }
+
+    window.addEventListener('load', async function() {
+      let g = document.getElementById('g');
+      let scale = 1.0;
+      let step = 0;
+      const totalSteps = 20;
+
+      function animate() {
+        if (step < totalSteps) {
+          scale = 1.0 - (step / totalSteps) * 0.7;
+          g.setAttribute('transform', 'scale(' + scale + ')');
+          step++;
+          requestAnimationFrame(animate);
+        } else {
+          g.setAttribute('transform', 'scale(0.3)');
+          finishTest();
+        }
+      }
+
+      async function finishTest() {
+        await UIHelper.renderingUpdate();
+        await UIHelper.renderingUpdate();
+        document.documentElement.classList.remove('reftest-wait');
+        if (window.testRunner)
+          testRunner.notifyDone();
+      }
+
+      requestAnimationFrame(animate);
+    });
+  </script>
+</head>
+<body>
+  <svg width="400" height="300">
+    <g id="g">
+      <rect x="100" y="80" width="200" height="120"
+            fill="none"
+            stroke="blue"
+            stroke-width="2"
+            vector-effect="non-scaling-stroke"/>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
+++ b/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt
@@ -1,9 +1,5 @@
 Hello
  (repaint rects
   (rect 9 12 48 30)
-  (rect 9 12 4 30)
-  (rect 53 12 4 30)
-  (rect 9 12 48 4)
-  (rect 9 38 48 4)
 )
 

--- a/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
+++ b/LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-expected.txt
@@ -1,9 +1,5 @@
 Hello
  (repaint rects
   (rect 9 12 48 30)
-  (rect 9 12 4 30)
-  (rect 53 12 4 30)
-  (rect 9 12 48 4)
-  (rect 9 38 48 4)
 )
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -92,6 +92,11 @@ public:
 
     static FloatRect calculateApproximateStrokeBoundingBox(const RenderElement&);
 
+    static void updateAncestorNonScalingStrokeCounts(RenderElement&, int delta);
+
+    static void elementInsertedIntoTree(RenderElement&);
+    static void elementWillBeRemovedFromTree(RenderElement&);
+
     // Shared between SVG renderers and resources.
     static void applyStrokeStyleToContext(GraphicsContext&, const RenderStyle&, const RenderElement&);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -208,6 +208,13 @@ FloatRect LegacyRenderSVGContainer::strokeBoundingBox() const
 
 FloatRect LegacyRenderSVGContainer::repaintRectInLocalCoordinates(RepaintRectCalculation repaintRectCalculation) const
 {
+    if (hasNonScalingStrokeDescendant()) {
+        auto boundingBoxes = SVGRenderSupport::computeContainerBoundingBoxes(*this, repaintRectCalculation);
+        FloatRect repaintBoundingBox = boundingBoxes.repaintBoundingBox;
+        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, repaintRectCalculation);
+        return repaintBoundingBox;
+    }
+
     if (repaintRectCalculation == RepaintRectCalculation::Fast)
         return m_repaintBoundingBox;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -39,6 +39,12 @@ public:
     virtual bool didTransformToRootUpdate() { return false; }
     bool isObjectBoundingBoxValid() const { return static_cast<bool>(m_objectBoundingBox); }
     bool isRepaintSuspendedForChildren() const { return m_repaintIsSuspendedForChildrenDuringLayout; }
+    bool hasNonScalingStrokeDescendant() const { return m_nonScalingStrokeDescendantCount > 0; }
+    void adjustNonScalingStrokeDescendantCount(int delta)
+    {
+        ASSERT(delta > 0 || m_nonScalingStrokeDescendantCount >= static_cast<unsigned>(-delta));
+        m_nonScalingStrokeDescendantCount += delta;
+    }
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox.value_or(FloatRect()); }
 
@@ -80,6 +86,7 @@ private:
 
     bool m_needsBoundariesUpdate { true };
     bool m_repaintIsSuspendedForChildrenDuringLayout { false };
+    unsigned m_nonScalingStrokeDescendantCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -129,8 +129,15 @@ void LegacyRenderSVGModelObject::absoluteQuads(Vector<FloatQuad>& quads, bool* w
 
 void LegacyRenderSVGModelObject::willBeDestroyed()
 {
+    SVGRenderSupport::elementWillBeRemovedFromTree(*this);
     SVGResourcesCache::clientDestroyed(*this);
     RenderElement::willBeDestroyed();
+}
+
+void LegacyRenderSVGModelObject::insertedIntoTree()
+{
+    RenderElement::insertedIntoTree();
+    SVGRenderSupport::elementInsertedIntoTree(*this);
 }
 
 void LegacyRenderSVGModelObject::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -73,6 +73,7 @@ protected:
     LegacyRenderSVGModelObject(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 
     void willBeDestroyed() override;
+    void insertedIntoTree() override;
 
 private:
     // This method should never be called, SVG uses a different nodeAtPoint method

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -492,6 +492,14 @@ FloatRect LegacyRenderSVGRoot::strokeBoundingBox() const
 
 FloatRect LegacyRenderSVGRoot::repaintRectInLocalCoordinates(RepaintRectCalculation repaintRectCalculation) const
 {
+    if (hasNonScalingStrokeDescendant()) {
+        auto boundingBoxes = SVGRenderSupport::computeContainerBoundingBoxes(*this, repaintRectCalculation);
+        FloatRect repaintBoundingBox = boundingBoxes.repaintBoundingBox;
+        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, repaintRectCalculation);
+        repaintBoundingBox.inflate(horizontalBorderAndPaddingExtent());
+        return repaintBoundingBox;
+    }
+
     if (repaintRectCalculation == RepaintRectCalculation::Fast)
         return m_repaintBoundingBox;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -66,6 +66,13 @@ public:
     // method during layout when they are invalidated by a filter.
     static void addResourceForClientInvalidation(LegacyRenderSVGResourceContainer*);
 
+    bool hasNonScalingStrokeDescendant() const { return m_nonScalingStrokeDescendantCount > 0; }
+    void adjustNonScalingStrokeDescendantCount(int delta)
+    {
+        ASSERT(delta > 0 || m_nonScalingStrokeDescendantCount >= static_cast<unsigned>(-delta));
+        m_nonScalingStrokeDescendantCount += delta;
+    }
+
 private:
     void element() const = delete;
 
@@ -125,6 +132,7 @@ private:
     bool m_isLayoutSizeChanged : 1 { false };
     bool m_needsBoundariesOrTransformUpdate : 1 { true };
     bool m_hasBoxDecorations : 1 { false };
+    unsigned m_nonScalingStrokeDescendantCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -441,6 +441,13 @@ void LegacyRenderSVGShape::updateRepaintBoundingBox()
 
 FloatRect LegacyRenderSVGShape::repaintRectInLocalCoordinates(RepaintRectCalculation repaintRectCalculation) const
 {
+    // During initial layout the path may not exist yet, so check path before calculating.
+    if (hasNonScalingStroke() && hasPath()) {
+        FloatRect repaintBoundingBox = SVGRenderSupport::calculateApproximateStrokeBoundingBox(*this);
+        SVGRenderSupport::intersectRepaintRectWithResources(*this, repaintBoundingBox, repaintRectCalculation);
+        return repaintBoundingBox;
+    }
+
     if (repaintRectCalculation == RepaintRectCalculation::Fast)
         return m_repaintBoundingBox;
 


### PR DESCRIPTION
#### 8ddcdb6f831a833b2e2faa9a13e3c42642ed6502
<pre>
Fix repaint artifacts for non-scaling-stroke with animated transforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=278231">https://bugs.webkit.org/show_bug.cgi?id=278231</a>
<a href="https://rdar.apple.com/134313456">rdar://134313456</a>

Reviewed by Simon Fraser.

When an SVG element has vector-effect: non-scaling-stroke and its ancestor
transform is animated, the legacy SVG engine leaves visual artifacts from
previous frames. This is because the stroke bounding box depends on the
screen CTM, but the repaint bounding boxes were cached and not recomputed
when ancestor transforms changed.

The fix requires bypassing caching at two levels: Shape level, and Container level

Both fixes are required: the container fix ensures children are queried,
and the shape fix ensures children return correct (non-cached) answers.

* LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt:
* LayoutTests/platform/glib/svg/repaint/repaint-non-scaling-stroke-text-expected.txt:
* LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt:
* LayoutTests/platform/ios/svg/repaint/repaint-non-scaling-stroke-text-expected.txt:
* LayoutTests/svg/custom/non-scaling-stroke-expected.txt:
* LayoutTests/svg/repaint/non-scaling-stroke-transform-animation-expected.html: Added.
* LayoutTests/svg/repaint/non-scaling-stroke-transform-animation.html: Added.
* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt:
* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-expected.txt:

The bounding boxes are getting slightly tigther because
it&apos;s computing more accurate bounds for non-scaling-stroke cases.

* LayoutTests/svg/repaint/non-scaling-stroke-transform-animation-expected.html: Added.
* LayoutTests/svg/repaint/non-scaling-stroke-transform-animation.html: Added.
* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-decoration-expected.txt:
* LayoutTests/svg/repaint/repaint-non-scaling-stroke-text-expected.txt:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::styleChanged):
(WebCore::SVGRenderSupport::updateAncestorNonScalingStrokeCounts):
(WebCore::SVGRenderSupport::elementInsertedIntoTree):
(WebCore::SVGRenderSupport::elementWillBeRemovedFromTree):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h:
(WebCore::LegacyRenderSVGContainer::hasNonScalingStrokeDescendant const):
(WebCore::LegacyRenderSVGContainer::adjustNonScalingStrokeDescendantCount):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::willBeDestroyed):
(WebCore::LegacyRenderSVGModelObject::insertedIntoTree):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::repaintRectInLocalCoordinates const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::repaintRectInLocalCoordinates const):

Canonical link: <a href="https://commits.webkit.org/307282@main">https://commits.webkit.org/307282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1560a7003a6661813677c8c530c174c7326fb6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152583 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/733c6e0a-28a3-4935-877e-aba5669ab738) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16484 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110666 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84b3d21d-ef7c-4267-80a1-408b6a1c4c93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91584 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3929e24-bb6f-4655-896b-50b6fcdd7227) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12562 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10293 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5957 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154895 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16444 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118676 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30515 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14947 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127168 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71867 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16065 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5627 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15799 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16011 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15868 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->