### PR TITLE
[Build] libswiftCompatibilitySpan.dylib not loading in STP

### DIFF
--- a/Source/WebKit/Configurations/BaseXPCService.xcconfig
+++ b/Source/WebKit/Configurations/BaseXPCService.xcconfig
@@ -83,7 +83,7 @@ WK_PATH_FROM_SERVICE_EXECUTABLE_TO_FRAMEWORK_SHALLOW_BUNDLE_YES_DEPLOYMENT_NO = 
 // In relocatable builds, dyld needs to find any Swift compatibility libraries
 // that were copied into the application bundle.
 LD_RUNPATH_SEARCH_PATHS = $(LD_RUNPATH_SEARCH_PATHS_$(WK_RELOCATABLE_FRAMEWORKS));
-LD_RUNPATH_SEARCH_PATHS_YES = @loader_path/../../../;
+LD_RUNPATH_SEARCH_PATHS_YES = @executable_path/$(WK_PATH_FROM_SERVICE_EXECUTABLE_TO_FRAMEWORKS) @executable_path/$(WK_PATH_FROM_SERVICE_EXECUTABLE_TO_LIBRARIES);
 
 // We want this to always be NO for non-simulator builds. If set to YES, Xcode will invoke codesign with an --entitlements parameter that points to the platform's BaseEntitlements.plist. This parameter would override any --entitlements parameter that we establish in WK_LIBRARY_VALIDATION_CODE_SIGN_FLAGS, causing our entitlements to be ignored.
 CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;


### PR DESCRIPTION
#### 8b758523d2a21ba207b2a19fb479a7de7f33ae44
<pre>
[Build] libswiftCompatibilitySpan.dylib not loading in STP
<a href="https://bugs.webkit.org/show_bug.cgi?id=307097">https://bugs.webkit.org/show_bug.cgi?id=307097</a>
<a href="https://rdar.apple.com/169536254">rdar://169536254</a>

Unreviewed build fix. Change the path logic for loading rpath libraries
(namely swift compatibility libraries) to actually point to the correct
location in the app bundle.

* Source/WebKit/Configurations/BaseXPCService.xcconfig:

Canonical link: <a href="https://commits.webkit.org/306965@main">https://commits.webkit.org/306965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6adf2ea0c9846335e8004804de8f187c7e4f0dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15175 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151377 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95892 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66926482-1bdd-483f-9795-25ec11dc5b2c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109749 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95892 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2176697d-cbd2-44bc-b889-d9e5253ea594) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90656 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d364acbd-d3f4-4d5f-9b66-61365adec871) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11713 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9394 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1376 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121084 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153690 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14801 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118095 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30232 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14105 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70498 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14844 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3930 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14787 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14641 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->