### PR TITLE
Use ancestor filter to optimize querySelector for descendant selectors

### DIFF
--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -36,6 +36,7 @@
 #include "HTMLNames.h"
 #include "SVGElement.h"
 #include "SelectorChecker.h"
+#include "SelectorMatchingState.h"
 #include "StaticNodeList.h"
 #include "StyledElement.h"
 #include "TreeScopeInlines.h"
@@ -484,6 +485,59 @@ ALWAYS_INLINE void SelectorDataList::executeSingleSelectorData(const ContainerNo
 }
 
 template<typename OutputType>
+ALWAYS_INLINE void SelectorDataList::executeSingleSelectorDataWithAncestorFilter(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData& selectorData, OutputType& output) const
+{
+    ASSERT(m_selectors.size() == 1);
+
+    // Skip ancestor filter optimization for disconnected trees
+    if (!searchRootNode.isConnected()) {
+        executeSingleSelectorData(rootNode, searchRootNode, selectorData, output);
+        return;
+    }
+
+    if (!m_ancestorHashes[0])
+        m_ancestorHashes = SelectorFilter::collectHashes(selectorData.selector);
+
+    if (!m_ancestorHashes[0]) {
+        executeSingleSelectorData(rootNode, searchRootNode, selectorData, output);
+        return;
+    }
+
+    Style::SelectorMatchingState selectorMatchingState;
+
+    if (RefPtr parentElement = searchRootNode.parentElement())
+        selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(*parentElement);
+    Vector<Element*, 20> parentStack;
+    RefPtr previousElement = dynamicDowncast<Element>(searchRootNode);
+
+    for (auto it = descendantsOfType<Element>(const_cast<ContainerNode&>(searchRootNode)).begin(); it; it.traverseNext()) {
+        Ref descendant = *it;
+        RefPtr parent = descendant->parentElement();
+        if (parent && (parentStack.isEmpty() || parentStack.last() != parent.get())) {
+            if (parent.get() == previousElement.get()) {
+                parentStack.append(parent.get());
+                selectorMatchingState.selectorFilter.pushParentInitializingIfNeeded(*parent);
+            } else {
+                while (!parentStack.isEmpty() && parentStack.last() != parent.get()) {
+                    parentStack.removeLast();
+                    selectorMatchingState.selectorFilter.popParent();
+                }
+            }
+        }
+
+        previousElement = descendant.ptr();
+        if (selectorMatchingState.selectorFilter.fastRejectSelector(m_ancestorHashes))
+            continue;
+
+        if (selectorMatches(selectorData, descendant, rootNode, &selectorMatchingState)) {
+            appendOutputForElement(output, descendant);
+            if constexpr (std::is_same_v<OutputType, Element*>)
+                return;
+        }
+    }
+}
+
+template<typename OutputType>
 ALWAYS_INLINE void SelectorDataList::executeSingleMultiSelectorData(const ContainerNode& rootNode, OutputType& output) const
 {
     Style::SelectorMatchingState selectorMatchingState;
@@ -653,7 +707,7 @@ ALWAYS_INLINE void SelectorDataList::execute(ContainerNode& rootNode, OutputType
         [[fallthrough]];
     case SingleSelector:
         SingleSelectorCase:
-        executeSingleSelectorData(rootNode, *searchRootNode, m_selectors.first(), output);
+        executeSingleSelectorDataWithAncestorFilter(rootNode, *searchRootNode, m_selectors.first(), output);
         break;
 
     case TagNameMatch:

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -30,6 +30,7 @@
 #include "NodeList.h"
 #include "SecurityOriginData.h"
 #include "SelectorCompiler.h"
+#include "SelectorFilter.h"
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
@@ -74,6 +75,7 @@ private:
     template <typename OutputType> void executeSingleClassNameSelectorData(const ContainerNode& rootNode, const SelectorData&, OutputType&) const;
     template <typename OutputType> void executeSingleAttributeExactSelectorData(const ContainerNode& rootNode, const SelectorData&, OutputType&) const;
     template <typename OutputType> void executeSingleSelectorData(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData&, OutputType&) const;
+    template <typename OutputType> void executeSingleSelectorDataWithAncestorFilter(const ContainerNode& rootNode, const ContainerNode& searchRootNode, const SelectorData&, OutputType&) const;
     template <typename OutputType> void executeSingleMultiSelectorData(const ContainerNode& rootNode, OutputType&) const;
 #if ENABLE(CSS_SELECTOR_JIT)
     template <typename Checker, typename OutputType> void executeCompiledSimpleSelectorChecker(const ContainerNode& searchRootNode, Checker, OutputType&, const SelectorData&) const;
@@ -98,6 +100,7 @@ private:
         AttributeExactMatch,
         MultipleSelectorMatch,
     } m_matchType;
+    mutable SelectorFilter::Hashes m_ancestorHashes { };
 };
 
 class SelectorQuery {


### PR DESCRIPTION
#### 4bee47c589adafa07a4bd8d2b700f3a05f9952dc
<pre>
Use ancestor filter to optimize querySelector for descendant selectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=307082">https://bugs.webkit.org/show_bug.cgi?id=307082</a>
<a href="https://rdar.apple.com/169719780">rdar://169719780</a>

Reviewed by NOBODY (OOPS!).

For selectors with descendant/child combinators we can use
the existing SelectorFilter bloom filter to fast-reject elements
whose ancestors don&apos;t contain the required classes/ids/tags.

This avoids full selector matching for elements that can&apos;t
possibly match based on their ancestor chain.

* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorDataList::executeSingleSelectorDataWithAncestorFilter const):
(WebCore::SelectorDataList::execute const):
* Source/WebCore/dom/SelectorQuery.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bee47c589adafa07a4bd8d2b700f3a05f9952dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151476 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109817 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79143 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90726 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9455 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1475 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153789 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14900 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117832 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118165 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14156 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70597 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14943 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4005 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78652 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->