### PR TITLE
Allow implicit conversion from RetainPtr<T> to T*

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -125,10 +125,10 @@ public:
     id bridgingAutorelease();
 #endif
 
-    constexpr PtrType get() const LIFETIME_BOUND { return m_ptr; }
-    constexpr PtrType unsafeGet() const { return m_ptr; } // FIXME: Replace with get() then remove.
-    constexpr PtrType operator->() const LIFETIME_BOUND { return m_ptr; }
-    constexpr explicit operator PtrType() const LIFETIME_BOUND { return m_ptr; }
+    constexpr PtrType get() const LIFETIME_BOUND { return static_cast<PtrType>(const_cast<std::remove_const_t<std::remove_pointer_t<StorageType>>*>(m_ptr)); }
+    constexpr PtrType unsafeGet() const { return static_cast<PtrType>(const_cast<std::remove_const_t<std::remove_pointer_t<StorageType>>*>(m_ptr)); } // FIXME: Replace with get() then remove.
+    constexpr PtrType operator->() const LIFETIME_BOUND { return get(); }
+    constexpr operator PtrType() const LIFETIME_BOUND { return get(); }
     constexpr explicit operator bool() const { return m_ptr; }
 
     constexpr bool operator!() const { return !m_ptr; }
@@ -347,6 +347,9 @@ template<typename T> struct IsSmartPtr<RetainPtr<T>> {
     static constexpr bool value = true;
     static constexpr bool isNullable = true;
 };
+
+template<typename T> inline constexpr bool IsRetainPtr = false;
+template<typename T> inline constexpr bool IsRetainPtr<RetainPtr<T>> = true;
 
 template<typename P> struct HashTraits<RetainPtr<P>> : SimpleClassHashTraits<RetainPtr<P>> {
     static RetainPtr<P>::PtrType emptyValue() { return nullptr; }

--- a/Source/WTF/wtf/cf/TypeCastsCF.h
+++ b/Source/WTF/wtf/cf/TypeCastsCF.h
@@ -88,7 +88,9 @@ inline CFTypeRef bridgeCFCast(id object)
 
 // Use bridge_id_cast to convert from CF -> id without ref churn.
 
-inline id bridge_id_cast(CFTypeRef object)
+template<typename T>
+    requires (!IsRetainPtr<std::remove_cvref_t<T>>)
+inline id bridge_id_cast(T object)
 {
 #ifdef __OBJC__
     return (__bridge id)object;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -467,7 +467,7 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
     ALWAYS_LOG(LOGIDENTIFIER);
     tearDownVideoRendering();
 
-    [[NSNotificationCenter defaultCenter] removeObserver:m_objcObserver.get()];
+    [[NSNotificationCenter defaultCenter] removeObserver:m_objcObserver];
     [m_objcObserver disconnect];
 
     // Tell our observer to do nothing when our cancellation of pending loading calls its completion handler.
@@ -481,7 +481,7 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
 
     if (m_legibleOutput) {
         if (m_avPlayerItem)
-            [m_avPlayerItem removeOutput:m_legibleOutput.get()];
+            [m_avPlayerItem removeOutput:m_legibleOutput];
         m_legibleOutput = nil;
     }
 
@@ -494,7 +494,7 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
 
     if (m_metadataOutput) {
         if (m_avPlayerItem)
-            [m_avPlayerItem removeOutput:m_metadataOutput.get()];
+            [m_avPlayerItem removeOutput:m_metadataOutput];
         m_metadataOutput = nil;
     }
 
@@ -506,11 +506,11 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
     }
     if (m_avPlayer) {
         if (m_timeObserver)
-            [m_avPlayer removeTimeObserver:m_timeObserver.get()];
+            [m_avPlayer removeTimeObserver:m_timeObserver];
         m_timeObserver = nil;
 
         for (NSString *keyName in playerKVOProperties())
-            [m_avPlayer removeObserver:m_objcObserver.get() forKeyPath:keyName];
+            [m_avPlayer removeObserver:m_objcObserver forKeyPath:keyName];
 
         setShouldObserveTimeControlStatus(false);
 
@@ -520,17 +520,17 @@ void MediaPlayerPrivateAVFoundationObjC::cancelLoad()
 #endif
 
         if (m_currentTimeObserver)
-            [m_avPlayer removeTimeObserver:m_currentTimeObserver.get()];
+            [m_avPlayer removeTimeObserver:m_currentTimeObserver];
         m_currentTimeObserver = nil;
 
         if (m_videoFrameMetadataGatheringObserver) {
-            [m_avPlayer removeTimeObserver:m_videoFrameMetadataGatheringObserver.get()];
+            [m_avPlayer removeTimeObserver:m_videoFrameMetadataGatheringObserver];
             m_videoFrameMetadataGatheringObserver = nil;
         }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     if (m_videoTarget)
-        [m_avPlayer removeVideoTarget:m_videoTarget.get()];
+        [m_avPlayer removeVideoTarget:m_videoTarget];
 #endif
 
         m_avPlayer = nil;
@@ -585,7 +585,7 @@ void MediaPlayerPrivateAVFoundationObjC::createImageGenerator()
     if (!m_avAsset || m_imageGenerator)
         return;
 
-    m_imageGenerator = [PAL::getAVAssetImageGeneratorClassSingleton() assetImageGeneratorWithAsset:m_avAsset.get()];
+    m_imageGenerator = [PAL::getAVAssetImageGeneratorClassSingleton() assetImageGeneratorWithAsset:m_avAsset];
 
     [m_imageGenerator setApertureMode:AVAssetImageGeneratorApertureModeCleanAperture];
     [m_imageGenerator setAppliesPreferredTrackTransform:YES];
@@ -647,7 +647,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     m_videoLayer = adoptNS([PAL::allocAVPlayerLayerInstance() init]);
-    [m_videoLayer setPlayer:m_avPlayer.get()];
+    [m_videoLayer setPlayer:m_avPlayer];
 
     [m_videoLayer setName:@"MediaPlayerPrivate AVPlayerLayer"];
     [m_videoLayer addObserver:m_objcObserver.get() forKeyPath:@"readyForDisplay" options:NSKeyValueObservingOptionNew context:(void *)MediaPlayerAVFoundationObservationContextAVPlayerLayer];
@@ -1012,7 +1012,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL(const URL& url, Ret
 
     resourceLoader.URLSession = (NSURLSession *)adoptNS([[WebCoreNSURLSession alloc] initWithResourceLoader:m_mediaResourceLoader delegate:resourceLoader.URLSessionDataDelegate delegateQueue:resourceLoader.URLSessionDataDelegateQueue]).get();
 
-    [[NSNotificationCenter defaultCenter] addObserver:m_objcObserver.get() selector:@selector(chapterMetadataDidChange:) name:AVAssetChapterMetadataGroupsDidChangeNotification object:m_avAsset.get()];
+    [[NSNotificationCenter defaultCenter] addObserver:m_objcObserver selector:@selector(chapterMetadataDidChange:) name:AVAssetChapterMetadataGroupsDidChangeNotification object:m_avAsset.get()];
 
     m_haveCheckedPlayability = false;
 
@@ -1159,7 +1159,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     if (m_videoTarget) {
         INFO_LOG(LOGIDENTIFIER, "Setting videoTarget");
-        [m_avPlayer addVideoTarget:m_videoTarget.get()];
+        [m_avPlayer addVideoTarget:m_videoTarget];
     }
 #endif
 
@@ -1179,9 +1179,9 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     // Create the player item so we can load media data.
-    m_avPlayerItem = adoptNS([PAL::allocAVPlayerItemInstance() initWithAsset:m_avAsset.get()]);
+    m_avPlayerItem = adoptNS([PAL::allocAVPlayerItemInstance() initWithAsset:m_avAsset]);
 
-    [[NSNotificationCenter defaultCenter] addObserver:m_objcObserver.get() selector:@selector(didEnd:) name:AVPlayerItemDidPlayToEndTimeNotification object:m_avPlayerItem.get()];
+    [[NSNotificationCenter defaultCenter] addObserver:m_objcObserver selector:@selector(didEnd:) name:AVPlayerItemDidPlayToEndTimeNotification object:m_avPlayerItem.get()];
 
     for (NSString *keyName in itemKVOProperties()) {
         NSKeyValueObservingOptions options = NSKeyValueObservingOptionNew | NSKeyValueObservingOptionPrior;
@@ -1209,10 +1209,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     m_legibleOutput = adoptNS([PAL::allocAVPlayerItemLegibleOutputInstance() initWithMediaSubtypesForNativeRepresentation:subtypes.get()]);
     [m_legibleOutput setSuppressesPlayerRendering:YES];
 
-    [m_legibleOutput setDelegate:m_objcObserver.get() queue:mainDispatchQueueSingleton()];
+    [m_legibleOutput setDelegate:m_objcObserver queue:mainDispatchQueueSingleton()];
     [m_legibleOutput setAdvanceIntervalForDelegateInvocation:avPlayerOutputAdvanceInterval];
     [m_legibleOutput setTextStylingResolution:AVPlayerItemLegibleOutputTextStylingResolutionSourceAndRulesOnly];
-    [m_avPlayerItem addOutput:m_legibleOutput.get()];
+    [m_avPlayerItem addOutput:m_legibleOutput];
 
 #if ENABLE(WEB_AUDIO) && USE(MEDIATOOLBOX)
     if (RefPtr provider = m_provider) {
@@ -1222,13 +1222,13 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 #endif
 
     m_metadataCollector = adoptNS([PAL::allocAVPlayerItemMetadataCollectorInstance() initWithIdentifiers:nil classifyingLabels:nil]);
-    [m_metadataCollector setDelegate:m_objcObserver.get() queue:mainDispatchQueueSingleton()];
-    [m_avPlayerItem addMediaDataCollector:m_metadataCollector.get()];
+    [m_metadataCollector setDelegate:m_objcObserver queue:mainDispatchQueueSingleton()];
+    [m_avPlayerItem addMediaDataCollector:m_metadataCollector];
 
     m_metadataOutput = adoptNS([PAL::allocAVPlayerItemMetadataOutputInstance() initWithIdentifiers:nil]);
-    [m_metadataOutput setDelegate:m_objcObserver.get() queue:mainDispatchQueueSingleton()];
+    [m_metadataOutput setDelegate:m_objcObserver queue:mainDispatchQueueSingleton()];
     [m_metadataOutput setAdvanceIntervalForDelegateInvocation:avPlayerOutputAdvanceInterval];
-    [m_avPlayerItem addOutput:m_metadataOutput.get()];
+    [m_avPlayerItem addOutput:m_metadataOutput];
 }
 
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
@@ -4184,14 +4184,14 @@ void MediaPlayerPrivateAVFoundationObjC::setVideoTarget(const PlatformVideoTarge
 
     ALWAYS_LOG(LOGIDENTIFIER, !!videoTarget);
     if (m_videoTarget)
-        [m_avPlayer removeVideoTarget:m_videoTarget.get()];
+        [m_avPlayer removeVideoTarget:m_videoTarget];
 
     m_videoTarget = videoTarget;
 
     if (m_videoTarget)
-        [m_avPlayer addVideoTarget:m_videoTarget.get()];
+        [m_avPlayer addVideoTarget:m_videoTarget];
     else
-        [m_videoLayer setPlayer:m_avPlayer.get()];
+        [m_videoLayer setPlayer:m_avPlayer];
 #else
     UNUSED_PARAM(videoTarget);
 #endif
@@ -4209,7 +4209,7 @@ void MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged
     else if (RetainPtr videoTarget = std::exchange(m_videoTarget, nullptr)) {
         INFO_LOG(LOGIDENTIFIER, "Clearing videoTarget");
         [m_avPlayer removeVideoTarget:videoTarget.get()];
-        [m_videoLayer setPlayer:m_avPlayer.get()];
+        [m_videoLayer setPlayer:m_avPlayer];
     }
 #else
     UNUSED_PARAM(isInFullscreenOrPictureInPicture);

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -530,7 +530,7 @@ RetainPtr<id> IOSurface::asCAIOSurfaceLayerContents() const
         if (m_contentEDRHeadroom && *m_contentEDRHeadroom != 1 && PAL::canLoad_QuartzCore_CAIOSurfaceReloadColorAttributes())
             CAIOSurfaceReloadColorAttributes(result.get());
 #endif
-        return bridge_id_cast(result);
+        return bridge_id_cast(WTF::move(result));
     }
     return asLayerContents();
 }

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -80,7 +80,7 @@ LocaleCocoa::LocaleCocoa(const AtomString& locale)
     NSString* language = [m_locale objectForKey:NSLocaleLanguageCode];
     if ([availableLanguages indexOfObject:language] == NSNotFound)
         m_locale = adoptNS([[NSLocale alloc] initWithLocaleIdentifier:defaultLanguage().createNSString().get()]);
-    [m_gregorianCalendar setLocale:m_locale.get()];
+    [m_gregorianCalendar setLocale:m_locale];
 }
 
 LocaleCocoa::~LocaleCocoa()
@@ -89,7 +89,7 @@ LocaleCocoa::~LocaleCocoa()
 
 RetainPtr<NSDateFormatter> LocaleCocoa::shortDateFormatter()
 {
-    return createDateTimeFormatter(m_locale.get(), m_gregorianCalendar.get(), NSDateFormatterShortStyle, NSDateFormatterNoStyle);
+    return createDateTimeFormatter(m_locale, m_gregorianCalendar, NSDateFormatterShortStyle, NSDateFormatterNoStyle);
 }
 
 String LocaleCocoa::formatDateTime(const DateComponents& dateComponents, FormatType)
@@ -114,15 +114,15 @@ String LocaleCocoa::formatDateTime(const DateComponents& dateComponents, FormatT
 
     // Return a formatted string.
     RetainPtr dateFormatter = localizedDateCache().formatterForDateType(type);
-    return [dateFormatter.get() stringFromDate:date];
+    return [dateFormatter stringFromDate:date];
 }
 
 const Vector<String>& LocaleCocoa::monthLabels()
 {
     if (!m_monthLabels.isEmpty())
         return m_monthLabels;
-    RetainPtr array = [shortDateFormatter().get() monthSymbols];
-    if ([array.get() count] == 12) {
+    RetainPtr array = [shortDateFormatter() monthSymbols];
+    if ([array count] == 12) {
         m_monthLabels = makeVector<String>(array.get());
         return m_monthLabels;
     }
@@ -132,22 +132,22 @@ const Vector<String>& LocaleCocoa::monthLabels()
 
 RetainPtr<NSDateFormatter> LocaleCocoa::timeFormatter()
 {
-    return createDateTimeFormatter(m_locale.get(), m_gregorianCalendar.get(), NSDateFormatterNoStyle, NSDateFormatterMediumStyle);
+    return createDateTimeFormatter(m_locale, m_gregorianCalendar, NSDateFormatterNoStyle, NSDateFormatterMediumStyle);
 }
 
 RetainPtr<NSDateFormatter> LocaleCocoa::shortTimeFormatter()
 {
-    return createDateTimeFormatter(m_locale.get(), m_gregorianCalendar.get(), NSDateFormatterNoStyle, NSDateFormatterShortStyle);
+    return createDateTimeFormatter(m_locale, m_gregorianCalendar, NSDateFormatterNoStyle, NSDateFormatterShortStyle);
 }
 
 RetainPtr<NSDateFormatter> LocaleCocoa::dateTimeFormatterWithSeconds()
 {
-    return createDateTimeFormatter(m_locale.get(), m_gregorianCalendar.get(), NSDateFormatterShortStyle, NSDateFormatterMediumStyle);
+    return createDateTimeFormatter(m_locale, m_gregorianCalendar, NSDateFormatterShortStyle, NSDateFormatterMediumStyle);
 }
 
 RetainPtr<NSDateFormatter> LocaleCocoa::dateTimeFormatterWithoutSeconds()
 {
-    return createDateTimeFormatter(m_locale.get(), m_gregorianCalendar.get(), NSDateFormatterShortStyle, NSDateFormatterShortStyle);
+    return createDateTimeFormatter(m_locale, m_gregorianCalendar, NSDateFormatterShortStyle, NSDateFormatterShortStyle);
 }
 
 Locale::WritingDirection LocaleCocoa::defaultWritingDirection() const
@@ -166,7 +166,7 @@ String LocaleCocoa::dateFormat()
 {
     if (!m_dateFormat.isNull())
         return m_dateFormat;
-    m_dateFormat = [shortDateFormatter().get() dateFormat];
+    m_dateFormat = [shortDateFormatter() dateFormat];
     return m_dateFormat;
 }
 
@@ -176,7 +176,7 @@ String LocaleCocoa::monthFormat()
         return m_monthFormat;
     // Gets a format for "MMMM" because Windows API always provides formats for
     // "MMMM" in some locales.
-    m_monthFormat = [NSDateFormatter dateFormatFromTemplate:@"yyyyMMMM" options:0 locale:m_locale.get()];
+    m_monthFormat = [NSDateFormatter dateFormatFromTemplate:@"yyyyMMMM" options:0 locale:m_locale];
     return m_monthFormat;
 }
 
@@ -184,7 +184,7 @@ String LocaleCocoa::shortMonthFormat()
 {
     if (!m_shortMonthFormat.isNull())
         return m_shortMonthFormat;
-    m_shortMonthFormat = [NSDateFormatter dateFormatFromTemplate:@"yM" options:0 locale:m_locale.get()];
+    m_shortMonthFormat = [NSDateFormatter dateFormatFromTemplate:@"yM" options:0 locale:m_locale];
     return m_shortMonthFormat;
 }
 
@@ -192,7 +192,7 @@ String LocaleCocoa::timeFormat()
 {
     if (!m_timeFormatWithSeconds.isNull())
         return m_timeFormatWithSeconds;
-    m_timeFormatWithSeconds = [timeFormatter().get() dateFormat];
+    m_timeFormatWithSeconds = [timeFormatter() dateFormat];
     return m_timeFormatWithSeconds;
 }
 
@@ -200,7 +200,7 @@ String LocaleCocoa::shortTimeFormat()
 {
     if (!m_timeFormatWithoutSeconds.isNull())
         return m_timeFormatWithoutSeconds;
-    m_timeFormatWithoutSeconds = [shortTimeFormatter().get() dateFormat];
+    m_timeFormatWithoutSeconds = [shortTimeFormatter() dateFormat];
     return m_timeFormatWithoutSeconds;
 }
 
@@ -208,7 +208,7 @@ String LocaleCocoa::dateTimeFormatWithSeconds()
 {
     if (!m_dateTimeFormatWithSeconds.isNull())
         return m_dateTimeFormatWithSeconds;
-    m_dateTimeFormatWithSeconds = [dateTimeFormatterWithSeconds().get() dateFormat];
+    m_dateTimeFormatWithSeconds = [dateTimeFormatterWithSeconds() dateFormat];
     return m_dateTimeFormatWithSeconds;
 }
 
@@ -216,7 +216,7 @@ String LocaleCocoa::dateTimeFormatWithoutSeconds()
 {
     if (!m_dateTimeFormatWithoutSeconds.isNull())
         return m_dateTimeFormatWithoutSeconds;
-    m_dateTimeFormatWithoutSeconds = [dateTimeFormatterWithoutSeconds().get() dateFormat];
+    m_dateTimeFormatWithoutSeconds = [dateTimeFormatterWithoutSeconds() dateFormat];
     return m_dateTimeFormatWithoutSeconds;
 }
 
@@ -224,8 +224,8 @@ const Vector<String>& LocaleCocoa::shortMonthLabels()
 {
     if (!m_shortMonthLabels.isEmpty())
         return m_shortMonthLabels;
-    RetainPtr array = [shortDateFormatter().get() shortMonthSymbols];
-    if ([array.get() count] == 12) {
+    RetainPtr array = [shortDateFormatter() shortMonthSymbols];
+    if ([array count] == 12) {
         m_shortMonthLabels = makeVector<String>(array.get());
         return m_shortMonthLabels;
     }
@@ -237,8 +237,8 @@ const Vector<String>& LocaleCocoa::standAloneMonthLabels()
 {
     if (!m_standAloneMonthLabels.isEmpty())
         return m_standAloneMonthLabels;
-    RetainPtr array = [shortDateFormatter().get() standaloneMonthSymbols];
-    if ([array.get() count] == 12) {
+    RetainPtr array = [shortDateFormatter() standaloneMonthSymbols];
+    if ([array count] == 12) {
         m_standAloneMonthLabels = makeVector<String>(array.get());
         return m_standAloneMonthLabels;
     }
@@ -251,8 +251,8 @@ const Vector<String>& LocaleCocoa::shortStandAloneMonthLabels()
     if (!m_shortStandAloneMonthLabels.isEmpty())
         return m_shortStandAloneMonthLabels;
 
-    RetainPtr array = [shortDateFormatter().get() shortStandaloneMonthSymbols];
-    if ([array.get() count] == 12) {
+    RetainPtr array = [shortDateFormatter() shortStandaloneMonthSymbols];
+    if ([array count] == 12) {
         m_shortStandAloneMonthLabels = makeVector<String>(array.get());
         return m_shortStandAloneMonthLabels;
     }
@@ -315,12 +315,12 @@ void LocaleCocoa::initializeLocaleData()
     m_didInitializeNumberData = true;
 
     RetainPtr<NSNumberFormatter> formatter = adoptNS([[NSNumberFormatter alloc] init]);
-    [formatter setLocale:m_locale.get()];
+    [formatter setLocale:m_locale];
     [formatter setNumberStyle:NSNumberFormatterDecimalStyle];
     [formatter setUsesGroupingSeparator:NO];
 
     RetainPtr<NSNumber> sampleNumber = adoptNS([[NSNumber alloc] initWithDouble:9876543210]);
-    String nineToZero([formatter stringFromNumber:sampleNumber.get()]);
+    String nineToZero([formatter stringFromNumber:sampleNumber]);
     if (nineToZero.length() != 10)
         return;
     Vector<String, DecimalSymbolsSize> symbols;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1227,7 +1227,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     configuration.get()._preventsSystemHTTPProxyAuthentication = parameters.preventsSystemHTTPProxyAuthentication;
     configuration.get()._requiresSecureHTTPSProxyConnection = parameters.requiresSecureHTTPSProxyConnection;
-    configuration.get().connectionProxyDictionary = RetainPtr { (NSDictionary *)parameters.proxyConfiguration.get()?: proxyDictionary(parameters.httpProxy, parameters.httpsProxy) }.get();
+    configuration.get().connectionProxyDictionary = parameters.proxyConfiguration ? RetainPtr { (NSDictionary *)parameters.proxyConfiguration.get() }.get() : proxyDictionary(parameters.httpProxy, parameters.httpsProxy).get();
 
 #if PLATFORM(IOS_FAMILY)
     if (!m_dataConnectionServiceType.isEmpty())

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -59,22 +59,10 @@ template<> NSArray *filterObjects<NSArray>(NSArray *, bool NS_NOESCAPE (^block)(
 template<> NSDictionary *filterObjects<NSDictionary>(NSDictionary *, bool NS_NOESCAPE (^block)(id key, id value));
 template<> NSSet *filterObjects<NSSet>(NSSet *, bool NS_NOESCAPE (^block)(id key, id value));
 
-template<typename T>
-T *filterObjects(const RetainPtr<T>& container, bool NS_NOESCAPE (^block)(id key, id value))
-{
-    return filterObjects<T>(container.get(), block);
-}
-
 template<typename T> T *mapObjects(T *container, id NS_NOESCAPE (^block)(id key, id value));
 template<> NSArray *mapObjects<NSArray>(NSArray *, id NS_NOESCAPE (^block)(id key, id value));
 template<> NSDictionary *mapObjects<NSDictionary>(NSDictionary *, id NS_NOESCAPE (^block)(id key, id value));
 template<> NSSet *mapObjects<NSSet>(NSSet *, id NS_NOESCAPE (^block)(id key, id value));
-
-template<typename T>
-T *mapObjects(const RetainPtr<T>& container, id NS_NOESCAPE (^block)(id key, id value))
-{
-    return mapObjects<T>(container.get(), block);
-}
 
 template<typename T>
 T *objectForKey(NSDictionary *dictionary, id key, bool returningNilIfEmpty = true, Class containingObjectsOfClass = Nil)
@@ -83,12 +71,6 @@ T *objectForKey(NSDictionary *dictionary, id key, bool returningNilIfEmpty = tru
     ASSERT(!containingObjectsOfClass);
     // Specialized implementations in CocoaHelpers.mm handle returningNilIfEmpty and containingObjectsOfClass for different Foundation types.
     return dynamic_objc_cast<T>(dictionary[key]);
-}
-
-template<typename T>
-T *objectForKey(const RetainPtr<NSDictionary>& dictionary, id key, bool returningNilIfEmpty = true, Class containingObjectsOfClass = Nil)
-{
-    return objectForKey<T>(dictionary.get(), key, returningNilIfEmpty, containingObjectsOfClass);
 }
 
 inline bool boolForKey(NSDictionary *dictionary, id key, bool defaultValue)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3341,7 +3341,9 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
             return;
         }
 
-        RetainPtr edgeColor = cocoaColorOrNil(_fixedContainerEdges.predominantColor(side)) ?: self.underPageBackgroundColor;
+        RetainPtr edgeColor = cocoaColorOrNil(_fixedContainerEdges.predominantColor(side));
+        if (!edgeColor)
+            edgeColor = self.underPageBackgroundColor;
         if (side == WebCore::BoxSide::Top) {
 #if PLATFORM(MAC)
             edgeColor = [self _adjustedColorForTopContentInsetColorFromUIDelegate:edgeColor.get()];

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1096,7 +1096,7 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
     ASSERT(interface->videoView());
 #endif
 
-    RetainPtr view = interface->layerHostView() ? static_cast<WKLayerHostView*>(interface->layerHostView()) : createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
+    RetainPtr view = interface->layerHostView() ? RetainPtr { static_cast<WKLayerHostView*>(interface->layerHostView()) } : createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
 #if USE(EXTENSIONKIT)
     RefPtr pageClient = page->pageClient();
     if (RetainPtr visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nil)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4593,7 +4593,7 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
             newTraits |= UIFontDescriptorTraitItalic;
 
         if (originalTraits != newTraits) {
-            RetainPtr descriptor = [[font fontDescriptor] ?: adoptNS([UIFontDescriptor new]) fontDescriptorWithSymbolicTraits:newTraits];
+            RetainPtr descriptor = [[font fontDescriptor] ?: adoptNS([UIFontDescriptor new]).get() fontDescriptorWithSymbolicTraits:newTraits];
             if (RetainPtr fontWithTraits = [UIFont fontWithDescriptor:descriptor.get() size:[font pointSize]])
                 font = WTF::move(fontWithTraits);
         }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4762,7 +4762,7 @@ static RetainPtr<NSString> pathWithUniqueFilenameForPath(NSString *path)
 
         for (unsigned i = 1; ; i++) {
             RetainPtr pathWithAppendedNumber = adoptNS([[NSString alloc] initWithFormat:@"%@-%d", pathWithoutExtensions.get(), i]);
-            updatedPath = [extensions length] ? [pathWithAppendedNumber stringByAppendingPathExtension:extensions.get()] : pathWithAppendedNumber;
+            updatedPath = [extensions length] ? [pathWithAppendedNumber stringByAppendingPathExtension:extensions.get()] : pathWithAppendedNumber.get();
             if (!fileExists(updatedPath.get()))
                 break;
         }

--- a/Tools/DumpRenderTree/mac/EventSendingController.mm
+++ b/Tools/DumpRenderTree/mac/EventSendingController.mm
@@ -729,7 +729,8 @@ static NSInteger swizzledEventButtonNumber()
     // FIXME: Silly hack to teach DRT to respect capturing mouse events outside the WebView.
     // The right solution is just to use NSApplication's built-in event sending methods,
     // instead of rolling our own algorithm for selecting an event target.
-    targetView = targetView ? targetView : [[mainFrame frameView] documentView];
+    if (!targetView)
+        targetView = [[mainFrame frameView] documentView];
     assert(targetView);
 #if !PLATFORM(IOS_FAMILY)
     [NSApp _setCurrentEvent:event.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -1754,7 +1754,7 @@ TEST_F(PointerLockTests, MouseDeviceMove)
     float deltaY = 5.0f;
     RetainPtr mouseInput = [fakeMouse() mouseInput];
     if (GCMouseMoved handler = [mouseInput mouseMovedHandler]) {
-        RetainPtr profile = dynamic_objc_cast<GCPhysicalInputProfile>(mouseInput);
+        RetainPtr profile = dynamic_objc_cast<GCPhysicalInputProfile>(mouseInput.get());
         dispatch_async([profile handlerQueue], ^{
             // Positive cursor movement is a move up, not down.
             handler(mouseInput.get(), deltaX, -deltaY);

--- a/Tools/TestWebKitAPI/ios/TestWKWebViewController.mm
+++ b/Tools/TestWebKitAPI/ios/TestWKWebViewController.mm
@@ -59,7 +59,7 @@
         return nil;
 
     _initialViewFrame = frame;
-    _configuration = configuration ?: adoptNS([[WKWebViewConfiguration alloc] init]);
+    _configuration = configuration ? RetainPtr { configuration } : adoptNS([[WKWebViewConfiguration alloc] init]);
     return self;
 }
 


### PR DESCRIPTION
#### ff6a1063628ca379696a8a9d0ab1edb603884b93
<pre>
Allow implicit conversion from RetainPtr&lt;T&gt; to T*
<a href="https://bugs.webkit.org/show_bug.cgi?id=307043">https://bugs.webkit.org/show_bug.cgi?id=307043</a>

Reviewed by Geoffrey Garen.

Allow implicit conversion from RetainPtr&lt;T&gt; to T* for consistency with
other smart pointer types.

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr::unsafeGet const):
- Remove explicit from operator PtrType() to enable implicit conversion
- Update get() and unsafeGet() to properly handle the StorageType-to-PtrType conversion when they differ (in non-ObjC contexts where StorageType is CFTypeRef for NS types). The new implementation uses const_cast to remove const first, then static_cast to convert from void* to the target type.
- Add IsRetainPtr&lt;T&gt; type trait for use in SFINAE/requires clauses

* Source/WTF/wtf/cf/TypeCastsCF.h:
(WTF::bridge_id_cast):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::cancelLoad):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createImageGenerator):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVAssetForURL):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerItem):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setVideoTarget):
(WebCore::MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged):
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::asCAIOSurfaceLayerContents const):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::LocaleCocoa):
(WebCore::LocaleCocoa::shortDateFormatter):
(WebCore::LocaleCocoa::formatDateTime):
(WebCore::LocaleCocoa::monthLabels):
(WebCore::LocaleCocoa::timeFormatter):
(WebCore::LocaleCocoa::shortTimeFormatter):
(WebCore::LocaleCocoa::dateTimeFormatterWithSeconds):
(WebCore::LocaleCocoa::dateTimeFormatterWithoutSeconds):
(WebCore::LocaleCocoa::dateFormat):
(WebCore::LocaleCocoa::monthFormat):
(WebCore::LocaleCocoa::shortMonthFormat):
(WebCore::LocaleCocoa::timeFormat):
(WebCore::LocaleCocoa::shortTimeFormat):
(WebCore::LocaleCocoa::dateTimeFormatWithSeconds):
(WebCore::LocaleCocoa::dateTimeFormatWithoutSeconds):
(WebCore::LocaleCocoa::shortMonthLabels):
(WebCore::LocaleCocoa::standAloneMonthLabels):
(WebCore::LocaleCocoa::shortStandAloneMonthLabels):
(WebCore::LocaleCocoa::initializeLocaleData):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
(WebKit::filterObjects): Deleted.
(WebKit::mapObjects): Deleted.
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(encodeError):
(decodeError):
(encodeObject):
(decodeInvocation):
(decodeObject):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedColorExtensionViews]):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView textStylingAtPosition:inDirection:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::pathWithUniqueFilenameForPath):
* Tools/DumpRenderTree/mac/EventSendingController.mm:
(-[EventSendingController mouseUp:withModifiers:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
((PointerLockTests, MouseDeviceMove)):
* Tools/TestWebKitAPI/ios/TestWKWebViewController.mm:
(-[TestWKWebViewController initWithFrame:configuration:]):

Canonical link: <a href="https://commits.webkit.org/306907@main">https://commits.webkit.org/306907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a0a60b276a031c16694f0affc4bf36f8ec35265

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142729 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15201 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151403 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e521150d-eb58-441a-b7a9-2e2756451311) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109763 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66cc9d16-f449-4121-8c37-6a8e7483ac2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145678 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90671 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1402 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134718 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153716 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/3536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117779 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/14864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30124 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14870 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174018 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78579 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44982 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14667 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->