### PR TITLE
[EGL] Add backtrace on errors when GLContext logging is enabled

### DIFF
--- a/Source/WebKit/glib/environment-variables.md.in
+++ b/Source/WebKit/glib/environment-variables.md.in
@@ -19,7 +19,9 @@ Defines a comma-separated list of logging channels and their levels for WebKit's
         - `SessionHost` - For messages related to the management of the Browser under automation.
     - **OpenGL context debugging**: When the `GLContext` logging channel is enabled, WebKit creates
       EGL contexts with [debug logging](https://wikis.khronos.org/opengl/Debug_Output) configured,
-      which may result in a small graphics performance penalty.
+      which may result in a small graphics performance penalty. If the log level is set to `debug`,
+      e.g. with `WEBKIT_DEBUG='GLContext=debug'`, backtraces leading to errors are added to the
+      error messages.
 
 ## Graphics-related variables
 


### PR DESCRIPTION
#### cbcb2837f082adb93d0cfb9c5775b07e86ad2998
<pre>
[EGL] Add backtrace on errors when GLContext logging is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=307055">https://bugs.webkit.org/show_bug.cgi?id=307055</a>

Reviewed by Carlos Garcia Campos.

Debugging of GL contexts was added in 306778@main but given the limited
information provided by some OpenGL implementations to the logging
callback function may be insufficient to pinpoint the source of the
reported issues. Add a backtrace to reported errors which, while it is
not the most convenient aid, helps when paired with builds that include
symbols.

Note that OpenGL implementations are not required to invoke the debug
logging callback as soon as an issue is found or in the same execution
context, which means using the GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR option
is needed to obtain relevant backtraces. Therefore, backtraces are only
added when the log channel is set to the debug log level, i.e. with
WEBKIT_DEBUG=&apos;GLContext=debug&apos;.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::logGLDebugMessage): Append a backtrace for errors when the
log channel is enabled at the debug level.
(WebCore::GLContext::enableDebugLogging): Switch to synchronous debug
logging when the log channel is at the debug level.
* Source/WebKit/glib/environment-variables.md.in: Document the added
behaviour.

Canonical link: <a href="https://commits.webkit.org/306862@main">https://commits.webkit.org/306862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c188b4ec54d8c57fa06cdbbb44a747f262d0fbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151269 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109671 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90580 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1270 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4072 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153584 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14697 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118026 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14045 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124895 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70388 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14739 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3850 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78441 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->