### PR TITLE
Dispatch willPresentModalUI for lockdown mode alert and AirPlay picker on Vision

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3751,6 +3751,9 @@ static bool isLockdownModeWarningNeeded()
 
             [alert addAction:[UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"OK", "Lockdown Mode alert OK button") style:UIAlertActionStyleDefault handler:nil]];
 
+#if PLATFORM(VISION)
+            [protectedSelf _page]->dispatchWillPresentModalUI();
+#endif
             auto presentationViewController = [protectedSelf _wk_viewControllerForFullScreenPresentation];
             [presentationViewController presentViewController:alert.get() animated:YES completion:nil];
             [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WebKitLockdownModeAlertShownKey];

--- a/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
@@ -30,6 +30,8 @@
 
 #import "UIKitSPI.h"
 #import "UIKitUtilities.h"
+#import "WKContentView.h"
+#import "WebPageProxy.h"
 #import <WebCore/AudioSession.h>
 #import <pal/spi/ios/MediaPlayerSPI.h>
 #import <wtf/RetainPtr.h>
@@ -97,6 +99,10 @@ typedef NSInteger WKAirPlayRoutePickerRouteSharingPolicy;
         _actionSheet = nil;
     };
 
+#if PLATFORM(VISION)
+    if (auto* contentView = dynamic_objc_cast<WKContentView>(view))
+        contentView->_page->dispatchWillPresentModalUI();
+#endif
     auto viewControllerForPresentation = view._wk_viewControllerForFullScreenPresentation;
     [viewControllerForPresentation presentViewController:_actionSheet.get() animated:YES completion:nil];
 }


### PR DESCRIPTION
#### 5710bb871469ed463023a0b03eac544ecba9213d
<pre>
Dispatch willPresentModalUI for lockdown mode alert and AirPlay picker on Vision
<a href="https://bugs.webkit.org/show_bug.cgi?id=307044">https://bugs.webkit.org/show_bug.cgi?id=307044</a>
<a href="https://rdar.apple.com/169664640">rdar://169664640</a> ([Models] Audit _wk_viewControllerForFullScreenPresentation use)

Reviewed by NOBODY (OOPS!).

Audit all uses of _wk_viewControllerForFullScreenPresentation and call dispatchWillPresentModalUI() before presenting modal UI on Vision for the remaining cases:
- before presenting lockdown mode alert
- before presenting AirPlay route picker

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _presentLockdownMode]):
* Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm:
(-[WKAirPlayRoutePicker showFromView:routeSharingPolicy:routingContextUID:hasVideo:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5710bb871469ed463023a0b03eac544ecba9213d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95728 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109618 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79088 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90528 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11610 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9279 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Compiled WebKit (warnings); run-api-tests-without-change; Found 1 new API test failure: TestWebKitAPI.WebKit2.GetUserMediaAfterMuting (failure)") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/120968 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14637 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117642 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/117979 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14000 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124847 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70328 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14679 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3804 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14416 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78381 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14624 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->