### PR TITLE
Adopt protect() for memory safety in WebCore/history

### DIFF
--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -61,11 +61,6 @@ RefPtr<HistoryItem> BackForwardController::forwardItem(std::optional<FrameIdenti
     return itemAtIndex(1, frameID);
 }
 
-Ref<Page> BackForwardController::protectedPage() const
-{
-    return m_page;
-}
-
 bool BackForwardController::canGoBackOrForward(int distance) const
 {
     if (!distance)
@@ -96,7 +91,7 @@ void BackForwardController::goBackOrForward(int distance)
     if (!historyItem)
         return;
 
-    Ref page { protectedPage() };
+    Ref page = m_page;
     RefPtr localMainFrame = page->localMainFrame();
     if (!localMainFrame)
         return;
@@ -110,7 +105,7 @@ bool BackForwardController::goBack()
     if (!historyItem)
         return false;
 
-    Ref page { protectedPage() };
+    Ref page = m_page;
     RefPtr localMainFrame = page->localMainFrame();
     if (!localMainFrame)
         return false;
@@ -125,7 +120,7 @@ bool BackForwardController::goForward()
     if (!historyItem)
         return false;
 
-    Ref page { protectedPage() };
+    Ref page = m_page;
     RefPtr localMainFrame = page->localMainFrame();
     if (!localMainFrame)
         return false;

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -76,8 +76,6 @@ public:
     void close();
 
 private:
-    Ref<Page> protectedPage() const;
-
     WeakRef<Page> m_page;
     const Ref<BackForwardClient> m_client;
 };

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -232,9 +232,4 @@ bool CachedPage::hasExpired() const
     return MonotonicTime::now() > m_expirationTime;
 }
 
-RefPtr<DocumentLoader> CachedPage::protectedDocumentLoader() const
-{
-    return documentLoader();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -50,10 +50,8 @@ public:
     void clear();
 
     Page& page() const { return m_page; }
-    Ref<Page> protectedPage() const { return page(); }
     Document* document() const { return m_cachedMainFrame->document(); }
     DocumentLoader* documentLoader() const { return m_cachedMainFrame->documentLoader(); }
-    RefPtr<DocumentLoader> protectedDocumentLoader() const;
 
     bool hasExpired() const;
     

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2591,7 +2591,7 @@ void FrameLoader::transitionToCommitted(CachedPage* cachedPage)
             // Create a document view for this document, or used the cached view.
             if (cachedPage) {
                 ASSERT(cachedPage->documentLoader());
-                cachedPage->protectedDocumentLoader()->attachToFrame(protect(m_frame));
+                protect(cachedPage->documentLoader())->attachToFrame(protect(m_frame));
                 m_client->transitionToCommittedFromCachedFrame(cachedPage->cachedMainFrame());
             } else
                 m_client->transitionToCommittedForNewPage(m_documentLoader && m_documentLoader->isInFinishedLoadingOfEmptyDocument() ?


### PR DESCRIPTION
#### b920f4835a7183a0a2dfb1aaf7b56443b2795d28
<pre>
Adopt protect() for memory safety in WebCore/history
<a href="https://bugs.webkit.org/show_bug.cgi?id=306999">https://bugs.webkit.org/show_bug.cgi?id=306999</a>
<a href="https://rdar.apple.com/169657277">rdar://169657277</a>

Reviewed by Chris Dumez.

Adopt the `protect()` style instead of `protectedFoo()` in WebCore/history

* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::goBackOrForward):
(WebCore::BackForwardController::goBack):
(WebCore::BackForwardController::goForward):
(WebCore::BackForwardController::protectedPage const): Deleted.
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::protectedDocumentLoader const): Deleted.
* Source/WebCore/history/CachedPage.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::transitionToCommitted):

Canonical link: <a href="https://commits.webkit.org/306923@main">https://commits.webkit.org/306923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfb1efdd971fc91558ae6e0b84ed266a59a28b96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151441 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95956 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39e4317f-a88a-40ed-bb83-6466db197560) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144634 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109792 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b01a78fe-c4c9-441a-9351-251dd7e9fb1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90700 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5425598-c593-4209-bc31-4fb9b5d6f2dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11751 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9432 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1440 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153754 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14865 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117808 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14902 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118140 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14131 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125022 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70562 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14908 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3983 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14643 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78617 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->