### PR TITLE
Address more uncounted local variable Safer CPP warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -322,7 +322,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
     auto pageID = page->identifier();
     GestureID gestureID = m_currentGestureID;
     [m_swipeTransitionContext _setCompletionHandler:[pageID, gestureID, targetItem] (_UIViewControllerTransitionContext *context, BOOL didComplete) {
-        if (auto gestureController = controllerForGesture(pageID, gestureID))
+        if (RefPtr gestureController = controllerForGesture(pageID, gestureID))
             gestureController->endSwipeGesture(targetItem.get(), context, !didComplete);
     }];
 
@@ -431,7 +431,7 @@ void ViewGestureController::endSwipeGesture(WebBackForwardListItem* targetItem, 
         }
 
         page->callAfterNextPresentationUpdate([pageID, gestureID] {
-            if (auto gestureController = controllerForGesture(pageID, gestureID))
+            if (RefPtr gestureController = controllerForGesture(pageID, gestureID))
                 gestureController->willCommitPostSwipeTransitionLayerTree(true);
         });
         drawingArea->hideContentUntilPendingUpdate();

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -1026,7 +1026,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!page)
         return nullptr;
 
-    WebKit::PlaybackSessionManagerProxy* playbackSessionManager = page->playbackSessionManager();
+    RefPtr playbackSessionManager = page->playbackSessionManager();
     if (!playbackSessionManager)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp
@@ -345,7 +345,7 @@ void RemoteGraphicsContextProxy::drawSystemImage(SystemImage& systemImage, const
     appendStateChangeItemIfNecessary();
 #if USE(SYSTEM_PREVIEW)
     if (RefPtr badgeSystemImage = dynamicDowncast<ARKitBadgeSystemImage>(systemImage)) {
-        if (auto image = badgeSystemImage->image()) {
+        if (RefPtr image = badgeSystemImage->image()) {
             auto nativeImage = image->nativeImage();
             if (!nativeImage)
                 return;

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -145,7 +145,7 @@
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction
 {
     if (RefPtr plugin = _pdfPlugin.get()) {
-        if (auto coreObject = plugin->accessibilityCoreObject())
+        if (RefPtr coreObject = plugin->accessibilityCoreObject())
             [coreObject->protectedWrapper() accessibilityScroll:direction];
     }
     return YES;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1583,7 +1583,7 @@ void WebPage::cancelPotentialTapInFrame(WebFrame& frame)
         selectionChangedHandler();
 
     if (m_potentialTapNode) {
-        auto* potentialTapFrame = m_potentialTapNode->document().frame();
+        RefPtr potentialTapFrame = m_potentialTapNode->document().frame();
         if (potentialTapFrame && !potentialTapFrame->tree().isDescendantOf(frame.coreLocalFrame()))
             return;
     }
@@ -3148,12 +3148,12 @@ void WebPage::prepareToRunModalJavaScriptDialog()
     preemptivelySendAutocorrectionContext();
 }
 
-static HTMLAnchorElement* containingLinkAnchorElement(Element& element)
+static RefPtr<HTMLAnchorElement> containingLinkAnchorElement(Element& element)
 {
     // FIXME: There is code in the drag controller that supports any link, even if it's not an HTMLAnchorElement. Why is this different?
-    for (auto& currentElement : lineageOfType<HTMLAnchorElement>(element)) {
-        if (currentElement.isLink())
-            return &currentElement;
+    for (Ref currentElement : lineageOfType<HTMLAnchorElement>(element)) {
+        if (currentElement->isLink())
+            return currentElement;
     }
     return nullptr;
 }
@@ -3316,7 +3316,7 @@ static std::optional<std::pair<RenderImage&, Image&>> imageRendererAndImage(Elem
     if (!renderImage->cachedImage() || renderImage->cachedImage()->errorOccurred())
         return std::nullopt;
 
-    auto* image = renderImage->cachedImage()->imageForRenderer(renderImage);
+    RefPtr image = renderImage->cachedImage()->imageForRenderer(renderImage);
     if (!image || image->width() <= 1 || image->height() <= 1)
         return std::nullopt;
 
@@ -3421,7 +3421,7 @@ static void elementPositionInformation(WebPage& page, Element& element, const In
 
     RefPtr elementForScrollTesting = linkElement ? linkElement.get() : &element;
     if (CheckedPtr renderer = elementForScrollTesting->renderer()) {
-        if (auto* scrollingCoordinator = page.scrollingCoordinator())
+        if (RefPtr scrollingCoordinator = page.scrollingCoordinator())
             info.containerScrollingNodeID = scrollingCoordinator->scrollableContainerNodeID(*renderer);
     }
 
@@ -3454,7 +3454,7 @@ static void elementPositionInformation(WebPage& page, Element& element, const In
     
 static void selectionPositionInformation(WebPage& page, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)
 {
-    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page.corePage()->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page.corePage()->mainFrame());
     if (!localMainFrame)
         return;
 
@@ -3532,7 +3532,7 @@ static void textInteractionPositionInformation(WebPage& page, const HTMLInputEle
         return;
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowVisibleChildFrameContentOnly };
-    auto* localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page.corePage()->mainFrame());
+    RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(page.corePage()->mainFrame());
     if (!localMainFrame)
         return;
     HitTestResult result = localMainFrame->eventHandler().hitTestResultAtPoint(request.point, hitType);
@@ -3942,7 +3942,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         information.insideFixedPosition = inFixed;
         information.isRTL = renderer->writingMode().isBidiRTL();
 
-        if (auto* scrollingCoordinator = this->scrollingCoordinator())
+        if (RefPtr scrollingCoordinator = this->scrollingCoordinator())
             information.containerScrollingNodeID = scrollingCoordinator->scrollableContainerNodeID(*renderer);
     } else
         information.interactionRect = { };
@@ -4884,13 +4884,13 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
         return;
     RefPtr frameView = *localMainFrame->view();
 
-    if (auto* scrollingCoordinator = this->scrollingCoordinator()) {
-        auto& remoteScrollingCoordinator = downcast<RemoteScrollingCoordinator>(*scrollingCoordinator);
+    if (RefPtr scrollingCoordinator = this->scrollingCoordinator()) {
+        Ref remoteScrollingCoordinator = downcast<RemoteScrollingCoordinator>(*scrollingCoordinator);
         if (auto mainFrameScrollingNodeID = frameView->scrollingNodeID()) {
             if (visibleContentRectUpdateInfo.viewStability().contains(ViewStabilityFlag::ScrollViewRubberBanding))
-                remoteScrollingCoordinator.addNodeWithActiveRubberBanding(*mainFrameScrollingNodeID);
+                remoteScrollingCoordinator->addNodeWithActiveRubberBanding(*mainFrameScrollingNodeID);
             else
-                remoteScrollingCoordinator.removeNodeWithActiveRubberBanding(*mainFrameScrollingNodeID);
+                remoteScrollingCoordinator->removeNodeWithActiveRubberBanding(*mainFrameScrollingNodeID);
         }
     }
 


### PR DESCRIPTION
#### 736bae90876d11c43378485c9fb4c735804a7f21
<pre>
Address more uncounted local variable Safer CPP warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307050">https://bugs.webkit.org/show_bug.cgi?id=307050</a>

Reviewed by Ryosuke Niwa and Darin Adler.

* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
(WebKit::ViewGestureController::endSwipeGesture):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController _playbackSessionInterface]):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextProxy.cpp:
(WebKit::RemoteGraphicsContextProxy::drawSystemImage):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityScroll:]):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::setCanIgnoreViewportArgumentsToAvoidExcessiveZoomIfNeeded):
(WebKit::setCanIgnoreViewportArgumentsToAvoidEnlargedViewIfNeeded):
(WebKit::WebPage::systemPreviewActionTriggered):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::attemptSyntheticClick):
(WebKit::WebPage::handleTwoFingerTapAtPoint):
(WebKit::WebPage::cancelPotentialTapInFrame):
(WebKit::WebPage::inspectorNodeSearchEndedAtPosition):
(WebKit::rangeForPointInRootViewCoordinates):
(WebKit::WebPage::requestEvasionRectsAboveSelection):
(WebKit::containingLinkAnchorElement):
(WebKit::imageRendererAndImage):
(WebKit::elementPositionInformation):
(WebKit::selectionPositionInformation):
(WebKit::textInteractionPositionInformation):
(WebKit::cursorContext):
(WebKit::WebPage::focusedElementInformation):
(WebKit::WebPage::dynamicViewportSizeUpdate):
(WebKit::WebPage::viewportConfigurationChanged):
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/306908@main">https://commits.webkit.org/306908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e33d05a1c59407230bbf80538a200895a5ecf671

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151402 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109762 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90670 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33dedda9-81a0-4219-9398-f3fd666a1ca2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1401 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153715 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117778 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30125 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/14110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124982 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14869 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3938 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78578 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->