### PR TITLE
Improve filter-build-webkit to reduce clang module verifier noise

### DIFF
--- a/Tools/Scripts/filter-build-webkit
+++ b/Tools/Scripts/filter-build-webkit
@@ -309,6 +309,9 @@ sub main() {
         } elsif ($line =~ /^(Setting fixed entry values for )(\S+)/) {
             my ($file) = basename($2);
             printLine("$1 $file", $target, $project, STYLE_PLAIN);
+        } elsif ($line =~ /^xcrun clang -x (\S+) -target \S+ -std=(\S+) .*-Wsystem-headers-in-module=(\S+)/) {
+            my ($lang, $std, $module) = ($1, $2, $3);
+            printLine("VerifyModule $module ($lang, $std)", $target, $project, STYLE_PLAIN);
         } else {
             # This only gets hit if stderr is redirected to stdout.
             if (($line =~ /\*\* BUILD FAILED \*\*/) || ($line =~ /^Build FAILED./)) {
@@ -563,6 +566,13 @@ sub shouldIgnoreLine($$)
 
     # FIXME: rdar://106775772
     return 1 if $line =~ /DVTAssertions/;
+
+    # Strip module verifier noise, get the useful info from xcrun clang lines instead.
+    return 1 if $line =~ /^Verifying clang module /;
+    return 1 if $line =~ /^validation skipped$/;
+    return 1 if $line =~ /^Generating inputs for module verifier/;
+    return 1 if $line =~ /^Generated inputs for module verifier/;
+    return 1 if $line =~ /^Verified module!$/;
 
     return 0;
 }


### PR DESCRIPTION
#### 22581f71013068324efe1dd5a4a6d74d51ba6766
<pre>
Improve filter-build-webkit to reduce clang module verifier noise
<a href="https://bugs.webkit.org/show_bug.cgi?id=307001">https://bugs.webkit.org/show_bug.cgi?id=307001</a>
<a href="https://rdar.apple.com/169658081">rdar://169658081</a>

Reviewed by NOBODY (OOPS!).

With recent enablement of clang verification code, there&apos;s a lot of
additional output/noise that can be filtered by `filter-build-webkit`.

Implement a regex that extracts useful information from the output,
and removes unnecessary noise.

Example, after change:
```
VerifyModule bmalloc (c, gnu99)
VerifyModule bmalloc (c, c23)
VerifyModule bmalloc (c, gnu23)
VerifyModule bmalloc (c++, c++2b)
VerifyModule bmalloc (objective-c++, c++2b)
```

* Tools/Scripts/filter-build-webkit:
(main):
(shouldIgnoreLine):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22581f71013068324efe1dd5a4a6d74d51ba6766

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95640 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14d66692-3cda-4147-a587-68146c43a543) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15003 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109545 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79056 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dd6fc49-10cb-4ac6-9ac6-a5e8c0498f64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90452 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd213b4e-133c-4f82-ad7d-249e6a3b8c84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11562 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9223 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1121 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153436 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14528 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117576 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117908 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13948 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70240 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14577 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3743 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14536 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14354 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->