### PR TITLE
Support enabling Enhanced Security for specific URLs

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2674,6 +2674,25 @@ EnhancedSecurityHeuristicsEnabled:
       "PLATFORM(COCOA)": true
       default: false
 
+EnhancedSecurityLinksEnabled:
+  type: bool
+  status: stable
+  category: security
+  condition: HAVE(ENHANCED_SECURITY_LINKS)
+  defaultsOverridable: true
+  humanReadableName: "Enhanced Security for links"
+  humanReadableDescription: "Enables additional Enhanced Security support for certain links"
+  defaultValue:
+    WebKitLegacy:
+      "PLATFORM(COCOA)": true
+      default: false
+    WebKit:
+      "PLATFORM(COCOA)": true
+      default: false
+    WebCore:
+      "PLATFORM(COCOA)": true
+      default: false
+
 EnterKeyHintEnabled:
   type: bool
   status: internal

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -326,6 +326,11 @@ public:
     bool privateClickMeasurementEnabled() const;
     void setPrivateClickMeasurementDebugMode(PAL::SessionID, bool);
 
+#if HAVE(ENHANCED_SECURITY_LINKS)
+    void setIsEnhancedSecurityLinksEnabled(bool);
+    bool isEnhancedSecurityLinksEnabled() const;
+#endif
+
     void setShouldSendPrivateTokenIPCForTesting(PAL::SessionID, bool) const;
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES)
     void setOptInCookiePartitioningEnabled(PAL::SessionID, bool) const;
@@ -482,6 +487,10 @@ public:
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     void allowEvaluatedURL(const WebCore::ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
+#endif
+
+#if HAVE(ENHANCED_SECURITY_LINKS)
+    void isEnhancedSecurityLink(const URL&, CompletionHandler<void(bool)>&&);
 #endif
 
 private:
@@ -665,6 +674,9 @@ private:
     bool m_isParentProcessFullWebBrowserOrRunningTest { false };
 #endif
     bool m_enableModernDownloadProgress { false };
+#if HAVE(ENHANCED_SECURITY_LINKS)
+    bool m_isEnhancedSecurityLinksEnabled { false };
+#endif
 
     struct DeleteWebsiteDataTask {
         std::optional<PAL::SessionID> sessionID;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -295,4 +295,8 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if HAVE(WEBCONTENTRESTRICTIONS)
     AllowEvaluatedURL(struct WebCore::ParentalControlsURLFilterParameters parameters) -> (bool allowed)
 #endif
+
+#if HAVE(ENHANCED_SECURITY_LINKS)
+    IsEnhancedSecurityLink(URL url) -> (bool isEnhancedSecurityLink)
+#endif
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h
@@ -79,6 +79,9 @@ struct NetworkProcessCreationParameters {
 #if PLATFORM(COCOA)
     bool enableModernDownloadProgress { false };
 #endif
+#if HAVE(ENHANCED_SECURITY_LINKS)
+    bool enableEnhancedSecurityLinks { false };
+#endif
     Vector<WebsiteDataStoreParameters> websiteDataStoreParameters;
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;
     HashMap<WebCore::ProcessIdentifier, Vector<String>> allowedFilePaths;

--- a/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in
@@ -56,6 +56,9 @@ headers: "NetworkProcessCreationParameters.h" "AuxiliaryProcessCreationParameter
 #if PLATFORM(COCOA)
     bool enableModernDownloadProgress
 #endif
+#if HAVE(ENHANCED_SECURITY_LINKS)
+    bool enableEnhancedSecurityLinks
+#endif
 
     Vector<WebKit::WebsiteDataStoreParameters> websiteDataStoreParameters
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> allowedFirstPartiesForCookies;

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -888,3 +888,7 @@
 (allow mach-lookup
     (global-name "com.apple.familycontrols"))
 #endif
+
+#if HAVE(ENHANCED_SECURITY_LINKS) && __has_include(<WebKitAdditions/EnhancedSecurityLinks-macos.sb>)
+#include <WebKitAdditions/EnhancedSecurityLinks-macos.sb>
+#endif

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in
@@ -177,3 +177,7 @@
     (require-all
         (extension-class "com.apple.app-sandbox.read" "com.apple.app-sandbox.read-write")
         (extension "com.apple.app-sandbox.read-write")))
+
+#if HAVE(ENHANCED_SECURITY_LINKS) && __has_include(<WebKitAdditions/EnhancedSecurityLinks-ios.sb>)
+#include <WebKitAdditions/EnhancedSecurityLinks-ios.sb>
+#endif

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -307,3 +307,7 @@
     (require-all
         (extension-class "com.apple.app-sandbox.read" "com.apple.app-sandbox.read-write")
         (extension "com.apple.app-sandbox.read-write")))
+
+#if HAVE(ENHANCED_SECURITY_LINKS) && __has_include(<WebKitAdditions/EnhancedSecurityLinks-ios.sb>)
+#include <WebKitAdditions/EnhancedSecurityLinks-ios.sb>
+#endif

--- a/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h
+++ b/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,18 @@
 
 #pragma once
 
-#include <WebCore/RegistrableDomain.h>
+#include <wtf/Forward.h>
+
+#if HAVE(ENHANCED_SECURITY_LINKS)
+
+namespace WTF {
+class URL;
+}
 
 namespace WebKit {
 
-enum class EnhancedSecurity : uint8_t { Disabled, EnabledInsecure, EnabledLinkSecurity, EnabledPolicy };
-enum class EnhancedSecurityReason : uint8_t { None, InsecureProvisional, InsecureLoad, LinkSecurity, Policy };
+void isEnhancedSecurityEnabledForURL(const WTF::URL&, CompletionHandler<void(bool)>&&);
 
-ALWAYS_INLINE bool isEnhancedSecurityEnabledForState(EnhancedSecurity state)
-{
-    return state != EnhancedSecurity::Disabled;
-}
+} // namespace WebKit
 
-ALWAYS_INLINE bool enhancedSecurityStatesAreConsistent(EnhancedSecurity state, EnhancedSecurity other)
-{
-    return isEnhancedSecurityEnabledForState(state) == isEnhancedSecurityEnabledForState(other);
-}
-
-};
+#endif // HAVE(ENHANCED_SECURITY_LINKS)

--- a/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm
+++ b/Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,23 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import "config.h"
+#import "EnhancedSecurityLinkUtilities.h"
 
-#include <WebCore/RegistrableDomain.h>
+#if HAVE(ENHANCED_SECURITY_LINKS)
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/EnhancedSecurityLinkAdditions.mm>)
+#import <WebKitAdditions/EnhancedSecurityLinkAdditions.mm>
+#else
 namespace WebKit {
 
-enum class EnhancedSecurity : uint8_t { Disabled, EnabledInsecure, EnabledLinkSecurity, EnabledPolicy };
-enum class EnhancedSecurityReason : uint8_t { None, InsecureProvisional, InsecureLoad, LinkSecurity, Policy };
-
-ALWAYS_INLINE bool isEnhancedSecurityEnabledForState(EnhancedSecurity state)
+void isEnhancedSecurityEnabledForURL(const WTF::URL& url, CompletionHandler<void(bool)>&& completionHandler)
 {
-    return state != EnhancedSecurity::Disabled;
+    completionHandler(false);
 }
 
-ALWAYS_INLINE bool enhancedSecurityStatesAreConsistent(EnhancedSecurity state, EnhancedSecurity other)
-{
-    return isEnhancedSecurityEnabledForState(state) == isEnhancedSecurityEnabledForState(other);
 }
+#endif
 
-};
+#endif // HAVE(ENHANCED_SECURITY_LINKS)

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -182,6 +182,7 @@ Shared/Cocoa/AuxiliaryProcessCocoa.mm @nonARC
 Shared/Cocoa/CodeSigning.mm @nonARC
 Shared/Cocoa/CompletionHandlerCallChecker.mm @nonARC
 Shared/Cocoa/DefaultWebBrowserChecks.mm @nonARC
+Shared/Cocoa/EnhancedSecurityLinkUtilities.mm @nonARC
 Shared/Cocoa/InteractionInformationAtPosition.mm @nonARC
 Shared/Cocoa/InteractionInformationRequest.cpp
 Shared/Cocoa/LoadParametersCocoa.mm @nonARC

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -116,6 +116,7 @@ void Navigation::setCurrentRequest(ResourceRequest&& request, std::optional<Proc
     m_currentRequest = WTF::move(request);
     m_currentRequestProcessIdentifier = processIdentifier;
     m_hasStorageForCurrentSite = false;
+    m_isEnhancedSecurityLinkForCurrentSite = false;
 }
 
 void Navigation::appendRedirectionURL(const WTF::URL& url)

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -200,6 +200,9 @@ public:
     void setHasStorageForCurrentSite(bool);
     bool hasStorageForCurrentSite() const { return m_hasStorageForCurrentSite; }
 
+    void setIsEnhancedSecurityLinkForCurrentSite(bool isEnhancedSecurityLink) { m_isEnhancedSecurityLinkForCurrentSite = isEnhancedSecurityLink; }
+    bool isEnhancedSecurityLinkForCurrentSite() const { return m_isEnhancedSecurityLinkForCurrentSite; }
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -231,6 +234,7 @@ private:
     bool m_isFromLoadData : 1 { false };
     bool m_safeBrowsingCheckTimedOut : 1 { false };
     bool m_hasStorageForCurrentSite : 1 { false };
+    bool m_isEnhancedSecurityLinkForCurrentSite : 1 { false };
     RefPtr<API::WebsitePolicies> m_websitePolicies;
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> m_originatorAdvancedPrivacyProtections;
     MonotonicTime m_requestStart { MonotonicTime::now() };

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -585,6 +585,9 @@ void WebProcessPool::platformInitializeNetworkProcess(NetworkProcessCreationPara
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     parameters.storageAccessPromptQuirksData = StorageAccessPromptQuirkController::sharedSingleton().cachedListData();
 #endif
+#if HAVE(ENHANCED_SECURITY_LINKS)
+    parameters.enableEnhancedSecurityLinks = ![defaults objectForKey:WebPreferencesKey::enhancedSecurityLinksEnabledKey().createNSString().get()] || [defaults boolForKey:WebPreferencesKey::enhancedSecurityLinksEnabledKey().createNSString().get()];
+#endif
 }
 
 void WebProcessPool::platformInvalidateContext()

--- a/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
+++ b/Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp
@@ -88,6 +88,9 @@ EnhancedSecurity EnhancedSecurityTracking::enhancedSecurityState() const
     case EnhancedSecurityReason::InsecureLoad:
         return EnhancedSecurity::EnabledInsecure;
 
+    case EnhancedSecurityReason::LinkSecurity:
+        return EnhancedSecurity::EnabledLinkSecurity;
+
     case EnhancedSecurityReason::Policy:
         return EnhancedSecurity::EnabledPolicy;
     }
@@ -123,6 +126,9 @@ static EnhancedSecurityReason reasonForEnhancedSecurity(EnhancedSecurity state)
 
     case EnhancedSecurity::EnabledPolicy:
         return EnhancedSecurityReason::Policy;
+
+    case EnhancedSecurity::EnabledLinkSecurity:
+        return EnhancedSecurityReason::LinkSecurity;
     }
 
     ASSERT_NOT_REACHED();
@@ -172,6 +178,11 @@ bool EnhancedSecurityTracking::enableIfRequired(const API::Navigation& navigatio
     if (currentRequestURL.protocolIs("http"_s)
         && !SecurityOrigin::isLocalHostOrLoopbackIPAddress(currentRequestURL.host())) {
         enableFor(EnhancedSecurityReason::InsecureProvisional, navigation);
+        return true;
+    }
+
+    if (navigation.isEnhancedSecurityLinkForCurrentSite()) {
+        enableFor(EnhancedSecurityReason::LinkSecurity, navigation);
         return true;
     }
 

--- a/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h
@@ -44,15 +44,16 @@ enum class ShouldExpectSafeBrowsingResult : bool { No, Yes };
 enum class ShouldExpectAppBoundDomainResult : bool { No, Yes };
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool { No, Yes };
 enum class ShouldWaitForSiteHasStorageCheck : bool { No, Yes };
+enum class ShouldWaitForEnhancedSecurityLinkCheck : bool { No, Yes };
 enum class WasNavigationIntercepted : bool { No, Yes };
 
 class WebFramePolicyListenerProxy : public API::ObjectImpl<API::Object::Type::FramePolicyListener>, public CanMakeWeakPtr<WebFramePolicyListenerProxy> {
 public:
 
     using Reply = CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>;
-    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck)
+    static Ref<WebFramePolicyListenerProxy> create(Reply&& reply, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
     {
-        return adoptRef(*new WebFramePolicyListenerProxy(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck));
+        return adoptRef(*new WebFramePolicyListenerProxy(WTF::move(reply), expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck));
     }
     ~WebFramePolicyListenerProxy();
 
@@ -65,14 +66,16 @@ public:
     void didReceiveManagedDomainResult(std::optional<NavigatingToAppBoundDomain>);
     void didReceiveInitialLinkDecorationFilteringData();
     void didReceiveSiteHasStorageResults();
+    void didReceiveEnhancedSecurityLinkResults();
 
 private:
-    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck);
+    WebFramePolicyListenerProxy(Reply&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
 
     std::optional<std::pair<RefPtr<API::WebsitePolicies>, ProcessSwapRequestedByClient>> m_policyResult;
     std::optional<RefPtr<BrowsingWarning>> m_safeBrowsingWarning;
     std::optional<std::optional<NavigatingToAppBoundDomain>> m_isNavigatingToAppBoundDomain;
     bool m_doneWaitingForSiteHasStorage { false };
+    bool m_doneWaitingForEnhancedSecurityLink { false };
     bool m_doneWaitingForLinkDecorationFilteringData { false };
     Reply m_reply;
 };

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -359,7 +359,7 @@ void WebFrameProxy::didChangeTitle(String&& title)
     m_title = WTF::move(title);
 }
 
-WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck)
+WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionHandler<void(PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&& completionHandler, ShouldExpectSafeBrowsingResult expectSafeBrowsingResult, ShouldExpectAppBoundDomainResult expectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData shouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck shouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck shouldWaitForEnhancedSecurityLinkCheck)
 {
     if (RefPtr previousListener = m_activeListener)
         previousListener->ignore();
@@ -369,7 +369,7 @@ WebFramePolicyListenerProxy& WebFrameProxy::setUpPolicyListenerProxy(CompletionH
 
         completionHandler(action, policies, processSwapRequestedByClient, isNavigatingToAppBoundDomain, wasNavigationIntercepted);
         m_activeListener = nullptr;
-    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck);
+    }, expectSafeBrowsingResult, expectAppBoundDomainResult, shouldWaitForInitialLinkDecorationFilteringData, shouldWaitForSiteHasStorageCheck, shouldWaitForEnhancedSecurityLinkCheck);
     return *m_activeListener;
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -118,6 +118,7 @@ enum class ShouldExpectSafeBrowsingResult : bool;
 enum class ShouldExpectAppBoundDomainResult : bool;
 enum class ShouldWaitForInitialLinkDecorationFilteringData : bool;
 enum class ShouldWaitForSiteHasStorageCheck : bool;
+enum class ShouldWaitForEnhancedSecurityLinkCheck : bool;
 enum class ProcessSwapRequestedByClient : bool;
 enum class WasNavigationIntercepted : bool;
 
@@ -198,7 +199,7 @@ public:
     void didSameDocumentNavigation(URL&&); // eg. anchor navigation, session state change.
     void didChangeTitle(String&&);
 
-    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck);
+    WebFramePolicyListenerProxy& setUpPolicyListenerProxy(CompletionHandler<void(WebCore::PolicyAction, API::WebsitePolicies*, ProcessSwapRequestedByClient, std::optional<NavigatingToAppBoundDomain>, WasNavigationIntercepted)>&&, ShouldExpectSafeBrowsingResult, ShouldExpectAppBoundDomainResult, ShouldWaitForInitialLinkDecorationFilteringData, ShouldWaitForSiteHasStorageCheck, ShouldWaitForEnhancedSecurityLinkCheck);
 
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler contentFilterUnblockHandler) { m_contentFilterUnblockHandler = WTF::move(contentFilterUnblockHandler); }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3592,6 +3592,7 @@ private:
 #endif
 
     void beginSiteHasStorageCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
+    void beginEnhancedSecurityLinkCheck(const URL&, API::Navigation&, WebFramePolicyListenerProxy&);
 
     const UniqueRef<Internals> m_internals;
     Identifier m_identifier;

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6324,6 +6324,8 @@
 		5628440D2ED9E5250080DD29 /* EnhancedSecuritySitesPersistence.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EnhancedSecuritySitesPersistence.cpp; sourceTree = "<group>"; };
 		5628440E2ED9E5440080DD29 /* EnhancedSecuritySitesHolder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecuritySitesHolder.h; sourceTree = "<group>"; };
 		5628440F2ED9E5580080DD29 /* EnhancedSecuritySitesHolder.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EnhancedSecuritySitesHolder.cpp; sourceTree = "<group>"; };
+		5630659E2F2A2E70000BF1BF /* EnhancedSecurityLinkUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EnhancedSecurityLinkUtilities.mm; sourceTree = "<group>"; };
+		5630659F2F2A2E92000BF1BF /* EnhancedSecurityLinkUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EnhancedSecurityLinkUtilities.h; sourceTree = "<group>"; };
 		564599932B71BBA000BC59E6 /* CoreIPCPresentationIntent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPresentationIntent.serialization.in; sourceTree = "<group>"; };
 		564599942B71BBB200BC59E6 /* CoreIPCPresentationIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCPresentationIntent.h; sourceTree = "<group>"; };
 		564599952B71BBC300BC59E6 /* CoreIPCPresentationIntent.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCPresentationIntent.mm; sourceTree = "<group>"; };
@@ -13216,6 +13218,8 @@
 				86AA5252293674E30065399E /* DataDetectionResult.serialization.in */,
 				49DAA38D24CBA1BD00793D75 /* DefaultWebBrowserChecks.h */,
 				49DAA38B24CBA1A800793D75 /* DefaultWebBrowserChecks.mm */,
+				5630659F2F2A2E92000BF1BF /* EnhancedSecurityLinkUtilities.h */,
+				5630659E2F2A2E70000BF1BF /* EnhancedSecurityLinkUtilities.mm */,
 				07187E092F2DC276005FC058 /* GestureTypes.h */,
 				07187E0A2F2DC284005FC058 /* GestureTypes.serialization.in */,
 				CE550E12228373C800D28791 /* InsertTextOptions.h */,

--- a/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
+++ b/Tools/TestWebKitAPI/Scripts/process-entitlements.sh
@@ -36,6 +36,7 @@ process_restricted_testwebkitapi_entitlements()
     plistbuddy Add :com.apple.private.webkit.adattributiond.testing bool YES
     plistbuddy Add :com.apple.private.webkit.webpush bool YES
     plistbuddy Add :com.apple.private.webkit.webpush.inject bool YES
+    plistbuddy Add :com.apple.private.messages.enhanced-link-security bool YES
 }
 
 # ========================================

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -1407,4 +1407,8 @@ TEST(EnhancedSecurityPolicies, HistoryEventsUseCorrectOriginalRequest)
     EXPECT_WK_STREQ([historyDelegate->lastRedirectDestination absoluteString], destinationURL);
 }
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/EnhancedSecurityPoliciesAdditions.mm>)
+#import <WebKitAdditions/EnhancedSecurityPoliciesAdditions.mm>
+#endif
+
 #endif


### PR DESCRIPTION
#### aae6a13f406fe29df1873f31f6f3e801dbf32e26
<pre>
Support enabling Enhanced Security for specific URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=307067">https://bugs.webkit.org/show_bug.cgi?id=307067</a>
<a href="https://rdar.apple.com/162785415">rdar://162785415</a>

Reviewed by Per Arne Vollan.

We want to be able to support enabling Enhanced Security
for a main frame navigation that has a URL matching certain
criteria.

This change modifies Enhanced Security heuristics to
support extra decision making based on a given navigation URL.

Test is added in WebKitAdditions.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::initializeNetworkProcess):
(WebKit::NetworkProcess::setIsEnhancedSecurityLinksEnabled):
(WebKit::NetworkProcess::isEnhancedSecurityLinksEnabled const):
(WebKit::NetworkProcess::isEnhancedSecurityLink):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkProcessCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.Development.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.h: Copied from Source/WebKit/Shared/EnhancedSecurity.h.
* Source/WebKit/Shared/Cocoa/EnhancedSecurityLinkUtilities.mm: Copied from Source/WebKit/Shared/EnhancedSecurity.h.
(WebKit::isEnhancedSecurityEnabledForURL):
* Source/WebKit/Shared/EnhancedSecurity.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/APINavigation.cpp:
(API::Navigation::setCurrentRequest):
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::setIsEnhancedSecurityLinkForCurrentSite):
(API::Navigation::isEnhancedSecurityLinkForCurrentSite const):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeNetworkProcess):
* Source/WebKit/UIProcess/EnhancedSecurityTracking.cpp:
(WebKit::EnhancedSecurityTracking::enhancedSecurityState const):
(WebKit::reasonForEnhancedSecurity):
(WebKit::EnhancedSecurityTracking::enableIfRequired):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.cpp:
(WebKit::WebFramePolicyListenerProxy::WebFramePolicyListenerProxy):
(WebKit::WebFramePolicyListenerProxy::didReceiveAppBoundDomainResult):
(WebKit::WebFramePolicyListenerProxy::didReceiveSafeBrowsingResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveInitialLinkDecorationFilteringData):
(WebKit::WebFramePolicyListenerProxy::didReceiveSiteHasStorageResults):
(WebKit::WebFramePolicyListenerProxy::didReceiveEnhancedSecurityLinkResults):
(WebKit::WebFramePolicyListenerProxy::use):
* Source/WebKit/UIProcess/WebFramePolicyListenerProxy.h:
(WebKit::WebFramePolicyListenerProxy::create):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setUpPolicyListenerProxy):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::beginEnhancedSecurityLinkCheck):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Scripts/process-entitlements.sh:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:

Canonical link: <a href="https://commits.webkit.org/307368@main">https://commits.webkit.org/307368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/225567e6258d27d339b9a2bb29d94001df0c03a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152825 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110850 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129519 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91768 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10453 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/271 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136146 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6173 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155137 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4963 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118864 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14012 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119222 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30568 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15108 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72107 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16308 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5821 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175442 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16042 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45219 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16108 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->