### PR TITLE
Add ScriptAccessCategory NetworkRequest category

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h
@@ -220,11 +220,16 @@ typedef NS_OPTIONS(NSUInteger, WPScriptAccessCategories) {
     WPScriptAccessCategoryScreenOrViewport      = 1 << 8,
     WPScriptAccessCategorySpeech                = 1 << 9,
     WPScriptAccessCategoryFormControls          = 1 << 10,
+    WPScriptAccessCategoryNetworkRequests       = 1 << 11,
 };
 
 @interface WPFingerprintingScript (Staging_155749047)
 @property (nonatomic, readonly) WPScriptAccessCategories allowedCategories;
 @end
+
+#elif !defined(WP_SUPPORTS_SCRIPT_ACCESS_CATEGORY_NETWORK)
+
+#define WPScriptAccessCategoryNetworkRequests (1 << 11)
 
 #endif // !defined(WP_SUPPORTS_SCRIPT_ACCESS_CATEGORY)
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -790,6 +790,8 @@ static WebCore::ScriptTrackingPrivacyFlags allowedScriptTrackingCategories(WPScr
         result.add(WebCore::ScriptTrackingPrivacyFlag::Speech);
     if (categories & WPScriptAccessCategoryFormControls)
         result.add(WebCore::ScriptTrackingPrivacyFlag::FormControls);
+    if (categories & WPScriptAccessCategoryNetworkRequests)
+        result.add(WebCore::ScriptTrackingPrivacyFlag::NetworkRequests);
     return result;
 }
 


### PR DESCRIPTION
#### 2c3d421e83cffaf678c70fe828a5066adb7c47f3
<pre>
Add ScriptAccessCategory NetworkRequest category
<a href="https://bugs.webkit.org/show_bug.cgi?id=307015">https://bugs.webkit.org/show_bug.cgi?id=307015</a>
<a href="https://rdar.apple.com/169668119">rdar://169668119</a>

Reviewed by Charlie Wolfe.

Follow up to 305956@main, plumb new category from WebPrivacy.

* Source/WebCore/PAL/pal/spi/cocoa/WebPrivacySPI.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::allowedScriptTrackingCategories):

Canonical link: <a href="https://commits.webkit.org/307229@main">https://commits.webkit.org/307229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f344fa832a7feb5230c5f54c023b43f34c4a53fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152461 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110577 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11cbce82-0009-4d92-a9cb-06fc9ce684dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91494 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/846ef72a-d7ac-44cb-961d-656900dd3944) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10211 "Passed tests") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/2463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121939 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154773 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16322 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30475 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14872 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127023 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71735 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15943 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5535 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15677 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15889 "Failed to checkout and rebase branch from PR 57908") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->