### PR TITLE
[AutoFill Debugging] Add a way to enforce paragraph word limit only if the total amount of visible text is large

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt
@@ -1,0 +1,29 @@
+root
+    'Welcome to Test Page'
+    navigation
+        list
+            list-item
+                link,'Section 1'
+            list-item
+                link,'Section 2'
+    'Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.'
+    section
+        button,'Click Me'
+        'This button does nothing'
+        input,'text',placeholder='Enter text here'
+        'Clickable Div'
+    section
+        article
+            'Article Title'
+            'January 1, 2024'
+            'This is some article content with highlighted text.'
+        'Related Links'
+        list
+            list-item
+                link,'Example Link'
+            list-item
+                link,'Test Link'
+        'Ready'
+        button,'Update Status'
+    'The quick brown fox jumped over the lazy dog.'
+    'Footer content with © 2024'

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary.html
@@ -1,0 +1,102 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+.clickable {
+    background-color: lightblue;
+    padding: 10px;
+    margin: 5px;
+    cursor: pointer;
+}
+
+.focusable {
+    border: 2px solid green;
+    padding: 5px;
+    margin: 3px;
+}
+
+.interactive {
+    background-color: lightyellow;
+    padding: 8px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div role="banner">
+    <h1 id="main-title" aria-label="Main Page Title">Welcome to Test Page</h1>
+</div>
+<nav role="navigation" aria-label="Main navigation">
+    <ul>
+        <li><a href="mailto:wenson_hsieh@apple.com" onclick="return false;">Section 1</a></li>
+        <li><a href="https://example.com/" onclick="return false;">Section 2</a></li>
+    </ul>
+</nav>
+<main role="main">
+    <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo.</p>
+    <section id="section1" aria-label="Interactive Elements">
+        <button class="clickable" onclick="console.log('clicked')" aria-label="Test button" aria-describedby="btn-help">Click Me</button>
+        <div id="btn-help" aria-hidden="true">This button does nothing</div>
+        <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
+        <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
+    </section>
+    <section id="section2" aria-label="Content with Roles">
+        <article role="article">
+            <header>
+                <h3>Article Title</h3>
+                <time datetime="2024-01-01">January 1, 2024</time>
+            </header>
+            <p>This is some article content with <mark>highlighted text</mark>.</p>
+        </article>
+        <aside role="complementary" aria-label="Related information">
+            <h4>Related Links</h4>
+            <ul>
+                <li><a href="https://webkit.org" onmouseover="this.style.color='red'">Example Link</a></li>
+                <li><a href="https://apple.com" onmouseout="this.style.color=''">Test Link</a></li>
+            </ul>
+        </aside>
+        <div role="region">
+            <div role="status" aria-live="polite" id="status-msg">Ready</div>
+            <button onclick="document.getElementById('status-msg').textContent = 'Updated!'">Update Status</button>
+        </div>
+    </section>
+    <p>The quick brown fox jumped over the lazy dog.</p>
+</main>
+<footer role="contentinfo">
+    <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024</p>
+</footer>
+<div role="dialog" aria-hidden="true" style="display: none;">
+    <p>This dialog is hidden and should not be extracted.</p>
+</div>
+
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    document.body.textContent = await UIHelper.requestDebugText({
+        normalize: true,
+        includeRects: false,
+        includeURLs: false,
+        nodeIdentifierInclusion: "none",
+        includeEventListeners: false,
+        includeAccessibilityAttributes: false,
+        wordLimit: 10,
+        wordLimitPolicy: "discretionary"
+    });
+
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -39,7 +39,7 @@ enum class ExceptionCode : uint8_t;
 
 namespace TextExtraction {
 
-WEBCORE_EXPORT Item extractItem(Request&&, LocalFrame&);
+WEBCORE_EXPORT Result extractItem(Request&&, LocalFrame&);
 
 WEBCORE_EXPORT Vector<std::pair<String, FloatRect>> extractAllTextAndRects(Page&);
 

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -201,8 +201,6 @@ enum class ContainerType : uint8_t {
 using ItemData = Variant<ContainerType, TextItemData, ScrollableItemData, ImageItemData, SelectData, ContentEditableData, TextFormControlData, FormData, LinkItemData, IFrameData>;
 
 struct Item {
-    WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(Item, WEBCORE_EXPORT);
-
     ItemData data;
     FloatRect rectInRootView;
     Vector<Item> children;
@@ -229,12 +227,19 @@ struct Item {
     }
 };
 
-struct PageItems {
-    Item mainFrameItem;
-    HashMap<FrameIdentifier, UniqueRef<Item>> subFrameItems;
+struct Result {
+    WTF_MAKE_STRUCT_TZONE_ALLOCATED_EXPORT(Result, WEBCORE_EXPORT);
+
+    Item rootItem;
+    unsigned visibleTextLength { 0 };
 };
 
-WEBCORE_EXPORT Item collatePageItems(PageItems&&);
+struct PageResults {
+    Result mainFrameResult;
+    HashMap<FrameIdentifier, UniqueRef<Result>> subFrameResults;
+};
+
+WEBCORE_EXPORT Result collatePageResults(PageResults&&);
 
 struct FilterRuleData {
     String name;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1410,6 +1410,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::TextCheckingType': ['<WebCore/TextChecking.h>'],
         'WebCore::TextDrawingModeFlags': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::TextExtraction::Item': ['<WebCore/TextExtractionTypes.h>'],
+        'WebCore::TextExtraction::Result': ['<WebCore/TextExtractionTypes.h>'],
         'WebCore::TextIndicatorData': ['<WebCore/TextIndicator.h>'],
         'WebCore::TextIndicatorLifetime': ['<WebCore/TextIndicator.h>'],
         'WebCore::TextManipulationControllerManipulationResult': ['<WebCore/TextManipulationControllerManipulationFailure.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6900,6 +6900,12 @@ header: <WebCore/TextExtractionTypes.h>
 };
 
 header: <WebCore/TextExtractionTypes.h>
+[CustomHeader] struct WebCore::TextExtraction::Result {
+    WebCore::TextExtraction::Item rootItem;
+    unsigned visibleTextLength;
+};
+
+header: <WebCore/TextExtractionTypes.h>
 [CustomHeader] struct WebCore::TextExtraction::Editable {
     String label;
     String placeholder;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -701,7 +701,7 @@ struct PerWebProcessState {
 
 #if !__has_feature(modules) || WK_SUPPORTS_SWIFT_OBJCXX_INTEROP
 
-- (void)_requestTextExtractionInternal:(nullable _WKTextExtractionConfiguration *)configuration completion:(CompletionHandler<void(std::optional<WebCore::TextExtraction::Item>&&)>&&)completion;
+- (void)_requestTextExtractionInternal:(nullable _WKTextExtractionConfiguration *)configuration completion:(CompletionHandler<void(std::optional<WebCore::TextExtraction::Result>&&)>&&)completion;
 
 #if ENABLE(TEXT_EXTRACTION_FILTER)
 - (void)_validateText:(const String&)text inFrame:(std::optional<WebCore::FrameIdentifier>&&)frameIdentifier inNode:(std::optional<WebCore::NodeIdentifier>&&)nodeIdentifier completionHandler:(CompletionHandler<void(const String&)>&&)completionHandler;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -66,6 +66,11 @@ typedef NS_OPTIONS(NSUInteger, _WKTextExtractionDataDetectorTypes) {
     _WKTextExtractionDataDetectorAll                = NSUIntegerMax,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+typedef NS_ENUM(NSInteger, _WKTextExtractionWordLimitPolicy) {
+    _WKTextExtractionWordLimitPolicyAlways,
+    _WKTextExtractionWordLimitPolicyDiscretionary,
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @interface _WKTextExtractionConfiguration : NSObject
 
@@ -130,6 +135,14 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  The default value is `NSUIntegerMax`.
  */
 @property (nonatomic) NSUInteger maxWordsPerParagraph;
+
+/*!
+ Policy around when to enforce the max number of words to include per paragraph.
+ `.always`          Always enforce word limits per paragraph.
+ `.discretionary`   Limits may be ignored in cases where the total length of output text size is small.
+ The default value is `.always`.
+ */
+@property (nonatomic) _WKTextExtractionWordLimitPolicy maxWordsPerParagraphPolicy;
 
 /*!
  If specified, text extraction is limited to the subtree of this node.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -66,6 +66,7 @@
     _onlyIncludeVisibleText = onlyVisibleText;
     _targetRect = CGRectNull;
     _maxWordsPerParagraph = NSUIntegerMax;
+    _maxWordsPerParagraphPolicy = _WKTextExtractionWordLimitPolicyAlways;
     return self;
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -895,7 +895,7 @@ void WebFrameProxy::sendMessageToInspectorFrontend(const String& targetId, const
         page->inspectorController().sendMessageToInspectorFrontend(targetId, message);
 }
 
-void WebFrameProxy::requestTextExtraction(WebCore::TextExtraction::Request&& request, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&& completion)
+void WebFrameProxy::requestTextExtraction(WebCore::TextExtraction::Request&& request, CompletionHandler<void(WebCore::TextExtraction::Result&&)>&& completion)
 {
     if (RefPtr page = m_page.get(); !page || !page->hasRunningProcess())
         return completion({ });

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -86,8 +86,8 @@ namespace TextExtraction {
 struct ExtractedText;
 struct InteractionDescription;
 struct Interaction;
-struct Item;
 struct Request;
+struct Result;
 }
 
 using FrameIdentifier = ObjectIdentifier<FrameIdentifierType>;
@@ -296,7 +296,7 @@ public:
 
     void sendMessageToInspectorFrontend(const String& targetId, const String& message);
 
-    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Result&&)>&&);
     void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
     void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
     void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1630,7 +1630,7 @@ void WebFrame::sendMessageToInspectorTarget(const String& message)
     ensureInspectorTarget()->sendMessageToTargetBackend(message);
 }
 
-void WebFrame::requestTextExtraction(TextExtraction::Request&& request, CompletionHandler<void(TextExtraction::Item&&)>&& completion)
+void WebFrame::requestTextExtraction(TextExtraction::Request&& request, CompletionHandler<void(TextExtraction::Result&&)>&& completion)
 {
     RefPtr frame = coreLocalFrame();
     if (!frame)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -73,8 +73,8 @@ namespace TextExtraction {
 struct ExtractedText;
 struct InteractionDescription;
 struct Interaction;
-struct Item;
 struct Request;
+struct Result;
 }
 
 enum class FocusDirection : uint8_t;
@@ -287,7 +287,7 @@ public:
     void disconnectInspector();
     void sendMessageToInspectorTarget(const String& message);
 
-    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
+    void requestTextExtraction(WebCore::TextExtraction::Request&&, CompletionHandler<void(WebCore::TextExtraction::Result&&)>&&);
     void handleTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(bool, String&&)>&&);
     void describeTextExtractionInteraction(WebCore::TextExtraction::Interaction&&, CompletionHandler<void(WebCore::TextExtraction::InteractionDescription&&)>&&);
     void takeSnapshotOfExtractedText(WebCore::TextExtraction::ExtractedText&&, CompletionHandler<void(RefPtr<WebCore::TextIndicator>&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -37,7 +37,7 @@ messages -> WebFrame {
     SendMessageToInspectorTarget(String message)
 
     # Text extraction support
-    RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Item item)
+    RequestTextExtraction(struct WebCore::TextExtraction::Request request) -> (struct WebCore::TextExtraction::Result result)
     HandleTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (bool succeeded, String description)
     DescribeTextExtractionInteraction(struct WebCore::TextExtraction::Interaction interaction) -> (struct WebCore::TextExtraction::InteractionDescription description)
     TakeSnapshotOfExtractedText(struct WebCore::TextExtraction::ExtractedText text) -> (RefPtr<WebCore::TextIndicator> textIndicator)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -56,6 +56,7 @@ dictionary TextExtractionTestOptions {
     boolean skipNearlyTransparentContent = false;
     DOMString outputFormat;
     object dataDetectorTypes;
+    DOMString wordLimitPolicy;
 };
 
 dictionary TextExtractionInteractionOptions {

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -71,6 +71,7 @@ struct TextExtractionTestOptions {
     bool skipNearlyTransparentContent { false };
     JSRetainPtr<JSStringRef> outputFormat;
     JSValueRef dataDetectorTypes { nullptr };
+    JSRetainPtr<JSStringRef> wordLimitPolicy;
 };
 
 TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef, JSValueRef);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -90,6 +90,7 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     }();
     options.nodeIdentifierInclusion = stringProperty(context, (JSObjectRef)argument, "nodeIdentifierInclusion");
     options.outputFormat = stringProperty(context, (JSObjectRef)argument, "outputFormat");
+    options.wordLimitPolicy = stringProperty(context, (JSObjectRef)argument, "wordLimitPolicy");
     return &options;
 }
 

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -415,8 +415,17 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     if (outputFormat)
         [configuration setOutputFormat:*outputFormat];
 
-    if (auto wordLimit = options ? options->wordLimit : 0)
-        [configuration setMaxWordsPerParagraph:static_cast<NSUInteger>(wordLimit)];
+    if (options) {
+        if (auto wordLimit = options->wordLimit)
+            [configuration setMaxWordsPerParagraph:static_cast<NSUInteger>(wordLimit)];
+
+        auto policy = toWTFString(options->wordLimitPolicy);
+        if (equalLettersIgnoringASCIICase(policy, "always"_s))
+            [configuration setMaxWordsPerParagraphPolicy:_WKTextExtractionWordLimitPolicyAlways];
+        else if (equalLettersIgnoringASCIICase(policy, "discretionary"_s))
+            [configuration setMaxWordsPerParagraphPolicy:_WKTextExtractionWordLimitPolicyDiscretionary];
+    }
+
     [configuration setTargetRect:extractionRect];
     [configuration setMergeParagraphs:options && options->mergeParagraphs];
     [configuration setSkipNearlyTransparentContent:options && options->skipNearlyTransparentContent];


### PR DESCRIPTION
#### 06048ae563649413a3a23b7b1793d0fa879dc124
<pre>
[AutoFill Debugging] Add a way to enforce paragraph word limit only if the total amount of visible text is large
<a href="https://bugs.webkit.org/show_bug.cgi?id=307023">https://bugs.webkit.org/show_bug.cgi?id=307023</a>
<a href="https://rdar.apple.com/169675190">rdar://169675190</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Add support for a `maxWordsPerParagraphPolicy` property on the text extraction configuration, which
determines when `maxWordsPerParagraph` should be applied. The supported values are `.always` (the
current behavior) and `.discretionary`, which leaves the decision up to the engine.

When `.discretionary` is set, we&apos;ll currently only enforce the word limit if the total size of the
document is &quot;small&quot; (arbitrarily set to under ~4k characters of visible text).

Test: fast/text-extraction/debug-text-extraction-lightweight-discretionary.html

* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary.html: Added.

Add a layout test that passes `discretionary` for the max word limit policy, and verifies that we
don&apos;t end up truncating any text in this test case.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):

Increment the total length of all visible text items encountered while recursively collecting text
extraction items.

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebCore/page/text-extraction/TextExtractionTypes.cpp:
(WebCore::TextExtraction::collateRecursive):
(WebCore::TextExtraction::collatePageResults):
(WebCore::TextExtraction::collateItemsRecursive): Deleted.
(WebCore::TextExtraction::collatePageItems): Deleted.
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Refactor `TextExtraction::extractItem` to return a `TextExtraction::Result` instead of an `Item`.
The `Result` struct is just a basic wrapper around an `Item` and some metadata (which currently only
includes the character count of all extracted visible text). In the future, this could include more
information, such as any data detector results or general information about the DOM or meta tags.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _extractDebugTextWithConfigurationWithoutUpdatingFilterRules:assertionScope:completionHandler:]):
(-[WKWebView _requestTextExtractionInternal:completion:]):
(-[WKWebView _requestTextExtraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration _initForOnlyVisibleText:]):

Add the new policy flag.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::requestTextExtraction):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::requestTextExtraction):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:

Make `requestTextExtraction` return a `Result` instead of an `Item` (see above).

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Make it possible for layout tests to set the new policy property.

Canonical link: <a href="https://commits.webkit.org/306843@main">https://commits.webkit.org/306843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/247c21ce513e250cb18dfd06784b178536b0a20a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151169 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e245da2-ee8c-48e7-b253-60c0b43a73e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109590 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/102eeb4d-9a35-4edb-82fe-e6a108e6bdff) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90498 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0726ea54-578d-4ae0-bf3b-fd7d52c8ad86) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/141849 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11591 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9260 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153493 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14606 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117618 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30080 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13989 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124828 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70297 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14648 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3785 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14385 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78350 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->