### PR TITLE
[Style] Reduce number of specialized mutation functions on RenderStyle/Style::ComputedStyle

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -75,67 +75,7 @@ inline void RenderStyle::copyPseudoElementBitsFrom(const RenderStyle& other)
     return m_computedStyle.copyPseudoElementBitsFrom(other.m_computedStyle);
 }
 
-// MARK: - Style adjustment utilities
-
-inline void RenderStyle::setPageScaleTransform(float scale)
-{
-    m_computedStyle.setPageScaleTransform(scale);
-}
-
-inline void RenderStyle::setColumnStylesFromPaginationMode(PaginationMode paginationMode)
-{
-    m_computedStyle.setColumnStylesFromPaginationMode(paginationMode);
-}
-
-inline void RenderStyle::adjustAnimations()
-{
-    m_computedStyle.adjustAnimations();
-}
-
-inline void RenderStyle::adjustTransitions()
-{
-    m_computedStyle.adjustTransitions();
-}
-
-inline void RenderStyle::adjustBackgroundLayers()
-{
-    m_computedStyle.adjustBackgroundLayers();
-}
-
-inline void RenderStyle::adjustMaskLayers()
-{
-    m_computedStyle.adjustMaskLayers();
-}
-
-inline void RenderStyle::adjustScrollTimelines()
-{
-    m_computedStyle.adjustScrollTimelines();
-}
-
-inline void RenderStyle::adjustViewTimelines()
-{
-    m_computedStyle.adjustViewTimelines();
-}
-
-inline void RenderStyle::addToTextDecorationLineInEffect(Style::TextDecorationLine value)
-{
-    m_computedStyle.addToTextDecorationLineInEffect(value);
-}
-
-inline void RenderStyle::containIntrinsicWidthAddAuto()
-{
-    m_computedStyle.containIntrinsicWidthAddAuto();
-}
-
-inline void RenderStyle::containIntrinsicHeightAddAuto()
-{
-    m_computedStyle.containIntrinsicHeightAddAuto();
-}
-
-inline void RenderStyle::setGridAutoFlowDirection(Style::GridAutoFlow::Direction direction)
-{
-    m_computedStyle.setGridAutoFlowDirection(direction);
-}
+// MARK: - Style reset utilities
 
 inline void RenderStyle::resetBorderBottom()
 {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -86,21 +86,7 @@ public:
     bool fontCascadeEqual(const RenderStyle&) const;
     bool scrollSnapDataEquivalent(const RenderStyle&) const;
 
-    // MARK: - Style adjustment utilities
-
-    inline void setPageScaleTransform(float);
-    inline void setColumnStylesFromPaginationMode(PaginationMode);
-    inline void addToTextDecorationLineInEffect(Style::TextDecorationLine);
-    inline void containIntrinsicWidthAddAuto();
-    inline void containIntrinsicHeightAddAuto();
-    inline void setGridAutoFlowDirection(Style::GridAutoFlow::Direction);
-
-    void adjustAnimations();
-    void adjustTransitions();
-    void adjustBackgroundLayers();
-    void adjustMaskLayers();
-    void adjustScrollTimelines();
-    void adjustViewTimelines();
+    // MARK: - Style reset utilities
 
     inline void resetBorder();
     inline void resetBorderExceptRadius();

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -40,6 +40,7 @@ class SVGElement;
 class Settings;
 
 enum class AnimationImpact : uint8_t;
+enum class PaginationMode : uint8_t;
 
 namespace Style {
 
@@ -58,6 +59,7 @@ public:
     static void adjustFirstLineStyle(RenderStyle&);
     static void adjustSVGElementStyle(RenderStyle&, const SVGElement&);
     static bool adjustEventListenerRegionTypesForRootStyle(RenderStyle&, const Document&);
+    static void adjustColumnStylesForPaginationMode(RenderStyle&, PaginationMode);
     static void propagateToDocumentElementAndInitialContainingBlock(Update&, const Document&);
     static std::unique_ptr<RenderStyle> restoreUsedDocumentElementStyleToComputed(const RenderStyle&);
 
@@ -78,6 +80,13 @@ private:
     void adjustForSiteSpecificQuirks(RenderStyle&) const;
 
     void adjustThemeStyle(RenderStyle&, const RenderStyle& parentStyle) const;
+
+    static void adjustAnimations(RenderStyle&);
+    static void adjustTransitions(RenderStyle&);
+    static void adjustBackgroundLayers(RenderStyle&);
+    static void adjustMaskLayers(RenderStyle&);
+    static void adjustScrollTimelines(RenderStyle&);
+    static void adjustViewTimelines(RenderStyle&);
 
     static OptionSet<EventListenerRegionType> computeEventListenerRegionTypes(const Document&, const RenderStyle&, const EventTarget&, OptionSet<EventListenerRegionType>);
 

--- a/Source/WebCore/style/computed/StyleComputedStyle+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle+SettersInlines.h
@@ -45,27 +45,6 @@ inline void ComputedStyle::inheritColumnPropertiesFrom(const ComputedStyle& pare
 
 // MARK: - Style adjustment utilities
 
-inline void ComputedStyle::addToTextDecorationLineInEffect(TextDecorationLine value)
-{
-    m_inheritedFlags.textDecorationLineInEffect = textDecorationLineInEffect().addOrReplaceIfNotNone(value);
-}
-
-inline void ComputedStyle::containIntrinsicWidthAddAuto()
-{
-    setContainIntrinsicWidth(containIntrinsicWidth().addingAuto());
-}
-
-inline void ComputedStyle::containIntrinsicHeightAddAuto()
-{
-    setContainIntrinsicHeight(containIntrinsicHeight().addingAuto());
-}
-
-inline void ComputedStyle::setGridAutoFlowDirection(GridAutoFlow::Direction direction)
-{
-    if (m_nonInheritedData->rareData->grid->gridAutoFlow.direction() != direction)
-        m_nonInheritedData.access().rareData.access().grid.access().gridAutoFlow.setDirection(direction);
-}
-
 inline void ComputedStyle::resetBorderBottom()
 {
     setBorderBottom(BorderValue { });

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -285,58 +285,6 @@ float ComputedStyle::computeLineHeight(const LineHeight& lineHeight) const
     );
 }
 
-void ComputedStyle::setPageScaleTransform(float scale)
-{
-    if (scale == 1)
-        return;
-
-    setTransform(Style::Transform { Style::TransformFunction { Style::ScaleTransformFunction::create(scale, scale, Style::TransformFunctionType::Scale) } });
-    setTransformOriginX(0_css_px);
-    setTransformOriginY(0_css_px);
-}
-
-void ComputedStyle::setColumnStylesFromPaginationMode(PaginationMode paginationMode)
-{
-    if (paginationMode == Pagination::Mode::Unpaginated)
-        return;
-    
-    setColumnFill(ColumnFill::Auto);
-    
-    switch (paginationMode) {
-    case Pagination::Mode::LeftToRightPaginated:
-        setColumnAxis(ColumnAxis::Horizontal);
-        if (writingMode().isHorizontal())
-            setColumnProgression(writingMode().isBidiLTR() ? ColumnProgression::Normal : ColumnProgression::Reverse);
-        else
-            setColumnProgression(writingMode().isBlockFlipped() ? ColumnProgression::Reverse : ColumnProgression::Normal);
-        break;
-    case Pagination::Mode::RightToLeftPaginated:
-        setColumnAxis(ColumnAxis::Horizontal);
-        if (writingMode().isHorizontal())
-            setColumnProgression(writingMode().isBidiLTR() ? ColumnProgression::Reverse : ColumnProgression::Normal);
-        else
-            setColumnProgression(writingMode().isBlockFlipped() ? ColumnProgression::Normal : ColumnProgression::Reverse);
-        break;
-    case Pagination::Mode::TopToBottomPaginated:
-        setColumnAxis(ColumnAxis::Vertical);
-        if (writingMode().isHorizontal())
-            setColumnProgression(writingMode().isBlockFlipped() ? ColumnProgression::Reverse : ColumnProgression::Normal);
-        else
-            setColumnProgression(writingMode().isBidiLTR() ? ColumnProgression::Normal : ColumnProgression::Reverse);
-        break;
-    case Pagination::Mode::BottomToTopPaginated:
-        setColumnAxis(ColumnAxis::Vertical);
-        if (writingMode().isHorizontal())
-            setColumnProgression(writingMode().isBlockFlipped() ? ColumnProgression::Normal : ColumnProgression::Reverse);
-        else
-            setColumnProgression(writingMode().isBidiLTR() ? ColumnProgression::Reverse : ColumnProgression::Normal);
-        break;
-    case Pagination::Mode::Unpaginated:
-        ASSERT_NOT_REACHED();
-        break;
-    }
-}
-
 bool ComputedStyle::scrollSnapDataEquivalent(const ComputedStyle& other) const
 {
     if (m_nonInheritedData.ptr() == other.m_nonInheritedData.ptr()
@@ -347,74 +295,6 @@ bool ComputedStyle::scrollSnapDataEquivalent(const ComputedStyle& other) const
         && m_nonInheritedData->rareData->scrollSnapAlign == other.m_nonInheritedData->rareData->scrollSnapAlign
         && m_nonInheritedData->rareData->scrollSnapStop == other.m_nonInheritedData->rareData->scrollSnapStop
         && m_nonInheritedData->rareData->scrollSnapAlign == other.m_nonInheritedData->rareData->scrollSnapAlign;
-}
-
-// MARK: - Style adjustment utilities
-
-void ComputedStyle::adjustAnimations()
-{
-    if (animations().isInitial())
-        return;
-
-    ensureAnimations().prepareForUse();
-}
-
-void ComputedStyle::adjustTransitions()
-{
-    if (transitions().isInitial())
-        return;
-
-    ensureTransitions().prepareForUse();
-}
-
-void ComputedStyle::adjustBackgroundLayers()
-{
-    if (backgroundLayers().isInitial())
-        return;
-
-    ensureBackgroundLayers().prepareForUse();
-}
-
-void ComputedStyle::adjustMaskLayers()
-{
-    if (maskLayers().isInitial())
-        return;
-
-    ensureMaskLayers().prepareForUse();
-}
-
-void ComputedStyle::adjustScrollTimelines()
-{
-    auto& names = scrollTimelineNames();
-    if (names.isNone() && scrollTimelines().isEmpty())
-        return;
-
-    auto& axes = scrollTimelineAxes();
-    auto numberOfAxes = axes.size();
-    ASSERT(numberOfAxes > 0);
-
-    m_nonInheritedData.access().rareData.access().scrollTimelines = { FixedVector<Ref<ScrollTimeline>>::createWithSizeFromGenerator(names.size(), [&](auto i) {
-        return ScrollTimeline::create(names[i].value.value, axes[i % numberOfAxes]);
-    }) };
-}
-
-void ComputedStyle::adjustViewTimelines()
-{
-    auto& names = viewTimelineNames();
-    if (names.isNone() && viewTimelines().isEmpty())
-        return;
-
-    auto& axes = viewTimelineAxes();
-    auto numberOfAxes = axes.size();
-    ASSERT(numberOfAxes > 0);
-
-    auto& insets = viewTimelineInsets();
-    auto numberOfInsets = insets.size();
-    ASSERT(numberOfInsets > 0);
-
-    m_nonInheritedData.access().rareData.access().viewTimelines = { FixedVector<Ref<ViewTimeline>>::createWithSizeFromGenerator(names.size(), [&](auto i) {
-        return ViewTimeline::create(names[i].value.value, axes[i % numberOfAxes], insets[i % numberOfInsets]);
-    }) };
 }
 
 } // namespace Style

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -59,21 +59,7 @@ public:
     inline bool fontCascadeEqual(const ComputedStyle&) const;
     bool scrollSnapDataEquivalent(const ComputedStyle&) const;
 
-    // MARK: - Style adjustment utilities
-
-    void setPageScaleTransform(float);
-    void setColumnStylesFromPaginationMode(PaginationMode);
-    inline void addToTextDecorationLineInEffect(TextDecorationLine);
-    inline void containIntrinsicWidthAddAuto();
-    inline void containIntrinsicHeightAddAuto();
-    inline void setGridAutoFlowDirection(GridAutoFlow::Direction);
-
-    void adjustAnimations();
-    void adjustTransitions();
-    void adjustBackgroundLayers();
-    void adjustMaskLayers();
-    void adjustScrollTimelines();
-    void adjustViewTimelines();
+    // MARK: - Style reset utilities
 
     inline void resetBorder();
     inline void resetBorderExceptRadius();

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -822,6 +822,7 @@ public:
     };
 
 protected:
+    friend class Adjuster;
     friend class ChangedAnimatablePropertiesFunctions;
     friend class DifferenceFunctions;
     friend class WebCore::RenderStyle;

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp
@@ -49,7 +49,7 @@ TextStream& operator<<(TextStream& ts, Style::TextDecorationLine::Flag flag)
 }
 namespace Style {
 
-uint8_t TextDecorationLine::addOrReplaceIfNotNone(const TextDecorationLine& value)
+void TextDecorationLine::addOrReplaceIfNotNone(TextDecorationLine value)
 {
     value.switchOn(
         [&](CSS::Keyword::None) {
@@ -64,7 +64,6 @@ uint8_t TextDecorationLine::addOrReplaceIfNotNone(const TextDecorationLine& valu
             setFlags(newValue);
         }
     );
-    return m_packed;
 }
 
 // MARK: - Conversion

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h
@@ -159,7 +159,7 @@ struct TextDecorationLine {
         }
     }
 
-    uint8_t addOrReplaceIfNotNone(const TextDecorationLine&);
+    void addOrReplaceIfNotNone(TextDecorationLine);
 
     template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
     {
@@ -168,14 +168,13 @@ struct TextDecorationLine {
         switch (type()) {
         case Type::Flags:
             return visitor(unpackFlags());
-        case Type::SingleValue: {
+        case Type::SingleValue:
             if (isNone())
                 return visitor(CSS::Keyword::None { });
             if (isSpellingError())
                 return visitor(CSS::Keyword::SpellingError { });
             ASSERT(isGrammarError());
             return visitor(CSS::Keyword::GrammarError { });
-            }
         }
         ASSERT_NOT_REACHED();
         return visitor(CSS::Keyword::None { });


### PR DESCRIPTION
#### 99382c058ceabd63ec897b7c5874610dc2e0890b
<pre>
[Style] Reduce number of specialized mutation functions on RenderStyle/Style::ComputedStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=307093">https://bugs.webkit.org/show_bug.cgi?id=307093</a>

Reviewed by Darin Adler.

Reduce number of specialized mutation functions on RenderStyle/Style::ComputedStyle
by moving some to Style::Adjuster and inlining others that only have one caller.

* Source/WebCore/rendering/style/RenderStyle+SettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleResolveForDocument.cpp:
* Source/WebCore/style/computed/StyleComputedStyle+SettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp:
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.h:

Canonical link: <a href="https://commits.webkit.org/306940@main">https://commits.webkit.org/306940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26de76a75a9de3b68863f041a6b985fabc3cd23a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151365 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95880 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109740 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95880 "An unexpected error occured. Recent messages:Printed configuration") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90647 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11709 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9387 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153678 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14789 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118087 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30211 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14094 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70486 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14832 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78541 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->