### PR TITLE
Subtitles stop rendering after entering/exiting PIP on apple.com

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -896,10 +896,32 @@ auto MediaControlsHost::sourceType() const -> std::optional<SourceType>
     return protectedMediaElement()->sourceType();
 }
 
+bool MediaControlsHost::needsCaptionVisibilityInFullscreenAndPictureInPictureQuirk() const
+{
+    return protect(protectedMediaElement()->document())->quirks().ensureCaptionVisibilityInFullscreenAndPictureInPicture();
+}
+
+void MediaControlsHost::handleCaptionVisibilityInFullscreenAndPictureInPictureQuirk()
+{
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (!needsCaptionVisibilityInFullscreenAndPictureInPictureQuirk())
+        return;
+
+    RefPtr textTrackContainer = m_textTrackContainer;
+    if (!textTrackContainer)
+        return;
+
+    if (protectedMediaElement()->isInFullscreenOrPictureInPicture())
+        textTrackContainer->setInlineStyleProperty(CSSPropertyVisibility, CSSValueVisible);
+    else
+        textTrackContainer->setInlineStyleProperty(CSSPropertyVisibility, CSSValueInherit);
+#endif
+}
 
 void MediaControlsHost::presentationModeChanged()
 {
     restorePreviouslySelectedTextTrackIfNecessary();
+    handleCaptionVisibilityInFullscreenAndPictureInPictureQuirk();
 }
 
 void MediaControlsHost::savePreviouslySelectedTextTrackIfNecessary()

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -154,6 +154,8 @@ public:
 private:
     void savePreviouslySelectedTextTrackIfNecessary();
     void restorePreviouslySelectedTextTrackIfNecessary();
+    void handleCaptionVisibilityInFullscreenAndPictureInPictureQuirk();
+    bool needsCaptionVisibilityInFullscreenAndPictureInPictureQuirk() const;
 
     MediaControlTextTrackContainerElement* ensureTextTrackContainer();
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -372,6 +372,17 @@ bool Quirks::isYoutubeEmbedDomain() const
     return isEmbedDomain("youtube.com"_s) || isEmbedDomain("youtube-nocookie.com"_s);
 }
 
+// apple.com rdar://154434137
+bool Quirks::ensureCaptionVisibilityInFullscreenAndPictureInPicture() const
+{
+#if PLATFORM(IOS_FAMILY)
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::EnsureCaptionVisibilityInFullscreenAndPictureInPicture);
+#else
+    return false;
+#endif
+}
+
 bool Quirks::shouldDisableElementFullscreenQuirk() const
 {
 #if PLATFORM(IOS_FAMILY)
@@ -3094,6 +3105,14 @@ static void handlePinterestQuirks(QuirksData& quirksData, const URL& /* quirksUR
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldAllowNotificationPermissionWithoutUserGesture);
 }
 
+static void handleAppleQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
+{
+    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("apple.com"_s);
+
+    // apple.com rdar://154434137
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::EnsureCaptionVisibilityInFullscreenAndPictureInPicture);
+}
+
 static void handlePremierLeagueQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("premierleague.com"_s);
@@ -3388,6 +3407,7 @@ void Quirks::determineRelevantQuirks()
         { "actesting"_s, &handleACTestingQuirks },
 #endif
         { "amazon"_s, &handleAmazonQuirks },
+        { "apple"_s, &handleAppleQuirks },
 #if PLATFORM(IOS_FAMILY)
         { "as"_s, &handleASQuirks },
         { "att"_s, &handleATTQuirks },

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -300,6 +300,8 @@ public:
     bool shouldRewriteMediaRangeRequestForURL(const URL&) const;
     bool shouldDelayReloadWhenRegisteringServiceWorker() const;
 
+    bool ensureCaptionVisibilityInFullscreenAndPictureInPicture() const;
+
     bool shouldPreventKeyframeEffectAcceleration(const KeyframeEffect&) const;
 
     bool shouldEnterNativeFullscreenWhenCallingElementRequestFullscreenQuirk() const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -60,6 +60,7 @@ struct QuirksData {
         BlocksEnteringStandardFullscreenFromPictureInPictureQuirk,
         BlocksReturnToFullscreenFromPictureInPictureQuirk,
 #endif
+        EnsureCaptionVisibilityInFullscreenAndPictureInPicture,
         HasBrokenEncryptedMediaAPISupportQuirk,
         ImplicitMuteWhenVolumeSetToZero,
         InputMethodUsesCorrectKeyEventOrder,


### PR DESCRIPTION
#### bb389b9c4ae0d39f673961754ad40e32bd911505
<pre>
Subtitles stop rendering after entering/exiting PIP on apple.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=307099">https://bugs.webkit.org/show_bug.cgi?id=307099</a>
<a href="https://rdar.apple.com/154434137">rdar://154434137</a>

Reviewed by Eric Carlson.

Apple.com/apple-events, which uses natively rendered WebVTT, sets visibility: hidden
on their video. Our caption container inherits visibility from the video. Because the
captions are hidden, our rendering optimizations skip drawing them, and they do not make
it into the image that we send to PIP. The captions also do not appear when after returning
to fullscreen from PIP. To fix this, we should set visibility: visible on the captions
container in fullscreen and PIP.

This change should be restricted to an apple.com quirk because of the side effect we expect
on other websites that hide their video with visibility: hidden. If a video were hidden,
and we un-hid the captions in PIP, the captions would appear both on the page and in PIP,
because the placard (which hides the captions on the page while in PIP) would also be
invisible.

This side effect does not occur on apple.com/apple-events because they place the video
behind other elements via z-index, so the captions are hidden regardless.

No new tests.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::needsCaptionVisibilityInFullscreenAndPictureInPictureQuirk const):
(WebCore::MediaControlsHost::handleCaptionVisibilityInFullscreenAndPictureInPictureQuirk):
(WebCore::MediaControlsHost::presentationModeChanged):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::ensureCaptionVisibilityInFullscreenAndPictureInPicture const):
(WebCore::handleAppleQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/307084@main">https://commits.webkit.org/307084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9059eba815d9a67af4a3418d9e28738b4750c459

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151565 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96084 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109893 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79185 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1586b82b-8c57-40dc-a951-d7ec2f0d1681) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90803 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed1a8feb-3ab1-4be1-aeac-fa8ced4a9175) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11844 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9529 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153878 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14989 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117910 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118246 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14234 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125207 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70696 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22095 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15032 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4117 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14767 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78743 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14829 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->