### PR TITLE
[Site Isolation] Pass DocumentSecurityPolicy as parameter to Document::initSecurityContext()

### DIFF
--- a/LayoutTests/http/tests/security/aboutBlank/cross-origin-iframe-window-open-about-blank-expected.txt
+++ b/LayoutTests/http/tests/security/aboutBlank/cross-origin-iframe-window-open-about-blank-expected.txt
@@ -1,0 +1,3 @@
+ALERT: should be empty:
+ALERT: should also be empty:
+

--- a/LayoutTests/http/tests/security/aboutBlank/cross-origin-iframe-window-open-about-blank.html
+++ b/LayoutTests/http/tests/security/aboutBlank/cross-origin-iframe-window-open-about-blank.html
@@ -1,0 +1,9 @@
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    document.cookie = 'key1=value1';
+</script>
+<iframe src="http://localhost:8000/security/aboutBlank/resources/open-about-blank.html"></iframe>

--- a/LayoutTests/http/tests/security/aboutBlank/resources/cross-origin-open-about-blank.html
+++ b/LayoutTests/http/tests/security/aboutBlank/resources/cross-origin-open-about-blank.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+function log(msg) {
+    window.top.postMessage(msg, "*");
+}
+
+// Listen for messages from the popup and relay them to top
+window.addEventListener("message", function(event) {
+    // Relay messages from popup to top
+    window.top.postMessage(event.data, "*");
+}, false);
+
+function runTest() {
+    log("--- Test begins ---");
+    log("Opener origin (this iframe): " + window.location.origin);
+
+    // Set cookie before opening popup so it's available
+    document.cookie = "iframe_cookie=from_localhost";
+
+    let popup = window.open("about:blank");
+    if (!popup) {
+        log("FAIL: Could not open popup");
+        log("--- Test ends ---");
+        log("TEST COMPLETE");
+        return;
+    }
+
+    // Test 1: Verify about:blank has correct origin (inherited from opener)
+    // We can verify this by checking if we can access the popup's document
+    try {
+        let popupDoc = popup.document;
+        log("PASS: Can access popup.document (same-origin with opener)");
+    } catch (e) {
+        log("FAIL: Cannot access popup.document - " + e.name);
+    }
+
+    // Write all tests to popup at once
+    popup.document.write('<!DOCTYPE html><html><body><script>' +
+        // Test 2: Verify about:blank can access its opener
+        'try {' +
+        '    let openerLoc = window.opener.location.href;' +
+        '    window.opener.postMessage("PASS: about:blank can access opener", "*");' +
+        '} catch (e) {' +
+        '    window.opener.postMessage("FAIL: about:blank cannot access opener - " + e.name, "*");' +
+        '}' +
+
+        // Test 3: Verify about:blank CANNOT access top-level document (different origin)
+        'try {' +
+        '    let topDoc = window.opener.top.document.body;' +
+        '    window.opener.postMessage("FAIL: about:blank should not be able to access top document", "*");' +
+        '} catch (e) {' +
+        '    window.opener.postMessage("PASS: about:blank correctly blocked from accessing cross-origin top document (" + e.name + ")", "*");' +
+        '}' +
+
+        // Test 4: Verify cookie behavior with opener
+        // Note: about:blank documents opened from cross-origin contexts may have
+        // empty cookies due to cookie URL handling
+        'let cookies = document.cookie;' +
+        'if (cookies === "") {' +
+        '    window.opener.postMessage("PASS: about:blank has empty cookies (expected for cross-origin opener)", "*");' +
+        '} else if (cookies.includes("iframe_cookie")) {' +
+        '    window.opener.postMessage("PASS: about:blank shares cookies with opener", "*");' +
+        '} else {' +
+        '    window.opener.postMessage("INFO: about:blank has cookies: " + cookies, "*");' +
+        '}' +
+        '<\/script></body></html>');
+    popup.document.close();
+
+    setTimeout(function() {
+        popup.close();
+        log("--- Test ends ---");
+        log("TEST COMPLETE");
+    }, 500);
+}
+
+window.onload = runTest;
+</script>
+</head>
+<body>
+<p>Cross-origin iframe at localhost that opens about:blank</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/aboutBlank/resources/open-about-blank.html
+++ b/LayoutTests/http/tests/security/aboutBlank/resources/open-about-blank.html
@@ -1,0 +1,9 @@
+<script>
+    alert('should be empty:' + document.cookie);
+    document.cookie = 'key2=value2';
+    let w = window.open('about:blank');
+    alert('should also be empty:' + w.document.cookie);
+    if (window.testRunner) {
+        testRunner.notifyDone()
+    }
+</script>

--- a/LayoutTests/http/tests/security/aboutBlank/security-context-cross-origin-opener-expected.txt
+++ b/LayoutTests/http/tests/security/aboutBlank/security-context-cross-origin-opener-expected.txt
@@ -1,0 +1,11 @@
+Tests that about:blank opened via window.open() from a cross-origin iframe inherits the opener's security origin, not the top-level document's origin.
+
+--- Test begins ---
+Opener origin (this iframe): http://localhost:8000
+PASS: Can access popup.document (same-origin with opener)
+PASS: about:blank can access opener
+PASS: about:blank correctly blocked from accessing cross-origin top document (SecurityError)
+PASS: about:blank has empty cookies (expected for cross-origin opener)
+--- Test ends ---
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/aboutBlank/security-context-cross-origin-opener.html
+++ b/LayoutTests/http/tests/security/aboutBlank/security-context-cross-origin-opener.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(msg) {
+    document.getElementById('console').appendChild(document.createTextNode(msg + '\n'));
+}
+
+window.addEventListener("message", function(event) {
+    log(event.data);
+    if (event.data.includes("TEST COMPLETE")) {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+}, false);
+</script>
+</head>
+<body>
+<p>Tests that about:blank opened via window.open() from a cross-origin iframe inherits the opener's security origin, not the top-level document's origin.</p>
+<pre id="console"></pre>
+<iframe id="crossOriginFrame" src="http://localhost:8000/security/aboutBlank/resources/cross-origin-open-about-blank.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/csp-inherited-by-about-blank-from-cross-origin-opener-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/csp-inherited-by-about-blank-from-cross-origin-opener-expected.txt
@@ -1,0 +1,12 @@
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/resources/abe.png because it does not appear in the img-src directive of the Content Security Policy.
+Tests that about:blank opened via window.open() inherits CSP from its cross-origin opener, not from the top-level document.
+
+The top-level page (127.0.0.1) has CSP "img-src 'self'" which allows images from same origin.
+
+The cross-origin helper (localhost) has CSP "img-src 'none'" which blocks all images.
+
+When the helper opens about:blank, about:blank should inherit the helper's CSP and block the image.
+
+PASS: Image blocked by inherited CSP from cross-origin opener
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/csp-inherited-by-about-blank-from-cross-origin-opener.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/csp-inherited-by-about-blank-from-cross-origin-opener.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; img-src 'self'">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.addEventListener("message", function(event) {
+    document.getElementById("console").textContent += event.data + "\n";
+    if (event.data.includes("TEST COMPLETE")) {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+}, false);
+</script>
+</head>
+<body>
+<p>Tests that about:blank opened via window.open() inherits CSP from its cross-origin opener, not from the top-level document.</p>
+<p>The top-level page (127.0.0.1) has CSP "img-src 'self'" which allows images from same origin.</p>
+<p>The cross-origin helper (localhost) has CSP "img-src 'none'" which blocks all images.</p>
+<p>When the helper opens about:blank, about:blank should inherit the helper's CSP and block the image.</p>
+<pre id="console"></pre>
+<iframe src="http://localhost:8000/security/contentSecurityPolicy/resources/cross-origin-opener-with-csp.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/cross-origin-opener-with-csp.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/cross-origin-opener-with-csp.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'; img-src 'none'">
+<script>
+// This page is opened/loaded by the main test page. It opens about:blank and tests CSP inheritance.
+// Results are posted back to window.opener or window.top.
+
+function sendResult(msg) {
+    if (window.opener) {
+        window.opener.postMessage(msg, "*");
+    } else if (window.top !== window) {
+        window.top.postMessage(msg, "*");
+    }
+}
+
+// Listen for messages from the about:blank popup and relay
+window.addEventListener("message", function(event) {
+    sendResult(event.data);
+}, false);
+
+window.onload = function() {
+    let popup = window.open("about:blank");
+    if (popup) {
+        // Write content to about:blank that tries to load an image
+        popup.document.write('<img src="http://127.0.0.1:8000/security/resources/abe.png" ' +
+            'onerror="window.opener.postMessage(\'PASS: Image blocked by inherited CSP from cross-origin opener\', \'*\')" ' +
+            'onload="window.opener.postMessage(\'FAIL: Image loaded - CSP was not inherited from cross-origin opener\', \'*\')">');
+        popup.document.close();
+        // Send completion message after a delay to allow image load/error to fire
+        setTimeout(function() {
+            sendResult("TEST COMPLETE");
+            popup.close();
+            if (window.opener) window.close();
+        }, 500);
+    } else {
+        sendResult("FAIL: Could not open popup");
+        sendResult("TEST COMPLETE");
+        if (window.opener) window.close();
+    }
+};
+</script>
+</head>
+<body>
+<p>Cross-origin helper with CSP: img-src 'none'</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/about-blank-inherits-upgrade.https-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/about-blank-inherits-upgrade.https-expected.txt
@@ -1,0 +1,9 @@
+CONSOLE MESSAGE: The page at about:blank requested insecure content from http://127.0.0.1:8443/security/resources/abe.png. This content was automatically upgraded and should be served over HTTPS.
+
+Tests that about:blank opened via window.open() inherits upgrade-insecure-requests behavior from its opener.
+
+The opener has upgrade-insecure-requests CSP directive. The about:blank window should inherit this and upgrade HTTP requests to HTTPS.
+
+
+PASS Verify that about:blank opened via window.open() inherits upgrade-insecure-requests from opener.
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/about-blank-inherits-upgrade.https.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/about-blank-inherits-upgrade.https.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>Upgrade Insecure Requests: Inheritance by about:blank via window.open()</title>
+<script src="/js-test-resources/testharness.js"></script>
+<script src="/js-test-resources/testharnessreport.js"></script>
+
+<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+// This is a bit of a hack. UPGRADE doesn't upgrade the port number, so we
+// specify this non-existent URL ('http' over port 8443). If UPGRADE works,
+// it will be upgraded to https and load. If not, it fails.
+var insecureImage = "http://127.0.0.1:8443/security/resources/abe.png";
+
+(function() {
+    var t = async_test("Verify that about:blank opened via window.open() inherits upgrade-insecure-requests from opener.");
+    t.step(function () {
+        var popup = window.open("about:blank");
+        if (!popup) {
+            assert_unreached("Could not open popup");
+            return;
+        }
+
+        t.add_cleanup(function () { popup.close(); });
+
+        // Write content to about:blank that tries to load an insecure image
+        // If upgrade-insecure-requests is inherited, the image will be upgraded to HTTPS and load
+        // If not inherited, the image will fail to load (http on port 8443 doesn't exist)
+        var script = popup.document.createElement('script');
+        script.textContent = `
+            var img = document.createElement('img');
+            img.onload = function() {
+                window.opener.postMessage({success: true, width: img.naturalWidth, height: img.naturalHeight}, '*');
+            };
+            img.onerror = function() {
+                window.opener.postMessage({success: false}, '*');
+            };
+            img.src = "${insecureImage}";
+            document.body.appendChild(img);
+        `;
+        popup.document.body.appendChild(script);
+
+        window.addEventListener("message", t.step_func(function (event) {
+            if (event.data.success) {
+                assert_equals(event.data.height, 103, "Height of upgraded image.");
+                assert_equals(event.data.width, 76, "Width of upgraded image.");
+                t.done();
+            } else {
+                assert_unreached("The image should load successfully if upgrade-insecure-requests was inherited.");
+            }
+        }), {once: true});
+    });
+}());
+
+</script>
+<p>Tests that about:blank opened via window.open() inherits upgrade-insecure-requests behavior from its opener.</p>
+<p>The opener has upgrade-insecure-requests CSP directive. The about:blank window should inherit this and upgrade HTTP requests to HTTPS.</p>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -87,6 +87,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentResourceLoader.h"
 #include "DocumentSecurityOrigin.h"
+#include "DocumentSecurityPolicy.h"
 #include "DocumentSharedObjectPool.h"
 #include "DocumentSyncData.h"
 #include "DocumentTimeline.h"
@@ -722,7 +723,24 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     if (!frame)
         setUsesNullCustomElementRegistry();
 
-    initSecurityContext();
+    // Compute owner security policy before calling initSecurityContext.
+    // The owner is the parent frame if available, otherwise the opener frame.
+    std::optional<DocumentSecurityPolicy> ownerSecurityPolicy;
+    RefPtr<SecurityOrigin> ownerSecurityOrigin;
+    bool ownerIsOpener = false;
+    if (frame) {
+        RefPtr ownerFrame = frame->tree().parent();
+        if (!ownerFrame) {
+            ownerFrame = frame->opener();
+            ownerIsOpener = !!ownerFrame;
+        }
+        if (ownerFrame) {
+            ownerSecurityPolicy = ownerFrame->frameDocumentSecurityPolicy();
+            ownerSecurityOrigin = ownerFrame->frameDocumentSecurityOrigin();
+        }
+    }
+
+    initSecurityContext(WTF::move(ownerSecurityPolicy), WTF::move(ownerSecurityOrigin), ownerIsOpener);
 
     InspectorInstrumentation::addEventListenersToNode(*this);
     setStorageBlockingPolicy(m_settings->storageBlockingPolicy());
@@ -8428,7 +8446,7 @@ ExceptionOr<Ref<XPathResult>> Document::evaluate(const String& expression, Node&
     return m_xpathEvaluator->evaluate(expression, contextNode, WTF::move(resolver), type, result);
 }
 
-void Document::initSecurityContext()
+void Document::initSecurityContext(std::optional<DocumentSecurityPolicy> ownerSecurityPolicy, RefPtr<SecurityOrigin> ownerSecurityOrigin, bool ownerIsOpener)
 {
     if (haveInitializedSecurityOrigin()) {
         ASSERT(SecurityContext::securityOrigin());
@@ -8506,75 +8524,92 @@ void Document::initSecurityContext()
         return;
 
     // If we do not obtain a meaningful origin from the URL, then we try to
-    // find one via the frame hierarchy.
-    RefPtr parentFrame = m_frame->tree().parent();
-    RefPtr openerFrame = dynamicDowncast<LocalFrame>(m_frame->opener());
-
-    RefPtr ownerFrame = dynamicDowncast<LocalFrame>(parentFrame.get());
-    if (!ownerFrame)
-        ownerFrame = openerFrame;
-
-    if (!ownerFrame) {
+    // find one via the owner (passed in as a parameter).
+    if (!ownerSecurityPolicy && !ownerSecurityOrigin) {
         didFailToInitializeSecurityOrigin();
         return;
     }
 
     CheckedPtr contentSecurityPolicy = this->contentSecurityPolicy();
-    contentSecurityPolicy->copyStateFrom(protect(ownerFrame->document())->checkedContentSecurityPolicy().get());
-    contentSecurityPolicy->updateSourceSelf(protect(ownerFrame->document()->securityOrigin()));
-
-    setCrossOriginEmbedderPolicy(ownerFrame->document()->crossOriginEmbedderPolicy());
+    if (ownerSecurityPolicy) {
+        contentSecurityPolicy->inheritHeadersFrom(ownerSecurityPolicy->contentSecurityPolicyResponseHeaders);
+        contentSecurityPolicy->setReferrer(ownerSecurityPolicy->cspReferrer);
+        contentSecurityPolicy->setHttpStatusCode(ownerSecurityPolicy->cspHttpStatusCode);
+        if (ownerSecurityOrigin)
+            contentSecurityPolicy->updateSourceSelf(*ownerSecurityOrigin);
+        setCrossOriginEmbedderPolicy(ownerSecurityPolicy->crossOriginEmbedderPolicy);
+    }
 
     // https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context (Step 12)
     // If creator is non-null and creator's origin is same origin with creator's relevant settings object's top-level origin, then set coop
     // to creator's browsing context's top-level browsing context's active document's cross-origin opener policy.
-    if (m_frame->isMainFrame() && openerFrame && openerFrame->document() && openerFrame->document()->isSameOriginAsTopDocument())
-        setCrossOriginOpenerPolicy(openerFrame->document()->crossOriginOpenerPolicy());
+    if (m_frame->isMainFrame() && ownerIsOpener && ownerSecurityPolicy && ownerSecurityPolicy->isSameOriginAsTopDocument)
+        setCrossOriginOpenerPolicy(ownerSecurityPolicy->crossOriginOpenerPolicy);
 
     // Per <http://www.w3.org/TR/upgrade-insecure-requests/>, new browsing contexts must inherit from an
     // ongoing set of upgraded requests. When opening a new browsing context, we need to capture its
     // existing upgrade request. Nested browsing contexts are handled during DocumentWriter::begin.
-    if (RefPtr openerDocument = openerFrame ? openerFrame->document() : nullptr)
-        contentSecurityPolicy->inheritInsecureNavigationRequestsToUpgradeFromOpener(*openerDocument->checkedContentSecurityPolicy());
+    if (ownerIsOpener && ownerSecurityPolicy)
+        contentSecurityPolicy->setInsecureNavigationRequestsToUpgrade(HashSet { ownerSecurityPolicy->insecureNavigationRequestsToUpgrade });
 
     if (isSandboxed(SandboxFlag::Origin)) {
         // If we're supposed to inherit our security origin from our owner,
         // but we're also sandboxed, the only thing we inherit is the ability
         // to load local resources. This lets about:blank iframes in file://
         // URL documents load images and other resources from the file system.
-        if (ownerFrame->document()->securityOrigin().canLoadLocalResources())
+        if (ownerSecurityOrigin && ownerSecurityOrigin->canLoadLocalResources())
             securityOrigin().grantLoadLocalResources();
         return;
     }
 
-    setCookieURL(ownerFrame->document()->cookieURL());
+    // cookieURL inheritance only works with LocalFrame owners.
+    // This is correct because documents that inherit security context (about:blank, etc.)
+    // are same-origin with their owner, meaning same process with Site Isolation.
+    RefPtr<LocalFrame> ownerLocalFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
+    if (!ownerLocalFrame)
+        ownerLocalFrame = dynamicDowncast<LocalFrame>(m_frame->opener());
+    if (ownerLocalFrame) {
+        if (RefPtr ownerDocument = ownerLocalFrame->document())
+            setCookieURL(ownerDocument->cookieURL());
+    }
+
     // We alias the SecurityOrigins to match Firefox, see Bug 15313
     // https://bugs.webkit.org/show_bug.cgi?id=15313
-    setSecurityOriginPolicy(ownerFrame->document()->securityOriginPolicy());
+    if (ownerSecurityOrigin)
+        setSecurityOriginPolicy(SecurityOriginPolicy::create(Ref { *ownerSecurityOrigin }));
 }
 
 void Document::initContentSecurityPolicy()
 {
     if (!m_frame)
         return;
-    RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
-    if (parentFrame)
-        checkedContentSecurityPolicy()->copyUpgradeInsecureRequestStateFrom(*protect(parentFrame->document())->checkedContentSecurityPolicy());
+
+    RefPtr parentFrame = m_frame->tree().parent();
+    if (parentFrame) {
+        if (auto parentSecurityPolicy = parentFrame->frameDocumentSecurityPolicy()) {
+            checkedContentSecurityPolicy()->setUpgradeInsecureRequests(parentSecurityPolicy->upgradeInsecureRequests);
+            checkedContentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(HashSet { parentSecurityPolicy->insecureNavigationRequestsToUpgrade });
+        }
+    }
 
     // FIXME: Remove this special plugin document logic. We are stricter than the CSP 3 spec. with regards to plugins: we prefer to
     // inherit the full policy unless the plugin document is opened in a new window. The CSP 3 spec. implies that only plugin documents
     // delivered with a local scheme (e.g. blob, file, data) should inherit a policy.
     if (!isPluginDocument())
         return;
-    RefPtr openerFrame = dynamicDowncast<LocalFrame>(m_frame->opener());
-    bool shouldInhert = parentFrame || (openerFrame && protect(openerFrame->document()->securityOrigin())->isSameOriginDomain(securityOrigin()));
-    if (!shouldInhert)
+
+    RefPtr openerFrame = m_frame->opener();
+    RefPtr<LocalFrame> localParentFrame = dynamicDowncast<LocalFrame>(parentFrame.get());
+    RefPtr<LocalFrame> localOpenerFrame = dynamicDowncast<LocalFrame>(openerFrame.get());
+    bool shouldInherit = localParentFrame || (localOpenerFrame && protect(localOpenerFrame->document()->securityOrigin())->isSameOriginDomain(securityOrigin()));
+    if (!shouldInherit)
         return;
+
     setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { m_url }, *this));
-    if (openerFrame)
-        checkedContentSecurityPolicy()->createPolicyForPluginDocumentFrom(*protect(openerFrame->document())->checkedContentSecurityPolicy());
-    else
-        checkedContentSecurityPolicy()->copyStateFrom(protect(parentFrame->document())->checkedContentSecurityPolicy().get());
+    if (localOpenerFrame)
+        checkedContentSecurityPolicy()->createPolicyForPluginDocumentFrom(*protect(localOpenerFrame->document())->checkedContentSecurityPolicy());
+    else if (localParentFrame)
+        checkedContentSecurityPolicy()->copyStateFrom(protect(localParentFrame->document())->checkedContentSecurityPolicy().get());
 }
 
 void Document::inheritPolicyContainerFrom(const PolicyContainer& policyContainer)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -34,6 +34,7 @@
 #include <WebCore/DocumentClasses.h>
 #include <WebCore/DocumentEnums.h>
 #include <WebCore/DocumentEventTiming.h>
+#include <WebCore/DocumentSecurityPolicy.h>
 #include <WebCore/Element.h>
 #include <WebCore/ExceptionOr.h>
 #include <WebCore/FocusControllerTypes.h>
@@ -1423,7 +1424,7 @@ public:
     WEBCORE_EXPORT SVGDocumentExtensions& svgExtensions();
     WEBCORE_EXPORT CheckedRef<SVGDocumentExtensions> checkedSVGExtensions();
 
-    void initSecurityContext();
+    void initSecurityContext(std::optional<DocumentSecurityPolicy> ownerSecurityPolicy = std::nullopt, RefPtr<SecurityOrigin> ownerSecurityOrigin = nullptr, bool ownerIsOpener = false);
     void initContentSecurityPolicy();
 
     void inheritPolicyContainerFrom(const PolicyContainer&) final;

--- a/Source/WebCore/dom/DocumentSecurityPolicy.h
+++ b/Source/WebCore/dom/DocumentSecurityPolicy.h
@@ -25,14 +25,24 @@
 
 #pragma once
 
+#include <WebCore/ContentSecurityPolicyResponseHeaders.h>
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
+#include <WebCore/SecurityOriginData.h>
+#include <wtf/HashSet.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 struct DocumentSecurityPolicy {
     CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     CrossOriginOpenerPolicy crossOriginOpenerPolicy;
+    ContentSecurityPolicyResponseHeaders contentSecurityPolicyResponseHeaders;
+    HashSet<SecurityOriginData> insecureNavigationRequestsToUpgrade;
+    String cspReferrer;
+    int cspHttpStatusCode { 0 };
+    bool isSameOriginAsTopDocument { false };
+    bool upgradeInsecureRequests { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1040,8 +1040,27 @@ DOMWindow* LocalFrame::virtualWindow() const
 
 void LocalFrame::reinitializeDocumentSecurityContext()
 {
-    if (RefPtr document = this->document())
-        document->initSecurityContext();
+    RefPtr document = this->document();
+    if (!document)
+        return;
+
+    // Compute owner security policy before calling initSecurityContext.
+    // The owner is the parent frame if available, otherwise the opener frame.
+    std::optional<DocumentSecurityPolicy> ownerSecurityPolicy;
+    RefPtr<SecurityOrigin> ownerSecurityOrigin;
+    bool ownerIsOpener = false;
+
+    RefPtr ownerFrame = tree().parent();
+    if (!ownerFrame) {
+        ownerFrame = opener();
+        ownerIsOpener = !!ownerFrame;
+    }
+    if (ownerFrame) {
+        ownerSecurityPolicy = ownerFrame->frameDocumentSecurityPolicy();
+        ownerSecurityOrigin = ownerFrame->frameDocumentSecurityOrigin();
+    }
+
+    document->initSecurityContext(WTF::move(ownerSecurityPolicy), WTF::move(ownerSecurityOrigin), ownerIsOpener);
 }
 
 void LocalFrame::disconnectView()
@@ -1685,7 +1704,29 @@ std::optional<DocumentSecurityPolicy> LocalFrame::frameDocumentSecurityPolicy() 
     if (!document)
         return std::nullopt;
 
-    return DocumentSecurityPolicy { document->crossOriginEmbedderPolicy(), document->crossOriginOpenerPolicy() };
+    ContentSecurityPolicyResponseHeaders cspHeaders;
+    HashSet<SecurityOriginData> insecureNavRequests;
+    String cspReferrer;
+    int cspHttpStatusCode = 0;
+    bool upgradeInsecureRequests = false;
+    if (CheckedPtr csp = document->contentSecurityPolicy()) {
+        cspHeaders = csp->responseHeaders();
+        insecureNavRequests = csp->insecureNavigationRequestsToUpgrade();
+        cspReferrer = csp->referrer();
+        cspHttpStatusCode = csp->httpStatusCode();
+        upgradeInsecureRequests = csp->upgradeInsecureRequests();
+    }
+
+    return DocumentSecurityPolicy {
+        document->crossOriginEmbedderPolicy(),
+        document->crossOriginOpenerPolicy(),
+        WTF::move(cspHeaders),
+        WTF::move(insecureNavRequests),
+        WTF::move(cspReferrer),
+        cspHttpStatusCode,
+        document->isSameOriginAsTopDocument(),
+        upgradeInsecureRequests
+    };
 }
 
 Ref<FrameInspectorController> LocalFrame::protectedInspectorController() const

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -222,6 +222,7 @@ public:
     WEBCORE_EXPORT void upgradeInsecureRequestIfNeeded(URL&, InsecureRequestType, AlwaysUpgradeRequest = AlwaysUpgradeRequest::No) const;
 
     HashSet<SecurityOriginData> takeNavigationRequestsToUpgrade();
+    const HashSet<SecurityOriginData>& insecureNavigationRequestsToUpgrade() const { return m_insecureNavigationRequestsToUpgrade; }
     void inheritInsecureNavigationRequestsToUpgradeFromOpener(const ContentSecurityPolicy&);
     void setInsecureNavigationRequestsToUpgrade(HashSet<SecurityOriginData>&&);
 
@@ -231,6 +232,11 @@ public:
     void setDocumentURL(URL& documentURL) { m_documentURL = documentURL; }
 
     SandboxFlags sandboxFlags() const { return m_sandboxFlags; }
+
+    const String& referrer() const { return m_referrer; }
+    void setReferrer(const String& referrer) { m_referrer = referrer; }
+    int httpStatusCode() const { return m_httpStatusCode; }
+    void setHttpStatusCode(int httpStatusCode) { m_httpStatusCode = httpStatusCode; }
 
     bool isHeaderDelivered() const { return m_isHeaderDelivered; }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9155,6 +9155,12 @@ enum class WebCore::ShouldGoToHistoryItem : uint8_t {
 struct WebCore::DocumentSecurityPolicy {
     WebCore::CrossOriginEmbedderPolicy crossOriginEmbedderPolicy;
     WebCore::CrossOriginOpenerPolicy crossOriginOpenerPolicy;
+    WebCore::ContentSecurityPolicyResponseHeaders contentSecurityPolicyResponseHeaders;
+    HashSet<WebCore::SecurityOriginData> insecureNavigationRequestsToUpgrade;
+    String cspReferrer;
+    int cspHttpStatusCode;
+    bool isSameOriginAsTopDocument;
+    bool upgradeInsecureRequests;
 };
 
 header: <WebCore/ProcessSwapDisposition.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1793,6 +1793,12 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     m_mainFrame = WebFrameProxy::create(*this, browsingContextGroup->ensureProcessForSite(effectiveSite, site, process, preferences), generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, WebFrameProxy::protectedWebFrame(m_openerFrameIdentifier).get(), IsMainFrame::Yes);
     if (preferences->siteIsolationEnabled())
         browsingContextGroup->addPage(*this);
+
+    // Register the cookie domain for this new page. For about:blank pages opened via window.open,
+    // effectiveSite contains the opener's origin which is the correct domain for cookie access.
+    if (!effectiveSite.domain().isEmpty())
+        protect(protect(websiteDataStore())->networkProcess())->addAllowedFirstPartyForCookies(CheckedRef { RefPtr { m_mainFrame }->process() }, effectiveSite.domain(), LoadedWebArchive::No, [] { });
+
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protect(drawingArea()), m_mainFrame->frameID(), std::nullopt)), 0);
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)


### PR DESCRIPTION
#### 63f7a3ca5cc872b0febba9338cc7f29ca6f7bf15
<pre>
[Site Isolation] Pass DocumentSecurityPolicy as parameter to Document::initSecurityContext()
<a href="https://bugs.webkit.org/show_bug.cgi?id=284343">https://bugs.webkit.org/show_bug.cgi?id=284343</a>
<a href="https://rdar.apple.com/141188809">rdar://141188809</a>

Reviewed by NOBODY (OOPS!).

Refactor Document::initSecurityContext() to accept DocumentSecurityPolicy as a parameter
rather than internally querying the owner frame (parent or opener). This makes the
dependency explicit.

The caller (Document constructor and LocalFrame::reinitializeDocumentSecurityContext)
now computes the owner frame and retrieves the security policy before calling
initSecurityContext(). Opener-specific logic (COOP, insecure navigation requests to
upgrade) is handled via the ownerIsOpener parameter.

Tests: http/tests/security/aboutBlank/cross-origin-iframe-window-open-about-blank.html
       http/tests/security/aboutBlank/security-context-cross-origin-opener.html
       http/tests/security/contentSecurityPolicy/csp-inherited-by-about-blank-from-cross-origin-opener.html
       http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/about-blank-inherits-upgrade.https.html

* LayoutTests/http/tests/security/aboutBlank/cross-origin-iframe-window-open-about-blank-expected.txt: Added.
* LayoutTests/http/tests/security/aboutBlank/cross-origin-iframe-window-open-about-blank.html: Added.
* LayoutTests/http/tests/security/aboutBlank/resources/cross-origin-open-about-blank.html: Added.
* LayoutTests/http/tests/security/aboutBlank/resources/open-about-blank.html: Added.
* LayoutTests/http/tests/security/aboutBlank/security-context-cross-origin-opener-expected.txt: Added.
* LayoutTests/http/tests/security/aboutBlank/security-context-cross-origin-opener.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/csp-inherited-by-about-blank-from-cross-origin-opener-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/csp-inherited-by-about-blank-from-cross-origin-opener.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/cross-origin-opener-with-csp.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/about-blank-inherits-upgrade.https-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/about-blank-inherits-upgrade.https.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::m_syncData):
(WebCore::Document::initSecurityContext):
(WebCore::Document::initContentSecurityPolicy):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentSecurityPolicy.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::reinitializeDocumentSecurityContext):
(WebCore::LocalFrame::frameDocumentSecurityPolicy const):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63f7a3ca5cc872b0febba9338cc7f29ca6f7bf15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152176 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96747 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fa84471-7049-46cb-be84-42292d450454) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79442 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5687e9fe-9531-48ad-ba68-22f97058fde3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91284 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff48bbf7-fb96-461b-9c9c-ea864fc00a90) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12301 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10016 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2178 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154488 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6536 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118375 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118728 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14672 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71453 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15660 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5313 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15395 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15459 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->