### PR TITLE
Use protect() instead of protectedFoo() for memory safety in rendering code

### DIFF
--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1165,7 +1165,7 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
         if (paintInfo.paintBehavior.contains(PaintBehavior::EventRegionIncludeBackground) && visibleToHitTesting()) {
             auto borderShape = BorderShape::shapeForBorderRect(style(), borderRect);
             LOG_WITH_STREAM(EventRegions, stream << "RenderBlock " << *this << " uniting region " << borderShape.deprecatedRoundedRect() << " event listener types " << style().eventListenerRegionTypes());
-            bool overrideUserModifyIsEditable = isRenderTextControl() && downcast<RenderTextControl>(*this).protectedTextFormControlElement()->isInnerTextElementEditable();
+            bool overrideUserModifyIsEditable = isRenderTextControl() && protect(downcast<RenderTextControl>(*this).textFormControlElement())->isInnerTextElementEditable();
             paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(document->deviceScaleFactor()), *this, style(), overrideUserModifyIsEditable);
         }
 

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -82,12 +82,12 @@ void RenderSearchField::willBeDestroyed()
 
 inline HTMLElement* RenderSearchField::resultsButtonElement() const
 {
-    return protectedInputElement()->resultsButtonElement();
+    return protect(inputElement())->resultsButtonElement();
 }
 
 inline HTMLElement* RenderSearchField::cancelButtonElement() const
 {
-    return protectedInputElement()->cancelButtonElement();
+    return protect(inputElement())->cancelButtonElement();
 }
 
 void RenderSearchField::showPopup()
@@ -98,7 +98,7 @@ void RenderSearchField::showPopup()
 
 
     if (!m_searchPopup)
-        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protectedInputElement()->inputType()));
+        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protect(inputElement())->inputType()));
 
     Ref popup = *m_searchPopup;
     if (!popup->enabled())
@@ -106,16 +106,16 @@ void RenderSearchField::showPopup()
 
     m_searchPopupIsVisible = true;
 
-    auto recentSearches = downcast<SearchInputType>(*protectedInputElement()->inputType()).recentSearches();
+    auto recentSearches = downcast<SearchInputType>(*protect(inputElement())->inputType()).recentSearches();
     const AtomString& name = autosaveName();
     popup->loadRecentSearches(name, recentSearches);
 
     // Trim the recent searches list if the maximum size has changed since we last saved.
 
-    if (static_cast<int>(recentSearches.size()) > protectedInputElement()->maxResults()) {
+    if (static_cast<int>(recentSearches.size()) > protect(inputElement())->maxResults()) {
         do {
             recentSearches.removeLast();
-        } while (static_cast<int>(recentSearches.size()) > protectedInputElement()->maxResults());
+        } while (static_cast<int>(recentSearches.size()) > protect(inputElement())->maxResults());
 
         popup->saveRecentSearches(name, recentSearches);
     }
@@ -153,9 +153,9 @@ LayoutUnit RenderSearchField::computeControlLogicalHeight(LayoutUnit lineHeight,
 std::span<const RecentSearch> RenderSearchField::recentSearches()
 {
     if (!m_searchPopup)
-        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protectedInputElement()->inputType()));
+        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protect(inputElement())->inputType()));
 
-    auto& recentSearches = downcast<SearchInputType>(*protectedInputElement()->inputType()).recentSearches();
+    auto& recentSearches = downcast<SearchInputType>(*protect(inputElement())->inputType()).recentSearches();
 
     const AtomString& name = autosaveName();
     protectedSearchPopup()->loadRecentSearches(name, recentSearches);
@@ -192,18 +192,18 @@ void RenderSearchField::updateCancelButtonVisibility() const
 
 Visibility RenderSearchField::visibilityForCancelButton() const
 {
-    return (style().usedVisibility() == Visibility::Hidden || protectedInputElement()->value()->isEmpty()) ? Visibility::Hidden : Visibility::Visible;
+    return (style().usedVisibility() == Visibility::Hidden || protect(inputElement())->value()->isEmpty()) ? Visibility::Hidden : Visibility::Visible;
 }
 
 const AtomString& RenderSearchField::autosaveName() const
 {
-    return protectedInputElement()->attributeWithoutSynchronization(nameAttr);
+    return protect(inputElement())->attributeWithoutSynchronization(nameAttr);
 }
 
 void RenderSearchField::updatePopup(const AtomString& name, const Vector<RecentSearch>& searchItems)
 {
     if (!m_searchPopup)
-        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protectedInputElement()->inputType()));
+        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protect(inputElement())->inputType()));
     protectedSearchPopup()->saveRecentSearches(name, searchItems);
 }
 

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -57,11 +57,6 @@ HTMLTextFormControlElement& RenderTextControl::textFormControlElement() const
     return downcast<HTMLTextFormControlElement>(nodeForNonAnonymous());
 }
 
-Ref<HTMLTextFormControlElement> RenderTextControl::protectedTextFormControlElement() const
-{
-    return textFormControlElement();
-}
-
 RefPtr<TextControlInnerTextElement> RenderTextControl::innerTextElement() const
 {
     return textFormControlElement().innerTextElement();

--- a/Source/WebCore/rendering/RenderTextControl.h
+++ b/Source/WebCore/rendering/RenderTextControl.h
@@ -37,7 +37,6 @@ public:
     virtual ~RenderTextControl();
 
     WEBCORE_EXPORT HTMLTextFormControlElement& textFormControlElement() const;
-    WEBCORE_EXPORT Ref<HTMLTextFormControlElement> protectedTextFormControlElement() const;
 
 #if PLATFORM(IOS_FAMILY)
     bool canScroll() const;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -510,11 +510,6 @@ HTMLInputElement& RenderTextControlSingleLine::inputElement() const
     return downcast<HTMLInputElement>(RenderTextControl::textFormControlElement());
 }
 
-Ref<HTMLInputElement> RenderTextControlSingleLine::protectedInputElement() const
-{
-    return downcast<HTMLInputElement>(RenderTextControl::textFormControlElement());
-}
-
 RenderTextControlInnerBlock* RenderTextControlSingleLine::innerTextRenderer() const
 {
     return innerTextElement() ? innerTextElement()->renderer() : nullptr;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -43,7 +43,6 @@ protected:
     HTMLElement* containerElement() const;
     HTMLElement* innerBlockElement() const;
     HTMLInputElement& inputElement() const;
-    Ref<HTMLInputElement> protectedInputElement() const;
 
 private:
     void textFormControlElement() const = delete;


### PR DESCRIPTION
#### 4df1deaa1e567ffbf9318c221c65dce7c4de97a6
<pre>
Use protect() instead of protectedFoo() for memory safety in rendering code
<a href="https://bugs.webkit.org/show_bug.cgi?id=307110">https://bugs.webkit.org/show_bug.cgi?id=307110</a>
<a href="https://rdar.apple.com/169746867">rdar://169746867</a>

Reviewed by NOBODY (OOPS!).

Move to using the newer `protect()` style for call site memory
protection.

No new tests, as this has no impact on functionalty.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintObject):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::resultsButtonElement const):
(WebCore::RenderSearchField::cancelButtonElement const):
(WebCore::RenderSearchField::showPopup):
(WebCore::RenderSearchField::recentSearches):
(WebCore::RenderSearchField::visibilityForCancelButton const):
(WebCore::RenderSearchField::autosaveName const):
(WebCore::RenderSearchField::updatePopup):
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::textFormControlElement const):
(WebCore::RenderTextControl::protectedTextFormControlElement const): Deleted.
* Source/WebCore/rendering/RenderTextControl.h:
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::protectedInputElement const): Deleted.
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4df1deaa1e567ffbf9318c221c65dce7c4de97a6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151413 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95928 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/494aac37-2352-43e2-bbb1-8f900396cb41) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109771 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95928 "An unexpected error occured. Recent messages:Printed configuration") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90679 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ad74644-0443-426c-8be6-899a232bfa10) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9415 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1412 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153726 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14837 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117787 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14874 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118118 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30408 "Failed to checkout and rebase branch from PR 58002") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14115 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124990 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14880 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3946 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14615 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78589 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14823 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14677 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->