### PR TITLE
Migrate PKPaymentMethod to Wrapped WKKeyedCoder

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -270,6 +270,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNSValue.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCNull.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKDateComponentsRange.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentMethod.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKPaymentToken.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCPKShippingMethod.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -675,6 +675,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCPersonNameComponents.serialization.in \
 	Shared/Cocoa/CoreIPCPKDateComponentsRange.serialization.in \
 	Shared/Cocoa/CoreIPCPKPaymentMerchantSession.serialization.in \
+	Shared/Cocoa/CoreIPCPKPaymentMethod.serialization.in \
 	Shared/Cocoa/CoreIPCPKPaymentSetupFeature.serialization.in \
 	Shared/Cocoa/CoreIPCPKPaymentToken.serialization.in \
 	Shared/Cocoa/CoreIPCPKShippingMethod.serialization.in \

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h
@@ -30,6 +30,9 @@
 #include "ArgumentCodersCocoa.h"
 #include "CoreIPCPKDateComponentsRange.h"
 #if USE(PASSKIT)
+#if HAVE(WK_SECURE_CODING_PKPAYMENTMETHOD)
+#include "CoreIPCPKPaymentMethod.h"
+#endif
 #if HAVE(WK_SECURE_CODING_PKPAYMENTMERCHANTSESSION)
 #include "CoreIPCPKPaymentMerchantSession.h"
 #endif
@@ -52,7 +55,9 @@ class CoreIPCArray;
 class CoreIPCCFType;
 class CoreIPCColor;
 #if USE(PASSKIT)
+#if !HAVE(WK_SECURE_CODING_PKPAYMENTMETHOD)
 class CoreIPCPKPaymentMethod;
+#endif
 #if !HAVE(WK_SECURE_CODING_PKPAYMENTMERCHANTSESSION)
 class CoreIPCPKPaymentMerchantSession;
 #endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/RetainPtr.h>
+
+OBJC_CLASS CNContact;
+OBJC_CLASS PKPaymentMethod;
+OBJC_CLASS PKSecureElementPass;
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKPAYMENTMETHOD)
+
+namespace WebKit {
+
+enum class PKPaymentMethodType : uint8_t {
+    Unknown = 0,
+    Debit = 1,
+    Credit = 2,
+    Prepaid = 3,
+    Store = 4,
+    EMoney = 5,
+};
+
+struct CoreIPCPKPaymentMethodData {
+    std::optional<PKPaymentMethodType> type;
+    RetainPtr<NSString> displayName;
+    RetainPtr<NSString> network;
+    RetainPtr<PKSecureElementPass> paymentPass;
+    RetainPtr<NSString> peerPaymentQuoteIdentifier;
+    RetainPtr<CNContact> billingAddress;
+    RetainPtr<NSString> installmentBindToken;
+    std::optional<bool> usePeerPaymentBalance;
+};
+
+class CoreIPCPKPaymentMethod {
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCPKPaymentMethod);
+public:
+    CoreIPCPKPaymentMethod(PKPaymentMethod *);
+    CoreIPCPKPaymentMethod(std::optional<CoreIPCPKPaymentMethodData>&&);
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCPKPaymentMethod>;
+
+    std::optional<CoreIPCPKPaymentMethodData> m_data;
+};
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.mm
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCPKPaymentMethod.h"
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKPAYMENTMETHOD)
+
+#import "ArgumentCodersCocoa.h"
+#import "Logging.h"
+#import "WKKeyedCoder.h"
+#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <pal/cocoa/ContactsSoftLink.h>
+#import <pal/cocoa/PassKitSoftLink.h>
+
+
+namespace WebKit {
+
+CoreIPCPKPaymentMethod::CoreIPCPKPaymentMethod(PKPaymentMethod *paymentMethod)
+{
+    if (!paymentMethod)
+        return;
+
+    RetainPtr archiver = adoptNS([WKKeyedCoder new]);
+    [paymentMethod encodeWithCoder:archiver.get()];
+    RetainPtr dictionary = [archiver accumulatedDictionary];
+
+    CoreIPCPKPaymentMethodData data;
+
+    if (RetainPtr typeNumber = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"type"])) {
+        auto value = [typeNumber unsignedCharValue];
+        if (isValidEnum<PKPaymentMethodType>(value))
+            data.type = static_cast<PKPaymentMethodType>(value);
+    }
+
+    if (RetainPtr displayName = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"displayName"]))
+        data.displayName = WTF::move(displayName);
+
+    if (RetainPtr network = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"network"]))
+        data.network = WTF::move(network);
+
+    if (id paymentPass = [dictionary.get() objectForKey:@"paymentPass"]) {
+        if ([paymentPass isKindOfClass:PAL::getPKSecureElementPassClassSingleton()])
+            data.paymentPass = paymentPass;
+    }
+
+    if (RetainPtr peerPaymentQuoteIdentifier = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"peerPaymentQuoteIdentifier"]))
+        data.peerPaymentQuoteIdentifier = WTF::move(peerPaymentQuoteIdentifier);
+
+    if (id billingAddress = [dictionary.get() objectForKey:@"billingAddress"]) {
+        if ([billingAddress isKindOfClass:PAL::getCNContactClassSingleton()])
+            data.billingAddress = billingAddress;
+    }
+
+    if (RetainPtr installmentBindToken = dynamic_objc_cast<NSString>([dictionary.get() objectForKey:@"installmentBindToken"]))
+        data.installmentBindToken = WTF::move(installmentBindToken);
+
+    if (RetainPtr usePeerPaymentBalanceValue = dynamic_objc_cast<NSNumber>([dictionary.get() objectForKey:@"usePeerPaymentBalance"]))
+        data.usePeerPaymentBalance = [usePeerPaymentBalanceValue boolValue];
+
+    m_data = WTF::move(data);
+}
+
+CoreIPCPKPaymentMethod::CoreIPCPKPaymentMethod(std::optional<CoreIPCPKPaymentMethodData>&& data)
+    : m_data { WTF::move(data) }
+{
+}
+
+RetainPtr<id> CoreIPCPKPaymentMethod::toID() const
+{
+    if (!m_data)
+        return { };
+
+    RetainPtr dictionary = [NSMutableDictionary dictionaryWithCapacity:8];
+
+    if (m_data->type)
+        [dictionary setObject:[NSNumber numberWithUnsignedChar:static_cast<uint8_t>(*m_data->type)] forKey:@"type"];
+    if (m_data->displayName)
+        [dictionary setObject:m_data->displayName.get() forKey:@"displayName"];
+    if (m_data->network)
+        [dictionary setObject:m_data->network.get() forKey:@"network"];
+    if (m_data->paymentPass)
+        [dictionary setObject:m_data->paymentPass.get() forKey:@"paymentPass"];
+    if (m_data->peerPaymentQuoteIdentifier)
+        [dictionary setObject:m_data->peerPaymentQuoteIdentifier.get() forKey:@"peerPaymentQuoteIdentifier"];
+    if (m_data->billingAddress)
+        [dictionary setObject:m_data->billingAddress.get() forKey:@"billingAddress"];
+    if (m_data->installmentBindToken)
+        [dictionary setObject:m_data->installmentBindToken.get() forKey:@"installmentBindToken"];
+    if (m_data->usePeerPaymentBalance)
+        [dictionary setObject:[NSNumber numberWithBool:*m_data->usePeerPaymentBalance] forKey:@"usePeerPaymentBalance"];
+
+    RetainPtr unarchiver = adoptNS([[WKKeyedCoder alloc] initWithDictionary:dictionary.get()]);
+    RetainPtr paymentMethod = adoptNS([[PAL::getPKPaymentMethodClassSingleton() alloc] initWithCoder:unarchiver.get()]);
+    if (!paymentMethod)
+        RELEASE_LOG_ERROR(IPC, "CoreIPCPKPaymentMethod was not able to reconstruct a PKPaymentMethod object");
+    return paymentMethod;
+}
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.serialization.in
@@ -1,0 +1,52 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(PASSKIT) && HAVE(WK_SECURE_CODING_PKPAYMENTMETHOD)
+
+header: "CoreIPCPKPaymentMethod.h"
+webkit_platform_headers: "CoreIPCPKPaymentMethod.h"
+
+[CustomHeader, WebKitPlatform] enum class WebKit::PKPaymentMethodType : uint8_t {
+    Unknown,
+    Debit,
+    Credit,
+    Prepaid,
+    Store,
+    EMoney,
+}
+
+[CustomHeader, WebKitPlatform] struct WebKit::CoreIPCPKPaymentMethodData {
+    std::optional<WebKit::PKPaymentMethodType> type;
+    RetainPtr<NSString> displayName;
+    RetainPtr<NSString> network;
+    RetainPtr<PKSecureElementPass> paymentPass;
+    RetainPtr<NSString> peerPaymentQuoteIdentifier;
+    RetainPtr<CNContact> billingAddress;
+    RetainPtr<NSString> installmentBindToken;
+    std::optional<bool> usePeerPaymentBalance;
+}
+
+[WebKitPlatform] class WebKit::CoreIPCPKPaymentMethod {
+    std::optional<WebKit::CoreIPCPKPaymentMethodData> m_data;
+}
+
+#endif

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in
@@ -107,6 +107,7 @@ webkit_platform_headers: "CoreIPCPKSecureElementPass.h"
 #endif
 
 additional_forward_declaration: OBJC_CLASS PKSecureElementPass
+#if !HAVE(WK_SECURE_CODING_PKPAYMENTMETHOD)
 [WebKitSecureCodingClass=PAL::getPKPaymentMethodClassSingleton(), SupportWKKeyedCoder, WebKitPlatform] webkit_secure_coding PKPaymentMethod {
     type: Number
     displayName: String
@@ -117,6 +118,7 @@ additional_forward_declaration: OBJC_CLASS PKSecureElementPass
     installmentBindToken: String
     usePeerPaymentBalance: Number
 }
+#endif
 
 #if !HAVE(WK_SECURE_CODING_PKPAYMENTSETUPFEATURE)
 additional_forward_declaration: OBJC_CLASS NSSet

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2544,6 +2544,8 @@
 		F48C81E42AE0BA8E00073850 /* CoreIPCData.h in Headers */ = {isa = PBXBuildFile; fileRef = F48C81E32AE0BA6E00073850 /* CoreIPCData.h */; };
 		F48D2A8521583A7E00C6752B /* AppKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = F48D2A8421583A0200C6752B /* AppKitSPI.h */; };
 		F48EC3582B75895800D1B886 /* WKTextExtractionUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */; };
+		F48F411C2F3A573F0095484F /* CoreIPCPKPaymentMethod.h in Headers */ = {isa = PBXBuildFile; fileRef = F48F41192F3A57350095484F /* CoreIPCPKPaymentMethod.h */; };
+		F48F411D2F3A57450095484F /* CoreIPCPKPaymentMethod.mm in Sources */ = {isa = PBXBuildFile; fileRef = F48F411A2F3A57350095484F /* CoreIPCPKPaymentMethod.mm */; };
 		F496A4311F58A272004C1757 /* DragDropInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = F496A42F1F58A272004C1757 /* DragDropInteractionState.h */; };
 		F4974E76265ECBBC00B49B8C /* WKRevealItemPresenter.h in Headers */ = {isa = PBXBuildFile; fileRef = F446EDEF265EB2B00031DA8F /* WKRevealItemPresenter.h */; };
 		F4975CF22624B80A003C626E /* WKQuickLookPreviewController.h in Headers */ = {isa = PBXBuildFile; fileRef = F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */; };
@@ -8782,6 +8784,9 @@
 		F48D2F452BDAEC7F0057BB0E /* CoreIPCNSURLRequest.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCNSURLRequest.serialization.in; sourceTree = "<group>"; };
 		F48EC3542B7585A300D1B886 /* WKTextExtractionUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKTextExtractionUtilities.mm; sourceTree = "<group>"; };
 		F48EC3562B7585A300D1B886 /* WKTextExtractionUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextExtractionUtilities.h; sourceTree = "<group>"; };
+		F48F41192F3A57350095484F /* CoreIPCPKPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPKPaymentMethod.h; sourceTree = "<group>"; };
+		F48F411A2F3A57350095484F /* CoreIPCPKPaymentMethod.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPKPaymentMethod.mm; sourceTree = "<group>"; };
+		F48F411B2F3A57350095484F /* CoreIPCPKPaymentMethod.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPKPaymentMethod.serialization.in; sourceTree = "<group>"; };
 		F496A42F1F58A272004C1757 /* DragDropInteractionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DragDropInteractionState.h; sourceTree = "<group>"; };
 		F496A4301F58A272004C1757 /* DragDropInteractionState.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DragDropInteractionState.mm; sourceTree = "<group>"; };
 		F4975CF12624B80A003C626E /* WKQuickLookPreviewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKQuickLookPreviewController.h; sourceTree = "<group>"; };
@@ -13008,6 +13013,9 @@
 		37C4C0901814B37B003688B9 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				F48F41192F3A57350095484F /* CoreIPCPKPaymentMethod.h */,
+				F48F411A2F3A57350095484F /* CoreIPCPKPaymentMethod.mm */,
+				F48F411B2F3A57350095484F /* CoreIPCPKPaymentMethod.serialization.in */,
 				48B188FE2E789A3B009B57A9 /* AccessibilityPreferences.mm */,
 				E3C3D1AE2E007922004B306A /* AnnotatedMachSendRight.mm */,
 				1A1EF1971A1D5B420023200A /* APIDataCocoa.mm */,
@@ -18396,6 +18404,7 @@
 				E4D54D0421F1D72D007E3C36 /* ScrollingTreeFrameScrollingNodeRemoteIOS.h in Headers */,
 				0F931C1C18C5711900DBA7C3 /* ScrollingTreeOverflowScrollingNodeIOS.h in Headers */,
 				0F931C1C18C5711900DBB8D4 /* ScrollingTreeScrollingNodeDelegateIOS.h in Headers */,
+				F48F411C2F3A573F0095484F /* CoreIPCPKPaymentMethod.h in Headers */,
 				51D130541382EAC000351EDD /* SecItemRequestData.h in Headers */,
 				51D130561382EAC000351EDD /* SecItemResponseData.h in Headers */,
 				86EB7204298D310A00C1DC77 /* SecItemShim.h in Headers */,
@@ -21543,6 +21552,7 @@
 				7B9FC5A828A38D1E007570E7 /* PlatformUnifiedSource1.cpp in Sources */,
 				7B9FC5D028A5300D007570E7 /* PlatformUnifiedSource2-nonARC.mm in Sources */,
 				7B9FC5D428A53023007570E7 /* PlatformUnifiedSource2.cpp in Sources */,
+				F48F411D2F3A57450095484F /* CoreIPCPKPaymentMethod.mm in Sources */,
 				7B9FC5DE28A53CCD007570E7 /* PlatformUnifiedSource3-nonARC.mm in Sources */,
 				7B9FC5D328A5301D007570E7 /* PlatformUnifiedSource3.cpp in Sources */,
 				7B9FC5D228A53018007570E7 /* PlatformUnifiedSource4.cpp in Sources */,


### PR DESCRIPTION
#### 726e80b578868e53d42be37bd93f98c324ab9e3c
<pre>
Migrate PKPaymentMethod to Wrapped WKKeyedCoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=307013">https://bugs.webkit.org/show_bug.cgi?id=307013</a>
<a href="https://rdar.apple.com/137148760">rdar://137148760</a>

Reviewed by Abrar Rahman Protyasha.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Cocoa/CoreIPCNSCFObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.h: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.mm: Added.
(WebKit::CoreIPCPKPaymentMethod::CoreIPCPKPaymentMethod):
(WebKit::CoreIPCPKPaymentMethod::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCPKPaymentMethod.serialization.in: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCPassKit.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, PKPaymentMethod)):

Canonical link: <a href="https://commits.webkit.org/307111@main">https://commits.webkit.org/307111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d734cd1e12fd7bc614de42fb44f390c0634ca75a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152069 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8bc8433-528e-470c-9ce9-f8c4045dcb9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110280 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/556ac827-98c4-4a5b-a685-fca3327b0d01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128903 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91192 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3683994-0bcc-43a0-a0f4-1c0bffd20a5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12236 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9956 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2071 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154381 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15932 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6438 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118302 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118643 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30404 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14600 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71346 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/15553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5233 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15500 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->