### PR TITLE
Web Inspector: Support inspector protocol in copy-user-interface-resources.pl

### DIFF
--- a/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl
+++ b/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl
@@ -278,6 +278,12 @@ sub combineOrStripResourcesForWebKitAdditions() {
         debugLog("Stripping resources provided by WebKitAdditions.");
         stripResourcesForWebKitAdditions();
     }
+
+    # Copy the contents of the Protocol/Legacy directory from WebKitAdditions/WebInspectorUI/ if it exists
+    my $protocolLegacyAdditionsDir = File::Spec->catdir($webInspectorUIAdditionsDir, 'Protocol', 'Legacy');
+    if (-d $protocolLegacyAdditionsDir) {
+        ditto($protocolLegacyAdditionsDir, File::Spec->catdir($protocolDir, 'Legacy'));
+    }
 }
 
 sub stripResourcesForWebKitAdditions() {


### PR DESCRIPTION
#### e1e099481155a35b84553a1cbdfc9438a5129621
<pre>
Web Inspector: Support inspector protocol in copy-user-interface-resources.pl
<a href="https://bugs.webkit.org/show_bug.cgi?id=307075">https://bugs.webkit.org/show_bug.cgi?id=307075</a>
<a href="https://rdar.apple.com/169715531">rdar://169715531</a>

Reviewed by Alexey Proskuryakov.

Copy inspector protocol snapshots from WebKitAdditions

* Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl:
(combineOrStripResourcesForWebKitAdditions):

Canonical link: <a href="https://commits.webkit.org/307092@main">https://commits.webkit.org/307092@main</a>
</pre>
