### PR TITLE
create extensive WPT tests for fx, fy default initial values when undefined

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/radial-gradient-undefined-fx-fy-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/radial-gradient-undefined-fx-fy-expected.txt
@@ -1,0 +1,9 @@
+
+PASS radialGradient fx and fy default to 50% when no attributes are set
+PASS radialGradient fx and fy remain 50% when cx and cy are set to different values
+PASS radialGradient fx and fy return to 50% when explicitly set then removed
+PASS radialGradient fx and fy do not follow cx and cy changes
+PASS radialGradient explicit fx and fy are independent of cx and cy
+PASS radialGradient fx and fy fall back to 50% with invalid values
+PASS radialGradient fx and fy are 50% when cx and cy are invalid
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/radial-gradient-undefined-fx-fy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/radial-gradient-undefined-fx-fy.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>SVG radialGradient fx and fy default to 50%</title>
+<link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFXAttribute">
+<link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFYAttribute">
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+'use strict';
+
+test(function() {
+  const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+
+  assert_equals(grad.fx.baseVal.valueAsString, '50%', 'fx initial value should be 50%');
+  assert_equals(grad.fy.baseVal.valueAsString, '50%', 'fy initial value should be 50%');
+}, 'radialGradient fx and fy default to 50% when no attributes are set');
+
+test(function() {
+  const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+
+  // Set cx and cy to different values
+  grad.setAttribute('cx', '30%');
+  grad.setAttribute('cy', '40%');
+
+  // fx and fy should remain at 50%, not inherit from cx/cy
+  assert_equals(grad.fx.baseVal.valueAsString, '50%', 'fx should remain 50% when cx is set');
+  assert_equals(grad.fy.baseVal.valueAsString, '50%', 'fy should remain 50% when cy is set');
+}, 'radialGradient fx and fy remain 50% when cx and cy are set to different values');
+
+test(function() {
+  const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+
+  // Set cx, cy, fx, fy
+  grad.setAttribute('cx', '30%');
+  grad.setAttribute('cy', '40%');
+  grad.setAttribute('fx', '20%');
+  grad.setAttribute('fy', '25%');
+
+  assert_equals(grad.fx.baseVal.valueAsString, '20%', 'fx should be 20% when explicitly set');
+  assert_equals(grad.fy.baseVal.valueAsString, '25%', 'fy should be 25% when explicitly set');
+
+  // Remove fx and fy attributes
+  grad.removeAttribute('fx');
+  grad.removeAttribute('fy');
+
+  // fx and fy should return to 50%, not follow cx/cy
+  assert_equals(grad.fx.baseVal.valueAsString, '50%', 'fx should return to 50% when attribute is removed');
+  assert_equals(grad.fy.baseVal.valueAsString, '50%', 'fy should return to 50% when attribute is removed');
+}, 'radialGradient fx and fy return to 50% when explicitly set then removed');
+
+test(function() {
+  const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+
+  // Set cx and cy
+  grad.setAttribute('cx', '70%');
+  grad.setAttribute('cy', '80%');
+
+  assert_equals(grad.fx.baseVal.valueAsString, '50%', 'fx should be 50%');
+  assert_equals(grad.fy.baseVal.valueAsString, '50%', 'fy should be 50%');
+
+  // Change cx and cy
+  grad.setAttribute('cx', '10%');
+  grad.setAttribute('cy', '20%');
+
+  // fx and fy should still be 50%
+  assert_equals(grad.fx.baseVal.valueAsString, '50%', 'fx should remain 50% when cx changes');
+  assert_equals(grad.fy.baseVal.valueAsString, '50%', 'fy should remain 50% when cy changes');
+}, 'radialGradient fx and fy do not follow cx and cy changes');
+
+test(function() {
+  const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+
+  // Set fx and fy explicitly
+  grad.setAttribute('fx', '25%');
+  grad.setAttribute('fy', '35%');
+
+  assert_equals(grad.fx.baseVal.valueAsString, '25%', 'fx should be 25%');
+  assert_equals(grad.fy.baseVal.valueAsString, '35%', 'fy should be 35%');
+
+  // Set cx and cy
+  grad.setAttribute('cx', '60%');
+  grad.setAttribute('cy', '70%');
+
+  // fx and fy should remain at their explicit values
+  assert_equals(grad.fx.baseVal.valueAsString, '25%', 'fx should remain 25% when cx is set');
+  assert_equals(grad.fy.baseVal.valueAsString, '35%', 'fy should remain 35% when cy is set');
+}, 'radialGradient explicit fx and fy are independent of cx and cy');
+
+test(function() {
+  const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+
+  // Set invalid values for fx and fy
+  grad.setAttribute('fx', 'invalid');
+  grad.setAttribute('fy', 'invalid');
+
+  // Should fall back to default of 50%
+  assert_equals(grad.fx.baseVal.valueAsString, '50%', 'fx should fall back to 50% when invalid');
+  assert_equals(grad.fy.baseVal.valueAsString, '50%', 'fy should fall back to 50% when invalid');
+}, 'radialGradient fx and fy fall back to 50% with invalid values');
+
+test(function() {
+  const grad = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+
+  // Set cx and cy to invalid values
+  grad.setAttribute('cx', 'invalid');
+  grad.setAttribute('cy', 'invalid');
+
+  // fx and fy should still be 50%
+  assert_equals(grad.fx.baseVal.valueAsString, '50%', 'fx should be 50% when cx is invalid');
+  assert_equals(grad.fy.baseVal.valueAsString, '50%', 'fy should be 50% when cy is invalid');
+}, 'radialGradient fx and fy are 50% when cx and cy are invalid');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### c07799a8739599ad602206515e40d9dcca48f526
<pre>
create extensive WPT tests for fx, fy default initial values when undefined
<a href="https://bugs.webkit.org/show_bug.cgi?id=307054">https://bugs.webkit.org/show_bug.cgi?id=307054</a>
<a href="https://rdar.apple.com/169700935">rdar://169700935</a>

Reviewed by Alan Baradlay.

This adds a new WPT test for a recent fix in the SVG spec which aligns
with current browser behavior. This is a companion test for
<a href="https://webkit.org/b/306976">https://webkit.org/b/306976</a>
SVG WG resolution: <a href="https://github.com/w3c/svgwg/issues/1054">https://github.com/w3c/svgwg/issues/1054</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/radial-gradient-undefined-fx-fy-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/radial-gradient-undefined-fx-fy.html: Added.

Canonical link: <a href="https://commits.webkit.org/306863@main">https://commits.webkit.org/306863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ed7366b15ef24f3391aebea66fc83b843eaddfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142602 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151270 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fbffd7d-0e42-4960-93d6-bdb831ea3160) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90581 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/763ecd42-e20c-4a4b-8e07-feb25727efb3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1271 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153585 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14698 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4724 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117692 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118027 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14048 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124899 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70389 "Failed to checkout and rebase branch from PR 57953") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21989 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14740 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3854 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14477 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14538 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->