### PR TITLE
Re-Re-land [AppKit Gestures] Add initial support for handling clicks during text selection

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -1,26 +1,156 @@
-module WebKit_Internal {
-    module WKWebViewIOS {
-        header "../../UIProcess/API/ios/WKWebViewIOS.h"
+module WebKit_Internal [system] {
+    module AppKitSPI {
+        requires cplusplus20
+        header "../../Platform/spi/mac/AppKitSPI.h"
+        export *
+    }
+
+    module APIObject {
+        requires cplusplus20
+        header "../../Shared/API/APIObject.h"
         export *
     }
 
     module FrameInfoData {
+        requires cplusplus20
         header "../../Shared/FrameInfoData.h"
         export *
     }
 
     module FrameTreeNodeData {
+        requires cplusplus20
         header "../../Shared/FrameTreeNodeData.h"
         export *
     }
 
+    module GamepadData {
+        requires cplusplus20
+        header "../../Shared/Gamepad/GamepadData.h"
+        export *
+    }
+
+    module GestureTypes {
+        requires cplusplus20
+        header "../../Shared/Cocoa/GestureTypes.h"
+        export *
+    }
+
+    module HistoryClient {
+        requires cplusplus20
+        header "../../UIProcess/API/APIHistoryClient.h"
+        export *
+    }
+
     module JSHandleInfo {
+        requires cplusplus20
         header "../../Shared/JSHandleInfo.h"
         export *
     }
 
+    module JavaScriptEvaluationResult {
+        requires cplusplus20
+        header "../../Shared/JavaScriptEvaluationResult.h"
+        export *
+    }
+
+    module MessageReceiver {
+        requires cplusplus20
+        header "../../Platform/IPC/MessageReceiver.h"
+        export *
+    }
+
+    module NavigationClient {
+        requires cplusplus20
+        header "../../UIProcess/API/APINavigationClient.h"
+        export *
+    }
+
+    module WKObject {
+        requires cplusplus20
+        header "../../Shared/Cocoa/WKObject.h"
+        export *
+    }
+
+    module WKTextSelectionController {
+        requires cplusplus20
+        header "../../UIProcess/mac/WKTextSelectionController.h"
+        export *
+    }
+
+    module WKTextSelectionRect {
+        requires cplusplus20
+        header "../../UIProcess/Cocoa/WKTextSelectionRect.h"
+        export *
+    }
+
+    module WKWebViewIOS {
+        header "../../UIProcess/API/ios/WKWebViewIOS.h"
+        export *
+    }
+
+    module WebExtensionCookieParameters {
+        requires cplusplus20
+        header "../../Shared/Extensions/WebExtensionCookieParameters.h"
+        export *
+    }
+
+    module WebAutocorrectionData {
+        requires cplusplus20
+        header "../../Shared/ios/WebAutocorrectionData.h"
+        export *
+    }
+
     module WebFrameMetrics {
+        requires cplusplus20
         header "../../Shared/WebFrameMetrics.h"
+        export *
+    }
+
+    module WebKeyboardEvent {
+        requires cplusplus20
+        header "../../Shared/WebKeyboardEvent.h"
+        export *
+    }
+
+    module WebNavigationState {
+        requires cplusplus20
+        header "../../UIProcess/WebNavigationState.h"
+        export *
+    }
+
+    module WebPageCreationParameters {
+        requires cplusplus20
+        header "../../Shared/WebPageCreationParameters.h"
+        export *
+    }
+
+    module WebPageInspectorController {
+        requires cplusplus20
+        header "../../UIProcess/Inspector/WebPageInspectorController.h"
+        export *
+    }
+
+    module WebPageProxy {
+        requires cplusplus20
+        header "../../UIProcess/WebPageProxy.h"
+        export *
+    }
+
+    module WebPageProxyInternals {
+        requires cplusplus20
+        header "../../UIProcess/WebPageProxyInternals.h"
+        export *
+    }
+
+    module WebProcessActivityState {
+        requires cplusplus20
+        header "../../UIProcess/WebProcessActivityState.h"
+        export *
+    }
+
+    module WebPushMessage {
+        requires cplusplus20
+        header "../../Shared/WebPushMessage.h"
         export *
     }
 
@@ -30,12 +160,8 @@ module WebKit_Internal {
     }
 
     module WebsiteData {
+        requires cplusplus20
         header "../../Shared/WebsiteData/WebsiteData.h"
-        export *
-    }
-
-    module WebPushMessage {
-        header "../../Shared/WebPushMessage.h"
         export *
     }
 

--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#import <wtf/Compiler.h>
+#import <wtf/Platform.h>
+
 DECLARE_SYSTEM_HEADER
 
 #if PLATFORM(MAC)
@@ -53,6 +56,10 @@ DECLARE_SYSTEM_HEADER
 
 #if HAVE(NSVIEW_CORNER_CONFIGURATION)
 #import <AppKit/NSViewCornerConfiguration_Private.h>
+#endif
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+#import <AppKit/NSTextSelectionManager.h>
 #endif
 
 #else
@@ -199,5 +206,30 @@ typedef void (^NSWindowSnapshotReadinessHandler) (void);
 - (NSWindowSnapshotReadinessHandler)_holdResizeSnapshotWithReason:(NSString *)reason;
 @end
 #endif
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+@protocol NSTextSelectionManagerDelegateForWebKit <NSObject>
+
+- (BOOL)isTextSelectedAtPoint:(NSPoint)point;
+- (void)moveInsertionCursorToPoint:(NSPoint)point;
+- (void)handleClickAtPoint:(NSPoint)point;
+- (void)showContextMenuAtPoint:(NSPoint)point;
+- (void)dragSelectionWithGesture:(NSGestureRecognizer *)gesture completionHandler:(void(^)(NSDraggingSession*))completionHandler;
+- (void)beginRangeSelectionAtPoint:(NSPoint)point withGranularity:(NSTextSelectionGranularity)granularity;
+- (void)continueRangeSelectionAtPoint:(NSPoint)point;
+- (void)endRangeSelectionAtPoint:(NSPoint)point;
+
+@end
+
+@interface NSTextSelectionManager (WebKit_SPI)
+@property (weak) id <NSTextSelectionManagerDelegateForWebKit> _webkitDelegate;
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
+
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -25,9 +25,12 @@
 
 #pragma once
 
+#include <wtf/Platform.h>
+
+#if !PLATFORM(COCOA) || !__has_feature(modules) || (defined(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP) && WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)
+
 #include <wtf/HashTable.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/Platform.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainReleaseSwift.h>
@@ -347,3 +350,5 @@ inline void derefObject(API::Object* WTF_NONNULL obj)
 SPECIALIZE_TYPE_TRAITS_BEGIN(API::ClassName) \
 static bool isType(const API::Object& object) { return object.type() == API::Object::Type::ClassName; } \
 SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // !PLATFORM(COCOA) || !__has_feature(modules) || (defined(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP) && WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)

--- a/Source/WebKit/UIProcess/API/Cocoa/Logger+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/Logger+Extras.swift
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import os
+
+extension Logger {
+    static let viewGestures = Logger(subsystem: "com.apple.WebKit", category: "ViewGestures")
+}

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -730,6 +730,10 @@ static void addBrowsingContextControllerMethodStubsIfNeeded()
 #if PLATFORM(IOS_FAMILY)
     _pointerTouchCompatibilitySimulator = WTF::makeUnique<WebKit::PointerTouchCompatibilitySimulator>(self);
 #endif
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    _impl->addTextSelectionManager();
+#endif
 }
 
 - (void)_setupPageConfiguration:(Ref<API::PageConfiguration>&)pageConfiguration withPool:(WebKit::WebProcessPool&)pool

--- a/Source/WebKit/UIProcess/WebPageProxy.swift
+++ b/Source/WebKit/UIProcess/WebPageProxy.swift
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)
+
+import Foundation
+internal import WebKit_Internal
+internal import WebCore_Private
+
+extension WebKit.WebPageProxy {
+    @MainActor
+    func selectWithGesture(
+        at point: WebCore.IntPoint,
+        type: WebKit.GestureType,
+        state: WebKit.GestureRecognizerState,
+        isInteractingWithFocusedElement: Bool
+    ) async {
+        await withCheckedContinuation { continuation in
+            selectWithGesture(
+                point,
+                type,
+                state,
+                isInteractingWithFocusedElement,
+                consuming: .init({ _, _, _, _ in continuation.resume() }, WTF.ThreadLikeAssertion(WTF.CurrentThreadLike()))
+            )
+        }
+    }
+
+    private borrowing func editorStateCopy() -> WebKit.EditorState {
+        __editorStateUnsafe().pointee
+    }
+
+    var editorState: WebKit.EditorState {
+        editorStateCopy()
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
-#if PLATFORM(MAC)
+#import <wtf/Platform.h>
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
 
 #import <AppKit/NSGestureRecognizer.h>
 #import <wtf/Forward.h>
@@ -44,4 +46,4 @@ OBJC_CLASS NSPanGestureRecognizer;
 
 @end
 
-#endif
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "WKAppKitGestureController.h"
 
-#if PLATFORM(MAC)
+#if HAVE(APPKIT_GESTURES_SUPPORT)
 
 #import "AppKitSPI.h"
 #import "NativeWebWheelEvent.h"
@@ -108,6 +108,8 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKAppKitGestureControllerAdditions.mm>)
 #import <WebKitAdditions/WKAppKitGestureControllerAdditions.mm>
 #else
+
+static NSString * const textSelectionClickGestureName = @"";
 
 - (void)configureForScrolling:(NSPanGestureRecognizer *)gesture
 {
@@ -459,8 +461,14 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 - (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
 {
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
+
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), _panGestureRecognizer.get()))
         return YES;
+
+    if ((gestureRecognizer == _singleClickGestureRecognizer.get() && [otherGestureRecognizer.name isEqualToString:textSelectionClickGestureName])
+        || (otherGestureRecognizer == _singleClickGestureRecognizer.get() && [gestureRecognizer.name isEqualToString:textSelectionClickGestureName]))
+        return YES;
+
     return NO;
 }
 
@@ -481,4 +489,4 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
 #undef WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG
 
-#endif
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,40 +25,29 @@
 
 #pragma once
 
-#include <wtf/Platform.h>
+#import <wtf/Platform.h>
 
-#if PLATFORM(IOS_FAMILY)
+#if HAVE(APPKIT_GESTURES_SUPPORT)
 
-#include <wtf/RetainPtr.h>
-#include <wtf/Vector.h>
-#include <wtf/text/WTFString.h>
+#import "AppKitSPI.h"
 
-namespace IPC {
-class Decoder;
-class Encoder;
-}
+@class WKWebView;
 
-namespace WebCore {
-class FloatRect;
-}
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-OBJC_CLASS UIFont;
+NS_SWIFT_UI_ACTOR
+@interface WKTextSelectionController : NSObject
 
-namespace WebKit {
+- (instancetype)initWithView:(WKWebView *)view;
 
-struct WebAutocorrectionData {
-    WebAutocorrectionData() = default;
-    WebAutocorrectionData(Vector<WebCore::FloatRect>&& textRects, std::optional<String>&& fontName, double pointSize, double weight);
-    WebAutocorrectionData(const Vector<WebCore::FloatRect>& textRects, const RetainPtr<UIFont>&);
+- (void)addTextSelectionManager;
 
-    std::optional<String> fontName() const;
-    double fontPointSize() const;
-    double fontWeight() const;
+@end
 
-    Vector<WebCore::FloatRect> textRects;
-    RetainPtr<UIFont> font;
-};
+@interface WKTextSelectionController (NSTextSelectionManagerDelegate) <NSTextSelectionManagerDelegateForWebKit>
 
-} // namespace WebKit
+@end
 
-#endif // PLATFORM(IOS_FAMILY)
+NS_HEADER_AUDIT_END(nullability, sendability)
+
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -1,0 +1,169 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)
+
+import Foundation
+internal import WebKit_Internal
+import AppKit
+internal import WebCore_Private
+
+@objc
+@implementation
+extension WKTextSelectionController {
+    private weak let view: WKWebView?
+
+    init(view: WKWebView) {
+        self.view = view
+        super.init()
+    }
+
+    func addTextSelectionManager() {
+        guard let view, let page = view._protectedPage().get() else {
+            return
+        }
+
+        guard page.preferences().useAppKitGestures() else {
+            return
+        }
+
+        Logger.viewGestures.log("Creating a text selection manager for view \(view)")
+
+        let manager = NSTextSelectionManager()
+        manager._webkitDelegate = self
+        view.textSelectionManager = manager
+
+        for case let gestureRecognizer as NSPressGestureRecognizer in manager.gesturesForFailureRequirements {
+            gestureRecognizer.buttonMask = 0
+        }
+    }
+}
+
+@objc(NSTextSelectionManagerDelegate)
+@implementation
+extension WKTextSelectionController {
+    @objc(isTextSelectedAtPoint:)
+    func isTextSelected(at point: NSPoint) -> Bool {
+        // FIXME: Address warning "Cannot infer ownership of foreign reference value returned by 'get()'"
+        guard let page = view?._protectedPage().get() else {
+            return false
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Checking if text is selected at point \(point.debugDescription)...")
+
+        let editorState = unsafe page.editorState
+        let hasSelection = unsafe !editorState.selectionIsNone
+
+        if unsafe !hasSelection || !editorState.hasPostLayoutAndVisualData() {
+            Logger.viewGestures.log(
+                "[pageProxyID=\(page.logIdentifier())] Editor state has no selection, post layout data, or visual data"
+            )
+            return false
+        }
+
+        let isRange = unsafe editorState.selectionIsRange
+        let isContentEditable = unsafe editorState.isContentEditable
+
+        if !isContentEditable && !isRange {
+            Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Selection is neither contenteditable nor a range")
+            return false
+        }
+
+        // FIXME: If the state's selection is not a range, is the number of selection geometries always zero?
+        // If so, then the rest of the logic in this function can be elided in that case.
+
+        var selectionRects: [WKTextSelectionRect] = []
+        let selectionGeometries = unsafe editorState.visualData.pointee.selectionGeometries
+
+        // FIXME: `WTF::Vector` should be able to be used as a Swift `Sequence`.
+        for i in unsafe 0..<selectionGeometries.size() {
+            let selectionGeometry = unsafe selectionGeometries.__atUnsafe(i).pointee
+            selectionRects.append(.init(selectionGeometry: selectionGeometry, delegate: nil))
+        }
+
+        let result = selectionRects.contains { $0.rect.contains(point) }
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Text is selected => \(result)")
+
+        return result
+    }
+
+    @objc(moveInsertionCursorToPoint:)
+    func moveInsertionCursor(to point: NSPoint) {
+        guard let page = view?._protectedPage().get() else {
+            return
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Moving insertion cursor to point \(point.debugDescription)...")
+    }
+
+    @objc(handleClickAtPoint:)
+    func handleClick(at point: NSPoint) {
+        guard let page = view?._protectedPage().get() else {
+            return
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Handling click at point \(point.debugDescription)...")
+
+        Task.immediate {
+            // Move the insertion point to the nearest word granularity boundary.
+
+            await page.selectWithGesture(
+                at: WebCore.IntPoint(point),
+                type: .OneFingerTap,
+                state: .Ended,
+                isInteractingWithFocusedElement: true, // FIXME: Properly handle the case where this isn't actually true.
+            )
+
+            Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Done handling click.")
+        }
+
+        // FIXME: If the click was near where the selection was, and the selection did not change, show context menu.
+    }
+
+    @objc(showContextMenuAtPoint:)
+    func showContextMenu(at point: NSPoint) {
+        guard let page = view?._protectedPage().get() else {
+            return
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Showing context menu at point \(point.debugDescription)...")
+    }
+
+    @objc(dragSelectionWithGesture:completionHandler:)
+    func dragSelection(withGesture gesture: NSGestureRecognizer, completionHandler: @escaping @Sendable (NSDraggingSession) -> Void) {
+    }
+
+    @objc(beginRangeSelectionAtPoint:withGranularity:)
+    func beginRangeSelection(at point: NSPoint, with granularity: NSTextSelection.Granularity) {
+    }
+
+    @objc(continueRangeSelectionAtPoint:)
+    func continueRangeSelection(at point: NSPoint) {
+    }
+
+    @objc(endRangeSelectionAtPoint:)
+    func endRangeSelection(at point: NSPoint) {
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -85,6 +85,7 @@ OBJC_CLASS WKRevealItemPresenter;
 OBJC_CLASS _WKWarningView;
 OBJC_CLASS WKShareSheet;
 OBJC_CLASS WKTextAnimationManager;
+OBJC_CLASS WKTextSelectionController;
 OBJC_CLASS WKViewLayoutStrategy;
 OBJC_CLASS WKWebView;
 OBJC_CLASS WKWindowVisibilityObserver;
@@ -836,6 +837,10 @@ public:
     void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&);
 #endif
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    void addTextSelectionManager();
+#endif
+
 private:
 #if HAVE(TOUCH_BAR)
     void setUpTextTouchBar(NSTouchBar *);
@@ -1130,7 +1135,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     bool m_inlinePredictionsEnabled { false };
 #endif
 
+    // FIXME: Perhaps merge these types at some point?
+#if HAVE(APPKIT_GESTURES_SUPPORT)
     RetainPtr<WKAppKitGestureController> m_appKitGestureController;
+    RetainPtr<WKTextSelectionController> m_textSelectionController;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -76,6 +76,7 @@
 #import "WKRevealItemPresenter.h"
 #import "WKTextAnimationManagerMac.h"
 #import "WKTextPlaceholder.h"
+#import "WKTextSelectionController.h"
 #import "WKViewLayoutStrategy.h"
 #import "WKWebViewMac.h"
 #import "WebBackForwardList.h"
@@ -1400,7 +1401,10 @@ WebViewImpl::WebViewImpl(WKWebView *view, WebProcessPool& processPool, Ref<API::
             checkedImpl->pageScrollingHysteresisFired(state);
     }, viewStateHysteresis);
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
     m_appKitGestureController = adoptNS([[WKAppKitGestureController alloc] initWithPage:m_page viewImpl:*this]);
+    m_textSelectionController = adoptNS([[WKTextSelectionController alloc] initWithView:view]);
+#endif
 
     WebProcessPool::statistics().wkViewCount++;
 }
@@ -3616,8 +3620,10 @@ void WebViewImpl::preferencesDidChange()
 {
     updateNeedsViewFrameInWindowCoordinatesIfNeeded();
 
+#if HAVE(APPKIT_GESTURES_SUPPORT)
     if (RetainPtr appKitGestureController = m_appKitGestureController)
         [appKitGestureController enableGesturesIfNeeded];
+#endif
 }
 
 CALayer* WebViewImpl::textIndicatorInstallationLayer()
@@ -7397,6 +7403,13 @@ void WebViewImpl::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier
     completionHandler({ });
 }
 #endif
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+void WebViewImpl::addTextSelectionManager()
+{
+    [m_textSelectionController addTextSelectionManager];
+}
+#endif // HAVE(APPKIT_GESTURES_SUPPORT)
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -141,6 +141,10 @@
 		029D6BB42C407AA30068CF99 /* JSWebExtensionAPISidePanel.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D6BAF2C407AA30068CF99 /* JSWebExtensionAPISidePanel.h */; };
 		0701789E23BE9CFC005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0701789B23BAE261005F0FAA /* RemoteMediaPlayerMIMETypeCache.cpp */; };
 		071467782DFE84E500F77867 /* WebPage+Transferable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 071467772DFE84E500F77867 /* WebPage+Transferable.swift */; };
+		07152D072F2F037D00B56C0E /* WKTextSelectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07152D062F2F037D00B56C0E /* WKTextSelectionController.swift */; };
+		07152D092F2F038A00B56C0E /* WKTextSelectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 07152D082F2F038A00B56C0E /* WKTextSelectionController.h */; };
+		0715310D2F3036F400B56C0E /* Logger+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0715310C2F3036F400B56C0E /* Logger+Extras.swift */; };
+		0715310F2F3037C100B56C0E /* WebPageProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0715310E2F3037C100B56C0E /* WebPageProxy.swift */; };
 		07187E0B2F2DC28E005FC058 /* GestureTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 07187E092F2DC276005FC058 /* GestureTypes.h */; };
 		071BC59023CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 071BC58D23CE1EAA00680D7C /* RemoteMediaPlayerProxyMessages.h */; };
 		07275C612D00CD24002315A5 /* CrossImportOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07275C602D00CD24002315A5 /* CrossImportOverlay.swift */; };
@@ -3310,6 +3314,10 @@
 		0701789C23BAE262005F0FAA /* RemoteMediaPlayerMIMETypeCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerMIMETypeCache.h; sourceTree = "<group>"; };
 		070259BE2522841C00153405 /* UserMediaPermissionRequestManagerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UserMediaPermissionRequestManagerProxy.mm; sourceTree = "<group>"; };
 		071467772DFE84E500F77867 /* WebPage+Transferable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Transferable.swift"; sourceTree = "<group>"; };
+		07152D062F2F037D00B56C0E /* WKTextSelectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKTextSelectionController.swift; sourceTree = "<group>"; };
+		07152D082F2F038A00B56C0E /* WKTextSelectionController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextSelectionController.h; sourceTree = "<group>"; };
+		0715310C2F3036F400B56C0E /* Logger+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+Extras.swift"; sourceTree = "<group>"; };
+		0715310E2F3037C100B56C0E /* WebPageProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageProxy.swift; sourceTree = "<group>"; };
 		07187E092F2DC276005FC058 /* GestureTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GestureTypes.h; sourceTree = "<group>"; };
 		07187E0A2F2DC284005FC058 /* GestureTypes.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = GestureTypes.serialization.in; sourceTree = "<group>"; };
 		071BC57723C93BB700680D7C /* AudioTrackPrivateRemote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AudioTrackPrivateRemote.h; sourceTree = "<group>"; };
@@ -12779,6 +12787,7 @@
 				7CEFA9601AC0999300B910FD /* APIContentRuleListStoreCocoa.mm */,
 				FAB751D12BACB65D00AC26DB /* APIPageConfigurationCocoa.mm */,
 				1AFDE64319510B5500C48FFA /* LegacyBundleForClass.mm */,
+				0715310C2F3036F400B56C0E /* Logger+Extras.swift */,
 				1C20935E22318CB000026A39 /* NSAttributedString.h */,
 				1C20935F22318CB000026A39 /* NSAttributedString.mm */,
 				1C2184012233872800BAC700 /* NSAttributedStringPrivate.h */,
@@ -15582,6 +15591,7 @@
 				BC111B0B112F5E4F00337BAB /* WebPageProxy.cpp */,
 				BC032DCB10F4389F0058C15A /* WebPageProxy.h */,
 				BCBD38FA125BAB9A00D2C29F /* WebPageProxy.messages.in */,
+				0715310E2F3037C100B56C0E /* WebPageProxy.swift */,
 				46C392282316EC4D008EED9B /* WebPageProxyIdentifier.h */,
 				939EF86D29D0C16400F23AEE /* WebPageProxyInternals.h */,
 				5CEB40A32A535E8E00563C91 /* WebPageProxyMessageReceiverRegistration.cpp */,
@@ -16406,6 +16416,8 @@
 				440C0BE22BBCA9E00086046E /* WKTextAnimationManagerMac.mm */,
 				2DD67A331BD861060053B251 /* WKTextFinderClient.h */,
 				2DD67A341BD861060053B251 /* WKTextFinderClient.mm */,
+				07152D082F2F038A00B56C0E /* WKTextSelectionController.h */,
+				07152D062F2F037D00B56C0E /* WKTextSelectionController.swift */,
 				2D28A4951AF965A100F190C9 /* WKViewLayoutStrategy.h */,
 				2D28A4961AF965A100F190C9 /* WKViewLayoutStrategy.mm */,
 			);
@@ -19236,6 +19248,7 @@
 				F4D5F51D206087A10038BBA8 /* WKTextInputListViewController.h in Headers */,
 				F4C359532AF19BC40083B0EA /* WKTextInteractionWrapper.h in Headers */,
 				CE21215F240EE571006ED443 /* WKTextPlaceholder.h in Headers */,
+				07152D092F2F038A00B56C0E /* WKTextSelectionController.h in Headers */,
 				CE45945C240F88550078019F /* WKTextSelectionRect.h in Headers */,
 				2EB6FC01203021960017E619 /* WKTimePickerViewController.h in Headers */,
 				71A676A622C62325007D6295 /* WKTouchActionGestureRecognizer.h in Headers */,
@@ -21600,6 +21613,7 @@
 				C1710CF724AA643200D7C112 /* LaunchServicesDatabaseObserver.mm in Sources */,
 				41A0EB142641714900794471 /* LibWebRTCCodecsProxy.mm in Sources */,
 				449D90DA21FDC30B00F677C0 /* LocalAuthenticationSoftLink.mm in Sources */,
+				0715310D2F3036F400B56C0E /* Logger+Extras.swift in Sources */,
 				E326F4DC2CA6C44F00182187 /* LogStream.mm in Sources */,
 				9B4790912531563200EC11AB /* MessageArgumentDescriptions.cpp in Sources */,
 				EBA8D3B627A5E33F00CB7900 /* MockPushServiceConnection.mm in Sources */,
@@ -21946,6 +21960,7 @@
 				078B04A02CF18EAB00B453A6 /* WebPage+NavigationPreferences.swift in Sources */,
 				071467782DFE84E500F77867 /* WebPage+Transferable.swift in Sources */,
 				07CB79962CE9435700199C49 /* WebPage.swift in Sources */,
+				0715310F2F3037C100B56C0E /* WebPageProxy.swift in Sources */,
 				7CE9CE101FA0767A000177DE /* WebPageUpdatePreferences.cpp in Sources */,
 				079A4DA12D72CC0D00CA387F /* WebPageWebView.swift in Sources */,
 				7CEB00DD1FA69ABE0065473B /* WebPreferencesFeatures.cpp in Sources */,
@@ -21982,6 +21997,7 @@
 				B68905162EF46B0A009187D8 /* WKSeparatedImageViewConstants.swift in Sources */,
 				1DB01944211CF005009FB3E8 /* WKShareSheet.mm in Sources */,
 				7A78FF332241919B0096483E /* WKStorageAccessAlert.mm in Sources */,
+				07152D072F2F037D00B56C0E /* WKTextSelectionController.swift in Sources */,
 				076897F02D07B330006F9FA7 /* WKUIDelegateAdapter.swift in Sources */,
 				079A4DB02D73EA4A00CA387F /* WKURLSchemeHandlerAdapter.swift in Sources */,
 				079A4DA52D72CE3F00CA387F /* WKWebpagePreferences+Extras.swift in Sources */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -507,6 +507,16 @@ void WebEditorClient::subFrameScrollPositionChanged()
 
 #endif
 
+#if PLATFORM(COCOA)
+
+bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
+{
+    RefPtr page = m_page.get();
+    return page ? page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection) : false;
+}
+
+#endif // PLATFORM(COCOA)
+
 static bool getActionTypeForKeyEvent(KeyboardEvent* event, WKInputFieldActionType& type)
 {
     String key = event->keyIdentifier();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -192,6 +192,10 @@ private:
     void didDispatchInputMethodKeydown(WebCore::KeyboardEvent&) final;
 #endif
 
+#if PLATFORM(COCOA)
+    bool shouldAllowSingleClickToChangeSelection(WebCore::Node&, const WebCore::VisibleSelection&) const final;
+#endif
+
 #if PLATFORM(IOS_FAMILY)
     void startDelayingAndCoalescingContentChangeNotifications() final;
     void stopDelayingAndCoalescingContentChangeNotifications() final;
@@ -200,7 +204,6 @@ private:
     RefPtr<WebCore::DocumentFragment> documentFragmentFromDelegate(int index) final;
     bool performsTwoStepPaste(WebCore::DocumentFragment*) final;
     void updateStringForFind(const String&) final;
-    bool shouldAllowSingleClickToChangeSelection(WebCore::Node&, const WebCore::VisibleSelection&) const final;
     bool shouldRevealCurrentSelectionAfterInsertion() const final;
     bool shouldSuppressPasswordEcho() const final;
     bool shouldRemoveDictationAlternativesAfterEditing() const final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm
@@ -106,12 +106,6 @@ void WebEditorClient::subFrameScrollPositionChanged()
         page->didScrollSelection();
 }
 
-bool WebEditorClient::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection) const
-{
-    RefPtr page = m_page.get();
-    return page ? page->shouldAllowSingleClickToChangeSelection(targetNode, newSelection) : false;
-}
-
 bool WebEditorClient::shouldRevealCurrentSelectionAfterInsertion() const
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2116,6 +2116,30 @@ bool WebPage::isSpeaking() const
     return result;
 }
 
+bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection)
+{
+#if !PLATFORM(MAC) || HAVE(APPKIT_GESTURES_SUPPORT)
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    if (!m_page->settings().useAppKitGestures())
+        return true;
+#endif
+
+    if (RefPtr editableRoot = newSelection.rootEditableElement(); editableRoot && editableRoot == targetNode.rootEditableElement()) {
+        // FIXME: This logic should be made consistent for both macOS and iOS.
+#if PLATFORM(MAC)
+        return false;
+#else
+        // Text interaction gestures will handle selection in the case where we are already editing the node. In the case where we're
+        // just starting to focus an editable element by tapping on it, only change the selection if we weren't already showing an
+        // input view prior to handling the tap.
+        return !(m_completingSyntheticClick ? m_wasShowingInputViewForFocusedElementDuringLastPotentialTap : m_isShowingInputViewForFocusedElement);
+#endif
+    }
+#endif // !PLATFORM(MAC) || HAVE(APPKIT_GESTURES_SUPPORT)
+
+    return true;
+}
+
 void WebPage::selectWithGesture(const IntPoint& point, GestureType gestureType, GestureRecognizerState gestureState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&& completionHandler)
 {
     if (gestureState == GestureRecognizerState::Began)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1057,10 +1057,11 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
+    bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection);
     void selectWithGesture(const WebCore::IntPoint&, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
     void updateFocusBeforeSelectingTextAtLocation(const WebCore::IntPoint&);
     WebCore::VisiblePosition visiblePositionInFocusedNodeForPoint(const WebCore::LocalFrame&, const WebCore::IntPoint&, bool isInteractingWithFocusedElement);
-#endif
+#endif // PLATFORM(COCOA)
 
 #if PLATFORM(IOS_FAMILY)
     void textInputContextsInRect(WebCore::FloatRect, CompletionHandler<void(const Vector<WebCore::ElementContext>&)>&&);
@@ -1173,7 +1174,6 @@ public:
 
     void updateSelectionWithDelta(int64_t locationDelta, int64_t lengthDelta, CompletionHandler<void()>&&);
     void requestDocumentEditingContext(WebKit::DocumentEditingContextRequest&&, CompletionHandler<void(WebKit::DocumentEditingContext&&)>&&);
-    bool shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection);
     bool shouldDrawVisuallyContiguousBidiSelection() const;
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5871,17 +5871,6 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
     completionHandler(WTF::move(context));
 }
 
-bool WebPage::shouldAllowSingleClickToChangeSelection(WebCore::Node& targetNode, const WebCore::VisibleSelection& newSelection)
-{
-    if (RefPtr editableRoot = newSelection.rootEditableElement(); editableRoot && editableRoot == targetNode.rootEditableElement()) {
-        // Text interaction gestures will handle selection in the case where we are already editing the node. In the case where we're
-        // just starting to focus an editable element by tapping on it, only change the selection if we weren't already showing an
-        // input view prior to handling the tap.
-        return !(m_completingSyntheticClick ? m_wasShowingInputViewForFocusedElementDuringLastPotentialTap : m_isShowingInputViewForFocusedElement);
-    }
-    return true;
-}
-
 void WebPage::setShouldRevealCurrentSelectionAfterInsertion(bool shouldRevealCurrentSelectionAfterInsertion)
 {
     if (m_shouldRevealCurrentSelectionAfterInsertion == shouldRevealCurrentSelectionAfterInsertion)


### PR DESCRIPTION
#### 94da893ecfe885a3fc90692899e1b0efa2db8a55
<pre>
Re-Re-land [AppKit Gestures] Add initial support for handling clicks during text selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=307076">https://bugs.webkit.org/show_bug.cgi?id=307076</a>
<a href="https://rdar.apple.com/169715675">rdar://169715675</a>

Unreviewed re-land of 306753@main

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/Shared/API/APIObject.h:
* Source/WebKit/Shared/ios/WebAutocorrectionData.h:
* Source/WebKit/UIProcess/API/Cocoa/Logger+Extras.swift: Added.
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/WebPageProxy.swift: Added.
(WebKit.editorStateCopy):
(WebKit.editorState):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
* Source/WebKit/UIProcess/mac/WKTextSelectionController.h: Copied from Source/WebKit/UIProcess/mac/WKAppKitGestureController.h.
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift: Added.
(WKTextSelectionController.addTextSelectionManager):
(WKTextSelectionController.isTextSelected(at:)):
(WKTextSelectionController.moveInsertionCursor(to:)):
(WKTextSelectionController.handleClick(at:)):
(WKTextSelectionController.showContextMenu(at:)):
(WKTextSelectionController.dragSelection(withGesture:completionHandler:)):
(WKTextSelectionController.beginRangeSelection(at:with:)):
(WKTextSelectionController.continueRangeSelection(at:)):
(WKTextSelectionController.endRangeSelection(at:)):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::preferencesDidChange):
(WebKit::WebViewImpl::addTextSelectionManager):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::shouldAllowSingleClickToChangeSelection const):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/ios/WebEditorClientIOS.mm:
(WebKit::WebEditorClient::shouldAllowSingleClickToChangeSelection const): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::shouldAllowSingleClickToChangeSelection):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::shouldAllowSingleClickToChangeSelection): Deleted.

Canonical link: <a href="https://commits.webkit.org/306904@main">https://commits.webkit.org/306904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70596e1de84f8b941ad5ffd06aad00d4db914ded

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151321 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74cf274f-4d12-4aae-9464-f0d3868e0a87) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d429d8a-a94e-4098-82a2-1ebae3c49296) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90622 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/423b37c4-9cd0-4e24-8ded-934c4b30070f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11688 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9366 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1325 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121057 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153639 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117731 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118062 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14076 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70447 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14793 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3901 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14528 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78502 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14736 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->