### PR TITLE
[Yarr] Clear start and end for subpattern

### DIFF
--- a/JSTests/stress/regexp-fixedcount-stale-endindex.js
+++ b/JSTests/stress/regexp-fixedcount-stale-endindex.js
@@ -1,0 +1,69 @@
+// Regression test for bug where FixedCount parentheses could leave stale endIndex
+// when a match failed mid-iteration. The issue was that clearSubpatternStart only
+// cleared the start index, leaving end with garbage that could cause incorrect
+// length calculations.
+
+// Test 1: Negative lookahead with backreference to unset group in FixedCount
+(function testNegativeLookaheadBackref() {
+    var re = /(?!(\3){4,7})/gi;
+    var s = "\u1DD2";
+    var result = re.exec(s);
+    // Should match at the beginning (negative lookahead succeeds because \3 is unset)
+    if (result === null)
+        throw new Error("Test 1 failed: expected match, got null");
+    if (result.index !== 0)
+        throw new Error("Test 1 failed: expected index 0, got " + result.index);
+})();
+
+// Test 2: Similar pattern with different character
+(function testNegativeLookaheadBackref2() {
+    var re = /(?!(\2){2,3})/;
+    var result = re.test("x");
+    if (result !== true)
+        throw new Error("Test 2 failed: expected true, got " + result);
+})();
+
+// Test 3: FixedCount with nested groups that may partially match
+(function testFixedCountNestedGroups() {
+    var re = /(?:(a)|(b)){2}/;
+    var result = "ab".match(re);
+    if (!result)
+        throw new Error("Test 3 failed: expected match, got null");
+    if (result[0] !== "ab")
+        throw new Error("Test 3 failed: expected 'ab', got " + result[0]);
+    // result[1] should be undefined (last iteration matched 'b', not 'a')
+    if (result[1] !== undefined)
+        throw new Error("Test 3 failed: expected result[1] to be undefined, got " + result[1]);
+    // result[2] should be 'b'
+    if (result[2] !== "b")
+        throw new Error("Test 3 failed: expected result[2] to be 'b', got " + result[2]);
+})();
+
+// Test 4: Run many iterations to trigger JIT
+(function testManyIterations() {
+    var re = /(?!(\3){4,7})/gi;
+    for (var i = 0; i < 10000; i++) {
+        var result = re.exec("\u1DD2");
+        re.lastIndex = 0;
+        if (result === null)
+            throw new Error("Test 4 failed at iteration " + i);
+    }
+})();
+
+// Test 5: Greedy quantifier with backreference
+(function testGreedyWithBackref() {
+    var re = /(?:(\w)(\1){3})+/;
+    var result = "aaaa".match(re);
+    if (!result)
+        throw new Error("Test 5 failed: expected match, got null");
+    if (result[0] !== "aaaa")
+        throw new Error("Test 5 failed: expected 'aaaa', got " + result[0]);
+})();
+
+// Test 6: Empty backreference
+(function testEmptyBackref() {
+    var re = /(\1)*/;
+    var result = re.exec("");
+    if (result === null)
+        throw new Error("Test 6 failed: expected match, got null");
+})();

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -958,8 +958,9 @@ private:
                         resultArray.append(string.substring(result.start, result.end - result.start));
                         for (unsigned i = 1; i <= regExp->numSubpatterns(); ++i) {
                             int start = ovector[2 * i];
-                            if (start >= 0)
-                                resultArray.append(string.substring(start, ovector[2 * i + 1] - start));
+                            int end = ovector[2 * i + 1];
+                            if (start >= 0 && end >= start)
+                                resultArray.append(string.substring(start, end - start));
                             else
                                 resultArray.append(String());
                         }

--- a/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
+++ b/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
@@ -222,7 +222,7 @@ static String findMagicComment(const String& content, ASCIILiteral patternString
     if (result == offsetNoMatch)
         return String();
 
-    ASSERT(matches[2] > 0 && matches[3] > 0);
+    ASSERT(matches[2] > 0 && matches[3] >= matches[2]);
     return content.substring(matches[2], matches[3] - matches[2]);
 }
 

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -63,8 +63,10 @@ void RegExpFunctionalTestCollector::outputOneTest(RegExp* regExp, StringView s, 
     for (unsigned i = 0; i <= regExp->numSubpatterns(); i++) {
         int subpatternBegin = ovector[i * 2];
         int subpatternEnd = ovector[i * 2 + 1];
-        if (subpatternBegin == -1)
+        if (subpatternBegin == -1 || subpatternEnd < subpatternBegin) {
+            subpatternBegin = -1;
             subpatternEnd = -1;
+        }
         fprintf(m_file, "%d, %d", subpatternBegin, subpatternEnd);
         if (i < regExp->numSubpatterns())
             fputs(", ", m_file);

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
@@ -146,9 +146,10 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
 
         for (unsigned i = 1; i <= numSubpatterns; ++i) {
             int start = subpatternResults[2 * i];
+            int end = subpatternResults[2 * i + 1];
             JSValue value;
-            if (start >= 0)
-                value = jsSubstringOfResolved(vm, &deferralContext, input, start, subpatternResults[2 * i + 1] - start);
+            if (start >= 0 && end >= start)
+                value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
             else
                 value = jsUndefined();
             array->initializeIndexWithoutBarrier(matchesArrayScope, i, value);
@@ -157,9 +158,10 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
         if (createIndices) {
             for (unsigned i = 0; i <= numSubpatterns; ++i) {
                 int start = subpatternResults[2 * i];
+                int end = subpatternResults[2 * i + 1];
                 JSValue value;
-                if (start >= 0)
-                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, subpatternResults[2 * i + 1]));
+                if (start >= 0 && end >= start)
+                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, end));
                 else
                     indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, jsUndefined());
             }
@@ -185,9 +187,10 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
         
         for (unsigned i = 1; i <= numSubpatterns; ++i) {
             int start = subpatternResults[2 * i];
+            int end = subpatternResults[2 * i + 1];
             JSValue value;
-            if (start >= 0)
-                value = jsSubstringOfResolved(vm, &deferralContext, input, start, subpatternResults[2 * i + 1] - start);
+            if (start >= 0 && end >= start)
+                value = jsSubstringOfResolved(vm, &deferralContext, input, start, end - start);
             else
                 value = jsUndefined();
             array->initializeIndexWithoutBarrier(matchesArrayScope, i, value, ArrayWithContiguous);
@@ -196,8 +199,9 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
         if (createIndices) {
             for (unsigned i = 0; i <= numSubpatterns; ++i) {
                 int start = subpatternResults[2 * i];
-                if (start >= 0)
-                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, subpatternResults[2 * i + 1]));
+                int end = subpatternResults[2 * i + 1];
+                if (start >= 0 && end >= start)
+                    indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, createIndexArray(deferralContext, start, end));
                 else
                     indicesArray->initializeIndexWithoutBarrier(indicesArrayScope, i, jsUndefined());
             }

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -604,7 +604,8 @@ void genericSplit(
             // a. Let nextCapture be ? Get(z, ! ToString(i)).
             // b. Perform ! CreateDataProperty(A, ! ToString(lengthA), nextCapture).
             int sub = ovector[i * 2];
-            auto result = push(sub >= 0, sub, ovector[i * 2 + 1] - sub);
+            int subEnd = ovector[i * 2 + 1];
+            auto result = push(sub >= 0 && subEnd >= sub, sub, subEnd - sub);
             RETURN_IF_EXCEPTION(scope, void());
             if (result == AbortSplit)
                 return;

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -217,17 +217,17 @@ NEVER_INLINE void substituteBackreferencesSlow(StringBuilder& result, StringView
         }
 
         int backrefStart;
-        int backrefLength;
+        int backrefEnd;
         int advance = 0;
         if (ref == '&') {
             backrefStart = ovector[0];
-            backrefLength = ovector[1] - backrefStart;
+            backrefEnd = ovector[1];
         } else if (ref == '`') {
             backrefStart = 0;
-            backrefLength = ovector[0];
+            backrefEnd = ovector[0];
         } else if (ref == '\'') {
             backrefStart = ovector[1];
-            backrefLength = source.length() - backrefStart;
+            backrefEnd = source.length();
         } else if (reg && ref == '<') {
             // Named back reference
             if (!hasNamedCaptures)
@@ -242,10 +242,10 @@ NEVER_INLINE void substituteBackreferencesSlow(StringBuilder& result, StringView
 
             if (!backrefIndex || backrefIndex > reg->numSubpatterns()) {
                 backrefStart = 0;
-                backrefLength = 0;
+                backrefEnd = 0;
             } else {
                 backrefStart = ovector[2 * backrefIndex];
-                backrefLength = ovector[2 * backrefIndex + 1] - backrefStart;
+                backrefEnd = ovector[2 * backrefIndex + 1];
             }
             advance = nameLength + 1;
         } else if (reg && isASCIIDigit(ref)) {
@@ -266,7 +266,7 @@ NEVER_INLINE void substituteBackreferencesSlow(StringBuilder& result, StringView
             if (!backrefIndex)
                 continue;
             backrefStart = ovector[2 * backrefIndex];
-            backrefLength = ovector[2 * backrefIndex + 1] - backrefStart;
+            backrefEnd = ovector[2 * backrefIndex + 1];
         } else
             continue;
 
@@ -274,8 +274,8 @@ NEVER_INLINE void substituteBackreferencesSlow(StringBuilder& result, StringView
             result.append(replacement.substring(offset, i - offset));
         i += 1 + advance;
         offset = i + 1;
-        if (backrefStart >= 0)
-            result.append(source.substring(backrefStart, backrefLength));
+        if (backrefStart >= 0 && backrefEnd >= backrefStart)
+            result.append(source.substring(backrefStart, backrefEnd - backrefStart));
     } while ((i = replacement.find('$', i + 1)) != notFound);
 
     if (replacement.length() - offset)

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -753,14 +753,14 @@ ALWAYS_INLINE JSCellButterfly* addToRegExpSearchCache(VM& vm, JSGlobalObject* gl
 
         for (unsigned i = 0; i < regExp->numSubpatterns() + 1; ++i) {
             int matchStart = ovector[i * 2];
-            int matchLen = ovector[i * 2 + 1] - matchStart;
+            int matchEnd = ovector[i * 2 + 1];
 
             JSValue patternValue;
 
-            if (matchStart < 0)
+            if (matchStart < 0 || matchEnd < matchStart)
                 patternValue = jsUndefined();
             else {
-                patternValue = jsSubstringOfResolved(vm, string, matchStart, matchLen);
+                patternValue = jsSubstringOfResolved(vm, string, matchStart, matchEnd - matchStart);
                 RETURN_IF_EXCEPTION(scope, { });
             }
 
@@ -1377,14 +1377,14 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
 
             for (unsigned i = 0; i < regExp->numSubpatterns() + 1; ++i) {
                 int matchStart = ovector[i * 2];
-                int matchLen = ovector[i * 2 + 1] - matchStart;
+                int matchEnd = ovector[i * 2 + 1];
 
                 JSValue patternValue;
 
-                if (matchStart < 0)
+                if (matchStart < 0 || matchEnd < matchStart)
                     patternValue = jsUndefined();
                 else {
-                    patternValue = jsSubstring(globalObject, vm, string, matchStart, matchLen);
+                    patternValue = jsSubstring(globalObject, vm, string, matchStart, matchEnd - matchStart);
                     RETURN_IF_EXCEPTION(scope, nullptr);
                 }
 
@@ -1399,12 +1399,12 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
                             groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
                         else if (captureIndex > 0) {
                             int captureStart = ovector[captureIndex * 2];
-                            int captureLen = ovector[captureIndex * 2 + 1] - captureStart;
+                            int captureEnd = ovector[captureIndex * 2 + 1];
                             JSValue captureValue;
-                            if (captureStart < 0)
+                            if (captureStart < 0 || captureEnd < captureStart)
                                 captureValue = jsUndefined();
                             else {
-                                captureValue = jsSubstring(globalObject, vm, string, captureStart, captureLen);
+                                captureValue = jsSubstring(globalObject, vm, string, captureStart, captureEnd - captureStart);
                                 RETURN_IF_EXCEPTION(scope, nullptr);
                             }
                             groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);
@@ -1462,14 +1462,14 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
 
             for (unsigned i = 0; i < regExp->numSubpatterns() + 1; ++i) {
                 int matchStart = ovector[i * 2];
-                int matchLen = ovector[i * 2 + 1] - matchStart;
+                int matchEnd = ovector[i * 2 + 1];
 
                 JSValue patternValue;
 
-                if (matchStart < 0)
+                if (matchStart < 0 || matchEnd < matchStart)
                     patternValue = jsUndefined();
                 else {
-                    patternValue = jsSubstring(globalObject, vm, string, matchStart, matchLen);
+                    patternValue = jsSubstring(globalObject, vm, string, matchStart, matchEnd - matchStart);
                     RETURN_IF_EXCEPTION(scope, nullptr);
                 }
 
@@ -1484,12 +1484,12 @@ ALWAYS_INLINE JSString* replaceUsingRegExpSearch(VM& vm, JSGlobalObject* globalO
                             groups->putDirect(vm, Identifier::fromString(vm, groupName), patternValue);
                         else if (captureIndex > 0) {
                             int captureStart = ovector[captureIndex * 2];
-                            int captureLen = ovector[captureIndex * 2 + 1] - captureStart;
+                            int captureEnd = ovector[captureIndex * 2 + 1];
                             JSValue captureValue;
-                            if (captureStart < 0)
+                            if (captureStart < 0 || captureEnd < captureStart)
                                 captureValue = jsUndefined();
                             else {
-                                captureValue = jsSubstring(globalObject, vm, string, captureStart, captureLen);
+                                captureValue = jsSubstring(globalObject, vm, string, captureStart, captureEnd - captureStart);
                                 RETURN_IF_EXCEPTION(scope, nullptr);
                             }
                             groups->putDirect(vm, Identifier::fromString(vm, groupName), captureValue);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1082,7 +1082,7 @@ public:
         unsigned matchBegin = output[(subpatternId << 1)];
         unsigned matchEnd = output[(subpatternId << 1) + 1];
 
-        if (matchBegin == offsetNoMatch)
+        if (matchBegin == offsetNoMatch || matchEnd == offsetNoMatch)
             return false;
 
         ASSERT(matchBegin <= matchEnd);
@@ -1356,8 +1356,10 @@ public:
         // We've reached the end of the parens; if they are inverted, this is failure.
         if (term.invert()) {
             if (term.containsAnyCaptures()) {
-                for (unsigned subpattern = term.subpatternId(); subpattern <= term.lastSubpatternId(); subpattern++)
+                for (unsigned subpattern = term.subpatternId(); subpattern <= term.lastSubpatternId(); subpattern++) {
                     output[subpattern << 1] = offsetNoMatch;
+                    output[(subpattern << 1) + 1] = offsetNoMatch;
+                }
             }
             context->term -= term.atom.parenthesesWidth;
             return false;
@@ -1395,8 +1397,10 @@ public:
         input.setPos(backTrack->begin);
 
         if (term.containsAnyCaptures()) {
-            for (unsigned subpattern = term.subpatternId(); subpattern <= term.lastSubpatternId(); subpattern++)
+            for (unsigned subpattern = term.subpatternId(); subpattern <= term.lastSubpatternId(); subpattern++) {
                 output[subpattern << 1] = offsetNoMatch;
+                output[(subpattern << 1) + 1] = offsetNoMatch;
+            }
         }
 
         context->term -= term.atom.parenthesesWidth;


### PR DESCRIPTION
#### 9068c0916cf912475266066b148857ed2739fdc2
<pre>
[Yarr] Clear start and end for subpattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=307041">https://bugs.webkit.org/show_bug.cgi?id=307041</a>
<a href="https://rdar.apple.com/169681715">rdar://169681715</a>

Reviewed by Sosuke Suzuki.

When FixedCount parentheses iteration failed, we leave the end index -1
while we already set the begin index with the starting value. Also we
are not clearing end index before the iteration. As a result, we end up
having previous garbage value for the end index and we have broken
range, while this begin/end pair is a failed one.

This patch clears both begin/end to -1 when clearing. Also we check both
begin/end to determine whether this capture is having an actual value.

Test: JSTests/stress/regexp-fixedcount-stale-endindex.js

* JSTests/stress/regexp-fixedcount-stale-endindex.js: Added.
(testNegativeLookaheadBackref):
(testNegativeLookaheadBackref2):
(testFixedCountNestedGroups):
(testManyIterations):
(testGreedyWithBackref):
(testEmptyBackref):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp:
(Inspector::ContentSearchUtilities::findMagicComment):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExpFunctionalTestCollector::outputOneTest):
* Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
(JSC::createRegExpMatchesArray):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::genericSplit):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::substituteBackreferencesSlow):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::addToRegExpSearchCache):
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::backtrackBackReference):
(JSC::Yarr::Interpreter::matchParentheticalAssertionEnd):
(JSC::Yarr::Interpreter::backtrackParentheticalAssertionEnd):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/306841@main">https://commits.webkit.org/306841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fffae7064f3a39bd1225e6a00f3c3fe4451b7733

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151206 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36b4cc14-8e24-47d4-aeef-8ce264cb6f71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109622 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0343a751-87ac-4f11-8de9-3d5c8ffbdb5c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90531 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2330d5f-f43c-4296-8e31-9d7a3271c01f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1212 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134528 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153527 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3348 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14640 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4676 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117645 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12743 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117982 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14003 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70331 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21985 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14682 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3807 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173833 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78384 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44952 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14480 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->