### PR TITLE
[iOS] webrtc/video-addTransceiver.html is flaky failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1298,8 +1298,6 @@ webkit.org/b/228210 [ Debug ] inspector/model/remote-object/iterator-large.html 
 
 webkit.org/b/228591 fast/scrolling/mac/programmatic-scroll-overrides-rubberband.html [ Pass Failure ]
 
-webkit.org/b/229163 webrtc/video-addTransceiver.html [ Pass Failure ]
-
 #rdar://82043074 ([Star wk2 Debug arm64,Sky/AzulE wk2 Guard-Malloc] imported/w3c/web-platform-tests/xhr/xhr-timeout-longtask.any.html is a flaky failure)
 imported/w3c/web-platform-tests/xhr/xhr-timeout-longtask.any.html [ Pass Failure ]
 

--- a/LayoutTests/webrtc/video-addTransceiver.html
+++ b/LayoutTests/webrtc/video-addTransceiver.html
@@ -29,6 +29,8 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getVideoTracks()[0].stop());
+
     var pc = new RTCPeerConnection();
     pc.addTransceiver("video", {direction:"recvonly"});
     pc.getSenders()[0].replaceTrack(stream.getVideoTracks()[0]);
@@ -44,6 +46,7 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getVideoTracks()[0].stop());
     var pc = new RTCPeerConnection();
     pc.addTransceiver(stream.getVideoTracks()[0]);
     await pc.getSenders()[0].replaceTrack(null);
@@ -87,6 +90,7 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     const stream = await navigator.mediaDevices.getUserMedia({ video: true});
+    test.add_cleanup(() => stream.getVideoTracks()[0].stop());
     const track = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             var track = stream.getVideoTracks()[0];
@@ -118,6 +122,8 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     const stream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    test.add_cleanup(() => stream.getAudioTracks()[0].stop());
+    test.add_cleanup(() => stream.getVideoTracks()[0].stop());
 
     const remoteStream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {


### PR DESCRIPTION
#### d536042768b9d1a6344f78449b2577a8f827ead9
<pre>
[iOS] webrtc/video-addTransceiver.html is flaky failure
<a href="https://rdar.apple.com/169454192">rdar://169454192</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306778">https://bugs.webkit.org/show_bug.cgi?id=306778</a>

Reviewed by Eric Carlson.

Stopping tracks explicitly to prevent console warnings.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webrtc/video-addTransceiver.html:

Canonical link: <a href="https://commits.webkit.org/306941@main">https://commits.webkit.org/306941@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e319816f0d2c19931878006b8a1e6cccb8b7f03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151422 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95937 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109776 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95937 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9db463ef-8d46-4d75-a752-cbad68ad6f1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127715 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90684 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f82a8211-8b4e-4634-97f8-701724aae6ad) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11753 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9425 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1421 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153735 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14846 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117793 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30212 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14123 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125001 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70543 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14889 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3961 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14832 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14686 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->