### PR TITLE
[GTK3] Deprecate on-demand hardware acceleration policy

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -135,10 +135,6 @@ static ASCIILiteral hardwareAccelerationPolicy(WebKitURISchemeRequest* request)
         return "never"_s;
     case WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS:
         return "always"_s;
-#if !USE(GTK4)
-    case WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND:
-        return "on demand"_s;
-#endif
     }
 #endif
     RELEASE_ASSERT_NOT_REACHED();
@@ -747,6 +743,10 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
 
         if (uiProcessContextIsEGL() && eglGetCurrentContext() != EGL_NO_CONTEXT)
             addEGLInfo(hardwareAccelerationObject);
+    } else {
+#if PLATFORM(GTK)
+        addTableRow(hardwareAccelerationObject, "Buffer format"_s, renderBufferDescription(request));
+#endif
     }
 
     stopTable();

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -73,7 +73,7 @@ WEBKIT_DECLARE_FINAL_TYPE (WebKitSettings, webkit_settings, WEBKIT, SETTINGS, GO
 #else
 /**
  * WebKitHardwareAccelerationPolicy:
- * @WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND: Hardware acceleration is enabled/disabled as request by web contents.
+ * @WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND: Hardware acceleration is enabled/disabled as request by web contents. Deprecated 2.54.
  * @WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS: Hardware acceleration is always enabled, even for websites not requesting it.
  * @WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER: Hardware acceleration is always disabled, even for websites requesting it.
  *

--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -67,7 +67,8 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
 
     // If hardware acceleration is available and not forced already, force it always for the remote inspector view.
     const auto& hardwareAccelerationManager = HardwareAccelerationManager::singleton();
-    if (hardwareAccelerationManager.canUseHardwareAcceleration() && !hardwareAccelerationManager.forceAcceleratedCompositingMode()) {
+    if (hardwareAccelerationManager.canUseHardwareAcceleration()) {
+        preferences->setAcceleratedCompositingEnabled(true);
         preferences->setForceCompositingMode(true);
         preferences->setThreadedScrollingEnabled(true);
     }

--- a/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
+++ b/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp
@@ -42,16 +42,8 @@ HardwareAccelerationManager::HardwareAccelerationManager()
     if (!AcceleratedBackingStore::canUseHardwareAcceleration()) {
         m_canUseHardwareAcceleration = false;
         m_acceleratedCompositingModeEnabled = false;
-        m_forceAcceleratedCompositingMode = false;
-    } else {
-        if (const auto disableCompositingMode = CStringView::unsafeFromUTF8(getenv("WEBKIT_DISABLE_COMPOSITING_MODE"))) {
-            m_acceleratedCompositingModeEnabled = disableCompositingMode == "0"_s;
-            m_forceAcceleratedCompositingMode = m_acceleratedCompositingModeEnabled;
-        }
-
-        if (const auto forceCompositingMode = CStringView::unsafeFromUTF8(getenv("WEBKIT_FORCE_COMPOSITING_MODE")))
-            m_forceAcceleratedCompositingMode = forceCompositingMode != "0"_s;
-    }
+    } else if (const auto disableCompositingMode = CStringView::unsafeFromUTF8(getenv("WEBKIT_DISABLE_COMPOSITING_MODE")))
+        m_acceleratedCompositingModeEnabled = disableCompositingMode == "0"_s;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.h
+++ b/Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.h
@@ -37,14 +37,12 @@ public:
 
     bool canUseHardwareAcceleration() const { return m_canUseHardwareAcceleration; }
     bool acceleratedCompositingModeEnabled() const { return m_acceleratedCompositingModeEnabled; }
-    bool forceAcceleratedCompositingMode() const { return m_forceAcceleratedCompositingMode; }
 
 private:
     HardwareAccelerationManager();
 
     bool m_canUseHardwareAcceleration : 1 { true };
     bool m_acceleratedCompositingModeEnabled : 1 { true };
-    bool m_forceAcceleratedCompositingMode : 1 { true };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp
@@ -35,12 +35,11 @@ void WebPreferences::platformInitializeStore()
 {
     const bool canUseHardwareAcceleration = HardwareAccelerationManager::singleton().canUseHardwareAcceleration();
     const bool acceleratedCompositingEnabled = HardwareAccelerationManager::singleton().acceleratedCompositingModeEnabled();
-    const bool forceCompositingMode = HardwareAccelerationManager::singleton().forceAcceleratedCompositingMode();
 
     setHardwareAccelerationEnabled(canUseHardwareAcceleration);
     setAcceleratedCompositingEnabled(acceleratedCompositingEnabled);
-    setForceCompositingMode(forceCompositingMode);
-    setThreadedScrollingEnabled(forceCompositingMode);
+    setForceCompositingMode(acceleratedCompositingEnabled);
+    setThreadedScrollingEnabled(acceleratedCompositingEnabled);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
@@ -109,14 +109,8 @@ private:
     void commitTransientZoom(double scale, WebCore::FloatPoint origin, CompletionHandler<void()>&&) override;
 #endif
 
-    void exitAcceleratedCompositingModeSoon();
-    bool exitAcceleratedCompositingModePending() const { return m_exitCompositingTimer.isActive(); }
-
     void suspendPainting();
     void resumePainting();
-
-    void enterAcceleratedCompositingMode(WebCore::GraphicsLayer*);
-    void exitAcceleratedCompositingMode();
 
     void scheduleDisplay();
     void displayTimerFired();
@@ -126,22 +120,16 @@ private:
     // Whether we're currently processing an UpdateGeometry message.
     bool m_inUpdateGeometry { false };
 
-    // True between sending the 'enter compositing' messages, and the 'exit compositing' message.
+    // True after sending the 'enter compositing' messages
     bool m_compositingAccordingToProxyMessages { false };
 
     // When true, we maintain the layer tree in its current state by not leaving accelerated compositing mode
     // and not scheduling layer flushes.
     bool m_layerTreeStateIsFrozen { false };
 
-    // True when we were asked to exit accelerated compositing mode but couldn't because layer tree
-    // state was frozen.
-    bool m_wantsToExitAcceleratedCompositingMode { false };
-
     // Whether painting is suspended. We'll still keep track of the dirty region but we
     // won't paint until painting has resumed again.
     bool m_isPaintingSuspended { false };
-
-    RunLoop::Timer m_exitCompositingTimer;
 
     // The layer tree host that handles accelerated compositing.
     std::unique_ptr<LayerTreeHost> m_layerTreeHost;
@@ -158,9 +146,7 @@ private:
     bool m_isWaitingForDidUpdate { false };
     bool m_scheduledWhileWaitingForDidUpdate { false };
 
-    bool m_alwaysUseCompositing { false };
     bool m_supportsAsyncScrolling { true };
-    bool m_shouldSendEnterAcceleratedCompositingMode { false };
 
     RunLoop::Timer m_displayTimer;
 

--- a/Tools/MiniBrowser/gtk/BrowserSettingsDialog.c
+++ b/Tools/MiniBrowser/gtk/BrowserSettingsDialog.c
@@ -73,13 +73,12 @@ static const char *hardwareAccelerationPolicyToString(WebKitHardwareAcceleration
         return "never";
 #if !GTK_CHECK_VERSION(3, 98, 0)
     case WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND:
-        return "ondemand";
+        break;
 #endif
-
     }
 
     g_assert_not_reached();
-    return "ondemand";
+    return "always";
 }
 
 static int stringToHardwareAccelerationPolicy(const char *policy)
@@ -88,10 +87,6 @@ static int stringToHardwareAccelerationPolicy(const char *policy)
         return WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS;
     if (!g_ascii_strcasecmp(policy, "never"))
         return WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER;
-#if !GTK_CHECK_VERSION(3, 98, 0)
-    if (!g_ascii_strcasecmp(policy, "ondemand"))
-        return WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND;
-#endif
 
     g_warning("Invalid value %s for hardware-acceleration-policy setting", policy);
     return -1;
@@ -342,7 +337,7 @@ static void browserSettingsDialogConstructed(GObject *object)
         if (!g_strcmp0(name, "hardware-acceleration-policy")) {
             g_value_init(&value, G_TYPE_STRING);
             g_value_set_string(&value, hardwareAccelerationPolicyToString(webkit_settings_get_hardware_acceleration_policy(settings)));
-            char *extendedBlutb = g_strdup_printf("%s (always, never or ondemand)", blurb);
+            char *extendedBlutb = g_strdup_printf("%s (always or never)", blurb);
             g_free(blurb);
             blurb = extendedBlutb;
         } else {

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -370,10 +370,7 @@ static void testWebKitSettings(Test*, gconstpointer)
     g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
     webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
     g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_NEVER);
-#if !USE(GTK4)
-    webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
-    g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_ON_DEMAND);
-#endif
+
     webkit_settings_set_hardware_acceleration_policy(settings, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
     g_assert_cmpuint(webkit_settings_get_hardware_acceleration_policy(settings), ==, WEBKIT_HARDWARE_ACCELERATION_POLICY_ALWAYS);
 


### PR DESCRIPTION
#### 1a162b7b97dc8fccb32a8190a74028bee7fe0f51
<pre>
[GTK3] Deprecate on-demand hardware acceleration policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=307052">https://bugs.webkit.org/show_bug.cgi?id=307052</a>

Reviewed by Alejandro G. Castro.

It&apos;s rarely used nowadays and removing it makes it possible to simplify
the drawing area implementation. It&apos;s now the same as always which means
we can either have hardware acceleration or not. When acceleration is
available and accelerated compositring is enabled it&apos;s always forced now.
This allows us to remove all the code to exit accelerated compositing
mode in DrawingAreaCoordinatedGraphicsGLib.

* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::hardwareAccelerationPolicy):
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_get_hardware_acceleration_policy):
(webkit_settings_set_hardware_acceleration_policy):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow):
* Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.cpp:
(WebKit::HardwareAccelerationManager::HardwareAccelerationManager):
* Source/WebKit/UIProcess/gtk/HardwareAccelerationManager.h:
(WebKit::HardwareAccelerationManager::acceleratedCompositingModeEnabled const):
(WebKit::HardwareAccelerationManager::forceAcceleratedCompositingMode const): Deleted.
* Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp:
(WebKit::WebPreferences::platformInitializeStore):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics):
(WebKit::DrawingAreaCoordinatedGraphics::setLayerTreeStateIsFrozen):
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences):
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingModeIfNeeded):
(WebKit::DrawingAreaCoordinatedGraphics::graphicsLayerFactory):
(WebKit::DrawingAreaCoordinatedGraphics::setRootCompositingLayer):
(WebKit::DrawingAreaCoordinatedGraphics::sendEnterAcceleratedCompositingModeIfNeeded):
(WebKit::DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingModeSoon): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h:
* Tools/MiniBrowser/gtk/BrowserSettingsDialog.c:
(hardwareAccelerationPolicyToString):
(stringToHardwareAccelerationPolicy):
(browserSettingsDialogConstructed):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):

Canonical link: <a href="https://commits.webkit.org/306855@main">https://commits.webkit.org/306855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/028262a6ffe0aca8a6266b77c7d3b492d373dd71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15048 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151250 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109655 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145533 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12127 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90564 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1253 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/120997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153567 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14680 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/4716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117676 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118011 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14027 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/124891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21987 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/14722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/3847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78424 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->