### PR TITLE
REGRESSION(306485@main): [GTK] Crashes or bad rendering with compositing mode disabled or with hardware acceleration disabled and softGL.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3447,6 +3447,20 @@ HTTPSByDefaultEnabled:
     WebCore:
       default: false
 
+HardwareAccelerationEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Hardware acceleration"
+  humanReadableDescription: "Enable hardware acceleration"
+  condition: PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 HiddenPageCSSAnimationSuspensionEnabled:
   type: bool
   status: embedder
@@ -8580,17 +8594,6 @@ UseGiantTiles:
       default: false
     WebCore:
       default: false
-
-UseHardwareBuffersForFrameRendering:
-  type: bool
-  status: embedder
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
 
 UseIFCForSVGText:
   type: bool

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -630,8 +630,6 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
 
 #if PLATFORM(GTK)
     addTableRow(versionObject, "GTK version"_s, makeString(GTK_MAJOR_VERSION, '.', GTK_MINOR_VERSION, '.', GTK_MICRO_VERSION, " (build) "_s, gtk_get_major_version(), '.', gtk_get_minor_version(), '.', gtk_get_micro_version(), " (runtime)"_s));
-
-    bool usingDMABufRenderer = AcceleratedBackingStore::checkRequirements();
 #endif
 
 #if PLATFORM(WPE)
@@ -725,7 +723,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
     if (policy != "never"_s) {
         addTableRow(hardwareAccelerationObject, "API"_s, String::fromUTF8(openGLAPI()));
 #if PLATFORM(GTK)
-        bool showBuffersInfo = usingDMABufRenderer;
+        bool showBuffersInfo = true;
 #elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
         bool showBuffersInfo = usingWPEPlatformAPI;
 #else

--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -67,7 +67,7 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
 
     // If hardware acceleration is available and not forced already, force it always for the remote inspector view.
     const auto& hardwareAccelerationManager = HardwareAccelerationManager::singleton();
-    if (hardwareAccelerationManager.canUseHardwareAcceleration() && !hardwareAccelerationManager.forceHardwareAcceleration()) {
+    if (hardwareAccelerationManager.canUseHardwareAcceleration() && !hardwareAccelerationManager.forceAcceleratedCompositingMode()) {
         preferences->setForceCompositingMode(true);
         preferences->setThreadedScrollingEnabled(true);
     }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -135,7 +135,7 @@ static bool gtkCanUseHardwareAcceleration()
     return canUseHardwareAcceleration;
 }
 
-bool AcceleratedBackingStore::checkRequirements()
+bool AcceleratedBackingStore::canUseHardwareAcceleration()
 {
     if (!rendererBufferTransportMode().isEmpty())
         return gtkCanUseHardwareAcceleration();
@@ -190,11 +190,8 @@ Vector<RendererBufferFormat> AcceleratedBackingStore::preferredBufferFormats()
 }
 #endif
 
-RefPtr<AcceleratedBackingStore> AcceleratedBackingStore::create(WebPageProxy& webPage)
+Ref<AcceleratedBackingStore> AcceleratedBackingStore::create(WebPageProxy& webPage)
 {
-    if (!HardwareAccelerationManager::singleton().canUseHardwareAcceleration() || !checkRequirements())
-        return nullptr;
-
     return adoptRef(*new AcceleratedBackingStore(webPage));
 }
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
@@ -64,11 +64,11 @@ public:
     using Rects = Vector<WebCore::IntRect, 1>;
 
     static OptionSet<RendererBufferTransportMode> rendererBufferTransportMode();
-    static bool checkRequirements();
+    static bool canUseHardwareAcceleration();
 #if USE(GBM)
     static Vector<RendererBufferFormat> preferredBufferFormats();
 #endif
-    static RefPtr<AcceleratedBackingStore> create(WebPageProxy&);
+    static Ref<AcceleratedBackingStore> create(WebPageProxy&);
     ~AcceleratedBackingStore();
 
     void ref() const final { RefCounted::ref(); }

--- a/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.h
+++ b/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.h
@@ -36,13 +36,15 @@ public:
     static HardwareAccelerationManager& singleton();
 
     bool canUseHardwareAcceleration() const { return m_canUseHardwareAcceleration; }
-    bool forceHardwareAcceleration() const { return m_forceHardwareAcceleration; }
+    bool acceleratedCompositingModeEnabled() const { return m_acceleratedCompositingModeEnabled; }
+    bool forceAcceleratedCompositingMode() const { return m_forceAcceleratedCompositingMode; }
 
 private:
     HardwareAccelerationManager();
 
-    bool m_canUseHardwareAcceleration : 1;
-    bool m_forceHardwareAcceleration : 1;
+    bool m_canUseHardwareAcceleration : 1 { true };
+    bool m_acceleratedCompositingModeEnabled : 1 { true };
+    bool m_forceAcceleratedCompositingMode : 1 { true };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp
@@ -33,19 +33,14 @@ namespace WebKit {
 
 void WebPreferences::platformInitializeStore()
 {
-    struct {
-        bool acceleratedCompositingEnabled { true };
-        bool forceCompositingMode { false };
-    } compositingState;
+    const bool canUseHardwareAcceleration = HardwareAccelerationManager::singleton().canUseHardwareAcceleration();
+    const bool acceleratedCompositingEnabled = HardwareAccelerationManager::singleton().acceleratedCompositingModeEnabled();
+    const bool forceCompositingMode = HardwareAccelerationManager::singleton().forceAcceleratedCompositingMode();
 
-    if (!HardwareAccelerationManager::singleton().canUseHardwareAcceleration())
-        compositingState = { false, false };
-    else if (HardwareAccelerationManager::singleton().forceHardwareAcceleration())
-        compositingState = { true, true };
-
-    setAcceleratedCompositingEnabled(compositingState.acceleratedCompositingEnabled);
-    setForceCompositingMode(compositingState.forceCompositingMode);
-    setThreadedScrollingEnabled(compositingState.forceCompositingMode);
+    setHardwareAccelerationEnabled(canUseHardwareAcceleration);
+    setAcceleratedCompositingEnabled(acceleratedCompositingEnabled);
+    setForceCompositingMode(forceCompositingMode);
+    setThreadedScrollingEnabled(forceCompositingMode);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -119,7 +119,7 @@ AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& fram
     : m_webPage(webPage)
     , m_frameCompleteHandler(WTF::move(frameCompleteHandler))
     , m_id(generateID())
-    , m_swapChain(m_id, renderingPurpose, webPage.corePage()->settings().useHardwareBuffersForFrameRendering())
+    , m_swapChain(m_id, renderingPurpose, webPage.corePage()->settings().hardwareAccelerationEnabled())
     , m_isVisible(webPage.activityState().contains(ActivityState::IsVisible))
     , m_useExplicitSync(usesGL() && useExplicitSync())
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -65,9 +65,6 @@ bool NonCompositedFrameRenderer::initialize()
     }
 
     m_surface->didCreateCompositingRunLoop(RunLoop::mainSingleton());
-    LayerTreeContext layerTreeContext;
-    layerTreeContext.contextID = m_surface->surfaceID();
-    m_webPage.get().send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(0, layerTreeContext), m_webPage.get().drawingArea()->identifier().toUInt64(), { });
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
@@ -40,6 +40,8 @@ public:
     NonCompositedFrameRenderer(WebPage&);
     ~NonCompositedFrameRenderer();
 
+    uint64_t surfaceID() const { return m_surface->surfaceID(); }
+
     void setNeedsDisplayInRect(const WebCore::IntRect&);
 
     void display();

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -235,7 +235,17 @@ static gboolean parseOptionEntryCallback(const gchar *optionNameFull, const gcha
         break;
     }
     default:
-        g_assert_not_reached();
+        if (G_PARAM_SPEC_VALUE_TYPE(spec) == WEBKIT_TYPE_HARDWARE_ACCELERATION_POLICY) {
+            GEnumClass *enumClass = g_type_class_ref(WEBKIT_TYPE_HARDWARE_ACCELERATION_POLICY);
+            GEnumValue *enumValue = g_enum_get_value_by_nick(enumClass, value);
+            g_type_class_unref(enumClass);
+            if (!enumValue) {
+                g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE, "Hardware acceleration policy '%s' is not valid", value);
+                return FALSE;
+            }
+            webkit_settings_set_hardware_acceleration_policy(webSettings, enumValue->value);
+        } else
+            g_assert_not_reached();
     }
 
     return TRUE;
@@ -243,8 +253,7 @@ static gboolean parseOptionEntryCallback(const gchar *optionNameFull, const gcha
 
 static gboolean isValidParameterType(GType gParamType)
 {
-    return (gParamType == G_TYPE_BOOLEAN || gParamType == G_TYPE_STRING || gParamType == G_TYPE_INT
-            || gParamType == G_TYPE_FLOAT);
+    return (gParamType == G_TYPE_BOOLEAN || gParamType == G_TYPE_STRING || gParamType == G_TYPE_INT || gParamType == G_TYPE_FLOAT || gParamType == WEBKIT_TYPE_HARDWARE_ACCELERATION_POLICY);
 }
 
 static WebKitFeature* findFeature(WebKitFeatureList *featureList, const char *identifier)


### PR DESCRIPTION
#### 1050700930f62adfc55694d8cbd8d008fde112c3
<pre>
REGRESSION(306485@main): [GTK] Crashes or bad rendering with compositing mode disabled or with hardware acceleration disabled and softGL.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306993">https://bugs.webkit.org/show_bug.cgi?id=306993</a>

Reviewed by Alejandro G. Castro.

The crashes happen because we still assume that AcceleratedBackingStore
can only be used for hardware acceleration, but we are now using it when
hardware acceleration is disabled. This patch removes the checks for
acceleration in AcceleratedBackingStore::create(). It also removes the
UseHardwareBuffersForFrameRendering and adds HardwareAccelerationEnabled
that matches the hardware acceleration policy setting exposed in the
public API. When accelerated compositing mode is disabled, hardware
buffers will be used for frame rendering if hardware acceleration is
enabled. This patch also adds support for setting the hardware
acceleration policy from the command line to MiniBrowser using
--hardware-acceleration-policy=always|never

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_get_hardware_acceleration_policy):
(webkit_settings_set_hardware_acceleration_policy):
* Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::canUseHardwareAcceleration):
(WebKit::AcceleratedBackingStore::create):
(WebKit::AcceleratedBackingStore::checkRequirements): Deleted.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h:
* Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp:
(WebKit::HardwareAccelerationManager::HardwareAccelerationManager):
* Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.h:
(WebKit::HardwareAccelerationManager::acceleratedCompositingModeEnabled const):
(WebKit::HardwareAccelerationManager::forceAcceleratedCompositingMode const):
(WebKit::HardwareAccelerationManager::forceHardwareAcceleration const): Deleted.
* Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp:
(WebKit::WebPreferences::platformInitializeStore):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::AcceleratedSurface):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences):
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingModeIfNeeded):
(WebKit::DrawingAreaCoordinatedGraphics::graphicsLayerFactory):
(WebKit::DrawingAreaCoordinatedGraphics::setRootCompositingLayer):
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode):
(WebKit::DrawingAreaCoordinatedGraphics::sendEnterAcceleratedCompositingModeIfNeeded):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::initialize):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h:
(WebKit::NonCompositedFrameRenderer::surfaceID const):
* Tools/MiniBrowser/gtk/main.c:
(isValidParameterType):

Canonical link: <a href="https://commits.webkit.org/306842@main">https://commits.webkit.org/306842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e038642cda84f4dd2ba8a2e4f85022854529f05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151199 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109620 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90530 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1206 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134522 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153521 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3342 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14634 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4677 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117643 "Found 1 new test failure: media/media-sources-selection.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117980 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14004 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70325 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21986 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14676 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3808 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/173827 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14413 "Failed to checkout and rebase branch from PR 57933") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78378 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44951 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->