### PR TITLE
[GFC] Add indefinite free space support for flex tracks.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -67,9 +67,11 @@ private:
     static LayoutUnit findSizeOfFr(const UnsizedTracks&, const LayoutUnit& availableSpace, const LayoutUnit& gapSize);
 
     // Expand Flexible Tracks (spec section 11.7)
-    static void expandFlexibleTracks(UnsizedTracks&, const FreeSpaceScenario&, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit& gapSize);
+    static void expandFlexibleTracks(UnsizedTracks&, const FreeSpaceScenario&, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit& gapSize,
+        const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingGridItemConstraintList&, const GridItemSizingFunctions&);
     static void expandFlexibleTracksForMinContent(UnsizedTracks&);
-    static void expandFlexibleTracksForMaxContent(UnsizedTracks&, const FlexTracks&, double totalFlex);
+    static void expandFlexibleTracksForMaxContent(UnsizedTracks&, const FlexTracks&, const LayoutUnit& gapSize,
+        const PlacedGridItems&, const PlacedGridItemSpanList&, const TrackSizingGridItemConstraintList&, const GridItemSizingFunctions&);
     static void expandFlexibleTracksForDefiniteLength(UnsizedTracks&, const FlexTracks&, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit& gapSize);
 };
 


### PR DESCRIPTION
#### c90715b4cf97033fd5acc77e7f4329771d21d1e4
<pre>
[GFC] Add indefinite free space support for flex tracks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306932">https://bugs.webkit.org/show_bug.cgi?id=306932</a>
&lt;<a href="https://rdar.apple.com/169596001">rdar://169596001</a>&gt;

Reviewed by Sammy Gill.

This PR implements flex track sizing when sized under a max content
constraint with indefinite free space.

Specifically, it implements this part of the spec:

Otherwise, if the free space is an indefinite length:
    The used flex fraction is the maximum of:
    - For each flexible track, if the flexible track’s flex factor is greater than one,
    the result of dividing the track’s base size by its flex factor; otherwise, the track’s base size.
    - For each grid item that crosses a flexible track, the result of finding the size of an fr using
    all the grid tracks that the item crosses and a space to fill of the item’s max-content contribution.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
(WebCore::Layout::flexFractionFromTrackBaseSize):
(WebCore::Layout::itemCrossesFlexibleTrack):
(WebCore::Layout::applyFlexFractionToTracks):
(WebCore::Layout::TrackSizingAlgorithm::expandFlexibleTracksForMaxContent):
(WebCore::Layout::TrackSizingAlgorithm::expandFlexibleTracksForDefiniteLength):
(WebCore::Layout::TrackSizingAlgorithm::expandFlexibleTracks):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/307367@main">https://commits.webkit.org/307367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04fc2f4db30130b410fbff537f855a215e717eb7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97342 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17264 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110808 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de7c4d02-e2f5-4d20-a2c8-0ff7a3848bd4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91726 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12681 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/219 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155085 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16634 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118822 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119180 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30569 "Failed to checkout and rebase branch from PR 57970") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15063 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72055 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22238 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16256 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5776 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80035 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16056 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->