### PR TITLE
Convert MathMLFractionElement::FractionAlignment to a scoped enum class

### DIFF
--- a/Source/WebCore/mathml/MathMLFractionElement.cpp
+++ b/Source/WebCore/mathml/MathMLFractionElement.cpp
@@ -88,17 +88,17 @@ MathMLFractionElement::FractionAlignment MathMLFractionElement::cachedFractionAl
         return alignment.value();
 
     if (document().settings().coreMathMLEnabled()) {
-        alignment = FractionAlignmentCenter;
+        alignment = FractionAlignment::Center;
         return alignment.value();
     }
 
     auto& value = attributeWithoutSynchronization(name);
     if (equalLettersIgnoringASCIICase(value, "left"_s))
-        alignment = FractionAlignmentLeft;
+        alignment = FractionAlignment::Left;
     else if (equalLettersIgnoringASCIICase(value, "right"_s))
-        alignment = FractionAlignmentRight;
+        alignment = FractionAlignment::Right;
     else
-        alignment = FractionAlignmentCenter;
+        alignment = FractionAlignment::Center;
     return alignment.value();
 }
 

--- a/Source/WebCore/mathml/MathMLFractionElement.h
+++ b/Source/WebCore/mathml/MathMLFractionElement.h
@@ -37,10 +37,10 @@ class MathMLFractionElement final : public MathMLRowElement {
 public:
     static Ref<MathMLFractionElement> create(const QualifiedName& tagName, Document&);
     const Length& lineThickness();
-    enum FractionAlignment {
-        FractionAlignmentCenter,
-        FractionAlignmentLeft,
-        FractionAlignmentRight
+    enum class FractionAlignment : uint8_t {
+        Center,
+        Left,
+        Right
     };
     FractionAlignment numeratorAlignment();
     FractionAlignment denominatorAlignment();

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -209,11 +209,11 @@ LayoutUnit RenderMathMLFraction::horizontalOffset(RenderBox& child, MathMLFracti
     LayoutUnit contentBoxInlineSize = logicalWidth();
     LayoutUnit childMarginBoxInlineSize = child.marginStart() + child.logicalWidth() + child.marginEnd();
     switch (align) {
-    case MathMLFractionElement::FractionAlignmentRight:
+    case MathMLFractionElement::FractionAlignment::Right:
         return LayoutUnit(contentBoxInlineSize - childMarginBoxInlineSize);
-    case MathMLFractionElement::FractionAlignmentCenter:
+    case MathMLFractionElement::FractionAlignment::Center:
         return LayoutUnit((contentBoxInlineSize - childMarginBoxInlineSize) / 2);
-    case MathMLFractionElement::FractionAlignmentLeft:
+    case MathMLFractionElement::FractionAlignment::Left:
         return 0_lu;
     }
 


### PR DESCRIPTION
#### 54fef734c36142f52c3392debb5f30e3a55e3591
<pre>
Convert MathMLFractionElement::FractionAlignment to a scoped enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=307009">https://bugs.webkit.org/show_bug.cgi?id=307009</a>
<a href="https://rdar.apple.com/169663062">rdar://169663062</a>

Reviewed by Vitor Roriz, Alan Baradlay, and Sammy Gill.

Use an enum class with `uint8_t` as the underlying type and shorter value
 names (Center, Left, Right) instead of the C-style enum values.

This provides stronger type safety by preventing implicit conversions to ints,
avoids polluting the enclosing namespace with enumerator names, and reduces storage
size from `int` to `uint8_t`.

No new tests, since there is no change in functionality.

* Source/WebCore/mathml/MathMLFractionElement.cpp:
(WebCore::MathMLFractionElement::cachedFractionAlignment):
* Source/WebCore/mathml/MathMLFractionElement.h:
* Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp:
(WebCore::RenderMathMLFraction::horizontalOffset const):

Canonical link: <a href="https://commits.webkit.org/306827@main">https://commits.webkit.org/306827@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4a2362cfec8c2fd0a86883a3696f6a9e4553590

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151130 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1bb3278-b675-4039-8f4e-7ae890135258) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144341 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/15601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109559 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db1453d5-4943-447f-9fc9-d965589f2a88) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145423 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/15601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90467 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec89a789-93af-4320-b8d4-428b484ee53a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/15601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1142 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/15601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/3960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153457 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117587 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/14590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117922 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30067 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124784 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/14612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78314 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14394 "Failed to checkout and rebase branch from PR 57903") | | | | 
<!--EWS-Status-Bubble-End-->