### PR TITLE
[iOS] Rendering updates may not happen when `WKWebView` moves between screens

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -85,6 +85,7 @@ OBJC_CLASS NSObject;
 OBJC_CLASS NSSet;
 OBJC_CLASS NSTextAlternatives;
 OBJC_CLASS UIGestureRecognizer;
+OBJC_CLASS UIScreen;
 OBJC_CLASS UIScrollView;
 OBJC_CLASS UIView;
 OBJC_CLASS UIViewController;
@@ -616,6 +617,8 @@ public:
     virtual bool isScreenBeingCaptured() = 0;
 
     virtual String sceneID() = 0;
+
+    virtual UIScreen *screen() = 0;
 
     virtual void beginTextRecognitionForFullscreenVideo(WebCore::ShareableBitmap::Handle&&, AVPlayerViewController *) = 0;
     virtual void cancelTextRecognitionForFullscreenVideo(AVPlayerViewController *) = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -63,6 +63,8 @@ private:
 
     void didRefreshDisplay() override;
 
+    void windowScreenDidChange(WebCore::PlatformDisplayID) override;
+
     std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() override;
 
     WKDisplayLinkHandler *displayLinkHandler();

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -36,6 +36,7 @@
 #import <wtf/WeakObjCPtr.h>
 
 OBJC_CLASS PlatformTextAlternatives;
+OBJC_CLASS UIScreen;
 OBJC_CLASS WKContentView;
 OBJC_CLASS WKEditorUndoTarget;
 
@@ -147,6 +148,8 @@ private:
     void doneDeferringTouchMove(bool preventNativeGestures) override;
     void doneDeferringTouchEnd(bool preventNativeGestures) override;
 #endif
+
+    UIScreen *screen() override;
 
 #if ENABLE(IMAGE_ANALYSIS)
     void requestTextRecognition(const URL& imageURL, WebCore::ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(WebCore::TextRecognitionResult&&)>&&) final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -636,6 +636,11 @@ void PageClientImpl::doneDeferringTouchEnd(bool preventNativeGestures)
 
 #endif // ENABLE(IOS_TOUCH_EVENTS)
 
+UIScreen *PageClientImpl::screen()
+{
+    return [contentView() _screen];
+}
+
 #if ENABLE(IMAGE_ANALYSIS)
 
 void PageClientImpl::requestTextRecognition(const URL& imageURL, ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(TextRecognitionResult&&)>&& completion)

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -91,6 +91,8 @@ enum class ViewStabilityFlag : uint8_t;
 - (WKWebView *)webView;
 - (UIView *)rootContentView;
 
+- (UIScreen *)_screen;
+
 - (Ref<WebKit::DrawingAreaProxy>)_createDrawingAreaProxy:(WebKit::WebProcessProxy&)webProcessProxy;
 - (void)_processDidExit;
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -243,6 +243,8 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 #endif // !USE(EXTENSIONKIT)
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW)
 
+    __weak UIScreen *_screen;
+
     RetainPtr<WKNSUndoManager> _undoManager;
     RetainPtr<WKNSKeyEventSimulatorUndoManager> _undoManagerForSimulatingKeyEvents;
 
@@ -786,6 +788,12 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 - (void)_updateForScreen:(UIScreen *)screen
 {
     ASSERT(screen);
+
+    _screen = screen;
+
+    if (RefPtr page = _page)
+        page->windowScreenDidChange(page->generateDisplayIDFromPageID());
+
     [self _accessibilityRegisterUIProcessTokens];
 }
 
@@ -1052,6 +1060,11 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 - (double)_targetContentZoomScaleForRect:(const WebCore::FloatRect&)targetRect currentScale:(double)currentScale fitEntireRect:(BOOL)fitEntireRect minimumScale:(double)minimumScale maximumScale:(double)maximumScale
 {
     return [_webView _targetContentZoomScaleForRect:targetRect currentScale:currentScale fitEntireRect:fitEntireRect minimumScale:minimumScale maximumScale:maximumScale];
+}
+
+- (UIScreen *)_screen
+{
+    return _screen;
 }
 
 #if ENABLE(MODEL_PROCESS)


### PR DESCRIPTION
#### 735e4235a2dedc7d662436831d96d28d57a40d05
<pre>
[iOS] Rendering updates may not happen when `WKWebView` moves between screens
<a href="https://bugs.webkit.org/show_bug.cgi?id=307005">https://bugs.webkit.org/show_bug.cgi?id=307005</a>
<a href="https://rdar.apple.com/169659972">rdar://169659972</a>

Reviewed by Wenson Hsieh.

`-[CADisplayLink displayLinkWithTarget:selector:]` creates a display link
associated with the &quot;main screen&quot; (`-[UIScreen mainScreen]` in UIKit). It is
possible that the `CADisplayLink` associated with the main screen is paused
by the system. In these scenarios, the display link created in `WKDisplayLinkHandler`
stops triggering, preventing rendering updates from occurring.

To fix, create a new display link associated with the screen the web view is
currently on. This is achieved using `-[UIScreen displayLinkWithTarget:selector:]`,
ensuring the used display link is active and rendering updates occur.

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler initWithDrawingAreaProxy:]):
(-[WKDisplayLinkHandler windowScreenDidChange]):

If the current screen is equal to the screen that created the display link, avoid
recreation. Additionally, skip recreation is the current screen is the main screen.
This can be done since `-[CADisplayLink displayLinkWithTarget:selector:]` vends
a display link associated with the main screen.

(-[WKDisplayLinkHandler _screenForDisplayLink]):
(-[WKDisplayLinkHandler _createDisplayLink]):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::windowScreenDidChange):

`PlatformDisplayID` is not meaningful on iOS. `UIScreen`s do not have an identifier.
Use `m_displayLinkHandler` rather than `displayLinkHandler()` to avoid unnecessary
creation.

* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::screen):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _updateForScreen:]):

Whenever the web view is moved/added to a screen, inform `WebPageProxy` and
the `DrawingAreaProxy`.

(-[WKContentView _screen]):

The screen is stored as a weak instance variable. This is necessary since WebKit
may first be informed of the screen in `-[WKContentView willMoveToWindow]`. In
this case, the `WKContentView`&apos;s window may still be `nil`, resulting in an
inability to get the scene outside of the notification.

Canonical link: <a href="https://commits.webkit.org/306881@main">https://commits.webkit.org/306881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1370849f8e050b6baea38e37e37a87d27a140ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142537 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95724 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f814aab-087d-423d-8842-cfe6f50daa12) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109613 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79087 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cba9397b-93d6-49a8-8e7c-1f48e60903ff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90523 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e26530f6-a6d1-451b-9683-f204b0a40f0e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9276 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120966 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153520 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117639 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117975 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13998 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124844 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70324 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21998 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14675 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3801 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78377 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14473 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->