### PR TITLE
Address more unretained local variable Safer CPP warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -1016,7 +1016,7 @@ static NSMutableArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr
             textAtSelection = [_delegate selectedTextForActionSheetAssistant:self];
 
         NSDictionary *newContext = nil;
-        DDResultRef ddResult = [controller resultForURL:_positionInformation->url.createNSURL().get() identifier:_positionInformation->dataDetectorIdentifier.createNSString().get() selectedText:textAtSelection results:_positionInformation->dataDetectorResults.get() context:context extendedContext:&newContext];
+        RetainPtr ddResult = [controller resultForURL:_positionInformation->url.createNSURL().get() identifier:_positionInformation->dataDetectorIdentifier.createNSString().get() selectedText:textAtSelection results:_positionInformation->dataDetectorResults.get() context:context extendedContext:&newContext];
 
         CGRect sourceRect;
         if (_positionInformation->isLink && _positionInformation->textIndicator)
@@ -1028,7 +1028,7 @@ static NSMutableArray<UIMenuElement *> *menuElementsFromDefaultActions(RetainPtr
         auto finalContext = [ddContextMenuActionClass updateContext:newContext withSourceRect:sourceRect];
 
         if (ddResult)
-            return [ddContextMenuActionClass contextMenuConfigurationWithResult:ddResult inView:_view.getAutoreleased() context:finalContext menuIdentifier:nil];
+            return [ddContextMenuActionClass contextMenuConfigurationWithResult:ddResult.get() inView:_view.getAutoreleased() context:finalContext menuIdentifier:nil];
         return [ddContextMenuActionClass contextMenuConfigurationWithURL:_positionInformation->url.createNSURL().get() inView:_view.getAutoreleased() context:finalContext menuIdentifier:nil];
     }
 #endif // ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
+++ b/Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm
@@ -134,8 +134,8 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
     [alert addAction:allowAction.get()];
 
     RefPtr page = _webView.get()->_page;
-    UIViewController *presentingViewController = page->uiClient().presentingViewController();
-    [presentingViewController presentViewController:alert.get() animated:YES completion:nil];
+    RetainPtr presentingViewController = page->uiClient().presentingViewController();
+    [presentingViewController.get() presentViewController:alert.get() animated:YES completion:nil];
 }
 
 - (void)_layoutThumbnailView
@@ -164,9 +164,9 @@ static RetainPtr<NSString> getUTIForUSDMIMEType(const String& mimeType)
     // FIXME: When in element fullscreen, UIClient::presentingViewController() may not return the
     // WKFullScreenViewController even though that is the presenting view controller of the WKWebView.
     // We should call PageClientImpl::presentingViewController() instead.
-    UIViewController *presentingViewController = page->uiClient().presentingViewController();
+    RetainPtr presentingViewController = page->uiClient().presentingViewController();
 
-    [presentingViewController presentViewController:previewController animated:YES completion:nil];
+    [presentingViewController.get() presentViewController:previewController animated:YES completion:nil];
 }
 
 #pragma mark WKWebViewContentProvider protocol

--- a/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm
@@ -175,15 +175,15 @@ struct PermissionRequest {
             return;
         }
 
-        NSString *applicationName = appDisplayName();
+        RetainPtr applicationName = appDisplayName();
         RetainPtr<NSString> message;
 
     IGNORE_WARNINGS_BEGIN("format-nonliteral")
         RetainPtr title = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("“%@” would like to use your current location.", "Prompt for a webpage to request location access. The parameter is the domain for the webpage.").createNSString().get(), _activeChallenge->token.get()]);
         if (appHasPreciseLocationPermission())
-            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your precise location because “%@” currently has access to your precise location.", "Message informing the user that the website will have precise location data").createNSString().get(), applicationName]);
+            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your precise location because “%@” currently has access to your precise location.", "Message informing the user that the website will have precise location data").createNSString().get(), applicationName.get()]);
         else
-            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your approximate location because “%@” currently has access to your approximate location.", "Message informing the user that the website will have approximate location data").createNSString().get(), applicationName]);
+            message = adoptNS([[NSString alloc] initWithFormat:WEB_UI_STRING("This website will use your approximate location because “%@” currently has access to your approximate location.", "Message informing the user that the website will have approximate location data").createNSString().get(), applicationName.get()]);
     IGNORE_WARNINGS_END
 
         RetainPtr allowActionTitle = WEB_UI_STRING("Allow", "Action authorizing a webpage to access the user’s location.").createNSString();


### PR DESCRIPTION
#### 779b476f51937d4dfe0600bc353fbf9f36fb5f45
<pre>
Address more unretained local variable Safer CPP warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307053">https://bugs.webkit.org/show_bug.cgi?id=307053</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Address more unretained local variable Safer CPP warnings in Source/WebKit
on iOS.

* Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm:
(-[WKActionSheetAssistant contextMenuInteraction:configurationForMenuAtLocation:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _createTargetedContextMenuHintPreviewForFocusedElement:]):
(-[WKContentView _insertDynamicImageAnalysisContextMenuItemsIfPossible]):
(menuFromLegacyPreviewOrDefaultActions):
(-[WKContentView assignLegacyDataForContextMenuInteraction]):
(-[WKContentView continueContextMenuInteraction:]):
(-[WKContentView contextMenuInteraction:willPerformPreviewActionForMenuWithConfiguration:animator:]):
(-[WKContentView _dataForPreviewItemController:atPosition:type:]):
(-[WKContentView _presentedViewControllerForPreviewItemController:]):
* Source/WebKit/UIProcess/ios/WKUSDPreviewView.mm:
(-[WKUSDPreviewView web_setContentProviderData:suggestedFilename:completionHandler:]):
(-[WKUSDPreviewView thumbnailView:wantsToPresentPreviewController:forItem:]):
* Source/WebKit/UIProcess/ios/WKWebGeolocationPolicyDeciderIOS.mm:
(-[WKWebGeolocationPolicyDecider _executeNextChallenge]):
* Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm:

Canonical link: <a href="https://commits.webkit.org/306902@main">https://commits.webkit.org/306902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84b9168d3ee69036b2fffe10460ecd893b007eef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142588 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95777 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109661 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79102 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90570 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11640 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9312 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1257 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121001 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153571 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14684 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117681 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30122 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14033 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124886 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70375 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14726 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3842 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14463 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14671 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14524 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->