### PR TITLE
Use SIMD in TextCodecUTF8.cpp

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -27,6 +27,7 @@
 #include "TextCodecUTF8.h"
 
 #include "TextCodecASCIIFastPath.h"
+#include <wtf/SIMDHelpers.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>
@@ -334,6 +335,20 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
         while (!source.empty()) {
             if (isASCII(source[0])) {
                 // Fast path for ASCII. Most UTF-8 text will be ASCII.
+                constexpr size_t simdStride = SIMD::stride<uint8_t>;
+                constexpr auto asciiHighBitMask = SIMD::splat<uint8_t>(0x80);
+                while (source.size() >= simdStride && destination.size() >= simdStride) {
+                    auto chunk = SIMD::load(source.data());
+                    if (SIMD::isNonZero(SIMD::bitAnd2(chunk, asciiHighBitMask)))
+                        break;
+                    SIMD::store(chunk, reinterpret_cast<uint8_t*>(destination.data()));
+                    skip(source, simdStride);
+                    skip(destination, simdStride);
+                }
+                if (source.empty())
+                    break;
+                if (!isASCII(source[0]))
+                    continue;
                 if (WTF::isAlignedToMachineWord(source.data())) {
                     while (source.data() < alignedEnd) {
                         auto chunk = reinterpretCastSpanStartTo<const WTF::MachineWord>(source);
@@ -419,6 +434,25 @@ upConvertTo16Bit:
         while (!source.empty()) {
             if (isASCII(source[0])) {
                 // Fast path for ASCII. Most UTF-8 text will be ASCII.
+                constexpr size_t simdStride = SIMD::stride<uint8_t>;
+                constexpr auto asciiHighBitMask = SIMD::splat<uint8_t>(0x80);
+                while (source.size() >= simdStride && destination16.size() >= simdStride) {
+                    auto chunk = SIMD::load(source.data());
+                    if (SIMD::isNonZero(SIMD::bitAnd2(chunk, asciiHighBitMask)))
+                        break;
+                    auto low8 = simde_vget_low_u8(chunk);
+                    auto high8 = simde_vget_high_u8(chunk);
+                    auto low16 = simde_vmovl_u8(low8);
+                    auto high16 = simde_vmovl_u8(high8);
+                    simde_vst1q_u16(reinterpret_cast<uint16_t*>(destination16.data()), low16);
+                    simde_vst1q_u16(reinterpret_cast<uint16_t*>(destination16.subspan(8).data()), high16);
+                    skip(source, simdStride);
+                    skip(destination16, simdStride);
+                }
+                if (source.empty())
+                    break;
+                if (!isASCII(source[0]))
+                    continue;
                 if (WTF::isAlignedToMachineWord(source.data())) {
                     while (source.data() < alignedEnd) {
                         auto chunk = reinterpretCastSpanStartTo<const WTF::MachineWord>(source);


### PR DESCRIPTION
#### 011eb8ac1e626bca1567c34f0c9af9c732c76e7f
<pre>
Use SIMD in TextCodecUTF8.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=307078">https://bugs.webkit.org/show_bug.cgi?id=307078</a>
<a href="https://rdar.apple.com/169717226">rdar://169717226</a>

Reviewed by NOBODY (OOPS!).

Add SIMD-accelerated ASCII detection and processing for both
Latin1 and UTF-16 output paths, processing 16 bytes per iteration
instead of scalar byte-by-byte conversion. This should be a small
progression in PLT7.

There is no change in behavior so correctness will be ensured
using existing tests.

* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::decode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/011eb8ac1e626bca1567c34f0c9af9c732c76e7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151332 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95847 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109721 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95847 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9367 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153645 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118068 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14081 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124952 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70453 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14799 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78508 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->