### PR TITLE
RTCRtpSynchronizationSource.timestamp should use wall time, not monotonic time

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https-expected.txt
@@ -3,13 +3,13 @@ PASS [audio] getSynchronizationSources() eventually returns a non-empty list
 PASS [audio] RTCRtpSynchronizationSource.timestamp is a number
 PASS [audio] RTCRtpSynchronizationSource.rtpTimestamp is a number [0, 2^32-1]
 PASS [audio] getSynchronizationSources() does not contain SSRCs older than 10 seconds
-FAIL [audio] RTCRtpSynchronizationSource.timestamp is comparable to performance.timeOrigin + performance.now() assert_true: expected true got false
+PASS [audio] RTCRtpSynchronizationSource.timestamp is comparable to performance.timeOrigin + performance.now()
 PASS [audio] RTCRtpSynchronizationSource.source is a number
 PASS [video] getSynchronizationSources() eventually returns a non-empty list
 PASS [video] RTCRtpSynchronizationSource.timestamp is a number
 PASS [video] RTCRtpSynchronizationSource.rtpTimestamp is a number [0, 2^32-1]
 PASS [video] getSynchronizationSources() does not contain SSRCs older than 10 seconds
-FAIL [video] RTCRtpSynchronizationSource.timestamp is comparable to performance.timeOrigin + performance.now() assert_true: expected true got false
+PASS [video] RTCRtpSynchronizationSource.timestamp is comparable to performance.timeOrigin + performance.now()
 PASS [video] RTCRtpSynchronizationSource.source is a number
 PASS [audio-only] RTCRtpSynchronizationSource.audioLevel is a number [0, 1]
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,8 +55,11 @@ private:
     Ref<RTCRtpTransformBackend> rtcRtpTransformBackend() final;
     std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend() final;
 
+    double webrtcToWallTimeOffset() const;
+
     const Ref<webrtc::RtpReceiverInterface> m_rtcReceiver;
     const RefPtr<RTCRtpTransformBackend> m_transformBackend;
+    mutable std::optional<double> m_webrtcToWallTimeOffset;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ade17394d9f35fee6901de14e429172e39b20022
<pre>
RTCRtpSynchronizationSource.timestamp should use wall time, not monotonic time
<a href="https://bugs.webkit.org/show_bug.cgi?id=307036">https://bugs.webkit.org/show_bug.cgi?id=307036</a>
<a href="https://rdar.apple.com/169679084">rdar://169679084</a>

Reviewed by Youenn Fablet.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The timestamp field in RTCRtpSynchronizationSource and
RTCRtpContributingSource was using libwebrtc&apos;s monotonic timestamp
directly, but the WebRTC spec requires DOMHighResTimeStamp which is
relative to the Unix epoch (wall time).

This caused test failures where timestamps were not comparable to
performance.timeOrigin + performance.now().

Fix by converting from libwebrtc&apos;s monotonic time to wall time using
the offset between webrtc::TimeMillis() and WallTime::now(). The
offset is computed once per LibWebRTCRtpReceiverBackend instance and
cached to avoid repeated calculations.

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.cpp:
(WebCore::LibWebRTCRtpReceiverBackend::webrtcToWallTimeOffset const):
(WebCore::fillRTCRtpContributingSource):
(WebCore::toRTCRtpContributingSource):
(WebCore::toRTCRtpSynchronizationSource):
(WebCore::LibWebRTCRtpReceiverBackend::getContributingSources const):
(WebCore::LibWebRTCRtpReceiverBackend::getSynchronizationSources const):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpReceiverBackend.h:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/307063@main">https://commits.webkit.org/307063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbb90a5f125dea7fd29b884c7c6840ffa5e2dce7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a80a84f5-3b0f-482c-a9fe-1f6c95483337) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109841 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79160 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16442826-5397-45f5-ab2d-21d60e4b8340) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90750 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be671c65-5ea5-4e67-9860-dae82e53fece) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11805 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9480 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1506 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153820 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14931 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117857 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118191 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30358 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14178 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70628 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14974 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4040 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14709 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78718 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14917 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->