### PR TITLE
Use bit flag to identify whether Element has shadowRoot

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3295,6 +3295,7 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
             RenderTreeUpdater::tearDownRenderersForShadowRootInsertion(*this);
 
         ensureElementRareData().setShadowRoot(WTF::move(newShadowRoot));
+        setHasShadowRoot(true);
 
         shadowRoot->setHost(*this);
         shadowRoot->setParentTreeScope(treeScope());
@@ -3340,6 +3341,7 @@ void Element::removeShadowRootSlow(ShadowRoot& oldRoot)
     ASSERT(!oldRoot.renderer());
 
     elementRareData()->clearShadowRoot();
+    setHasShadowRoot(false);
 
     oldRoot.setHost(nullptr);
     oldRoot.setParentTreeScope(document());

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -370,14 +370,12 @@ inline ElementRareData* Element::elementRareData() const
 
 inline ShadowRoot* Node::shadowRoot() const
 {
-    if (auto* element = dynamicDowncast<Element>(*this))
-        return element->shadowRoot();
-    return nullptr;
+    return hasShadowRoot() ? downcast<Element>(*this).shadowRoot() : nullptr;
 }
 
 inline ShadowRoot* Element::shadowRoot() const
 {
-    return hasRareData() ? elementRareData()->shadowRoot() : nullptr;
+    return hasShadowRoot() ? elementRareData()->shadowRoot() : nullptr;
 }
 
 inline void Element::removeShadowRoot()

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -278,6 +278,9 @@ public:
     bool hasShadowRootContainingSlots() const { return hasEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots); }
     void setHasShadowRootContainingSlots(bool flag) { setEventTargetFlag(EventTargetFlag::HasShadowRootContainingSlots, flag); }
 
+    bool hasShadowRoot() const { return hasStateFlag(StateFlag::HasShadowRoot); }
+    void setHasShadowRoot(bool flag) { setStateFlag(StateFlag::HasShadowRoot, flag); }
+
     bool needsSVGRendererUpdate() const { return hasStateFlag(StateFlag::NeedsSVGRendererUpdate); }
     void setNeedsSVGRendererUpdate(bool flag) { setStateFlag(StateFlag::NeedsSVGRendererUpdate, flag); }
 
@@ -679,8 +682,9 @@ protected:
         IsShadowRootAttachedEventPending = 1 << 20,
         InLargestContentfulPaintTextContentSet = 1 << 21,
         DidMutateSubtreeAfterSetInnerHTML = 1 << 22,
-        WasParsedWithFastPath = 1 << 23
-        // 8 bits free.
+        WasParsedWithFastPath = 1 << 23,
+        HasShadowRoot = 1 << 24
+        // 7 bits free.
     };
 
     enum class TabIndexState : uint8_t {


### PR DESCRIPTION
#### 062b738e29f11571137df04410bc53a5fe5fc72b
<pre>
Use bit flag to identify whether Element has shadowRoot
<a href="https://bugs.webkit.org/show_bug.cgi?id=307083">https://bugs.webkit.org/show_bug.cgi?id=307083</a>
<a href="https://rdar.apple.com/169720290">rdar://169720290</a>

Reviewed by Ryosuke Niwa.

Add HasShadowRoot bit flag to optimize Element::shadowRoot()
by allowing fast-path early return when an element has no shadow
root, commonly avoiding ElementRareData access.

This change does not introduce any new behavior.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addShadowRoot):
(WebCore::Element::removeShadowRootSlow):
* Source/WebCore/dom/ElementRareData.h:
(WebCore::Node::shadowRoot const):
(WebCore::Element::shadowRoot const):
* Source/WebCore/dom/Node.h:
(WebCore::Node::hasShadowRoot const):
(WebCore::Node::setHasShadowRoot):

Canonical link: <a href="https://commits.webkit.org/306921@main">https://commits.webkit.org/306921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d7216c7944339d359f77fe1fc5a785cd3ee44c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151341 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95856 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109729 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95856 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90636 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9375 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1340 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14765 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4783 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117744 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30140 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14085 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70462 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14808 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3912 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14543 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78517 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->