### PR TITLE
[GFC] Rename availableSpace in TrackSizingAlgorithm to availableGridSpace

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -321,7 +321,7 @@ static void resolveIntrinsicTrackSizes(UnsizedTracks& unsizedTracks, const Place
 // https://drafts.csswg.org/css-grid-1/#algo-track-sizing
 TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const ComputedSizesList& gridItemComputedSizesList,
     const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions,
-    std::optional<LayoutUnit> availableSpace, const GridItemSizingFunctions& gridItemSizingFunctions,
+    std::optional<LayoutUnit> availableGridSpace, const GridItemSizingFunctions& gridItemSizingFunctions,
     const IntegrationUtils& integrationUtils, const FreeSpaceScenario& freeSpaceScenario, const LayoutUnit& gapSize)
 {
     ASSERT(gridItems.size() == gridItemSpanList.size());
@@ -358,25 +358,25 @@ TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, co
         if (freeSpaceScenario == FreeSpaceScenario::Indefinite) {
             // FIXME: Implement indefinite free space (spec §11.7 Scenario 3).
             // Compute flex fraction based on max-content contributions.
-            ASSERT(!availableSpace);
+            ASSERT(!availableGridSpace);
             notImplemented();
             return;
         }
 
         ASSERT(freeSpaceScenario == FreeSpaceScenario::Definite);
-        ASSERT(availableSpace.has_value());
+        ASSERT(availableGridSpace.has_value());
 
         // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
         // "If the free space is zero...the used flex fraction is zero."
         // If availableSpace is zero, free space must also be 0.
-        if (availableSpace.value() == 0_lu)
+        if (availableGridSpace.value() == 0_lu)
             return;
 
         // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks
         // Otherwise, if the free space is a definite length:
         // The used flex fraction is the result of finding the size of an fr using all of the
         // grid tracks and a space to fill of the available grid space (minus gutters).
-        auto frSize = findSizeOfFr(unsizedTracks, availableSpace.value(), gapSize);
+        auto frSize = findSizeOfFr(unsizedTracks, availableGridSpace.value(), gapSize);
 
         // For each flexible track, if the product of the used flex fraction and the track's flex factor is greater than the track's base size, set its base size to that product.
         for (auto& flexTrack : flexTracks) {

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -49,7 +49,7 @@ struct GridItemSizingFunctions {
 class TrackSizingAlgorithm {
 public:
     static TrackSizes sizeTracks(const PlacedGridItems&, const ComputedSizesList&, const PlacedGridItemSpanList&,
-    const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableSpace,
+    const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableGridSpace,
     const GridItemSizingFunctions&, const IntegrationUtils&, const FreeSpaceScenario&, const LayoutUnit& gapSize);
 
 private:


### PR DESCRIPTION
#### 6627969abb9ebfea7fb3d5ad4550c1ff526942e0
<pre>
[GFC] Rename availableSpace in TrackSizingAlgorithm to availableGridSpace
<a href="https://bugs.webkit.org/show_bug.cgi?id=307105">https://bugs.webkit.org/show_bug.cgi?id=307105</a>
<a href="https://rdar.apple.com/169738465">rdar://169738465</a>

Reviewed by Brandon Stewart.

This concept has a name and definition in the spec when it comes to
track sizing:
<a href="https://drafts.csswg.org/css-grid-1/#algo-terms">https://drafts.csswg.org/css-grid-1/#algo-terms</a>

The &quot;available grid space,&quot; is what we should be passing into the track
sizing algorithm and this makes the variable match the spec writing.

Canonical link: <a href="https://commits.webkit.org/306910@main">https://commits.webkit.org/306910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b03ebeaf812f4ea19c7588b500edb04a9f3ea16a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151388 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10c36266-2a0e-4448-8d28-da93a5befef0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109756 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b61e6c1d-23a2-4308-bd9d-e349fc49b9a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90663 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1387 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153701 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117770 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30127 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14102 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124980 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14855 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3936 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78564 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->