### PR TITLE
[visionOS] Add support for RemoteEffects based OverlayRegions

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -155,6 +155,10 @@ public:
     virtual void scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID) { }
 
     virtual void stickyScrollingTreeNodeBeganSticking(ScrollingNodeID) { }
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    virtual void stickyScrollingTreeNodeEndedSticking(ScrollingNodeID) { }
+    virtual void scrollingTreeNodeWillBeRemoved(ScrollingNodeID) { }
+#endif
 
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegions::EventType, IntPoint);
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h
@@ -47,6 +47,9 @@ private:
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
     void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    void willBeDestroyed() final;
+#endif
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const final;
 

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm
@@ -78,6 +78,19 @@ void ScrollingTreeFixedNodeCocoa::applyLayerPositions()
     [m_layer _web_setLayerTopLeftPosition:layerPosition - m_constraints.alignmentOffset()];
 }
 
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+void ScrollingTreeFixedNodeCocoa::willBeDestroyed()
+{
+    RefPtr scrollingTree = this->scrollingTree();
+    if (!scrollingTree)
+        return;
+
+    ensureOnMainRunLoop([scrollingTree = WTF::move(scrollingTree), nodeID = scrollingNodeID()] {
+        scrollingTree->scrollingTreeNodeWillBeRemoved(nodeID);
+    });
+}
+#endif
+
 void ScrollingTreeFixedNodeCocoa::dumpProperties(TextStream& ts, OptionSet<ScrollingStateTreeAsTextBehavior> behavior) const
 {
     ScrollingTreeFixedNode::dumpProperties(ts, behavior);

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h
@@ -45,6 +45,9 @@ private:
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
     void applyLayerPositions() final WTF_REQUIRES_LOCK(scrollingTree()->treeLock());
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    void willBeDestroyed() final;
+#endif
     FloatPoint layerTopLeft() const final;
     CALayer *layer() const final { return m_layer.get(); }
     bool hasViewportClippingLayer() const final;

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -643,6 +643,8 @@ extern NSString * const UIPresentationControllerDismissalTransitionDidEndComplet
 @end
 @interface UIView ()
 - (void)_requestRemoteEffects:(NSArray *)effects forKey:(NSString *)key;
+- (void)_removeRemoteEffectsForKey:(NSString *)key;
+- (NSArray *)_remoteEffectsForKey:(NSString *)key;
 @end
 #endif // PLATFORM(VISION)
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -584,7 +584,7 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
         node.setEventRegion(properties.eventRegion);
     updateMask(node, properties, relatedLayers);
 
-#if ENABLE(GAZE_GLOW_FOR_INTERACTION_REGIONS) || HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
+#if ENABLE(GAZE_GLOW_FOR_INTERACTION_REGIONS) || HAVE(CORE_ANIMATION_SEPARATED_LAYERS) || ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
     if (properties.changedProperties & LayerChange::VisibleRectChanged)
         node.setVisibleRect(properties.visibleRect);
 #endif
@@ -605,6 +605,11 @@ void RemoteLayerTreePropertyApplier::applyProperties(RemoteLayerTreeNode& node, 
         } else if (node.layer().isSeparated)
             node.layer().separated = false;
     }
+#endif
+
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    if (properties.changedProperties & LayerChange::VisibleRectChanged)
+        node.visibleRectChangedForOverlayRegions();
 #endif
 
 #if ENABLE(SCROLLING_THREAD)
@@ -658,6 +663,9 @@ void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& 
 #if ENABLE(GAZE_GLOW_FOR_INTERACTION_REGIONS)
         node.updateInteractionRegionAfterHierarchyChange();
 #endif
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+        node.updateOverlayRegionAfterHierarchyChange();
+#endif
         return;
     }
 #endif
@@ -678,6 +686,10 @@ void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& 
 #endif
         return childNode->layer();
     }).get()];
+
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    node.updateOverlayRegionAfterHierarchyChange();
+#endif
 
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -77,6 +77,22 @@ public:
     void setShouldBeSeparated(bool value) { m_shouldBeSeparated = value; }
 #endif
 
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    bool isLookToScrollExclusion() const { return m_isLookToScrollExclusion; }
+    void setIsLookToScrollExclusion(bool);
+
+    bool isFixedSubtreeRoot() const { return m_isFixedSubtreeRoot; }
+    void setIsFixedSubtreeRoot(bool value) { m_isFixedSubtreeRoot = value; }
+
+    enum class EventRegionChanged : bool { No, Yes };
+    void updateExclusionRegion(EventRegionChanged = EventRegionChanged::No);
+
+    void updateExclusionRegionAndDescendants(bool isExclusion);
+
+    void visibleRectChangedForOverlayRegions();
+    void updateOverlayRegionAfterHierarchyChange();
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     UIView *uiView() const { return m_uiView.get(); }
 #endif
@@ -179,6 +195,13 @@ private:
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool m_shouldBeSeparated { false };
+#endif
+
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    bool m_isLookToScrollExclusion { false };
+    bool m_isFixedSubtreeRoot { false };
+    bool m_hasLookToScrollExclusionEffect { false };
+    bool m_hasVisibleRect { false };
 #endif
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -114,7 +114,11 @@ public:
     const RemoteLayerTreeHost* layerTreeHost() const;
     WebPageProxy& webPageProxy() const;
 
-    void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID);
+    virtual void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID);
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    virtual void stickyScrollingTreeNodeEndedSticking(WebCore::ScrollingNodeID) { };
+    virtual void scrollingTreeNodeWillBeRemoved(WebCore::ScrollingNodeID) { };
+#endif
 
     std::optional<WebCore::RequestedScrollData> commitScrollingTreeState(IPC::Connection&, const RemoteScrollingCoordinatorTransaction&, std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -191,6 +191,20 @@ void RemoteScrollingTree::stickyScrollingTreeNodeBeganSticking(ScrollingNodeID n
         scrollingCoordinatorProxy->stickyScrollingTreeNodeBeganSticking(nodeID);
 }
 
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+void RemoteScrollingTree::stickyScrollingTreeNodeEndedSticking(ScrollingNodeID nodeID)
+{
+    if (CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get())
+        scrollingCoordinatorProxy->stickyScrollingTreeNodeEndedSticking(nodeID);
+}
+
+void RemoteScrollingTree::scrollingTreeNodeWillBeRemoved(ScrollingNodeID nodeID)
+{
+    if (CheckedPtr scrollingCoordinatorProxy = m_scrollingCoordinatorProxy.get())
+        scrollingCoordinatorProxy->scrollingTreeNodeWillBeRemoved(nodeID);
+}
+#endif
+
 Ref<ScrollingTreeNode> RemoteScrollingTree::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     switch (nodeType) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -85,6 +85,10 @@ public:
     void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) override;
 
     void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID) final;
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    void stickyScrollingTreeNodeEndedSticking(WebCore::ScrollingNodeID) final;
+    void scrollingTreeNodeWillBeRemoved(WebCore::ScrollingNodeID) final;
+#endif
 
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) override;
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -93,7 +93,17 @@ private:
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     void selectOverlayRegionScrollViewIfNeeded();
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    void updateAllFixedAndStickyOverlayRegions();
+    void updateOverlayRegionForNode(WebCore::ScrollingNodeID);
+    bool nodeQualifiesForOverlayRegionExclusions(const RemoteLayerTreeNode&, bool) const;
+
+    void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID) override;
+    void stickyScrollingTreeNodeEndedSticking(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeWillBeRemoved(WebCore::ScrollingNodeID) override;
+#else
     void updateOverlayRegionLayers();
+#endif
 #endif
 
     WebCore::FloatRect currentLayoutViewport() const;
@@ -110,11 +120,15 @@ private:
     HashMap<unsigned, OptionSet<WebCore::TouchAction>> m_touchActionsByTouchIdentifier;
 
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    HashMap<WebCore::PlatformLayerIdentifier, WebCore::ScrollingNodeID> m_fixedScrollingNodesByLayerID;
     HashMap<WebCore::PlatformLayerIdentifier, WebCore::ScrollingNodeID> m_scrollingNodesByLayerID;
+    HashMap<WebCore::PlatformLayerIdentifier, WebCore::ScrollingNodeID> m_fixedAndStickyScrollingNodesByLayerID;
+#if ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT)
+    HashMap<WebCore::ScrollingNodeID, WebCore::PlatformLayerIdentifier> m_layerIDsByFixedAndStickyScrollingNodeID;
+#else
+    HashSet<WebCore::IntRect> m_lastOverlayRegionRects;
+#endif
 
     bool m_needsOverlayRegionScrollViewSelection { false };
-    HashSet<WebCore::IntRect> m_lastOverlayRegionRects;
     RetainPtr<WKBaseScrollView> m_selectedOverlayRegionScrollView;
 #endif
 


### PR DESCRIPTION
#### fb771a5f14b71e6ac44d8b879e9085e752685278
<pre>
[visionOS] Add support for RemoteEffects based OverlayRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=307059">https://bugs.webkit.org/show_bug.cgi?id=307059</a>
&lt;<a href="https://rdar.apple.com/163353038">rdar://163353038</a>&gt;

Reviewed by Mike Wyrzykowski.

Add support for new Remote Effect based Overlay Regions behind a compile
time flag.

Instead of doing big tree traversals after each rendering update, this
API let&apos;s us use clearer signals:
- EventRegion changes (setEventRegion)
- VisibleRect changes (visibleRectChangedForOverlayRegions)
- RLT hierarchy changes (updateOverlayRegionAfterHierarchyChange)
- Sticky nodes begin/end sticking (stickyScrollingTreeNodeBeganSticking/EndedSticking)
- Fixed/sticky nodes added/removed (fixedOrStickyScrollingTreeNodeWillBeRemoved)

It also removes the need for doing coordinate space conversions and
clipping on our end!

Tests: LayoutTests/overlay-region/*

* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::stickyScrollingTreeNodeEndedSticking):
(WebCore::ScrollingTree::scrollingTreeNodeWillBeRemoved):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeFixedNodeCocoa.mm:
(WebCore::ScrollingTreeFixedNodeCocoa::willBeDestroyed):
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingTreeStickyNodeCocoa.mm:
(WebCore::ScrollingTreeStickyNodeCocoa::willBeDestroyed):
(WebCore::ScrollingTreeStickyNodeCocoa::setIsSticking):
Gather signals on begin sticking, end sticking and node removal to
update the effects.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
Complete the SPI header for remote effects.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyProperties):
(WebKit::RemoteLayerTreePropertyApplier::applyHierarchyUpdates):
Gather signals on visible rect and hierarchy changes.

* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(dumpUIView):
Add testing support for the new RemoteEffect based system.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setEventRegion):
(WebKit::RemoteLayerTreeNode::setIsLookToScrollExclusion):
(WebKit::RemoteLayerTreeNode::updateExclusionRegion):
(WebKit::RemoteLayerTreeNode::updateExclusionRegionAndDescendants):
(WebKit::RemoteLayerTreeNode::visibleRectChangedForOverlayRegions):
(WebKit::RemoteLayerTreeNode::updateOverlayRegionAfterHierarchyChange):
Introduce methods to manage overlay region effects on
RemoteLayerTreeNodes and subtrees.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::stickyScrollingTreeNodeEndedSticking):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeWillBeRemoved):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::stickyScrollingTreeNodeEndedSticking):
(WebKit::RemoteScrollingTree::scrollingTreeNodeWillBeRemoved):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateOverlayRegions):
(WebKit::RemoteScrollingCoordinatorProxyIOS::overlayRegionsEnabledChanged):
(WebKit::RemoteScrollingCoordinatorProxyIOS::selectOverlayRegionScrollViewIfNeeded):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateOverlayRegionLayers):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateAllFixedAndStickyOverlayRegions):
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateOverlayRegionForNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::nodeQualifiesForOverlayRegionExclusions const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::stickyScrollingTreeNodeBeganSticking):
(WebKit::RemoteScrollingCoordinatorProxyIOS::stickyScrollingTreeNodeEndedSticking):
(WebKit::RemoteScrollingCoordinatorProxyIOS::scrollingTreeNodeWillBeRemoved):
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
Bifurcate code paths based on ENABLE(OVERLAY_REGIONS_REMOTE_EFFECT).

Canonical link: <a href="https://commits.webkit.org/307168@main">https://commits.webkit.org/307168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab08c1e31e3c7e8c38bddcae56a30091398a12b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96542 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/887097ab-1cfa-4898-9ef6-d152ad61bdac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110228 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79355 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3770900-d922-4702-8b75-cf3b97660774) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91137 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18a526da-ec78-41a7-bb1d-979670b8f327) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12163 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9870 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1995 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154308 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15840 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118243 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15877 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118584 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30444 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14526 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71235 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22142 "") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15465 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5006 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15199 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15410 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15261 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->