### PR TITLE
[GTK][WPE] Add webkit_feature_list_find() to the API

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
@@ -124,6 +124,10 @@ WEBKIT_API WebKitFeature *
 webkit_feature_list_get          (WebKitFeatureList *feature_list,
                                   gsize              index);
 
+WEBKIT_API WebKitFeature *
+webkit_feature_list_find         (WebKitFeatureList *feature_list,
+                                  const gchar       *identifier);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(WebKitFeatureList, webkit_feature_list_unref)
 
 G_END_DECLS

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -256,16 +256,6 @@ static gboolean isValidParameterType(GType gParamType)
     return (gParamType == G_TYPE_BOOLEAN || gParamType == G_TYPE_STRING || gParamType == G_TYPE_INT || gParamType == G_TYPE_FLOAT || gParamType == WEBKIT_TYPE_HARDWARE_ACCELERATION_POLICY);
 }
 
-static WebKitFeature* findFeature(WebKitFeatureList *featureList, const char *identifier)
-{
-    for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
-        WebKitFeature *feature = webkit_feature_list_get(featureList, i);
-        if (!g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature)))
-            return feature;
-    }
-    return NULL;
-}
-
 static gboolean parseFeaturesOptionCallback(const gchar *option, const gchar *value, WebKitSettings *webSettings, GError **error)
 {
     g_autoptr(WebKitFeatureList) featureList = webkit_settings_get_all_features();
@@ -310,7 +300,7 @@ static gboolean parseFeaturesOptionCallback(const gchar *option, const gchar *va
             return FALSE;
         }
 
-        WebKitFeature *feature = findFeature(featureList, item);
+        WebKitFeature *feature = webkit_feature_list_find(featureList, item);
         if (!feature) {
             g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Feature '%s' is not available", item);
             return FALSE;

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -436,16 +436,6 @@ static void automationStartedCallback(WebKitWebContext*, WebKitAutomationSession
     g_signal_connect(session, "create-web-view", G_CALLBACK(createWebViewForAutomationCallback), view);
 }
 
-static WebKitFeature* findFeature(WebKitFeatureList* featureList, const char* identifier)
-{
-    for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
-        WebKitFeature* feature = webkit_feature_list_get(featureList, i);
-        if (!g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature)))
-            return feature;
-    }
-    return nullptr;
-}
-
 #if ENABLE_WPE_PLATFORM
 void loadConfigFile(WPESettings* settings)
 {
@@ -589,7 +579,7 @@ static void activate(GApplication* application, gpointer)
                 continue;
             }
 
-            if (auto* feature = findFeature(features, item))
+            if (auto* feature = webkit_feature_list_find(features, item))
                 webkit_settings_set_feature_enabled(settings, feature, enabled);
             else
                 g_printerr("Feature '%s' is not available.", item);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -507,6 +507,22 @@ void testWebKitFeatures(Test* test, gconstpointer)
 
         g_assert(webkit_settings_get_feature_enabled(settings.get(), feature) == webkit_feature_get_default_value(feature));
     }
+
+    // Check finding features given their identifier.
+    if (webkit_feature_list_get_length(allFeatures)) {
+        WebKitFeature* firstFeature = webkit_feature_list_get(allFeatures, 0);
+        WebKitFeature* foundFeature = webkit_feature_list_find(allFeatures, webkit_feature_get_identifier(firstFeature));
+        g_assert_nonnull(foundFeature);
+        g_assert(firstFeature == foundFeature);
+
+        g_autofree char* lowerCaseIdentifier = g_utf8_strdown(webkit_feature_get_identifier(firstFeature), -1);
+        foundFeature = webkit_feature_list_find(allFeatures, lowerCaseIdentifier);
+        g_assert_nonnull(foundFeature);
+        g_assert(firstFeature == foundFeature);
+    }
+
+    WebKitFeature* foundFeature = webkit_feature_list_find(allFeatures, "ThisFeatureIdentifierCannotPossiblyExist");
+    g_assert_null(foundFeature);
 }
 
 void testWebKitSettingsApplyFromConfigFile(Test* test, gconstpointer)


### PR DESCRIPTION
#### 1d012f3372ab8ec4c7a71a0b61ab0e0405a8218f
<pre>
[GTK][WPE] Add webkit_feature_list_find() to the API
<a href="https://bugs.webkit.org/show_bug.cgi?id=307069">https://bugs.webkit.org/show_bug.cgi?id=307069</a>

Reviewed by Michael Catanzaro and Patrick Griffis.

Add a convenience function to find a WebKitFeature from a given
WebKitFeatureList. This will avoid code repetition in different
projects.

* Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp:
(webkit_feature_list_find):
* Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in:
* Tools/MiniBrowser/gtk/main.c:
(parseFeaturesOptionCallback):
(findFeature): Deleted. Replaced with webkit_feature_list_find().
* Tools/MiniBrowser/wpe/main.cpp:
(activate):
(findFeature): Deleted. Replaced with webkit_feature_list_find().
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitFeatures): Add a few test cases for the new function.

Canonical link: <a href="https://commits.webkit.org/307348@main">https://commits.webkit.org/307348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3240b54a41fd44e6d2309c3f915165361d7e4eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16829 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/8385 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152820 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16723 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110842 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13260 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91760 "Found 1 new API test failure: WPE/TestWebKitSettings:/webkit/WebKitSettings/features (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/266 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/6164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155132 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/7219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16718 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/14004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119216 "Found 1 new API test failure: WebKitGTK/TestWebKitSettings:/webkit/WebKitSettings/features (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30550 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/15098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/127375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16303 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16037 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->