### PR TITLE
[WPE] Web Inspector: implement platformSave

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -245,6 +245,7 @@ UIProcess/geoclue/GeoclueGeolocationProvider.cpp
 
 UIProcess/Inspector/glib/RemoteInspectorClient.cpp
 UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
 
 UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
 UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -256,6 +256,7 @@ UIProcess/gstreamer/WebPageProxyGStreamer.cpp
 
 UIProcess/Inspector/glib/RemoteInspectorClient.cpp
 UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
 
 UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
 

--- a/Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebInspectorUIProxyGLib.h"
+
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/Base64.h>
+
+namespace WebKit {
+
+struct PlatformSaveData {
+    Vector<uint8_t> dataVector;
+    CString dataString;
+};
+WEBKIT_DEFINE_ASYNC_DATA_STRUCT(PlatformSaveData)
+
+using PlatformSaveDataPtr = std::unique_ptr<PlatformSaveData, decltype(&destroyPlatformSaveData)>;
+
+static void fileReplaceContentsCallback(GObject* sourceObject, GAsyncResult* result, gpointer userData)
+{
+    PlatformSaveDataPtr data(static_cast<PlatformSaveData*>(userData), destroyPlatformSaveData);
+    GFile* file = G_FILE(sourceObject);
+
+    WTF::GUniqueOutPtr<GError> error;
+    if (!g_file_replace_contents_finish(file, result, nullptr, &error.outPtr()))
+        LOG_ERROR("Error replacing contents to file %s: %s", g_file_get_path(file), error->message);
+}
+
+void platformSaveDataToFile(GRefPtr<GFile>&& file, const String& content, bool base64Encoded)
+{
+    PlatformSaveDataPtr platformSaveData(createPlatformSaveData(), destroyPlatformSaveData);
+
+    if (base64Encoded) {
+        auto decodedData = base64Decode(content);
+        if (!decodedData)
+            return;
+        decodedData->shrinkToFit();
+        platformSaveData->dataVector = WTF::move(*decodedData);
+    } else
+        platformSaveData->dataString = content.utf8();
+
+    const char* data = !platformSaveData->dataString.isNull() ? platformSaveData->dataString.data() : reinterpret_cast<const char*>(platformSaveData->dataVector.span().data());
+    size_t dataLength = !platformSaveData->dataString.isNull() ? platformSaveData->dataString.length() : platformSaveData->dataVector.size();
+
+    g_file_replace_contents_async(file.get(), data, dataLength, nullptr, false,
+        G_FILE_CREATE_NONE, nullptr, fileReplaceContentsCallback, platformSaveData.release());
+}
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.h
+++ b/Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,51 +23,14 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WebInspectorUI.h"
-
-#if ENABLE(WPE_PLATFORM)
+#pragma once
 
 #include <gio/gio.h>
-#include <wtf/glib/GResources.h>
-#include <wtf/glib/GUniquePtr.h>
+#include <wtf/Forward.h>
+#include <wtf/glib/GRefPtr.h>
 
 namespace WebKit {
 
-void WebInspectorUI::didEstablishConnection()
-{
-    WTF::registerInspectorResourceIfNeeded();
-}
-
-bool WebInspectorUI::canSave(InspectorFrontendClient::SaveMode saveMode)
-{
-    switch (saveMode) {
-    case InspectorFrontendClient::SaveMode::SingleFile:
-        return true;
-
-    case InspectorFrontendClient::SaveMode::FileVariants:
-        return false;
-    }
-
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
-bool WebInspectorUI::canLoad()
-{
-    return false;
-}
-
-bool WebInspectorUI::canPickColorFromScreen()
-{
-    return false;
-}
-
-String WebInspectorUI::localizedStringsURL() const
-{
-    return "resource:///org/webkit/inspector/Localizations/en.lproj/localizedStrings.js"_s;
-}
+void platformSaveDataToFile(GRefPtr<GFile>&&, const String& content, bool base64Encoded);
 
 } // namespace WebKit
-
-#endif // ENABLE(WPE_PLATFORM)


### PR DESCRIPTION
#### c6483e96e3ff2375cafcb657a0692fc94efb480b
<pre>
[WPE] Web Inspector: implement platformSave
<a href="https://bugs.webkit.org/show_bug.cgi?id=306768">https://bugs.webkit.org/show_bug.cgi?id=306768</a>

Reviewed by Adrian Perez de Castro.

Extracted a common GIO-based implementation for WebKitGTK and WPE WebKit
into WebInspectorUIProxyGLib.

For WebKitGTK, the logic keeps using file chooser dialog to get an
appropriate destination filename.

For WPE, this uses G_USER_DIRECTORY_DOWNLOAD and falls back to the
user&apos;s home directory if undefined, saving the file there with the first
8 elements of the contents hash to avoid accidental overwrites.

* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.cpp: Added.
(WebKit::fileReplaceContentsCallback):
(WebKit::platformSaveDataToFile):
* Source/WebKit/UIProcess/Inspector/glib/WebInspectorUIProxyGLib.h:
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformSave):
(WebKit::fileReplaceContentsCallback): Deleted.
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::computeContentHash):
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/WebProcess/Inspector/wpe/WebInspectorUIWPE.cpp:
(WebKit::WebInspectorUI::canSave):

Canonical link: <a href="https://commits.webkit.org/306914@main">https://commits.webkit.org/306914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7a2997bb619524bf1d6a5899c4611e29a7f32d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95827 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109699 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127652 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90608 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11684 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9356 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1307 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121053 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153621 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14734 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117718 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118052 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14070 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70434 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14780 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3894 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14513 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78489 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->