### PR TITLE
[grid-lanes] Fix masonry track sizing to properly handle subgrid children's intrinsic contributions

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1826,7 +1826,6 @@ imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/parsing/grid-l
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/parsing/grid-lanes-shorthand-serialization.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/parsing/grid-lanes-shorthand-valid.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001a.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001e.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002a.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-expected.html
@@ -39,7 +39,7 @@
 </grid>
 
 <grid>
-  <item style="width: 2ch">1</item>
+  <item style="width: 1ch">1</item>
   <subgrid>
     <item style="width: 2ch">2</item>
     <item style="width: 2ch">3</item>
@@ -59,7 +59,7 @@
 </grid>
 
 <grid>
-  <item style="width: 4ch">1</item>
+  <item style="width: 1ch">1</item>
   <subgrid>
     <item>2</item>
     <item style="width: 4ch">3</item>
@@ -69,7 +69,7 @@
 </grid>
 
 <grid>
-  <item style="width: 3ch">1</item>
+  <item style="width: 1ch">1</item>
   <subgrid>
     <item style="width: 3ch">2</item>
     <item style="width: 3ch">3</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-ref.html
@@ -39,7 +39,7 @@
 </grid>
 
 <grid>
-  <item style="width: 2ch">1</item>
+  <item style="width: 1ch">1</item>
   <subgrid>
     <item style="width: 2ch">2</item>
     <item style="width: 2ch">3</item>
@@ -59,7 +59,7 @@
 </grid>
 
 <grid>
-  <item style="width: 4ch">1</item>
+  <item style="width: 1ch">1</item>
   <subgrid>
     <item>2</item>
     <item style="width: 4ch">3</item>
@@ -69,7 +69,7 @@
 </grid>
 
 <grid>
-  <item style="width: 3ch">1</item>
+  <item style="width: 1ch">1</item>
   <subgrid>
     <item style="width: 3ch">2</item>
     <item style="width: 3ch">3</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
@@ -19,7 +19,7 @@
     }
 
     subgrid {
-      display: grid;
+      display: grid-lanes;
       grid-template-columns: subgrid;
       grid-column: 2 / span 2;
       background: lightblue;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -255,7 +255,7 @@ private:
     // Build up a map of min/max sizes for each span length for use during resolving intrinsic track sizes.
     // We also need to keep track of definite items separately, since they do not contribute to every track like indefinite items do.
     void computeDefiniteAndIndefiniteItemsForMasonry(StdMap<SpanLength, MasonryMinMaxTrackSize>&, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&, Vector<MasonryMinMaxTrackSizeWithGridSpan>&, RenderGridLayoutState&);
-    bool shouldExcludeGridItemForMasonryTrackSizing(const RenderBox& gridItem, unsigned trackIndex, GridSpan itemSpan) const;
+
     // Track sizing algorithm steps. Note that the "Maximize Tracks" step is done
     // entirely inside the strategies, that's why we don't need an additional
     // method at this level.
@@ -273,6 +273,12 @@ private:
     void resolveIntrinsicTrackSizesMasonry(RenderGridLayoutState&);
     void stretchFlexibleTracks(std::optional<LayoutUnit> freeSpace, RenderGridLayoutState&);
     void stretchAutoTracks();
+
+    // Shared stack-based traversal that visits every grid item (including those nested inside subgrids).
+    // For subgrids, it accumulates margin/border/padding into each spanned track and recurses into children.
+    // For leaf items, it invokes |handleLeafItem(gridItem, gridItemSpan)|.
+    template<typename LeafItemHandler>
+    void traverseSubgridTreeForIntrinsicSizing(LeafItemHandler&&);
 
     void aggregateGridItemsForIntrinsicSizing(Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, RenderGridLayoutState&);
 


### PR DESCRIPTION
#### f435986450ce50cc8971309175b0986b5dfa75c8
<pre>
[grid-lanes] Fix masonry track sizing to properly handle subgrid children&apos;s intrinsic contributions
<a href="https://bugs.webkit.org/show_bug.cgi?id=307109">https://bugs.webkit.org/show_bug.cgi?id=307109</a>
<a href="https://rdar.apple.com/problem/169743714">rdar://problem/169743714</a>

Reviewed by Sammy Gill.

The previous GridIterator-based approach in
computeDefiniteAndIndefiniteItemsForMasonry() did not walk into subgrids,
causing their children&apos;s intrinsic sizes to be ignored during masonry track
sizing. For example, a masonry grid with `auto min-content max-content`
columns and a subgrid spanning columns 2–3 would fail to propagate the
subgrid children&apos;s widths into the parent tracks.

Fix this by adopting the same stack-based depth-first traversal used by
aggregateGridItemsForIntrinsicSizing(), which correctly recurses into
subgrids while accumulating margin/border/padding contributions along
the way.

Factor the shared traversal logic into a new template helper,
forEachGridItemForIntrinsicSizing(), so both functions use the same
code path for subgrid handling. This eliminates ~30 lines of duplication
and ensures future traversal changes only need to happen in one place.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::traverseSubgridTreeForIntrinsicSizing):
(WebCore::GridTrackSizingAlgorithm::aggregateGridItemsForIntrinsicSizing):
(WebCore::GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry):
(WebCore::GridTrackSizingAlgorithm::shouldExcludeGridItemForMasonryTrackSizing const): Deleted.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/307260@main">https://commits.webkit.org/307260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71bddc7b601272df16fff4ddc02e25d5330ae2f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152092 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96662 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f5d83c8-31b5-4399-aba5-2d31f90530cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110296 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79411 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92d5eb27-72f8-418d-83e6-7aeabbf699cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91208 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce90ec64-5a7e-44a4-bb98-29c2f5f95698) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12251 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9969 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2094 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154404 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15955 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118315 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15991 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118657 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30499 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14618 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126624 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15576 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5253 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15311 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79290 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->