### PR TITLE
[Swift in WebKit] Disable Cxx interop in WebKit in configurations where it's not actually needed

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -41,30 +41,15 @@ OTHER_MODULE_VERIFIER_FLAGS_ = -iframework "$(WK_PRIVATE_SDK_DIR)$(WK_OVERRIDE_F
 WK_HAS_VALID_OBJCXX_MODULE = YES;
 
 WK_HAS_VALID_OBJCXX_MODULE[sdk=macosx15*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=macosx26.0*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=macosx26.1*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=macosx26.2*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=macosx26.3*] = ;
+WK_HAS_VALID_OBJCXX_MODULE[sdk=macosx26.*] = ;
 
-WK_HAS_VALID_OBJCXX_MODULE[sdk=iphone*26.0*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=iphone*26.1*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=iphone*26.2*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=iphone*26.3*] = ;
+WK_HAS_VALID_OBJCXX_MODULE[sdk=iphone*26.*] = ;
 
-WK_HAS_VALID_OBJCXX_MODULE[sdk=appletv*26.0*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=appletv*26.1*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=appletv*26.2*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=appletv*26.3*] = ;
+WK_HAS_VALID_OBJCXX_MODULE[sdk=appletv*26.*] = ;
 
-WK_HAS_VALID_OBJCXX_MODULE[sdk=watch*26.0*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=watch*26.1*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=watch*26.2*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=watch*26.3*] = ;
+WK_HAS_VALID_OBJCXX_MODULE[sdk=watch*26.*] = ;
 
-WK_HAS_VALID_OBJCXX_MODULE[sdk=xr*26.0*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=xr*26.1*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=xr*26.2*] = ;
-WK_HAS_VALID_OBJCXX_MODULE[sdk=xr*26.3*] = ;
+WK_HAS_VALID_OBJCXX_MODULE[sdk=xr*26.*] = ;
 
 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=300146
 WK_HAS_VALID_OBJCXX_MODULE[sdk=iphonesimulator*] = ;


### PR DESCRIPTION
#### e0d4fa4ccab6222370abec2cbfdb6f995ce373bc
<pre>
[Swift in WebKit] Disable Cxx interop in WebKit in configurations where it&apos;s not actually needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=307022">https://bugs.webkit.org/show_bug.cgi?id=307022</a>
<a href="https://rdar.apple.com/169673887">rdar://169673887</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Such configurations have various bugs when trying to use Cxx interop with them, and they&apos;re not actually needed anyways,
so just disable it in those places.

* Source/WebKit/Configurations/WebKit.xcconfig:

Canonical link: <a href="https://commits.webkit.org/306867@main">https://commits.webkit.org/306867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c16a88322a7faab8ca68e54eda32231bbafa769

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95689 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/53c890f1-f5c1-435c-9127-683bc7bee0df) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109585 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79075 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2807c957-e501-4619-8b97-eeedbc4a3353) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12075 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90493 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6525a33-36e8-4b1b-98c4-f649a32b143a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11585 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9254 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1170 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120942 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153485 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14598 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117610 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14631 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117945 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30101 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13974 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124810 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70289 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14640 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3768 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->