### PR TITLE
[iOS] Focused element is not revealed if the focusRequiresStrongPasswordAssistance delegate takes too long

### DIFF
--- a/LayoutTests/fast/forms/ios/zoom-to-reveal-focused-element-after-delay-expected.txt
+++ b/LayoutTests/fast/forms/ios/zoom-to-reveal-focused-element-after-delay-expected.txt
@@ -1,0 +1,11 @@
+
+Verifies that we zoom and scroll to reveal the focused element; requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS pageYOffset > 0 became true
+PASS visualViewport.scale > 1 became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/zoom-to-reveal-focused-element-after-delay.html
+++ b/LayoutTests/fast/forms/ios/zoom-to-reveal-focused-element-after-delay.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <script src="../../../resources/js-test.js"></script>
+    <script src="../../../resources/ui-helper.js"></script>
+    <style>
+        input {
+            font-size: 12px;
+        }
+
+        .input-container {
+            margin: 80vh auto;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+
+        addEventListener("load", async () => {
+            description("Verifies that we zoom and scroll to reveal the focused element; requires WebKitTestRunner.");
+
+            const inputContainer = document.querySelector(".input-container");
+            const textField = document.querySelector("input");
+
+            await UIHelper.setHardwareKeyboardAttached(false);
+            await UIHelper.setShowKeyboardAfterElementFocusDelay(0.25);
+            await UIHelper.activateElementAndWaitForInputSession(textField);
+            await UIHelper.waitForZoomingOrScrollingToEnd();
+
+            await shouldBecomeEqual("pageYOffset > 0", "true");
+            await shouldBecomeEqual("visualViewport.scale > 1", "true");
+
+            textField.blur();
+            await UIHelper.waitForKeyboardToHide();
+            finishJSTest();
+        });
+    </script>
+</head>
+<body>
+    <div class="input-container">
+        <input type="text" placeholder="Focus me">
+    </div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1791,6 +1791,11 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => testRunner.runUIScript(`uiController.setHardwareKeyboardAttached(${attached ? "true" : "false"})`, resolve));
     }
 
+    static setShowKeyboardAfterElementFocusDelay(delay)
+    {
+        return new Promise(resolve => testRunner.runUIScript(`uiController.setShowKeyboardAfterElementFocusDelay(${delay})`, resolve));
+    }
+
     static setWebViewEditable(editable)
     {
         return new Promise(resolve => testRunner.runUIScript(`uiController.setWebViewEditable(${editable ? "true" : "false"})`, resolve));

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -423,6 +423,7 @@ interface UIScriptController {
     readonly attribute boolean isWebContentFirstResponder;
 
     undefined setHardwareKeyboardAttached(boolean attached);
+    undefined setShowKeyboardAfterElementFocusDelay(double delay);
 
     undefined setWebViewEditable(boolean editable);
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -286,6 +286,7 @@ public:
     virtual bool hasInputSession() const { notImplemented(); return false; }
 
     virtual void setHardwareKeyboardAttached(bool) { }
+    virtual void setShowKeyboardAfterElementFocusDelay(double) { }
 
     virtual void setKeyboardInputModeIdentifier(JSStringRef) { notImplemented(); }
     virtual void setFocusStartsInputSessionPolicy(JSStringRef) { notImplemented(); }

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h
@@ -74,6 +74,8 @@
 @property (nonatomic, readonly, getter=isInteractingWithFormControl) BOOL interactingWithFormControl;
 @property (nonatomic) _WKFocusStartsInputSessionPolicy focusStartsInputSessionPolicy;
 
+@property (nonatomic) NSTimeInterval showKeyboardAfterElementFocusDelay;
+
 @property (nonatomic, readonly) BOOL didCallEnsurePositionInformationIsUpToDateSinceLastCheck;
 - (void)clearEnsurePositionInformationIsUpToDateTracking;
 

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -34,6 +34,8 @@
 #import <wtf/Assertions.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/RunLoop.h>
+#import <wtf/Seconds.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
@@ -665,6 +667,17 @@ static bool isQuickboardViewController(UIViewController *viewController)
 - (_WKFocusStartsInputSessionPolicy)_webView:(WKWebView *)webView decidePolicyForFocusedElement:(id<_WKFocusedElementInfo>)info
 {
     return self.focusStartsInputSessionPolicy;
+}
+
+- (void)_webView:(WKWebView *)webView focusRequiresStrongPasswordAssistance:(id<_WKFocusedElementInfo>)info completionHandler:(void(^)(BOOL))completionHandler
+{
+    auto delay = Seconds { self.showKeyboardAfterElementFocusDelay };
+    if (!delay)
+        return completionHandler(NO);
+
+    RunLoop::mainSingleton().dispatchAfter(delay, [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler(NO);
+    });
 }
 
 #pragma mark - UIGestureRecognizerDelegate

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -393,6 +393,7 @@ bool TestController::platformResetStateToConsistentValues(const TestOptions& opt
         webView.suppressInputAccessoryView = options.suppressInputAccessoryView();
         webView.scrollView.showsVerticalScrollIndicator = options.showsScrollIndicators();
         webView.scrollView.showsHorizontalScrollIndicator = options.showsScrollIndicators();
+        webView.showKeyboardAfterElementFocusDelay = 0;
 
 #if HAVE(UIFINDINTERACTION)
         webView.findInteractionEnabled = options.findInteractionEnabled();

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -158,6 +158,7 @@ private:
     UIView *platformContentView() const override;
     JSObjectRef calendarType() const override;
     void setHardwareKeyboardAttached(bool) override;
+    void setShowKeyboardAfterElementFocusDelay(double) override;
     void setAllowsViewportShrinkToFit(bool) override;
     void copyText(JSStringRef) override;
     void installTapGestureOnWindow(JSValueRef) override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1567,6 +1567,11 @@ void UIScriptControllerIOS::setHardwareKeyboardAttached(bool attached)
     TestController::singleton().setIsInHardwareKeyboardMode(attached);
 }
 
+void UIScriptControllerIOS::setShowKeyboardAfterElementFocusDelay(double delay)
+{
+    webView().showKeyboardAfterElementFocusDelay = delay;
+}
+
 void UIScriptControllerIOS::setAllowsViewportShrinkToFit(bool allows)
 {
     webView()._allowsViewportShrinkToFit = allows;


### PR DESCRIPTION
#### f716dbb1d140cb25e91af82f263a1e61ea5d6b21
<pre>
[iOS] Focused element is not revealed if the focusRequiresStrongPasswordAssistance delegate takes too long
<a href="https://bugs.webkit.org/show_bug.cgi?id=307081">https://bugs.webkit.org/show_bug.cgi?id=307081</a>
<a href="https://rdar.apple.com/169666776">rdar://169666776</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

In the case where the WebKit client defers the call to `-_continueElementDidFocus:` via the input
delegate method `-_webView:focusRequiresStrongPasswordAssistance:completionHandler:` until after
the first editor state update after element focus arrives in the UI process, we end up never calling
`-_zoomToRevealFocusedElement` (which is responsible for zooming and centering the newly focused
element). The sequence of events is:

1. Element did focus is called.
2. Editor state arrives.
3. Element did focus continues (after the client invokes the completion handler).

...which means `m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement` is stuck at `true`
after step (3). To fix this, we set `m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement`
*before* calling into the delegate, and then defer until the next `EditorState` update upon step (3)
only if the editor state update hasn&apos;t arrived yet; otherwise, we just zoom to the focused element
immediately, after showing the keyboard.

Test: fast/forms/ios/zoom-to-reveal-focused-element-after-delay.html

* LayoutTests/fast/forms/ios/zoom-to-reveal-focused-element-after-delay-expected.txt: Added.
* LayoutTests/fast/forms/ios/zoom-to-reveal-focused-element-after-delay.html: Added.

Add a test to simulate the race condition above by forcing a hard-coded 250 ms delay in the input
delegate method.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.setShowKeyboardAfterElementFocusDelay):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _elementDidFocus:userIsInteracting:blurPreviousNode:activityStateChanges:userObject:]):
(-[WKContentView _continueElementDidFocus:requiresStrongPasswordAssistance:focusedElementInfo:activityStateChanges:restoreValues:]):

Implement the main fix here — see above for more details.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::setShowKeyboardAfterElementFocusDelay):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.h:
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView _webView:focusRequiresStrongPasswordAssistance:completionHandler:]):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformResetStateToConsistentValues):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::setShowKeyboardAfterElementFocusDelay):

Add test runner infrastructure to set a hard-coded delay before allowing element focus to continue.

Canonical link: <a href="https://commits.webkit.org/306897@main">https://commits.webkit.org/306897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ed8d246f1b96a3046de8900fcd3596d61f9a499

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151343 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94b39667-1de7-41c5-8e73-fbfaaa57c92a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109727 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d002040d-489a-4995-9bf5-d66e1bc2e886) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90634 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0faf65c-3ff7-42eb-b02d-cd42c82d4fda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11695 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9374 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1342 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153656 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14767 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4785 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117740 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118071 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30119 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14088 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124958 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14810 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3914 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78519 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->