### PR TITLE
Speculative fix for crashes underneath StyleLengthResolution::adjustValueForPageZoom

### DIFF
--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -42,11 +42,19 @@ CSSToLengthConversionData::CSSToLengthConversionData() = default;
 CSSToLengthConversionData::CSSToLengthConversionData(const CSSToLengthConversionData&) = default;
 CSSToLengthConversionData::CSSToLengthConversionData(CSSToLengthConversionData&&) = default;
 
+// FIXME: Only rely on the RenderView for style resolution if we have an active LocalFrameView.
+static RenderView* renderViewForDocument(const Document& document)
+{
+    if (document.view()) [[likely]]
+        return document.renderView();
+    return nullptr;
+}
+
 CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, Style::BuilderState& builderState)
     : m_style(&style)
     , m_rootStyle(builderState.rootElementRenderStyle())
     , m_parentStyle(&builderState.parentRenderStyle())
-    , m_renderView(builderState.document().renderView())
+    , m_renderView(renderViewForDocument(builderState.document()))
     , m_elementForContainerUnitResolution(builderState.element())
     , m_styleBuilderState(&builderState)
 {

--- a/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthResolution.cpp
@@ -53,10 +53,11 @@ static double adjustValueForPageZoom(double dimension, const CSSToLengthConversi
         return dimension;
 
     auto* style = conversionData.style();
-    if (!style || !evaluationTimeZoomEnabled(*style))
+    auto* renderView = conversionData.renderView();
+    if (!renderView || !style || !evaluationTimeZoomEnabled(*style))
         return dimension;
 
-    return dimension / conversionData.renderView()->zoomFactor();
+    return dimension / renderView->zoomFactor();
 }
 
 static double lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis logicalAxis, const FloatSize& size, const RenderStyle* style)


### PR DESCRIPTION
#### a7e0750c30773838d1fd76787cc3d86dda56bc8c
<pre>
Speculative fix for crashes underneath StyleLengthResolution::adjustValueForPageZoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=306989">https://bugs.webkit.org/show_bug.cgi?id=306989</a>
<a href="https://rdar.apple.com/168722605">rdar://168722605</a>

Reviewed by Brent Fulgham.

Stability data seems to suggest that it is possible to hit some crashes
underneath StyleLengthResolution::adjustValueForPageZoom. These crashes
seem to be coming from the fact that we attempt to access the page zoom
factor via the RenderView on CSSToLengthConversionData.

It is not very clear how we can get into this state since code
inspection seems to indicate that we try very hard to make sure that
cleanup between these two objects is handled properly. An investigation
to attempt to reproduce this crash has also not been very fruitful since
it seems at least some of those who experienced this crash were not
aware that it happened, could not remember it occurring, or were not
able to get it to reproduce either by navigating through history.

In order to increase stability, and also hopefully be able to obtain
more actionable bug reports, we attempt a speculative fix for
addressing this crash. The main change is that in the constructor for
CSSToLengthConversionData, we use a new helper function to figure out
what we should use for the RenderView field. Since we cannot directly
check the existence of the LocalFrameView on the RenderView, we
look at the Document, which is the sole owner of the RenderView, to see
if it is still there. If the Document no longer has its LocalFrameView,
then we will return nullptr for the RenderView. Much of the other code
in CSSToLengthConversionData already performs a nullptr check for
RenderView, so we also need to start doing the same in
adjustValueForPageZoom since there is no guarantee that this pointer is
always non-null.

Canonical link: <a href="https://commits.webkit.org/306918@main">https://commits.webkit.org/306918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed59ff6179db819a0145414ebd15d8eaed1f09e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151357 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95872 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/436c1750-b478-48cc-8edb-f4363f0a03a2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109736 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95872 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90643 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92b2d172-bddd-449d-a1e1-5f4bec9a9e86) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11712 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9381 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1356 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153670 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117751 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118082 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14092 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70478 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14824 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3920 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78533 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14767 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14621 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->