### PR TITLE
Reduce the background suspension timeout from 8 minutes to 4 minutes

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -47,7 +47,7 @@
 namespace WebKit {
     
 static constexpr Seconds processSuspensionTimeout { 20_s };
-static constexpr Seconds removeAllAssertionsTimeout { 8_min };
+static constexpr Seconds removeAllAssertionsTimeout { 4_min };
 static constexpr Seconds processAssertionCacheLifetime { 1_s };
 
 Ref<ProcessThrottlerActivity> ProcessThrottlerActivity::create(ProcessThrottler& throttler, ASCIILiteral name, ProcessThrottlerActivityType type, IsQuietActivity isQuietActivity)

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2824,7 +2824,7 @@ Seconds WebProcessPool::defaultWebProcessSuspensionDelay()
 {
     static Seconds delay = []() {
         auto value = CFPreferencesGetAppIntegerValue(CFSTR("DebugWebProcessSuspensionDelay"), kCFPreferencesCurrentApplication, nullptr);
-        return value > 0 ? Seconds(value) : 8_min;
+        return value > 0 ? Seconds(value) : 4_min;
     }();
     return delay;
 }


### PR DESCRIPTION
#### 59ac2fa8c11f710f39faa57d8ba4b14be98b6431
<pre>
Reduce the background suspension timeout from 8 minutes to 4 minutes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307039">https://bugs.webkit.org/show_bug.cgi?id=307039</a>
<a href="https://rdar.apple.com/169042521">rdar://169042521</a>

Reviewed by Ben Nham.

Cut the default background tab suspension timeout in half. This can save
anywhere from 0.4% to 1% in a browsing power benchmark by more quickly suspending
web processes which are not meeting the criteria for indefinite background activity.

No new tests since this just reduces a default constant.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::defaultWebProcessSuspensionDelay):

Canonical link: <a href="https://commits.webkit.org/306947@main">https://commits.webkit.org/306947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/705d0a30fc77716d16747664b653074d34547850

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/14989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95713 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109605 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79084 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdf4f44a-f554-4581-91f0-f04b7166ea16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145475 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90515 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11599 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9270 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1194 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120958 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153509 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14622 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117631 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117967 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30219 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/13988 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124833 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70313 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14664 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3790 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14609 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->