### PR TITLE
REGRESSION(306261@main): [VisionOS] interaction-region/interaction-layers-culling-layer-type-change.html is a constant text failure.

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -2,6 +2,7 @@
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 85950])
   (layer position [x: 400 y: 400])
+  (layer background color rgba(0, 0, 0, 0))
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0])

--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
@@ -2,6 +2,7 @@
 (CALayer tree root
   (layer bounds [x: 0 y: 0 width: 800 height: 700])
   (layer position [x: 400 y: 400])
+  (layer background color rgba(0, 0, 0, 0))
   (sublayers
     (
       (layer bounds [x: 0 y: 0 width: 0 height: 0])

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -171,8 +171,6 @@ fast/forms/form-control-refresh/progress-window-inactive-state-light-mode.html [
 # webkit.org/b/300929 REGRESSION(297559@main): interaction-region/form-control-refresh/date-native-interaction-region.html does not pass on visionOS
 interaction-region/form-control-refresh/date-native-interaction-region.html [ Failure ]
 
-#webkit.org/b/306905 REGRESSION(306261@main): [VisionOS] interaction-region/interaction-layers-culling-layer-type-change.html is a constant text failure.
-interaction-region/interaction-layers-culling-layer-type-change.html [ Failure ]
 interaction-region/interaction-layers-culling.html [ Failure ]
 platform/visionos/transforms/separated-update.html [ Failure ]
 platform/visionos/transforms/separated-video.html [ Failure ]

--- a/LayoutTests/platform/visionos/transforms/separated-update-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-update-expected.txt
@@ -9,7 +9,8 @@
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
-          (layer anchorPoint [x: 0 y: 0]))))
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(128, 0, 128)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
       (layer position [x: 100 y: 100])
@@ -17,7 +18,8 @@
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
-          (layer anchorPoint [x: 0 y: 0]))))
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(128, 0, 128)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
       (layer position [x: 100 y: 100])
@@ -25,7 +27,8 @@
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
-          (layer anchorPoint [x: 0 y: 0]))))
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(128, 0, 128)))))
     (
       (layer bounds [x: 0 y: 0 width: 200 height: 200])
       (layer position [x: 100 y: 100])
@@ -33,4 +36,5 @@
       (sublayers
         (
           (layer bounds [x: 0 y: 0 width: 200 height: 200])
-          (layer anchorPoint [x: 0 y: 0]))))))
+          (layer anchorPoint [x: 0 y: 0])
+          (layer background color rgb(128, 0, 128)))))))

--- a/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
+++ b/LayoutTests/platform/visionos/transforms/separated-video-expected.txt
@@ -1,6 +1,6 @@
 
 (CALayer tree root
-  (layer bounds [x: 0 y: 0 width: 800 height: 292.5])
+  (layer bounds [x: 0 y: 0 width: 800 height: 293])
   (layer position [x: 400 y: 400])
   (sublayers
     (
@@ -50,7 +50,8 @@
                           (sublayers
                             (
                               (layer bounds [x: 0 y: 0 width: 31 height: 31])
-                              (layer anchorPoint [x: 0 y: 0]))))
+                              (layer anchorPoint [x: 0 y: 0])
+                              (layer background color rgb(255, 255, 255)))))
                         (
                           (layer bounds [x: 0 y: 0 width: 0 height: 0])
                           (sublayers


### PR DESCRIPTION
#### 3e1fc9f36956aefc5a4ada8569ddca36e0afee98
<pre>
REGRESSION(306261@main): [VisionOS] interaction-region/interaction-layers-culling-layer-type-change.html is a constant text failure.
<a href="https://rdar.apple.com/169569193">rdar://169569193</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306905">https://bugs.webkit.org/show_bug.cgi?id=306905</a>

Reviewed by Etienne Segonzac.

Rebaslined the following tests so that CALayerTreeAsText now includes background color information in its output.

* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt:
* LayoutTests/platform/visionos/TestExpectations:
* LayoutTests/platform/visionos/transforms/separated-update-expected.txt:
* LayoutTests/platform/visionos/transforms/separated-video-expected.txt:

Canonical link: <a href="https://commits.webkit.org/307010@main">https://commits.webkit.org/307010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6189d40f655686e311948d37ed83eb6db5c269c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151671 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90875 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11920 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 3 flakes 1 failures; Uploaded test results; layout-tests (exception)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9616 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1670 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121296 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153984 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15095 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117993 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118322 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14282 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125284 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70802 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22058 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15138 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4174 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14873 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14935 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->