### PR TITLE
Remote audio/video track IDs should not be derived from SDP

### DIFF
--- a/LayoutTests/fast/mediastream/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-setRemoteDescription-offer.html
@@ -48,7 +48,6 @@
 
                 debug("*** Remote track properties should match track added at remote side (remotePc)");
                 shouldBe("trackEvent.track.kind", `${remotePcTrackName}.kind`);
-                shouldBe("trackEvent.track.id", `${remotePcTrackName}.id`);
                 shouldBe("trackEvent.track.label", `'remote ${mediaType.toLocaleLowerCase()}'`);
 
                 debug("*** Check local and remote transceivers");

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-remote-track-properties.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-remote-track-properties.https-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Remote video track and stream
 PASS Remote audio track and stream
-FAIL Remote audio track ID is different on different PCs assert_greater_than: Remote tracks should have their own id expected a number greater than 1 but got 1
-FAIL Remote video track ID is different on different PCs assert_greater_than: Remote tracks should have their own id expected a number greater than 1 but got 1
+PASS Remote audio track ID is different on different PCs
+PASS Remote video track ID is different on different PCs
 PASS Stream id for video
 PASS Track label for video
 PASS Stream id for audio

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-setRemoteDescription-offer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-setRemoteDescription-offer-expected.txt
@@ -18,7 +18,6 @@ PASS pc.getTransceivers().includes(trackEvent.transceiver) is true
 PASS trackEvent.track.muted is true
 *** Remote track properties should match track added at remote side (remotePc)
 PASS trackEvent.track.kind is remotePcAudioTrack.kind
-PASS trackEvent.track.id is remotePcAudioTrack.id
 PASS trackEvent.track.label is 'remote audio'
 *** Check local and remote transceivers
 PASS trackEvent.transceiver.mid is remotePcAudioTransceiver.mid
@@ -48,7 +47,6 @@ PASS pc.getTransceivers().includes(trackEvent.transceiver) is true
 PASS trackEvent.track.muted is true
 *** Remote track properties should match track added at remote side (remotePc)
 PASS trackEvent.track.kind is remotePcVideoTrack.kind
-PASS trackEvent.track.id is remotePcVideoTrack.id
 PASS trackEvent.track.label is 'remote video'
 *** Check local and remote transceivers
 PASS trackEvent.transceiver.mid is remotePcVideoTransceiver.mid

--- a/LayoutTests/webrtc/getDisplayMedia-pc.html
+++ b/LayoutTests/webrtc/getDisplayMedia-pc.html
@@ -64,7 +64,6 @@
                          assert_true(Object.isFrozen(trackEvent.streams), "Object.isFrozen() should return true");
                          assert_equals(trackEvent.streams.length, 1);
                          assert_equals(trackEvent.streams[0].id, localStream.id, "first stream id");
-                         assert_equals(trackEvent.track.id, localStream.getVideoTracks()[0].id);
                          assert_equals(trackEvent.track, trackEvent.streams[0].getVideoTracks()[0]);
                          resolve(trackEvent.streams[0]);
                      };

--- a/LayoutTests/webrtc/utf8-sdp.html
+++ b/LayoutTests/webrtc/utf8-sdp.html
@@ -30,7 +30,7 @@ promise_test(async (test) => {
         setTimeout(() => reject("Test timed out"), 5000);
     });
 
-    assert_equals(remoteStream.getVideoTracks()[0].id, unicodeString);
+    assert_not_equals(remoteStream.getVideoTracks()[0].id, unicodeString);
     video.srcObject = remoteStream;
     return video.play();
 }, "Testing video exchange with UTF-8 track id");

--- a/LayoutTests/webrtc/video-addTrack.html
+++ b/LayoutTests/webrtc/video-addTrack.html
@@ -56,10 +56,6 @@ function testBasicVideoExchangeWithAddTrack(waitForSecondTrack)
                 var count = 0;
                 secondConnection.ontrack = (trackEvent) => {
                     window.test(function() {
-                        if (trackEvent.track.kind === "video")
-                            assert_equals(trackEvent.track.id, stream.getVideoTracks()[0].id);
-                        else
-                            assert_equals(trackEvent.track.id, stream.getAudioTracks()[0].id);
                         assert_equals(trackEvent.streams.length, 1);
                         assert_equals(trackEvent.streams[0].getTracks().length, 2);
                     }, " track " + count + ", wait = " + waitForSecondTrack);

--- a/LayoutTests/webrtc/video-interruption.html
+++ b/LayoutTests/webrtc/video-interruption.html
@@ -56,7 +56,6 @@ promise_test((test) => {
                     assert_true(trackEvent.receiver instanceof RTCRtpReceiver);
                     assert_true(Array.isArray(trackEvent.streams), "Array.isArray() should return true");
                     assert_true(Object.isFrozen(trackEvent.streams), "Object.isFrozen() should return true");
-                    assert_equals(trackEvent.track.id, stream.getVideoTracks()[0].id);
                     assert_equals(trackEvent.track, trackEvent.streams[0].getVideoTracks()[0]);
                     resolve(trackEvent.streams[0]);
                 };

--- a/LayoutTests/webrtc/video.html
+++ b/LayoutTests/webrtc/video.html
@@ -67,7 +67,6 @@ promise_test(async (test) => {
                 assert_equals(trackEvent.streams.length, 2);
                 assert_equals(trackEvent.streams[0].id, localStream.id, "first stream id");
                 assert_equals(trackEvent.streams[1].id, localStream2.id, "second stream id");
-                assert_equals(trackEvent.track.id, localStream.getVideoTracks()[0].id);
                 assert_equals(trackEvent.track, trackEvent.streams[0].getVideoTracks()[0]);
                 assert_equals(trackEvent.track.getSettings().aspectRatio, undefined);
                 assert_equals(trackEvent.track.getSettings().width, undefined);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -256,8 +256,7 @@ Ref<RTCRtpReceiver> GStreamerPeerConnectionBackend::createReceiver(std::unique_p
     auto source = backend->createSource(trackKind, trackId);
     // Remote source is initially muted and will be unmuted when receiving the first packet.
     source->setMuted(true);
-    auto trackID = source->persistentID();
-    auto remoteTrackPrivate = MediaStreamTrackPrivate::create(document.logger(), WTF::move(source), WTF::move(trackID));
+    auto remoteTrackPrivate = MediaStreamTrackPrivate::create(document.logger(), WTF::move(source), createVersion4UUIDString());
     auto remoteTrack = MediaStreamTrack::create(document, WTF::move(remoteTrackPrivate));
 
     return RTCRtpReceiver::create(*this, WTF::move(remoteTrack), WTF::move(backend));

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -297,8 +297,7 @@ Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(std::unique_p
 
     // Remote source is initially muted and will be unmuted when receiving the first packet.
     source->setMuted(true);
-    auto trackID = source->persistentID();
-    Ref remoteTrackPrivate = MediaStreamTrackPrivate::create(document->logger(), WTF::move(source), WTF::move(trackID));
+    Ref remoteTrackPrivate = MediaStreamTrackPrivate::create(document->logger(), WTF::move(source), createVersion4UUIDString());
     Ref remoteTrack = MediaStreamTrack::create(document.get(), WTF::move(remoteTrackPrivate));
 
     return RTCRtpReceiver::create(*this, WTF::move(remoteTrack), WTF::move(backend));


### PR DESCRIPTION
#### 9e4178b110f62534400f716a41c86bf9fe5d8d6f
<pre>
Remote audio/video track IDs should not be derived from SDP
<a href="https://rdar.apple.com/169705644">rdar://169705644</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307062">https://bugs.webkit.org/show_bug.cgi?id=307062</a>

Reviewed by Eric Carlson.

Align implementation with specification, in particular <a href="https://w3c.github.io/webrtc-pc/#dfn-create-an-rtcrtpreceiver">https://w3c.github.io/webrtc-pc/#dfn-create-an-rtcrtpreceiver</a>,
which states that track ID is generated by the user agent.

Covered by rebased test.
We update WebKit webrtc tests that were checking this property.

Canonical link: <a href="https://commits.webkit.org/307161@main">https://commits.webkit.org/307161@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00e344782662aade5d18edb31e66063f12832bf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96577 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15885 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110235 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79378 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91144 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58dac09d-cb6c-42e0-808a-8d294ecbc42a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9878 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2003 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121592 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154316 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15848 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118253 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30435 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14528 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71243 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15473 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5047 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15207 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15418 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->